### PR TITLE
[fix][build] Fix docker image building by replacing deprecated and removed compress argument

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,7 +61,7 @@ RUN apk add --no-cache binutils
 
 # Use JLink to create a slimmer JDK distribution (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
 # This still includes all JDK modules, though in the future we could compile a list of required modules
-RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
+RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
@@ -36,8 +36,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-// TODO: This test is disabled until CI is fixed. To be addressed as part of https://github.com/apache/pulsar/pull/24154
-@Test(groups = "broker", enabled = false)
+// TODO: This test is in flaky group until CI is fixed.
+// To be addressed as part of https://github.com/apache/pulsar/pull/24154
+@Test(groups = "flaky")
 public class BrokerServiceChaosTest extends CanReconnectZKClientPulsarServiceBaseTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceChaosTest.java
@@ -36,7 +36,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "broker")
+// TODO: This test is disabled until CI is fixed. To be addressed as part of https://github.com/apache/pulsar/pull/24154
+@Test(groups = "broker", enabled = false)
 public class BrokerServiceChaosTest extends CanReconnectZKClientPulsarServiceBaseTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -41,8 +41,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-// TODO: This test is disabled until CI is fixed. To be addressed as part of https://github.com/apache/pulsar/pull/24154
-@Test(groups = "broker", enabled = false)
+// TODO: This test is in flaky group until CI is fixed.
+// To be addressed as part of https://github.com/apache/pulsar/pull/24154
+@Test(groups = "flaky")
 public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicatorTest {
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -41,7 +41,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "broker")
+// TODO: This test is disabled until CI is fixed. To be addressed as part of https://github.com/apache/pulsar/pull/24154
+@Test(groups = "broker", enabled = false)
 public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicatorTest {
 
     @Override


### PR DESCRIPTION
### Motivation

Building docker images have started to fail due to the use of a deprecated `--compress zip-9` argument for `jlink`.
This parameter was deprecated in Java 16. It seems that the removal was delayed and now master branch is broken with most recent Corretto 21 and 17 JDK versions (Corretto-21.0.6.7.1 and also Corretto-17.0.14.7.1). 

Valid `jlink` compress argument options:
```
  -c, --compress=<0|1|2>                Enable compression of resources:
                                          Level 0: No compression
                                          Level 1: Constant string sharing
                                          Level 2: ZIP
```

The replacement for `--compress zip-9`  is `--compress=2` (zip). 

### Modifications

Replace `--compress zip-9` with `--compress=2`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->