### PR TITLE
[fix][broker] Fixes Inconsistent ServiceUnitStateData View (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateData.java
@@ -75,19 +75,4 @@ public record ServiceUnitStateData(
     public static ServiceUnitState state(ServiceUnitStateData data) {
         return data == null ? ServiceUnitState.Init : data.state();
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ServiceUnitStateData that = (ServiceUnitStateData) o;
-
-        return versionId == that.versionId;
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateDataTest.java
@@ -21,10 +21,13 @@ package org.apache.pulsar.broker.loadbalance.extensions.channel;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Assigning;
 import static org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState.Owned;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.testng.annotations.Test;
 
@@ -75,5 +78,26 @@ public class ServiceUnitStateDataTest {
         String json = mapper.writeValueAsString(src);
         ServiceUnitStateData dst = mapper.readValue(json, ServiceUnitStateData.class);
         assertEquals(dst, src);
+    }
+
+    @Test
+    public void equalsTest() {
+        // record ServiceUnitStateData(
+        //        ServiceUnitState state, String dstBroker, String sourceBroker,
+        //       Map<String, Optional<String>> splitServiceUnitToDestBroker, boolean force,
+        //       long timestamp, long versionId) {
+        var d1 = new ServiceUnitStateData(Assigning, "A", "B", Map.of("A", Optional.of("B")), true, 0, 1);
+        var d2 = new ServiceUnitStateData(Assigning, "A", "B", Map.of("A", Optional.of("B")), true, 0, 1);
+        assertEquals(d1, d2);
+        var d3 = new ServiceUnitStateData(Assigning, "C", "B", 1);
+        var d4 = new ServiceUnitStateData(Assigning, "A", "B", Map.of("A", Optional.of("C")), true, 0, 1);
+        assertNotEquals(d1, d3);
+        assertNotEquals(d1, d4);
+
+        var d5 = new ServiceUnitStateData(Assigning, "A", "B", Map.of("A", Optional.of("B")), true, 0, 2);
+        assertNotEquals(d1, d5);
+
+        var d6 = new ServiceUnitStateData(Assigning, "C", "B", Map.of("A", Optional.of("B")), true, 0, 1);
+        assertNotEquals(d1, d6);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Backoff.java
@@ -43,9 +43,13 @@ public class Backoff {
             TimeUnit unitMandatoryStop, Clock clock) {
         this.initial = unitInitial.toMillis(initial);
         this.max = unitMax.toMillis(max);
+        if (initial == 0 && max == 0 && mandatoryStop == 0) {
+            this.mandatoryStopMade = true;
+        }
         this.next = this.initial;
         this.mandatoryStop = unitMandatoryStop.toMillis(mandatoryStop);
         this.clock = clock;
+        this.firstBackoffTimeInMillis = 0;
     }
 
     public Backoff(long initial, TimeUnit unitInitial, long max, TimeUnit unitMax, long mandatoryStop,
@@ -91,7 +95,11 @@ public class Backoff {
 
     public void reset() {
         this.next = this.initial;
-        this.mandatoryStopMade = false;
+        if (initial == 0 && max == 0 && mandatoryStop == 0) {
+            this.mandatoryStopMade = true;
+        } else {
+            this.mandatoryStopMade = false;
+        }
     }
 
     public static boolean shouldBackoff(long initialTimestamp, TimeUnit unitInitial, int failedAttempts,

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -103,22 +103,6 @@ public interface MetadataCache<T> {
     CompletableFuture<T> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction);
 
     /**
-     * Perform an atomic read-modify-update of the value with the cached version.
-     * <p>
-     * This fail-fasts without retries (e.g. fail-fast upon BadVersionException)
-     * <p>
-     * If the object does not exist yet, the <code>modifyFunction</code> will get passed an {@link Optional#empty()}
-     * object.
-     *
-     * @param path
-     *            the path of the object in the metadata store
-     * @param modifyFunction
-     *            a function that will be passed the current value and returns a modified value to be stored
-     * @return a future to track the completion of the operation
-     */
-    CompletableFuture<T> readModifyUpdateOrCreateOnce(String path, Function<Optional<T>, T> modifyFunction);
-
-    /**
      * Perform an atomic read-modify-update of the value.
      * <p>
      * The modify function can potentially be called multiple times if there are concurrent updates happening.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCache.java
@@ -103,6 +103,22 @@ public interface MetadataCache<T> {
     CompletableFuture<T> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction);
 
     /**
+     * Perform an atomic read-modify-update of the value with the cached version.
+     * <p>
+     * This fail-fasts without retries (e.g. fail-fast upon BadVersionException)
+     * <p>
+     * If the object does not exist yet, the <code>modifyFunction</code> will get passed an {@link Optional#empty()}
+     * object.
+     *
+     * @param path
+     *            the path of the object in the metadata store
+     * @param modifyFunction
+     *            a function that will be passed the current value and returns a modified value to be stored
+     * @return a future to track the completion of the operation
+     */
+    CompletableFuture<T> readModifyUpdateOrCreateOnce(String path, Function<Optional<T>, T> modifyFunction);
+
+    /**
      * Perform an atomic read-modify-update of the value.
      * <p>
      * The modify function can potentially be called multiple times if there are concurrent updates happening.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataCacheConfig.java
@@ -39,6 +39,11 @@ public class MetadataCacheConfig<T> {
                     .setMax(3, TimeUnit.SECONDS)
                     .setMandatoryStop(30, TimeUnit.SECONDS);
 
+    public static final BackoffBuilder NO_RETRY_BACKOFF_BUILDER =
+            new BackoffBuilder().setInitialTime(0, TimeUnit.MILLISECONDS)
+                    .setMax(0, TimeUnit.SECONDS)
+                    .setMandatoryStop(0, TimeUnit.SECONDS);
+
     /**
      * Specifies that active entries are eligible for automatic refresh once a fixed duration has
      * elapsed after the entry's creation, or the most recent replacement of its value.

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -165,12 +165,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     @Override
     public CompletableFuture<T> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction) {
-        return executeWithRetry(() -> readModifyUpdateOrCreateOnce(path, modifyFunction), path);
-    }
-
-    @Override
-    public CompletableFuture<T> readModifyUpdateOrCreateOnce(String path, Function<Optional<T>, T> modifyFunction) {
-        return objCache.get(path)
+        return executeWithRetry(() -> objCache.get(path)
                 .thenCompose(optEntry -> {
                     Optional<T> currentValue;
                     long expectedVersion;
@@ -203,7 +198,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(__ -> {
                         refresh(path);
                     }).thenApply(__ -> newValueObj);
-                });
+                }), path);
     }
 
     @Override
@@ -344,8 +339,12 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                 objCache.synchronous().invalidate(key);
                 long elapsed = System.currentTimeMillis() - backoff.getFirstBackoffTimeInMillis();
                 if (backoff.isMandatoryStopMade()) {
-                    result.completeExceptionally(new TimeoutException(
-                            String.format("Timeout to update key %s. Elapsed time: %d ms", key, elapsed)));
+                    if (backoff.getFirstBackoffTimeInMillis() == 0) {
+                        result.completeExceptionally(ex.getCause());
+                    } else {
+                        result.completeExceptionally(new TimeoutException(
+                                String.format("Timeout to update key %s. Elapsed time: %d ms", key, elapsed)));
+                    }
                     return null;
                 }
                 final var next = backoff.next();

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -170,7 +170,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     @Override
     public CompletableFuture<T> readModifyUpdateOrCreateOnce(String path, Function<Optional<T>, T> modifyFunction) {
-        return executeWithRetry(() -> objCache.get(path)
+        return objCache.get(path)
                 .thenCompose(optEntry -> {
                     Optional<T> currentValue;
                     long expectedVersion;
@@ -203,7 +203,7 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
                     return store.put(path, newValue, Optional.of(expectedVersion)).thenAccept(__ -> {
                         refresh(path);
                     }).thenApply(__ -> newValueObj);
-                }), path);
+                });
     }
 
     @Override

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/cache/impl/MetadataCacheImpl.java
@@ -165,6 +165,11 @@ public class MetadataCacheImpl<T> implements MetadataCache<T>, Consumer<Notifica
 
     @Override
     public CompletableFuture<T> readModifyUpdateOrCreate(String path, Function<Optional<T>, T> modifyFunction) {
+        return executeWithRetry(() -> readModifyUpdateOrCreateOnce(path, modifyFunction), path);
+    }
+
+    @Override
+    public CompletableFuture<T> readModifyUpdateOrCreateOnce(String path, Function<Optional<T>, T> modifyFunction) {
         return executeWithRetry(() -> objCache.get(path)
                 .thenCompose(optEntry -> {
                     Optional<T> currentValue;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
@@ -111,6 +111,7 @@ public class MetadataStoreTableViewImpl<T> implements MetadataStoreTableView<T> 
                 MetadataCacheConfig.<T>builder()
                         .expireAfterWriteMillis(-1)
                         .refreshAfterWriteMillis(CACHE_REFRESH_FREQUENCY_IN_MILLIS)
+                        .retryBackoff(MetadataCacheConfig.NO_RETRY_BACKOFF_BUILDER)
                         .asyncReloadConsumer(this::consumeAsyncReload)
                         .build());
         store.registerListener(this::handleNotification);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
@@ -299,23 +299,22 @@ public class MetadataStoreTableViewImpl<T> implements MetadataStoreTableView<T> 
 
     public CompletableFuture<Void> put(String key, T value) {
         String path = getPath(key);
-        return cache.readModifyUpdateOrCreateOnce(path, (old) -> {
-                    if (conflictResolver.test(old.orElse(null), value)) {
-                        return value;
-                    } else {
-                        throw new ConflictException(
-                                String.format("Failed to update from old:%s to value:%s", old, value));
-                    }
-                })
-                .thenCompose(__ -> doHandleNotification(path))  // immediately notify local tableview
-                .exceptionally(e -> {
-                    if (e.getCause() instanceof MetadataStoreException.BadVersionException) {
-                        throw FutureUtil.wrapToCompletionException(new ConflictException(
-                                String.format("Failed to update to value:%s", value)));
-                    }
+        return cache.readModifyUpdateOrCreate(path, (old) -> {
+            if (conflictResolver.test(old.orElse(null), value)) {
+                return value;
+            } else {
+                throw new ConflictException(
+                        String.format("Failed to update from old:%s to value:%s", old, value));
+            }
+        }).thenCompose(__ -> doHandleNotification(path)) // immediately notify local tableview
+        .exceptionally(e -> {
+            if (e.getCause() instanceof MetadataStoreException.BadVersionException) {
+                throw FutureUtil.wrapToCompletionException(new ConflictException(
+                        String.format("Failed to update to value:%s", value)));
+            }
 
-                    throw FutureUtil.wrapToCompletionException(e.getCause());
-                });
+            throw FutureUtil.wrapToCompletionException(e.getCause());
+        });
     }
 
     public CompletableFuture<Void> delete(String key) {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -702,4 +702,41 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         assertEquals(backoff.getMax(), 3000);
         assertEquals(backoff.getMandatoryStop(), 30_000);
     }
+
+    @Test
+    public void testNoBackoffMetadataCacheConfig() {
+        final var config = MetadataCacheConfig.builder().retryBackoff(
+                MetadataCacheConfig.NO_RETRY_BACKOFF_BUILDER).build();
+
+        final var backoff = config.getRetryBackoff().create();
+
+        assertEquals(backoff.getInitial(), 0);
+        assertEquals(backoff.getMax(),0);
+        assertEquals(backoff.getMandatoryStop(), 0);
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+
+        backoff.reduceToHalf();
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+
+        backoff.reset();
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertEquals(backoff.next(), 0);
+        assertTrue(backoff.isMandatoryStopMade());
+        assertEquals(backoff.getFirstBackoffTimeInMillis(), 0);
+    }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Although we do CAS updates on ServiceUnitStateMetadataStoreTableViewImpl.put, ServiceUnitStateData.versionId can still conflict if cache.readModifyUpdateOrCreate retries multiple times with the updated value's GetResult.Stats.version. 

We should fail-fast if the readModifyUpdateOrCreate fails once(e.g. upon first BadVersionException) not to cause inconsistent ServiceUnitStateData views from different brokers.

Also, to fix the worst case, any inconsistent ServiceUnitStateData views, ServiceUnitStateMetadataStoreTableViewImpl should update the latest value(not only compare the versionId but also all fields) from the MetadataStore by its cache refresh cycles.

### Modifications

- Added No backoff config in MetadataCacheConfig and use it from ServiceUnitStateMetadataStoreTableViewImpl.
- Update ServiceUnitStateData.equals to compare all fields.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
