### PR TITLE
[improve][build] Upgrade Lombok to 1.18.38 to support JDK 24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@ flexible messaging model and an intuitive client API.</description>
     <hppc.version>0.9.1</hppc.version>
     <spark-streaming_2.10.version>2.1.0</spark-streaming_2.10.version>
     <assertj-core.version>3.24.2</assertj-core.version>
-    <lombok.version>1.18.36</lombok.version>
+    <lombok.version>1.18.38</lombok.version>
     <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
     <jaxb-api>2.3.1</jaxb-api>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>


### PR DESCRIPTION
### Motivation

The goal is to enable JDK 24 support for building and testing Pulsar.
Lombok [1.18.38 supports JDK 24](https://projectlombok.org/changelog).

### Modifications

Upgrade Lombok to 1.18.38.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->