### PR TITLE
[feat][pip]PIP-415: Support getting message ID by Index

### DIFF
--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -86,15 +86,33 @@ Add a new admin API endpoint `getMessageIdByIndex` to `org.apache.pulsar.broker.
 
 **notes: If the specified index points to a system message, return the first valid user message following this index.**
 
+When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer). If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+
+**Example Scenario** (partition with 2 entries):
+
+| Entry | Ledger ID | Entry ID | Index | Messages |  
+| :--- | ---: | ---: | ---: | ---: |  
+| A | 0 | 0 | 2 | 0,1,2 |  
+| B | 0 | 1 | 4 | 3,4 |  
+
+- Param indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+- To achieve **precise message-level consumption**, you can first locate the entry using the MessageID, then filter messages by their indexes during client-side processing.
+  - Example: To consume from index 1, retrieve all messages in Entry A and filter out messages with indexes below 1.
+
+**Why Precise Index Matching Isn't Implemented on the Broker Side:**
+1. **Metadata Parsing Constraints**: Precise matching requires parsing `MessageMetadata`, but brokers are designed to parse only `BrokerEntryMetadata`.
+2. **Limited Benefits**: Even if the exact `batchIndex` and `batchSize` are determined, the broker must still send the **entire entry** to the client, offering no network bandwidth savings.
+3. **Client-Side Efficiency**: Once the client receives the entry, users can directly filter messages by index (after parsing `MessageMetadata`, which includes unique indexes for each message).
+
 ##### Error Responses
 
-| Status Code                 | Description                                                                 | 
-|-----------------------------|-----------------------------------------------------------------------------|
-| **307 Temporary Redirect**  | The current broker does not own this topic. Redirect to the correct broker. | 
-| **403 Forbidden**           | Client lacks permissions to access the topic/namespace.                     |       
-| **404 Not Found**           | Topic/namespace does not exist, or the specified `index` is invalid.        |
-| **406 Not Acceptable**      | The topic is not a persistent topic.                                        |
-| **412 Precondition Failed** | The broker is not configured to enable broker entry metadata.               |
+| Status Code                 | Description                                                                                                                                                  | 
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **307 Temporary Redirect**  | The current broker does not own this topic. Redirect to the correct broker.                                                                                  | 
+| **403 Forbidden**           | Client lacks permissions to access the topic/namespace.                                                                                                      |       
+| **404 Not Found**           | Topic/namespace does not exist, or the specified `index` is invalid. An index value of -1 or one that exceeds the maximum index range is considered invalid. |
+| **406 Not Acceptable**      | The topic is not a persistent topic.                                                                                                                         |
+| **412 Precondition Failed** | The broker is not configured to enable broker entry metadata.                                                                                                |
 
 #### Pulsar Admin
 Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java`
@@ -103,7 +121,15 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
      * Get the message id by index.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
-     * @return the message id of the message
+     * @return the message id of the message. 
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
      */
     MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
 
