### PR TITLE
[feat][broker] add consumer first consume/flow timestamp

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -101,7 +101,7 @@ public class Consumer {
     private final LongAdder messageAckCounter;
     private final Rate messageAckRate;
 
-    private volatile long firstConsumedTimestamp;
+    private volatile long firstMessagesSentTimestamp;
     private volatile long lastConsumedTimestamp;
     private volatile long lastAckedTimestamp;
     private volatile long firstConsumedFlowTimestamp;
@@ -434,8 +434,8 @@ public class Consumer {
         writeAndFlushPromise.addListener(status -> {
             // only increment counters after the messages have been successfully written to the TCP/IP connection
             if (status.isSuccess()) {
-                if (firstConsumedTimestamp == 0) {
-                    firstConsumedTimestamp =  System.currentTimeMillis();
+                if (firstMessagesSentTimestamp == 0) {
+                    firstMessagesSentTimestamp =  System.currentTimeMillis();
                 }
                 msgOut.recordMultipleEvents(totalMessages, totalBytes);
                 msgOutCounter.add(totalMessages);
@@ -983,7 +983,7 @@ public class Consumer {
         stats.lastAckedTimestamp = lastAckedTimestamp;
         stats.lastConsumedTimestamp = lastConsumedTimestamp;
         stats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
-        stats.firstConsumedTimestamp = firstConsumedTimestamp;
+        stats.firstMessagesSentTimestamp = firstMessagesSentTimestamp;
         stats.firstConsumedFlowTimestamp = firstConsumedFlowTimestamp;
         stats.availablePermits = getAvailablePermits();
         stats.unackedMessages = unackedMessages;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -101,8 +101,10 @@ public class Consumer {
     private final LongAdder messageAckCounter;
     private final Rate messageAckRate;
 
+    private volatile long firstConsumedTimestamp;
     private volatile long lastConsumedTimestamp;
     private volatile long lastAckedTimestamp;
+    private volatile long firstConsumedFlowTimestamp;
     private volatile long lastConsumedFlowTimestamp;
     private Rate chunkedMessageRate;
 
@@ -432,6 +434,9 @@ public class Consumer {
         writeAndFlushPromise.addListener(status -> {
             // only increment counters after the messages have been successfully written to the TCP/IP connection
             if (status.isSuccess()) {
+                if (firstConsumedTimestamp == 0) {
+                    firstConsumedTimestamp =  System.currentTimeMillis();
+                }
                 msgOut.recordMultipleEvents(totalMessages, totalBytes);
                 msgOutCounter.add(totalMessages);
                 bytesOutCounter.add(totalBytes);
@@ -839,7 +844,11 @@ public class Consumer {
 
     public void flowPermits(int additionalNumberOfMessages) {
         checkArgument(additionalNumberOfMessages > 0);
-        this.lastConsumedFlowTimestamp = System.currentTimeMillis();
+        final long currentTs = System.currentTimeMillis();
+        if (firstConsumedFlowTimestamp == 0) {
+            firstConsumedFlowTimestamp  = currentTs;
+        }
+        this.lastConsumedFlowTimestamp = currentTs;
 
         // block shared consumer when unacked-messages reaches limit
         if (shouldBlockConsumerOnUnackMsgs() && unackedMessages >= getMaxUnackedMessages()) {
@@ -974,6 +983,8 @@ public class Consumer {
         stats.lastAckedTimestamp = lastAckedTimestamp;
         stats.lastConsumedTimestamp = lastConsumedTimestamp;
         stats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
+        stats.firstConsumedTimestamp = firstConsumedTimestamp;
+        stats.firstConsumedFlowTimestamp = firstConsumedFlowTimestamp;
         stats.availablePermits = getAvailablePermits();
         stats.unackedMessages = unackedMessages;
         stats.blockedConsumerOnUnackedMsgs = blockedConsumerOnUnackedMsgs;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1444,7 +1444,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     @Test(timeOut = 30000)
-    public void testConsumerStatsLastTimestamp() throws PulsarClientException, PulsarAdminException, InterruptedException {
+    public void testConsumerStatsTimestamps() throws PulsarClientException, PulsarAdminException, InterruptedException {
         long timestamp = System.currentTimeMillis();
         final String topicName = "consumer-stats-" + timestamp;
         final String subscribeName = topicName + "-test-stats-sub";
@@ -1505,6 +1505,9 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long consumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long ackedTimestamp = consumerStats.getLastAckedTimestamp();
+        final long firstConsumedTimestamp = consumerStats.getFirstConsumedTimestamp();
+        final long firstConsumedFlowTimestamp = consumerStats.getFirstConsumedFlowTimestamp();
+
 
         // The lastConsumedTimestamp should same as the last time because the broker does not push any messages and the
         // consumer does not pull any messages.
@@ -1512,6 +1515,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertTrue(startAckedTimestampInConsumerStats < ackedTimestamp);
         assertNotEquals(0, consumedFlowTimestamp);
         assertTrue(startAckedTimestampInSubStats < ackedTimestampInSubStats);
+        assertNotEquals(0, firstConsumedFlowTimestamp);
+        assertNotEquals(0, firstConsumedTimestamp);
 
         // d. Send another messages. The lastConsumedTimestamp should be updated.
         producer.send("message-2".getBytes(StandardCharsets.UTF_8));
@@ -1537,6 +1542,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long lastConsumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long lastAckedTimestamp = consumerStats.getLastAckedTimestamp();
+        final long firstConsumedTimestamp2 = consumerStats.getFirstConsumedTimestamp();
+        final long firstConsumedFlowTimestamp2 = consumerStats.getFirstConsumedFlowTimestamp();
 
         assertTrue(consumedTimestamp < lastConsumedTimestamp);
         assertTrue(ackedTimestamp < lastAckedTimestamp);
@@ -1544,6 +1551,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(lastConsumedFlowTimestamp, consumedFlowTimestamp);
         assertTrue(ackedTimestampInSubStats < lastAckedTimestampInSubStats);
         assertEquals(lastConsumedTimestamp, lastConsumedTimestampInSubStats);
+        assertEquals(firstConsumedFlowTimestamp, firstConsumedFlowTimestamp2);
+        assertEquals(firstConsumedTimestamp, firstConsumedTimestamp2);
 
         consumer.close();
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1505,7 +1505,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long consumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long ackedTimestamp = consumerStats.getLastAckedTimestamp();
-        final long firstConsumedTimestamp = consumerStats.getFirstConsumedTimestamp();
+        final long firstMessagesSentTimestamp = consumerStats.getFirstMessagesSentTimestamp();
         final long firstConsumedFlowTimestamp = consumerStats.getFirstConsumedFlowTimestamp();
 
 
@@ -1516,7 +1516,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertNotEquals(0, consumedFlowTimestamp);
         assertTrue(startAckedTimestampInSubStats < ackedTimestampInSubStats);
         assertNotEquals(0, firstConsumedFlowTimestamp);
-        assertNotEquals(0, firstConsumedTimestamp);
+        assertNotEquals(0, firstMessagesSentTimestamp);
 
         // d. Send another messages. The lastConsumedTimestamp should be updated.
         producer.send("message-2".getBytes(StandardCharsets.UTF_8));
@@ -1542,7 +1542,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long lastConsumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long lastAckedTimestamp = consumerStats.getLastAckedTimestamp();
-        final long firstConsumedTimestamp2 = consumerStats.getFirstConsumedTimestamp();
+        final long firstMessageSentTimestamp2 = consumerStats.getFirstMessagesSentTimestamp();
         final long firstConsumedFlowTimestamp2 = consumerStats.getFirstConsumedFlowTimestamp();
 
         assertTrue(consumedTimestamp < lastConsumedTimestamp);
@@ -1552,7 +1552,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertTrue(ackedTimestampInSubStats < lastAckedTimestampInSubStats);
         assertEquals(lastConsumedTimestamp, lastConsumedTimestampInSubStats);
         assertEquals(firstConsumedFlowTimestamp, firstConsumedFlowTimestamp2);
-        assertEquals(firstConsumedTimestamp, firstConsumedTimestamp2);
+        assertEquals(firstMessagesSentTimestamp, firstMessageSentTimestamp2);
 
         consumer.close();
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -268,7 +268,7 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 "lastAckedTimestamp",
                 "lastConsumedTime",
                 "lastConsumedTimestamp",
-                "firstConsumedTimestamp",
+                "firstMessagesSentTimestamp",
                 "firstConsumedFlowTimestamp",
                 "lastConsumedFlowTimestamp",
                 "metadata",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -268,6 +268,8 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 "lastAckedTimestamp",
                 "lastConsumedTime",
                 "lastConsumedTimestamp",
+                "firstConsumedTimestamp",
+                "firstConsumedFlowTimestamp",
                 "lastConsumedFlowTimestamp",
                 "metadata",
                 "address",

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -120,7 +120,7 @@ public interface ConsumerStats {
     long getLastAckedTimestamp();
     long getLastConsumedTimestamp();
     long getLastConsumedFlowTimestamp();
-    long getFirstConsumedTimestamp();
+    long getFirstMessagesSentTimestamp();
     long getFirstConsumedFlowTimestamp();
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -120,6 +120,8 @@ public interface ConsumerStats {
     long getLastAckedTimestamp();
     long getLastConsumedTimestamp();
     long getLastConsumedFlowTimestamp();
+    long getFirstConsumedTimestamp();
+    long getFirstConsumedFlowTimestamp();
 
     /**
      * Hash ranges assigned to this consumer if in Key_Shared subscription mode.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -161,6 +161,8 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.keyHashRanges = stats.keyHashRanges;
         this.keyHashRangeArrays = stats.keyHashRangeArrays;
         this.consumerName = stats.consumerName;
+        this.firstConsumedTimestamp = stats.firstConsumedTimestamp;
+        this.firstConsumedFlowTimestamp = stats.firstConsumedFlowTimestamp;
         return this;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -119,7 +119,12 @@ public class ConsumerStatsImpl implements ConsumerStats {
     @Deprecated
     public long lastConsumedTimestamp;
 
+    // The first timestamp of successfully sending a message to the consumer
+    public long firstConsumedTimestamp;
     public long lastConsumedFlowTimestamp;
+    // The first timestamp of consumer flow request
+    public long firstConsumedFlowTimestamp;
+
 
     /**
      * Hash ranges assigned to this consumer if in Key_Shared subscription mode.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -120,7 +120,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
     public long lastConsumedTimestamp;
 
     // The first timestamp of successfully sending a message to the consumer
-    public long firstConsumedTimestamp;
+    public long firstMessagesSentTimestamp;
     public long lastConsumedFlowTimestamp;
     // The first timestamp of consumer flow request
     public long firstConsumedFlowTimestamp;
@@ -161,7 +161,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.keyHashRanges = stats.keyHashRanges;
         this.keyHashRangeArrays = stats.keyHashRangeArrays;
         this.consumerName = stats.consumerName;
-        this.firstConsumedTimestamp = stats.firstConsumedTimestamp;
+        this.firstMessagesSentTimestamp = stats.firstMessagesSentTimestamp;
         this.firstConsumedFlowTimestamp = stats.firstConsumedFlowTimestamp;
         return this;
     }


### PR DESCRIPTION
### Motivation

This PR supports two stats for the consumer side to help identify the first message dispatch latency.

### Modifications

- Add stats `firstConsumedFlowTimestamp`
- Add stats `firstMessagesSentTimestamp `

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

