### PR TITLE
[fix][broker]Fix incorrect priority between topic policies and global topic policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -279,8 +279,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 isGlobalPolicies);
         topicPolicies.getDelayedDeliveryMaxDelayInMillis().updateTopicValue(data.getDelayedDeliveryMaxDelayInMillis(),
                 isGlobalPolicies);
-        topicPolicies.getSubscribeRate().updateTopicValue(SubscribeRate.normalize(data.getSubscribeRate()),
-                isGlobalPolicies);
+        topicPolicies.getSubscribeRate().updateTopicValue(
+                SubscribeRate.normalize(data.getSubscribeRate()), isGlobalPolicies);
         topicPolicies.getSubscriptionDispatchRate().updateTopicValue(
             DispatchRateImpl.normalize(data.getSubscriptionDispatchRate()), isGlobalPolicies);
         topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold(),isGlobalPolicies);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -233,52 +233,64 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     }
 
     protected void updateTopicPolicy(TopicPolicies data) {
+        boolean isGlobalPolicies = data.isGlobalPolicies();
         if (!isSystemTopic()) {
             // Only use namespace level setting for system topic.
-            topicPolicies.getReplicationClusters().updateTopicValue(data.getReplicationClusters());
+            topicPolicies.getReplicationClusters().updateTopicValue(data.getReplicationClusters(), isGlobalPolicies);
             topicPolicies.getSchemaCompatibilityStrategy()
-                    .updateTopicValue(formatSchemaCompatibilityStrategy(data.getSchemaCompatibilityStrategy()));
+                    .updateTopicValue(formatSchemaCompatibilityStrategy(data.getSchemaCompatibilityStrategy()),
+                            isGlobalPolicies);
         }
-        topicPolicies.getRetentionPolicies().updateTopicValue(data.getRetentionPolicies());
+        topicPolicies.getRetentionPolicies().updateTopicValue(data.getRetentionPolicies(), isGlobalPolicies);
         topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled()
-                .updateTopicValue(data.getDispatcherPauseOnAckStatePersistentEnabled());
+                .updateTopicValue(data.getDispatcherPauseOnAckStatePersistentEnabled(), isGlobalPolicies);
         topicPolicies.getMaxSubscriptionsPerTopic()
-                .updateTopicValue(normalizeValue(data.getMaxSubscriptionsPerTopic()));
+                .updateTopicValue(normalizeValue(data.getMaxSubscriptionsPerTopic()), isGlobalPolicies);
         topicPolicies.getMaxUnackedMessagesOnConsumer()
-                .updateTopicValue(normalizeValue(data.getMaxUnackedMessagesOnConsumer()));
+                .updateTopicValue(normalizeValue(data.getMaxUnackedMessagesOnConsumer()), isGlobalPolicies);
         topicPolicies.getMaxUnackedMessagesOnSubscription()
-                .updateTopicValue(normalizeValue(data.getMaxUnackedMessagesOnSubscription()));
-        topicPolicies.getMaxProducersPerTopic().updateTopicValue(normalizeValue(data.getMaxProducerPerTopic()));
-        topicPolicies.getMaxConsumerPerTopic().updateTopicValue(normalizeValue(data.getMaxConsumerPerTopic()));
+                .updateTopicValue(normalizeValue(data.getMaxUnackedMessagesOnSubscription()), isGlobalPolicies);
+        topicPolicies.getMaxProducersPerTopic().updateTopicValue(normalizeValue(data.getMaxProducerPerTopic()),
+                isGlobalPolicies);
+        topicPolicies.getMaxConsumerPerTopic().updateTopicValue(normalizeValue(data.getMaxConsumerPerTopic()),
+                isGlobalPolicies);
         topicPolicies.getMaxConsumersPerSubscription()
-                .updateTopicValue(normalizeValue(data.getMaxConsumersPerSubscription()));
-        topicPolicies.getInactiveTopicPolicies().updateTopicValue(data.getInactiveTopicPolicies());
-        topicPolicies.getDeduplicationEnabled().updateTopicValue(data.getDeduplicationEnabled());
+                .updateTopicValue(normalizeValue(data.getMaxConsumersPerSubscription()), isGlobalPolicies);
+        topicPolicies.getInactiveTopicPolicies().updateTopicValue(data.getInactiveTopicPolicies(), isGlobalPolicies);
+        topicPolicies.getDeduplicationEnabled().updateTopicValue(data.getDeduplicationEnabled(), isGlobalPolicies);
         topicPolicies.getDeduplicationSnapshotIntervalSeconds().updateTopicValue(
-                data.getDeduplicationSnapshotIntervalSeconds());
+                data.getDeduplicationSnapshotIntervalSeconds(), isGlobalPolicies);
         topicPolicies.getSubscriptionTypesEnabled().updateTopicValue(
                 CollectionUtils.isEmpty(data.getSubscriptionTypesEnabled()) ? null :
-                        EnumSet.copyOf(data.getSubscriptionTypesEnabled()));
+                        EnumSet.copyOf(data.getSubscriptionTypesEnabled()), isGlobalPolicies);
         Arrays.stream(BacklogQuota.BacklogQuotaType.values()).forEach(type ->
                 this.topicPolicies.getBackLogQuotaMap().get(type).updateTopicValue(
-                        data.getBackLogQuotaMap() == null ? null : data.getBackLogQuotaMap().get(type.toString())));
-        topicPolicies.getTopicMaxMessageSize().updateTopicValue(normalizeValue(data.getMaxMessageSize()));
-        topicPolicies.getMessageTTLInSeconds().updateTopicValue(normalizeValue(data.getMessageTTLInSeconds()));
-        topicPolicies.getPublishRate().updateTopicValue(PublishRate.normalize(data.getPublishRate()));
-        topicPolicies.getDelayedDeliveryEnabled().updateTopicValue(data.getDelayedDeliveryEnabled());
+                        data.getBackLogQuotaMap() == null ? null : data.getBackLogQuotaMap().get(type.toString()),
+                        isGlobalPolicies));
+        topicPolicies.getTopicMaxMessageSize().updateTopicValue(normalizeValue(data.getMaxMessageSize()),
+                isGlobalPolicies);
+        topicPolicies.getMessageTTLInSeconds().updateTopicValue(normalizeValue(data.getMessageTTLInSeconds()),
+                isGlobalPolicies);
+        topicPolicies.getPublishRate().updateTopicValue(PublishRate.normalize(data.getPublishRate()), isGlobalPolicies);
+        topicPolicies.getDelayedDeliveryEnabled().updateTopicValue(data.getDelayedDeliveryEnabled(), isGlobalPolicies);
         topicPolicies.getReplicatorDispatchRate().updateTopicValue(
-            DispatchRateImpl.normalize(data.getReplicatorDispatchRate()));
-        topicPolicies.getDelayedDeliveryTickTimeMillis().updateTopicValue(data.getDelayedDeliveryTickTimeMillis());
-        topicPolicies.getDelayedDeliveryMaxDelayInMillis().updateTopicValue(data.getDelayedDeliveryMaxDelayInMillis());
-        topicPolicies.getSubscribeRate().updateTopicValue(SubscribeRate.normalize(data.getSubscribeRate()));
+            DispatchRateImpl.normalize(data.getReplicatorDispatchRate()), isGlobalPolicies);
+        topicPolicies.getDelayedDeliveryTickTimeMillis().updateTopicValue(data.getDelayedDeliveryTickTimeMillis(),
+                isGlobalPolicies);
+        topicPolicies.getDelayedDeliveryMaxDelayInMillis().updateTopicValue(data.getDelayedDeliveryMaxDelayInMillis(),
+                isGlobalPolicies);
+        topicPolicies.getSubscribeRate().updateTopicValue(SubscribeRate.normalize(data.getSubscribeRate()),
+                isGlobalPolicies);
         topicPolicies.getSubscriptionDispatchRate().updateTopicValue(
-            DispatchRateImpl.normalize(data.getSubscriptionDispatchRate()));
-        topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold());
-        topicPolicies.getDispatchRate().updateTopicValue(DispatchRateImpl.normalize(data.getDispatchRate()));
-        topicPolicies.getSchemaValidationEnforced().updateTopicValue(data.getSchemaValidationEnforced());
-        topicPolicies.getEntryFilters().updateTopicValue(data.getEntryFilters());
+            DispatchRateImpl.normalize(data.getSubscriptionDispatchRate()), isGlobalPolicies);
+        topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold(),isGlobalPolicies);
+        topicPolicies.getDispatchRate().updateTopicValue(DispatchRateImpl.normalize(data.getDispatchRate()),
+                isGlobalPolicies);
+        topicPolicies.getSchemaValidationEnforced().updateTopicValue(data.getSchemaValidationEnforced(),
+                isGlobalPolicies);
+        topicPolicies.getEntryFilters().updateTopicValue(data.getEntryFilters(), isGlobalPolicies);
         topicPolicies.getDispatcherPauseOnAckStatePersistentEnabled()
