### PR TITLE
[feat][admin] PIP-415: Support getting message ID by index

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5533,8 +5533,7 @@ public class PersistentTopicsBase extends AdminResource {
                     ManagedLedger managedLedger = persistentTopic.getManagedLedger();
                     Position lastPosition = managedLedger.getLastConfirmedEntry();
                     Position firstPosition = managedLedger.getFirstPosition();
-                    if (firstPosition == null || lastPosition == null ||
-                            firstPosition.equals(lastPosition)) {
+                    if (firstPosition == null || lastPosition == null || firstPosition.equals(lastPosition)) {
                         return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
                                 "No messages found in topic " + topicName));
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5493,7 +5493,7 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<MessageId> internalGetMessageIDByIndexAsync(Long offset, boolean authoritative) {
         if (pulsar().getBrokerService().isBrokerEntryMetadataEnabled()) {
             return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
-                    "GetMessageIDByIndex is not allowed when broker entry metadata is enabled"));
+                    "GetMessageIDByIndex is not allowed when broker entry metadata is disabled"));
         }
         int partitionIndex = topicName.getPartitionIndex();
         CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.PEEK_MESSAGES);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5555,7 +5555,7 @@ public class PersistentTopicsBase extends AdminResource {
                                                 // we continue searching
                                                 return messageIndex < index;
                                             }
