### PR TITLE
[improve][ci] Disable detailed console logging for integration tests in CI

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -572,24 +572,28 @@ jobs:
 
           - name: Shade on Java 8
             group: SHADE_RUN
+            upload_name: SHADE_RUN_8
             runtime_jdk: 8
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
 
           - name: Shade on Java 11
             group: SHADE_RUN
+            upload_name: SHADE_RUN_11
             runtime_jdk: 11
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
 
           - name: Shade on Java 17
             group: SHADE_RUN
+            upload_name: SHADE_RUN_17
             runtime_jdk: 17
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
 
           - name: Shade on Java 21
             group: SHADE_RUN
+            upload_name: SHADE_RUN_21
             runtime_jdk: 21
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
@@ -693,7 +697,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}
         with:
-          name: Integration-${{ matrix.group }}-surefire-reports
+          name: Integration-${{ matrix.upload_name || matrix.group }}-surefire-reports
           path: surefire-reports
           retention-days: 7
 
@@ -702,7 +706,7 @@ jobs:
         if: ${{ !success() }}
         continue-on-error: true
         with:
-          name: Integration-${{ matrix.group }}-container-logs
+          name: Integration-${{ matrix.upload_name || matrix.group }}-container-logs
           path: tests/integration/target/container-logs
           retention-days: 7
 

--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -100,7 +100,7 @@ mvn_run_integration_test() {
   if [[ $build_only -ne 1 ]]; then
     echo "::group::Run tests for " "$@"
     # use "verify" instead of "test"
-    mvn -B -ntp -pl "$modules" $failfast_args $coverage_args -DskipDocker -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DredirectTestOutputToFile=false $clean_arg verify "$@"
+    mvn -B -ntp -pl "$modules" $failfast_args $coverage_args -DskipDocker -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true -Dcheckstyle.skip=true -Drat.skip=true $clean_arg verify "$@"
     echo "::endgroup::"
     set +x
     "$SCRIPT_DIR/pulsar_ci_tool.sh" move_test_reports || true


### PR DESCRIPTION
### Motivation

- currently integration tests produce so much log output that the GitHub Actions UI stalls 
- when a test fails, the logs will get uploaded so that they can be downloaded

### Modifications

- remove `-DredirectTestOutputToFile=false` command line option passed to integration test maven command line

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->