### PR TITLE
[fix][client] Fix incorrect producer.getPendingQueueSize due to incomplete queue implementation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -99,7 +99,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -1458,9 +1458,9 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
     }
 
     /**
-     * This test validates that consumer/producers should recover on topic whose 
+     * This test validates that consumer/producers should recover on topic whose
      * schema ledgers are not able to open due to non-recoverable error.
-     * 
+     *
      * @throws Exception
      */
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -56,6 +57,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema.Parser;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry;
@@ -65,6 +67,7 @@ import org.apache.pulsar.broker.service.schema.SchemaStorageFormat.SchemaLocator
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -76,6 +79,7 @@ import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
+import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
 import org.apache.pulsar.client.impl.schema.ProtobufSchema;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
@@ -95,6 +99,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataSerde;
 import org.apache.pulsar.metadata.api.Stat;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -1493,6 +1498,32 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertNotNull(producer);
         consumer.close();
         producer.close();
+    }
+
+    @Test
+    public void testPendingQueueSizeIfIncompatible() throws Exception {
+        final String namespace = BrokerTestUtil.newUniqueName(PUBLIC_TENANT + "/ns");
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet(CLUSTER_NAME));
+        admin.namespaces().setSchemaCompatibilityStrategy(namespace, SchemaCompatibilityStrategy.ALWAYS_INCOMPATIBLE);
+        final String topic = BrokerTestUtil.newUniqueName(namespace + "/tp");
+        admin.topics().createNonPartitionedTopic(topic);
+
+        ProducerImpl producer = (ProducerImpl) pulsarClient.newProducer(Schema.AUTO_PRODUCE_BYTES())
+                .maxPendingMessages(50).enableBatching(false).topic(topic).create();
+        producer.newMessage(Schema.STRING).value("msg").sendAsync();
+        AtomicReference<CompletableFuture<MessageId>> latestSend = new AtomicReference<>();
+        for (int i = 0; i < 100; i++) {
+            latestSend.set(producer.newMessage(Schema.BOOL).value(false).sendAsync());
+        }
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(latestSend.get().isDone());
+        });
+
+        assertEquals(producer.getPendingQueueSize(), 0);
+
+        // cleanup.
+        producer.close();
+        admin.topics().delete(topic, false);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -1545,9 +1545,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         }
         Awaitility.await().untilAsserted(() -> {
             assertTrue(latestSend.get().isDone());
+            assertEquals(producer.getPendingQueueSize(), 0);
         });
-
-        assertEquals(producer.getPendingQueueSize(), 0);
 
         // cleanup.
         producer.close();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1794,7 +1794,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         public Iterator<OpSendMsg> iterator() {
             Iterator<OpSendMsg> delegateIterator = delegate.iterator();
             return new Iterator<OpSendMsg>() {
-
+                OpSendMsg currentOp;
+                
                 @Override
                 public boolean hasNext() {
                     return delegateIterator.hasNext();
@@ -1802,13 +1803,17 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
                 @Override
                 public OpSendMsg next() {
-                    return delegateIterator.next();
+                    currentOp = delegateIterator.next();
+                    return currentOp;
                 }
 
                 @Override
                 public void remove() {
                     delegateIterator.remove();
-                    messagesCount.addAndGet(-1);
+                    if (currentOp != null) {
+                       messagesCount.addAndGet(-currentOp.numMessagesInBatch);
+                       currentOp = null;
+                     }
                 }
 
                 @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1795,7 +1795,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             Iterator<OpSendMsg> delegateIterator = delegate.iterator();
             return new Iterator<OpSendMsg>() {
                 OpSendMsg currentOp;
-                
+
                 @Override
                 public boolean hasNext() {
                     return delegateIterator.hasNext();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/OpSendMsgQueueTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/OpSendMsgQueueTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
+import java.util.Iterator;
 import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -82,5 +83,22 @@ public class OpSendMsgQueueTest {
 
         // then
         assertEquals(Lists.newArrayList(queue), Arrays.asList(opSendMsg, opSendMsg2, opSendMsg3, opSendMsg4));
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        ProducerImpl.OpSendMsgQueue queue = new ProducerImpl.OpSendMsgQueue();
+        for (int i = 0; i < 10; i++) {
+            queue.add(createDummyOpSendMsg());
+        }
+
+        Iterator<ProducerImpl.OpSendMsg> iterator = queue.iterator();
+        while (iterator.hasNext()) {
+            iterator.next();
+            iterator.remove();
+        }
+        // Verify: the result of "messagesCount()" is 0 after removed all items.
+        assertEquals(queue.delegate.size(), 0);
+        assertEquals(queue.messagesCount(), 0);
     }
 }


### PR DESCRIPTION
### Motivation

`ProducerImpl.OpSendMsgQueue` is a customized collection, but it will not decrease `size` when calling `ProducerImpl.OpSendMsgQueue.Iterator -> remove()`, which causes incorrect `producer.getPendingQueueSize()`

### Modifications

- fix the issue

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
