### PR TITLE
[improve][broker]Improve the feature "Optimize subscription seek (cursor reset) by timestamp": search less entries

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
@@ -72,6 +72,7 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
                             ledgerCloseTimestampMaxClockSkewMillis);
             cursor.asyncFindNewestMatching(ManagedCursor.FindPositionConstraint.SearchAllAvailableEntries, entry -> {
                 try {
+                    // Find the latest entry that is earlier than the target timestamp.
                     long entryTimestamp = Commands.getEntryTimestamp(entry.getDataBuffer());
                     return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
                 } catch (Exception e) {
@@ -92,6 +93,12 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
         }
     }
 
+    /**
+     * The range may be across multi ledgers:
+     *   - start: the latest ledger that closed before {@param targetTimestamp}.
+     *     - only the latest entry is useful.
+     *   - end: the earliest ledger that is larger than the target timestamp.
+     */
     @VisibleForTesting
     public static Pair<Position, Position> getFindPositionRange(Iterable<LedgerInfo> ledgerInfos,
                                                                 Position lastConfirmedEntry, long targetTimestamp,
@@ -107,6 +114,10 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
         Position start = null;
         Position end = null;
 
+        // We do not use binary search here:
+        // Since "managedLedger.ledgers" os a map, we can hardly use a binary search except to copy items to an array,
+        // which causes frequently young GC. And "collection.toArray()" also loops the collection once, which does not
+        // benefit performance anymore.
         for (LedgerInfo info : ledgerInfos) {
             if (!info.hasTimestamp()) {
                 // unexpected case, don't set start and end
@@ -119,7 +130,9 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
                 break;
             }
             if (closeTimestamp <= targetTimestampMin) {
-                start = PositionFactory.create(info.getLedgerId(), 0);
+                // Since we have "broker.conf -> managedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis", which
+                // already expanded the scope for searching, the entries before the latest one is not useful.
+                start = PositionFactory.create(info.getLedgerId(), info.getEntries() - 1);
             } else if (closeTimestamp > targetTimestampMax) {
                 // If the close timestamp is greater than the timestamp
                 end = PositionFactory.create(info.getLedgerId(), info.getEntries() - 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -619,7 +619,6 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
         assertEquals(range.getLeft(), PositionFactory.create(2, 9));
-        assertEquals(range.getRight(), PositionFactory.create(2, 9));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -618,7 +618,8 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
+        assertEquals(range.getRight(), PositionFactory.create(2, 9));
     }
 
     @Test
@@ -636,7 +637,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
     }
 
     @Test
@@ -654,7 +655,8 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
     }
 
     @Test
@@ -689,7 +691,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
         assertEquals(range.getRight(), PositionFactory.create(3, 9));
     }
 
@@ -709,7 +711,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(3, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(3, 9));
         // there might be entries in the next ledger with the same timestamp as the target timestamp, even though
         // the close timestamp of ledger 3 is equals to the target timestamp
         assertEquals(range.getRight(), PositionFactory.create(4, 9));
@@ -732,7 +734,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(1, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(1, 9));
         assertEquals(range.getRight(), PositionFactory.create(4, 9));
     }
 
@@ -753,7 +755,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
         assertEquals(range.getRight(), PositionFactory.create(4, 9));
     }
 
@@ -774,7 +776,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
         assertEquals(range.getRight(), PositionFactory.create(4, 9));
     }
 
@@ -825,6 +827,6 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(1, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(1, 9));
     }
 }


### PR DESCRIPTION
### Motivation

**Background**
https://github.com/apache/pulsar/pull/22792 improved the behavior that searching messages by timestamp. For example:
There are ledgers as follows:

```json
[{
	"ledger": "1",
	"entries": "10",
	"closed_time": "1000"
},{
	"ledger": "2",
	"entries": "10",
	"closed_time": "1010"
},{
	"ledger": "3",
	"entries": "10",
	"closed_time": "3000"
}]
```

And the config `broker.conf -> managedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis` is `20ms`, when you search for timestamp `1000`, the broker will find ledgers whose timestamp is larger than `ledger.closed_time-20` and less than `ledger.closed_time+20`. Then the result range is `[1:0 ~ 3:9]`.

### Modifications

Since we have the configuration `broker.conf -> managedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis`, the entries `[1:0 ~ 1:8]` can be skipped to search, because we have already given enough scope expanded by `managedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis`, which improves the search.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
