### PR TITLE
[improve][PIP-413] Expose Index Through Message ID to Clients

### DIFF
--- a/pip/pip-413.md
+++ b/pip/pip-413.md
@@ -1,0 +1,190 @@
+# PIP-413: Expose Index Through Message ID to Clients
+
+## Background Knowledge
+
+In [PIP-70](https://github.com/apache/pulsar/wiki/PIP-70%3A-Introduce-lightweight-broker-entry-metadata), we introduced `Broker Entry Metadata` containing an `index` field - a continuous sequence identifier for messages within a topic partition. This sequence ID simplifies message sequence management compared to the composite MessageId (ledgerId+entryId+batchIndex) which becomes discontinuous across ledgers.
+
+[PIP-90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client) subsequently exposed this metadata via the `Message.getIndex()` API. However, current implementations create confusion - while the index serves similar positioning functionality to MessageId, there's no formal API support for index-based operations like `seekByIndex` or index-based acknowledgments.
+
+## Motivation
+
+Our organization is currently planning a migration from RocketMQ to Pulsar. To facilitate this transition, we aim to implement a standardized abstraction layer for MQ clients that encapsulates implementation details of specific messaging systems. This abstraction layer will allow seamless engine replacement while maintaining consistent client interfaces. However, two critical compatibility issues hinder the unification of message fetching patterns between RocketMQ/Kafka and Pulsar:
+
+1. **Interface Disparity**:
+   Pulsar currently lacks native support for offset-based message fetching (fetch/pull paradigm) that allows specifying exact message positions and batch sizes.
+
+2. **Positioning Mechanism Mismatch**:
+    - RocketMQ/Kafka: Utilize monotonically increasing numerical offsets for message positioning and acknowledgment
+    - Pulsar: Relies on composite MessageID (ledgerId + entryId + batchIndex) for message identification
+
+_This proposal specifically addresses the second issue while leaving the fetch/pull API discussion for future consideration._
+
+The current implementation exposes message index (through `Message.getIndex()`) but fails to provide corresponding operational APIs. This creates an inconsistency where:
+
+- Index values are available in message metadata
+- Core operations (seek/ack) still require MessageID-based parameters
+- Clients cannot fully leverage the offset-like index for position management
+
+By integrating index into MessageID, we can unify positioning mechanisms while maintaining backward compatibility.
+
+---
+
+## Goals
+
+### In Scope
+
+1. **Index Exposure Standardization**:
+
+    - Propagate broker entry metadata index through MessageID interface
+
+    - Enable index-based operations via existing APIs:
+
+      ```java
+      consumer.acknowledge(message.getMessageId()); // MessageID now contains index
+      consumer.seek(messageIdWithIndex); 
+      ```
+
+### Out of Scope
+
+1. Implementation of new pull/fetch APIs
+2. Other APIs besides the enhanced seek/ack APIs supporting index-based operations
+
+## High Level Design
+
+We propose extending the MessageId system to incorporate index metadata:
+
+1. **Protocol Extension**: Add optional `index` field to MessageIdData protobuf
+2. **Interface Enhancement**: Introduce `getIndex()` in MessageIdAdv interface
+3. **Backward Compatibility**: Maintain existing MessageId construction patterns while enabling index-aware operations
+
+## Detailed Design
+
+### Design & Implementation Details
+
+#### Protocol Buffers Extension
+
+```protobuf
+message MessageIdData {
+    required uint64 ledgerId = 1;
+    required uint64 entryId = 2;
+    optional int32 partition = 3 [default = -1];
+    optional int32 batchIndex = 4 [default = -1];
+    optional int64 batchSize = 5;
+    optional int64 ack_set = 6;
+    optional int64 timestamp = 7;
+    optional int64 index = 8; // New index field
+}
+```
+
+#### Java Interface Update
+
+```java
+public interface MessageIdAdv extends MessageId {
+    /**
+     * Retrieves the continuous sequence index from broker entry metadata
+     * @return index value or -1 if unavailable
+     */
+    default long getIndex() {
+        return -1;
+    }
+}
+```
+
+#### Enhanced MessageId Implementation
+
+```java
+public class MessageIdImpl implements MessageIdAdv {
+    private final long index;
+    // Existing fields: partitionIndex, ledgerId, entryId, batchIndex, etc.
+
+    // Existing constructors with ledgerId, entryId, partitionIndex
+    public MessageIdImpl(long ledgerId, long entryId, int partitionIndex) {
+        // Existing initialization
+    }
+    // New constructor with partitionIndex and index
+    public MessageIdImpl(int partitionIndex, long index) {
+        this.partitionIndex = partitionIndex;
+        this.index = index;
+    }
+
+    @Override
+    public long getIndex() {
+        return index;
+    }
+}
+```
+
+### Public-facing Changes
+
+#### Public API
+
+- New `getIndex()` method in MessageIdAdv interface
+- Updated MessageId constructors supporting index initialization
+- Enhanced seek/ack APIs supporting index-based operations
+
+#### Binary Protocol
+
+- Extended MessageIdData protobuf definition with optional index field
+
+#### Compatibility Considerations
+
+- Old clients ignore new index field during deserialization
+- New clients fall back to legacy positioning when index unavailable
+- Broker configuration controls index inclusion in responses
+
+## Monitoring
+
+No new metrics required. Existing message tracking metrics automatically incorporate index information when available.
+
+## Security Considerations
+
+NONE
+
+## Backward & Forward Compatibility
+
+### Upgrade
+
+#### For Index-based Message Positioning
+
+**Required Steps**:
+
+1. Upgrade brokers to versions supporting this feature
+2. Upgrade clients to versions supporting this feature
+
+#### For Legacy Usage
+
+- Follow standard upgrade procedures
+- **No breaking changes** introduced by this proposal
+
+### Downgrade/Rollback
+
+#### If Index Feature Was Adopted
+
+**Rollback Procedure**:
+
+1. Application code modification: Remove index-dependent implementations
+2. Downgrade client libraries to pre-feature versions
+3. Downgrade brokers to pre-feature versions
+
+#### If Index Feature Was Not Used
+
+- Follow standard downgrade procedures
+
+## Alternatives
+
+1. **New Index-Specific APIs**
+    - Rejected due to interface proliferation and migration complexity
+
+## General Notes
+
+This change enables Pulsar to better support:
+
+1. Offset-based messaging patterns
+2. Simplified migration from other messaging systems
+
+# Links
+
+- [PIP-70: Broker Entry Metadata](https://github.com/apache/pulsar/wiki/PIP-70)
+- [PIP-90: Metadata Exposure](https://github.com/apache/pulsar/wiki/PIP-90)
+- Mailing List Discussion: [thread-link]
+- Voting Thread: [voting-link]


### PR DESCRIPTION
## Background Knowledge

In [PIP-70](https://github.com/apache/pulsar/wiki/PIP-70%3A-Introduce-lightweight-broker-entry-metadata), we introduced `Broker Entry Metadata` containing an `index` field - a continuous sequence identifier for messages within a topic partition. This sequence ID simplifies message sequence management compared to the composite MessageId (ledgerId+entryId+batchIndex) which becomes discontinuous across ledgers.

[PIP-90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client) subsequently exposed this metadata via the `Message.getIndex()` API. However, current implementations create confusion - while the index serves similar positioning functionality to MessageId, there's no formal API support for index-based operations like `seekByIndex` or index-based acknowledgments.

## Motivation

Our organization is currently planning a migration from RocketMQ to Pulsar. To facilitate this transition, we aim to implement a standardized abstraction layer for MQ clients that encapsulates implementation details of specific messaging systems. This abstraction layer will allow seamless engine replacement while maintaining consistent client interfaces. However, two critical compatibility issues hinder the unification of message fetching patterns between RocketMQ/Kafka and Pulsar:

1. **Interface Disparity**:
   Pulsar currently lacks native support for offset-based message fetching (fetch/pull paradigm) that allows specifying exact message positions and batch sizes.

2. **Positioning Mechanism Mismatch**:
    - RocketMQ/Kafka: Utilize monotonically increasing numerical offsets for message positioning and acknowledgment
    - Pulsar: Relies on composite MessageID (ledgerId + entryId + batchIndex) for message identification

_This proposal specifically addresses the second issue while leaving the fetch/pull API discussion for future consideration._

The current implementation exposes message index (through `Message.getIndex()`) but fails to provide corresponding operational APIs. This creates an inconsistency where:

- Index values are available in message metadata
- Core operations (seek/ack) still require MessageID-based parameters
- Clients cannot fully leverage the offset-like index for position management

By integrating index into MessageID, we can unify positioning mechanisms while maintaining backward compatibility.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
