### PR TITLE
[fix][build] Fix errorprone maven profile configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2707,6 +2707,7 @@ flexible messaging model and an intuitive client API.</description>
               <maxmem>1024m</maxmem>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
                 <arg>-Xlint:-options</arg>
                 <!-- configure Error Prone . Disable some checks that crash the compiler or are annoying -->
                 <!-- the following argument must be kept on one line when building with JDK8 -->

--- a/pom.xml
+++ b/pom.xml
@@ -2682,6 +2682,7 @@ flexible messaging model and an intuitive client API.</description>
 
          usage example:
          echo lombok.addJavaxGeneratedAnnotation=true >> lombok.config
+         echo lombok.addNullAnnotations=jspecify >> lombok.config
          mvn -Perrorprone,main compile
 
          Revisiting warnings and errors is possible in IntelliJ after activating
@@ -2744,6 +2745,20 @@ flexible messaging model and an intuitive client API.</description>
           </plugin>
         </plugins>
       </build>
+      <dependencies>
+        <!-- required for "lombok.addJavaxGeneratedAnnotation=true" support -->
+        <dependency>
+          <groupId>jakarta.annotation</groupId>
+          <artifactId>jakarta.annotation-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <!-- required for lombok.addNullAnnotations=jspecify support -->
+        <dependency>
+          <groupId>org.jspecify</groupId>
+          <artifactId>jspecify</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>integrationTests</id>


### PR DESCRIPTION
### Motivation

[Error Prone](https://errorprone.info/) was upgraded in #24242. The upgrade broke the configuration. It would be useful to be able to use errorprone for static code analysis since it detects some issues that SpotBugs doesn't detect.

### Modifications

- pass `--should-stop=ifError=FLOW"` compiler argument which is required after [errorprone 2.34.0](https://github.com/google/error-prone/releases/tag/v2.34.0)
- add instructions to use jspecify nullness annotations for Lombok when enabling errorprone
- add required dependencies to compile will temporary Lombok config for errorprone analysis

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->