@@ -112,6 +138,14 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
      * @return the message id of the message
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
      */
     CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 ```

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -143,5 +143,5 @@ Add new subcommand to pulsar-admin:
 
 # Links
 
-* Mailing List discussion thread:
-* Mailing List voting thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/7kmo3robyx74p81891h3q8f1cq5lomfv
+* Mailing List voting thread: https://lists.apache.org/thread/mn694h98nmdtddx4co9w0zo94jolzj68

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -1,0 +1,112 @@
+# PIP-415: Support getting message ID by offset
+
+# Background knowledge
+
+
+- In [PIP-70](https://github.com/apache/pulsar/wiki/PIP-70%3A-Introduce-lightweight-broker-entry-metadata), we introduced `Broker Entry Metadata` containing an `index` field - a continuous sequence identifier for messages within a topic partition.
+This sequence ID simplifies message sequence management compared to the composite MessageId (ledgerId+entryId+batchIndex) which becomes discontinuous across ledgers.
+- In [PIP-90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client), we exposed this metadata via the `Message.getIndex()` API. 
+- In [PR-6331](https://github.com/apache/pulsar/pull/6331), we added a new `get-message-by-id` cmd into pulsar-admin.
+
+After these three works, we can now obtain the offset of a message by its message id:
+
+1. Get the message by id using `get-message-by-id` cmd
+2. Get the index of the message using `Message.getIndex()`
+
+But we cannot obtain the message id by offset. Then we need to add a new API to get the message id by offset.
+
+# Motivation
+
+Our organization is currently planning a migration from RocketMQ to Pulsar. To facilitate this transition, we aim to implement a standardized abstraction layer for MQ clients that encapsulates implementation details of specific messaging systems. This abstraction layer will allow seamless engine replacement while maintaining consistent client interfaces.
+However, one critical compatibility issues hinder the unification of message fetching pat terns between RocketMQ/Kafka and Pulsar:
+
+**Positioning Mechanism Mismatch**:
+- RocketMQ/Kafka: Utilize monotonically increasing numerical offsets for message positioning and acknowledgment
+- Pulsar: Relies on composite MessageID (ledgerId + entryId + batchIndex) for message identification
+
+We propose to add a new API to retrieve the message ID by offset, enabling us to cache the mapping between message ID and offset.
+This will allow us to use offsets for seek and acknowledgment operations when consuming messages through the standardized API.
+
+# Goals
+
+## In Scope
+
+- Add a new API to retrieve the message ID by offset
+
+# High Level Design
+
+# Detailed Design
+The core implementation involves adding a new HTTP endpoint to query MessageId by offset (index). Underlying implementation will leverage existing `Broker Entry Metadata` containing index values.
+
+## Design & Implementation Details
+
+## Public-facing Changes
+
+### Public API
+
+```java
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByOffset")
+    @ApiOperation(hidden = true, value = "Get Message ID by offset.",
+            notes = "If the specified offset is a system message, "
+                    + "it will return the message id of the later message.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
+                    + "or the offset is invalid")})
+    public void getMessageIDByOffsetAndPartitionID(@Suspended final AsyncResponse asyncResponse,
+                                                   @PathParam("tenant") String tenant,
+                                                   @PathParam("namespace") String namespace,
+                                                   @PathParam("topic") @Encoded String encodedTopic,
+                                                   @QueryParam("offset") long offset,
+                                                   @QueryParam("authoritative") @DefaultValue("false")
+                                                   boolean authoritative){
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetMessageIDByOffsetAsync(offset, authoritative)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    if (!isRedirectException(ex)) {
+                        log.error("[{}] Failed to get message id by offset for topic {}, partition id {}, offset {}",
+                                clientAppId(), topicName, offset, ex);
+                    }
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+```
+
+### Binary protocol
+
+### Configuration
+
+### CLI
+Add new subcommand to pulsar-admin:
+
+```bash
+    pulsar-admin topics get-message-id-by-offset \
+    --offset 12345 \
+    persistent://tenant/ns/topic
+```
+### Metrics
+
+# Monitoring
+
+# Security Considerations
+# Backward & Forward Compatibility
+
+## Upgrade
+
+## Downgrade / Rollback
+
+## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
+
+
+# Alternatives
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -84,7 +84,7 @@ Add a new admin API endpoint `getMessageIdByIndex` to `org.apache.pulsar.broker.
     - `entryId`: Unique identifier of the message within the ledger.
     - `partitionIndex`: Partition index (relevant for partitioned topics; `-1` for non-partitioned topics).
 
-**notes: If the specified index points to a system message, return the first valid user message following this index.**
+**notes: If the index points to a system message, return the first user message following it; if the specified message has expired and been deleted, return MessageId.Earliest.**
 
 When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer). If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
 
