### PR TITLE
[improve][io] Upgrade Kafka client and compatible Confluent platform version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.5.0</aerospike-client.version>
-    <kafka-client.version>3.4.0</kafka-client.version>
+    <kafka-client.version>3.8.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.638</aws-sdk.version>
     <avro.version>1.11.4</avro.version>
@@ -215,7 +215,7 @@ flexible messaging model and an intuitive client API.</description>
     <guava.version>32.1.2-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
-    <confluent.version>6.2.8</confluent.version>
+    <confluent.version>7.8.2</confluent.version>
     <aircompressor.version>0.27</aircompressor.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <commons-lang3.version>3.11</commons-lang3.version>

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/PulsarOffsetBackingStore.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -259,5 +260,12 @@ public class PulsarOffsetBackingStore implements OffsetBackingStore {
         } else {
             return Collections.emptyMap();
         }
+    }
+
+    @Override
+    public Set<Map<String, Object>> connectorPartitions(String connectorName) {
+        // skip implementing this method which was added in Kafka for
+        // KIP-875: First-class offsets support in Kafka Connect
+        return null;
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
@@ -78,8 +78,8 @@ public class KafkaSinkTester extends SinkTester<KafkaContainer> {
         ExecResult execResult = serviceContainer.execInContainer(
                 "/usr/bin/kafka-topics",
                 "--create",
-                "--zookeeper",
-                "localhost:2181",
+                "--bootstrap-server",
+                "localhost:9092",
                 "--partitions",
                 "1",
                 "--replication-factor",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KafkaSinkTester.java
@@ -42,7 +42,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Slf4j
 public class KafkaSinkTester extends SinkTester<KafkaContainer> {
-    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "6.2.8");
+    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "7.8.2");
 
     private final String kafkaTopicName;
     private KafkaConsumer<String, String> kafkaConsumer;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -397,7 +397,11 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
         log.info("script results: "+execResult.getStdout());
         log.info("script stderr: "+execResult.getStderr());
         assertTrue(execResult.getStdout().contains("Closing the Kafka producer"), execResult.getStdout()+" "+execResult.getStderr());
-        assertTrue(execResult.getStderr().isEmpty(), execResult.getStderr());
+        // filter out the SLF4J warnings
+        String stderrFiltered = execResult.getStderr()
+                .replaceAll("(?m)^SLF4J: .*?[\\r\\n]+", "")
+                .trim();
+        assertTrue(stderrFiltered.isEmpty(), stderrFiltered);
 
         log.info("Successfully produced {} messages to kafka topic {}", numMessages, kafkaTopicName);
         return written;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -18,8 +18,20 @@
  */
 package org.apache.pulsar.tests.integration.io.sources;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -29,11 +41,15 @@ import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.SourceStatus;
 import org.apache.pulsar.common.policies.data.SourceStatusUtil;
 import org.apache.pulsar.tests.integration.docker.ContainerExecException;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
@@ -48,18 +64,6 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.policies.data.SourceStatus;
-
-import static org.testng.Assert.*;
 
 /**
  * A tester for testing kafka source with Avro Messages.
@@ -162,8 +166,8 @@ public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
         ExecResult execResult = kafkaContainer.execInContainer(
             "/usr/bin/kafka-topics",
             "--create",
-            "--zookeeper",
-                getZooKeeperAddressInDockerNetwork(),
+            "--bootstrap-server",
+            getBootstrapServersOnDockerNetwork(),
             "--partitions",
             "1",
             "--replication-factor",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/AvroKafkaSourceTest.java
@@ -71,7 +71,7 @@ import static org.testng.Assert.*;
  */
 @Slf4j
 public class AvroKafkaSourceTest extends PulsarFunctionsTestBase {
-    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "6.2.8");
+    public static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluent.version", "7.8.2");
 
     private static final String SOURCE_TYPE = "kafka";
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/KafkaSourceTester.java
@@ -76,8 +76,8 @@ public class KafkaSourceTester extends SourceTester<KafkaContainer> {
         ExecResult execResult = kafkaContainer.execInContainer(
             "/usr/bin/kafka-topics",
             "--create",
-            "--zookeeper",
-            "localhost:2181",
+            "--bootstrap-server",
+            "localhost:9092",
             "--partitions",
             "1",
             "--replication-factor",


### PR DESCRIPTION
### Motivation

- addresses CVE-2024-31141 in the Pulsar IO Kafka connectors

### Modifications

- upgrade `kafka-client.version` used in Pulsar IO Kafka connectors to `3.8.1`
  - according to https://endoflife.date/apache-kafka, 3.8.x is currently supported
- upgrade `confluent.version` to `7.8.2` since it matches the Kafka version `3.8.x` according to ["Confluent Platform and Apache Kafka compatibility" page](https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->