-                .updateTopicValue(data.getDispatcherPauseOnAckStatePersistentEnabled());
+                .updateTopicValue(data.getDispatcherPauseOnAckStatePersistentEnabled(), isGlobalPolicies);
         this.subscriptionPolicies = data.getSubscriptionPolicies();
 
         updateEntryFilters();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -283,7 +283,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 SubscribeRate.normalize(data.getSubscribeRate()), isGlobalPolicies);
         topicPolicies.getSubscriptionDispatchRate().updateTopicValue(
             DispatchRateImpl.normalize(data.getSubscriptionDispatchRate()), isGlobalPolicies);
-        topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold(),isGlobalPolicies);
+        topicPolicies.getCompactionThreshold().updateTopicValue(data.getCompactionThreshold(), isGlobalPolicies);
         topicPolicies.getDispatchRate().updateTopicValue(DispatchRateImpl.normalize(data.getDispatchRate()),
                 isGlobalPolicies);
         topicPolicies.getSchemaValidationEnforced().updateTopicValue(data.getSchemaValidationEnforced(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.GLOBAL_ONLY;
+import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.LOCAL_ONLY;
+import static org.apache.pulsar.common.naming.SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -28,6 +31,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,12 +57,16 @@ import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.PublishRateLimiterImpl;
 import org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService;
+import org.apache.pulsar.broker.service.TopicPoliciesService;
 import org.apache.pulsar.broker.service.TopicPolicyTestUtils;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.persistent.SubscribeRateLimiter;
+import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
+import org.apache.pulsar.broker.systopic.SystemTopicClient;
+import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
@@ -72,6 +80,10 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.events.ActionType;
+import org.apache.pulsar.common.events.EventType;
+import org.apache.pulsar.common.events.PulsarEvent;
+import org.apache.pulsar.common.events.TopicPoliciesEvent;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -97,6 +109,7 @@ import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.awaitility.reflect.WhiteboxImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -438,6 +451,369 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
 
         admin.topics().deletePartitionedTopic(testTopic, true);
     }
+
+    @Test
+    public void testInitTopicPolicy() throws Exception {
+        // create topic
+        final String topic = testTopic + UUID.randomUUID();
+        admin.topics().createNonPartitionedTopic(topic);
+        pulsarClient.newProducer().topic(topic).create().close();
+
+        // unload
+        admin.namespaces().unload(myNamespace);
+        // the policies cache
+        SystemTopicBasedTopicPoliciesService topicPoliciesService
+                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
+
+        // set up policies
+        TopicName topicName = TopicName.get(topic);
+        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
+        TopicPolicies globalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30)
+                .isGlobal(true).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
+
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
+                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
+                        .isCompletedExceptionally(), true));
+
+        // load up topic after the corresponding namespace's policy caches initialization to make sure the topic
+        // polices applied in `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
+        pulsarClient.newProducer().topic(topic).create().close();
+
+        // the final policies take effect in topic
+        HierarchyTopicPolicies hierarchyTopicPolicies =
+                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
+
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                .getMaxConsumerPerTopic(), 10);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                .getMaxConsumerPerTopic(), 20);
+        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                .getMaxProducerPerTopic(), null);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                .getMaxProducerPerTopic(), 30);
+        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
+    }
+
+    @Test
+    public void testInitPolicesCacheAndNotifyListeners() throws Exception {
+        // create topic
+        final String topic = testTopic + UUID.randomUUID();
+        admin.topics().createNonPartitionedTopic(topic);
+        pulsarClient.newProducer().topic(topic).create().close();
+
+        // set up policies for testTopic
+        TopicName topicName = TopicName.get(topic);
+        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
+        TopicPolicies globalInitPolicy =
+                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
+
+        /*
+          if the topic initialization is completed before the corresponding namespace's policy caches initialization,
+           the topic policies will be applied in
+          `org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.initPolicesCacheAndNotifyListeners`,
+          otherwise it will be applied in
+          `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
+          the topicPolicyEventsTopic initialization always completed before the corresponding namespace's policy
+          caches initialization, use topicPolicyEventsTopic to verify `initPolicesCacheAndNotifyListeners`
+         */
+        // set up policies for eventsTopic
+//        TopicName eventsTopicName = TopicName.get(topicPolicyEventsTopic);
+//        TopicPolicies eventsLocalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(40).build();
+//        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsLocalInitPolicy).get();
+//        TopicPolicies eventsGlobalInitPolicy =
+//                TopicPolicies.builder().maxConsumerPerTopic(50).maxProducerPerTopic(60).isGlobal(true).build();
+//        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsGlobalInitPolicy).get();
+
+        // reload namespace to trigger init polices cache and notify listeners
+        admin.namespaces().unload(myNamespace);
+        // the policies cache
+        SystemTopicBasedTopicPoliciesService topicPoliciesService
+                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
+
+        pulsarClient.newProducer().topic(topic).create().close();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
+                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
+                        .isCompletedExceptionally(), true));
+
+        // check testTopic start
+        // the final policies take effect in topic
+        HierarchyTopicPolicies hierarchyTopicPolicies =
+                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                .getMaxConsumerPerTopic(), 10);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                .getMaxConsumerPerTopic(), 20);
+        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                .getMaxProducerPerTopic(), null);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                .getMaxProducerPerTopic(), 30);
+        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
+        // check testTopic end
+
+        // check eventsTopic start
+        // the final policies take effect in topic
+//        HierarchyTopicPolicies eventsHierarchyTopicPolicies =
+//                pulsar.getBrokerService().getTopics().get(topicPolicyEventsTopic).get().get().getHierarchyTopicPolicies();
+//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 40);
+//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 50);
+//        assertEquals(eventsHierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 40);
+//
+//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
+//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 60);
+//        assertEquals(eventsHierarchyTopicPolicies.getMaxProducersPerTopic().get(), 60);
+        // check eventsTopic end
+    }
+
+    @Test
+    public void testDeleteOldKeyOnceNewKeyGenerated() throws Exception {
+        // create topic
+        final String topic = testTopic + UUID.randomUUID();
+        TopicName topicName = TopicName.get(topic);
+        admin.topics().createNonPartitionedTopic(topic);
+        pulsarClient.newProducer().topic(topic).create().close();
+
+        // simulate send old event start
+        SystemTopicBasedTopicPoliciesService topicPoliciesService
+                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        Field field = SystemTopicBasedTopicPoliciesService.class.getDeclaredField("namespaceEventsSystemTopicFactory");
+        field.setAccessible(true);
+        NamespaceEventsSystemTopicFactory systemTopicFactory = (NamespaceEventsSystemTopicFactory) field.get(topicPoliciesService);
+        SystemTopicClient<PulsarEvent> systemTopicClient =
+                systemTopicFactory.createTopicPoliciesSystemTopicClient(topicName.getNamespaceObject());
+        systemTopicClient.newWriterAsync()
+                .thenCompose(writer -> {
+                    TopicPolicies oldInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(1).build();
+                    PulsarEvent event = PulsarEvent.builder()
+                            .actionType(ActionType.UPDATE)
+                            .eventType(EventType.TOPIC_POLICY)
+                            .topicPoliciesEvent(
+                                    TopicPoliciesEvent.builder()
+                                            .domain(topicName.getDomain().toString())
+                                            .tenant(topicName.getTenant())
+                                            .namespace(topicName.getNamespaceObject().getLocalName())
+                                            .topic(TopicName.get(topicName.getPartitionedTopicName()).getLocalName())
+                                            .policies(oldInitPolicy)
+                                            .build())
+                            .build();
+                    // use topic name as old key
+                    writer.writeAsync(topicName.toString(), event);
+                    return CompletableFuture.completedFuture(null);
+                }).get();
+        // simulate send old event end
+
+        // set up policies for testTopic
+        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
+        TopicPolicies globalInitPolicy =
+                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
+
+        // read the system topic and counter the PoliciesEvent.
+        String topicPoliciesTopic = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
+        Consumer consumer = pulsarClient.newConsumer()
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .readCompacted(true)
+                .topic(topicPoliciesTopic).subscriptionName("sub").subscribe();
+        int count = 0;
+        while (true) {
+            Message message = consumer.receive(1, TimeUnit.SECONDS);
+            if (message != null) {
+                if (message.getKey().contains(topic)) {
+                    count++;
+                }
+                consumer.acknowledge(message);
+            } else {
+                break;
+            }
+        }
+        consumer.close();
+        // 1. old topic policies event
+        // 2. local topic policies event
+        // 3. global topic policies event
+        // 4. delete old topic policies event
+        assertEquals(count, 4);
+
+        // Trigger compaction and make sure it is finished.
+        PersistentTopic brokerTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicPolicyEventsTopic).get().get();
+        assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.NOT_RUN);
+        brokerTopic.triggerCompaction();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.SUCCESS));
+
+        // reload namespace to trigger init polices cache and notify listeners
+        admin.namespaces().unload(myNamespace);
+        // the policies cache
+        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
+
+        pulsarClient.newProducer().topic(topic).create().close();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
+                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
+                        .isCompletedExceptionally(), true));
+
+        // read the system topic and counter the PoliciesEvent again
+        consumer = pulsarClient.newConsumer()
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .readCompacted(true)
+                .topic(topicPoliciesTopic).subscriptionName("sub2").subscribe();
+        count = 0;
+        while (true) {
+            Message message = consumer.receive(1, TimeUnit.SECONDS);
+            if (message != null) {
+                if (message.getKey().contains(topic)) {
+                    count++;
+                }
+                consumer.acknowledge(message);
+            } else {
+                break;
+            }
+        }
+        consumer.close();
+        // 1. local topic policies event
+        // 2. global topic policies event
+        assertEquals(count, 2);
+
+    }
+
+    @Test
+    public void testGlobalPolicyAfterUnloadTopic() throws Exception {
+        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
+        final String subscriptionName = "s1";
+        final int dispatchThrottlingRateInMsg = 1000;
+        admin.topics().createNonPartitionedTopic(tpName);
+        PersistentTopic persistentTopic1 =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
+        Producer producer = pulsarClient.newProducer().topic(tpName).create();
+
+        // Set global policy.
+        DispatchRate dispatchRate = new DispatchRateImpl(dispatchThrottlingRateInMsg, 1, false, 1);
+        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRate);
+
+        // Assert policy was affected.
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+            HierarchyTopicPolicies policies = persistentTopic1.getHierarchyTopicPolicies();
+            assertNotNull(policies);
+            assertEquals(policies.getDispatchRate().get().getDispatchThrottlingRateInMsg(),
+                    dispatchThrottlingRateInMsg);
+            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
+            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        });
+
+        // Unload topic and check again.
+        admin.topics().unload(tpName);
+        // Wait topic load complete.
+        producer.send("1".getBytes(StandardCharsets.UTF_8));
+        PersistentTopic persistentTopic2 =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+        // Assert policy was affected.
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+            HierarchyTopicPolicies policies = persistentTopic2.getHierarchyTopicPolicies();
+            assertNotNull(policies);
+            assertEquals(policies.getDispatchRate().get().getDispatchThrottlingRateInMsg(),
+                    dispatchThrottlingRateInMsg);
+            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
+            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        });
+
+        // cleanup.
+        producer.close();
+        admin.topics().delete(tpName, false);
+    }
+
+    @Test
+    public void testInitPolicesCacheAndNotifyListenersAfterCompaction() throws Exception {
+        // create topic
+        final String topic = testTopic + UUID.randomUUID();
+        admin.topics().createNonPartitionedTopic(topic);
+        pulsarClient.newProducer().topic(topic).create().close();
+
+        // set up policies for testTopic
+        TopicName topicName = TopicName.get(topic);
+        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
+        TopicPolicies globalInitPolicy =
+                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
+
+        /*
+          if the topic initialization is completed before the corresponding namespace's policy caches initialization,
+           the topic policies will be applied in
+          `org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.initPolicesCacheAndNotifyListeners`,
+          otherwise it will be applied in
+          `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
+          the topicPolicyEventsTopic initialization always completed before the corresponding namespace's policy
+          caches initialization, use topicPolicyEventsTopic to verify `initPolicesCacheAndNotifyListeners`
+         */
+        // set up policies for eventsTopic
+        TopicName eventsTopicName = TopicName.get(topicPolicyEventsTopic);
+        TopicPolicies eventsLocalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(40).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsLocalInitPolicy).get();
+        TopicPolicies eventsGlobalInitPolicy =
+                TopicPolicies.builder().maxConsumerPerTopic(50).maxProducerPerTopic(60).isGlobal(true).build();
+        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsGlobalInitPolicy).get();
+
+        // Trigger compaction and make sure it is finished.
+        PersistentTopic brokerTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicPolicyEventsTopic).get().get();
+        assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.NOT_RUN);
+        brokerTopic.triggerCompaction();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.SUCCESS));
+
+        // reload namespace to trigger init polices cache and notify listeners
+        admin.namespaces().unload(myNamespace);
+        // the policies cache
+        SystemTopicBasedTopicPoliciesService topicPoliciesService
+                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
+        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
+
+        pulsarClient.newProducer().topic(topic).create().close();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
+                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
+                        .isCompletedExceptionally(), true));
+
+        // check testTopic start
+        // the final policies take effect in topic
+        HierarchyTopicPolicies hierarchyTopicPolicies =
+                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 10);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 20);
+        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 30);
+        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
+        // check testTopic end
+
+        // check eventsTopic start
+        // the final policies take effect in topic
+        HierarchyTopicPolicies eventsHierarchyTopicPolicies =
+                pulsar.getBrokerService().getTopics().get(topicPolicyEventsTopic).get().get().getHierarchyTopicPolicies();
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 40);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 50);
+        assertEquals(eventsHierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 40);
+
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
+        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 60);
+        assertEquals(eventsHierarchyTopicPolicies.getMaxProducersPerTopic().get(), 60);
+        // check eventsTopic end
+    }
+
 
     @Test(timeOut = 20000)
     public void testGetSizeBasedBacklogQuotaApplied() throws Exception {
@@ -3057,6 +3433,159 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 Assertions.assertThat(TopicPolicyTestUtils.getTopicPolicies(pulsar.getTopicPoliciesService(), TopicName.get(topic))).isNull();
             });
         }
