### PR TITLE
[fix][broker]fix memory leak, messages lost, incorrect replication state if using multiple schema versions(auto_produce)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -38,10 +38,13 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -79,6 +82,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -88,9 +92,12 @@ import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.impl.AutoTopicCreationOverrideImpl;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.awaitility.reflect.WhiteboxImpl;
@@ -1323,5 +1330,96 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // cleanup.
         admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1));
         admin1.topics().delete(topicName, false);
+    }
+
+    @DataProvider
+    public Object[][] enableDeduplication() {
+        return new Object[][] {
+            {false},
+            {true},
+        };
+    }
+
+    @Test(dataProvider = "enableDeduplication")
+    public void testIncompatibleMultiVersionSchema(boolean enableDeduplication) throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://"
+                + sourceClusterAlwaysSchemaCompatibleNamespace + "/tp_");
+        final String subscriptionName = "s1";
+        // 1.Create topic.
+        admin1.topics().createNonPartitionedTopic(topicName);
+        Producer<byte[]> producer1 = client1.newProducer(Schema.AUTO_PRODUCE_BYTES()).topic(topicName).create();
+        waitReplicatorStarted(topicName);
+        admin1.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
+        admin2.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
+        if (enableDeduplication) {
+            admin2.topicPolicies().setDeduplicationStatus(topicName, true);
+        }
+        // 2. Publish messages with multiple schemas.
+        producer1.newMessage(Schema.STRING).value("msg1").send();
+        producer1.newMessage(Schema.BOOL).value(false).send();
+        producer1.newMessage(Schema.STRING).value("msg3").send();
+        // 3. several unloading, which causes replicator internal producer reconnects.
+//        for (int i = 0; i < 3; i++) {
+            Thread.sleep(2000);
+            admin2.topics().unload(topicName);
+            waitReplicatorStarted(topicName);
+//        }
+        // Verify: no individual acks.
+        Awaitility.await().untilAsserted(() -> {
+           PersistentTopic persistentTopic2 =
+                   (PersistentTopic) pulsar2.getBrokerService().getTopic(topicName, false).join().get();
+           assertTrue(
+           persistentTopic2.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(true) > 0);
+            PersistentTopic persistentTopic1 =
+                    (PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false).join().get();
+            ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic1.getManagedLedger();
+            ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().get("pulsar.repl.r2");
+            assertEquals(cursor.getTotalNonContiguousDeletedMessagesRange(), 0);
+            //assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) < 0);
+        });
+        // 4. Adjust schema compatibility and unload topic on the remote side, which will solve the replication stuck
+        // issue.
+        admin2.namespaces().setSchemaCompatibilityStrategy(sourceClusterAlwaysSchemaCompatibleNamespace,
+                SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+        admin2.topics().unload(topicName);
+        admin1.topics().unload(topicName);
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic1 =
+                    (PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false).join().get();
+            ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic1.getManagedLedger();
+            ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().get("pulsar.repl.r2");
+            assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) >= 0);
+        });
+        // Verify: no out-of-order; schemas are as expected.
+        Consumer<GenericRecord> consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
+                .subscriptionName(subscriptionName).subscribe();
+        Collection<String> msgReceived;
+        if (enableDeduplication) {
+            msgReceived = new ArrayList<>();
+        } else {
+            msgReceived = new LinkedHashSet<>();
+        }
+        while (true) {
+            Message<GenericRecord> message = consumer2.receive(2, TimeUnit.SECONDS);
+            if (message == null) {
+                break;
+            }
+//            SchemaType schemaType = message.getValue().getSchemaType();
+//            assertTrue(schemaType.equals(SchemaType.STRING) || schemaType.equals(SchemaType.BOOLEAN));
+            msgReceived.add(message.getValue().getNativeObject().toString());
+            log.info("received msg: {}", message.getValue().getNativeObject().toString());
+        }
+        assertEquals(msgReceived, Arrays.asList("msg1", "false", "msg3"));
+        List<SchemaInfo> schemaInfoList = admin2.schemas().getAllSchemas(topicName);
+        assertEquals(schemaInfoList.size(), 2);
+        assertEquals(schemaInfoList.get(0).getType(), SchemaType.STRING);
+        assertEquals(schemaInfoList.get(1).getType(), SchemaType.BOOLEAN);
+
+        // cleanup.
+        consumer2.close();
+        producer1.close();
+        admin2.topics().deleteSubscription(topicName, subscriptionName);
+        admin2.namespaces().setSchemaCompatibilityStrategy(sourceClusterAlwaysSchemaCompatibleNamespace,
+                SchemaCompatibilityStrategy.FORWARD);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -1359,11 +1359,11 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         producer1.newMessage(Schema.BOOL).value(false).send();
         producer1.newMessage(Schema.STRING).value("msg3").send();
         // 3. several unloading, which causes replicator internal producer reconnects.
-//        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++) {
             Thread.sleep(2000);
             admin2.topics().unload(topicName);
             waitReplicatorStarted(topicName);
-//        }
+        }
         // Verify: no individual acks.
         Awaitility.await().untilAsserted(() -> {
            PersistentTopic persistentTopic2 =
@@ -1375,7 +1375,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic1.getManagedLedger();
             ManagedCursorImpl cursor = (ManagedCursorImpl) ml.getCursors().get("pulsar.repl.r2");
             assertEquals(cursor.getTotalNonContiguousDeletedMessagesRange(), 0);
-            //assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) < 0);
+            assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) < 0);
         });
         // 4. Adjust schema compatibility and unload topic on the remote side, which will solve the replication stuck
         // issue.
@@ -1404,8 +1404,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             if (message == null) {
                 break;
             }
-//            SchemaType schemaType = message.getValue().getSchemaType();
-//            assertTrue(schemaType.equals(SchemaType.STRING) || schemaType.equals(SchemaType.BOOLEAN));
+            SchemaType schemaType = message.getValue().getSchemaType();
+            assertTrue(schemaType.equals(SchemaType.STRING) || schemaType.equals(SchemaType.BOOLEAN));
             msgReceived.add(message.getValue().getNativeObject().toString());
             log.info("received msg: {}", message.getValue().getNativeObject().toString());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -49,6 +49,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.policies.data.TopicType;
@@ -65,6 +66,7 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
     protected final String defaultTenant = "public";
     protected final String replicatedNamespace = defaultTenant + "/default";
     protected final String nonReplicatedNamespace = defaultTenant + "/ns1";
+    protected final String sourceClusterAlwaysSchemaCompatibleNamespace = defaultTenant + "/always-compatible";
 
     protected final String cluster1 = "r1";
 
@@ -157,6 +159,10 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
         admin1.tenants().createTenant(defaultTenant, new TenantInfoImpl(Collections.emptySet(),
                 Sets.newHashSet(cluster1, cluster2)));
         admin1.namespaces().createNamespace(replicatedNamespace, Sets.newHashSet(cluster1, cluster2));
