### PR TITLE
[improve] Adapt startup scripts for Java 24 changes

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -197,6 +197,8 @@ OPTS="$OPTS --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java
 # https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
 # https://github.com/netty/netty/issues/12265
 OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
+# Required by RocksDB java.lang.System::loadLibrary call
+OPTS="$OPTS --enable-native-access=ALL-UNNAMED"
 
 OPTS="-cp $BOOKIE_CLASSPATH $OPTS"
 

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -202,6 +202,11 @@ OPTS="-cp $BOOKIE_CLASSPATH $OPTS"
 
 # Disable ipv6 as it can cause issues
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
 
 OPTS="$OPTS $BOOKIE_MEM $BOOKIE_GC $BOOKIE_GC_LOG $BOOKIE_EXTRA_OPTS"
 

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -132,6 +132,11 @@ fi
 # rarely needed when trying to list many z-nodes under a
 # directory)
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS -Djute.maxbuffer=10485760"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -54,7 +54,7 @@ PULSAR_MEM=${PULSAR_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
 # Garbage collection options
 if [ -z "$PULSAR_GC" ]; then
   PULSAR_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
-  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+  if [[ $JAVA_MAJOR_VERSION -eq 21 || $JAVA_MAJOR_VERSION -eq 22 ]]; then
     PULSAR_GC="-XX:+UseZGC -XX:+ZGenerational ${PULSAR_GC}"
   else
     PULSAR_GC="-XX:+UseZGC ${PULSAR_GC}"

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -274,6 +274,12 @@ OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 # rarely needed when trying to list many z-nodes under a
 # directory)
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS -Djute.maxbuffer=10485760"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
+
 # Enable TCP keepalive for all Zookeeper client connections
 OPTS="$OPTS -Dzookeeper.clientTcpKeepAlive=true"
 

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -298,6 +298,8 @@ OPTS="$OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
 OPTS="$OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
 # Required by LinuxInfoUtils
 OPTS="$OPTS --add-opens java.base/jdk.internal.platform=ALL-UNNAMED"
+# Required by RocksDB java.lang.System::loadLibrary call
+OPTS="$OPTS --enable-native-access=ALL-UNNAMED"
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 

--- a/bin/pulsar-admin-common.cmd
+++ b/bin/pulsar-admin-common.cmd
@@ -66,6 +66,12 @@ REM Allow Netty to use reflection access
 set "OPTS=%OPTS% -Dio.netty.tryReflectionSetAccessible=true"
 set "OPTS=%OPTS% -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
 
+if %JAVA_MAJOR_VERSION% GTR 23 (
+  REM Required to allow sun.misc.Unsafe on JDK 24 without warnings
+  REM Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+  set "OPTS=--sun-misc-unsafe-memory-access=allow %OPTS%"
+)
+
 if %JAVA_MAJOR_VERSION% GTR 8 (
   set "OPTS=%OPTS% --add-opens java.base/sun.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
   REM Required by Pulsar client optimized checksum calculation on other than Linux x86_64 platforms

--- a/bin/pulsar-admin-common.sh
+++ b/bin/pulsar-admin-common.sh
@@ -105,6 +105,11 @@ PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -102,6 +102,11 @@ fi
 PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
 
 # Allow Netty to use reflection access
 OPTS="$OPTS -Dio.netty.tryReflectionSetAccessible=true"

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -61,7 +61,7 @@ done
 BOOKIE_GC="${BOOKIE_GC:-${PULSAR_GC}}"
 if [ -z "$BOOKIE_GC" ]; then
   BOOKIE_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
-  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+  if [[ $JAVA_MAJOR_VERSION -eq 21 || $JAVA_MAJOR_VERSION -eq 22 ]]; then
     BOOKIE_GC="-XX:+UseZGC -XX:+ZGenerational ${BOOKIE_GC}"
   else
     BOOKIE_GC="-XX:+UseZGC ${BOOKIE_GC}"

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -67,7 +67,7 @@ done
 # Garbage collection options
 if [ -z "$PULSAR_GC" ]; then
   PULSAR_GC="-XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch"
-  if [[ $JAVA_MAJOR_VERSION -ge 21 ]]; then
+  if [[ $JAVA_MAJOR_VERSION -eq 21 || $JAVA_MAJOR_VERSION -eq 22 ]]; then
     PULSAR_GC="-XX:+UseZGC -XX:+ZGenerational ${PULSAR_GC}"
   else
     PULSAR_GC="-XX:+UseZGC ${PULSAR_GC}"

--- a/src/pulsar-io-gen.sh
+++ b/src/pulsar-io-gen.sh
@@ -109,6 +109,11 @@ fi
 PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_HOME/pulsar-io/docs/target/pulsar-io-docs.jar:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
 PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
 OPTS="-Djava.net.preferIPv4Stack=true $OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
+# Required to allow sun.misc.Unsafe on JDK 24 without warnings
+# Also required for enabling unsafe memory access for Netty since 4.1.121.Final
+if [[ $JAVA_MAJOR_VERSION -ge 23 ]]; then
+  OPTS="--sun-misc-unsafe-memory-access=allow $OPTS"
+fi
 
 OPTS="-cp $PULSAR_CLASSPATH $OPTS"
 OPTS="$OPTS $PULSAR_EXTRA_OPTS"


### PR DESCRIPTION
### Motivation

Adapt startup scripts for these Java 24 changes:
- [JEP 471: Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal](https://openjdk.org/jeps/471)
- [JEP 472: Prepare to Restrict the Use of JNI](https://openjdk.org/jeps/472)
- [JEP 474: ZGC: Generational Mode by Default](https://openjdk.org/jeps/474)
- [JEP 498: Warn upon Use of Memory-Access Methods in sun.misc.Unsafe](https://openjdk.org/jeps/498)

Adapt to JEP 498 and JEP 471 related Netty 4.1.121.Final change:
- https://github.com/netty/netty/pull/14943

### Modifications
- pass `--sun-misc-unsafe-memory-access=allow` on Java 23+
- pass `-XX:+ZGenerational` only on Java 21 or Java 22 by default
- pass `--enable-native-access=ALL-UNNAMED` in `bin/pulsar` and `bin/bookkeeper`, this option is supported also on Java 17

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->