### PR TITLE
[fix][client]Failure to load encryption key should not prevent creation of producer on client side

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -3145,9 +3145,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                     pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
                             .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
                             .create();
-            Assert.fail("Producer creation should not succeed if failing to read key");
         } catch (Exception e) {
-            // ok
+            Assert.fail("Producer creation should not fail if failing to read key");
         }
 
         // 2. Producer with valid key name
@@ -3289,6 +3288,204 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test(timeOut = 100000)
+    public void testSendFailureWhenProducerFailsToLoadEncryptionKey() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        class EncKeyReader implements CryptoKeyReader {
+
+            final EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
+            @Override
+            public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/private-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+        }
+
+        // 1. Invalid key name
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .enableBatching(false).create();
+            producer.send("my-test-message".getBytes());
+            Assert.fail("Producer send should not succeed if failing to read key");
+        } catch (Exception e) {
+           // OK
+        }
+        // 2. Invalid key name with ProducerCryptoFailureAction.SEND
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .cryptoFailureAction(ProducerCryptoFailureAction.SEND)
+                            .enableBatching(false).create();
+            MessageId messageId = producer.send("my-test-message".getBytes());
+            Assert.assertNotNull(messageId);
+        } catch (Exception e) {
+            Assert.fail("Producer send should not fail if crypto failure action is ProducerCryptoFailureAction.SEND");
+        }
+    }
+
+    @Test(timeOut = 100000)
+    public void testSendFailureWhenProducerFailsToLoadEncryptionKeyWithBatching() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        class EncKeyReader implements CryptoKeyReader {
+
+            final EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
+            @Override
+            public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/private-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+        }
+
+        // 1. Invalid key name
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .create();
+            for (int i = 0; i < 10; i++) {
+                producer.send(("my-message-" + i).getBytes());
+            }
+            Assert.fail("Producer send should not succeed if failing to read key");
+        } catch (Exception e) {
+            // OK
+        }
+        // 2. Invalid key name with ProducerCryptoFailureAction.SEND
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .cryptoFailureAction(ProducerCryptoFailureAction.SEND)
+                            .create();
+            int cnt = 0;
+            for (int i = 0; i < 10; i++) {
+                producer.send(("my-message-" + i).getBytes());
+                cnt++;
+            }
+            Assert.assertEquals(cnt, 10);
+        } catch (Exception e) {
+            Assert.fail("Producer send should not fail if crypto failure action is ProducerCryptoFailureAction.SEND");
+        }
+    }
+
+    @Test(timeOut = 100000)
+    public void testSendFailureWhenProducerFailsToLoadEncryptionKeyWithChunking() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        class EncKeyReader implements CryptoKeyReader {
+
+            final EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
+            @Override
+            public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/private-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        return keyInfo;
+                    } catch (IOException e) {
+                        log.error("Failed to read certificate from {}", CERT_FILE_PATH);
+                    }
+                }
+                return null;
+            }
+        }
+
+        // 1. Invalid key name
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .enableBatching(false).enableChunking(true).create();
+            producer.send("my-test-message".getBytes());
+            Assert.fail("Producer send should not succeed if failing to read key");
+        } catch (Exception e) {
+            // OK
+        }
+        // 2. Invalid key name with ProducerCryptoFailureAction.SEND
+        try {
+            @Cleanup
+            Producer<byte[]> producer =
+                    pulsarClient.newProducer().topic("persistent://my-property/my-ns/myenc-topic1")
+                            .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader())
+                            .cryptoFailureAction(ProducerCryptoFailureAction.SEND)
+                            .enableBatching(false).enableChunking(true).create();
+            MessageId messageId = producer.send("my-test-message".getBytes());
+            Assert.assertNotNull(messageId);
+        } catch (Exception e) {
+            Assert.fail("Producer send should not fail if crypto failure action is ProducerCryptoFailureAction.SEND");
+        }
     }
 
     private String decryptMessage(TopicMessageImpl<byte[]> msg,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -252,14 +252,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 try {
                     msgCrypto.addPublicKeyCipher(conf.getEncryptionKeys(), conf.getCryptoKeyReader());
                 } catch (CryptoException e) {
-                    if (!producerCreatedFuture.isDone()) {
                         log.warn("[{}] [{}] [{}] Failed to add public key cipher.", topic, producerName, producerId);
-                        producerCreatedFuture.completeExceptionally(
-                                PulsarClientException.wrap(e,
-                                        String.format("The producer %s of the topic %s "
-                                                        + "adds the public key cipher was failed",
-                                                producerName, topic)));
-                    }
                 }
             }), 0L, 4L, TimeUnit.HOURS);
         }
@@ -2375,6 +2368,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 batchMessageContainer.resetPayloadAfterFailedPublishing();
                 log.warn("[{}] [{}] Failed to create batch message for sending. Batch payloads have been reset and"
                                 + " messages will be retried in subsequent batches.", topic, producerName, t);
+                if (t instanceof PulsarClientException.CryptoException) {
+                    shouldScheduleNextBatchFlush = false;
+                }
             } finally {
                 if (shouldScheduleNextBatchFlush) {
                     maybeScheduleBatchFlushTask();


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24280

### Motivation

Failure to load the encryption public key while creating the producer creates a producer on the server side but returns an exception on client side. If the client application is retrying producer creation due to the failure on client side, this will create too many producer connection on the broker side and can bring down the broker.
I expected that the producer creation to be successful (client should not see failure if there is a failure to load the encryption key) and eventually send should fail with the failure to load the encryption key.

### Modifications

- Updated the producer creation to not throw an exception when there is a failure to load the encryption key.

### Verifying this change

- [ ] Added tests to verify the change

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
