### PR TITLE
[improve][build] Build apachepulsar/pulsar-io-kinesis-sink-kinesis_producer with Alpine 3.21

### DIFF
--- a/docker/kinesis-producer-alpine/Dockerfile
+++ b/docker/kinesis-producer-alpine/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG ALPINE_VERSION=3.20
+ARG ALPINE_VERSION=3.21
 
 # Builds an Alpine image with kinesis_producer compiled for Alpine Linux / musl
 

--- a/docker/kinesis-producer-alpine/README.md
+++ b/docker/kinesis-producer-alpine/README.md
@@ -31,7 +31,11 @@ This image only needs to be re-created when we want to upgrade to a newer versio
 1. Change the version in the Dockerfile for this directory.
 2. Rebuild the image and push it to Docker Hub:
 ```
-docker buildx build --platform=linux/amd64,linux/arm64 -t apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:0.15.12 . --push
+IMAGE=apachepulsar/pulsar-io-kinesis-sink-kinesis_producer
+KINESIS_PRODUCER_VERSION=0.15.12
+docker buildx build --platform=linux/amd64,linux/arm64 \
+ -t "$IMAGE:$KINESIS_PRODUCER_VERSION" -t "$IMAGE:${KINESIS_PRODUCER_VERSION}-$(date -I)" \
+ . --push
 ```
 
 The image tag is then used in `docker/pulsar-all/Dockerfile`. The `kinesis_producer` binary is copied from the image to the `pulsar-all` image that is used by Pulsar Functions to run the Pulsar IO Kinesis Sink connector. The environment variable `PULSAR_IO_KINESIS_KPL_PATH` is set to `/opt/amazon-kinesis-producer/bin/kinesis_producer` and this is how the Kinesis Sink connector knows where to find the `kinesis_producer` binary.

--- a/docker/kinesis-producer-alpine/build-alpine.sh
+++ b/docker/kinesis-producer-alpine/build-alpine.sh
@@ -58,7 +58,7 @@ fi
 
 # Build Boost
 if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
-  curl -LO https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
+  curl -LO https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
   tar xf boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
   rm boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
 


### PR DESCRIPTION
### Motivation

The current [`apachepulsar/pulsar-io-kinesis-sink-kinesis_producer` image](https://hub.docker.com/r/apachepulsar/pulsar-io-kinesis-sink-kinesis_producer/tags) has been built with Alpine 3.20.
Some strict security scanners seem to flag the binary due to outdated static libraries or something similar.

### Modifications

- Update Alpine version to 3.21 in the docker image
- The image will be built and pushed separately to https://hub.docker.com/r/apachepulsar/pulsar-io-kinesis-sink-kinesis_producer/tags. This is used in the pulsar-all Dockerfile to provide the kinesis_producer binary for the Pulsar IO Kinesis Sink.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->