+        admin1.namespaces().createNamespace(
+                sourceClusterAlwaysSchemaCompatibleNamespace, Sets.newHashSet(cluster1, cluster2));
+        admin1.namespaces().setSchemaCompatibilityStrategy(sourceClusterAlwaysSchemaCompatibleNamespace,
+                SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
         admin1.namespaces().createNamespace(nonReplicatedNamespace);
 
         if (!usingGlobalZK) {
@@ -177,6 +183,9 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
             admin2.tenants().createTenant(defaultTenant, new TenantInfoImpl(Collections.emptySet(),
                     Sets.newHashSet(cluster1, cluster2)));
             admin2.namespaces().createNamespace(replicatedNamespace);
+            admin2.namespaces().createNamespace(sourceClusterAlwaysSchemaCompatibleNamespace);
+            admin2.namespaces().setSchemaCompatibilityStrategy(sourceClusterAlwaysSchemaCompatibleNamespace,
+                    SchemaCompatibilityStrategy.FORWARD);
             admin2.namespaces().createNamespace(nonReplicatedNamespace);
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -204,4 +204,10 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
         admin2.topics().delete(topic);
         admin2.namespaces().deleteNamespace(ns1);
     }
+
+    @Override
+    @Test(dataProvider = "enableDeduplication", enabled = false)
+    public void testIncompatibleMultiVersionSchema(boolean enableDeduplication) throws Exception {
+        super.testIncompatibleMultiVersionSchema(enableDeduplication);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -223,4 +223,10 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         admin2.topics().delete(topic);
         admin2.namespaces().deleteNamespace(ns1);
     }
+
+    @Override
+    @Test(dataProvider = "enableDeduplication", enabled = false)
+    public void testIncompatibleMultiVersionSchema(boolean enableDeduplication) throws Exception {
+        super.testIncompatibleMultiVersionSchema(enableDeduplication);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -69,7 +69,7 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
@@ -42,25 +43,33 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.pulsar.TestNGInstanceOrder;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException.IncompatibleSchemaException;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidMessageException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.BinaryProtoLookupService;
+import org.apache.pulsar.client.impl.ClientBuilderImpl;
+import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.HttpLookupService;
 import org.apache.pulsar.client.impl.LookupService;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.client.impl.schema.reader.AvroReader;
 import org.apache.pulsar.client.impl.schema.writer.AvroWriter;
+import org.apache.pulsar.common.api.proto.CommandGetOrCreateSchemaResponse;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -76,6 +85,8 @@ import org.testng.annotations.Test;
 public class SimpleSchemaTest extends ProducerConsumerBase {
 
     private static final String NAMESPACE = "my-property/my-ns";
+    private static final String NAMESPACE_ALWAYS_COMPATIBLE = "my-property/always-compatible";
+    private static final String NAMESPACE_NEVER_COMPATIBLE = "my-property/never-compatible";
 
     @DataProvider(name = "batchingModes")
     public static Object[][] batchingModes() {
@@ -124,6 +135,12 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         this.isTcpLookup = true;
         super.internalSetup();
         super.producerBaseSetup();
+        admin.namespaces().createNamespace(NAMESPACE_ALWAYS_COMPATIBLE);
+        admin.namespaces().setSchemaCompatibilityStrategy(NAMESPACE_ALWAYS_COMPATIBLE,
+                SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE);
+        admin.namespaces().createNamespace(NAMESPACE_NEVER_COMPATIBLE);
+        admin.namespaces().setSchemaCompatibilityStrategy(NAMESPACE_NEVER_COMPATIBLE,
+                SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE);
     }
 
     @AfterClass(alwaysRun = true)
@@ -338,6 +355,78 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 }
             }
         }
+    }
+
+    @Test
+    public void testProducerConnectStateWhenRegisteringSchema() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName(NAMESPACE_ALWAYS_COMPATIBLE + "/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topics().createSubscription(topic, subscription, MessageId.earliest);
+
+        // Create a pulsar client with a delayed response of "getOrCreateSchemaResponse"
+        CompletableFuture<Void> responseSignal = new CompletableFuture<>();
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
+        PulsarClient client = InjectedClientCnxClientBuilder.create(clientBuilder, (conf, eventLoopGroup) ->
+            new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
+                protected void handleGetOrCreateSchemaResponse(
+                        CommandGetOrCreateSchemaResponse commandGetOrCreateSchemaResponse) {
+                    responseSignal.join();
+                    super.handleGetOrCreateSchemaResponse(commandGetOrCreateSchemaResponse);
+                }
+            });
+        Producer producer = client.newProducer(Schema.AUTO_PRODUCE_BYTES()).enableBatching(false).topic(topic).create();
+        producer.newMessage(Schema.STRING).value("msg").sendAsync();
+
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get();
+        assertEquals(persistentTopic.getProducers().size(), 1);
+        assertTrue(producer.isConnected());
+
+        // cleanup.
+        responseSignal.complete(null);
+        producer.close();
+        client.close();
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(persistentTopic.getProducers().size(), 0);
+        });
+        admin.topics().delete(topic);
+    }
+
+    @Test
+    public void testNoMemoryLeakIfSchemaIncompatible() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName(NAMESPACE_NEVER_COMPATIBLE + "/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topics().createSubscription(topic, subscription, MessageId.earliest);
+
+        // Create a pulsar client with a delayed response of "getOrCreateSchemaResponse"
+        CompletableFuture<Void> responseSignal = new CompletableFuture<>();
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString());
+        PulsarClient client = InjectedClientCnxClientBuilder.create(clientBuilder, (conf, eventLoopGroup) ->
+            new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup) {
+                protected void handleGetOrCreateSchemaResponse(
+                        CommandGetOrCreateSchemaResponse commandGetOrCreateSchemaResponse) {
+                    responseSignal.join();
+                    super.handleGetOrCreateSchemaResponse(commandGetOrCreateSchemaResponse);
+                }
+            });
+        Producer producer = client.newProducer(Schema.AUTO_PRODUCE_BYTES()).enableBatching(false).topic(topic).create();
+        producer.newMessage(Schema.STRING).value("msg").sendAsync();
+
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get();
+        assertEquals(persistentTopic.getProducers().size(), 1);
+        assertTrue(producer.isConnected());
+
+        // cleanup.
+        responseSignal.complete(null);
+        producer.close();
+        client.close();
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(persistentTopic.getProducers().size(), 0);
+        });
+        admin.topics().delete(topic);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLeakTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLeakTest.java
@@ -27,6 +27,7 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -39,9 +40,11 @@ import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
+import org.awaitility.reflect.WhiteboxImpl;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -52,11 +55,16 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-api")
 public class ProducerMemoryLeakTest extends ProducerConsumerBase {
 
+    private static final String NAMESPACE_NEVER_COMPATIBLE = "public/schema-never-compatible";
+
     @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
         super.producerBaseSetup();
+        admin.namespaces().createNamespace(NAMESPACE_NEVER_COMPATIBLE);
+        admin.namespaces().setSchemaCompatibilityStrategy(NAMESPACE_NEVER_COMPATIBLE,
+                SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE);
     }
 
     @AfterClass(alwaysRun = true)
@@ -268,6 +276,50 @@ public class ProducerMemoryLeakTest extends ProducerConsumerBase {
         admin.topics().delete(topicName);
     }
 