-                                        } catch (IOException e) {
+                                        } catch (Throwable e) {
                                             log.error("Error deserialize message for message position find", e);
                                             return false;
                                         } finally {
@@ -5591,7 +5591,7 @@ public class PersistentTopicsBase extends AdminResource {
                     } else {
                         indexFuture.complete(index);
                     }
-                } catch (IOException e) {
+                } catch (Throwable e) {
                     indexFuture.completeExceptionally(new RestException(Status.INTERNAL_SERVER_ERROR,
                             "Failed to get index from entry: " + e.getMessage()));
                 } finally {
@@ -5610,16 +5610,12 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
 
-    private static Long getIndexFromEntry(Entry entry) throws IOException {
-        try {
-            final var brokerEntryMetadata = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
-            if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
-                return brokerEntryMetadata.getIndex();
-            } else {
-                return null;
-            }
-        } catch (Throwable throwable) {
-            throw new IOException(throwable);
+    private static Long getIndexFromEntry(Entry entry) {
+        final var brokerEntryMetadata = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
+        if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
+            return brokerEntryMetadata.getIndex();
+        } else {
+            return null;
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5542,7 +5542,10 @@ public class PersistentTopicsBase extends AdminResource {
                                         try {
                                             BrokerEntryMetadata brokerEntryMetadata =
                                                     Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
-                                            assert brokerEntryMetadata != null;
+                                            // Skip messages without index
+                                            if (brokerEntryMetadata == null) {
+                                                return true;
+                                            }
                                             return brokerEntryMetadata.getIndex() < index;
                                         } catch (Exception e) {
                                             log.error("Error deserialize message for message position find", e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5525,10 +5525,10 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))
                 .thenCompose(topic -> {
                     if (!(topic instanceof PersistentTopic persistentTopic)) {
-                        log.error("[{}] Get message id by offset on a non-persistent topic {} is not allowed",
+                        log.error("[{}] Get message id by index on a non-persistent topic {} is not allowed",
                                 clientAppId(), topicName);
                         return FutureUtil.failedFuture(new RestException(Status.METHOD_NOT_ALLOWED,
-                                "Get message id by offset on a non-persistent topic is not allowed"));
+                                "Get message id by index on a non-persistent topic is not allowed"));
                     }
                     ManagedLedger managedLedger = persistentTopic.getManagedLedger();
                     return findMessageIndexByPosition(
@@ -5556,7 +5556,7 @@ public class PersistentTopicsBase extends AdminResource {
                                 Position lastPosition = managedLedger.getLastConfirmedEntry();
                                 if (position == null || position.compareTo(lastPosition) > 0) {
                                     return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
-                                            "Message not found for offset " + index));
+                                            "Message not found for index " + index));
                                 } else {
                                     return CompletableFuture.completedFuture(position);
                                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5490,7 +5490,7 @@ public class PersistentTopicsBase extends AdminResource {
                         }));
     }
 
-    protected CompletableFuture<MessageId> internalGetMessageIDByOffsetAsync(Long offset, boolean authoritative) {
+    protected CompletableFuture<MessageId> internalGetMessageIDByIndexAsync(Long offset, boolean authoritative) {
         int partitionIndex = topicName.getPartitionIndex();
         CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.PEEK_MESSAGES);
         return future.thenCompose(__ -> {
@@ -5506,10 +5506,10 @@ public class PersistentTopicsBase extends AdminResource {
                         return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                                 .thenAccept(topicMetadata -> {
                                     if (topicMetadata.partitions > 0) {
-                                        log.warn("[{}] Not supported getMessageIdByOffset operation on "
+                                        log.warn("[{}] Not supported getMessageIdByIndex operation on "
                                                         + "partitioned-topic {}", clientAppId(), topicName);
                                         throw new RestException(Status.METHOD_NOT_ALLOWED,
-                                                "GetMessageIDByOffset is not allowed on partitioned-topic");
+                                                "GetMessageIDByIndex is not allowed on partitioned-topic");
                                     }
                                 });
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5535,7 +5535,15 @@ public class PersistentTopicsBase extends AdminResource {
                 }
                 return false;
             });
-        }).thenCompose(position -> CompletableFuture
-                .completedFuture(new MessageIdImpl(position.getLedgerId(), position.getEntryId(), partitionIndex)));
+        }).thenCompose(position -> {
+            if (position == null) {
+                return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
+                        "Message not found for offset " + offset));
+            } else {
+                return CompletableFuture
+                        .completedFuture(new MessageIdImpl(position.getLedgerId(), position.getEntryId(),
+                                partitionIndex));
+            }
+        });
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5491,6 +5491,10 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected CompletableFuture<MessageId> internalGetMessageIDByIndexAsync(Long offset, boolean authoritative) {
+        if (pulsar().getBrokerService().isBrokerEntryMetadataEnabled()) {
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "GetMessageIDByIndex is not allowed when broker entry metadata is enabled"));
+        }
         int partitionIndex = topicName.getPartitionIndex();
         CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.PEEK_MESSAGES);
         return future.thenCompose(__ -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5016,29 +5016,29 @@ public class PersistentTopics extends PersistentTopicsBase {
     }
 
     @GET
-    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByOffset")
-    @ApiOperation(hidden = true, value = "Get Message ID by offset.",
-            notes = "If the specified offset is a system message, "
+    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByIndex")
+    @ApiOperation(hidden = true, value = "Get Message ID by index.",
+            notes = "If the specified index is a system message, "
                     + "it will return the message id of the later message.")
     @ApiResponses(value = {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
-                    + "or the offset is invalid")})
-    public void getMessageIDByOffsetAndPartitionID(@Suspended final AsyncResponse asyncResponse,
+                    + "or the index is invalid")})
+    public void getMessageIDByIndexAndPartitionID(@Suspended final AsyncResponse asyncResponse,
                                                    @PathParam("tenant") String tenant,
                                                    @PathParam("namespace") String namespace,
                                                    @PathParam("topic") @Encoded String encodedTopic,
-                                                   @QueryParam("offset") long offset,
+                                                   @QueryParam("index") long index,
                                                    @QueryParam("authoritative") @DefaultValue("false")
                                                    boolean authoritative){
         validateTopicName(tenant, namespace, encodedTopic);
-        internalGetMessageIDByOffsetAsync(offset, authoritative)
+        internalGetMessageIDByIndexAsync(index, authoritative)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to get message id by offset for topic {}, partition id {}, offset {}",
-                                clientAppId(), topicName, offset, ex);
+                        log.error("[{}] Failed to get message id by index for topic {}, partition id {}, index {}",
+                                clientAppId(), topicName, index, ex);
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5028,12 +5028,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiResponse(code = 406, message = "The topic is not a persistent topic"),
             @ApiResponse(code = 412, message = "The broker is not enable broker entry metadata"),
     })
