### PR TITLE
[fix][broker] Fix cluster level OffloadedReadPriority to bookkeeper-first does not work

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -95,8 +95,7 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             "managedLedgerOffloadAutoTriggerSizeThresholdBytes";
     public static final String DELETION_LAG_NAME_IN_CONF_FILE = "managedLedgerOffloadDeletionLagMs";
     public static final String DATA_READ_PRIORITY_NAME_IN_CONF_FILE = "managedLedgerDataReadPriority";
-    public static final OffloadedReadPriority DEFAULT_OFFLOADED_READ_PRIORITY =
-            OffloadedReadPriority.TIERED_STORAGE_FIRST;
+    public static final OffloadedReadPriority DEFAULT_OFFLOADED_READ_PRIORITY = null;
 
     // common config
     @Configuration

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.common.policies.data;
 
 import static org.apache.pulsar.common.policies.data.OffloadPoliciesImpl.EXTRA_CONFIG_PREFIX;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -471,5 +473,14 @@ public class OffloadPoliciesTest {
         extraConfiguration.put("key2", "value2");
         offloadPolicies.setManagedLedgerExtraConfigurations(extraConfiguration); 
         assertEquals(offloadPolicies, OffloadPoliciesImpl.create(offloadPolicies.toProperties()));
+    }
+
+    @Test
+    public void testDefaultOffloadPolicies() {
+        OffloadPoliciesImpl offloadPolicies = new OffloadPoliciesImpl();
+        assertNull(offloadPolicies.getManagedLedgerOffloadedReadPriority());
+        assertNull(offloadPolicies.getManagedLedgerOffloadDeletionLagInMillis());
+        assertNull(offloadPolicies.getManagedLedgerOffloadThresholdInSeconds());
+        assertNull(offloadPolicies.getManagedLedgerOffloadThresholdInBytes());
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
When we set cluster level `managedLedgerDataReadPriority` to `bookkeeper-first` in conf/broker.conf
https://github.com/apache/pulsar/blob/f2618c15bb5a9f3fcb577068584df5d0e2e4f335/conf/broker.conf#L1262-L1264

Then use the command `bin/pulsar-admin namespaces set-offload-threshold -s 0 <namespace>` to set the offload threshold in namespace level to trigger topic offload automatically.

However, the broker side will create an empty OffloadPolicy when setting the offload threshold
https://github.com/apache/pulsar/blob/f2618c15bb5a9f3fcb577068584df5d0e2e4f335/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java#L2174-L2176

However, the empty OffloadPolicy will set the `OffloadedReadPriority` to `TIERED_STORAGE_FIRST` in namespace level.
https://github.com/apache/pulsar/blob/f2618c15bb5a9f3fcb577068584df5d0e2e4f335/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java#L98-L99

The namespace level offload policy has higher priority than broker level offload policy, and it makes setting broker-level `OffloadedReadPriority` to `bookkeeper-first` doesn't work

### Modifications

Change OffloadPolicy's default OffloadedReadPriority to `null` to allow broker-level offload policy can take affect.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
