### PR TITLE
[feat][client]Add Fetch Consumer Support and Expose Continuous Sequence ID  (BrokerEntryMetadata Index) In MessageId

### DIFF
--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -58,6 +58,7 @@ message ManagedLedgerInfo {
         optional int64 size = 3;
         optional int64 timestamp = 4;
         optional OffloadContext offloadContext = 5;
+        optional int64 lastIndex = 6;
     }
 
   repeated LedgerInfo ledgerInfo = 1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -84,6 +84,8 @@ public interface Subscription extends MessageExpirer {
 
     CompletableFuture<Void> resetCursor(Position position);
 
+    CompletableFuture<Void> resetCursorByIndex(long index);
+
     CompletableFuture<Entry> peekNthMessage(int messagePosition);
 
     void redeliverUnacknowledgedMessages(Consumer consumer, long consumerEpoch);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -559,6 +559,12 @@ public class NonPersistentSubscription extends AbstractSubscription {
     }
 
     @Override
+    public CompletableFuture<Void> resetCursorByIndex(long index) {
+        // No-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction, long lowWaterMark) {
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         completableFuture.completeExceptionally(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinderByIndex.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinderByIndex.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
+import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.util.Codec;
+
+/**
+ * given a message index and find the first message (position) (published) at or before the index.
+ */
+@Slf4j
+public class PersistentMessageFinderByIndex implements AsyncCallbacks.FindEntryCallback {
+    private final ManagedCursor cursor;
+    private final String subName;
+    private final String topicName;
+    private long index = 0;
+
+    private static final int FALSE = 0;
+    private static final int TRUE = 1;
+    @SuppressWarnings("unused")
+    private volatile int messageFindInProgress = FALSE;
+    private static final AtomicIntegerFieldUpdater<PersistentMessageFinderByIndex> messageFindInProgressUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(PersistentMessageFinderByIndex.class, "messageFindInProgress");
+
+    public PersistentMessageFinderByIndex(String topicName, ManagedCursor cursor) {
+        this.topicName = topicName;
+        this.cursor = cursor;
+        this.subName = Codec.decode(cursor.getName());
+    }
+
+    public void findMessagesByIndex(final long index, AsyncCallbacks.FindEntryCallback callback) {
+        this.index = index;
+        if (messageFindInProgressUpdater.compareAndSet(this, FALSE, TRUE)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Starting message position find at index {}", subName, index);
+            }
+
+            cursor.asyncFindNewestMatching(ManagedCursor.FindPositionConstraint.SearchAllAvailableEntries, entry -> {
+                try {
+                    BrokerEntryMetadata meta = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
+                    if (meta != null) {
+                        return meta.getIndex() < index;
+                    }
+                } catch (Exception e) {
+                    log.error("[{}][{}] Error deserializing message for message position find", topicName, subName, e);
+                } finally {
+                    entry.release();
+                }
+                return false;
+            }, this, callback);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Ignore message position find scheduled task, last find is still running", topicName,
+                        subName);
+            }
+            callback.findEntryFailed(
+                    new ManagedLedgerException.ConcurrentFindCursorPositionException("last find is still running"),
+                    Optional.empty(), null);
+        }
+    }
+
+    @Override
+    public void findEntryComplete(Position position, Object ctx) {
+        checkArgument(ctx instanceof AsyncCallbacks.FindEntryCallback);
+        AsyncCallbacks.FindEntryCallback callback = (AsyncCallbacks.FindEntryCallback) ctx;
+        if (position != null) {
+            log.info("[{}][{}] Found position {} closest to provided index {}", topicName, subName, position,
+                    index);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] No position found closest to provided index {}", topicName, subName, index);
+            }
+        }
+        messageFindInProgress = FALSE;
+        callback.findEntryComplete(position, null);
+    }
+
+    @Override
+    public void findEntryFailed(ManagedLedgerException exception, Optional<Position> failedReadPosition, Object ctx) {
+        checkArgument(ctx instanceof AsyncCallbacks.FindEntryCallback);
+        AsyncCallbacks.FindEntryCallback callback = (AsyncCallbacks.FindEntryCallback) ctx;
+        if (log.isDebugEnabled()) {
+            log.debug("[{}][{}] message position find operation failed for provided index {}", topicName, subName,
+                    index, exception);
+        }
+        messageFindInProgress = FALSE;
+        callback.findEntryFailed(exception, failedReadPosition, null);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/FetchConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/FetchConsumerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.FetchConsumer;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class FetchConsumerTest extends BrokerTestBase {
+
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+
+    @Test
+    public void testFetchConsumerE2EWithMultiPartitionTopic() throws PulsarClientException {
+        String topic = "persistent://prop/ns-abc/testFetchConsumerE2EWithMultiPartitionTopic";
+        String subName = "testFetchConsumerE2EWithMultiPartitionTopic-sub";
+        String startMsg = "startMsg";
+        FetchConsumer<byte[]> fetchConsumer = pulsarClient.newFetchConsumer()
+                .topic(topic)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover)
+                .subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topic)
+                .enableBatching(false)
+                .create();
+
+        MessageIdAdv startMessageId = (MessageIdAdv) producer.newMessage().value(startMsg.getBytes()).send();
+        for (int i = 0; i < 100; i++) {
+            producer.newMessage().value(("msg_" + i).getBytes()).send();
+        }
+
+        Messages<byte[]> messages = fetchConsumer.fetchMessages(102, 10240, startMessageId, 10, TimeUnit.SECONDS);
+
+        assert messages.size() == 102;
+
+        messages.forEach(message -> {
+            System.out.println("Fetched message: " + new String(message.getData()));
+        });
+    }
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/FetchConsumer.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/FetchConsumer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+public interface FetchConsumer<T> extends Closeable, MessageAcknowledger {
+
+    /**
+     * Synchronously fetch a batch of messages.
+     *
+     * @param maxMessages the maximum number of messages to fetch
+     * @param maxBytes the maximum size of messages in bytes to fetch
+     * @param messageId the starting point message ID to fetch from
+     * @param timeout the maximum time to wait for fetching messages
+     * @param unit the time unit for the timeout
+     * @return a batch of messages
+     * @throws PulsarClientException if fetching messages fails
+     */
+    Messages<T> fetchMessages(int maxMessages, int maxBytes, MessageId messageId, int timeout, TimeUnit unit)
+            throws PulsarClientException;
+
+    /**
+     * Asynchronously fetch a batch of messages.
+     *
+     * @param maxMessages the maximum number of messages to fetch
+     * @param maxBytes the maximum size of messages in bytes to fetch
+     * @param offset the starting point message ID to fetch from (same as messageId in the synchronous method)
+     * @param timeout the maximum time to wait for fetching messages
+     * @param unit the time unit for the timeout
+     * @return a CompletableFuture that will contain the batch of messages when the fetch is complete
+     */
+    CompletableFuture<Messages<T>> fetchMessagesAsync(int maxMessages, int maxBytes, MessageId offset, int timeout,
+                                                      TimeUnit unit);
+
+    /**
+     * Close the consumer and stop the broker from pushing more messages.
+     *
+     * @throws PulsarClientException if there is a failure in closing the consumer
+     */
+    @Override
+    void close() throws PulsarClientException;
+
+    /**
+     * Asynchronously close the consumer and stop the broker from pushing more messages.
+     *
+     * @return a CompletableFuture that can be used to track the completion of the operation
+     */
+    CompletableFuture<Void> closeAsync();
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/FetchConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/FetchConsumerBuilder.java
@@ -1,0 +1,535 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * A consumer is only allowed to subscribe to one topic.
+ * The subscription type must be Exclusive or Failover,
+ * and autoScaledReceiverQueueSizeEnabled must be enabled.
+ * @param <T>
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+public interface FetchConsumerBuilder<T> extends Cloneable {
+
+    /**
+     * Load the configuration from provided <tt>config</tt> map.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Map<String, Object> config = new HashMap<>();
+     * config.put("ackTimeoutMillis", 1000);
+     * config.put("receiverQueueSize", 2000);
+     *
+     * Consumer<byte[]> builder = client.newFetchConsumer()
+     *              .loadConf(config)
+     *              .subscribe();
+     *
+     * Consumer<byte[]> consumer = builder.subscribe();
+     * }</pre>
+     *
+     * @param config configuration to load
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> loadConf(Map<String, Object> config);
+
+    /**
+     * Finalize the {@link FetchConsumer} creation by subscribing to the topic.
+     *
+     * <p>If the subscription does not exist, a new subscription is created. By default, the subscription
+     * is created at the end of the topic. See {@link #subscriptionInitialPosition(SubscriptionInitialPosition)}
+     * to configure the initial position behavior.
+     *
+     * <p>Once a subscription is created, it retains the data and the subscription cursor even if the consumer
+     * is not connected.
+     *
+     * @return the fetch consumer builder instance
+     * @throws PulsarClientException
+     *             if the subscribe operation fails
+     */
+    FetchConsumer<T> subscribe() throws PulsarClientException;
+
+    /**
+     * Finalize the {@link Consumer} creation by subscribing to the topic in asynchronous mode.
+     *
+     * <p>If the subscription does not exist, a new subscription is created. By default, the subscription
+     * is created at the end of the topic. See {@link #subscriptionInitialPosition(SubscriptionInitialPosition)}
+     * to configure the initial position behavior.
+     *
+     * <p>Once a subscription is created, it retains the data and the subscription cursor even
+     * if the consumer is not connected.
+     *
+     * @return a future that yields a {@link Consumer} instance
+     * @throws PulsarClientException
+     *             if the subscribe operation fails
+     */
+    CompletableFuture<FetchConsumer<T>> subscribeAsync();
+
+    /**
+     * Specify the topics this consumer subscribes to.
+     *
+     * @param topicNames a set of topics that the consumer subscribes to
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> topic(String... topicNames);
+
+    /**
+     * Specify a list of topics that this consumer subscribes to.
+     *
+     * @param topicNames a list of topics that the consumer subscribes to
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> topics(List<String> topicNames);
+
+    /**
+     * Specify the subscription name for this consumer.
+     *
+     * <p>This argument is required when constructing the consumer.
+     *
+     * @param subscriptionName the name of the subscription that this consumer should attach to
+     *
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> subscriptionName(String subscriptionName);
+
+    /**
+     * Specify the subscription properties for this subscription.
+     * Properties are immutable, and consumers under the same subscription will fail to create a subscription
+     * if they use different properties.
+     * @param subscriptionProperties the properties of the subscription
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> subscriptionProperties(Map<String, String> subscriptionProperties);
+
+    /**
+     * Enables or disables the acknowledgment receipt feature.
+     *
+     * <p>When this feature is enabled, the consumer ensures that acknowledgments are processed by the broker by
+     * waiting for a receipt from the broker. Even when the broker returns a receipt, it doesn't guarantee that the
+     * message won't be redelivered later due to certain implementation details.
+     * It is recommended to use the asynchronous {@link Consumer#acknowledgeAsync(Message)} method for acknowledgment
+     * when this feature is enabled. This is because using the synchronous {@link Consumer#acknowledge(Message)} method
+     * with acknowledgment receipt can cause performance issues due to the round trip to the server, which prevents
+     * pipelining (having multiple messages in-flight). With the asynchronous method, the consumer can continue
+     * consuming other messages while waiting for the acknowledgment receipts.
+     *
+     * @param isAckReceiptEnabled {@code true} to enable acknowledgment receipt, {@code false} to disable it
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> isAckReceiptEnabled(boolean isAckReceiptEnabled);
+
+    /**
+     * Select the subscription type to be used when subscribing to a topic.
+     *
+     * <p>Options are:
+     * <ul>
+     *  <li>{@link SubscriptionType#Exclusive} (Default)</li>
+     *  <li>{@link SubscriptionType#Failover}</li>
+     *  <li>{@link SubscriptionType#Shared}</li>
+     *  <li>{@link SubscriptionType#Key_Shared}</li>
+     * </ul>
+     *
+     * @param subscriptionType
+     *            the subscription type value
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> subscriptionType(SubscriptionType subscriptionType);
+
+    /**
+     * Selects the subscription mode to be used when subscribing to a topic.
+     *
+     * <p>Options are:
+     * <ul>
+     *  <li>{@link SubscriptionMode#Durable} (Default)</li>
+     *  <li>{@link SubscriptionMode#NonDurable}</li>
+     * </ul>
+     *
+     * @param subscriptionMode
+     *            the subscription mode value
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> subscriptionMode(SubscriptionMode subscriptionMode);
+
+    /**
+     * Sets a {@link CryptoKeyReader}.
+     *
+     * <p>Configure the key reader to be used to decrypt message payloads.
+     *
+     * @param cryptoKeyReader
+     *            CryptoKeyReader object
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader);
+
+    /**
+     * Sets the default implementation of {@link CryptoKeyReader}.
+     *
+     * <p>Configure the key reader to be used to decrypt message payloads.
+     *
+     * @param privateKey
+     *            the private key that is always used to decrypt message payloads.
+     * @return the fetch consumer builder instance
+     * @since 2.8.0
+     */
+    FetchConsumerBuilder<T> defaultCryptoKeyReader(String privateKey);
+
+    /**
+     * Sets the default implementation of {@link CryptoKeyReader}.
+     *
+     * <p>Configure the key reader to be used to decrypt the message payloads.
+     *
+     * @param privateKeys
+     *            the map of private key names and their URIs used to decrypt message payloads.
+     * @return the fetch consumer builder instance
+     * @since 2.8.0
+     */
+    FetchConsumerBuilder<T> defaultCryptoKeyReader(Map<String, String> privateKeys);
+
+    /**
+     * Sets a {@link MessageCrypto}.
+     *
+     * <p>Contains methods to encrypt/decrypt messages for end-to-end encryption.
+     *
+     * @param messageCrypto
+     *            MessageCrypto object
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> messageCrypto(MessageCrypto messageCrypto);
+
+    /**
+     * Sets the ConsumerCryptoFailureAction to the value specified.
+     *
+     * @param action
+     *            the action the consumer takes in case of decryption failures
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> cryptoFailureAction(ConsumerCryptoFailureAction action);
+
+
+    /**
+     * Sets amount of time for group consumer acknowledgments.
+     *
+     * <p>By default, the consumer uses a 100 ms grouping time to send out acknowledgments to the broker.
+     *
+     * <p>Setting a group time of 0 sends out acknowledgments immediately. A longer acknowledgment group time
+     * is more efficient, but at the expense of a slight increase in message re-deliveries after a failure.
+     *
+     * @param delay
+     *            the max amount of time an acknowledgement can be delayed
+     * @param unit
+     *            the time unit for the delay
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> acknowledgmentGroupTime(long delay, TimeUnit unit);
+
+    /**
+     * Set the number of messages for group consumer acknowledgments.
+     *
+     * <p>By default, the consumer uses at most 1000 messages to send out acknowledgments to the broker.
+     *
+     * @param messageNum
+     *
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> maxAcknowledgmentGroupSize(int messageNum);
+
+    /**
+     *
+     * @param replicateSubscriptionState
+     */
+    FetchConsumerBuilder<T> replicateSubscriptionState(boolean replicateSubscriptionState);
+
+    /**
+     * Sets the consumer name.
+     *
+     * <p>Consumer names are informative, and can be used to identify a particular consumer
+     * instance from the topic stats.
+     *
+     * @param consumerName
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> consumerName(String consumerName);
+
+    /**
+     * Sets a {@link ConsumerEventListener} for the consumer.
+     *
+     * <p>The consumer group listener is used for receiving consumer state changes in a consumer group for failover
+     * subscriptions. The application can then react to the consumer state changes.
+     *
+     * @param consumerEventListener
+     *            the consumer group listener object
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> consumerEventListener(ConsumerEventListener consumerEventListener);
+
+    /**
+     * If enabled, the consumer reads messages from the compacted topic rather than the full message topic backlog.
+     * This means that, if the topic has been compacted, the consumer will only see the latest value for
+     * each key in the topic, up until the point in the topic message backlog that has been compacted. Beyond that
+     * point, the messages are sent as normal.
+     *
+     * <p>readCompacted can only be enabled on subscriptions to persistent topics with a single active consumer
+     * (i.e. failover or exclusive subscriptions). Enabling readCompacted on subscriptions to non-persistent
+     * topics or on shared subscriptions will cause the subscription call to throw a PulsarClientException.
+     *
+     * @param readCompacted
+     *            whether to read from the compacted topic or full message topic backlog
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> readCompacted(boolean readCompacted);
+
+    /**
+     * Sets a name/value property with this consumer.
+     *
+     * <p>Properties are application-defined metadata that can be attached to the consumer.
+     * When getting topic stats, this metadata is associated with the consumer stats for easier identification.
+     *
+     * @param key
+     *            the property key
+     * @param value
+     *            the property value
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> property(String key, String value);
+
+    /**
+     * Add all the properties in the provided map to the consumer.
+     *
+     * <p>Properties are application-defined metadata that can be attached to the consumer.
+     * When getting topic stats, this metadata is associated with the consumer stats for easier identification.
+     *
+     * @param properties the map with properties
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> properties(Map<String, String> properties);
+
+    /**
+     * Sets the {@link SubscriptionInitialPosition} for the consumer.
+     *
+     * @param subscriptionInitialPosition
+     *            the position where to initialize a newly created subscription
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition);
+
+    /**
+     * Intercept {@link Consumer}.
+     *
+     * @param interceptors the list of interceptors to intercept the consumer created by this builder.
+     */
+    FetchConsumerBuilder<T> intercept(ConsumerInterceptor<T> ...interceptors);
+
+    /**
+     * Sets dead letter policy for a consumer.
+     *
+     * <p>By default, messages are redelivered as many times as possible until they are acknowledged.
+     * If you enable a dead letter mechanism, messages will have a maxRedeliverCount. When a message exceeds the maximum
+     * number of redeliveries, the message is sent to the Dead Letter Topic and acknowledged automatically.
+     *
+     * <p>Enable the dead letter mechanism by setting dead letter policy.
+     * example:
+     * <pre>
+     * client.newFetchConsumer()
+     *          .deadLetterPolicy(DeadLetterPolicy.builder().maxRedeliverCount(10).build())
+     *          .subscribe();
+     * </pre>
+     * Default dead letter topic name is {TopicName}-{Subscription}-DLQ.
+     * To set a custom dead letter topic name:
+     * <pre>
+     * client.newFetchConsumer()
+     *          .deadLetterPolicy(DeadLetterPolicy
+     *              .builder()
+     *              .maxRedeliverCount(10)
+     *              .deadLetterTopic("your-topic-name")
+     *              .build())
+     *          .subscribe();
+     * </pre>
+     */
+    FetchConsumerBuilder<T> deadLetterPolicy(DeadLetterPolicy deadLetterPolicy);
+
+    /**
+     * Sets {@link BatchReceivePolicy} for the consumer.
+     * By default, consumer uses {@link BatchReceivePolicy#DEFAULT_POLICY} as batch receive policy.
+     *
+     * <p>Example:
+     * <pre>
+     * client.newFetchConsumer().batchReceivePolicy(BatchReceivePolicy.builder()
+     *              .maxNumMessages(100)
+     *              .maxNumBytes(5 * 1024 * 1024)
+     *              .timeout(100, TimeUnit.MILLISECONDS)
+     *              .build()).subscribe();
+     * </pre>
+     */
+    FetchConsumerBuilder<T> batchReceivePolicy(BatchReceivePolicy batchReceivePolicy);
+
+    /**
+     * If enabled, the consumer auto-retries messages.
+     * Default: disabled.
+     *
+     * @param retryEnable
+     *            whether to auto retry message
+     */
+    FetchConsumerBuilder<T> enableRetry(boolean retryEnable);
+
+    /**
+     * Enable or disable batch index acknowledgment. To enable this feature, ensure batch index acknowledgment
+     * is enabled on the broker side.
+     */
+    FetchConsumerBuilder<T> enableBatchIndexAcknowledgment(boolean batchIndexAcknowledgmentEnabled);
+
+    /**
+     * Consumer buffers chunk messages into memory until it receives all the chunks of the original message. While
+     * consuming chunk-messages, chunks from same message might not be contiguous in the stream and they might be mixed
+     * with other messages' chunks. so, consumer has to maintain multiple buffers to manage chunks coming from different
+     * messages. This mainly happens when multiple publishers are publishing messages on the topic concurrently or
+     * publisher failed to publish all chunks of the messages.
+     *
+     * <pre>
+     * eg: M1-C1, M2-C1, M1-C2, M2-C2
+     * Here, Messages M1-C1 and M1-C2 belong to original message M1, M2-C1 and M2-C2 messages belong to M2 message.
+     * </pre>
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
+     * guarded by providing this @maxPendingChuckedMessage threshold. Once, consumer reaches this threshold, it drops
+     * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
+     * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
+     *
+     * The default value is 10.
+     *
+     * @param maxPendingChuckedMessage
+     * @return
+     * @deprecated use {@link #maxPendingChunkedMessage(int)}
+     */
+    @Deprecated
+    FetchConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage);
+
+    /**
+     * Consumer buffers chunk messages into memory until it receives all the chunks of the original message. While
+     * consuming chunk-messages, chunks from same message might not be contiguous in the stream and they might be mixed
+     * with other messages' chunks. so, consumer has to maintain multiple buffers to manage chunks coming from different
+     * messages. This mainly happens when multiple publishers are publishing messages on the topic concurrently or
+     * publisher failed to publish all chunks of the messages.
+     *
+     * <pre>
+     * eg: M1-C1, M2-C1, M1-C2, M2-C2
+     * Here, Messages M1-C1 and M1-C2 belong to original message M1, M2-C1 and M2-C2 messages belong to M2 message.
+     * </pre>
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once, consumer reaches this threshold, it drops
+     * the outstanding unchunked-messages by silently acking or asking broker to redeliver later by marking it unacked.
+     * This behavior can be controlled by configuration: @autoAckOldestChunkedMessageOnQueueFull
+     *
+     * The default value is 10.
+     *
+     * @param maxPendingChunkedMessage
+     * @return
+     */
+    FetchConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage);
+
+    /**
+     * Buffering large number of outstanding uncompleted chunked messages can create memory pressure and it can be
+     * guarded by providing this @maxPendingChunkedMessage threshold. Once the consumer reaches this threshold, it drops
+     * the outstanding unchunked-messages by silently acknowledging if autoAckOldestChunkedMessageOnQueueFull is true,
+     * otherwise it marks them for redelivery.
+     *
+     * @default false
+     *
+     * @param autoAckOldestChunkedMessageOnQueueFull
+     * @return
+     */
+    FetchConsumerBuilder<T> autoAckOldestChunkedMessageOnQueueFull(boolean autoAckOldestChunkedMessageOnQueueFull);
+
+    /**
+     * If the producer fails to publish all the chunks of a message, then the consumer can expire incomplete chunks if
+     * the consumer doesn't receive all chunks during the expiration period (default 1 minute).
+     *
+     * @param duration
+     * @param unit
+     * @return
+     */
+    FetchConsumerBuilder<T> expireTimeOfIncompleteChunkedMessage(long duration, TimeUnit unit);
+
+    /**
+     * Enable pooling of messages and the underlying data buffers.
+     * <p/>
+     * When pooling is enabled, the application is responsible for calling Message.release() after the handling of every
+     * received message. If “release()” is not called on a received message, it causes a memory leak. If an
+     * application attempts to use an already “released” message, it might experience undefined behavior (eg: memory
+     * corruption, deserialization error, etc.).
+     */
+    FetchConsumerBuilder<T> poolMessages(boolean poolMessages);
+
+    /**
+     * If configured with a non-null value, the consumer uses the processor to process the payload, including
+     * decoding it to messages and triggering the listener.
+     *
+     * Default: null
+     */
+    FetchConsumerBuilder<T> messagePayloadProcessor(MessagePayloadProcessor payloadProcessor);
+
+    /**
+     * negativeAckRedeliveryBackoff sets the redelivery backoff policy for messages that are negatively acknowledged
+     * using
+     * `consumer.negativeAcknowledge(Message<?> message)` but not with `consumer.negativeAcknowledge(MessageId
+     * messageId)`.
+     * This setting allows specifying a backoff policy for messages that are negatively acknowledged,
+     * enabling more flexible control over the delay before such messages are redelivered.
+     *
+     * <p>This configuration accepts a {@link RedeliveryBackoff} object that defines the backoff policy.
+     * The policy can be either a fixed delay or an exponential backoff. An exponential backoff policy
+     * is beneficial in scenarios where increasing the delay between consecutive redeliveries can help
+     * mitigate issues like temporary resource constraints or processing bottlenecks.
+     *
+     * <p>Note: This backoff policy does not apply when using `consumer.negativeAcknowledge(MessageId messageId)`
+     * because the redelivery count cannot be determined from just the message ID. It is recommended to use
+     * `consumer.negativeAcknowledge(Message<?> message)` if you want to leverage the redelivery backoff policy.
+     *
+     * <p>Example usage:
+     * <pre>{@code
+     * client.newFetchConsumer()
+     *       .negativeAckRedeliveryBackoff(ExponentialRedeliveryBackoff.builder()
+     *           .minDelayMs(1000)   // Set minimum delay to 1 second
+     *           .maxDelayMs(60000)  // Set maximum delay to 60 seconds
+     *           .build())
+     *       .subscribe();
+     * }</pre>
+     *
+     * @param negativeAckRedeliveryBackoff the backoff policy to use for negatively acknowledged messages
+     * @return the fetch consumer builder instance
+     */
+    FetchConsumerBuilder<T> negativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff);
+
+    /**
+     * Starts the consumer in a paused state. When enabled, the consumer does not immediately fetch messages when
+     * {@link #subscribe()} is called. Instead, the consumer waits to fetch messages until {@link Consumer#resume()} is
+     * called.
+     * <p/>
+     * See also {@link Consumer#pause()}.
+     * @default false
+     */
+    FetchConsumerBuilder<T> startPaused(boolean paused);
+
+    FetchConsumerBuilder<T> clone();
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -119,6 +119,8 @@ public interface PulsarClient extends Closeable {
      */
     ConsumerBuilder<byte[]> newConsumer();
 
+    FetchConsumerBuilder<byte[]> newFetchConsumer();
+
     /**
      * Create a consumer builder with a specific schema for subscribing on a specific topic
      *
@@ -145,6 +147,8 @@ public interface PulsarClient extends Closeable {
      * @since 2.0.0
      */
     <T> ConsumerBuilder<T> newConsumer(Schema<T> schema);
+
+    <T> FetchConsumerBuilder<T> newFetchConsumer(Schema<T> schema);
 
     /**
      * Create a topic reader builder with no schema ({@link Schema#BYTES}) to read from the specified topic.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionType.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SubscriptionType.java
@@ -58,5 +58,10 @@ public enum SubscriptionType {
      *
      * <p>Use ordering_key to overwrite the message key for message ordering.
      */
-    Key_Shared
+    Key_Shared,
+    /**
+     * FetchConsumer is a special type of consumer that allows the user to fetch messages from the server
+     * FetchConsumer does not support receive messages, it only supports fetch messages.
+     */
+    Fetch,
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -477,9 +477,11 @@ public class ClientCnx extends PulsarHandler {
         long highestSequenceId = sendReceipt.getHighestSequenceId();
         long ledgerId = -1;
         long entryId = -1;
+        long index = -1;
         if (sendReceipt.hasMessageId()) {
             ledgerId = sendReceipt.getMessageId().getLedgerId();
             entryId = sendReceipt.getMessageId().getEntryId();
+            index = sendReceipt.getMessageId().getIndex();
         }
         ProducerImpl<?> producer = producers.get(producerId);
         if (ledgerId == -1 && entryId == -1) {
@@ -495,7 +497,7 @@ public class ClientCnx extends PulsarHandler {
         }
 
         if (producer != null) {
-            producer.ackReceived(this, sequenceId, highestSequenceId, ledgerId, entryId);
+            producer.ackReceived(this, sequenceId, highestSequenceId, ledgerId, entryId, index);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Producer is {} already closed, ignore published message [{}-{}]", producerId, ledgerId,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2573,6 +2573,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (msgId.getFirstChunkMessageId() != null) {
             seek = Commands.newSeek(consumerId, requestId, firstChunkMsgId.getLedgerId(),
                     firstChunkMsgId.getEntryId(), new long[0]);
+        } else if (msgId.getOffset() > 0) {
+            seek = Commands.newSeek(consumerId, requestId, msgId.getOffset());
         } else {
             final long[] ackSetArr;
             if (MessageIdAdvUtils.isBatch(msgId)) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchConsumerBuilderImpl.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.ConsumerEventListener;
+import org.apache.pulsar.client.api.ConsumerInterceptor;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.FetchConsumer;
+import org.apache.pulsar.client.api.FetchConsumerBuilder;
+import org.apache.pulsar.client.api.MessageCrypto;
+import org.apache.pulsar.client.api.MessagePayloadProcessor;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.util.RetryMessageUtil;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
+
+@Slf4j
+public class FetchConsumerBuilderImpl<T> implements FetchConsumerBuilder<T>, Cloneable {
+    private final PulsarClientImpl client;
+    private ConsumerConfigurationData<T> conf;
+    private final Schema<T> schema;
+    private List<ConsumerInterceptor<T>> interceptorList;
+    private volatile boolean interruptedBeforeConsumerCreation;
+
+    public FetchConsumerBuilderImpl(PulsarClientImpl client, Schema<T> schema) {
+        this(client, new ConsumerConfigurationData<T>(), schema);
+    }
+
+    FetchConsumerBuilderImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf, Schema<T> schema) {
+        checkArgument(schema != null, "Schema should not be null.");
+        this.client = client;
+        this.conf = conf;
+        this.schema = schema;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> loadConf(Map<String, Object> config) {
+        this.conf = ConfigurationDataUtils.loadData(config, conf, ConsumerConfigurationData.class);
+        return this;
+    }
+
+    @Override
+    public FetchConsumer<T> subscribe() throws PulsarClientException {
+        CompletableFuture<FetchConsumer<T>> future = new CompletableFuture<>();
+        try {
+            subscribeAsync().whenComplete((c, e) -> {
+                if (e != null) {
+                    // If the subscription fails, there is no need to close the consumer here,
+                    // as it will be handled in the subscribeAsync method.
+                    future.completeExceptionally(e);
+                    return;
+                }
+                if (interruptedBeforeConsumerCreation) {
+                    c.closeAsync().exceptionally(closeEx -> {
+                        log.error("Failed to close consumer after interruption", closeEx.getCause());
+                        return null;
+                    });
+                    future.completeExceptionally(new PulsarClientException(
+                            "Subscription was interrupted before the consumer could be fully created"));
+                } else {
+                    future.complete(c);
+                }
+            });
+            return future.get();
+        } catch (InterruptedException e) {
+            interruptedBeforeConsumerCreation = true;
+            Thread.currentThread().interrupt();
+            throw PulsarClientException.unwrap(e);
+        } catch (Exception e) {
+            throw PulsarClientException.unwrap(e);
+        }
+    }
+
+    private CompletableFuture<Boolean> checkDlqAlreadyExists(String topic) {
+        CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
+        client.getPartitionedTopicMetadata(topic, false, true).thenAccept(metadata -> {
+            TopicName topicName = TopicName.get(topic);
+            if (topicName.isPersistent()) {
+                // Either partitioned or non-partitioned, it exists.
+                existsFuture.complete(true);
+            } else {
+                // If it is a non-persistent topic, return true only it is a partitioned topic.
+                existsFuture.complete(metadata != null && metadata.partitions > 0);
+            }
+        }).exceptionally(ex -> {
+            Throwable actEx = FutureUtil.unwrapCompletionException(ex);
+            if (actEx instanceof PulsarClientException.NotFoundException
+                    || actEx instanceof PulsarClientException.TopicDoesNotExistException
+                    || actEx instanceof PulsarAdminException.NotFoundException) {
+                existsFuture.complete(false);
+            } else {
+                existsFuture.completeExceptionally(ex);
+            }
+            return null;
+        });
+        return existsFuture;
+    }
+
+    @Override
+    public CompletableFuture<FetchConsumer<T>> subscribeAsync() {
+        if (conf.getTopicNames().isEmpty() && conf.getTopicsPattern() == null) {
+            return FutureUtil.failedFuture(new PulsarClientException
+                            .InvalidConfigurationException("Topic name must be set on the consumer builder"));
+        }
+
+        if (StringUtils.isBlank(conf.getSubscriptionName())) {
+            return FutureUtil.failedFuture(new PulsarClientException
+                            .InvalidConfigurationException("Subscription name must be set on the consumer builder"));
+        }
+
+        if (conf.getKeySharedPolicy() != null && conf.getSubscriptionType() != SubscriptionType.Key_Shared) {
+            return FutureUtil.failedFuture(new PulsarClientException
+                    .InvalidConfigurationException("KeySharedPolicy must set with KeyShared subscription"));
+        }
+        if (conf.getBatchReceivePolicy() != null) {
+            conf.setReceiverQueueSize(
+                    Math.max(conf.getBatchReceivePolicy().getMaxNumMessages(), conf.getReceiverQueueSize()));
+        }
+        CompletableFuture<Void> applyDLQConfig;
+        if (conf.isRetryEnable() && conf.getTopicNames().size() > 0) {
+            TopicName topicFirst = TopicName.get(conf.getTopicNames().iterator().next());
+            //Issue 9327: do compatibility check in case of the default retry and dead letter topic name changed
+            String oldRetryLetterTopic = TopicName.get(topicFirst.getDomain().value(), topicFirst.getNamespaceObject(),
+                    conf.getSubscriptionName() + RetryMessageUtil.RETRY_GROUP_TOPIC_SUFFIX).toString();
+            String oldDeadLetterTopic = TopicName.get(topicFirst.getDomain().value(), topicFirst.getNamespaceObject(),
+                    conf.getSubscriptionName() + RetryMessageUtil.DLQ_GROUP_TOPIC_SUFFIX).toString();
+            DeadLetterPolicy deadLetterPolicy = conf.getDeadLetterPolicy();
+            if (deadLetterPolicy == null || StringUtils.isBlank(deadLetterPolicy.getRetryLetterTopic())
+                    || StringUtils.isBlank(deadLetterPolicy.getDeadLetterTopic())) {
+                CompletableFuture<Boolean> retryLetterTopicMetadata = checkDlqAlreadyExists(oldRetryLetterTopic);
+                CompletableFuture<Boolean> deadLetterTopicMetadata = checkDlqAlreadyExists(oldDeadLetterTopic);
+                applyDLQConfig = CompletableFuture.allOf(retryLetterTopicMetadata, deadLetterTopicMetadata)
+                        .thenAccept(__ -> {
+                            String retryLetterTopic = RetryMessageUtil.getRetryTopic(topicFirst.toString(),
+                                    conf.getSubscriptionName());
+                            String deadLetterTopic = RetryMessageUtil.getDLQTopic(topicFirst.toString(),
+                                    conf.getSubscriptionName());
+                            if (retryLetterTopicMetadata.join()) {
+                                retryLetterTopic = oldRetryLetterTopic;
+                            }
+                            if (deadLetterTopicMetadata.join()) {
+                                deadLetterTopic = oldDeadLetterTopic;
+                            }
+                            if (deadLetterPolicy == null) {
+                                conf.setDeadLetterPolicy(DeadLetterPolicy.builder()
+                                        .maxRedeliverCount(RetryMessageUtil.MAX_RECONSUMETIMES)
+                                        .retryLetterTopic(retryLetterTopic)
+                                        .deadLetterTopic(deadLetterTopic)
+                                        .build());
+                            } else {
+                                if (StringUtils.isBlank(deadLetterPolicy.getRetryLetterTopic())) {
+                                    conf.getDeadLetterPolicy().setRetryLetterTopic(retryLetterTopic);
+                                }
+                                if (StringUtils.isBlank(deadLetterPolicy.getDeadLetterTopic())) {
+                                    conf.getDeadLetterPolicy().setDeadLetterTopic(deadLetterTopic);
+                                }
+                            }
+                            conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
+                        });
+            } else {
+                conf.getTopicNames().add(conf.getDeadLetterPolicy().getRetryLetterTopic());
+                applyDLQConfig = CompletableFuture.completedFuture(null);
+            }
+        } else {
+            applyDLQConfig = CompletableFuture.completedFuture(null);
+        }
+        return applyDLQConfig.thenCompose(__ -> {
+            if (interceptorList == null || interceptorList.size() == 0) {
+                return client.fetchConsumerSubscribeAsync(conf, schema, null);
+            } else {
+                return client.fetchConsumerSubscribeAsync(conf, schema, new ConsumerInterceptors<>(interceptorList));
+            }
+        });
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> topic(String... topicNames) {
+        checkArgument(topicNames != null && topicNames.length > 0,
+                "Passed in topicNames should not be null or empty.");
+        return topics(Arrays.stream(topicNames).collect(Collectors.toList()));
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> topics(List<String> topicNames) {
+        checkArgument(topicNames != null && !topicNames.isEmpty(),
+                "Passed in topicNames list should not be null or empty.");
+        topicNames.stream().forEach(topicName ->
+                checkArgument(StringUtils.isNotBlank(topicName), "topicNames cannot have blank topic"));
+        conf.getTopicNames().addAll(topicNames.stream().map(StringUtils::trim).collect(Collectors.toList()));
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> subscriptionName(String subscriptionName) {
+        checkArgument(StringUtils.isNotBlank(subscriptionName), "subscriptionName cannot be blank");
+        conf.setSubscriptionName(subscriptionName);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> subscriptionProperties(Map<String, String> subscriptionProperties) {
+        checkArgument(subscriptionProperties != null, "subscriptionProperties cannot be null");
+        conf.setSubscriptionProperties(Collections.unmodifiableMap(subscriptionProperties));
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> isAckReceiptEnabled(boolean isAckReceiptEnabled) {
+        conf.setAckReceiptEnabled(isAckReceiptEnabled);
+        return this;
+    }
+    @Override
+    public FetchConsumerBuilder<T> subscriptionType(@NonNull SubscriptionType subscriptionType) {
+        conf.setSubscriptionType(subscriptionType);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> subscriptionMode(@NonNull SubscriptionMode subscriptionMode) {
+        conf.setSubscriptionMode(subscriptionMode);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> consumerEventListener(@NonNull ConsumerEventListener consumerEventListener) {
+        conf.setConsumerEventListener(consumerEventListener);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> cryptoKeyReader(@NonNull CryptoKeyReader cryptoKeyReader) {
+        conf.setCryptoKeyReader(cryptoKeyReader);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> defaultCryptoKeyReader(String privateKey) {
+        checkArgument(StringUtils.isNotBlank(privateKey), "privateKey cannot be blank");
+        return cryptoKeyReader(DefaultCryptoKeyReader.builder().defaultPrivateKey(privateKey).build());
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> defaultCryptoKeyReader(@NonNull Map<String, String> privateKeys) {
+        checkArgument(!privateKeys.isEmpty(), "privateKeys cannot be empty");
+        return cryptoKeyReader(DefaultCryptoKeyReader.builder().privateKeys(privateKeys).build());
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> messageCrypto(@NonNull MessageCrypto messageCrypto) {
+        conf.setMessageCrypto(messageCrypto);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> cryptoFailureAction(@NonNull ConsumerCryptoFailureAction action) {
+        conf.setCryptoFailureAction(action);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> acknowledgmentGroupTime(long delay, TimeUnit unit) {
+        checkArgument(delay >= 0, "acknowledgmentGroupTime needs to be >= 0");
+        conf.setAcknowledgementsGroupTimeMicros(unit.toMicros(delay));
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> maxAcknowledgmentGroupSize(int messageNum) {
+        checkArgument(messageNum > 0, "acknowledgementsGroupSize needs to be > 0");
+        conf.setMaxAcknowledgmentGroupSize(messageNum);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> consumerName(String consumerName) {
+        checkArgument(StringUtils.isNotBlank(consumerName), "consumerName cannot be blank");
+        conf.setConsumerName(consumerName);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> maxPendingChuckedMessage(int maxPendingChuckedMessage) {
+        conf.setMaxPendingChunkedMessage(maxPendingChuckedMessage);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> maxPendingChunkedMessage(int maxPendingChunkedMessage) {
+        conf.setMaxPendingChunkedMessage(maxPendingChunkedMessage);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> autoAckOldestChunkedMessageOnQueueFull(
+            boolean autoAckOldestChunkedMessageOnQueueFull) {
+        conf.setAutoAckOldestChunkedMessageOnQueueFull(autoAckOldestChunkedMessageOnQueueFull);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> property(String key, String value) {
+        checkArgument(StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value),
+                "property key/value cannot be blank");
+        conf.getProperties().put(key, value);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> properties(@NonNull Map<String, String> properties) {
+        properties.entrySet().forEach(entry ->
+                checkArgument(
+                        StringUtils.isNotBlank(entry.getKey()) && StringUtils.isNotBlank(entry.getValue()),
+                        "properties' key/value cannot be blank"));
+        conf.getProperties().putAll(properties);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> readCompacted(boolean readCompacted) {
+        conf.setReadCompacted(readCompacted);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> subscriptionInitialPosition(@NonNull SubscriptionInitialPosition
+                                                                  subscriptionInitialPosition) {
+        conf.setSubscriptionInitialPosition(subscriptionInitialPosition);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> replicateSubscriptionState(boolean replicateSubscriptionState) {
+        conf.setReplicateSubscriptionState(replicateSubscriptionState);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> intercept(ConsumerInterceptor<T>... interceptors) {
+        if (interceptorList == null) {
+            interceptorList = new ArrayList<>();
+        }
+        interceptorList.addAll(Arrays.asList(interceptors));
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> deadLetterPolicy(DeadLetterPolicy deadLetterPolicy) {
+        if (deadLetterPolicy != null) {
+            checkArgument(deadLetterPolicy.getMaxRedeliverCount() > 0, "MaxRedeliverCount must be > 0.");
+        }
+        conf.setDeadLetterPolicy(deadLetterPolicy);
+        return this;
+    }
+
+    public FetchConsumerBuilder<T> batchReceivePolicy(BatchReceivePolicy batchReceivePolicy) {
+        checkArgument(batchReceivePolicy != null, "batchReceivePolicy must not be null.");
+        batchReceivePolicy.verify();
+        conf.setBatchReceivePolicy(batchReceivePolicy);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return conf != null ? conf.toString() : "";
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> enableRetry(boolean retryEnable) {
+        conf.setRetryEnable(retryEnable);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> enableBatchIndexAcknowledgment(boolean batchIndexAcknowledgmentEnabled) {
+        conf.setBatchIndexAckEnabled(batchIndexAcknowledgmentEnabled);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> expireTimeOfIncompleteChunkedMessage(long duration, TimeUnit unit) {
+        conf.setExpireTimeOfIncompleteChunkedMessageMillis(unit.toMillis(duration));
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> poolMessages(boolean poolMessages) {
+        conf.setPoolMessages(poolMessages);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> messagePayloadProcessor(MessagePayloadProcessor payloadProcessor) {
+        conf.setPayloadProcessor(payloadProcessor);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> negativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff) {
+        checkArgument(negativeAckRedeliveryBackoff != null, "negativeAckRedeliveryBackoff must not be null.");
+        conf.setNegativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> startPaused(boolean paused) {
+        conf.setStartPaused(paused);
+        return this;
+    }
+
+    @Override
+    public FetchConsumerBuilder<T> clone(){
+        return new FetchConsumerBuilderImpl<>(client, conf.clone(), schema);
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchConsumerImpl.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.BatchReceivePolicy;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.FetchConsumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.common.api.proto.ProtocolVersion;
+
+@Slf4j
+public class FetchConsumerImpl<T> extends ConsumerImpl<T> implements FetchConsumer<T> {
+
+    private final AtomicReference<CompletableFuture<Messages<T>>> lastFutureRef =
+            new AtomicReference<>(CompletableFuture.completedFuture(null));
+
+    protected FetchConsumerImpl(PulsarClientImpl client, String topic, ConsumerConfigurationData<T> conf,
+                                ExecutorProvider executorProvider, int partitionIndex,
+                                boolean hasParentConsumer,
+                                CompletableFuture<Consumer<T>> subscribeFuture,
+                                MessageId startMessageId, long startMessageRollbackDurationInSec,
+                                Schema<T> schema, ConsumerInterceptors<T> interceptors,
+                                boolean createTopicIfDoesNotExist) {
+        super(client, topic, conf, executorProvider, partitionIndex, hasParentConsumer, false,
+                subscribeFuture, startMessageId, startMessageRollbackDurationInSec, schema, interceptors,
+                createTopicIfDoesNotExist);
+        verifyConfig();
+    }
+
+    static <T> FetchConsumerImpl<T> create(PulsarClientImpl client, String topic,
+                                      ConsumerConfigurationData<T> conf,
+                                      ExecutorProvider executorProvider, int partitionIndex,
+                                      boolean hasParentConsumer,
+                                      CompletableFuture<Consumer<T>> subscribeFuture,
+                                      MessageId startMessageId, long startMessageRollbackDurationInSec,
+                                      Schema<T> schema, ConsumerInterceptors<T> interceptors,
+                                      boolean createTopicIfDoesNotExist) {
+        return new FetchConsumerImpl<>(client, topic, conf, executorProvider, partitionIndex,
+                hasParentConsumer, subscribeFuture, startMessageId,
+                startMessageRollbackDurationInSec, schema, interceptors, createTopicIfDoesNotExist);
+    }
+
+    @Override
+    public Messages<T> fetchMessages(int maxMessages, int maxBytes, MessageId messageId,
+                                     int timeout, TimeUnit unit) throws PulsarClientException {
+        try {
+            return fetchMessagesAsync(maxMessages, maxBytes, messageId, timeout, unit).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new PulsarClientException("Failed to fetch messages", e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Messages<T>> fetchMessagesAsync(int maxMessages, int maxBytes, MessageId messageId,
+                                                             int timeout, TimeUnit unit) {
+        // Link the new task to the end and execute it in series
+        return lastFutureRef.getAndUpdate(currentFuture ->
+                currentFuture.thenCompose(ignored ->
+                        internalFetchMessagesAsync(maxMessages, maxBytes, messageId, timeout, unit))
+        );
+    }
+
+    private CompletableFuture<Messages<T>> internalFetchMessagesAsync(int maxMessages, int maxBytes,
+                                                                      MessageId messageId,
+                                                                      int timeout, TimeUnit unit) {
+        CompletableFuture<Void> seekFuture = new CompletableFuture<>();
+        MessageIdAdv messageIdAdv = (MessageIdAdv) messageId;
+        if (cnx().getRemoteEndpointProtocolVersion() < ProtocolVersion.V22.getValue()
+                && (messageIdAdv.getLedgerId() == -1L || messageIdAdv.getEntryId() == -1L)) {
+            seekFuture.completeExceptionally(
+                    new PulsarClientException("Fetch messages by offset is not supported on this broker version, "
+                            + "please update broker version or use message id with ledgerId and entryId"));
+        }
+        // TODO：this logic can be improve to check where to seek.
+        if (((MessageIdAdv) super.lastDequeuedMessageId).getOffset() != ((MessageIdAdv) messageId).getOffset() - 1) {
+            super.seekAsync(messageId).whenComplete((v, ex) -> {
+                if (ex != null) {
+                    seekFuture.completeExceptionally(ex);
+                } else {
+                    seekFuture.complete(null);
+                }
+            });
+        } else {
+            seekFuture.complete(null);
+        }
+
+        return seekFuture.thenCompose(v -> {
+            super.conf.setBatchReceivePolicy(BatchReceivePolicy.builder().maxNumMessages(maxMessages)
+                    .maxNumBytes(maxBytes).timeout(timeout, unit).build());
+            //todo: 不立刻返回，如果最后的offset不满一个batch则剔除
+            return super.batchReceiveAsync();
+        });
+    }
+    private void verifyConfig() {
+        if (conf.getSubscriptionType() != SubscriptionType.Failover
+                && conf.getSubscriptionType() != SubscriptionType.Exclusive) {
+            throw new IllegalArgumentException("FetchConsumer can only be used with SubscriptionType.Fetch");
+        }
+        if (conf.getMessageListener() != null) {
+            throw new IllegalArgumentException("FetchConsumer cannot have a message listener");
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        if (!super.equals(object)) {
+            return false;
+        }
+        return super.equals(object);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), lastFutureRef);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/FetchMultiTopicsConsumerImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.FetchConsumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
+
+
+public class FetchMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T> implements FetchConsumer<T> {
+
+    public FetchMultiTopicsConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf,
+                                        ExecutorProvider executorProvider,
+                                        CompletableFuture<Consumer<T>> subscribeFuture,
+                                        Schema<T> schema, ConsumerInterceptors<T> interceptors,
+                                        boolean createTopicIfDoesNotExist) {
+        super(client, DUMMY_TOPIC_NAME_PREFIX + RandomStringUtils.randomAlphanumeric(5), conf,
+                executorProvider, subscribeFuture, schema, interceptors, createTopicIfDoesNotExist, null,
+                0, false);
+    }
+
+
+    @Override
+    public Messages<T> fetchMessages(int maxMessages, int maxBytes, MessageId messageId, int timeout, TimeUnit unit)
+            throws PulsarClientException {
+        try {
+            return fetchMessagesAsync(maxMessages, maxBytes, messageId, timeout, unit).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new PulsarClientException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Messages<T>> fetchMessagesAsync(int maxMessages, int maxBytes, MessageId messageId,
+                                                             int timeout, TimeUnit unit) {
+        MessageIdAdv messageIdAdv = (MessageIdAdv) messageId;
+        int partitionIndex = messageIdAdv.getPartitionIndex();
+        Consumer<T> consumer = super.consumers.get(TopicName.getTopicPartitionNameString(super.topic, partitionIndex));
+        if (consumer == null) {
+            return FutureUtil.failedFuture(new PulsarClientException(
+                    "Partition " + partitionIndex + "for topic " + super.topic + " not found"));
+        }
+        if (consumer instanceof FetchConsumer) {
+            return ((FetchConsumer<T>) consumer).fetchMessagesAsync(maxMessages, maxBytes, messageId, timeout, unit);
+        } else {
+            return FutureUtil.failedFuture(new PulsarClientException(
+                    "Consumer " + consumer.getTopic() + " is not a FetchConsumer"));
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -32,6 +32,7 @@ public class MessageIdImpl implements MessageIdAdv {
     protected final long ledgerId;
     protected final long entryId;
     protected final int partitionIndex;
+    protected final long offset;
 
     // Private constructor used only for json deserialization
     @SuppressWarnings("unused")
@@ -43,6 +44,21 @@ public class MessageIdImpl implements MessageIdAdv {
         this.ledgerId = ledgerId;
         this.entryId = entryId;
         this.partitionIndex = partitionIndex;
+        this.offset = -1;
+    }
+
+    public MessageIdImpl(long offset) {
+        this.ledgerId = -1;
+        this.entryId = -1;
+        this.partitionIndex = -1;
+        this.offset = offset;
+    }
+
+    public MessageIdImpl(long ledgerId, long entryId, int partitionIndex, long offset) {
+        this.ledgerId = ledgerId;
+        this.entryId = entryId;
+        this.partitionIndex = partitionIndex;
+        this.offset = offset;
     }
 
     @Override
@@ -58,6 +74,11 @@ public class MessageIdImpl implements MessageIdAdv {
     @Override
     public int getPartitionIndex() {
         return partitionIndex;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1262,8 +1262,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
         }
     }
-
     protected void ackReceived(ClientCnx cnx, long sequenceId, long highestSequenceId, long ledgerId, long entryId) {
+        ackReceived(cnx, sequenceId, highestSequenceId, ledgerId, entryId, -1);
+    }
+    protected void ackReceived(ClientCnx cnx, long sequenceId, long highestSequenceId, long ledgerId, long entryId,
+                               long index) {
         OpSendMsg op = null;
         synchronized (this) {
             op = pendingMessages.peek();

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/api/MessageIdAdv.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/api/MessageIdAdv.java
@@ -84,6 +84,10 @@ public interface MessageIdAdv extends MessageId {
         return null;
     }
 
+    default long getOffset() {
+        return -1;
+    }
+
     /**
      * Get the message ID of the first chunk if the current message ID represents the position of a chunked message.
      *

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -65,6 +65,7 @@ message MessageIdData {
 
     // For the chunk message id, we need to specify the first chunk message id.
     optional MessageIdData first_chunk_message_id = 7;
+    optional int64 index = 8;
 }
 
 message KeyValue {
@@ -265,6 +266,7 @@ enum ProtocolVersion {
     v19 = 19; // Add CommandTcClientConnectRequest and CommandTcClientConnectResponse
     v20 = 20; // Add client support for topic migration redirection CommandTopicMigrated
     v21 = 21; // Carry the AUTO_CONSUME schema to the Broker after this version
+    V22 = 22; // Add index in MessageIdData.
 }
 
 message CommandConnect {


### PR DESCRIPTION
### **Motivation**  

1. **Current Limitations**:  
   - Pulsar lacks native support for **Fetch Consumer**-style consumption, which limits flexibility in scenarios requiring explicit message retrieval.  
   -  message ID are discontinuous, complicating use cases that rely on strict sequential tracking (e.g., auditing, replay, or stateful processing).  
2. **Opportunity**:  
   - The existing **broker entry metadata** contains an `index` field that can serve as a continuous sequence identifier. However, this metadata is not propagated to clients, leaving it underutilized.  

---

### **Modifications**  

1. **Modify MessageIdData**:  

   - Modified the broker-to-client message pipeline to embed the broker entry metadata `index` field into `MessageIdData`.  

2. **Client API Exposure**:  

   - Expose the broker entry metadata's `index` as a continuous sequence ID in messageIdAdv.  

   - Clients can now access this via:  

     ```java  
     long sequenceId = messageIdAdv.getIndex();  
     ```

3. **Fetch Consumer Support**:  

   - Implemented logic for fetch conumer which can explicit aquire messages.



### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
