### PR TITLE
[fix][broker] Directly query single topic existence when the topic is partitioned

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1424,8 +1424,9 @@ public class NamespaceService implements AutoCloseable {
                             return CompletableFuture.completedFuture(
                                     TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
                         }
-                        // The non-persistent partitioned topic doesn't have the partition, quickly return.
                         if (!topic.isPersistent()) {
+                            // A non-persistent partitioned topic contains only metadata.
+                            // Since no actual partitions are created, there's no need to check under /managed-ledgers.
                             return CompletableFuture.completedFuture(topic.getPartitionIndex() < metadata.partitions
                                     ? TopicExistsInfo.newNonPartitionedTopicExists()
                                     : TopicExistsInfo.newTopicNotExists());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -947,12 +947,11 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     assertTrue(n.isExists());
                     assertEquals(n.getPartitions(), 0);
                     assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
                     n.recycle();
-                    return true;
                 });
     }
 
@@ -965,36 +964,33 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     assertTrue(n.isExists());
                     assertEquals(n.getPartitions(), 3);
                     assertEquals(n.getTopicType(), TopicType.PARTITIONED);
                     n.recycle();
-                    return true;
                 });
 
         // Check the specific partition.
         result = pulsar.getNamespaceService().checkTopicExists(topicName.getPartition(2));
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     assertTrue(n.isExists());
                     assertEquals(n.getPartitions(), 0);
                     assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
                     n.recycle();
-                    return true;
                 });
 
         // Partition index is out of range.
         result = pulsar.getNamespaceService().checkTopicExists(topicName.getPartition(10));
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     assertFalse(n.isExists());
                     assertEquals(n.getPartitions(), 0);
                     assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
                     n.recycle();
-                    return true;
                 });
     }
 
@@ -1004,14 +1000,13 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     // when using the pulsar client to check non_persistent topic, always return true, so ignore to
                     // check that.
                     if (topicDomain.equals(TopicDomain.persistent)) {
                         assertFalse(n.isExists());
                     }
                     n.recycle();
-                    return true;
                 });
     }
 
