### PR TITLE
[fix][broker] Fix HashedWheelTimer leak in PulsarService by stopping it in shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -661,6 +661,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (transactionExecutorProvider != null) {
                 transactionExecutorProvider.shutdownNow();
             }
+            if (transactionTimer != null) {
+                transactionTimer.stop();
+            }
             MLPendingAckStoreProvider.closeBufferedWriterMetrics();
             MLTransactionMetadataStoreProvider.closeBufferedWriterMetrics();
             if (this.offloaderStats != null) {


### PR DESCRIPTION
### Motivation

Netty leak detector detects also HashedWheelTimer leaks besides ByteBuf leaks. It reports in some tests that HashedWheelTimer has leaked. This leak doesn't seem to happen in all cases and doesn't really impact production usage. 
Fixing this is needed for executing the plan explained in [Enhancing Pulsar CI with Netty leak detection and reporting](https://lists.apache.org/thread/fh63hg31womzr64bc7djv3sovgcx6z99).

### Modifications

- stop the timer in shutdown

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->