@@ -118,7 +118,7 @@ When retrieving a message ID by index, the resolution is limited to the **entry*
 Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java`
 ```java
     /**
-     * Get the message id by index.
+     * Get the message id by index. If the index points to a system message, return the first user message following it; if the specified message has expired and been deleted, return MessageId.Earliest.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
      * @return the message id of the message. 
@@ -139,7 +139,7 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
     MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
 
     /**
-     * Get the message id by index asynchronously.
+     * Get the message id by index asynchronously. If the index points to a system message, return the first user message following it; if the specified message has expired and been deleted, return MessageId.Earliest.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
      * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer).

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -13,7 +13,7 @@ After these three works, we can now obtain the offset(index) of a message by its
 1. Get the message by id using `get-message-by-id` cmd
 2. Get the index of the message using `Message.getIndex()`
 
-But we cannot obtain the message id by offset(index). Then we need to add a new API to get the message id by offset(index).
+**But we cannot obtain the message id by offset(index). Then we need to add a new API to get the message id by offset(index).**
 
 # Motivation
 

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -101,7 +101,7 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
 ```java
     /**
      * Get the message id by index.
-     * @param topicName the partitioned topic name or non-partitioned topic name
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
      * @return the message id of the message
      */
@@ -109,7 +109,7 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
 
     /**
      * Get the message id by index asynchronously.
-     * @param topicName the topic name
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
      * @return the message id of the message
      */

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -130,6 +130,11 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
      * | A | 0 | 0 | 2 | 0,1,2 |
      * | B | 0 | 1 | 4 | 3,4 |
      * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @throws AuthorizationException      (HTTP 403 Forbidden) Client lacks permissions to access the topic/namespace.
+     * @throws NotFoundException           (HTTP 404 Not Found) Source topic/namespace does not exist, or invalid index.
+     * @throws PulsarAdminException        (HTTP 406 Not Acceptable) Specified topic is not a persistent topic.
+     * @throws PreconditionFailedException (HTTP 412 Precondition Failed) Broker entry metadata is disabled.
+     * @throws PulsarAdminException        For other errors (e.g., HTTP 500 Internal Server Error).
      */
     MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
 
@@ -137,7 +142,6 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
      * Get the message id by index asynchronously.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics.
      * @param index the index of a message
-     * @return the message id of the message
      * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal storage unit for messages in Pulsar's persistence layer).
      * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
      * Example Scenario (partition with 2 entries):
@@ -146,6 +150,16 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
      * | A | 0 | 0 | 2 | 0,1,2 |
      * | B | 0 | 1 | 4 | 3,4 |
      * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @implNote The return {@link CompletableFuture<MessageId>} that completes with the message id of the message.
+     *         The future may complete exceptionally with:
+     *         <ul>
+     *             <li>{@link AuthorizationException} (HTTP 403) Permission denied for topic/namespace access.</li>
+     *             <li>{@link NotFoundException} (HTTP 404) Shadow topic/namespace does not exist or invalid index.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 406) Shadow topic is not a persistent topic.</li>
+     *             <li>{@link PreconditionFailedException} (HTTP 412) Broker entry metadata is not enabled.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 307) Redirect required to the correct broker.</li>
+     *             <li>{@link PulsarAdminException} Other errors (e.g., HTTP 500).</li>
+     *         </ul>
      */
     CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 ```

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -60,13 +60,13 @@ Add a new admin API endpoint `getMessageIdByIndex` to `org.apache.pulsar.broker.
 
 #### Parameters
 
