### PR TITLE
[fix][test] Fix flaky ManagedCursorTest.testSkipEntriesWithIndividualDeletedMessages

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1843,6 +1843,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Position pos4 = ledger.addEntry("dummy-entry-4".getBytes(Encoding));
         Position pos5 = ledger.addEntry("dummy-entry-5".getBytes(Encoding));
 
+        // Wait until a new ledger is created after the previous one has been closed.
+        // This happens because maxEntriesPerLedger is set to 5, so a new ledger is opened after every 5 entries.
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(ledger.getLedgersInfo().lastEntry().getKey() > pos5.getLedgerId());
+        });
+
         // delete individual messages
         c1.delete(pos2);
         c1.delete(pos4);
@@ -1852,19 +1858,25 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c1.getReadPosition(), PositionFactory.create(pos5.getLedgerId() + 1, 0));
         assertEquals(c1.getMarkDeletedPosition(), pos5);
 
-        pos1 = ledger.addEntry("dummy-entry-1".getBytes(Encoding));
-        pos2 = ledger.addEntry("dummy-entry-2".getBytes(Encoding));
-        pos3 = ledger.addEntry("dummy-entry-3".getBytes(Encoding));
-        pos4 = ledger.addEntry("dummy-entry-4".getBytes(Encoding));
-        pos5 = ledger.addEntry("dummy-entry-5".getBytes(Encoding));
+        Position pos6 = ledger.addEntry("dummy-entry-1".getBytes(Encoding));
+        Position pos7 = ledger.addEntry("dummy-entry-2".getBytes(Encoding));
+        Position pos8 = ledger.addEntry("dummy-entry-3".getBytes(Encoding));
+        Position pos9 = ledger.addEntry("dummy-entry-4".getBytes(Encoding));
+        Position pos10 = ledger.addEntry("dummy-entry-5".getBytes(Encoding));
 
-        c1.delete(pos2);
-        c1.delete(pos4);
+        // Wait until a new ledger is created after the previous one has been closed.
+        // This happens because maxEntriesPerLedger is set to 5, so a new ledger is opened after every 5 entries.
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(ledger.getLedgersInfo().lastEntry().getKey() > pos10.getLedgerId());
+        });
+
+        c1.delete(pos7);
+        c1.delete(pos9);
 
         c1.skipEntries(4, IndividualDeletedEntries.Include);
         assertEquals(c1.getNumberOfEntries(), 1);
-        assertEquals(c1.getReadPosition(), pos5);
-        assertEquals(c1.getMarkDeletedPosition(), pos4);
+        assertEquals(c1.getReadPosition(), pos10);
+        assertEquals(c1.getMarkDeletedPosition(), pos9);
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")


### PR DESCRIPTION
### Motivation

A new ledger will be created once the previous one has reached the configured `maxEntriesPerLedger` limit (set to 5). However, if the ledger does not roll over as expected due to timing.

### Modifications

- Added logic to explicitly wait until a new ledger is created after reaching the max entries per ledger.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->