### PR TITLE
[improve][misc] Upgrade Guava to 33.4.8 that uses JSpecify annotations

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -56,7 +56,7 @@
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <netty.version>4.1.121.Final</netty.version>
     <guice.version>4.2.3</guice.version>
-    <guava.version>32.1.2-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
     <ant.version>1.10.12</ant.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <mockito.version>5.17.0</mockito.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -269,8 +269,8 @@ The Apache Software License, Version 2.0
     - com.google.code.gson-gson-2.8.9.jar
     - io.gsonfire-gson-fire-1.8.5.jar
  * Guava
-    - com.google.guava-guava-32.1.2-jre.jar
-    - com.google.guava-failureaccess-1.0.1.jar
+    - com.google.guava-guava-33.4.8-jre.jar
+    - com.google.guava-failureaccess-1.0.3.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -328,8 +328,8 @@ The Apache Software License, Version 2.0
  * Gson
     - gson-2.8.9.jar
  * Guava
-    - guava-32.1.2-jre.jar
-    - failureaccess-1.0.1.jar
+    - guava-33.4.8-jre.jar
+    - failureaccess-1.0.3.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- j2objc-annotations-1.3.jar
  * Netty Reactive Streams -- netty-reactive-streams-2.0.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@ flexible messaging model and an intuitive client API.</description>
     <dnsjava3.version>3.6.2</dnsjava3.version>
     <hdfs-offload-version3>${hadoop3.version}</hdfs-offload-version3>
     <hbase.version>2.6.0-hadoop3</hbase.version>
-    <guava.version>32.1.2-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>7.8.2</confluent.version>


### PR DESCRIPTION
### Motivation

Newer Guava versions have switched to use JSpecify annotations and avoid direct "Unsafe" usage (replaced with AtomicFieldUpdater usage).
- release notes https://github.com/google/guava/releases/tag/v33.4.8
The suggestion is to upgrade Guava in the master branch.

### Modifications

- upgrade Guava to 33.4.8

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->