### PR TITLE
[fix][broker] Unregister non-static metrics collectors registered in Prometheus default registry

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -815,6 +815,10 @@ public class BrokerService implements Closeable {
         try {
             log.info("Shutting down Pulsar Broker service");
 
+            // unregister non-static metrics collectors
+            pendingTopicLoadRequests.unregister();
+            pendingLookupRequests.unregister();
+
             // unloads all namespaces gracefully without disrupting mutually
             unloadNamespaceBundlesGracefully();
 


### PR DESCRIPTION
### Motivation

For upgrading Mockito to 5.17, it's necessary that already shutdown Pulsar broker test instances don't get referenced later. This is due to the way how Mockito mocks are cleaned up after each test. In newer Mockito versions, an exception will be thrown if such accesses happen.
Most metric collectors are static in Pulsar, but there are 2 instances in the broker where the collector dynamically gets the value. These should be unregistered at shutdown.

### Modifications

- add unregister logic to ObserverGauge class
- unregister pendingTopicLoadRequests and pendingLookupRequests at shutdown

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->