-| Type            | Name            | Data Type | Required | Description                                                                                                             |
-|-----------------|-----------------|-----------|----------|-------------------------------------------------------------------------------------------------------------------------|
-| **Path Param**  | `tenant`        | `String`  | Yes      | Tenant identifier for multi-tenancy isolation.                                                                          |
-|                 | `namespace`     | `String`  | Yes      | Namespace identifier to group topics under a tenant.                                                                    |
-|                 | `topic`         | `String`  | Yes      | Topic name (URL-encoded). The `@Encoded` annotation ensures raw URL decoding is avoided during parsing.                 |
-| **Query Param** | `index`         | `long`    | Yes      | Zero-based index of the message in the topic.                                                                           |
-|                 | `authoritative` | `boolean` | No       | If authoritative is true, it means the lookup had already been redirected here by a different broker. Default: `false`. |
+| Type            | Name            | Data Type | Required | Description                                                                                                                                               |
+|-----------------|-----------------|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Path Param**  | `tenant`        | `String`  | Yes      | Tenant identifier for multi-tenancy isolation.                                                                                                            |
+|                 | `namespace`     | `String`  | Yes      | Namespace identifier to group topics under a tenant.                                                                                                      |
+|                 | `topic`         | `String`  | Yes      | Topic Name - either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or the original topic name for non-partitioned topics. |
+| **Query Param** | `index`         | `long`    | Yes      | Zero-based index of the message in the topic.                                                                                                             |
+|                 | `authoritative` | `boolean` | No       | If authoritative is true, it means the lookup had already been redirected here by a different broker. Default: `false`.                                   |
 
 #### Response
 

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -1,4 +1,4 @@
-# PIP-415: Support getting message ID by offset
+# PIP-415: Support getting message ID by offset(index)
 
 # Background knowledge
 
