### PR TITLE
[fix][broker] fix ExtensibleLoadManager to override the ownerships concurrently without blocking load manager thread

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1586,6 +1586,13 @@ loadManagerServiceUnitStateTableViewClassName=org.apache.pulsar.broker.loadbalan
 # enable it. It accepts `None` to disable it."
 loadBalancerServiceUnitTableViewSyncer=None
 
+
+# Specify the maximum number of concurrent orphan bundle ownership overrides.
+# The leader broker triggers these overrides upon detecting orphaned bundles.
+# It identifies orphan bundle ownerships by periodically scanning ownership data
+# and monitoring for broker shutdowns or inactive states.
+loadBalancerServiceUnitStateMaxConcurrentOverrides = 10
+
 ### --- Replication --- ###
 
 # Enable replication metrics

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1591,7 +1591,7 @@ loadBalancerServiceUnitTableViewSyncer=None
 # The leader broker triggers these overrides upon detecting orphaned bundles.
 # It identifies orphan bundle ownerships by periodically scanning ownership data
 # and monitoring for broker shutdowns or inactive states.
-loadBalancerServiceUnitStateMaxConcurrentOverrides = 10
+loadBalancerServiceUnitStateMaxConcurrentOverrides = 64
 
 ### --- Replication --- ###
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3031,7 +3031,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "It identifies orphan bundle ownerships by periodically scanning ownership data "
                     + "and monitoring for broker shutdowns or inactive states."
     )
-    private int loadBalancerServiceUnitStateMaxConcurrentOverrides = 10;
+    private int loadBalancerServiceUnitStateMaxConcurrentOverrides = 64;
 
     /**** --- Replication. --- ****/
     @FieldContext(

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3023,6 +3023,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private ServiceUnitTableViewSyncerType loadBalancerServiceUnitTableViewSyncer = ServiceUnitTableViewSyncerType.None;
 
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "Specify the maximum number of concurrent orphan bundle ownership overrides. "
+                    + "The leader broker triggers these overrides upon detecting orphaned bundles. "
+                    + "It identifies orphan bundle ownerships by periodically scanning ownership data "
+                    + "and monitoring for broker shutdowns or inactive states."
+    )
+    private int loadBalancerServiceUnitStateMaxConcurrentOverrides = 10;
+
     /**** --- Replication. --- ****/
     @FieldContext(
         category = CATEGORY_REPLICATION,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -106,7 +106,6 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
     private static final int OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS = 5000;
     private static final int OWNERSHIP_CLEAN_UP_WAIT_RETRY_DELAY_IN_MILLIS = 100;
-    private static final int MAX_CONCURRENT_OWNERSHIP_OVERRIDE = 500;
     public static final long VERSION_ID_INIT = 1; // initial versionId
     public static final long MAX_CLEAN_UP_DELAY_TIME_IN_SECS = 3 * 60; // 3 mins
     private static final long MIN_CLEAN_UP_DELAY_TIME_IN_SECS = 0; // 0 secs to clean immediately
@@ -1503,7 +1502,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     }
 
     private void tryWaitForOverrides(List<CompletableFuture<Void>> overrideFutures, boolean force) {
-        if (overrideFutures.size() > MAX_CONCURRENT_OWNERSHIP_OVERRIDE || force) {
+        if (overrideFutures.size() >= config.getLoadBalancerServiceUnitStateMaxConcurrentOverrides() || force) {
             try {
                 FutureUtil.waitForAll(overrideFutures)
                         .get(config.getMetadataStoreOperationTimeoutSeconds(), SECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -463,8 +463,10 @@ public class TransferShedder implements NamespaceUnloadStrategy {
 
                 Optional<TopBundlesLoadData> bundlesLoadData = context.topBundleLoadDataStore().get(maxBroker);
                 if (bundlesLoadData.isEmpty() || bundlesLoadData.get().getTopBundlesLoadData().isEmpty()) {
-                    log.error(String.format(CANNOT_UNLOAD_BROKER_MSG
-                            + " TopBundlesLoadData is empty.", maxBroker));
+                    if (debugMode) {
+                        log.info(String.format(CANNOT_UNLOAD_BROKER_MSG
+                                + " TopBundlesLoadData is empty.", maxBroker));
+                    }
                     numOfBrokersWithEmptyLoadData++;
                     continue;
                 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Currently, ExtensibleLoadManager overrides orphan ownerships one by one while holding the monitor lock. This can delay the synchronized serviceUnitStateChannel.started() call(required for SystemTopicPoliciesService.getTopicPoliciesAsync and others) when the metadata service is slow(is overloaded).

### Modifications

<!-- Describe the modifications you've done. -->

- override orphan ownership concurrently (max 10 bundle ownerships by default and configurable by `loadBalancerServiceUnitStateMaxConcurrentOverrides`).
- removed unnecessary monitor lock from doCleanup
- minor change: put `TopBundlesLoadData is empty` log under debug flag

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
