### PR TITLE
[improve][io] Add configuration parameter for disabling aggregation for Kinesis Producers

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -185,7 +185,7 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<GenericObj
             .getCredentialProvider();
         kinesisConfig.setCredentialsProvider(credentialsProvider);
         kinesisConfig.setNativeExecutable(StringUtils.trimToEmpty(kinesisSinkConfig.getNativeExecutable()));
-        kinesisConfig.setAggregationEnabled(kinesisSinkConfig.isEnableAggregation());
+        kinesisConfig.setAggregationEnabled(kinesisSinkConfig.isAggregationEnabled());
 
         this.streamName = kinesisSinkConfig.getAwsKinesisStreamName();
         this.kinesisProducer = new KinesisProducer(kinesisConfig);

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -185,6 +185,7 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<GenericObj
             .getCredentialProvider();
         kinesisConfig.setCredentialsProvider(credentialsProvider);
         kinesisConfig.setNativeExecutable(StringUtils.trimToEmpty(kinesisSinkConfig.getNativeExecutable()));
+        kinesisConfig.setAggregationEnabled(kinesisSinkConfig.isEnableAggregation());
 
         this.streamName = kinesisSinkConfig.getAwsKinesisStreamName();
         this.kinesisProducer = new KinesisProducer(kinesisConfig);

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -177,5 +177,5 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
             defaultValue = "true",
             help = "Enable aggregation. With aggregation, multiple user records could be packed into a single\n"
                     + " KinesisRecord. If disabled, each user record is sent in its own KinesisRecord.")
-    private boolean enableAggregation = true;
+    private boolean aggregationEnabled = true;
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -172,4 +172,10 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
             help = "Custom AWS STS port to connect to"
     )
     private Integer awsStsPort;
+
+    @FieldDoc(
+            defaultValue = "true",
+            help = "Enable aggregation. With aggregation, multiple user records could be packed into a single\n"
+                    + " KinesisRecord. If disabled, each user record is sent in its own KinesisRecord.")
+    private boolean enableAggregation = true;
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24288

<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
The Kinesis Sink currently always enables aggregation of records while producing to the kinesis data streams. This results in records being merged in the final output described https://github.com/awslabs/amazon-kinesis-producer/issues/566. There are use cases like monitoring logs through streams UI and client applications expecting certain record type where this behaviour is not desirable.

### Modifications

<!-- Describe the modifications you've done. -->

Added an `enableAggregation` option to `KinesisSinkConfig` and updated `KinesisSink#open` so that it reads this flag when constructing the Kinesis producer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar/pull/21
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