+    @Test
+    public void testBrokenSchema() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + NAMESPACE_NEVER_COMPATIBLE
+                + "/tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+        ProducerImpl producer =
+                (ProducerImpl) pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES()).topic(topicName).create();
+        // Publish after the producer was closed.
+        MsgPayloadTouchableMessageBuilder<String> msgBuilder1 = newMessage(producer, Schema.STRING);
+        msgBuilder1.value("msg-1").send();
+        MsgPayloadTouchableMessageBuilder<Boolean> msgBuilder2 = newMessage(producer, Schema.BOOL);
+        try {
+            msgBuilder2.value(false).send();
+            fail("expected schema broken error");
+        } catch (Exception ex) {
+            assertTrue(FutureUtil.unwrapCompletionException(ex)
+                    instanceof PulsarClientException.IncompatibleSchemaException);
+        }
+        MsgPayloadTouchableMessageBuilder<String> msgBuilder3 = newMessage(producer, Schema.STRING);
+        msgBuilder3.value("msg-3").send();
+
+        // Verify: message payload has been released.
+        Awaitility.await().untilAsserted(() -> {
+            ProducerImpl.OpSendMsgQueue pendingMessages =
+                    WhiteboxImpl.getInternalState(producer, "pendingMessages");
+            Queue<ProducerImpl.OpSendMsg> pendingMessagesInternal =
+                    WhiteboxImpl.getInternalState(pendingMessages, "delegate");
+            assertEquals(pendingMessagesInternal.size(), 0);
+        });
+        assertEquals(msgBuilder1.payload.refCnt(), 1);
+        assertEquals(msgBuilder2.payload.refCnt(), 1);
+        assertEquals(msgBuilder3.payload.refCnt(), 1);
+
+        // cleanup.
+        msgBuilder1.release();
+        msgBuilder2.release();
+        msgBuilder3.release();
+        assertEquals(msgBuilder1.payload.refCnt(), 0);
+        assertEquals(msgBuilder2.payload.refCnt(), 0);
+        assertEquals(msgBuilder3.payload.refCnt(), 0);
+        producer.close();
+        admin.topics().delete(topicName);
+    }
+
     @DataProvider
     public Object[][] failedInterceptAt() {
         return new Object[][]{
@@ -338,7 +390,11 @@ public class ProducerMemoryLeakTest extends ProducerConsumerBase {
     }
 
     private <T> MsgPayloadTouchableMessageBuilder<T> newMessage(ProducerImpl<T> producer){
-        return new MsgPayloadTouchableMessageBuilder<T>(producer, producer.schema);
+        return newMessage(producer, producer.schema);
+    }
+
+    private <T> MsgPayloadTouchableMessageBuilder<T> newMessage(ProducerImpl<T> producer, Schema<T> schema){
+        return new MsgPayloadTouchableMessageBuilder<T>(producer, schema);
     }
 
     private static class MsgPayloadTouchableMessageBuilder<T> extends TypedMessageBuilderImpl {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -109,8 +109,8 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                 && (pendingLId < lastPersistedSourceLedgerId || (pendingLId.longValue() == lastPersistedSourceLedgerId
                   && pendingEId.longValue() <= lastPersistedSourceEntryId))) {
             if (MessageImpl.SchemaState.Broken.equals(op.msg.getSchemaState())) {
-                log.error("[{}] [{}] Replication due to incompatible schem and the replicator will be stuck by producer"
-                                + " queue size limitation."
+                log.error("[{}] [{}] Replication is stuck because there is a schema is incompatible with the remote"
+                                + " cluster, please modify the schema compatibility for the remote cluster."
                                 + " Latest published entry {}:{}, Entry who has broken schema: {}:{},"
                                 + " latest persisted source entry: {}:{}, pending queue size: {}.",
                         topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -108,6 +108,15 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         if (pendingLId != null && pendingEId != null
                 && (pendingLId < lastPersistedSourceLedgerId || (pendingLId.longValue() == lastPersistedSourceLedgerId
                   && pendingEId.longValue() <= lastPersistedSourceEntryId))) {
+            if (MessageImpl.SchemaState.Broken.equals(op.msg.getSchemaState())) {
+                log.error("[{}] [{}] Replication due to incompatible schem and the replicator will be stuck by producer"
+                                + " queue size limitation."
+                                + " Latest published entry {}:{}, Entry who has broken schema: {}:{},"
+                                + " latest persisted source entry: {}:{}, pending queue size: {}.",
+                        topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,
+                        lastPersistedSourceLedgerId, lastPersistedSourceEntryId, pendingMessages.messagesCount());
+                return;
+            }
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] Received an msg send receipt[pending send is repeated due to repl cursor rewind]:"
                                 + " source entry {}:{}, pending send: {}:{}, latest persisted: {}:{}",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -109,7 +109,7 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                 && (pendingLId < lastPersistedSourceLedgerId || (pendingLId.longValue() == lastPersistedSourceLedgerId
                   && pendingEId.longValue() <= lastPersistedSourceEntryId))) {
             if (MessageImpl.SchemaState.Broken.equals(op.msg.getSchemaState())) {
-                log.error("[{}] [{}] Replication is stuck because there is a schema is incompatible with the remote"
+                log.error("[{}] [{}] Replication is paused because the schema is incompatible with the remote"
                                 + " cluster, please modify the schema compatibility for the remote cluster."
                                 + " Latest published entry {}:{}, Entry who has broken schema: {}:{},"
                                 + " latest persisted source entry: {}:{}, pending queue size: {}.",

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -111,7 +111,7 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
             if (MessageImpl.SchemaState.Broken.equals(op.msg.getSchemaState())) {
                 log.error("[{}] [{}] Replication is paused because the schema is incompatible with the remote"
                                 + " cluster, please modify the schema compatibility for the remote cluster."
-                                + " Latest published entry {}:{}, Entry who has broken schema: {}:{},"
+                                + " Latest published entry {}:{}, Entry who has incompatible schema: {}:{},"
                                 + " latest persisted source entry: {}:{}, pending queue size: {}.",
                         topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,
                         lastPersistedSourceLedgerId, lastPersistedSourceEntryId, pendingMessages.messagesCount());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerState.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerState.java
@@ -68,6 +68,10 @@ abstract class HandlerState {
                 || STATE_UPDATER.compareAndSet(this, State.RegisteringSchema, State.Ready));
     }
 
+    protected boolean compareAndSetState(State expect, State update) {
+        return STATE_UPDATER.compareAndSet(this, expect, update);
+    }
+
     protected boolean changeToRegisteringSchemaState() {
         return STATE_UPDATER.compareAndSet(this, State.Ready, State.RegisteringSchema);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2509,6 +2509,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     if (op.cmd == null) {
                         op.rePopulate.run();
                     }
+                    msgIterator.remove();
                     ReferenceCountUtil.safeRelease(op.cmd);
                     try {
                         // Need to protect ourselves from any exception being thrown in the future handler from the
@@ -2518,7 +2519,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         log.warn("Got exception while completing the failed publishing: {}", failedMsg, t);
                     }
                     releaseSemaphoreForSendOp(op);
-                    msgIterator.remove();
                     op.recycle();
                     continue;
                 } else if (op.msg.getSchemaState() == None) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -200,9 +200,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         this.userProvidedProducerName = StringUtils.isNotBlank(producerName);
         this.partitionIndex = partitionIndex;
         this.pendingMessages = createPendingMessagesQueue();
-        // Replication needs to be paused when a message can not be replicated due to failed schema registration. Otherwise,
-        // it may cause an out-of-order issue, and it may lead to a messages lost issue if users enabled deduplication
-        // on the remote side.
+        // Replication needs to be paused when a message can not be replicated due to failed schema registration.
+        // Otherwise, it may cause an out-of-order issue, and it may lead to a messages lost issue if users enabled
+        // deduplication on the remote side.
         this.pauseSendingToPreservePublishOrderOnSchemaRegFailure = conf.isReplProducer();
         if (conf.getMaxPendingMessages() > 0) {
             this.semaphore = Optional.of(new Semaphore(conf.getMaxPendingMessages(), true));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -189,7 +189,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private final Counter producersOpenedCounter;
     private final Counter producersClosedCounter;
-    private final boolean needStuckForOrderingIfSchemaRegFailed;
+    private final boolean pauseSendingToPreservePublishOrderOnSchemaRegFailure;
 
     public ProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf,
                         CompletableFuture<Producer<T>> producerCreatedFuture, int partitionIndex, Schema<T> schema,
@@ -203,7 +203,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         // Replication need be stuck when a message can not be replicated due to failed schema registration. Otherwise,
         // it may cause an out-of-order issue, and it may lead to a messages lost issue if users enabled deduplication
         // on the remote side.
-        this.needStuckForOrderingIfSchemaRegFailed = conf.isReplProducer();
+        this.pauseSendingToPreservePublishOrderOnSchemaRegFailure = conf.isReplProducer();
         if (conf.getMaxPendingMessages() > 0) {
             this.semaphore = Optional.of(new Semaphore(conf.getMaxPendingMessages(), true));
         } else {
@@ -2431,8 +2431,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      *   2-2. {@link #pendingMessages} has no other messages that need to register new schema.
      * 3. If using multiple version producer, the new schema was failed to registered.
      *   3-1. If the new schema is incompatible.
-     *     3-1-1. If {@link #needStuckForOrderingIfSchemaRegFailed} is true stuck all following publishing to avoid
-     *            out-of-order issue.
+     *     3-1-1. If {@link #pauseSendingToPreservePublishOrderOnSchemaRegFailure} is true stuck all following
+     *       publishing to avoid out-of-order issue.
      *     3-1-2. Otherwise, discard the failed message anc continuously publishing the following messages.
      *   3-2. The new schema registration failed due to other error, retry registering.
      * Note: Since the current method accesses & modifies {@link #pendingMessages}, you should acquire a lock on
@@ -2466,7 +2466,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 if (Broken.equals(op.msg.getSchemaState())) {
                     // "Event 1-1" happens after "Event 3-1-1".
                     // Maybe user has changed the schema compatibility strategy, will retry to register the new schema.
-                    if (needStuckForOrderingIfSchemaRegFailed) {
+                    if (pauseSendingToPreservePublishOrderOnSchemaRegFailure) {
                         loopEndDueToSchemaRegisterNeeded = op;
                         break;
                     } else {
@@ -2490,7 +2490,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // Event 3-1-1.
                     // New schema is incompatible, if users need to guarantee the publishing ordering, we should let
                     // the producer be stuck until user changed the compatibility policy and unload the target topic.
-                    if (needStuckForOrderingIfSchemaRegFailed) {
+                    if (pauseSendingToPreservePublishOrderOnSchemaRegFailure) {
                         log.error("[{}] [{}] Producer was stuck due to incompatible schem, please adjust your"
                                 + " schema compatibility strategy and unload the topic on the target cluster. {}",
                                 topic, producerName, String.valueOf(msgSchemaInfo));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2445,8 +2445,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             // called again once the new connection registers the producer with the broker.
             log.info("[{}][{}] Producer epoch mismatch or the current connection is null. Skip re-sending the "
                             + " {} pending messages since they will deliver using another connection.", topic,
-                    producerName,
-                    pendingMessages.messagesCount());
+                    producerName, pendingMessages.messagesCount());
             return;
         }
         final boolean stripChecksum = cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -86,6 +86,7 @@ import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
 import org.apache.pulsar.client.impl.metrics.Unit;
 import org.apache.pulsar.client.impl.metrics.UpDownCounter;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.client.util.MathUtils;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
@@ -2475,7 +2476,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                 : op.msg.getSchemaInfo();
                         log.error("[{}] [{}] A message attempts to register new schema, but failed. It should be"
                             + " removed from the pending queue but not, which is not expected. {}",
-                            topic, producerName, String.valueOf(msgSchemaInfo));
+                            topic, producerName, SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false));
                         releaseSemaphoreForSendOp(op);
                         msgIterator.remove();
                         op.recycle();
@@ -2494,7 +2495,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         log.error("[{}] [{}] Publishing paused: message schema incompatible with target cluster."
                                 + " To resume publishing: 1) Adjust schema compatibility strategy on target cluster"
                                 + " 2) Unload topic on target cluster. Schema details: {}",
-                                topic, producerName, String.valueOf(msgSchemaInfo));
+                                topic, producerName, SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false));
                         loopEndDueToSchemaRegisterNeeded = op;
                         break;
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -74,6 +74,7 @@ import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.CryptoException;
+import org.apache.pulsar.client.api.PulsarClientException.IncompatibleSchemaException;
 import org.apache.pulsar.client.api.PulsarClientException.TimeoutException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.Transaction;
@@ -188,6 +189,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private final Counter producersOpenedCounter;
     private final Counter producersClosedCounter;
+    private final boolean needStuckIfSchemaIncompatible;
 
     public ProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf,
                         CompletableFuture<Producer<T>> producerCreatedFuture, int partitionIndex, Schema<T> schema,
@@ -198,6 +200,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         this.userProvidedProducerName = StringUtils.isNotBlank(producerName);
         this.partitionIndex = partitionIndex;
         this.pendingMessages = createPendingMessagesQueue();
+        // Replication need be stuck when a message can not be replicated due to failed schema registration. Otherwise,
+        // it may cause an out-of-order issue, and it may lead to a messages lost issue if users enabled deduplication
+        // on the remote side.
+        this.needStuckIfSchemaIncompatible = conf.isReplProducer();
         if (conf.getMaxPendingMessages() > 0) {
             this.semaphore = Optional.of(new Semaphore(conf.getMaxPendingMessages(), true));
         } else {
@@ -514,7 +520,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      *     <ol>
      *       <li>Release 1: When the message is written out by
      *       {@link ChannelOutboundHandler#write(ChannelHandlerContext, Object, ChannelPromise)}.</li>
-     *       <li>Release 2: In the method {@link SendCallback#sendComplete(Throwable, OpSendMsgStats)}.</li>
+     *       <li>Release 2: In the method {@link ByteBufPair#release()}, which was called by
+     *       {@link SendCallback#sendComplete(Throwable, OpSendMsgStats)}.</li>
      *     </ol>
      *   </li>
      * </ul>
@@ -876,7 +883,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return true;
     }
 
-    private void tryRegisterSchema(ClientCnx cnx, MessageImpl msg, SendCallback callback, long expectedCnxEpoch) {
+    private void tryRegisterSchema(ClientCnx cnx, final MessageImpl msg, SendCallback callback, long expectedCnxEpoch) {
         if (!changeToRegisteringSchemaState()) {
             return;
         }
@@ -889,8 +896,15 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 Throwable t = FutureUtil.unwrapCompletionException(ex);
                 log.warn("[{}] [{}] GetOrCreateSchema error", topic, producerName, t);
                 if (t instanceof PulsarClientException.IncompatibleSchemaException) {
-                    msg.setSchemaState(MessageImpl.SchemaState.Broken);
-                    callback.sendComplete(t, null);
+                    // Only the first time of failed schema registration will trigger a "recoverProcessOpSendMsgFrom".
+                    if (!Broken.equals(msg.getSchemaState())) {
+                        cnx.ctx().channel().eventLoop().execute(() -> {
+                            synchronized (ProducerImpl.this) {
+                                recoverProcessOpSendMsgFrom(cnx, msg, true, expectedCnxEpoch);
+                            }
+                        });
+                    }
+                    return null;
                 }
             } else {
                 log.info("[{}] [{}] GetOrCreateSchema succeed", topic, producerName);
@@ -908,7 +922,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
             cnx.ctx().channel().eventLoop().execute(() -> {
                 synchronized (ProducerImpl.this) {
-                    recoverProcessOpSendMsgFrom(cnx, msg, expectedCnxEpoch);
+                    recoverProcessOpSendMsgFrom(cnx, msg, false, expectedCnxEpoch);
                 }
             });
             return null;
@@ -1231,7 +1245,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      * verify that the returned cnx is not null before using reference.
      */
     protected ClientCnx getCnxIfReady() {
-        if (getState() == State.Ready) {
+        State state = getState();
+        // When a producer is publishing with multiple schema, it may be switched to a "RegisteringSchema" state, even
+        // if the connection is established.
+        if (State.Ready.equals(state) || State.RegisteringSchema.equals(state)) {
             return connectionHandler.cnx();
         } else {
             return null;
@@ -2069,7 +2086,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 }
 
                 log.info("[{}] [{}] Re-Sending {} messages to server", topic, producerName, messagesToResend);
-                recoverProcessOpSendMsgFrom(cnx, null, expectedEpoch);
+                recoverProcessOpSendMsgFrom(cnx, null, false, expectedEpoch);
             }
         });
     }
@@ -2367,7 +2384,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
             pendingMessages.add(op);
             updateLastSeqPushed(op);
-
+            if (State.RegisteringSchema.equals(getState())) {
+                // Since there is a in-progress schema registration, do not continuously publish to avoid break publish
+                // ordering. After the schema registration finished, it will trigger a "recoverProcessOpSendMsgFrom" to
+                // publish all messages in "pendingMessages".
+                return;
+            }
             final ClientCnx cnx = getCnxIfReady();
             if (cnx != null) {
                 if (op.msg != null && op.msg.getSchemaState() == None) {
@@ -2399,8 +2421,25 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
     }
 
-    // Must acquire a lock on ProducerImpl.this before calling method.
-    private void recoverProcessOpSendMsgFrom(ClientCnx cnx, MessageImpl from, long expectedEpoch) {
+    /**
+     * There are following events that will call this method.
+     * 1. Republish messages in {@link #pendingMessages} after a reconnect.
+     *   1-1. Using multiple version producer, and there is a message has new schema that should be registered.
+     *   1-2. No message should register new schema.
+     * 2. If using multiple version producer, the new schema was registered successfully.
+     *   2-1. There is another message needs to register new schema,which is in {@link #pendingMessages}.
+     *   2-2. {@link #pendingMessages} has no other messages that need to register new schema.
+     * 3. If using multiple version producer, the new schema was failed to registered.
+     *   3-1. If the new schema is incompatible.
+     *     3-1-1. If {@link #needStuckIfSchemaIncompatible} is true stuck all following publishing to avoid
+     *            out-of-order issue.
+     *     3-1-2. Otherwise, discard the failed message anc continuously publishing the following messages.
+     *   3-2. The new schema registration failed due to other error, retry registering.
+     * Note: Since the current method accesses & modifies {@link #pendingMessages}, you should acquire a lock on
+     *       {@link ProducerImpl} before calling method.
+     */
+    private void recoverProcessOpSendMsgFrom(ClientCnx cnx, MessageImpl latestMsgAttemptedRegisteredSchema,
+                                             boolean failedIncompatibleSchema, long expectedEpoch) {
         if (expectedEpoch != this.connectionHandler.getEpoch() || cnx() == null) {
             // In this case, the cnx passed to this method is no longer the active connection. This method will get
             // called again once the new connection registers the producer with the broker.
@@ -2412,28 +2451,84 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         final boolean stripChecksum = cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion();
         Iterator<OpSendMsg> msgIterator = pendingMessages.iterator();
-        OpSendMsg pendingRegisteringOp = null;
+        MessageImpl loopStartAt = latestMsgAttemptedRegisteredSchema;
+        OpSendMsg loopEndDueToSchemaRegisterNeeded = null;
         while (msgIterator.hasNext()) {
             OpSendMsg op = msgIterator.next();
-            if (from != null) {
-                if (op.msg == from) {
-                    from = null;
+            if (loopStartAt != null) {
+                if (op.msg == loopStartAt) {
+                    loopStartAt = null;
                 } else {
                     continue;
                 }
             }
             if (op.msg != null) {
-                if (op.msg.getSchemaState() == None) {
-                    if (!rePopulateMessageSchema(op.msg)) {
-                        pendingRegisteringOp = op;
+                if (Broken.equals(op.msg.getSchemaState())) {
+                    // "Event 1-1" happens after "Event 3-1-1".
+                    // Maybe user has changed the schema compatibility strategy, will retry to register the new schema.
+                    if (needStuckIfSchemaIncompatible) {
+                        loopEndDueToSchemaRegisterNeeded = op;
+                        break;
+                    } else {
+                        // This scenario will never happen because the message will be removed from the queue as soon
+                        // as it was set to "schemaState -> Broken".
+                        SchemaInfo msgSchemaInfo = op.msg.hasReplicateFrom() ? op.msg.getSchemaInfoForReplicator()
+                                : op.msg.getSchemaInfo();
+                        log.error("[{}] [{}] A message attempts to register new schema, but failed. It should be"
+                            + " removed from the pending queue but not, which is not expected. {}",
+                            topic, producerName, String.valueOf(msgSchemaInfo));
+                        releaseSemaphoreForSendOp(op);
+                        msgIterator.remove();
+                        op.recycle();
+                        continue;
+                    }
+                } else if (op.msg == latestMsgAttemptedRegisteredSchema && failedIncompatibleSchema
+                        && op.msg.getSchemaState() == None) {
+                    op.msg.setSchemaState(Broken);
+                    SchemaInfo msgSchemaInfo = op.msg.hasReplicateFrom() ? op.msg.getSchemaInfoForReplicator()
+                            : op.msg.getSchemaInfo();
+                    // Event 3-1-1.
+                    // New schema is incompatible, if users need to guarantee the publishing ordering, we should let
+                    // the producer be stuck until user changed the compatibility policy and unload the target topic.
+                    if (needStuckIfSchemaIncompatible) {
+                        log.error("[{}] [{}] Producer was stuck due to incompatible schem, please adjust your"
+                                + " schema compatibility strategy and unload the topic on the target cluster. {}",
+                                topic, producerName, String.valueOf(msgSchemaInfo));
+                        loopEndDueToSchemaRegisterNeeded = op;
                         break;
                     }
-                } else if (op.msg.getSchemaState() == Broken) {
-                    op.recycle();
+                    // Event 3-1-2.
+                    // Give user a failed callback and remove the message from "pendingMessages".
+                    String failedMsg = format("[%s] [%s] incompatible schema %s", topic, producerName,
+                            String.valueOf(msgSchemaInfo));
+                    log.error(failedMsg);
+                    // The messages' release rely on "op.cmd"'s release, we need to initialize "op.cmd" and
+                    // release it to release "msg.payload".
+                    if (op.cmd == null) {
+                        op.rePopulate.run();
+                    }
+                    ReferenceCountUtil.safeRelease(op.cmd);
+                    try {
+                        // Need to protect ourselves from any exception being thrown in the future handler from the
+                        // application
+                        op.sendComplete(new IncompatibleSchemaException(failedMsg));
+                    } catch (Throwable t) {
+                        log.warn("Got exception while completing the failed publishing: {}", failedMsg, t);
+                    }
+                    releaseSemaphoreForSendOp(op);
                     msgIterator.remove();
+                    op.recycle();
                     continue;
+                } else if (op.msg.getSchemaState() == None) {
+                    // Event 1-1.
+                    // There is a message needs to register new schema when flushing pending messages after reconnected.
+                    if (!rePopulateMessageSchema(op.msg)) {
+                        loopEndDueToSchemaRegisterNeeded = op;
+                        break;
+                    }
                 }
             }
+            // "Event 1-2" or "Event 2-2" or "Event 3-1-2".
             if (op.cmd == null) {
                 checkState(op.rePopulate != null);
                 op.rePopulate.run();
@@ -2454,6 +2549,32 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             stats.updateNumMsgsSent(op.numMessagesInBatch, op.batchSizeByte);
         }
         cnx.ctx().flush();
+
+        // "Event 1-1" or "Event 3-1-1" or "Event 3-2".
+        if (loopEndDueToSchemaRegisterNeeded != null) {
+            if (compareAndSetState(State.Connecting, State.Ready)) {
+                // "Event 1-1" happens after "Event 3-1-1".
+                // After a topic unload, ask the producer retry to register schema, which avoids restart client
+                // after users changed the compatibility strategy to make the schema is compatible.
+                tryRegisterSchema(cnx, loopEndDueToSchemaRegisterNeeded.msg, loopEndDueToSchemaRegisterNeeded.callback,
+                    expectedEpoch);
+            } else if (!needStuckIfSchemaIncompatible && compareAndSetState(State.RegisteringSchema, State.Ready)) {
+                // "Event 2-1" or "Event 3-2".
+                // "pendingMessages" has more messages to register new schema.
+                // This operation will not be conflict with another schema registration because both operations are
+                // attempt to acquire the same lock "ProducerImpl.this".
+                tryRegisterSchema(cnx, loopEndDueToSchemaRegisterNeeded.msg, loopEndDueToSchemaRegisterNeeded.callback,
+                        expectedEpoch);
+            }
+            // Nothing to do if the event is "Event 3-1-1", just keep stuck.
+            return;
+        } else if (latestMsgAttemptedRegisteredSchema != null) {
+            // Event 2-2 or "Event 3-1-2".
+            // Switch state to "Ready" after a successful schema registration.
+            compareAndSetState(State.RegisteringSchema, State.Ready);
+        }
+        // "Event 1-2".
+        // Change state to "Ready" after reconnected.
         if (!changeToReadyState()) {
             // Producer was closed while reconnecting, close the connection to make sure the broker
             // drops the producer on its side
@@ -2464,9 +2585,6 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         // scheduling the batch flush task. Schedule it now, if there are messages in the batch container.
         if (isBatchMessagingEnabled() && !batchMessageContainer.isEmpty()) {
             maybeScheduleBatchFlushTask();
-        }
-        if (pendingRegisteringOp != null) {
-            tryRegisterSchema(cnx, pendingRegisteringOp.msg, pendingRegisteringOp.callback, expectedEpoch);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2489,7 +2489,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // Event 3-1-1.
                     // When a schema is incompatible, we need to pause the producer to preserve message order.
                     // Otherwise, subsequent messages with compatible schemas would be delivered while this message
-                    // remains stuck, causing out-of-order delivery or potential message loss with deduplication.                    
+                    // remains stuck, causing out-of-order delivery or potential message loss with deduplication.
                     if (pauseSendingToPreservePublishOrderOnSchemaRegFailure) {
                         log.error("[{}] [{}] Publishing paused: message schema incompatible with target cluster."
                                 + " To resume publishing: 1) Adjust schema compatibility strategy on target cluster"

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -200,7 +200,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         this.userProvidedProducerName = StringUtils.isNotBlank(producerName);
         this.partitionIndex = partitionIndex;
         this.pendingMessages = createPendingMessagesQueue();
-        // Replication need be stuck when a message can not be replicated due to failed schema registration. Otherwise,
+        // Replication needs to be paused when a message can not be replicated due to failed schema registration. Otherwise,
         // it may cause an out-of-order issue, and it may lead to a messages lost issue if users enabled deduplication
         // on the remote side.
         this.pauseSendingToPreservePublishOrderOnSchemaRegFailure = conf.isReplProducer();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2558,7 +2558,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 // after users changed the compatibility strategy to make the schema is compatible.
                 tryRegisterSchema(cnx, loopEndDueToSchemaRegisterNeeded.msg, loopEndDueToSchemaRegisterNeeded.callback,
                     expectedEpoch);
-            } else if (!needStuckIfSchemaIncompatible && compareAndSetState(State.RegisteringSchema, State.Ready)) {
+            } else if (!failedIncompatibleSchema && compareAndSetState(State.RegisteringSchema, State.Ready)) {
                 // "Event 2-1" or "Event 3-2".
                 // "pendingMessages" has more messages to register new schema.
                 // This operation will not be conflict with another schema registration because both operations are

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2431,7 +2431,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      *   2-2. {@link #pendingMessages} has no other messages that need to register new schema.
      * 3. If using multiple version producer, the new schema was failed to registered.
      *   3-1. If the new schema is incompatible.
-     *     3-1-1. If {@link #pauseSendingToPreservePublishOrderOnSchemaRegFailure} is true stuck all following
+     *     3-1-1. If {@link #pauseSendingToPreservePublishOrderOnSchemaRegFailure} is true pause all following
      *       publishing to avoid out-of-order issue.
      *     3-1-2. Otherwise, discard the failed message anc continuously publishing the following messages.
      *   3-2. The new schema registration failed due to other error, retry registering.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImplementationBindingImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImplementationBindingImpl.java
@@ -327,7 +327,7 @@ public final class PulsarClientImplementationBindingImpl implements PulsarClient
      * @return the jsonified schema info
      */
     public String jsonifySchemaInfo(SchemaInfo schemaInfo) {
-        return SchemaUtils.jsonifySchemaInfo(schemaInfo);
+        return SchemaUtils.jsonifySchemaInfo(schemaInfo, false);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImplementationBindingImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImplementationBindingImpl.java
@@ -327,7 +327,7 @@ public final class PulsarClientImplementationBindingImpl implements PulsarClient
      * @return the jsonified schema info
      */
     public String jsonifySchemaInfo(SchemaInfo schemaInfo) {
-        return SchemaUtils.jsonifySchemaInfo(schemaInfo, false);
+        return SchemaUtils.jsonifySchemaInfo(schemaInfo, true);
     }
 
     /**

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -286,7 +286,7 @@ public class SchemaInfoTest {
 
     @Test(dataProvider = "schemas")
     public void testSchemaInfoToString(SchemaInfo si, String jsonifiedStr) {
-        assertEquals(si.toString(), removeBlank(jsonifiedStr));
+        assertEquals(si.toString(), jsonifiedStr);
     }
 
     public static class SchemaInfoBuilderTest {
@@ -335,11 +335,7 @@ public class SchemaInfoTest {
                     .build();
 
             // null key will be skipped by Gson when serializing JSON to String
-            assertEquals(si.toString(), removeBlank(INT32_SCHEMA_INFO));
+            assertEquals(si.toString(), INT32_SCHEMA_INFO);
         }
-    }
-
-    private static String removeBlank(String src) {
-        return src.replaceAll(" ", "").replaceAll("\n", "").replaceAll("\t", "");
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -286,7 +286,7 @@ public class SchemaInfoTest {
 
     @Test(dataProvider = "schemas")
     public void testSchemaInfoToString(SchemaInfo si, String jsonifiedStr) {
-        assertEquals(si.toString(), jsonifiedStr);
+        assertEquals(si.toString(), removeBlank(jsonifiedStr));
     }
 
     public static class SchemaInfoBuilderTest {
@@ -335,7 +335,11 @@ public class SchemaInfoTest {
                     .build();
 
             // null key will be skipped by Gson when serializing JSON to String
-            assertEquals(si.toString(), INT32_SCHEMA_INFO);
+            assertEquals(si.toString(), removeBlank(INT32_SCHEMA_INFO));
         }
+    }
+
+    private static String removeBlank(String src) {
+        return src.replaceAll(" ", "").replaceAll("\n", "").replaceAll("\t", "");
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -117,6 +117,6 @@ public class SchemaInfoImpl implements SchemaInfo {
 
     @Override
     public String toString() {
-        return SchemaUtils.jsonifySchemaInfo(this);
+        return SchemaUtils.jsonifySchemaInfo(this, false);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaInfoImpl.java
@@ -117,6 +117,6 @@ public class SchemaInfoImpl implements SchemaInfo {
 
     @Override
     public String toString() {
-        return SchemaUtils.jsonifySchemaInfo(this, false);
+        return SchemaUtils.jsonifySchemaInfo(this, true);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -200,12 +200,13 @@ public final class SchemaUtils {
      * @param schemaInfo the schema info
      * @return the jsonified schema info
      */
-    public static String jsonifySchemaInfo(SchemaInfo schemaInfo) {
+    public static String jsonifySchemaInfo(SchemaInfo schemaInfo, boolean prettyPrinting) {
         GsonBuilder gsonBuilder = new GsonBuilder()
-            .setPrettyPrinting()
             .registerTypeHierarchyAdapter(byte[].class, new ByteArrayToStringAdapter(schemaInfo))
             .registerTypeHierarchyAdapter(Map.class, SCHEMA_PROPERTIES_SERIALIZER);
-
+        if (prettyPrinting) {
+            gsonBuilder.setPrettyPrinting();
+        }
         return gsonBuilder.create().toJson(schemaInfo);
     }
 
@@ -285,8 +286,8 @@ public final class SchemaUtils {
                     KeyValue<SchemaInfo, SchemaInfo> schemaInfoKeyValue =
                         DefaultImplementation.getDefaultImplementation().decodeKeyValueSchemaInfo(schemaInfo);
                     JsonObject obj = new JsonObject();
-                    String keyJson = jsonifySchemaInfo(schemaInfoKeyValue.getKey());
-                    String valueJson = jsonifySchemaInfo(schemaInfoKeyValue.getValue());
+                    String keyJson = jsonifySchemaInfo(schemaInfoKeyValue.getKey(), false);
+                    String valueJson = jsonifySchemaInfo(schemaInfoKeyValue.getValue(), false);
                     obj.add("key", toJsonElement(keyJson));
                     obj.add("value", toJsonElement(valueJson));
                     return obj;
@@ -312,7 +313,7 @@ public final class SchemaUtils {
                                      Type type,
                                      JsonSerializationContext jsonSerializationContext) {
             // schema will not a json, so use toJsonElement
-            return toJsonElement(jsonifySchemaInfo(schemaInfo));
+            return toJsonElement(jsonifySchemaInfo(schemaInfo, false));
         }
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -286,8 +286,8 @@ public final class SchemaUtils {
                     KeyValue<SchemaInfo, SchemaInfo> schemaInfoKeyValue =
                         DefaultImplementation.getDefaultImplementation().decodeKeyValueSchemaInfo(schemaInfo);
                     JsonObject obj = new JsonObject();
-                    String keyJson = jsonifySchemaInfo(schemaInfoKeyValue.getKey(), false);
-                    String valueJson = jsonifySchemaInfo(schemaInfoKeyValue.getValue(), false);
+                    String keyJson = jsonifySchemaInfo(schemaInfoKeyValue.getKey(), true);
+                    String valueJson = jsonifySchemaInfo(schemaInfoKeyValue.getValue(), true);
                     obj.add("key", toJsonElement(keyJson));
                     obj.add("value", toJsonElement(valueJson));
                     return obj;
@@ -313,7 +313,7 @@ public final class SchemaUtils {
                                      Type type,
                                      JsonSerializationContext jsonSerializationContext) {
             // schema will not a json, so use toJsonElement
-            return toJsonElement(jsonifySchemaInfo(schemaInfo, false));
+            return toJsonElement(jsonifySchemaInfo(schemaInfo, true));
         }
     }
 


### PR DESCRIPTION
### Motivation

**Issue 1: memory leak when publishing messages with a broken schema**
- Pulsar client will discard messages which has a broken schema, but it never releases the message when discarding the message.
- You can reproduce the issue with the new test `testBrokenSchema`.

---

**Issue 2: incorrect replication/producer state**
- The internal producer of the replicator connected.
- The producer tries to register a new schema, and the state was changed: `Ready -> RegisteringSchema`.
- The topic's stats response shows there is a producer connected, but the value of `replication.connected` or `producer.connected` shows `false`
- You can reproduce the issue with the new test `testProducerConnectStateWhenRegisteringSchema`

---

**Issue 3: replication lost messages or is out of order**

| `time / task` | `internal producer of replicator` | 
| --- | --- |
| 1 | send async `msg1` with a compatible schema |
| 2 | send asycn `msg2` with a incompatible schema |
| 3 | send async `msg1` with a compatible schema |

Result:
- `msg1` was sent
- `msg2` was discarded due to incompatible schema
- `msg3` was sent

---

**Issue 4: Reused a recycled SendCallback, which causes a dangerous issue**
| `time / task` | `client: publish with a broken schema` | `broker-side: handle schema` | `broker-side: disconnect` | `client: close producer`|
| --- | --- | --- | --- | --- |
| 1 | Sends new schema to Broker |
| 2 | | received the request of new schema registration |
| 3 | | switch to `metadata store threads` or `Bookie client threads` |
| 4 | | | Disconnect producers due to the unloading topic or others, but the socket has not been closed yet |
| 5 | | | | start to close producer |
| 6 | | respond to client: `Broken schema`|
| 7 | Calls "op.callback.sendComplete()", but `op` is still in `producer.pendingMessages`<sup>[1]</sup> |
| 8 | `op.callback` was recycled`|
| 9 | | | `client-side`: disconnected |
| 10 | | | | Calls `failPendingMessages`, which provides a failed callback for all pending messages |

At `step 10`, the producer will call a failed callback on a recycled `SendCallback` which has been recycled at `step 8`, but the object `SendCallback` may be used by others, which will cause unexpected and dangenrous issues.

**[1]** https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L894

```java
    private void tryRegisterSchema(ClientCnx cnx, MessageImpl msg, SendCallback callback, long expectedCnxEpoch) {
        SchemaInfo schemaInfo = ...;
        getOrCreateSchemaAsync(cnx, schemaInfo).handle((v, ex) -> {
            if (ex instanceof PulsarClientException.IncompatibleSchemaException) {
                msg.setSchemaState(MessageImpl.SchemaState.Broken);
                callback.sendComplete(t, null); // This line calls "callback.sendComplete", but the callback was still related to "producer.pendingMessages"
            }
            ...
        });
    }
```

You can reproduce `issues 3 and 4` with the new test `testIncompatibleMultiVersionSchema `, and you will get following various errors, but the test is not in order to reproduce a special case.


```
2025-04-14T12:35:08,452 - WARN  - [pulsar-io-64-13:AbstractEventExecutor] - A task raised an exception. Task: org.apache.pulsar.client.impl.ProducerImpl$$Lambda$1827/0x0000000500c1ba58@1d15c41a
java.lang.IllegalStateException: Some required fields are missing
	at org.apache.pulsar.common.api.proto.MessageMetadata.checkRequiredFields(MessageMetadata.java:1378) ~[classes/:?]
	at org.apache.pulsar.common.api.proto.MessageMetadata.writeTo(MessageMetadata.java:945) ~[classes/:?]
	at org.apache.pulsar.common.protocol.Commands.serializeCommandSendWithSize(Commands.java:1705) ~[classes/:?]
	at org.apache.pulsar.common.protocol.Commands.newSend(Commands.java:585) ~[classes/:?]
	at org.apache.pulsar.common.protocol.Commands.newSend(Commands.java:532) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.sendMessage(ProducerImpl.java:970) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.lambda$serializeAndSendMessage$3(ProducerImpl.java:814) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.recoverProcessOpSendMsgFrom(ProducerImpl.java:2449) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.lambda$tryRegisterSchema$6(ProducerImpl.java:912) ~[classes/:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask$$$capture(AbstractEventExecutor.java:173) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java) ~[netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:166) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566) [netty-transport-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
...
...
2025-04-14T12:35:10,843 - WARN  - [pulsar-web-99-14:ProducerImpl] - [persistent://public/always-compatible/tp_-aa24e8d7-94b0-41fa-84df-e747895cafc6] [pulsar.repl.r1-->r2] Got exception while completing the callback for msg 1:
java.lang.NullPointerException: Cannot read field "replicatorId" because "x0" is null
	at org.apache.pulsar.broker.service.persistent.PersistentReplicator.access$000(PersistentReplicator.java:75) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentReplicator$ProducerSendCallback.sendComplete(PersistentReplicator.java:401) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl$OpSendMsg.sendComplete(ProducerImpl.java:1658) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.lambda$failPendingMessages$18(ProducerImpl.java:2225) ~[classes/:?]
	at java.base/java.util.ArrayDeque.forEach(ArrayDeque.java:888) ~[?:?]
	at org.apache.pulsar.client.impl.ProducerImpl$OpSendMsgQueue.forEach(ProducerImpl.java:1749) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.failPendingMessages(ProducerImpl.java:2215) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.closeAndClearPendingMessages(ProducerImpl.java:1219) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.closeAsync(ProducerImpl.java:1185) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractReplicator.doCloseProducerAsync(AbstractReplicator.java:385) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractReplicator.terminate(AbstractReplicator.java:407) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$close$52(PersistentTopic.java:1684) ~[classes/:?]
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.close(PersistentTopic.java:1684) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.close(PersistentTopic.java:1617) ~[classes/:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadNonPartitionedTopicAsync$115(PersistentTopicsBase.java:1124) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalUnloadNonPartitionedTopicAsync(PersistentTopicsBase.java:1124) ~[classes/:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadTopic$97(PersistentTopicsBase.java:947) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2182) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadTopic$99(PersistentTopicsBase.java:913) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2182) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalUnloadTopic(PersistentTopicsBase.java:903) ~[classes/:?]
	at org.apache.pulsar.broker.admin.v2.PersistentTopics.unloadTopic(PersistentTopics.java:1134) ~[classes/:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:256) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:235) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:359) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:312) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.apache.pulsar.broker.web.WebService$FilterInitializer$WaitUntilPulsarServiceIsReadyForIncomingRequestsFilter.doFilter(WebService.java:336) ~[classes/:?]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlets.QoSFilter.doFilter(QoSFilter.java:202) ~[jetty-servlets-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:552) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:722) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:181) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
2025-04-14T12:35:10,843 - ERROR - [pulsar-web-99-14:PersistentReplicator] - [persistent://public/always-compatible/tp_-aa24e8d7-94b0-41fa-84df-e747895cafc6 | r1-->r2] Error producing on remote broker
org.apache.pulsar.client.api.PulsarClientException$AlreadyClosedException: The producer pulsar.repl.r1-->r2 of the topic persistent://public/always-compatible/tp_-aa24e8d7-94b0-41fa-84df-e747895cafc6 was already closed when closing the producers
	at org.apache.pulsar.client.impl.ProducerImpl.closeAndClearPendingMessages(ProducerImpl.java:1216) ~[classes/:?]
	at org.apache.pulsar.client.impl.ProducerImpl.closeAsync(ProducerImpl.java:1185) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractReplicator.doCloseProducerAsync(AbstractReplicator.java:385) ~[classes/:?]
	at org.apache.pulsar.broker.service.AbstractReplicator.terminate(AbstractReplicator.java:407) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$close$52(PersistentTopic.java:1684) ~[classes/:?]
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.close(PersistentTopic.java:1684) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.close(PersistentTopic.java:1617) ~[classes/:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadNonPartitionedTopicAsync$115(PersistentTopicsBase.java:1124) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalUnloadNonPartitionedTopicAsync(PersistentTopicsBase.java:1124) ~[classes/:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadTopic$97(PersistentTopicsBase.java:947) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2182) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalUnloadTopic$99(PersistentTopicsBase.java:913) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2182) ~[?:?]
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.internalUnloadTopic(PersistentTopicsBase.java:903) ~[classes/:?]
	at org.apache.pulsar.broker.admin.v2.PersistentTopics.unloadTopic(PersistentTopics.java:1134) ~[classes/:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:256) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265) ~[jersey-common-2.42.jar:?]
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:235) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684) ~[jersey-server-2.42.jar:?]
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:359) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:312) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205) ~[jersey-container-servlet-core-2.42.jar:?]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.apache.pulsar.broker.web.WebService$FilterInitializer$WaitUntilPulsarServiceIsReadyForIncomingRequestsFilter.doFilter(WebService.java:336) ~[classes/:?]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlets.QoSFilter.doFilter(QoSFilter.java:202) ~[jetty-servlets-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:552) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[jetty-servlet-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:722) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:181) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) [jetty-server-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) [jetty-io-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) [jetty-util-9.4.56.v20240826.jar:9.4.56.v20240826]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
2025-04-14T12:35:10,843 - INFO  - [pulsar-web-99-14:ManagedCursorImpl] - [public/always-compatible/persistent/tp_-aa24e8d7-94b0-41fa-84df-e747895cafc6-pulsar.repl.r2] Rewind from 2:1 to 2:1
...
...
// A incorrect schema was registered
2025-04-14T12:35:16,257 - WARN  - [pulsar-client-io-187-3:HttpClient] - [http://localhost:59689/admin/v2/schemas/public/always-compatible/tp_-23441596-5a6b-4ea4-9723-1dd23f7cea43/schema/1] HTTP get request failed: Schema not found
2025-04-14T12:35:16,257 - INFO  - [main:AutoConsumeSchema] - Configure topic schema \x00\x00\x00\x00\x00\x00\x00\x01 for topic persistent://public/always-compatible/tp_-23441596-5a6b-4ea4-9723-1dd23f7cea43 : 
2025-04-14T12:35:16,257 - INFO  - [main:OneWayReplicatorTest] - received msg: [B@29caf222
```

---

### Modifications

- Fix the 3 issues that were described in Motivation
- Print schemas in one line instead of pretty printing, which is helpful for searching and filtering.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x