### PR TITLE
[improve][build] Suppress JVM class sharing warning when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@ flexible messaging model and an intuitive client API.</description>
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED <!--MBeanStatsGenerator-->
       --add-opens java.base/jdk.internal.platform=ALL-UNNAMED <!--LinuxInfoUtils-->
       -XX:+EnableDynamicAgentLoading <!-- byte-buddy-agent and mockito-core agent dynamic loading -->
+      -Xshare:off <!-- suppress sharing warning -->
       ${test.additional.args.jdk24}
     </test.additional.args>
     <test.additional.args.jdk24></test.additional.args.jdk24>


### PR DESCRIPTION
### Motivation

This type of warning gets logged to the console when the test starts:
```
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```

### Modifications

Suppress the warning with `-Xshare:off` since is a [common way to handle this for running tests](https://github.com/mockito/mockito/issues/3111#issuecomment-2364356045) using Mockito.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->