### PR TITLE
[fix][misc] Fix ByteBuf leaks in tests by making ByteBufPair.coalesce release the input ByteBufPair

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/ByteBufPair.java
@@ -82,13 +82,21 @@ public final class ByteBufPair extends AbstractReferenceCounted {
     }
 
     /**
-     * @return a single buffer with the content of both individual buffers
+     * Combines the content of both buffers into a single {@link ByteBuf}.
+     *
+     * <p>This method creates a new {@link ByteBuf} with the combined readable content
+     * of the two buffers in the given {@link ByteBufPair}. The original buffer is
+     * released after the data is written into the new buffer.
+     *
+     * @param pair the {@link ByteBufPair} containing the two buffers to be coalesced
+     * @return a new {@link ByteBuf} containing the combined content of both buffers
      */
     @VisibleForTesting
     public static ByteBuf coalesce(ByteBufPair pair) {
         ByteBuf b = Unpooled.buffer(pair.readableBytes());
         b.writeBytes(pair.b1, pair.b1.readerIndex(), pair.b1.readableBytes());
         b.writeBytes(pair.b2, pair.b2.readerIndex(), pair.b2.readableBytes());
+        pair.release();
         return b;
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
@@ -88,9 +88,9 @@ public class CommandsTest {
         metaPayloadFrame.writeInt(metadataSize);
         msgMetadata.writeTo(metaPayloadFrame);
         ByteBuf payload = compressedPayload.copy();
-        ByteBufPair metaPayloadBuf = ByteBufPair.get(metaPayloadFrame, payload);
-        int computedChecksum = Crc32cIntChecksum.computeChecksum(ByteBufPair.coalesce(metaPayloadBuf));
-        metaPayloadBuf.release();
+        ByteBuf byteBuf = ByteBufPair.coalesce(ByteBufPair.get(metaPayloadFrame, payload));
+        int computedChecksum = Crc32cIntChecksum.computeChecksum(byteBuf);
+        byteBuf.release();
         return computedChecksum;
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
@@ -22,11 +22,10 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.testng.annotations.Test;
 
@@ -83,4 +82,15 @@ public class ByteBufPairTest {
         assertEquals(b2.refCnt(), 0);
     }
 
+    @Test
+    public void testCoalesce() {
+        ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());
+        ByteBuf b2 = Unpooled.wrappedBuffer("world".getBytes());
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
+        ByteBuf coalesced = ByteBufPair.coalesce(buf);
+        assertEquals(b1.refCnt(), 0);
+        assertEquals(b2.refCnt(), 0);
+        assertEquals(new String(ByteBufUtil.getBytes(coalesced)), "helloworld");
+        coalesced.release();
+    }
 }


### PR DESCRIPTION
### Motivation

There are ByteBuf leaks in test code that use `ByteBufPair.coalesce` method. ByteBufPair.coalesce is only used in test code so this isn't an issue in production code. Fixing leaks in test code is needed for executing the plan explained in [Enhancing Pulsar CI with Netty leak detection and reporting](https://lists.apache.org/thread/fh63hg31womzr64bc7djv3sovgcx6z99).

### Modifications

- release the input ByteBufPair in ByteBufPair.coalesce.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->