### PR TITLE
[improve][build] Improve thread leak detector by ignoring "Attach Listener" thread

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -204,6 +204,10 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
             if (threadName.equals("process reaper")) {
                 return true;
             }
+            // skip JVM internal thread related to agent attach
+            if (threadName.equals("Attach Listener")) {
+                return true;
+            }
             // skip JVM internal thread used for CompletableFuture.delayedExecutor
             if (threadName.equals("CompletableFutureDelayScheduler")) {
                 return true;


### PR DESCRIPTION
### Motivation

The thread leak detector used in CI to report thread leaks currently reports false positives about "Attach Listener"

### Modifications

Ignore threads with the name "Attach Listener" in leak detection

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->