### PR TITLE
[fix][test] Fix flaky NamespacesTest.testNamespacesApiRedirects

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -721,6 +721,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                 + this.testLocalNamespaces.get(2).toString() + "/unload");
         doReturn(uri).when(uriInfo).getRequestUri();
 
+        response = mock(AsyncResponse.class);
         namespaces.unloadNamespaceBundle(response, this.testTenant, this.testOtherCluster,
                 this.testLocalNamespaces.get(2).getLocalName(), "0x00000000_0xffffffff", false, null);
         captor = ArgumentCaptor.forClass(WebApplicationException.class);
@@ -730,6 +731,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                 UriBuilder.fromUri(uri).host("127.0.0.3").port(8083).toString());
 
         // check the bundle should not unload to an inactive destination broker
+        response = mock(AsyncResponse.class);
         namespaces.unloadNamespaceBundle(response, this.testTenant, this.testOtherCluster,
                 this.testLocalNamespaces.get(2).getLocalName(), "0x00000000_0xffffffff", false, "inactive_destination:8080");
         captor = ArgumentCaptor.forClass(WebApplicationException.class);


### PR DESCRIPTION
Fixes #24193

### Motivation

NamespacesTest.testNamespacesApiRedirects is flaky due to invalid reuse of mocks.

### Modifications

- fix flakiness by creating new instances of with `mock(AsyncResponse.class)`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->