### PR TITLE
[fix][test] Fix UnfinishedStubbing issue in AuthZTests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AuthZTest.java
@@ -18,22 +18,25 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.mockito.Mockito.doReturn;
 import io.jsonwebtoken.Jwts;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.security.MockedPulsarStandalone;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import static org.mockito.Mockito.doReturn;
 
-public class AuthZTest extends MockedPulsarStandalone {
+public abstract class AuthZTest extends MockedPulsarStandalone {
 
     protected PulsarAdmin superUserAdmin;
 
@@ -46,6 +49,9 @@ public class AuthZTest extends MockedPulsarStandalone {
     protected static final String TENANT_ADMIN_SUBJECT =  UUID.randomUUID().toString();
     protected static final String TENANT_ADMIN_TOKEN = Jwts.builder()
             .claim("sub", TENANT_ADMIN_SUBJECT).signWith(SECRET_KEY).compact();
+
+    private volatile Consumer<InvocationOnMock> allowTopicOperationAsyncHandler;
+    private volatile Consumer<InvocationOnMock> allowNamespaceOperationAsyncHandler;
 
     @Override
     public void close() throws Exception {
@@ -65,48 +71,62 @@ public class AuthZTest extends MockedPulsarStandalone {
     @BeforeMethod(alwaysRun = true)
     public void before() throws IllegalAccessException {
         orignalAuthorizationService = getPulsarService().getBrokerService().getAuthorizationService();
-        authorizationService = Mockito.spy(orignalAuthorizationService);
+        authorizationService = BrokerTestUtil.spyWithoutRecordingInvocations(orignalAuthorizationService);
         FieldUtils.writeField(getPulsarService().getBrokerService(), "authorizationService",
                 authorizationService, true);
+        Mockito.doAnswer(invocationOnMock -> {
+            Consumer<InvocationOnMock> localAllowTopicOperationAsyncHandler =
+                    allowTopicOperationAsyncHandler;
+            if (localAllowTopicOperationAsyncHandler != null) {
+                localAllowTopicOperationAsyncHandler.accept(invocationOnMock);
+            }
+            return invocationOnMock.callRealMethod();
+        }).when(authorizationService).allowTopicOperationAsync(Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any());
+        doReturn(true)
+                .when(authorizationService).isValidOriginalPrincipal(Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.doAnswer(invocationOnMock -> {
+            Consumer<InvocationOnMock> localAllowNamespaceOperationAsyncHandler =
+                    allowNamespaceOperationAsyncHandler;
+            if (localAllowNamespaceOperationAsyncHandler != null) {
+                localAllowNamespaceOperationAsyncHandler.accept(invocationOnMock);
+            }
+            return invocationOnMock.callRealMethod();
+        }).when(authorizationService).allowNamespaceOperationAsync(Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any());
     }
 
     @AfterMethod(alwaysRun = true)
     public void after() throws IllegalAccessException {
         FieldUtils.writeField(getPulsarService().getBrokerService(), "authorizationService",
                 orignalAuthorizationService, true);
+        allowNamespaceOperationAsyncHandler = null;
+        allowTopicOperationAsyncHandler = null;
     }
 
     protected AtomicBoolean setAuthorizationTopicOperationChecker(String role, Object operation) {
         AtomicBoolean execFlag = new AtomicBoolean(false);
         if (operation instanceof TopicOperation) {
-            Mockito.doAnswer(invocationOnMock -> {
+            allowTopicOperationAsyncHandler = invocationOnMock -> {
                 String role_ = invocationOnMock.getArgument(2);
                 if (role.equals(role_)) {
                     TopicOperation operation_ = invocationOnMock.getArgument(1);
                     Assert.assertEquals(operation_, operation);
                 }
                 execFlag.set(true);
-                return invocationOnMock.callRealMethod();
-            }).when(authorizationService).allowTopicOperationAsync(Mockito.any(), Mockito.any(), Mockito.any(),
-                    Mockito.any(), Mockito.any());
+            };
         } else if (operation instanceof NamespaceOperation) {
-            doReturn(true)
-                    .when(authorizationService).isValidOriginalPrincipal(Mockito.any(), Mockito.any(), Mockito.any());
-            Mockito.doAnswer(invocationOnMock -> {
+            allowNamespaceOperationAsyncHandler = invocationOnMock -> {
                 String role_ = invocationOnMock.getArgument(2);
                 if (role.equals(role_)) {
                     TopicOperation operation_ = invocationOnMock.getArgument(1);
                     Assert.assertEquals(operation_, operation);
                 }
                 execFlag.set(true);
-                return invocationOnMock.callRealMethod();
-            }).when(authorizationService).allowNamespaceOperationAsync(Mockito.any(), Mockito.any(), Mockito.any(),
-                    Mockito.any(), Mockito.any());
+            };
         } else {
             throw new IllegalArgumentException("");
         }
-
-
         return execFlag;
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TransactionAndSchemaAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TransactionAndSchemaAuthZTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -43,12 +42,9 @@ import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -83,20 +79,6 @@ public class TransactionAndSchemaAuthZTest extends AuthZTest {
     @AfterClass(alwaysRun = true)
     public void cleanup() {
         close();
-    }
-
-    @BeforeMethod
-    public void before() throws IllegalAccessException {
-        orignalAuthorizationService = getPulsarService().getBrokerService().getAuthorizationService();
-        authorizationService = Mockito.spy(orignalAuthorizationService);
-        FieldUtils.writeField(getPulsarService().getBrokerService(), "authorizationService",
-                authorizationService, true);
-    }
-
-    @AfterMethod
-    public void after() throws IllegalAccessException {
-        FieldUtils.writeField(getPulsarService().getBrokerService(), "authorizationService",
-                orignalAuthorizationService, true);
     }
 
     protected void createTransactionCoordinatorAssign(int numPartitionsOfTC) throws MetadataStoreException {


### PR DESCRIPTION
### Motivation

[Mockito is not thread safe](https://github.com/mockito/mockito/wiki/FAQ#is-mockito-thread-safe) and modifying mocks in multi-threaded code will result in failures such as this one:

```
   [ERROR] Failures:
    [ERROR]   NamespaceAuthZTest.testMaxConsumersPerTopic:1537->setAuthorizationPolicyOperationChecker:183 » UnfinishedStubbing
    Unfinished stubbing detected here:
    -> at org.apache.pulsar.broker.admin.NamespaceAuthZTest.setAuthorizationPolicyOperationChecker(NamespaceAuthZTest.java:173)

    E.g. thenReturn() may be missing.
    Examples of correct stubbing:
        when(mock.isOk()).thenReturn(true);
        when(mock.isOk()).thenThrow(exception);
        doThrow(exception).when(mock).someVoidMethod();
    Hints:
     1. missing thenReturn()
     2. you are trying to stub a final method, which is not supported
     3. you are stubbing the behaviour of another mock inside before 'thenReturn' instruction is completed
```

### Modifications

- refactor the test code to setup the mock once and switch the implementation dynamically

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->