+    }
+
+    @Test
+    public void testLocalPolicyAffectAfterCompactionCase2() throws Exception {
+        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
+        final String tpNameChangeEvents = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
+        final String subscriptionName = "s1";
+        final int rateMsgLocal = 2000;
+        final int rateMsgGlobal = 1000;
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
+
+        // Set global policy and local policy.
+        DispatchRate dispatchRateLocal = new DispatchRateImpl(rateMsgLocal, 1, false, 1);
+        DispatchRate dispatchRateGlobal = new DispatchRateImpl(rateMsgGlobal, 1, false, 1);
+        admin.topicPolicies(false).setDispatchRate(tpName, dispatchRateLocal);
+        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRateGlobal);
+
+        // Trigger __change_events compaction and clear topic policies cache.
+        triggerAndWaitNewTopicCompaction(tpNameChangeEvents);
+        clearTopicPoliciesCache();
+
+        // Reload the topic policies.
+        // Verify the local policies was affected.
+        Optional<TopicPolicies> topicPoliciesOptional =
+                pulsar.getTopicPoliciesService().getTopicPoliciesAsync(TopicName.get(tpName),
+                        LOCAL_ONLY).join();
+        assertTrue(topicPoliciesOptional.isPresent());
+        assertEquals(topicPoliciesOptional.get().getDispatchRate().getDispatchThrottlingRateInMsg(),
+                rateMsgLocal);
+
+        // cleanup.
+        admin.topics().delete(tpName, false);
+    }
+
+    private void triggerAndWaitNewTopicCompaction(String topicName) throws Exception {
+        PersistentTopic tp =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        // Wait for the old task finish.
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture<Long> compactionTask = WhiteboxImpl.getInternalState(tp, "currentCompaction");
+            assertTrue(compactionTask == null || compactionTask.isDone());
+        });
+        // Trigger a new task.
+        tp.triggerCompaction();
+        // Wait for the new task finish.
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture<Long> compactionTask = WhiteboxImpl.getInternalState(tp, "currentCompaction");
+            assertTrue(compactionTask == null || compactionTask.isDone());
+        });
+    }
+
+    /***
+     * It is not a thread safety method, something will go to a wrong pointer if there is a task is trying to load a
+     * topic policies.
+     */
+    private void clearTopicPoliciesCache() {
+        TopicPoliciesService topicPoliciesService = pulsar.getTopicPoliciesService();
+        if (topicPoliciesService instanceof TopicPoliciesService.TopicPoliciesServiceDisabled) {
+            return;
+        }
+        assertTrue(topicPoliciesService instanceof SystemTopicBasedTopicPoliciesService);
+
+        Map<NamespaceName, CompletableFuture<Void>> policyCacheInitMap =
+                WhiteboxImpl.getInternalState(topicPoliciesService, "policyCacheInitMap");
+        for (CompletableFuture<Void> future : policyCacheInitMap.values()) {
+            future.join();
+        }
+        Map<TopicName, TopicPolicies> policiesCache =
+                WhiteboxImpl.getInternalState(topicPoliciesService, "policiesCache");
+        Map<TopicName, TopicPolicies> globalPoliciesCache =
+                WhiteboxImpl.getInternalState(topicPoliciesService, "globalPoliciesCache");
+
+        policyCacheInitMap.clear();
+        policiesCache.clear();
+        globalPoliciesCache.clear();
+    }
+
+    @Test
+    public void testLocalPolicyAffectAfterCompaction() throws Exception {
+        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
+        final String tpNameChangeEvents = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
+        final String subscriptionName = "s1";
+        final int rateMsgLocal = 2000;
+        final int rateMsgGlobal = 1000;
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
+
+        // Set global policy and local policy.
+        DispatchRate dispatchRateLocal = new DispatchRateImpl(rateMsgLocal, 1, false, 1);
+        DispatchRate dispatchRateGlobal = new DispatchRateImpl(rateMsgGlobal, 1, false, 1);
+        admin.topicPolicies(false).setDispatchRate(tpName, dispatchRateLocal);
+        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRateGlobal);
+
+        // Trigger __change_events compaction.
+        triggerAndWaitNewTopicCompaction(tpNameChangeEvents);
+
+        // Create a new SystemTopicBasedTopicPoliciesService and verify the local policies was affected.
+        Optional<TopicPolicies> topicPoliciesOptional =
+                new SystemTopicBasedTopicPoliciesService(pulsar).getTopicPoliciesAsync(TopicName.get(tpName),
+                        LOCAL_ONLY).join();
+        assertTrue(topicPoliciesOptional.isPresent());
+        assertEquals(topicPoliciesOptional.get().getDispatchRate().getDispatchThrottlingRateInMsg(),
+                rateMsgLocal);
+
+        // cleanup.
+        admin.topics().delete(tpName, false);
+    }
+
+    @Test
+    public void testGetTopicPoliciesWhenDeleteTopicPolicy2() throws Exception {
+        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
+        final String subscriptionName = "s1";
+        final int dispatchThrottlingRateInMsg = 1000;
+        admin.topics().createNonPartitionedTopic(tpName);
+        PersistentTopic persistentTopic1 =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
+        Producer producer = pulsarClient.newProducer().topic(tpName).create();
+
+        // Set global policy.
+        DispatchRate dispatchRate = new DispatchRateImpl(dispatchThrottlingRateInMsg, 1, false, 1);
+        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRate);
+
+        // Assert policy was affected.
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+            HierarchyTopicPolicies policies = persistentTopic1.getHierarchyTopicPolicies();
+            assertNotNull(policies);
+            assertEquals(policies.getDispatchRate().getTopicValue().getDispatchThrottlingRateInMsg(),
+                    dispatchThrottlingRateInMsg);
+            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
+            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        });
+
+        // Unload topic and check again.
+        admin.topics().unload(tpName);
+        // Wait topic load complete.
+        producer.send("1".getBytes(StandardCharsets.UTF_8));
+        PersistentTopic persistentTopic2 =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
+        // Assert policy was affected.
+        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+            HierarchyTopicPolicies policies = persistentTopic2.getHierarchyTopicPolicies();
+            assertNotNull(policies);
+            assertEquals(policies.getDispatchRate().getTopicValue().getDispatchThrottlingRateInMsg(),
+                    dispatchThrottlingRateInMsg);
+            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
+            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        });
+
+        // cleanup.
+        producer.close();
+        admin.topics().delete(tpName, false);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.admin;
 
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.GLOBAL_ONLY;
 import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.LOCAL_ONLY;
