### PR TITLE
[improve] Improve the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,7 +27,7 @@ body:
 
         For suggestions or help, please consider:
         1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](https://pulsar.apache.org/contact/#subscribing-to-a-mailing-list));
-        2. [Github Discussion](https://github.com/apache/pulsar/discussions).
+        2. [Github Discussion Q&A](https://github.com/apache/pulsar/discussions/categories/q-a).
 
         If you are reporting a security vulnerability, please instead follow the [security policy](https://pulsar.apache.org/en/security/).
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -48,7 +48,7 @@ body:
         Please check the [supported Pulsar versions in the release policy](https://pulsar.apache.org/contribute/release-policy/#supported-versions).
       options:
         - label: >
-            I understand that unsupported versions don't get bug fixes. I will attempt to reproduce the issue on a supported version of Pulsar client and Pulsar broker.
+            I understand that [unsupported versions](https://pulsar.apache.org/contribute/release-policy/#supported-versions) don't get bug fixes. I will attempt to reproduce the issue on a supported version of Pulsar client and Pulsar broker.
           required: true
   - type: textarea
     id: userEnvironment

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -62,7 +62,7 @@ body:
         - Client library type (Java/Python/Go/C++/C#/Node.js/etc)
         - Client library version
         - Client Operating system and hardware type (check with `uname -a`/`systeminfo`)
-        - Client Java version for the Java client (`java -version`)
+        - Client Java version (if using Java client) (`java -version`)
     validations:
       required: true
   - type: textarea
@@ -76,6 +76,7 @@ body:
           - What did you expect to happen?
           - What actually happened instead?
         - Why do you believe this is a bug?
+        - Please prefer using text in markdown code blocks instead of screenshots of console output since screenshots are not searchable.
     validations:
       required: true
   - type: textarea
@@ -84,8 +85,9 @@ body:
       label: Error messages
       description: |
         Were there any error messages or stack traces in the logs? 
-          - If yes, please include them in a markdown code block, limited to 100 lines maximum.
+          - If yes, please include them, limited to 100 lines maximum.
           - For longer stack traces, please share them in a [GitHub Gist](https://gist.github.com/) and provide the link.
+          - You can also attach logs to the additional information section below.
           - Remember to obfuscate any sensitive information before sharing.
       render: text
       placeholder: Copy-paste the error messages or stack traces (max 100 lines) here, or provide a link to the GitHub Gist.
@@ -104,12 +106,20 @@ body:
           - Any error messages, stacktraces or logs. Obfuscate any sensitive information before sharing.
           - Test data or files needed (if applicable)
           - Please use [GitHub Gist](https://gist.github.com/) to share larger text files
+          - Please prefer using text in markdown code blocks instead of screenshots of console output since screenshots are not searchable.
     validations:
       required: true
   - type: textarea
     id: additionalInformation
     attributes:
       label: Additional information
+      description: |
+        Please provide any additional information that may help us understand the issue better. This could include:
+        - Any other relevant details or context
+        - Links to related issues or discussions
+        - Any other information you think might be helpful
+        - Attachments (e.g. logs)
+        - Remember to obfuscate any sensitive information before sharing.
   - type: checkboxes
     id: willSubmitPR
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
   - type: checkboxes
     id: confirmSearch
     attributes:
-      label: Search before asking
+      label: Search before reporting
       description: >
         Please search [issues](https://github.com/apache/pulsar/issues) to check if your issue has already been reported.
       options:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,6 +31,7 @@ body:
 
         If you are reporting a security vulnerability, please instead follow the [security policy](https://pulsar.apache.org/en/security/).
   - type: checkboxes
+    id: confirmSearch
     attributes:
       label: Search before asking
       description: >
@@ -40,41 +41,76 @@ body:
             I searched in the [issues](https://github.com/apache/pulsar/issues) and found nothing similar.
           required: true
   - type: checkboxes
+    id: confirmPolicy
     attributes:
       label: Read release policy
       description: >
-        Please check the [supported Pulsar versions in the release policy](https://pulsar.apache.org/contribute/release-policy/#supported-versions). 
+        Please check the [supported Pulsar versions in the release policy](https://pulsar.apache.org/contribute/release-policy/#supported-versions).
       options:
         - label: >
             I understand that unsupported versions don't get bug fixes. I will attempt to reproduce the issue on a supported version of Pulsar client and Pulsar broker.
           required: true
   - type: textarea
+    id: userEnvironment
     attributes:
-      label: Version
-      description: >
-        Please provide the OS, Java version and Pulsar versions (client + broker) you are using.
+      label: User environment
+      description: |+
+        Please describe your environment where Pulsar is used:
+        - Broker version (check with `bin/pulsar version`) 
+        - Broker Operating system and hardware type (check with `uname -a` on Unixes / `systeminfo` on Windows)
+        - Broker Java version (check with `java -version`)
+        - Client library type (Java/Python/Go/C++/C#/Node.js/etc)
+        - Client library version
+        - Client Operating system and hardware type (check with `uname -a`/`systeminfo`)
+        - Client Java version for the Java client (`java -version`)
     validations:
       required: true
   - type: textarea
+    id: issueDescription
     attributes:
-      label: Minimal reproduce step
-      description: Please try to give reproducing steps to facilitate quick location of the problem.
+      label: Issue Description
+      description: |
+        Please describe what happened when you encountered the issue. This will help us understand it better.
+        - What happened?
+          - What were you trying to do?
+          - What did you expect to happen?
+          - What actually happened instead?
+        - Why do you believe this is a bug?
     validations:
       required: true
   - type: textarea
+    id: logs
     attributes:
-      label: What did you expect to see?
+      label: Error messages
+      description: |
+        Were there any error messages or stack traces in the logs? 
+          - If yes, please include them in a markdown code block, limited to 100 lines maximum.
+          - For longer stack traces, please share them in a [GitHub Gist](https://gist.github.com/) and provide the link.
+          - Remember to obfuscate any sensitive information before sharing.
+      render: text
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproducing the issue
+      description: |
+        Please provide detailed steps to reproduce the issue. This will help us investigate and fix the problem faster.
+        - What exact steps did you take that led to the issue?
+        - If you are running an [unsupported Pulsar version](https://pulsar.apache.org/contribute/release-policy/#supported-versions) on the broker or client, can you reproduce the issue after upgrading to a [supported version](https://pulsar.apache.org/contribute/release-policy/#supported-versions)?
+        - Can you reproduce this with [Pulsar standalone](https://pulsar.apache.org/docs/getting-started-docker/)? If possible, this makes it easier to debug.
+        - If standalone repro is not possible, please provide detailed reproduction steps in your environment, including:
+          - Relevant configuration/settings used
+          - Sample code or commands that trigger the issue
+          - Any error messages, stacktraces or logs. Obfuscate any sensitive information before sharing.
+          - Test data or files needed (if applicable)
+          - Please use [GitHub Gist](https://gist.github.com/) to share larger text files
     validations:
       required: true
   - type: textarea
+    id: additionalInformation
     attributes:
-      label: What did you see instead?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Anything else?
+      label: Additional information
   - type: checkboxes
+    id: willSubmitPR
     attributes:
       label: Are you willing to submit a PR?
       description: >

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -88,6 +88,7 @@ body:
           - For longer stack traces, please share them in a [GitHub Gist](https://gist.github.com/) and provide the link.
           - Remember to obfuscate any sensitive information before sharing.
       render: text
+      placeholder: Copy-paste the error messages or stack traces (max 100 lines) here, or provide a link to the GitHub Gist.
   - type: textarea
     id: reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,7 +26,7 @@ body:
         Thank you very much for your feedback!
 
         For suggestions or help, please consider:
-        1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](mailto:users-subscribe@pulsar.apache.org));
+        1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](https://pulsar.apache.org/contact/#subscribing-to-a-mailing-list));
         2. [Github Discussion](https://github.com/apache/pulsar/discussions).
 
         If you are reporting a security vulnerability, please instead follow the [security policy](https://pulsar.apache.org/en/security/).

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -33,7 +33,7 @@ body:
   - type: checkboxes
     id: confirmSearch
     attributes:
-      label: Search before asking
+      label: Search before reporting
       description: >
         Please search [issues](https://github.com/apache/pulsar/issues) to check if your issue has already been reported.
       options:

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -27,7 +27,7 @@ body:
 
         For suggestions or help, please consider:
         1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](https://pulsar.apache.org/contact/#subscribing-to-a-mailing-list));
-        2. [Github Discussion](https://github.com/apache/pulsar/discussions).
+        2. [Github Discussion Q&A](https://github.com/apache/pulsar/discussions/categories/q-a).
 
         Otherwise, please answer the following questions before submitting a doc issue.
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -26,7 +26,7 @@ body:
         Thank you very much for your suggestion!
 
         For suggestions or help, please consider:
-        1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](mailto:users-subscribe@pulsar.apache.org));
+        1. [User Mail List](mailto:users@pulsar.apache.org) ([subscribe](https://pulsar.apache.org/contact/#subscribing-to-a-mailing-list));
         2. [Github Discussion](https://github.com/apache/pulsar/discussions).
 
         Otherwise, please answer the following questions before submitting a doc issue.

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -31,6 +31,7 @@ body:
 
         Otherwise, please answer the following questions before submitting a doc issue.
   - type: checkboxes
+    id: confirmSearch
     attributes:
       label: Search before asking
       description: >
@@ -40,22 +41,26 @@ body:
             I searched in the [issues](https://github.com/apache/pulsar/issues) and found nothing similar.
           required: true
   - type: textarea
+    id: issue
     attributes:
       label: What issue do you find in Pulsar docs?
       description: For example, something missing, inaccurate, incomplete, hard to use/understand/find, etc.
     validations:
       required: true
   - type: textarea
+    id: suggestion
     attributes:
       label: What is your suggestion?
       description: For example, add explanations, correct descriptions, delete information, etc.
     validations:
       required: true
   - type: textarea
+    id: reference
     attributes:
       label: Any reference?
       description: (For example, website links, etc)?
   - type: checkboxes
+    id: willSubmitPR
     attributes:
       label: Are you willing to submit a PR?
       description: >

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -24,6 +24,7 @@ body:
       value: |
         Thank you very much for your enhancement!
   - type: checkboxes
+    id: confirmSearch
     attributes:
       label: Search before asking
       description: >
@@ -33,23 +34,28 @@ body:
             I searched in the [issues](https://github.com/apache/pulsar/issues) and found nothing similar.
           required: true
   - type: textarea
+    id: motivation
     attributes:
       label: Motivation
       description: Describe the motivations for this enhancement.
     validations:
       required: true
   - type: textarea
+    id: solution
     attributes:
       label: Solution
       description: Describe the proposed solution and add related materials like links if any.
   - type: textarea
+    id: alternatives
     attributes:
       label: Alternatives
       description: Describe other alternative solutions or features you considered, but rejected.
   - type: textarea
+    id: anythingElse
     attributes:
       label: Anything else?
   - type: checkboxes
+    id: willSubmitPR
     attributes:
       label: Are you willing to submit a PR?
       description: >

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -26,7 +26,7 @@ body:
   - type: checkboxes
     id: confirmSearch
     attributes:
-      label: Search before asking
+      label: Search before reporting
       description: >
         Please search [issues](https://github.com/apache/pulsar/issues) to check if your issue has already been reported.
       options:

--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -27,7 +27,7 @@ body:
   - type: checkboxes
     id: confirmSearch
     attributes:
-      label: Search before asking
+      label: Search before reporting
       description: >
         Please search [issues](https://github.com/apache/pulsar/issues) to check if your issue has already been reported. First search with the test method name and then with the test class name to see if there are reports for the same test method or the same test class.
       options:

--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -49,11 +49,7 @@ body:
       label: Exception stacktrace
       description: |
         Copy-paste the stack trace from the build log. If the stacktrace is >100 lines, you can limit the stack trace to the point where it includes the stack frame for the test method so that it's possible to find out where the exception occurred in the test.
-      value: |
-        <!-- copy-paste the stack trace in the code block below -->
-        ```
-
-        ```
+      render: text
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -25,6 +25,7 @@ body:
       value: |
         Thank you very much for reporting flaky tests!
   - type: checkboxes
+    id: confirmSearch
     attributes:
       label: Search before asking
       description: >
@@ -34,6 +35,7 @@ body:
             I searched in the [issues](https://github.com/apache/pulsar/issues) and found nothing similar.
           required: true
   - type: input
+    id: failureUrl
     attributes:
       label: Example failure
       description: |
@@ -42,6 +44,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: stacktrace
     attributes:
       label: Exception stacktrace
       description: |
@@ -54,6 +57,7 @@ body:
     validations:
       required: true
   - type: checkboxes
+    id: willSubmitPR
     attributes:
       label: Are you willing to submit a PR?
       description: >

--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -41,8 +41,6 @@ body:
       description: |
         Attach a url to the example failure. In the Github Actions workflow run logs, you can right click on the line number to copy a link to the line.
       placeholder: e.g. https://github.com/apache/pulsar/runs/7612690351?check_suite_focus=true#step:2:20
-    validations:
-      required: true
   - type: textarea
     id: stacktrace
     attributes:


### PR DESCRIPTION
### Motivation

- Reporting an issue with the current bug reporting template is very cumbersome due to multiple fields such as "Minimal reproduce step", "What did you expect to see?", and "What did you see instead?". In many cases, the order is just wrong for describing the issue and puts the issue reporter off track.
- There's not enough guidance to provide relevant information for a bug report.
- Some reporters are sharing long logs or stacktraces in markdown fields or screenshots of logs, which makes it harder to read the relevant details of the issue. In the case of screenshots, it makes the error log messages unsearchable.
- The template id attributes are currently missing. This is mainly a limitation with the https://github.com/lhotari/pulsar-flakes prefilling of template fields. In apache/pulsar, blank issues aren't enabled and the pulsar-flakes prefilling of flaky test issue fields isn't working at the moment. It requires that template id attributes are available to fix the issue.

### Modifications

- Improve the bug reporting template.
- Add id attributes to all template fields.
- Make general improvements to templates.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->