### PR TITLE
[fix][io] Fix SyntaxWarning in Pulsar Python functions

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -210,7 +210,7 @@ class ContextImpl(pulsar.Context):
       topic_consumer = self.consumers[topic]
     else:
       # if this topic is a partitioned topic
-      m = re.search('(.+)-partition-(\d+)', topic)
+      m = re.search(r'(.+)-partition-(\d+)', topic)
       if not m:
         raise ValueError('Invalid topicname %s' % topic)
       elif m.group(1) in self.consumers:


### PR DESCRIPTION
Fixes #24295

### Motivation

See #24295

### Modifications

The solution is to prefix the regular expressions with `r` to use Python’s raw string notation.
This is explained in https://docs.python.org/3/library/re.html

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->