-import static org.apache.pulsar.common.naming.SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -31,7 +30,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,16 +55,12 @@ import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.PublishRateLimiterImpl;
 import org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService;
-import org.apache.pulsar.broker.service.TopicPoliciesService;
 import org.apache.pulsar.broker.service.TopicPolicyTestUtils;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.persistent.SubscribeRateLimiter;
-import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
-import org.apache.pulsar.broker.systopic.SystemTopicClient;
-import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
@@ -80,10 +74,6 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
-import org.apache.pulsar.common.events.ActionType;
-import org.apache.pulsar.common.events.EventType;
-import org.apache.pulsar.common.events.PulsarEvent;
-import org.apache.pulsar.common.events.TopicPoliciesEvent;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -109,7 +99,6 @@ import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.awaitility.reflect.WhiteboxImpl;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -453,367 +442,142 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testInitTopicPolicy() throws Exception {
-        // create topic
-        final String topic = testTopic + UUID.randomUUID();
-        admin.topics().createNonPartitionedTopic(topic);
-        pulsarClient.newProducer().topic(topic).create().close();
-
-        // unload
-        admin.namespaces().unload(myNamespace);
-        // the policies cache
-        SystemTopicBasedTopicPoliciesService topicPoliciesService
+    public void testPriorityOfGlobalPolicies() throws Exception {
+        final SystemTopicBasedTopicPoliciesService topicPoliciesService
                 = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
-        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
-
-        // set up policies
-        TopicName topicName = TopicName.get(topic);
-        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
-        TopicPolicies globalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30)
-                .isGlobal(true).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
-
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
-                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
-                        .isCompletedExceptionally(), true));
-
-        // load up topic after the corresponding namespace's policy caches initialization to make sure the topic
-        // polices applied in `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
-        pulsarClient.newProducer().topic(topic).create().close();
-
-        // the final policies take effect in topic
-        HierarchyTopicPolicies hierarchyTopicPolicies =
-                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
-
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
-                .getMaxConsumerPerTopic(), 10);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
-                .getMaxConsumerPerTopic(), 20);
-        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
-
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
-                .getMaxProducerPerTopic(), null);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
-                .getMaxProducerPerTopic(), 30);
-        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
-    }
-
-    @Test
-    public void testInitPolicesCacheAndNotifyListeners() throws Exception {
-        // create topic
-        final String topic = testTopic + UUID.randomUUID();
+        final JerseyClient httpClient = JerseyClientBuilder.createClient();
+        // create topic and load it up.
+        final String namespace = myNamespace;
+        final String topic = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp");
+        final TopicName topicName = TopicName.get(topic);
+        final String hostAndPort = pulsar.getWebServiceAddress();
+        final String httpPath = "/admin/v2/persistent/" + namespace + "/" + TopicName.get(topic).getLocalName()
+                + "/maxConsumers";
         admin.topics().createNonPartitionedTopic(topic);
-        pulsarClient.newProducer().topic(topic).create().close();
+        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopics().get(topic).get().get();
 
-        // set up policies for testTopic
-        TopicName topicName = TopicName.get(topic);
-        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
-        TopicPolicies globalInitPolicy =
-                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
-
-        /*
-          if the topic initialization is completed before the corresponding namespace's policy caches initialization,
-           the topic policies will be applied in
-          `org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.initPolicesCacheAndNotifyListeners`,
-          otherwise it will be applied in
-          `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
-          the topicPolicyEventsTopic initialization always completed before the corresponding namespace's policy
-          caches initialization, use topicPolicyEventsTopic to verify `initPolicesCacheAndNotifyListeners`
-         */
-        // set up policies for eventsTopic
-//        TopicName eventsTopicName = TopicName.get(topicPolicyEventsTopic);
-//        TopicPolicies eventsLocalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(40).build();
-//        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsLocalInitPolicy).get();
-//        TopicPolicies eventsGlobalInitPolicy =
-//                TopicPolicies.builder().maxConsumerPerTopic(50).maxProducerPerTopic(60).isGlobal(true).build();
-//        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsGlobalInitPolicy).get();
-
-        // reload namespace to trigger init polices cache and notify listeners
-        admin.namespaces().unload(myNamespace);
-        // the policies cache
-        SystemTopicBasedTopicPoliciesService topicPoliciesService
-                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
-        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
-
-        pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
-                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
-                        .isCompletedExceptionally(), true));
-
-        // check testTopic start
-        // the final policies take effect in topic
-        HierarchyTopicPolicies hierarchyTopicPolicies =
-                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
-                .getMaxConsumerPerTopic(), 10);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
-                .getMaxConsumerPerTopic(), 20);
-        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
-
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
-                .getMaxProducerPerTopic(), null);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
-                .getMaxProducerPerTopic(), 30);
-        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
-        // check testTopic end
-
-        // check eventsTopic start
-        // the final policies take effect in topic
-//        HierarchyTopicPolicies eventsHierarchyTopicPolicies =
-//                pulsar.getBrokerService().getTopics().get(topicPolicyEventsTopic).get().get().getHierarchyTopicPolicies();
-//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 40);
-//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 50);
-//        assertEquals(eventsHierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 40);
-//
-//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
-//        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 60);
-//        assertEquals(eventsHierarchyTopicPolicies.getMaxProducersPerTopic().get(), 60);
-        // check eventsTopic end
-    }
-
-    @Test
-    public void testDeleteOldKeyOnceNewKeyGenerated() throws Exception {
-        // create topic
-        final String topic = testTopic + UUID.randomUUID();
-        TopicName topicName = TopicName.get(topic);
-        admin.topics().createNonPartitionedTopic(topic);
-        pulsarClient.newProducer().topic(topic).create().close();
-
-        // simulate send old event start
-        SystemTopicBasedTopicPoliciesService topicPoliciesService
-                = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
-        Field field = SystemTopicBasedTopicPoliciesService.class.getDeclaredField("namespaceEventsSystemTopicFactory");
-        field.setAccessible(true);
-        NamespaceEventsSystemTopicFactory systemTopicFactory = (NamespaceEventsSystemTopicFactory) field.get(topicPoliciesService);
-        SystemTopicClient<PulsarEvent> systemTopicClient =
-                systemTopicFactory.createTopicPoliciesSystemTopicClient(topicName.getNamespaceObject());
-        systemTopicClient.newWriterAsync()
-                .thenCompose(writer -> {
-                    TopicPolicies oldInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(1).build();
-                    PulsarEvent event = PulsarEvent.builder()
-                            .actionType(ActionType.UPDATE)
-                            .eventType(EventType.TOPIC_POLICY)
-                            .topicPoliciesEvent(
-                                    TopicPoliciesEvent.builder()
-                                            .domain(topicName.getDomain().toString())
-                                            .tenant(topicName.getTenant())
-                                            .namespace(topicName.getNamespaceObject().getLocalName())
-                                            .topic(TopicName.get(topicName.getPartitionedTopicName()).getLocalName())
-                                            .policies(oldInitPolicy)
-                                            .build())
-                            .build();
-                    // use topic name as old key
-                    writer.writeAsync(topicName.toString(), event);
-                    return CompletableFuture.completedFuture(null);
-                }).get();
-        // simulate send old event end
-
-        // set up policies for testTopic
-        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
-        TopicPolicies globalInitPolicy =
-                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
-
-        // read the system topic and counter the PoliciesEvent.
-        String topicPoliciesTopic = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
-        Consumer consumer = pulsarClient.newConsumer()
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .readCompacted(true)
-                .topic(topicPoliciesTopic).subscriptionName("sub").subscribe();
-        int count = 0;
-        while (true) {
-            Message message = consumer.receive(1, TimeUnit.SECONDS);
-            if (message != null) {
-                if (message.getKey().contains(topic)) {
-                    count++;
-                }
-                consumer.acknowledge(message);
-            } else {
-                break;
-            }
-        }
-        consumer.close();
-        // 1. old topic policies event
-        // 2. local topic policies event
-        // 3. global topic policies event
-        // 4. delete old topic policies event
-        assertEquals(count, 4);
-
-        // Trigger compaction and make sure it is finished.
-        PersistentTopic brokerTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicPolicyEventsTopic).get().get();
-        assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.NOT_RUN);
-        brokerTopic.triggerCompaction();
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.SUCCESS));
-
-        // reload namespace to trigger init polices cache and notify listeners
-        admin.namespaces().unload(myNamespace);
-        // the policies cache
-        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
-
-        pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
-                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
-                        .isCompletedExceptionally(), true));
-
-        // read the system topic and counter the PoliciesEvent again
-        consumer = pulsarClient.newConsumer()
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .readCompacted(true)
-                .topic(topicPoliciesTopic).subscriptionName("sub2").subscribe();
-        count = 0;
-        while (true) {
-            Message message = consumer.receive(1, TimeUnit.SECONDS);
-            if (message != null) {
-                if (message.getKey().contains(topic)) {
-                    count++;
-                }
-                consumer.acknowledge(message);
-            } else {
-                break;
-            }
-        }
-        consumer.close();
-        // 1. local topic policies event
-        // 2. global topic policies event
-        assertEquals(count, 2);
-
-    }
-
-    @Test
-    public void testGlobalPolicyAfterUnloadTopic() throws Exception {
-        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
-        final String subscriptionName = "s1";
-        final int dispatchThrottlingRateInMsg = 1000;
-        admin.topics().createNonPartitionedTopic(tpName);
-        PersistentTopic persistentTopic1 =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
-        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
-        Producer producer = pulsarClient.newProducer().topic(tpName).create();
-
-        // Set global policy.
-        DispatchRate dispatchRate = new DispatchRateImpl(dispatchThrottlingRateInMsg, 1, false, 1);
-        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRate);
-
-        // Assert policy was affected.
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
-            HierarchyTopicPolicies policies = persistentTopic1.getHierarchyTopicPolicies();
-            assertNotNull(policies);
-            assertEquals(policies.getDispatchRate().get().getDispatchThrottlingRateInMsg(),
-                    dispatchThrottlingRateInMsg);
-            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
-            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        // Set non global policy.
+        // Verify: it affects.
+        Response res = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "false")
+                .request()
+                .header("Content-Type", "application/json")
+                .post(Entity.json(10));
+        assertTrue(res.getStatus() == 200 || res.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 10);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
         });
 
