### PR TITLE
[fix][sec] Upgrade Jetty to 9.4.57.v20241219 to mitigate CVE-2024-6763

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -393,25 +393,25 @@ The Apache Software License, Version 2.0
     - org.asynchttpclient-async-http-client-2.12.4.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.4.jar
  * Jetty
-    - org.eclipse.jetty-jetty-client-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-continuation-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-http-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-io-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-proxy-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-security-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-server-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-servlet-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-servlets-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-util-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-util-ajax-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-websocket-api-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-websocket-client-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-websocket-common-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-websocket-server-9.4.56.v20240826.jar
-    - org.eclipse.jetty.websocket-websocket-servlet-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.56.v20240826.jar
-    - org.eclipse.jetty-jetty-alpn-server-9.4.56.v20240826.jar
+    - org.eclipse.jetty-jetty-client-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-continuation-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-http-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-io-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-proxy-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-security-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-server-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-servlet-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-servlets-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-util-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-util-ajax-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-javax-websocket-client-impl-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-websocket-api-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-websocket-client-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-websocket-common-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-websocket-server-9.4.57.v20241219.jar
+    - org.eclipse.jetty.websocket-websocket-servlet-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-alpn-conscrypt-server-9.4.57.v20241219.jar
+    - org.eclipse.jetty-jetty-alpn-server-9.4.57.v20241219.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.24.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -402,14 +402,14 @@ The Apache Software License, Version 2.0
     - async-http-client-2.12.4.jar
     - async-http-client-netty-utils-2.12.4.jar
  * Jetty
-    - jetty-client-9.4.56.v20240826.jar
-    - jetty-http-9.4.56.v20240826.jar
-    - jetty-io-9.4.56.v20240826.jar
-    - jetty-util-9.4.56.v20240826.jar
-    - javax-websocket-client-impl-9.4.56.v20240826.jar
-    - websocket-api-9.4.56.v20240826.jar
-    - websocket-client-9.4.56.v20240826.jar
-    - websocket-common-9.4.56.v20240826.jar
+    - jetty-client-9.4.57.v20241219.jar
+    - jetty-http-9.4.57.v20241219.jar
+    - jetty-io-9.4.57.v20241219.jar
+    - jetty-util-9.4.57.v20241219.jar
+    - javax-websocket-client-impl-9.4.57.v20241219.jar
+    - websocket-api-9.4.57.v20241219.jar
+    - websocket-client-9.4.57.v20241219.jar
+    - websocket-common-9.4.57.v20241219.jar
  * SnakeYaml -- snakeyaml-2.0.jar
  * Google Error Prone Annotations - error_prone_annotations-2.24.0.jar
  * Javassist -- javassist-3.25.0-GA.jar

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.7.1</curator.version>
     <netty.version>4.1.121.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
-    <jetty.version>9.4.56.v20240826</jetty.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.42</jersey.version>
     <athenz.version>1.10.62</athenz.version>


### PR DESCRIPTION
Fixes #24114

### Motivation & Modifications

Upgrade Jetty to 9.4.57.v20241219 to address CVE-2024-6763
Jetty 9.4.57.v20241219 contains backported CVE-2024-6763 fix in https://github.com/jetty/jetty.project/pull/12532 although it's not explicitly mentioned and most security scanners don't yet contain the information that it's been addressed in 9.4.57.
More details:
* https://github.com/jetty/jetty.project/issues/12630
* https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.57.v20241219

Note: The backport is a partial mitigation and Jetty 9.4.57 will continue to be marked as vulnerable. There's a discussion and explanation here: https://gitlab.eclipse.org/security/cve-assignement/-/issues/25#note_2968611

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->