### PR TITLE
[improve][io] support kafka connect transforms and predicates

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -110,6 +110,18 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>connect-transforms</artifactId>
+      <version>${kafka-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>jose4j</artifactId>
+          <groupId>org.bitbucket.b_c</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- pulsar-client is only needed for MessageId conversion (for seeking), commons-lang3 and Netty buffer manipulation -->
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -156,19 +168,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-file</artifactId>
-      <version>${kafka-client.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>jose4j</artifactId>
-          <groupId>org.bitbucket.b_c</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>connect-transforms</artifactId>
       <version>${kafka-client.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -167,6 +167,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>connect-transforms</artifactId>
+      <version>${kafka-client.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>jose4j</artifactId>
+          <groupId>org.bitbucket.b_c</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>testmocks</artifactId>
       <version>${project.version}</version>

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -176,7 +176,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
             }
             if (currentBatch.hasNext()) {
                 AbstractKafkaSourceRecord<T> processRecord = processSourceRecord(currentBatch.next());
-                if (processRecord.isEmpty()) {
+                if (processRecord == null || processRecord.isEmpty()) {
                     outstandingRecords.decrementAndGet();
                     continue;
                 } else {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -30,13 +30,12 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -58,7 +57,7 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
     private static final String JSON_WITH_ENVELOPE_CONFIG = "json-with-envelope";
 
     private Map<String, Predicate<SourceRecord>> predicates = new HashMap<>();
-    
+
     private record PredicatedTransform(
             Predicate<SourceRecord> predicate,
             Transformation<SourceRecord> transform,
@@ -177,11 +176,11 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
             if (current == null) {
                 break;
             }
-            
+
             if (pt.predicate != null && (pt.negated != pt.predicate.test(current))) {
                 continue;
             }
-            
+
             current = pt.transform.apply(current);
         }
         return current;

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -178,7 +178,7 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                 break;
             }
 
-            if (pt.predicate != null && (pt.negated != pt.predicate.test(current))) {
+            if (pt.predicate != null && !(pt.negated != pt.predicate.test(current))) {
                 continue;
             }
 

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -163,11 +163,13 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
 
     public synchronized KafkaSourceRecord processSourceRecord(final SourceRecord srcRecord) {
         SourceRecord transformedRecord = applyTransforms(srcRecord);
+
+        offsetWriter.offset(srcRecord.sourcePartition(), srcRecord.sourceOffset());
         if (transformedRecord == null) {
             return null;
         }
+
         KafkaSourceRecord record = new KafkaSourceRecord(transformedRecord);
-        offsetWriter.offset(transformedRecord.sourcePartition(), transformedRecord.sourceOffset());
         return record;
     }
 

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -140,7 +140,7 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                         ));
                     log.info("transform config: {}", transformConfig);
                     String predicateName = (String) transformConfig.get("predicate");
-                    boolean negated = (boolean) transformConfig.getOrDefault("negated", false);
+                    boolean negated = Boolean.parseBoolean(String.valueOf(transformConfig.getOrDefault("negated", "false")));
                     Predicate<SourceRecord> predicate = null;
                     if (predicateName != null) {
                         predicate = predicates.get(predicateName);

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -21,7 +21,9 @@ package org.apache.pulsar.io.kafka.connect;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.confluent.connect.avro.AvroData;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +33,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -51,6 +54,8 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
     private boolean jsonWithEnvelope = false;
     private static final String JSON_WITH_ENVELOPE_CONFIG = "json-with-envelope";
 
+    private List<Transformation<SourceRecord>> transformations = new ArrayList<>();
+
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         if (config.get(JSON_WITH_ENVELOPE_CONFIG) != null) {
             jsonWithEnvelope = Boolean.parseBoolean(config.get(JSON_WITH_ENVELOPE_CONFIG).toString());
@@ -60,17 +65,67 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
         }
         log.info("jsonWithEnvelope: {}", jsonWithEnvelope);
 
+        initTransforms(config);
         super.open(config, sourceContext);
     }
 
-
-    public synchronized KafkaSourceRecord processSourceRecord(final SourceRecord srcRecord) {
-        KafkaSourceRecord record = new KafkaSourceRecord(srcRecord);
-        offsetWriter.offset(srcRecord.sourcePartition(), srcRecord.sourceOffset());
-        return record;
+    private void initTransforms(Map<String, Object> config) {
+        transformations.clear();
+        Object transformsListObj = config.get("transforms");
+        if (transformsListObj != null) {
+            String transformsList = transformsListObj.toString();
+            for (String transformName : transformsList.split(",")) {
+                transformName = transformName.trim();
+                String prefix = "transforms." + transformName + ".";
+                String typeKey = prefix + "type";
+                Object classNameObj = config.get(typeKey);
+                if (classNameObj == null) {
+                    continue;
+                }
+                String className = classNameObj.toString();
+                try {
+                    @SuppressWarnings("unchecked")
+                    Class<Transformation<SourceRecord>> clazz =
+                        (Class<Transformation<SourceRecord>>) Class.forName(className);
+                    Transformation<SourceRecord> transform = clazz.getDeclaredConstructor().newInstance();
+                    java.util.Map<String, Object> transformConfig = config.entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(prefix))
+                        .collect(java.util.stream.Collectors.toMap(
+                            e -> e.getKey().substring(prefix.length()),
+                            java.util.Map.Entry::getValue
+                        ));
+                    log.info("transform config: {}", transformConfig);
+                    transform.configure(transformConfig);
+                    transformations.add(transform);
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to instantiate SMT: " + className, e);
+                }
+            }
+        }
     }
 
     private static final AvroData avroData = new AvroData(1000);
+
+    public synchronized KafkaSourceRecord processSourceRecord(final SourceRecord srcRecord) {
+        SourceRecord transformedRecord = applyTransforms(srcRecord);
+        if (transformedRecord == null) {
+            return null;
+        }
+        KafkaSourceRecord record = new KafkaSourceRecord(transformedRecord);
+        offsetWriter.offset(transformedRecord.sourcePartition(), transformedRecord.sourceOffset());
+        return record;
+    }
+
+    public SourceRecord applyTransforms(SourceRecord record) {
+        SourceRecord current = record;
+        for (Transformation<SourceRecord> transform : transformations) {
+            if (current == null) {
+                break;
+            }
+            current = transform.apply(current);
+        }
+        return current;
+    }
 
     public class KafkaSourceRecord extends AbstractKafkaSourceRecord<KeyValue<byte[], byte[]>>
             implements KVRecord<byte[], byte[]> {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -141,7 +141,7 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                     log.info("transform config: {}", transformConfig);
                     String predicateName = (String) transformConfig.get("predicate");
                     boolean negated = Boolean.parseBoolean(
-                        String.valueOf(transformConfig.getOrDefault("negated", "false")));
+                        String.valueOf(transformConfig.getOrDefault("negate", "false")));
                     Predicate<SourceRecord> predicate = null;
                     if (predicateName != null) {
                         predicate = predicates.get(predicateName);

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -140,7 +140,8 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                         ));
                     log.info("transform config: {}", transformConfig);
                     String predicateName = (String) transformConfig.get("predicate");
-                    boolean negated = Boolean.parseBoolean(String.valueOf(transformConfig.getOrDefault("negated", "false")));
+                    boolean negated = Boolean.parseBoolean(
+                        String.valueOf(transformConfig.getOrDefault("negated", "false")));
                     Predicate<SourceRecord> predicate = null;
                     if (predicateName != null) {
                         predicate = predicates.get(predicateName);


### PR DESCRIPTION
### Motivation

The current implementation of the Kafka Connect adaptor in Pulsar IO does not support [Kafka Connect transforms](https://github.com/apache/kafka/tree/3.8/connect/transforms/src/main/java/org/apache/kafka/connect/transforms) and [predicates](https://github.com/apache/kafka/tree/3.8/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/predicates). This limits the flexibility and potential of using Kafka Connect-based source connectors, such as the Debezium PostgreSQL source connector, which [rely heavily on transformations](https://debezium.io/documentation/reference/1.9/transformations/index.html) to modify, filter, or enrich records before they are ingested. By adding support for transforms, we enable users to fully leverage these connectors' capabilities, sparing them the need to deploy additional Pulsar Functions to perform simple message-level transformations.

### Modifications

Extended `KafkaConnectSource` with three additional steps: `initPredicates`, `initTransforms` and `applyTransforms`.

- `initPredicates` and `initTransforms` are called during the initialization of the Kafka Connect adaptor and are responsible for setting up any configured predicates and transforms.

- `applyTransforms` is executed during `processRecords` and applies all available transforms to each source record before it is processed.

`kafka-connect-adaptor` has been updated to include the `connect-transforms` package.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended the existing `KafkaConnectSourceTest` test to verify that transforms can be initialized and applied

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->