-        // Unload topic and check again.
-        admin.topics().unload(tpName);
-        // Wait topic load complete.
-        producer.send("1".getBytes(StandardCharsets.UTF_8));
-        PersistentTopic persistentTopic2 =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
-        // Assert policy was affected.
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
-            HierarchyTopicPolicies policies = persistentTopic2.getHierarchyTopicPolicies();
-            assertNotNull(policies);
-            assertEquals(policies.getDispatchRate().get().getDispatchThrottlingRateInMsg(),
-                    dispatchThrottlingRateInMsg);
-            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
-            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
+        // Set global policy.
+        // Verify: topic policies has higher priority than global policies.
+        Response globalRes = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "true")
+                .request()
+                .header("Content-Type", "application/json")
+                .post(Entity.json(20));
+        assertTrue(globalRes.getStatus() == 200 || globalRes.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 10);
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 20);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+        });
+
+        // Remove non-global policy.
+        // Verify: global policy affects.
+        Response removeRes = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "false")
+                .request()
+                .header("Content-Type", "application/json")
+                .delete();
+        assertTrue(removeRes.getStatus() == 200 || removeRes.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 20);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 20);
         });
 
         // cleanup.
         producer.close();
-        admin.topics().delete(tpName, false);
+        admin.topics().delete(topic, false);
     }
 
     @Test
