### PR TITLE
[fix][broker] Fix ByteBuf memory leak in REST API for publishing messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -282,19 +282,21 @@ public class TopicsBase extends PersistentTopicsBase {
                 pulsar().getBrokerService().getOwningTopics().get(topicName.getPartitionedTopicName())
                         .remove(topicName.getPartitionIndex());
             } else {
-                ByteBuf headersAndPayload = messageToByteBuf(message);
                 try {
-                    Topic topicObj = t.get();
-                    topicObj.publishMessage(headersAndPayload,
-                            RestMessagePublishContext.get(publishResult, topicObj, System.nanoTime()));
+                    ByteBuf headersAndPayload = messageToByteBuf(message);
+                    try {
+                        Topic topicObj = t.get();
+                        topicObj.publishMessage(headersAndPayload,
+                                RestMessagePublishContext.get(publishResult, topicObj, System.nanoTime()));
+                    } finally {
+                        headersAndPayload.release();
+                    }
                 } catch (Exception e) {
                     if (log.isDebugEnabled()) {
                         log.debug("Fail to publish single messages to topic  {}: {} ",
                                 topicName, e.getCause());
                     }
                     publishResult.completeExceptionally(e);
-                } finally {
-                    headersAndPayload.release();
                 }
             }
         });


### PR DESCRIPTION
Fixes #24227

### Motivation

See #24227. Using the REST API for publishing messages to the broker leads to `io.netty.util.internal.OutOfDirectMemoryError`.

### Modifications

Release the `ByteBuf` after passing it on to publishing by the broker. The reference count will get increased internally.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->