### PR TITLE
[fix][broker] Allow recreation of partitioned topic after metadata loss

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import javax.ws.rs.WebApplicationException;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -664,7 +664,7 @@ public abstract class AdminResource extends PulsarWebResource {
                         for (String s : list) {
                             TopicName item = TopicName.get(s);
                             if (item.isPartitioned() && item.getPartitionedTopicName()
-                                    .startsWith(topicName.getPartitionedTopicName())) {
+                                    .equals(topicName.getPartitionedTopicName())) {
                                 if (item.getPartitionIndex() > maxIndex) {
                                     maxIndex = item.getPartitionIndex();
                                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -775,7 +775,7 @@ public abstract class AdminResource extends PulsarWebResource {
      * @param topicName given topic name
      */
     protected CompletableFuture<TopicExistsInfo> checkTopicExistsAsync(TopicName topicName) {
-        return pulsar().getNamespaceService().checkTopicExists(topicName);
+        return pulsar().getNamespaceService().checkTopicExistsAsync(topicName);
     }
 
     private CompletableFuture<Void> provisionPartitionedTopicPath(int numPartitions,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -659,19 +659,19 @@ public abstract class AdminResource extends PulsarWebResource {
 
     private CompletableFuture<Integer> getMaxPartitionIndex(TopicName topicName) {
         if (topicName.getDomain() == TopicDomain.persistent) {
-            AtomicInteger maxIndex = new AtomicInteger(-1);
             return getPulsarResources().getTopicResources().listPersistentTopicsAsync(topicName.getNamespaceObject())
                     .thenApply(list -> {
+                        int maxIndex = -1;
                         for (String s : list) {
                             TopicName item = TopicName.get(s);
                             if (item.isPartitioned() && item.getPartitionedTopicName()
                                     .startsWith(topicName.getPartitionedTopicName())) {
-                                if (item.getPartitionIndex() > maxIndex.get()) {
-                                    maxIndex.set(item.getPartitionIndex());
+                                if (item.getPartitionIndex() > maxIndex) {
+                                    maxIndex = item.getPartitionIndex();
                                 }
                             }
                         }
-                        return maxIndex.get();
+                        return maxIndex;
                     });
         }
         return CompletableFuture.completedFuture(-1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3720,8 +3720,9 @@ public class PersistentTopicsBase extends AdminResource {
         }
         return ret
                 .thenCompose(__ -> checkTopicExistsAsync(topicName))
-                .thenCompose(exist -> {
-                    if (!exist) {
+                .thenCompose(topicExistsInfo -> {
+                    if (!topicExistsInfo.isExists()) {
+                        topicExistsInfo.recycle();
                         throw new RestException(Status.NOT_FOUND, getTopicNotFoundErrorMessage(topicName.toString()));
                     } else {
                         return getPartitionedTopicMetadataAsync(topicName, false, false)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1425,6 +1425,10 @@ public class NamespaceService implements AutoCloseable {
      */
     @Deprecated
     public CompletableFuture<TopicExistsInfo> checkTopicExists(TopicName topic) {
+        // Exclude the heartbeat topic.
+        if (isHeartbeatNamespace(topic)) {
+            return CompletableFuture.completedFuture(TopicExistsInfo.newNonPartitionedTopicExists());
+        }
         // For non-persistent/persistent partitioned topic, which has metadata.
         return pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(
                         topic.isPartitioned() ? TopicName.get(topic.getPartitionedTopicName()) : topic)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -3693,5 +3694,23 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             // reset config
             pulsar.getConfiguration().setAllowAclChangesOnNonExistentTopics(false);
         }
+    }
+
+    @Test
+    public void testRecreatePartitionedTopicAfterMetadataLoss()
+            throws PulsarAdminException, ExecutionException, InterruptedException {
+        String namespace = "prop-xyz/ns1/";
+        final String random = UUID.randomUUID().toString();
+        final String topic = "persistent://" + namespace + random;
+        admin.topics().createPartitionedTopic(topic, 5);
+
+        // Delete the topic metadata.
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .deletePartitionedTopicAsync(TopicName.get(topic)).get();
+        List<String> partitionedTopicList = admin.topics().getPartitionedTopicList(namespace);
+        assertThat(partitionedTopicList).doesNotContain(topic);
+
+        // Create the partitioned topic again.
+        admin.topics().createPartitionedTopic(topic, 5);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -69,7 +70,6 @@ import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
-import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -936,11 +936,10 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         final String partitionedTopicName = "error-500-topic";
         AsyncResponse response1 = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
-        NamespaceName namespaceName = NamespaceName.get(property, cluster, namespace);
         CompletableFuture<List<String>> future = new CompletableFuture();
         future.completeExceptionally(new RuntimeException("500 error contains error message"));
         NamespaceService namespaceService = pulsar.getNamespaceService();
-        doReturn(future).when(namespaceService).getListOfTopics(namespaceName, CommandGetTopicsOfNamespace.Mode.ALL);
+        doReturn(future).when(namespaceService).checkTopicExists(any());
         persistentTopics.createPartitionedTopic(response1, property, cluster, namespace, partitionedTopicName, 5, false);
         verify(response1, timeout(5000).times(1)).resume(responseCaptor.capture());
         Assert.assertEquals(responseCaptor.getValue().getResponse().getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());


### PR DESCRIPTION
### Motivation

In Pulsar, it's possible for actual partition topics (e.g., `public/default/test-partitioned-topic-partition-1`) to exist even though the corresponding partitioned topic metadata is missing. This inconsistency can occur due to human error (e.g., accidental deletion of metadata) or implicit topic creation via auto-topic creation settings.

Specifically, if `allowAutoTopicCreation=true` and `allowAutoTopicCreationType=non-partitioned`, then producing or consuming directly from a partition topic name like `test-partitioned-topic-partition-1` will cause Pulsar to auto-create a non-partitioned topic. This leads to an inconsistent state: the topic appears in `topics list`, but not in `topics list-partitioned-topics`. From the user's perspective, they expect to see a partitioned topic, but instead, `list-partitioned-topics` returns nothing, leading to confusion and potential automation failures.

Steps to reproduce:
```bash
$ docker run -it --name pulsar-partitioned-topic-test --rm apachepulsar/pulsar:4.0.3 bin/pulsar standalone -nfw
$ docker exec -it pulsar-partitioned-topic-test bash

# Produce to a partition name directly
$ bin/pulsar-client produce public/default/test-partitioned-topic-partition-1 -m "hello"
# Output: 1 messages successfully produced

# Listed non-partitioned topics
$ bin/pulsar-admin topics list public/default
persistent://public/default/test-partitioned-topic-partition-1

# Listed partitioned topics (none exists)
$ bin/pulsar-admin topics list-partitioned-topics public/default
```

Once such a partition is mistakenly created as a non-partitioned topic, it is no longer possible to convert it into a partitioned topic, because Pulsar does not allow overwriting existing topics. This results in effective metadata loss. A similar issue can occur in geo-replication scenarios, where only the individual partition topics are replicated, but the partitioned topic metadata is not.

Moreover, if the partitioned topic metadata is lost, running `pulsar-admin topics create-partitioned-topic` fails to recreate it:
```
> pulsar-admin topics create-partitioned-topic test-partitioned-topic -p 4
2025-04-25T19:45:14,373+0800 [AsyncHttpClient-7-2] WARN  org.apache.pulsar.client.admin.internal.BaseResource - [http://localhost:8080/admin/v2/persistent/public/default/test-partitioned-topic/partitions?createLocalTopicOnly=false] Failed to perform http put request: javax.ws.rs.ClientErrorException: HTTP 409 {"reason":"This topic already exists"}
This topic already exists
```

In this case, the partition still exist, but the partitioned topic metadata is missing—causing a `409 Conflict` when attempting to recreate it.

### Modifications

- Use `pulsar().getNamespaceService().checkTopicExists(topicName)` to verify the existence of the topic or its metadata. If the topic or its metadata does not exist, the system proceeds with the creation of the partitioned topic, allowing its recreation.
- When validating consistency with non-partitioned topics, ensure that the number of partitions is greater than or equal to the max partition index found in the non-partitioned topic list.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->