-    public void testInitPolicesCacheAndNotifyListenersAfterCompaction() throws Exception {
-        // create topic
-        final String topic = testTopic + UUID.randomUUID();
-        admin.topics().createNonPartitionedTopic(topic);
-        pulsarClient.newProducer().topic(topic).create().close();
-
-        // set up policies for testTopic
-        TopicName topicName = TopicName.get(topic);
-        TopicPolicies localInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(10).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, localInitPolicy).get();
-        TopicPolicies globalInitPolicy =
-                TopicPolicies.builder().maxConsumerPerTopic(20).maxProducerPerTopic(30).isGlobal(true).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(topicName, globalInitPolicy).get();
-
-        /*
-          if the topic initialization is completed before the corresponding namespace's policy caches initialization,
-           the topic policies will be applied in
-          `org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.initPolicesCacheAndNotifyListeners`,
-          otherwise it will be applied in
-          `org.apache.pulsar.broker.service.persistent.PersistentTopic.initTopicPolicy`
-          the topicPolicyEventsTopic initialization always completed before the corresponding namespace's policy
-          caches initialization, use topicPolicyEventsTopic to verify `initPolicesCacheAndNotifyListeners`
-         */
-        // set up policies for eventsTopic
-        TopicName eventsTopicName = TopicName.get(topicPolicyEventsTopic);
-        TopicPolicies eventsLocalInitPolicy = TopicPolicies.builder().maxConsumerPerTopic(40).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsLocalInitPolicy).get();
-        TopicPolicies eventsGlobalInitPolicy =
-                TopicPolicies.builder().maxConsumerPerTopic(50).maxProducerPerTopic(60).isGlobal(true).build();
-        pulsar.getTopicPoliciesService().updateTopicPoliciesAsync(eventsTopicName, eventsGlobalInitPolicy).get();
-
-        // Trigger compaction and make sure it is finished.
-        PersistentTopic brokerTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicPolicyEventsTopic).get().get();
-        assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.NOT_RUN);
-        brokerTopic.triggerCompaction();
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(brokerTopic.compactionStatus().status, LongRunningProcessStatus.Status.SUCCESS));
-
-        // reload namespace to trigger init polices cache and notify listeners
-        admin.namespaces().unload(myNamespace);
-        // the policies cache
-        SystemTopicBasedTopicPoliciesService topicPoliciesService
+    public void testPriorityOfGlobalPolicies2() throws Exception {
+        final SystemTopicBasedTopicPoliciesService topicPoliciesService
                 = (SystemTopicBasedTopicPoliciesService) pulsar.getTopicPoliciesService();
-        assertNull(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)));
+        final JerseyClient httpClient = JerseyClientBuilder.createClient();
+        // create topic and load it up.
+        final String namespace = myNamespace;
+        final String topic = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp");
+        final TopicName topicName = TopicName.get(topic);
+        final String hostAndPort = pulsar.getWebServiceAddress();
+        final String httpPath = "/admin/v2/persistent/" + namespace + "/" + TopicName.get(topic).getLocalName()
+                + "/maxConsumers";
+        admin.topics().createNonPartitionedTopic(topic);
+        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopics().get(topic).get().get();
 
