### PR TITLE
[cleanup] remove unused config messagePublishBufferCheckIntervalInMillis

### DIFF
--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -410,10 +410,6 @@ replicatedSubscriptionsSnapshotMaxCachedPerSubscription=10
 # Use -1 to disable the memory limitation. Default is 1/2 of direct memory.
 maxMessagePublishBufferSizeInMB=
 
-# Interval between checks to see if message publish buffer size is exceed the max message publish buffer size
-# Use 0 or negative number to disable the max publish buffer limiting.
-messagePublishBufferCheckIntervalInMillis=100
-
 # Check between intervals to see if consumed ledgers need to be trimmed
 # Use 0 or negative number to disable the check
 retentionCheckIntervalInSeconds=120

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1474,13 +1474,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int maxMessagePublishBufferSizeInMB = Math.max(64,
         (int) (DirectMemoryUtils.jvmMaxDirectMemory() / 2 / (1024 * 1024)));
 
-    @FieldContext(
-        category = CATEGORY_SERVER,
-        doc = "Interval between checks to see if message publish buffer size is exceed the max message publish "
-                + "buffer size"
-    )
-    private int messagePublishBufferCheckIntervalInMillis = 100;
-
     @FieldContext(category = CATEGORY_SERVER, doc = "Whether to recover cursors lazily when trying to recover a "
             + "managed ledger backing a persistent topic. It can improve write availability of topics.\n"
             + "The caveat is now when recovered ledger is ready to write we're not sure if all old consumers last mark "


### PR DESCRIPTION
### Motivation

This config was introduced by https://github.com/apache/pulsar/pull/6178, but it never used.

### Modifications

Remove unused config messagePublishBufferCheckIntervalInMillis

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->