### PR TITLE
[improve][io][kca] support fully-qualified topic names in source records

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.file.FileStreamSourceConnector;
 import org.apache.kafka.connect.runtime.TaskConfig;
@@ -39,6 +40,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SourceContext;
+import org.apache.pulsar.io.kafka.connect.KafkaConnectSource.KafkaSourceRecord;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -120,6 +122,47 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
     void testTransformationWithNegatedPredicate() throws Exception {
         Map<String, Object> config = setupTransformConfig(true, true);
         runTransformTest(config, false);
+    }
+
+    @Test
+    void testShortTopicNames() throws Exception {
+        Map<String, Object> config = getConfig();
+        config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");
+        config.put(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG, "default-tenant/default-ns");
+
+        runTopicNameTest(config, "a-topic", "persistent://default-tenant/default-ns/a-topic");
+    }
+
+    @Test
+    void testFullyQualifiedTopicNames() throws Exception {
+        Map<String, Object> config = getConfig();
+        config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");
+        config.put(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG, "default-tenant/default-ns");
+
+        runTopicNameTest(config, "persistent://a-tenant/a-ns/a-topic", "persistent://a-tenant/a-ns/a-topic");
+    }
+
+    private void runTopicNameTest(Map<String, Object> config, String topicName, String expectedDestinationTopicName) throws Exception {
+        config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");
+        config.put(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG, "default-tenant/default-ns");
+
+        kafkaConnectSource = new KafkaConnectSource();
+        kafkaConnectSource.open(config, context);
+
+        Map<String, Object> sourcePartition = new HashMap<>();
+        Map<String, Object> sourceOffset = new HashMap<>();
+        Map<String, Object> value = new HashMap<>();
+        sourcePartition.put("test", "test");
+        sourceOffset.put("test", 0);
+        value.put("myField", "42");
+        SourceRecord srcRecord = new SourceRecord(
+            sourcePartition, sourceOffset, topicName, null,
+            null, null, null, value
+        );
+
+        KafkaSourceRecord record = kafkaConnectSource.processSourceRecord(srcRecord);
+
+        assertEquals(Optional.of(expectedDestinationTopicName), record.destinationTopic);
     }
 
     private Map<String, Object> setupTransformConfig(boolean withPredicate, boolean negated) {


### PR DESCRIPTION
### Motivation

This change builds on the work previously done in #24221.

The current implementation of the Kafka Connect adaptor in Pulsar IO does not support fully-qualified Pulsar topic names in source records. Instead, it forcefully prepends the default `persistent://<tenant>/<namespace>/` prefix to all destination topics. This behavior can be problematic in multi-tenant environments where dynamic topic routing is required.

For example, consider a setup with:

- A shared PostgreSQL instance where tenants are isolated in separate schemas (e.g. `tenant1`, `tenant2`)
- A shared Pulsar cluster where each tenant has its own Pulsar tenant (e.g. `tenant1`, `tenant2`)
- A single Debezium PostgreSQL source connector deployed in the `global` (shared) tenant

Using Kafka Connect transformations, users may want to route records to tenant-specific topics based on the PostgreSQL schema:

```yaml
transforms.reroute.topic.regex: "mydatabaseserver.(.*).orders"
transforms.reroute.topic.replacement: "persistent://$1/procurement/orders"
```

With this configuration, changes to `tenant1.orders `should go to `persistent://tenant1/procurement/orders`, and `tenant2.orders` to `persistent://tenant2/procurement/orders`.

However, the current implementation prepends `persistent://global/procurement/` to the already fully-qualified topic, resulting in invalid topic names like `persistent://global/procurement/persistent://tenant1/procurement/orders`. This causes runtime exceptions and connector failure loops.

By supporting fully-qualified topic names, this change enables more flexible and tenant-aware architectures without requiring additional processing layers.


### Modifications

This change adjusts `AbstractKafkaConnectSource` to correctly handle fully-qualified topic names by using the `org.apache.pulsar.common.naming.TopicName` utility. If the topic name is valid and fully-qualified, it is respected as-is. Otherwise, the adaptor falls back to the existing behavior, ensuring backward compatibility.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended the existing `KafkaConnectSourceTest` test suite with a couple of tests to confirm Kafka Connect Adaptor can handle short and fully-qualified topic names

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->