@@ -8,12 +8,12 @@ This sequence ID simplifies message sequence management compared to the composit
 - In [PIP-90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client), we exposed this metadata via the `Message.getIndex()` API. 
 - In [PR-6331](https://github.com/apache/pulsar/pull/6331), we added a new `get-message-by-id` cmd into pulsar-admin.
 
-After these three works, we can now obtain the offset of a message by its message id:
+After these three works, we can now obtain the offset(index) of a message by its message id:
 
 1. Get the message by id using `get-message-by-id` cmd
 2. Get the index of the message using `Message.getIndex()`
 
-But we cannot obtain the message id by offset. Then we need to add a new API to get the message id by offset.
+But we cannot obtain the message id by offset(index). Then we need to add a new API to get the message id by offset(index).
 
 # Motivation
 
@@ -21,22 +21,22 @@ Our organization is currently planning a migration from RocketMQ to Pulsar. To f
 However, one critical compatibility issues hinder the unification of message fetching pat terns between RocketMQ/Kafka and Pulsar:
 
 **Positioning Mechanism Mismatch**:
-- RocketMQ/Kafka: Utilize monotonically increasing numerical offsets for message positioning and acknowledgment
+- RocketMQ/Kafka: Utilize monotonically increasing numerical offset(index)s for message positioning and acknowledgment
 - Pulsar: Relies on composite MessageID (ledgerId + entryId + batchIndex) for message identification
 
-We propose to add a new API to retrieve the message ID by offset, enabling us to cache the mapping between message ID and offset.
-This will allow us to use offsets for seek and acknowledgment operations when consuming messages through the standardized API.
+We propose to add a new API to retrieve the message ID by offset(index), enabling us to cache the mapping between message ID and offset(index).
+This will allow us to use offset(index)s for seek and acknowledgment operations when consuming messages through the standardized API.
 
 # Goals
 
 ## In Scope
 
-- Add a new API to retrieve the message ID by offset
+- Add a new API to retrieve the message ID by offset(index)
 
 # High Level Design
 
 # Detailed Design
-The core implementation involves adding a new HTTP endpoint to query MessageId by offset (index). Underlying implementation will leverage existing `Broker Entry Metadata` containing index values.
+The core implementation involves adding a new HTTP endpoint to query MessageId by offset(index). Underlying implementation will leverage existing `Broker Entry Metadata` containing index values.
 
 ## Design & Implementation Details
 
@@ -44,36 +44,71 @@ The core implementation involves adding a new HTTP endpoint to query MessageId b
 
 ### Public API
 
+#### Request Path
+- **Path Template**:  
+  ```http
+  GET /{tenant}/{namespace}/{topic}/getMessageIdByIndex
+  ```  
+- `{tenant}`: Tenant name (string, path parameter).
+- `{namespace}`: Namespace name (string, path parameter).
+- `{topic}`: Topic name (URL-encoded string, path parameter).
+
+#### HTTP Method
+- **Method**: `GET`
+- **Purpose**: Retrieve the message ID associated with a specific message index in a topic.
+
+#### Parameters
+
+| Type           | Name               | Data Type    | Required | Description                                                                                                           |
+|----------------|--------------------|--------------|----------|-----------------------------------------------------------------------------------------------------------------------|
+| **Path Param** | `tenant`           | `String`     | Yes      | Tenant identifier for multi-tenancy isolation.                                                                        |
+|                | `namespace`        | `String`     | Yes      | Namespace identifier to group topics under a tenant.                                                                  |
+|                | `topic`            | `String`     | Yes      | Topic name (URL-encoded). The `@Encoded` annotation ensures raw URL decoding is avoided during parsing.               |
+| **Query Param**| `index`            | `long`       | Yes      | Zero-based index of the message in the topic.                                                                         |
+|                | `authoritative`    | `boolean`    | No       | If `false`, the broker may return `307 Redirect` if it does not own the topic. Default: `false`.                      |
+
+#### Response
+
+##### Success Response
+- **Status Code**: `200 OK`
+- **Body Format**:
+  ```json
+  {
+    "ledgerId": 12345,
+    "entryId": 67890,
+    "partitionIndex": 0
+  }
+  ```  
+    - `ledgerId`: ID of the ledger where the message is stored.
+    - `entryId`: Unique identifier of the message within the ledger.
+    - `partitionIndex`: Partition index (relevant for partitioned topics; `0` for non-partitioned topics).
+
+##### Error Responses
+
+| Status Code          | Description                                                                                                  | Response Body Format                                                                 |
+|----------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| **307 Temporary Redirect** | Current broker does not serve the topic’s namespace. Redirect to the correct broker.                       | No body. `Location` header indicates the target broker URL.                         |
+| **403 Forbidden**           | Client lacks permissions to access the topic/namespace.                                                    | JSON with `code` (e.g., `PERMISSION_DENIED`) and `message` (error details).          |
+| **404 Not Found**           | Topic/namespace does not exist, or the specified `index` is invalid (out of bounds or points to a system message). | JSON with `code` (e.g., `INVALID_INDEX`) and `message` (error details).              |  
+
+#### Pulsar Admin
+Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java`
 ```java
-    @GET
-    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByOffset")
-    @ApiOperation(hidden = true, value = "Get Message ID by offset.",
-            notes = "If the specified offset is a system message, "
-                    + "it will return the message id of the later message.")
-    @ApiResponses(value = {
-            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
-            @ApiResponse(code = 403, message = "Don't have admin permission"),
-            @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
-                    + "or the offset is invalid")})
-    public void getMessageIDByOffsetAndPartitionID(@Suspended final AsyncResponse asyncResponse,
-                                                   @PathParam("tenant") String tenant,
-                                                   @PathParam("namespace") String namespace,
-                                                   @PathParam("topic") @Encoded String encodedTopic,
-                                                   @QueryParam("offset") long offset,
-                                                   @QueryParam("authoritative") @DefaultValue("false")
-                                                   boolean authoritative){
-        validateTopicName(tenant, namespace, encodedTopic);
-        internalGetMessageIDByOffsetAsync(offset, authoritative)
-                .thenAccept(asyncResponse::resume)
-                .exceptionally(ex -> {
-                    if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to get message id by offset for topic {}, partition id {}, offset {}",
-                                clientAppId(), topicName, offset, ex);
-                    }
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    return null;
-                });
-    }
+    /**
+     * Get the message id by index.
+     * @param topicName the partitioned topic name or non-partitioned topic name
+     * @param index the index of a message
+     * @return the message id of the message
+     */
+    MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
+
+    /**
+     * Get the message id by index asynchronously.
+     * @param topicName the topic name
+     * @param index the index of a message
+     * @return the message id of the message
+     */
+    CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 ```
 
 ### Binary protocol

--- a/pip/pip-415.md
+++ b/pip/pip-415.md
@@ -1,4 +1,4 @@
-# PIP-415: Support getting message ID by offset(index)
+# PIP-415: Support getting message ID by index
 
 # Background knowledge
 
@@ -8,35 +8,35 @@ This sequence ID simplifies message sequence management compared to the composit
 - In [PIP-90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client), we exposed this metadata via the `Message.getIndex()` API. 
 - In [PR-6331](https://github.com/apache/pulsar/pull/6331), we added a new `get-message-by-id` cmd into pulsar-admin.
 
-After these three works, we can now obtain the offset(index) of a message by its message id:
+After these three works, we can now obtain the index of a message by its message id:
 
 1. Get the message by id using `get-message-by-id` cmd
 2. Get the index of the message using `Message.getIndex()`
 
-**But we cannot obtain the message id by offset(index). Then we need to add a new API to get the message id by offset(index).**
-
+**We can retrieve the message index using a message ID, but lack the reverse capability to obtain message IDs by index. This breaks the logical circularity and creates operational confusion.**
+Then we need to add a new API to get the message id by index
 # Motivation
 
 Our organization is currently planning a migration from RocketMQ to Pulsar. To facilitate this transition, we aim to implement a standardized abstraction layer for MQ clients that encapsulates implementation details of specific messaging systems. This abstraction layer will allow seamless engine replacement while maintaining consistent client interfaces.
 However, one critical compatibility issues hinder the unification of message fetching pat terns between RocketMQ/Kafka and Pulsar:
 
 **Positioning Mechanism Mismatch**:
-- RocketMQ/Kafka: Utilize monotonically increasing numerical offset(index)s for message positioning and acknowledgment
+- RocketMQ/Kafka: Utilize monotonically increasing numerical index for message positioning and acknowledgment
 - Pulsar: Relies on composite MessageID (ledgerId + entryId + batchIndex) for message identification
 
-We propose to add a new API to retrieve the message ID by offset(index), enabling us to cache the mapping between message ID and offset(index).
-This will allow us to use offset(index)s for seek and acknowledgment operations when consuming messages through the standardized API.
+We propose to add a new API to retrieve the message ID by index, enabling us to cache the mapping between message ID and index.
+This will allow us to use index for seek and acknowledgment operations when consuming messages through the standardized API.
 
 # Goals
 
 ## In Scope
 
-- Add a new API to retrieve the message ID by offset(index)
+- Add a new API to retrieve the message ID by index
 
 # High Level Design
 
 # Detailed Design
-The core implementation involves adding a new HTTP endpoint to query MessageId by offset(index). Underlying implementation will leverage existing `Broker Entry Metadata` containing index values.
+The core implementation involves adding a new HTTP endpoint to query MessageId by index. Underlying implementation will leverage existing `Broker Entry Metadata` containing index values.
 
 ## Design & Implementation Details
 
@@ -44,6 +44,7 @@ The core implementation involves adding a new HTTP endpoint to query MessageId b
 
 ### Public API
 
+Add a new admin API endpoint `getMessageIdByIndex` to `org.apache.pulsar.broker.admin.v2.PersistentTopics`.
 #### Request Path
 - **Path Template**:  
   ```http