-    public void getMessageIDByIndexAndPartitionID(@Suspended final AsyncResponse asyncResponse,
-                                                   @PathParam("tenant") String tenant,
-                                                   @PathParam("namespace") String namespace,
-                                                   @PathParam("topic") @Encoded String encodedTopic,
-                                                   @QueryParam("index") long index,
-                                                   @QueryParam("authoritative") @DefaultValue("false")
+    public void getMessageIDByIndex(@Suspended final AsyncResponse asyncResponse,
+                                    @PathParam("tenant") String tenant,
+                                    @PathParam("namespace") String namespace,
+                                    @PathParam("topic") @Encoded String encodedTopic,
+                                    @QueryParam("index") long index,
+                                    @QueryParam("authoritative") @DefaultValue("false")
                                                    boolean authoritative){
         validateTopicName(tenant, namespace, encodedTopic);
         internalGetMessageIDByIndexAsync(index, authoritative)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5015,5 +5015,35 @@ public class PersistentTopics extends PersistentTopicsBase {
                 });
     }
 
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByOffset")
+    @ApiOperation(hidden = true, value = "Get Message ID by offset.",
+            notes = "If the specified offset is a system message, "
+                    + "it will return the message id of the later message.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
+                    + "or the offset is invalid")})
+    public void getMessageIDByOffsetAndPartitionID(@Suspended final AsyncResponse asyncResponse,
+                                                   @PathParam("tenant") String tenant,
+                                                   @PathParam("namespace") String namespace,
+                                                   @PathParam("topic") @Encoded String encodedTopic,
+                                                   @QueryParam("offset") long offset,
+                                                   @QueryParam("authoritative") @DefaultValue("false")
+                                                   boolean authoritative){
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetMessageIDByOffsetAsync(offset, authoritative)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    if (!isRedirectException(ex)) {
+                        log.error("[{}] Failed to get message id by offset for topic {}, partition id {}, offset {}",
+                                clientAppId(), topicName, offset, ex);
+                    }
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5024,7 +5024,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
-                    + "or the index is invalid")})
+                    + "or the index is invalid"),
+            @ApiResponse(code = 406, message = "The topic is not a persistent topic"),
+            @ApiResponse(code = 412, message = "The broker is not enable broker entry metadata"),
+    })
     public void getMessageIDByIndexAndPartitionID(@Suspended final AsyncResponse asyncResponse,
                                                    @PathParam("tenant") String tenant,
                                                    @PathParam("namespace") String namespace,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -2012,22 +2012,4 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
             assertEquals(batchMessage.getProperties().get("BaTcH-kEy3"), "BaTcH-vAlUe3");
         }
     }
-
-    @Test
-    public void testGetMessageIdByOffset() throws Exception {
-        String topicName = "persistent://" + testTenant + "/" + testNamespaceLocal + "/testGetMessageIdByOffset";
-        admin.topics().createNonPartitionedTopic(topicName);
-        @Cleanup
-        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
-                .topic(topicName)
-                .enableBatching(false)
-                .create();
-        MessageIdImpl messageId = (MessageIdImpl) producer.send("test");
-        producer.send("test");
-        Message<byte[]>
-                message = admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
-        long offset = message.getIndex().get();
-        MessageIdImpl messageIdByOffset = (MessageIdImpl) admin.topics().getMessageIdByOffset(topicName, offset);
-        Assert.assertEquals(messageIdByOffset, messageId);
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -2012,4 +2012,22 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
             assertEquals(batchMessage.getProperties().get("BaTcH-kEy3"), "BaTcH-vAlUe3");
         }
     }
+
+    @Test
+    public void testGetMessageIdByOffset() throws Exception {
+        String topicName = "persistent://" + testTenant + "/" + testNamespaceLocal + "/testGetMessageIdByOffset";
+        admin.topics().createNonPartitionedTopic(topicName);
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .enableBatching(false)
+                .create();
+        MessageIdImpl messageId = (MessageIdImpl) producer.send("test");
+        producer.send("test");
+        Message<byte[]>
+                message = admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
+        long offset = message.getIndex().get();
+        MessageIdImpl messageIdByOffset = (MessageIdImpl) admin.topics().getMessageIdByOffset(topicName, offset);
+        Assert.assertEquals(messageIdByOffset, messageId);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import static org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -36,7 +36,6 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -438,7 +437,8 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
                 .create();
         MessageIdImpl messageId = (MessageIdImpl) producer.send("test");
         Message<byte[]>
-                message = admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
+                message =
+                admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
         long index = message.getIndex().get();
         MessageIdImpl messageIdByIndex = (MessageIdImpl) admin.topics().getMessageIdByIndex(topicName, index);
         Assert.assertEquals(messageIdByIndex, messageId);
@@ -465,7 +465,8 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
                 messageId2.getLedgerId(), messageId2.getEntryId()).get(0);
         long index2 = message2.getIndex().get();
         // 2.1 test partitioned topic name with partition index
-        MessageIdImpl messageIdByIndex2 = (MessageIdImpl) admin.topics().getMessageIdByIndex(partitionedTopicName, index2);
+        MessageIdImpl messageIdByIndex2 =
+                (MessageIdImpl) admin.topics().getMessageIdByIndex(partitionedTopicName, index2);
         Assert.assertEquals(messageIdByIndex2, messageId2);
         // 2.2 test partitioned topic name without partition index
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -44,9 +44,9 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.util.Sets;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.function.Executable;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -507,10 +507,10 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
                 PulsarAdminException.class, NotFoundException.class);
     }
 