@@ -1022,14 +1017,13 @@ public class NamespaceServiceTest extends BrokerTestBase {
         CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
         assertThat(result)
                 .succeedsWithin(3, TimeUnit.SECONDS)
-                .matches(n -> {
+                .satisfies(n -> {
                     // when using the pulsar client to check non_persistent topic, always return true, so ignore to
                     // check that.
                     if (topicDomain.equals(TopicDomain.persistent)) {
                         assertFalse(n.isExists());
                     }
                     n.recycle();
-                    return true;
                 });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.namespace;
 
 import static org.apache.pulsar.broker.resources.LoadBalanceResources.BUNDLE_DATA_BASE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -86,6 +87,7 @@ import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -816,23 +818,6 @@ public class NamespaceServiceTest extends BrokerTestBase {
         };
     }
 
-    @Test(dataProvider = "topicDomain")
-    public void testCheckTopicExists(String topicDomain) throws Exception {
-        String topic = topicDomain + "://prop/ns-abc/" + UUID.randomUUID();
-        admin.topics().createNonPartitionedTopic(topic);
-        Awaitility.await().untilAsserted(() -> {
-            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(topic)).get().isExists());
-        });
-
-        String partitionedTopic = topicDomain + "://prop/ns-abc/" + UUID.randomUUID();
-        admin.topics().createPartitionedTopic(partitionedTopic, 5);
-        Awaitility.await().untilAsserted(() -> {
-            assertTrue(pulsar.getNamespaceService().checkTopicExists(TopicName.get(partitionedTopic)).get().isExists());
-            assertTrue(pulsar.getNamespaceService()
-                    .checkTopicExists(TopicName.get(partitionedTopic + "-partition-2")).get().isExists());
-        });
-    }
-
     @Test
     public void testAllowedClustersAtNamespaceLevelShouldBeIncludedInAllowedClustersAtTenantLevel() throws Exception {
         // 1. Setup
@@ -952,6 +937,100 @@ public class NamespaceServiceTest extends BrokerTestBase {
         }
         pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
         pulsar.getConfiguration().setForceDeleteTenantAllowed(false);
+    }
+
+
+    @Test(dataProvider = "topicDomain")
+    public void checkTopicExistsForNonPartitionedTopic(String topicDomain) throws Exception {
+        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        admin.topics().createNonPartitionedTopic(topicName.toString());
+        CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    assertTrue(n.isExists());
+                    assertEquals(n.getPartitions(), 0);
+                    assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
+                    n.recycle();
+                    return true;
+                });
+    }
+
+    @Test(dataProvider = "topicDomain")
+    public void checkTopicExistsForPartitionedTopic(String topicDomain) throws Exception {
+        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        admin.topics().createPartitionedTopic(topicName.toString(), 3);
+
+        // Check the topic exists by the partitions.
+        CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    assertTrue(n.isExists());
+                    assertEquals(n.getPartitions(), 3);
+                    assertEquals(n.getTopicType(), TopicType.PARTITIONED);
+                    n.recycle();
+                    return true;
+                });
+
+        // Check the specific partition.
+        result = pulsar.getNamespaceService().checkTopicExists(topicName.getPartition(2));
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    assertTrue(n.isExists());
+                    assertEquals(n.getPartitions(), 0);
+                    assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
+                    n.recycle();
+                    return true;
+                });
+
+        // Partition index is out of range.
+        result = pulsar.getNamespaceService().checkTopicExists(topicName.getPartition(10));
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    assertFalse(n.isExists());
+                    assertEquals(n.getPartitions(), 0);
+                    assertEquals(n.getTopicType(), TopicType.NON_PARTITIONED);
+                    n.recycle();
+                    return true;
+                });
+    }
+
+    @Test(dataProvider = "topicDomain")
+    public void checkTopicExistsForNonExistentNonPartitionedTopic(String topicDomain) {
+        TopicName topicName = TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID());
+        CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    // when using the pulsar client to check non_persistent topic, always return true, so ignore to
+                    // check that.
+                    if (topicDomain.equals(TopicDomain.persistent)) {
+                        assertFalse(n.isExists());
+                    }
+                    n.recycle();
+                    return true;
+                });
+    }
+
+    @Test(dataProvider = "topicDomain")
+    public void checkTopicExistsForNonExistentPartitionTopic(String topicDomain) {
+        TopicName topicName =
+                TopicName.get(topicDomain, "prop", "ns-abc", "topic-" + UUID.randomUUID() + "-partition-10");
+        CompletableFuture<TopicExistsInfo> result = pulsar.getNamespaceService().checkTopicExists(topicName);
+        assertThat(result)
+                .succeedsWithin(3, TimeUnit.SECONDS)
+                .matches(n -> {
+                    // when using the pulsar client to check non_persistent topic, always return true, so ignore to
+                    // check that.
+                    if (topicDomain.equals(TopicDomain.persistent)) {
+                        assertFalse(n.isExists());
+                    }
+                    n.recycle();
+                    return true;
+                });
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
@@ -36,9 +36,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-// TODO: This test is in flaky group until CI is fixed.
-// To be addressed as part of https://github.com/apache/pulsar/pull/24154
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class BrokerServiceChaosTest extends CanReconnectZKClientPulsarServiceBaseTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -41,9 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-// TODO: This test is in flaky group until CI is fixed.
-// To be addressed as part of https://github.com/apache/pulsar/pull/24154
-@Test(groups = "flaky")
+@Test(groups = "broker")
 public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicatorTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
@@ -117,7 +117,7 @@ public class ConsumerCreationTest extends ProducerConsumerBase {
             Consumer<byte[]> ignored =
                     pulsarClient.newConsumer().topic(partitionedTopic).subscriptionName("my-sub").subscribe();
         } else {
-            assertThrows(PulsarClientException.TopicDoesNotExistException.class, () -> {
+            assertThrows(PulsarClientException.NotFoundException.class, () -> {
                 @Cleanup
                 Consumer<byte[]> ignored =
                         pulsarClient.newConsumer().topic(partitionedTopic).subscriptionName("my-sub").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerCreationTest.java
@@ -258,7 +258,7 @@ public class ProducerCreationTest extends ProducerConsumerBase {
             @Cleanup
             Producer<byte[]> ignored = pulsarClient.newProducer().topic(partitionedTopic).create();
         } else {
-            assertThrows(PulsarClientException.TopicDoesNotExistException.class, () -> {
+            assertThrows(PulsarClientException.NotFoundException.class, () -> {
                 @Cleanup
                 Producer<byte[]> ignored = pulsarClient.newProducer().topic(partitionedTopic).create();
             });

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -963,6 +963,8 @@ public class PulsarClientException extends IOException {
         // wrap an exception with new message info
         if (t instanceof NotFoundException) {
             return new NotFoundException(msg);
+        } else if (t instanceof TopicDoesNotExistException) {
+            return new TopicDoesNotExistException(msg);
         } else if (t instanceof TimeoutException) {
             return new TimeoutException(msg);
         } else if (t instanceof InvalidConfigurationException) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -961,8 +961,8 @@ public class PulsarClientException extends IOException {
     public static Throwable wrap(Throwable t, String msg) {
         msg += "\n" + t.getMessage();
         // wrap an exception with new message info
-        if (t instanceof TopicDoesNotExistException) {
-            return new TopicDoesNotExistException(msg);
+        if (t instanceof NotFoundException) {
+            return new NotFoundException(msg);
         } else if (t instanceof TimeoutException) {
             return new TimeoutException(msg);
         } else if (t instanceof InvalidConfigurationException) {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24152

### Motivation

https://github.com/apache/pulsar/pull/24118 breaks `checkTopicExists`.  The topic metadata exists, but the topic may not exist.

~These changes are already covered by `org.apache.pulsar.broker.namespace.NamespaceServiceTest`. However, since this test belongs to the `flaky` test group, regressions might not be reliably caught.~

### Modifications

- Directly query single topic existence when the topic is partitioned.
- Use  `NotFoundException ` instead of `TopicDoesNotExistException` that is introduced by #24118.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->