### PR TITLE
[improve][build] Allow building and running tests on JDK 24 and upcoming JDK 25 LTS

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -44,7 +44,7 @@ on:
         options:
           - '17'
           - '21'
-        default: '17'
+        default: '21'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
         required: true
@@ -95,13 +95,13 @@ jobs:
       - name: Select JDK major version
         id: jdk_major_version
         run: |
-          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
+          # use JDK 17 for the scheduled build with cron expression '0 6 * * *'
           if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
-            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
+            echo "jdk_major_version=17" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # use JDK 17 for build unless overridden with workflow_dispatch input
-          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '17'}}" >> $GITHUB_OUTPUT
+          # use JDK 21 for build unless overridden with workflow_dispatch input
+          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '21'}}" >> $GITHUB_OUTPUT
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -44,6 +44,8 @@ on:
         options:
           - '17'
           - '21'
+          - '24'
+          - '25'
         default: '21'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -44,6 +44,8 @@ on:
         options:
           - '17'
           - '21'
+          - '24'
+          - '25'
         default: '21'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -600,6 +600,13 @@ jobs:
             setup: ./build/run_integration_group.sh SHADE_BUILD
             no_coverage: true
 
+          - name: Shade on Java 24
+            group: SHADE_RUN
+            upload_name: SHADE_RUN_24
+            runtime_jdk: 24
+            setup: ./build/run_integration_group.sh SHADE_BUILD
+            no_coverage: true
+
           - name: Standalone
             group: STANDALONE
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -61,7 +61,8 @@ RUN apk add --no-cache binutils
 
 # Use JLink to create a slimmer JDK distribution (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
 # This still includes all JDK modules, though in the future we could compile a list of required modules
-RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
+# first try with Java 17/21 compatible jlink command and if it fails, fallback to Java 24+ compatible command
+RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm || /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules ALL-MODULE-PATH --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,10 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED <!--MBeanStatsGenerator-->
       --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
       -XX:+EnableDynamicAgentLoading <!-- byte-buddy-agent and mockito-core agent dynamic loading -->
+      --enable-native-access=ALL-UNNAMED <!-- Required by java.lang.System::loadLibrary calls -->
+      ${test.additional.args.jdk24}
     </test.additional.args>
+    <test.additional.args.jdk24></test.additional.args.jdk24>
     <testMaxHeapSize>1300M</testMaxHeapSize>
     <testReuseFork>true</testReuseFork>
     <testForkCount>4</testForkCount>
@@ -2920,6 +2923,19 @@ flexible messaging model and an intuitive client API.</description>
       <properties>
         <!-- Override the default value with the environment variable -->
         <IMAGE_JDK_MAJOR_VERSION>${env.IMAGE_JDK_MAJOR_VERSION}</IMAGE_JDK_MAJOR_VERSION>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>jdk24</id>
+      <activation>
+        <jdk>24</jdk>
+      </activation>
+      <properties>
+        <!-- JDK 24+ specific arguments -->
+        <test.additional.args.jdk24>
+          --sun-misc-unsafe-memory-access=allow <!-- required for enabling unsafe memory access for Netty since 4.1.121.Final -->
+        </test.additional.args.jdk24>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2131,8 +2131,8 @@ flexible messaging model and an intuitive client API.</description>
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[17,18),[21,22)</version>
-                    <message>Java 17 or Java 21 is required to build Pulsar.</message>
+                    <version>[17,18),[21,22),[24,26)</version>
+                    <message>Java 17, 21, 24 or 25 is required to build Pulsar.</message>
                   </requireJavaVersion>
                   <requireMavenVersion>
                     <version>3.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED <!--MBeanStatsGenerator-->
       --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
       -XX:+EnableDynamicAgentLoading <!-- byte-buddy-agent and mockito-core agent dynamic loading -->
-      --enable-native-access=ALL-UNNAMED <!-- Required by java.lang.System::loadLibrary calls -->
       ${test.additional.args.jdk24}
     </test.additional.args>
     <test.additional.args.jdk24></test.additional.args.jdk24>
@@ -2934,6 +2933,7 @@ flexible messaging model and an intuitive client API.</description>
       <properties>
         <!-- JDK 24+ specific arguments -->
         <test.additional.args.jdk24>
+          --enable-native-access=ALL-UNNAMED <!-- Required by java.lang.System::loadLibrary calls -->
           --sun-misc-unsafe-memory-access=allow <!-- required for enabling unsafe memory access for Netty since 4.1.121.Final -->
         </test.additional.args.jdk24>
       </properties>


### PR DESCRIPTION
### Motivation

As a preparation for JDK 25 LTS version, Pulsar build should allow running with JDK 24 and with JDK 25 once it becomes available so that we can start fixing the different compatibility issues.

One of the already detected issues is that the Security Manager has been removed in JDK 24 with "JEP 486: Permanently Disable the Security Manager". This breaks at least tiered storage since it uses Hadoop libraries which depend on Security Manager (issue: [HDFS-17778](https://issues.apache.org/jira/browse/HDFS-17778)). There are also failing tests in Pulsar IO RabbitMQ connector which use Qpid libraries which require Security Manager features.



### Modifications

- change enforcer plugin config to allow building with JDK 24 and JDK 25 in addition to JDK 17 and JDK 24.
- add required JVM arguments for JDK 24+
- fix previous issue where Pulsar CI Flaky tests aren't built and run with JDK 21 by default
- Add JDK 24 and JDK 25 choices for triggered Pulsar CI and Pulsar CI Flaky GitHub Actions workflows
- Run Shade integration tests with JDK 24 too
- Fix issue in building the Docker image for JDK 24

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->