### PR TITLE
[improve][build] Upgrade errorprone to 2.38.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -414,7 +414,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty-jetty-alpn-server-9.4.57.v20241219.jar
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
- * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.24.0.jar
+ * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.38.0.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-4.9.3.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -411,7 +411,7 @@ The Apache Software License, Version 2.0
     - websocket-client-9.4.57.v20241219.jar
     - websocket-common-9.4.57.v20241219.jar
  * SnakeYaml -- snakeyaml-2.0.jar
- * Google Error Prone Annotations - error_prone_annotations-2.24.0.jar
+ * Google Error Prone Annotations - error_prone_annotations-2.38.0.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro
     - avro-1.11.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -312,8 +312,8 @@ flexible messaging model and an intuitive client API.</description>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
     <spotbugs.version>4.7.3</spotbugs.version>
-    <errorprone.version>2.24.0</errorprone.version>
-    <errorprone-slf4j.version>0.1.21</errorprone-slf4j.version>
+    <errorprone.version>2.38.0</errorprone.version>
+    <errorprone-slf4j.version>0.1.28</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
### Motivation & Modifications

Upgrade errorprone to 2.38.0 for Java 24 byte code support.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->