-        pulsarClient.newProducer().topic(topic).create().close();
-        Awaitility.await().untilAsserted(
-                () -> assertEquals(topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace)).isDone()
-                        && !topicPoliciesService.getPoliciesCacheInit(NamespaceName.get(myNamespace))
-                        .isCompletedExceptionally(), true));
+        // Set global policy.
+        // Verify: it affects.
+        Response globalRes = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "true")
+                .request()
+                .header("Content-Type", "application/json")
+                .post(Entity.json(20));
+        assertTrue(globalRes.getStatus() == 200 || globalRes.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 20);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 20);
+        });
 
-        // check testTopic start
-        // the final policies take effect in topic
-        HierarchyTopicPolicies hierarchyTopicPolicies =
-                pulsar.getBrokerService().getTopics().get(topic).get().get().getHierarchyTopicPolicies();
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 10);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 20);
-        assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+        // Set non global policy.
+        // Verify: topic policies has higher priority than global policies.
+        Response res = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "false")
+                .request()
+                .header("Content-Type", "application/json")
+                .post(Entity.json(10));
+        assertTrue(res.getStatus() == 200 || res.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 10);
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 20);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+        });
 
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 30);
-        assertEquals(hierarchyTopicPolicies.getMaxProducersPerTopic().get(), 30);
-        // check testTopic end
+        // Remove global policy.
+        // Verify: non-global policy affects.
+        Response removeRes = httpClient.target(hostAndPort).path(httpPath)
+                .queryParam("isGlobal", "true")
+                .request()
+                .header("Content-Type", "application/json")
+                .delete();
+        assertTrue(removeRes.getStatus() == 200 || removeRes.getStatus() == 204);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topicPoliciesService.getTopicPoliciesAsync(topicName, LOCAL_ONLY).join().get()
+                    .getMaxConsumerPerTopic(), 10);
+            HierarchyTopicPolicies hierarchyTopicPolicies = persistentTopic.getHierarchyTopicPolicies();
+            assertEquals(hierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 10);
+        });
 
-        // check eventsTopic start
-        // the final policies take effect in topic
-        HierarchyTopicPolicies eventsHierarchyTopicPolicies =
-                pulsar.getBrokerService().getTopics().get(topicPolicyEventsTopic).get().get().getHierarchyTopicPolicies();
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxConsumerPerTopic(), 40);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxConsumerPerTopic(), 50);
-        assertEquals(eventsHierarchyTopicPolicies.getMaxConsumerPerTopic().get(), 40);
-
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, LOCAL_ONLY).join().get().getMaxProducerPerTopic(), null);
-        assertEquals(topicPoliciesService.getTopicPoliciesAsync(eventsTopicName, GLOBAL_ONLY).join().get().getMaxProducerPerTopic(), 60);
-        assertEquals(eventsHierarchyTopicPolicies.getMaxProducersPerTopic().get(), 60);
-        // check eventsTopic end
+        // cleanup.
+        producer.close();
+        admin.topics().delete(topic, false);
     }
-
 
     @Test(timeOut = 20000)
     public void testGetSizeBasedBacklogQuotaApplied() throws Exception {
@@ -3433,159 +3197,6 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 Assertions.assertThat(TopicPolicyTestUtils.getTopicPolicies(pulsar.getTopicPoliciesService(), TopicName.get(topic))).isNull();
             });
         }
