### PR TITLE
[improve][test] Use configured session timeout for MockZooKeeper and TestZKServer in PulsarTestContext

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -239,6 +239,18 @@ public class PulsarTestContext implements AutoCloseable {
                 getPulsarService());
     }
 
+    private enum WithMockZooKeeperOrTestZKServer {
+        MOCKZOOKEEPER, MOCKZOOKEEPER_SEPARATE_GLOBAL, TEST_ZK_SERVER, TEST_ZK_SERVER_SEPARATE_GLOBAL;
+
+        boolean isMockZooKeeper() {
+            return this == MOCKZOOKEEPER || this == MOCKZOOKEEPER_SEPARATE_GLOBAL;
+        }
+
+        boolean isTestZKServer() {
+            return this == TEST_ZK_SERVER || this == TEST_ZK_SERVER_SEPARATE_GLOBAL;
+        }
+    }
+
     /**
      * A builder for a PulsarTestContext.
      *
@@ -255,6 +267,7 @@ public class PulsarTestContext implements AutoCloseable {
         protected boolean configOverrideCalled = false;
         protected Function<BrokerService, BrokerService> brokerServiceCustomizer = Function.identity();
         protected PulsarTestContext otherContextToClose;
+        protected WithMockZooKeeperOrTestZKServer withMockZooKeeperOrTestZKServer;
 
         /**
          * Initialize the ServiceConfiguration with default values.
@@ -475,31 +488,14 @@ public class PulsarTestContext implements AutoCloseable {
          * @return the builder
          */
         public Builder withMockZookeeper(boolean useSeparateGlobalZk) {
-            try {
-                mockZooKeeper(createMockZooKeeper());
-                if (useSeparateGlobalZk) {
-                    mockZooKeeperGlobal(createMockZooKeeper());
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (useSeparateGlobalZk) {
+                withMockZooKeeperOrTestZKServer = WithMockZooKeeperOrTestZKServer.MOCKZOOKEEPER_SEPARATE_GLOBAL;
+            } else {
+                withMockZooKeeperOrTestZKServer = WithMockZooKeeperOrTestZKServer.MOCKZOOKEEPER;
             }
             return this;
         }
 
-        private MockZooKeeper createMockZooKeeper() throws Exception {
-            MockZooKeeper zk = MockZooKeeper.newInstance();
-            initializeZookeeper(zk);
-            registerCloseable(zk::shutdown);
-            return zk;
-        }
-
-        private static void initializeZookeeper(ZooKeeper zk) throws KeeperException, InterruptedException {
-            ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-                    "".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-
-            zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE,
-                    CreateMode.PERSISTENT);
-        }
 
         /**
          * Configure this PulsarTestContext to use a test ZooKeeper instance which is
@@ -518,25 +514,12 @@ public class PulsarTestContext implements AutoCloseable {
          * @return the builder
          */
         public Builder withTestZookeeper(boolean useSeparateGlobalZk) {
-            try {
-                testZKServer(createTestZookeeper());
-                if (useSeparateGlobalZk) {
-                    testZKServerGlobal(createTestZookeeper());
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (useSeparateGlobalZk) {
+                withMockZooKeeperOrTestZKServer = WithMockZooKeeperOrTestZKServer.TEST_ZK_SERVER_SEPARATE_GLOBAL;
+            } else {
+                withMockZooKeeperOrTestZKServer = WithMockZooKeeperOrTestZKServer.TEST_ZK_SERVER;
             }
             return this;
-        }
-
-        private TestZKServer createTestZookeeper() throws Exception {
-            TestZKServer testZKServer = new TestZKServer();
-            try (ZooKeeper zkc = new ZooKeeper(testZKServer.getConnectionString(), 5000, event -> {
-            })) {
-                initializeZookeeper(zkc);
-            }
-            registerCloseable(testZKServer);
-            return testZKServer;
         }
 
         /**
@@ -626,6 +609,7 @@ public class PulsarTestContext implements AutoCloseable {
             if (configOverrideCustomizer != null) {
                 configOverrideCustomizer.accept(super.config);
             }
+            createWithMockZooKeeperOrTestZKServerInstances();
             if (super.managedLedgerStorage != null && !MockUtil.isMock(super.managedLedgerStorage)) {
                 super.managedLedgerStorage = spyConfig.getManagedLedgerStorage().spy(super.managedLedgerStorage);
             }
@@ -648,6 +632,57 @@ public class PulsarTestContext implements AutoCloseable {
             }
             brokerService(super.pulsarService.getBrokerService());
             return super.build();
+        }
+
+        void createWithMockZooKeeperOrTestZKServerInstances() {
+            if (withMockZooKeeperOrTestZKServer == null) {
+                return;
+            }
+            int sessionTimeout = (int) super.config.getMetadataStoreSessionTimeoutMillis();
+            try {
+                if (withMockZooKeeperOrTestZKServer.isMockZooKeeper()) {
+                    mockZooKeeper(createMockZooKeeper(sessionTimeout));
+                    if (withMockZooKeeperOrTestZKServer
+                            == WithMockZooKeeperOrTestZKServer.MOCKZOOKEEPER_SEPARATE_GLOBAL) {
+                        mockZooKeeperGlobal(createMockZooKeeper(sessionTimeout));
+                    }
+                } else if (withMockZooKeeperOrTestZKServer.isTestZKServer()) {
+                    testZKServer(createTestZookeeper(sessionTimeout));
+                    if (withMockZooKeeperOrTestZKServer
+                            == WithMockZooKeeperOrTestZKServer.TEST_ZK_SERVER_SEPARATE_GLOBAL) {
+                        testZKServerGlobal(createTestZookeeper(sessionTimeout));
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private MockZooKeeper createMockZooKeeper(int sessionTimeout) throws Exception {
+            MockZooKeeper zk = MockZooKeeper.newInstance();
+            zk.setSessionTimeout(sessionTimeout);
+            initializeZookeeper(zk);
+            registerCloseable(zk::shutdown);
+            return zk;
+        }
+
+        // this might not be required at all, but it's kept here as an example
+        private static void initializeZookeeper(ZooKeeper zk) throws KeeperException, InterruptedException {
+            ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
+                    "".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+
+            zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                    CreateMode.PERSISTENT);
+        }
+
+        private TestZKServer createTestZookeeper(int sessionTimeout) throws Exception {
+            TestZKServer testZKServer = new TestZKServer();
+            try (ZooKeeper zkc = new ZooKeeper(testZKServer.getConnectionString(), sessionTimeout, event -> {
+            })) {
+                initializeZookeeper(zkc);
+            }
+            registerCloseable(testZKServer);
+            return testZKServer;
         }
 
         protected void handlePreallocatePorts(ServiceConfiguration config) {
@@ -714,28 +749,30 @@ public class PulsarTestContext implements AutoCloseable {
             if (super.localMetadataStore == null || super.configurationMetadataStore == null) {
                 if (super.mockZooKeeper != null) {
                     MetadataStoreExtended mockZookeeperMetadataStore =
-                            createMockZookeeperMetadataStore(super.mockZooKeeper, MetadataStoreConfig.METADATA_STORE);
+                            createMockZookeeperMetadataStore(super.mockZooKeeper, super.config,
+                                    MetadataStoreConfig.METADATA_STORE);
                     if (super.localMetadataStore == null) {
                         localMetadataStore(mockZookeeperMetadataStore);
                     }
                     if (super.configurationMetadataStore == null) {
                         if (super.mockZooKeeperGlobal != null) {
                             configurationMetadataStore(createMockZookeeperMetadataStore(super.mockZooKeeperGlobal,
-                                    MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
+                                    super.config, MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
                         } else {
                             configurationMetadataStore(mockZookeeperMetadataStore);
                         }
                     }
                 } else if (super.testZKServer != null) {
                     MetadataStoreExtended testZookeeperMetadataStore =
-                            createTestZookeeperMetadataStore(super.testZKServer, MetadataStoreConfig.METADATA_STORE);
+                            createTestZookeeperMetadataStore(super.testZKServer, super.config,
+                                    MetadataStoreConfig.METADATA_STORE);
                     if (super.localMetadataStore == null) {
                         localMetadataStore(testZookeeperMetadataStore);
                     }
                     if (super.configurationMetadataStore == null) {
                         if (super.testZKServerGlobal != null) {
                             configurationMetadataStore(createTestZookeeperMetadataStore(super.testZKServerGlobal,
-                                    MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
+                                    super.config, MetadataStoreConfig.CONFIGURATION_METADATA_STORE));
                         } else {
                             configurationMetadataStore(testZookeeperMetadataStore);
                         }
@@ -765,16 +802,30 @@ public class PulsarTestContext implements AutoCloseable {
             }
         }
 
+        private MetadataStoreConfig createMetadataStoreConfig(ServiceConfiguration config, String metadataStoreName) {
+            return MetadataStoreConfig.builder()
+                    .sessionTimeoutMillis((int) config.getMetadataStoreSessionTimeoutMillis())
+                    .allowReadOnlyOperations(config.isMetadataStoreAllowReadOnlyOperations())
+                    .batchingEnabled(config.isMetadataStoreBatchingEnabled())
+                    .batchingMaxDelayMillis(config.getMetadataStoreBatchingMaxDelayMillis())
+                    .batchingMaxOperations(config.getMetadataStoreBatchingMaxOperations())
+                    .batchingMaxSizeKb(config.getMetadataStoreBatchingMaxSizeKb())
+                    .metadataStoreName(metadataStoreName)
+                    .build();
+        }
+
         private MetadataStoreExtended createMockZookeeperMetadataStore(MockZooKeeper mockZooKeeper,
+                                                                       ServiceConfiguration config,
                                                                        String metadataStoreName) {
             // provide a unique session id for each instance
             MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper, false);
+            mockZooKeeperSession.setSessionTimeout((int) config.getMetadataStoreSessionTimeoutMillis());
             registerCloseable(() -> {
                 mockZooKeeperSession.close();
                 resetSpyOrMock(mockZooKeeperSession);
             });
-            ZKMetadataStore zkMetadataStore = new ZKMetadataStore(mockZooKeeperSession,
-                    MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+            ZKMetadataStore zkMetadataStore =
+                    new ZKMetadataStore(mockZooKeeperSession, createMetadataStoreConfig(config, metadataStoreName));
             registerCloseable(() -> {
                 zkMetadataStore.close();
                 resetSpyOrMock(zkMetadataStore);
@@ -786,9 +837,10 @@ public class PulsarTestContext implements AutoCloseable {
 
         @SneakyThrows
         private MetadataStoreExtended createTestZookeeperMetadataStore(TestZKServer zkServer,
+                                                                       ServiceConfiguration config,
                                                                        String metadataStoreName) {
             MetadataStoreExtended store = MetadataStoreExtended.create("zk:" + zkServer.getConnectionString(),
-                    MetadataStoreConfig.builder().metadataStoreName(metadataStoreName).build());
+                    createMetadataStoreConfig(config, metadataStoreName));
             registerCloseable(store);
             MetadataStoreExtended nonClosingProxy =
                     NonClosingProxyHandler.createNonClosingProxy(store, MetadataStoreExtended.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -424,11 +424,13 @@ public class PulsarTestContext implements AutoCloseable {
         public Builder reuseMockBookkeeperAndMetadataStores(PulsarTestContext otherContext) {
             bookKeeperClient(otherContext.getBookKeeperClient());
             if (otherContext.getMockZooKeeper() != null) {
+                withMockZooKeeperOrTestZKServer = null;
                 mockZooKeeper(otherContext.getMockZooKeeper());
                 if (otherContext.getMockZooKeeperGlobal() != null) {
                     mockZooKeeperGlobal(otherContext.getMockZooKeeperGlobal());
                 }
             } else if (otherContext.getTestZKServer() != null) {
+                withMockZooKeeperOrTestZKServer = null;
                 testZKServer(otherContext.getTestZKServer());
                 if (otherContext.getTestZKServerGlobal() != null) {
                     testZKServerGlobal(otherContext.getTestZKServerGlobal());
@@ -641,16 +643,32 @@ public class PulsarTestContext implements AutoCloseable {
             int sessionTimeout = (int) super.config.getMetadataStoreSessionTimeoutMillis();
             try {
                 if (withMockZooKeeperOrTestZKServer.isMockZooKeeper()) {
-                    mockZooKeeper(createMockZooKeeper(sessionTimeout));
+                    if (super.mockZooKeeper == null) {
+                        mockZooKeeper(createMockZooKeeper(sessionTimeout));
+                    } else {
+                        log.warn("Skipping creating mockZooKeeper, already set");
+                    }
                     if (withMockZooKeeperOrTestZKServer
                             == WithMockZooKeeperOrTestZKServer.MOCKZOOKEEPER_SEPARATE_GLOBAL) {
-                        mockZooKeeperGlobal(createMockZooKeeper(sessionTimeout));
+                        if (super.mockZooKeeperGlobal == null) {
+                            mockZooKeeperGlobal(createMockZooKeeper(sessionTimeout));
+                        } else {
+                            log.warn("Skipping creating mockZooKeeperGlobal, already set");
+                        }
                     }
                 } else if (withMockZooKeeperOrTestZKServer.isTestZKServer()) {
-                    testZKServer(createTestZookeeper(sessionTimeout));
+                    if (super.testZKServer == null) {
+                        testZKServer(createTestZookeeper(sessionTimeout));
+                    } else {
+                        log.warn("Skipping creating testZKServer, already set");
+                    }
                     if (withMockZooKeeperOrTestZKServer
                             == WithMockZooKeeperOrTestZKServer.TEST_ZK_SERVER_SEPARATE_GLOBAL) {
-                        testZKServerGlobal(createTestZookeeper(sessionTimeout));
+                        if (super.testZKServerGlobal == null) {
+                            testZKServerGlobal(createTestZookeeper(sessionTimeout));
+                        } else {
+                            log.warn("Skipping creating testZKServerGlobal, already set");
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MockZooKeeperMetadataStoreProvider.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MockZooKeeperMetadataStoreProvider.java
@@ -43,6 +43,7 @@ public class MockZooKeeperMetadataStoreProvider implements MetadataStoreProvider
         MockZooKeeper mockZooKeeper = mockZooKeepers.computeIfAbsent(metadataURL,
                 k -> MockZooKeeper.newInstance().registerCloseable(() -> mockZooKeepers.remove(k)));
         MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper, true);
+        mockZooKeeperSession.setSessionTimeout(metadataStoreConfig.getSessionTimeoutMillis());
         ZKMetadataStore zkMetadataStore = new ZKMetadataStore(mockZooKeeperSession, metadataStoreConfig, true);
         return zkMetadataStore;
     }

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeper.java
@@ -137,6 +137,7 @@ public class MockZooKeeper extends ZooKeeper {
     private ThreadLocal<Boolean> inExecutorThreadLocal;
     private int referenceCount;
     private List<AutoCloseable> closeables;
+    private int sessionTimeout;
 
     //see details of Objenesis caching - http://objenesis.org/details.html
     //see supported jvms - https://github.com/easymock/objenesis/blob/master/SupportedJVMs.md
@@ -188,6 +189,7 @@ public class MockZooKeeper extends ZooKeeper {
         zk.readOpDelayMs = readOpDelayMs;
         zk.sequentialIdGenerator = new AtomicLong();
         zk.closeables = new ArrayList<>();
+        zk.sessionTimeout = 30_000;
         return zk;
     }
 
@@ -204,7 +206,11 @@ public class MockZooKeeper extends ZooKeeper {
 
     @Override
     public int getSessionTimeout() {
-        return 30_000;
+        return sessionTimeout;
+    }
+
+    public void setSessionTimeout(int sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
     }
 
     private MockZooKeeper(String quorum) throws Exception {

--- a/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
+++ b/testmocks/src/main/java/org/apache/zookeeper/MockZooKeeperSession.java
@@ -48,6 +48,8 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     private boolean closeMockZooKeeperOnClose;
 
+    private int sessionTimeout = -1;
+
     public static MockZooKeeperSession newInstance(MockZooKeeper mockZooKeeper) {
         return newInstance(mockZooKeeper, true);
     }
@@ -74,7 +76,15 @@ public class MockZooKeeperSession extends ZooKeeper {
 
     @Override
     public int getSessionTimeout() {
-        return mockZooKeeper.getSessionTimeout();
+        if (sessionTimeout > 0) {
+            return sessionTimeout;
+        } else {
+            return mockZooKeeper.getSessionTimeout();
+        }
+    }
+
+    public void setSessionTimeout(int sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

After #23988, MockZooKeeper is correctly single threaded and an injected delay will block the execution of this code in ZKSessionWatcher:

https://github.com/apache/pulsar/blob/6e8c3496647df275071190aec9d29ecbcee55e80/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java#L108-L115

This will trigger a ConnectionLost session event. That's why a delay should be kept under 2000 ms. 
Currently MockZooKeeper's session timeout is hard coded to 30000ms and the check interval is 1/15 of this, therefore 2000ms.

When there's a test that blocks the ZooKeeper thread for more than 2000ms, it will result in a ConnectionLost event.
This PR makes the session timeout configurable and it's possible to increase the session timeout for tests where it's necessary to use a longer session timeout to avoid ConnectionLost session events.

### Modifications

- refactor the code in PulsarTestContext to postpone creation of the instances after the configuration including the configured session timeout is available
- also configure other `MetadataStoreConfig` settings and pass them from the `ServiceConfiguration` instance

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->