@@ -59,13 +60,13 @@ The core implementation involves adding a new HTTP endpoint to query MessageId b
 
 #### Parameters
 
-| Type           | Name               | Data Type    | Required | Description                                                                                                           |
-|----------------|--------------------|--------------|----------|-----------------------------------------------------------------------------------------------------------------------|
-| **Path Param** | `tenant`           | `String`     | Yes      | Tenant identifier for multi-tenancy isolation.                                                                        |
-|                | `namespace`        | `String`     | Yes      | Namespace identifier to group topics under a tenant.                                                                  |
-|                | `topic`            | `String`     | Yes      | Topic name (URL-encoded). The `@Encoded` annotation ensures raw URL decoding is avoided during parsing.               |
-| **Query Param**| `index`            | `long`       | Yes      | Zero-based index of the message in the topic.                                                                         |
-|                | `authoritative`    | `boolean`    | No       | If `false`, the broker may return `307 Redirect` if it does not own the topic. Default: `false`.                      |
+| Type            | Name            | Data Type | Required | Description                                                                                                             |
+|-----------------|-----------------|-----------|----------|-------------------------------------------------------------------------------------------------------------------------|
+| **Path Param**  | `tenant`        | `String`  | Yes      | Tenant identifier for multi-tenancy isolation.                                                                          |
+|                 | `namespace`     | `String`  | Yes      | Namespace identifier to group topics under a tenant.                                                                    |
+|                 | `topic`         | `String`  | Yes      | Topic name (URL-encoded). The `@Encoded` annotation ensures raw URL decoding is avoided during parsing.                 |
+| **Query Param** | `index`         | `long`    | Yes      | Zero-based index of the message in the topic.                                                                           |
+|                 | `authoritative` | `boolean` | No       | If authoritative is true, it means the lookup had already been redirected here by a different broker. Default: `false`. |
 
 #### Response
 
