### PR TITLE
[fix][misc] Fix ByteBuf leak in SchemaUtils

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -370,6 +370,7 @@ public final class SchemaUtils {
         ByteBuf byteBuf = PulsarByteBufAllocator.DEFAULT.heapBuffer(dataLength);
         byteBuf.writeInt(keyBytes.length).writeBytes(keyBytes).writeInt(valueBytes.length).writeBytes(valueBytes);
         byteBuf.readBytes(schema);
+        byteBuf.release();
         return schema;
     }
 


### PR DESCRIPTION
### Motivation

Netty leak detection reporting catched this leak. Since it's using a heap buffer, it's possible that there's not real impact of the leak other than leak detection nagging about it. 

### Modifications

Release the buffer that is no longer used.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->