### PR TITLE
[fix][test] Fix resource leaks in ProxyTest and fix invalid tests

### DIFF
--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -155,12 +155,11 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
     @Override
     @AfterClass(alwaysRun = true)
     protected void cleanup() throws Exception {
-        internalCleanup();
-
         proxyService.close();
         if (proxyClientAuthentication != null) {
             proxyClientAuthentication.close();
         }
+        internalCleanup();
     }
 
     @Test
@@ -319,8 +318,9 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         };
     }
 
-    @Test(timeOut = 60_000, dataProvider = "topicTypes", invocationCount = 100)
+    @Test(timeOut = 60_000, dataProvider = "topicTypes")
     public void testRegexSubscriptionWithTopicDiscovery(TopicType topicType) throws Exception {
+        @Cleanup
         final PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl()).build();
         final int topics = 10;
         final String subName = "s1";


### PR DESCRIPTION
### Motivation

ProxyTest and derived ProxyDisableZeroCopyTest leak a lot of resources.
```
Warning: Summary: Tests in class org.apache.pulsar.proxy.server.ProxyTest created 1080 new threads. There are now 1090 threads in total.
Warning: Summary: Tests in class org.apache.pulsar.proxy.server.ProxyDisableZeroCopyTest created 1080 new threads. There are now 1090 threads in total.
```

In addition to this, the test `testGetPartitionedMetadataErrorCode` doesn't pass without a retry. There are conflicting tests that expect different `allowAutoTopicCreationType` and `defaultNumPartitions` settings.

### Modifications

- fix resource leaks
- remove `invocationCount = 100` for `testRegexSubscriptionWithTopicDiscovery`
- fix `allowAutoTopicCreationType` and `defaultNumPartitions` config conflicts

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->