@@ -81,15 +82,19 @@ The core implementation involves adding a new HTTP endpoint to query MessageId b
   ```  
     - `ledgerId`: ID of the ledger where the message is stored.
     - `entryId`: Unique identifier of the message within the ledger.
-    - `partitionIndex`: Partition index (relevant for partitioned topics; `0` for non-partitioned topics).
+    - `partitionIndex`: Partition index (relevant for partitioned topics; `-1` for non-partitioned topics).
+
+**notes: If the specified index points to a system message, return the first valid user message following this index.**
 
 ##### Error Responses
 
-| Status Code          | Description                                                                                                  | Response Body Format                                                                 |
-|----------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| **307 Temporary Redirect** | Current broker does not serve the topic’s namespace. Redirect to the correct broker.                       | No body. `Location` header indicates the target broker URL.                         |
-| **403 Forbidden**           | Client lacks permissions to access the topic/namespace.                                                    | JSON with `code` (e.g., `PERMISSION_DENIED`) and `message` (error details).          |
-| **404 Not Found**           | Topic/namespace does not exist, or the specified `index` is invalid (out of bounds or points to a system message). | JSON with `code` (e.g., `INVALID_INDEX`) and `message` (error details).              |  
+| Status Code                 | Description                                                                 | 
+|-----------------------------|-----------------------------------------------------------------------------|
+| **307 Temporary Redirect**  | The current broker does not own this topic. Redirect to the correct broker. | 
+| **403 Forbidden**           | Client lacks permissions to access the topic/namespace.                     |       
+| **404 Not Found**           | Topic/namespace does not exist, or the specified `index` is invalid.        |
+| **406 Not Acceptable**      | The topic is not a persistent topic.                                        |
+| **412 Precondition Failed** | The broker is not configured to enable broker entry metadata.               |
 
 #### Pulsar Admin
 Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java`
@@ -119,8 +124,8 @@ Add two api in `pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/a
 Add new subcommand to pulsar-admin:
 
 ```bash
-    pulsar-admin topics get-message-id-by-offset \
-    --offset 12345 \
+    pulsar-admin topics get-message-id-by-index \
+    --index 12345 \
     persistent://tenant/ns/topic
 ```
 ### Metrics


### PR DESCRIPTION
### Motivation
 we can now obtain the offset of a message by its message id:

1. Get the message by id using `get-message-by-id` cmd
2. Get the index of the message using `Message.getIndex()`

But we cannot obtain the message id by offset. Then we need to add a new API to get the message id by offset.


### Modifications

Add a new http API to retrieve the message ID by offset.
We propose to add a new API to retrieve the message ID by offset, enabling us to cache the mapping between message ID and offset.
This will allow us to use offsets for seek and acknowledgment operations when consuming messages through the standardized API.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
