### PR TITLE
[improve] Upgrade Apache Commons library versions to compatible versions

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -50,7 +50,7 @@
     <log4j2.version>2.23.1</log4j2.version>
     <slf4j.version>2.0.13</slf4j.version>
     <testng.version>7.7.1</testng.version>
-    <commons-lang3.version>3.11</commons-lang3.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -282,16 +282,16 @@ The Apache Software License, Version 2.0
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
  * Apache Commons
-    - commons-cli-commons-cli-1.5.0.jar
-    - commons-codec-commons-codec-1.15.jar
+    - commons-cli-commons-cli-1.9.0.jar
+    - commons-codec-commons-codec-1.18.0.jar
     - commons-configuration-commons-configuration-1.10.jar
-    - commons-io-commons-io-2.18.0.jar
+    - commons-io-commons-io-2.19.0.jar
     - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.1.1.jar
     - org.apache.commons-commons-collections4-4.4.jar
-    - org.apache.commons-commons-compress-1.26.0.jar
-    - org.apache.commons-commons-lang3-3.11.jar
-    - org.apache.commons-commons-text-1.10.0.jar
+    - org.apache.commons-commons-compress-1.27.0.jar
+    - org.apache.commons-commons-lang3-3.17.0.jar
+    - org.apache.commons-commons-text-1.13.1.jar
  * Netty
     - io.netty-netty-buffer-4.1.119.Final.jar
     - io.netty-netty-codec-4.1.119.Final.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -338,14 +338,14 @@ The Apache Software License, Version 2.0
     - memory-0.8.3.jar
     - sketches-core-0.8.3.jar
  * Apache Commons
-    - commons-codec-1.15.jar
+    - commons-codec-1.18.0.jar
     - commons-configuration-1.10.jar
-    - commons-io-2.18.0.jar
+    - commons-io-2.19.0.jar
     - commons-lang-2.6.jar
     - commons-logging-1.2.jar
-    - commons-lang3-3.11.jar
-    - commons-text-1.10.0.jar
-    - commons-compress-1.26.0.jar
+    - commons-lang3-3.17.0.jar
+    - commons-text-1.13.1.jar
+    - commons-compress-1.27.0.jar
  * Netty
     - netty-buffer-4.1.119.Final.jar
     - netty-codec-4.1.119.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -139,12 +139,12 @@ flexible messaging model and an intuitive client API.</description>
     <narPluginPhase>package</narPluginPhase>
 
     <!-- apache commons -->
-    <commons-compress.version>1.26.0</commons-compress.version>
+    <commons-compress.version>1.27.0</commons-compress.version>
 
     <bookkeeper.version>4.17.1</bookkeeper.version>
     <zookeeper.version>3.9.3</zookeeper.version>
-    <commons-cli.version>1.5.0</commons-cli.version>
-    <commons-text.version>1.10.0</commons-text.version>
+    <commons-cli.version>1.9.0</commons-cli.version>
+    <commons-text.version>1.13.1</commons-text.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
@@ -218,10 +218,10 @@ flexible messaging model and an intuitive client API.</description>
     <confluent.version>6.2.8</confluent.version>
     <aircompressor.version>0.27</aircompressor.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
-    <commons-lang3.version>3.11</commons-lang3.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
-    <commons-io.version>2.18.0</commons-io.version>
-    <commons-codec.version>1.15</commons-codec.version>
+    <commons-io.version>2.19.0</commons-io.version>
+    <commons-codec.version>1.18.0</commons-codec.version>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>

--- a/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
+++ b/pulsar-functions/runtime-all/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceDepsTest.java
@@ -48,13 +48,17 @@ import java.util.zip.ZipInputStream;
  *     10. Apache Commons Compress (dependency of AVRO)
  *     11. Apache Commons Lang (dependency of Apache Commons Compress)
  *     12. Apache Commons IO (dependency of Apache Commons Compress)
+ *     13. Apache Commons Codec
+ *        - this gets included possibly due to a maven-assembly-plugin bug since there is no direct or transitive
+ *          dependency in pulsar-functions/runtime-all to this library for runtime scope. In the test scope, it is
+ *          present.
  */
 public class JavaInstanceDepsTest {
 
     @Test
     public void testInstanceJarDeps() throws IOException {
         File jar = new File("target/java-instance.jar");
-        
+
         @Cleanup
         ZipInputStream zip = new ZipInputStream(jar.toURI().toURL().openStream());
 
@@ -75,6 +79,7 @@ public class JavaInstanceDepsTest {
                         && !name.startsWith("org/apache/commons/compress")
                         && !name.startsWith("org/apache/commons/lang3")
                         && !name.startsWith("org/apache/commons/io")
+                        && !name.startsWith("org/apache/commons/codec")
                         && !name.startsWith("com/google")
                         && !name.startsWith("org/checkerframework")
                         && !name.startsWith("javax/annotation")


### PR DESCRIPTION
### Motivation

Apache Commons libraries haven't been upgraded recently. In BookKeeper, the Apache Commons libraries were upgraded with PR https://github.com/apache/bookkeeper/pull/4582. It's better to keep the versions upgraded to recent versions to avoid compatibility issues as there were in BookKeeper where commons-codec wasn't compatible with the commons-compress version. It's also useful to keep the versions in sync with versions used in BookKeeper since Pulsar's distribution of BookKeeper uses the versions assigned in Pulsar's pom.xml.

### Modifications

- upgrade 
    - commons-cli to 1.9.0
    - commons-codec to 1.18.0
    - commons-io to 2.19.0
    - commons-compress to 1.27.0
    - commons-lang3 to 3.17.0
    - commons-text to 1.13.1

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->