-    private void assertThrowsWithCause(Executable executable,
+    private void assertThrowsWithCause(ThrowableAssert.ThrowingCallable executable,
                                        Class<? extends Throwable> expectedException,
                                        Class<? extends Throwable> expectedCause) {
-        assertThatThrownBy(executable::execute)
+        assertThatThrownBy(executable)
                 .isInstanceOf(expectedException)
                 .hasRootCauseInstanceOf(expectedCause);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -422,7 +422,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
     }
 
     @Test
-    public void testGetMessageIdByOffset() throws Exception {
+    public void testGetMessageIdByIndex() throws Exception {
         // 1. test no partitioned topic
         final String topicName = newTopicName();
         admin.topics().createNonPartitionedTopic(topicName);
@@ -434,9 +434,9 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
         MessageIdImpl messageId = (MessageIdImpl) producer.send("test");
         Message<byte[]>
                 message = admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
-        long offset = message.getIndex().get();
-        MessageIdImpl messageIdByOffset = (MessageIdImpl) admin.topics().getMessageIdByOffset(topicName, offset);
-        Assert.assertEquals(messageIdByOffset, messageId);
+        long index = message.getIndex().get();
+        MessageIdImpl messageIdByIndex = (MessageIdImpl) admin.topics().getMessageIdByIndex(topicName, index);
+        Assert.assertEquals(messageIdByIndex, messageId);
 
         // 2. test partitioned topic
         final String topicName2 = newTopicName();
@@ -458,8 +458,8 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
         Message<byte[]>
                 message2 = admin.topics().getMessagesById(partitionedTopicName,
                 messageId2.getLedgerId(), messageId2.getEntryId()).get(0);
-        long offset2 = message2.getIndex().get();
-        MessageIdImpl messageIdByOffset2 = (MessageIdImpl) admin.topics().getMessageIdByOffset(partitionedTopicName, offset2);
-        Assert.assertEquals(messageIdByOffset2, messageId2);
+        long index2 = message2.getIndex().get();
+        MessageIdImpl messageIdByIndex2 = (MessageIdImpl) admin.topics().getMessageIdByIndex(partitionedTopicName, index2);
+        Assert.assertEquals(messageIdByIndex2, messageId2);
     }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4560,18 +4560,18 @@ public interface Topics {
     }
 
     /**
-     * Get the message id by offset.
+     * Get the message id by index.
      * @param topicName the partitioned topic name or non-partitioned topic name
-     * @param offset the offset of a message
+     * @param index the index of a message
      * @return the message id of the message
      */
-    MessageId getMessageIdByOffset(String topicName, long offset) throws PulsarAdminException;
+    MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
 
     /**
-     * Get the message id by offset asynchronously.
+     * Get the message id by index asynchronously.
      * @param topicName the topic name
-     * @param offset the offset of a message
+     * @param index the index of a message
      * @return the message id of the message
      */
-    CompletableFuture<MessageId> getMessageIdByOffsetAsync(String topicName, long offset);
+    CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4558,4 +4558,20 @@ public interface Topics {
     default CompletableFuture<Void> createShadowTopicAsync(String shadowTopic, String sourceTopic) {
         return createShadowTopicAsync(shadowTopic, sourceTopic, null);
     }
+
+    /**
+     * Get the message id by offset.
+     * @param topicName the partitioned topic name or non-partitioned topic name
+     * @param offset the offset of a message
+     * @return the message id of the message
+     */
+    MessageId getMessageIdByOffset(String topicName, long offset) throws PulsarAdminException;
+
+    /**
+     * Get the message id by offset asynchronously.
+     * @param topicName the topic name
+     * @param offset the offset of a message
+     * @return the message id of the message
+     */
+    CompletableFuture<MessageId> getMessageIdByOffsetAsync(String topicName, long offset);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4562,6 +4562,8 @@ public interface Topics {
     /**
      * Get the message id by index. If the index points to a system message, return the first user message following it;
      * if the specified message has expired and been deleted, return MessageId.Earliest.
+     * The messages without entry metadata will be skipped, and the next matched message whose index >= the specified
+     * index will be returned.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0)
      *                 or the original topic name for non-partitioned topics.
      * @param index the index of a message
@@ -4587,6 +4589,8 @@ public interface Topics {
     /**
      * Get the message id by index asynchronously. If the index points to a system message, return the first user
      * message following it; if the specified message has expired and been deleted, return MessageId.Earliest.
+     * The messages without entry metadata will be skipped, and the next matched message whose index >= the specified
+     * index will be returned.
      * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or
      *                 the original topic name for non-partitioned topics.
      * @param index the index of a message

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4560,18 +4560,55 @@ public interface Topics {
     }
 
     /**
-     * Get the message id by index.
-     * @param topicName the partitioned topic name or non-partitioned topic name
+     * Get the message id by index. If the index points to a system message, return the first user message following it;
+     * if the specified message has expired and been deleted, return MessageId.Earliest.
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0)
+     *                 or the original topic name for non-partitioned topics.
      * @param index the index of a message
-     * @return the message id of the message
+     * @return the message id of the message.
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal
+     * storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @throws NotAuthorizedException      (HTTP 403 Forbidden) Client lacks permissions to access the topic/namespace.
+     * @throws NotFoundException           (HTTP 404 Not Found) Source topic/namespace does not exist, or invalid index.
+     * @throws PulsarAdminException        (HTTP 406 Not Acceptable) Specified topic is not a persistent topic.
+     * @throws PreconditionFailedException (HTTP 412 Precondition Failed) Broker entry metadata is disabled.
+     * @throws PulsarAdminException        For other errors (e.g., HTTP 500 Internal Server Error).
      */
     MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
 
+
     /**
-     * Get the message id by index asynchronously.
-     * @param topicName the topic name
+     * Get the message id by index asynchronously. If the index points to a system message, return the first user
+     * message following it; if the specified message has expired and been deleted, return MessageId.Earliest.
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or
+     *                 the original topic name for non-partitioned topics.
      * @param index the index of a message
-     * @return the message id of the message
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal
+     *              storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @implNote The return {@link CompletableFuture<MessageId>} that completes with the message id of the message.
+     *         The future may complete exceptionally with:
+     *         <ul>
+     *             <li>{@link NotAuthorizedException} (HTTP 403) Permission denied for topic/namespace access.</li>
+     *             <li>{@link NotFoundException} (HTTP 404) Shadow topic/namespace does not exist or invalid index.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 406) Shadow topic is not a persistent topic.</li>
+     *             <li>{@link PreconditionFailedException} (HTTP 412) Broker entry metadata is not enabled.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 307) Redirect required to the correct broker.</li>
+     *             <li>{@link PulsarAdminException} Other errors (e.g., HTTP 500).</li>
+     *         </ul>
      */
     CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2819,5 +2819,31 @@ public class TopicsImpl extends BaseResource implements Topics {
         });
     }
 
+    @Override
+    public MessageId getMessageIdByOffset(String topicName, long offset) throws PulsarAdminException {
+        return sync(() -> getMessageIdByOffsetAsync(topicName, offset));
+    }
+
+    @Override
+    public CompletableFuture<MessageId> getMessageIdByOffsetAsync(String topicName, long offset) {
+        final CompletableFuture<MessageId> messageIdCompletableFuture = new CompletableFuture<>();
+        TopicName topic = validateTopic(topicName);
+        WebTarget path = topicPath(topic, "getMessageIdByOffset");
+        path = path.queryParam("offset", offset);
+        asyncGetRequest(path, new InvocationCallback<MessageIdImpl>(){
+
+            @Override
+            public void completed(MessageIdImpl messageId) {
+                messageIdCompletableFuture.complete(messageId);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                messageIdCompletableFuture.completeExceptionally(throwable);
+            }
+        });
+        return messageIdCompletableFuture;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(TopicsImpl.class);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2820,16 +2820,16 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public MessageId getMessageIdByIndex(String topicName, long offset) throws PulsarAdminException {
-        return sync(() -> getMessageIdByIndexAsync(topicName, offset));
+    public MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException {
+        return sync(() -> getMessageIdByIndexAsync(topicName, index));
     }
 
     @Override
-    public CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long offset) {
+    public CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index) {
         final CompletableFuture<MessageId> messageIdCompletableFuture = new CompletableFuture<>();
         TopicName topic = validateTopic(topicName);
-        WebTarget path = topicPath(topic, "getMessageIdByOffset");
-        path = path.queryParam("offset", offset);
+        WebTarget path = topicPath(topic, "getMessageIdByIndex");
+        path = path.queryParam("index", index);
         asyncGetRequest(path, new InvocationCallback<MessageIdImpl>(){
 
             @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2820,12 +2820,12 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public MessageId getMessageIdByOffset(String topicName, long offset) throws PulsarAdminException {
-        return sync(() -> getMessageIdByOffsetAsync(topicName, offset));
+    public MessageId getMessageIdByIndex(String topicName, long offset) throws PulsarAdminException {
+        return sync(() -> getMessageIdByIndexAsync(topicName, offset));
     }
 
     @Override
-    public CompletableFuture<MessageId> getMessageIdByOffsetAsync(String topicName, long offset) {
+    public CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long offset) {
         final CompletableFuture<MessageId> messageIdCompletableFuture = new CompletableFuture<>();
         TopicName topic = validateTopic(topicName);
         WebTarget path = topicPath(topic, "getMessageIdByOffset");

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2090,8 +2090,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-shadow-source persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getShadowSource("persistent://myprop/clust/ns1/ds1");
 
-        cmdTopics.run(split("get-message-id-by-offset persistent://myprop/clust/ns1/ds1 -o 0"));
-        verify(mockTopics).getMessageIdByOffset("persistent://myprop/clust/ns1/ds1", 0);
+        cmdTopics.run(split("get-message-id-by-index persistent://myprop/clust/ns1/ds1 -i 0"));
+        verify(mockTopics).getMessageIdByIndex("persistent://myprop/clust/ns1/ds1", 0);
 
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2090,7 +2090,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-shadow-source persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getShadowSource("persistent://myprop/clust/ns1/ds1");
 
-
+        cmdTopics.run(split("get-message-id-by-offset persistent://myprop/clust/ns1/ds1 -o 0"));
+        verify(mockTopics).getMessageIdByOffset("persistent://myprop/clust/ns1/ds1", 0);
 
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -276,7 +276,7 @@ public class CmdTopics extends CmdBase {
 
         addCommand("trim-topic", new TrimTopic());
 
-        addCommand("get-message-id-by-offset", new GetMessageIdByOffset());
+        addCommand("get-message-id-by-index", new GetMessageIdByIndex());
     }
 
     @Command(description = "Get the list of topics under a namespace.")
@@ -3061,19 +3061,19 @@ public class CmdTopics extends CmdBase {
         }
     }
 
-    @Command(description = "Get message id by offset")
-    private class GetMessageIdByOffset extends CliCommand {
+    @Command(description = "Get message id by index")
+    private class GetMessageIdByIndex extends CliCommand {
 
         @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
         private String topicName;
 
-        @Option(names = { "--offset", "-o" }, description = "Offset to get message id for the topic", required = true)
-        private Long offset;
+        @Option(names = { "--index", "-i" }, description = "Index to get message id for the topic", required = true)
+        private Long index;
 
         @Override
         void run() throws Exception {
             String topic = validateTopicName(topicName);
-            getAdmin().topics().getMessageIdByOffset(topic, offset);
+            getAdmin().topics().getMessageIdByIndex(topic, index);
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -275,6 +275,8 @@ public class CmdTopics extends CmdBase {
         addCommand("set-schema-validation-enforce", new SetSchemaValidationEnforced());
 
         addCommand("trim-topic", new TrimTopic());
+
+        addCommand("get-message-id-by-offset", new GetMessageIdByOffset());
     }
 
     @Command(description = "Get the list of topics under a namespace.")
@@ -3056,6 +3058,22 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String topic = validateTopicName(topicName);
             getAdmin().topics().trimTopic(topic);
+        }
+    }
+
+    @Command(description = "Get message id by offset")
+    private class GetMessageIdByOffset extends CliCommand {
+
+        @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
+        private String topicName;
+
+        @Option(names = { "--offset", "-o" }, description = "Offset to get message id for the topic", required = true)
+        private Long offset;
+
+        @Override
+        void run() throws Exception {
+            String topic = validateTopicName(topicName);
+            getAdmin().topics().getMessageIdByOffset(topic, offset);
         }
     }
 }


### PR DESCRIPTION
PIP:https://github.com/apache/pulsar/pull/24220

### Motivation
 we can now obtain the offset of a message by its message id:

1. Get the message by id using `get-message-by-id` cmd
2. Get the index of the message using `Message.getIndex()`

But we cannot obtain the message id by offset. Then we need to add a new API to get the message id by offset.


### Modifications

Add a new http API to retrieve the message ID by offset.
We propose to add a new API to retrieve the message ID by offset, enabling us to cache the mapping between message ID and offset.
This will allow us to use offsets for seek and acknowledgment operations when consuming messages through the standardized API.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