-    }
-
-    @Test
-    public void testLocalPolicyAffectAfterCompactionCase2() throws Exception {
-        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
-        final String tpNameChangeEvents = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
-        final String subscriptionName = "s1";
-        final int rateMsgLocal = 2000;
-        final int rateMsgGlobal = 1000;
-        admin.topics().createNonPartitionedTopic(tpName);
-        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
-
-        // Set global policy and local policy.
-        DispatchRate dispatchRateLocal = new DispatchRateImpl(rateMsgLocal, 1, false, 1);
-        DispatchRate dispatchRateGlobal = new DispatchRateImpl(rateMsgGlobal, 1, false, 1);
-        admin.topicPolicies(false).setDispatchRate(tpName, dispatchRateLocal);
-        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRateGlobal);
-
-        // Trigger __change_events compaction and clear topic policies cache.
-        triggerAndWaitNewTopicCompaction(tpNameChangeEvents);
-        clearTopicPoliciesCache();
-
-        // Reload the topic policies.
-        // Verify the local policies was affected.
-        Optional<TopicPolicies> topicPoliciesOptional =
-                pulsar.getTopicPoliciesService().getTopicPoliciesAsync(TopicName.get(tpName),
-                        LOCAL_ONLY).join();
-        assertTrue(topicPoliciesOptional.isPresent());
-        assertEquals(topicPoliciesOptional.get().getDispatchRate().getDispatchThrottlingRateInMsg(),
-                rateMsgLocal);
-
-        // cleanup.
-        admin.topics().delete(tpName, false);
-    }
-
-    private void triggerAndWaitNewTopicCompaction(String topicName) throws Exception {
-        PersistentTopic tp =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
-        // Wait for the old task finish.
-        Awaitility.await().untilAsserted(() -> {
-            CompletableFuture<Long> compactionTask = WhiteboxImpl.getInternalState(tp, "currentCompaction");
-            assertTrue(compactionTask == null || compactionTask.isDone());
-        });
-        // Trigger a new task.
-        tp.triggerCompaction();
-        // Wait for the new task finish.
-        Awaitility.await().untilAsserted(() -> {
-            CompletableFuture<Long> compactionTask = WhiteboxImpl.getInternalState(tp, "currentCompaction");
-            assertTrue(compactionTask == null || compactionTask.isDone());
-        });
-    }
-
-    /***
-     * It is not a thread safety method, something will go to a wrong pointer if there is a task is trying to load a
-     * topic policies.
-     */
-    private void clearTopicPoliciesCache() {
-        TopicPoliciesService topicPoliciesService = pulsar.getTopicPoliciesService();
-        if (topicPoliciesService instanceof TopicPoliciesService.TopicPoliciesServiceDisabled) {
-            return;
-        }
-        assertTrue(topicPoliciesService instanceof SystemTopicBasedTopicPoliciesService);
-
-        Map<NamespaceName, CompletableFuture<Void>> policyCacheInitMap =
-                WhiteboxImpl.getInternalState(topicPoliciesService, "policyCacheInitMap");
-        for (CompletableFuture<Void> future : policyCacheInitMap.values()) {
-            future.join();
-        }
-        Map<TopicName, TopicPolicies> policiesCache =
-                WhiteboxImpl.getInternalState(topicPoliciesService, "policiesCache");
-        Map<TopicName, TopicPolicies> globalPoliciesCache =
-                WhiteboxImpl.getInternalState(topicPoliciesService, "globalPoliciesCache");
-
-        policyCacheInitMap.clear();
-        policiesCache.clear();
-        globalPoliciesCache.clear();
-    }
-
-    @Test
-    public void testLocalPolicyAffectAfterCompaction() throws Exception {
-        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
-        final String tpNameChangeEvents = "persistent://" + myNamespace + "/" + NAMESPACE_EVENTS_LOCAL_NAME;
-        final String subscriptionName = "s1";
-        final int rateMsgLocal = 2000;
-        final int rateMsgGlobal = 1000;
-        admin.topics().createNonPartitionedTopic(tpName);
-        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
-
-        // Set global policy and local policy.
-        DispatchRate dispatchRateLocal = new DispatchRateImpl(rateMsgLocal, 1, false, 1);
-        DispatchRate dispatchRateGlobal = new DispatchRateImpl(rateMsgGlobal, 1, false, 1);
-        admin.topicPolicies(false).setDispatchRate(tpName, dispatchRateLocal);
-        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRateGlobal);
-
-        // Trigger __change_events compaction.
-        triggerAndWaitNewTopicCompaction(tpNameChangeEvents);
-
-        // Create a new SystemTopicBasedTopicPoliciesService and verify the local policies was affected.
-        Optional<TopicPolicies> topicPoliciesOptional =
-                new SystemTopicBasedTopicPoliciesService(pulsar).getTopicPoliciesAsync(TopicName.get(tpName),
-                        LOCAL_ONLY).join();
-        assertTrue(topicPoliciesOptional.isPresent());
-        assertEquals(topicPoliciesOptional.get().getDispatchRate().getDispatchThrottlingRateInMsg(),
-                rateMsgLocal);
-
-        // cleanup.
-        admin.topics().delete(tpName, false);
-    }
-
-    @Test
-    public void testGetTopicPoliciesWhenDeleteTopicPolicy2() throws Exception {
-        final String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
-        final String subscriptionName = "s1";
-        final int dispatchThrottlingRateInMsg = 1000;
-        admin.topics().createNonPartitionedTopic(tpName);
-        PersistentTopic persistentTopic1 =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
-        admin.topics().createSubscription(tpName, subscriptionName, MessageId.earliest);
-        Producer producer = pulsarClient.newProducer().topic(tpName).create();
-
-        // Set global policy.
-        DispatchRate dispatchRate = new DispatchRateImpl(dispatchThrottlingRateInMsg, 1, false, 1);
-        admin.topicPolicies(true).setDispatchRate(tpName, dispatchRate);
-
-        // Assert policy was affected.
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
-            HierarchyTopicPolicies policies = persistentTopic1.getHierarchyTopicPolicies();
-            assertNotNull(policies);
-            assertEquals(policies.getDispatchRate().getTopicValue().getDispatchThrottlingRateInMsg(),
-                    dispatchThrottlingRateInMsg);
-            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
-            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
-        });
-
-        // Unload topic and check again.
-        admin.topics().unload(tpName);
-        // Wait topic load complete.
-        producer.send("1".getBytes(StandardCharsets.UTF_8));
-        PersistentTopic persistentTopic2 =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(tpName, false).join().get();
-        // Assert policy was affected.
-        Awaitility.await().ignoreExceptions().untilAsserted(() -> {
-            HierarchyTopicPolicies policies = persistentTopic2.getHierarchyTopicPolicies();
-            assertNotNull(policies);
-            assertEquals(policies.getDispatchRate().getTopicValue().getDispatchThrottlingRateInMsg(),
-                    dispatchThrottlingRateInMsg);
-            DispatchRate dispatchRateAp = admin.topicPolicies(true).getDispatchRate(tpName, true);
-            assertEquals(dispatchRateAp.getDispatchThrottlingRateInMsg(), dispatchThrottlingRateInMsg);
-        });
-
-        // cleanup.
-        producer.close();
-        admin.topics().delete(tpName, false);
     }
 
     @Test

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
@@ -38,6 +38,9 @@ public class PolicyHierarchyValue<T> {
     @Getter
     private volatile T topicValue;
 
+    @Getter
+    private volatile T topicGlobalValue;
+
     private volatile T value;
 
     public PolicyHierarchyValue() {
@@ -53,8 +56,12 @@ public class PolicyHierarchyValue<T> {
         updateValue();
     }
 
-    public void updateTopicValue(T topicValue) {
-        this.topicValue = topicValue;
+    public void updateTopicValue(T topicValue, boolean isGlobalPolicy) {
+        if (isGlobalPolicy) {
+            this.topicGlobalValue = topicValue;
+        } else {
+            this.topicValue = topicValue;
+        }
         updateValue();
     }
 
@@ -62,6 +69,8 @@ public class PolicyHierarchyValue<T> {
         VALUE_UPDATER.updateAndGet(this, (preValue) -> {
             if (topicValue != null) {
                 return topicValue;
+            } else if (topicGlobalValue != null) {
+                return topicGlobalValue;
             } else if (namespaceValue != null) {
                 return namespaceValue;
             } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValue.java
@@ -56,6 +56,11 @@ public class PolicyHierarchyValue<T> {
         updateValue();
     }
 
+    @Deprecated
+    public void updateTopicValue(T topicValue) {
+        updateTopicValue(topicValue, false);
+    }
+
     public void updateTopicValue(T topicValue, boolean isGlobalPolicy) {
         if (isGlobalPolicy) {
             this.topicGlobalValue = topicValue;

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PolicyHierarchyValueTest.java
@@ -33,13 +33,13 @@ public class PolicyHierarchyValueTest {
         value.updateNamespaceValue(2);
         Assert.assertEquals(value.get(), Integer.valueOf(2));
 
-        value.updateTopicValue(3);
+        value.updateTopicValue(3, false);
         Assert.assertEquals(value.get(), Integer.valueOf(3));
 
         value.updateNamespaceValue(null);
         Assert.assertEquals(value.get(), Integer.valueOf(3));
 
-        value.updateTopicValue(null);
+        value.updateTopicValue(null, false);
         Assert.assertEquals(value.get(), Integer.valueOf(1));
     }
 }


### PR DESCRIPTION
### Motivation

Steps for reproducing the issue
- Set a topic policy: max consumer per topic `10`
- Set a global policy: max consumer per topic `20`
- Expected: the non-global value has higher priority, so the value is `10`
- Actual behavior: the second setting has higher priority, in other words, the value is `20`

### Modifications

Fix the issue.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x