### PR TITLE
[fix][build] Fix skipTag and use explicit tag for image name

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -154,11 +154,11 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/${docker.image}-all</name>
+                      <name>${docker.organization}/${docker.image}-all:${docker.tag}</name>
                       <build>
                         <contextDir>${project.basedir}</contextDir>
+                        <skipTag>${docker.skip.tag}</skipTag>
                         <tags>
-                          <tag>${docker.tag}</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <args>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -77,7 +77,7 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/${docker.image}</name>
+                      <name>${docker.organization}/${docker.image}:${docker.tag}</name>
                       <build>
                         <args>
                           <PULSAR_TARBALL>target/pulsar-server-distribution-${project.version}-bin.tar.gz</PULSAR_TARBALL>
@@ -86,8 +86,8 @@
                           <IMAGE_JDK_MAJOR_VERSION>${IMAGE_JDK_MAJOR_VERSION}</IMAGE_JDK_MAJOR_VERSION>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
+                        <skipTag>${docker.skip.tag}</skipTag>
                         <tags>
-                          <tag>${docker.tag}</tag>
                           <tag>${project.version}-${git.commit.id.abbrev}</tag>
                         </tags>
                         <buildx>
@@ -127,6 +127,7 @@
       <id>docker-push</id>
       <properties>
         <docker.skip.push>false</docker.skip.push>
+        <docker.skip.tag>true</docker.skip.tag>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ flexible messaging model and an intuitive client API.</description>
     -->
     <docker.platforms></docker.platforms>
     <docker.skip.push>true</docker.skip.push>
+    <docker.skip.tag>false</docker.skip.tag>
 
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -148,16 +148,12 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/java-test-image</name>
+                      <name>${docker.organization}/java-test-image:${docker.tag}</name>
                       <build>
                         <args>
                           <PULSAR_IMAGE>${docker.organization}/${docker.image}:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
-                        <tags>
-                          <tag>${docker.tag}</tag>
-                          <tag>${project.version}</tag>
-                        </tags>
                         <noCache>true</noCache>
                       </build>
                     </image>

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -152,16 +152,12 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.organization}/${docker.image}-test-latest-version</name>
+                      <name>${docker.organization}/${docker.image}-test-latest-version:${docker.tag}</name>
                       <build>
                         <contextDir>${project.basedir}</contextDir>
                         <args>
                           <PULSAR_ALL_IMAGE>${docker.organization}/${docker.image}-all:${project.version}-${git.commit.id.abbrev}</PULSAR_ALL_IMAGE>
                         </args>
-                        <tags>
-                          <tag>${docker.tag}</tag>
-                          <tag>${project.version}</tag>
-                        </tags>
                         <noCache>true</noCache>
                         <buildx>
                           <platforms>


### PR DESCRIPTION
### Motivation

The `docker-maven-plugin` supports skipping Docker image tags using the `docker.skip.tag` property. However, it does not work correctly when building multi-architecture images using `buildx`. As a workaround, the plugin provides a `skipTag` option in the [build configuration](https://dmp.fabric8.io/#build-configuration), which successfully skips tagging in multi-arch builds/pushes.

**Issue (Old behavior):**

Running the following command:
```shell
cd docker/pulsar
mvn install -Pdocker -Ddocker.skip.tag=true -Ddocker.platforms=linux/arm64,linux/amd64
```

Still resulted in tagging:
```
--tag apachepulsar/pulsar:latest
--tag apachepulsar/pulsar:latest
--tag apachepulsar/pulsar:4.1.0-SNAPSHOT-e8be56d
```

**Fixed behavior:**

By using the `skipTag` configuration:
```
--tag apachepulsar/pulsar:latest
```

Only the explicitly defined tag is applied.

### My use case

If you want to publish only a single tag like `myorg/pulsar:3.0.1` to Docker Hub, you can use:
```shell
mvn -B -ntp package -pl docker/pulsar -Pdocker,docker-push \
  -Ddocker.platforms=linux/amd64,linux/arm64 \
  -Ddocker.organization=myorg \
  -Ddocker.image=pulsar \
  -Ddocker.tag=3.0.1 \
  -Ddocker.skip.tag=true
```

This ensures that only `myorg/pulsar:3.0.1` is pushed.

If you want to publish both `myorg/pulsar:3.0.1` and the default tag `myorg/pulsar:${project.version}-${git.commit.id.abbrev}` (commonly used for integration testing), set:
```shell
-Ddocker.skip.tag=false
```

For most production cases, a single stable tag is preferred, and the additional tag can be reserved for internal test pipelines.

### Modifications

- Explicitly set the Docker image tag using the `docker.tag` property.
- Added `skipTag` option in the `<build>` configuration for both `pulsar` and `pulsar-all` images to prevent unnecessary automatic tagging during multi-architecture builds, default to `false`.
- Removed the `<tags>` configuration from the test image, as no tags are required for it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
