### PR TITLE
[improve][broker] optimize the problem of subscription snapshot cache not hitting

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -211,7 +211,7 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
 
                 if (Markers.isReplicatedSubscriptionSnapshotMarker(msgMetadata)) {
                     final int readerIndex = metadataAndPayload.readerIndex();
-                    processReplicatedSubscriptionSnapshot(pos, metadataAndPayload);
+                    processReplicatedSubscriptionSnapshot(pos, metadataAndPayload, msgMetadata.getPublishTime());
                     metadataAndPayload.readerIndex(readerIndex);
                 }
 
@@ -358,13 +358,13 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
                 && maxConsumersPerSubscription <= consumerSize;
     }
 
-    private void processReplicatedSubscriptionSnapshot(Position pos, ByteBuf headersAndPayload) {
+    private void processReplicatedSubscriptionSnapshot(Position pos, ByteBuf headersAndPayload, long publishTime) {
         // Remove the protobuf headers
         Commands.skipMessageMetadata(headersAndPayload);
 
         try {
             ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(headersAndPayload);
-            subscription.processReplicatedSubscriptionSnapshot(snapshot);
+            subscription.processReplicatedSubscriptionSnapshot(snapshot, publishTime);
         } catch (Throwable t) {
             log.warn("Failed to process replicated subscription snapshot at {} -- {}", pos, t.getMessage(), t);
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -106,7 +106,7 @@ public interface Subscription extends MessageExpirer {
 
     boolean isSubscriptionMigrated();
 
-    default void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
+    default void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot, long publishTime) {
         // Default is no-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -210,7 +210,8 @@ public class PersistentSubscription extends AbstractSubscription {
             this.replicatedSubscriptionSnapshotCache = null;
         } else if (this.replicatedSubscriptionSnapshotCache == null) {
             this.replicatedSubscriptionSnapshotCache = new ReplicatedSubscriptionSnapshotCache(subName,
-                    config.getReplicatedSubscriptionsSnapshotMaxCachedPerSubscription());
+                    config.getReplicatedSubscriptionsSnapshotMaxCachedPerSubscription(),
+                    config.getReplicatedSubscriptionsSnapshotFrequencyMillis());
         }
 
         if (this.cursor != null) {
@@ -1523,10 +1524,10 @@ public class PersistentSubscription extends AbstractSubscription {
     }
 
     @Override
-    public void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
+    public void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot, long publishTime) {
         ReplicatedSubscriptionSnapshotCache snapshotCache = this.replicatedSubscriptionSnapshotCache;
         if (snapshotCache != null) {
-            snapshotCache.addNewSnapshot(new ReplicatedSubscriptionsSnapshot().copyFrom(snapshot));
+            snapshotCache.addNewSnapshot(new ReplicatedSubscriptionsSnapshot().copyFrom(snapshot), publishTime);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCacheTest.java
@@ -28,10 +28,13 @@ import org.testng.annotations.Test;
 
 @Test(groups = "broker")
 public class ReplicatedSubscriptionSnapshotCacheTest {
+    int snapshotFrequencyMillis = 1000;
 
     @Test
     public void testSnapshotCache() {
-        ReplicatedSubscriptionSnapshotCache cache = new ReplicatedSubscriptionSnapshotCache("my-subscription", 10);
+
+        ReplicatedSubscriptionSnapshotCache cache =
+                new ReplicatedSubscriptionSnapshotCache("my-subscription", 10, snapshotFrequencyMillis);
 
         assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(0, 0)));
         assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(100, 0)));
@@ -51,11 +54,11 @@ public class ReplicatedSubscriptionSnapshotCacheTest {
         ReplicatedSubscriptionsSnapshot s7 = new ReplicatedSubscriptionsSnapshot()
                 .setSnapshotId("snapshot-7");
         s7.setLocalMessageId().setLedgerId(7 ).setEntryId(7);
-
-        cache.addNewSnapshot(s1);
-        cache.addNewSnapshot(s2);
-        cache.addNewSnapshot(s5);
-        cache.addNewSnapshot(s7);
+        long publishTime = System.currentTimeMillis();
+        cache.addNewSnapshot(s1, publishTime);
+        cache.addNewSnapshot(s2, publishTime + snapshotFrequencyMillis);
+        cache.addNewSnapshot(s5, publishTime + 2L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s7, publishTime + 3L * snapshotFrequencyMillis);
 
         assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(0, 0)));
         assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(1, 0)));
@@ -73,8 +76,72 @@ public class ReplicatedSubscriptionSnapshotCacheTest {
     }
 
     @Test
+    public void testSnapshotCacheByRestCursor() {
+
+        ReplicatedSubscriptionSnapshotCache cache =
+                new ReplicatedSubscriptionSnapshotCache("my-subscription", 10, snapshotFrequencyMillis);
+        // The rest cursor is smaller than the cache first position
+        ReplicatedSubscriptionsSnapshot s1 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-1");
+        s1.setLocalMessageId().setLedgerId(10).setEntryId(10);
+
+        ReplicatedSubscriptionsSnapshot s2 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-2");
+        s2.setLocalMessageId().setLedgerId(20).setEntryId(20);
+
+        ReplicatedSubscriptionsSnapshot s3 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-3");
+        s3.setLocalMessageId().setLedgerId(30).setEntryId(30);
+
+        ReplicatedSubscriptionsSnapshot s4 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-4");
+        s4.setLocalMessageId().setLedgerId(1).setEntryId(1);
+
+        ReplicatedSubscriptionsSnapshot s5 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-5");
+        s5.setLocalMessageId().setLedgerId(10).setEntryId(10);
+        long publishTime = System.currentTimeMillis();
+        cache.addNewSnapshot(s1, publishTime);
+        cache.addNewSnapshot(s2, publishTime + 2L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s3, publishTime + 3L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s4, publishTime + 4L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s5, publishTime + 5L * snapshotFrequencyMillis);
+
+        ReplicatedSubscriptionsSnapshot snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(1, 1));
+        assertEquals(snapshot.getSnapshotId(), "snapshot-4");
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(10, 10));
+        assertEquals(snapshot.getSnapshotId(), "snapshot-5");
+        assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(20, 20)));
+        assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(30, 30)));
+
+        // The rest cursor is smaller than the cache last position
+        ReplicatedSubscriptionsSnapshot s6 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-6");
+        s6.setLocalMessageId().setLedgerId(10).setEntryId(10);
+        ReplicatedSubscriptionsSnapshot s7 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-7");
+        s7.setLocalMessageId().setLedgerId(20).setEntryId(20);
+        ReplicatedSubscriptionsSnapshot s8 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-8");
+        s8.setLocalMessageId().setLedgerId(30).setEntryId(30);
+        ReplicatedSubscriptionsSnapshot s9 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-9");
+        s9.setLocalMessageId().setLedgerId(20).setEntryId(20);
+        cache.addNewSnapshot(s6, publishTime + 6L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s7, publishTime + 7L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s8, publishTime + 8L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s9, publishTime + 9L * snapshotFrequencyMillis);
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(10, 10));
+        assertEquals(snapshot.getSnapshotId(), "snapshot-6");
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(20, 20));
+        assertEquals(snapshot.getSnapshotId(), "snapshot-9");
+        assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(30, 30)));
+    }
+
+    @Test
     public void testSnapshotCachePruning() {
-        ReplicatedSubscriptionSnapshotCache cache = new ReplicatedSubscriptionSnapshotCache("my-subscription", 3);
+        ReplicatedSubscriptionSnapshotCache cache =
+                new ReplicatedSubscriptionSnapshotCache("my-subscription", 4, snapshotFrequencyMillis);
 
         ReplicatedSubscriptionsSnapshot s1 = new ReplicatedSubscriptionsSnapshot()
                 .setSnapshotId("snapshot-1");
@@ -91,20 +158,37 @@ public class ReplicatedSubscriptionSnapshotCacheTest {
         ReplicatedSubscriptionsSnapshot s4 = new ReplicatedSubscriptionsSnapshot()
                 .setSnapshotId("snapshot-4");
         s4.setLocalMessageId().setLedgerId(4).setEntryId(4);
+        ReplicatedSubscriptionsSnapshot s5 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-5");
+        s5.setLocalMessageId().setLedgerId(5).setEntryId(5);
+        ReplicatedSubscriptionsSnapshot s6 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-6");
+        s6.setLocalMessageId().setLedgerId(6).setEntryId(6);
+        ReplicatedSubscriptionsSnapshot s7 = new ReplicatedSubscriptionsSnapshot()
+                .setSnapshotId("snapshot-7");
+        s7.setLocalMessageId().setLedgerId(7).setEntryId(7);
 
-        cache.addNewSnapshot(s1);
-        cache.addNewSnapshot(s2);
-        cache.addNewSnapshot(s3);
-        cache.addNewSnapshot(s4);
-
-        // Snapshot-1 was already pruned
-        assertNull(cache.advancedMarkDeletePosition(PositionFactory.create(1, 1)));
+        long publishTime = System.currentTimeMillis();
+        cache.addNewSnapshot(s1, publishTime + snapshotFrequencyMillis);
+        cache.addNewSnapshot(s2, publishTime + 2L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s3, publishTime + 3L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s4, publishTime + 4L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s5, publishTime + 5L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s6, publishTime + 5L * snapshotFrequencyMillis);
+        cache.addNewSnapshot(s7, publishTime + 7L * snapshotFrequencyMillis);
+        // snapshots = [s1, s2, s5, s7]
+        cache.advancedMarkDeletePosition(PositionFactory.create(1, 1));
         ReplicatedSubscriptionsSnapshot snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(2, 2));
-        assertNotNull(snapshot);
         assertEquals(snapshot.getSnapshotId(), "snapshot-2");
-
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(3, 3));
+        assertNull(snapshot);
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(4, 4));
+        assertNull(snapshot);
         snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(5, 5));
-        assertNotNull(snapshot);
-        assertEquals(snapshot.getSnapshotId(), "snapshot-4");
+        assertEquals(snapshot.getSnapshotId(), "snapshot-5");
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(6, 6));
+        assertNull(snapshot);
+        snapshot = cache.advancedMarkDeletePosition(PositionFactory.create(7, 7));
+        assertEquals(snapshot.getSnapshotId(), "snapshot-7");
     }
 }


### PR DESCRIPTION

### Motivation

- When message acknowledgment confirmation is slower than message consumption rate, subscription cursor synchronization fails to complete. This occurs because:

1. Current Behavior
   - With large receiver queues (e.g., `receiverQueueSize=1000`), the cursor never synchronizes
    ```
     Consumer<String> consumer = client.newConsumer(Schema.STRING)
               .topic(topic)
               .subscriptionName("sub")
               .receiverQueueSize(1000)
                .subscribe();
      while (true) {
                Message<String> msg = consumer.receive();
                 consumer.acknowledge(msg);
                 Thread.sleep(100);
            }
    
    ```
   - With small queues (e.g., `receiverQueueSize=1`), synchronization works properly
    ```
     Consumer<String> consumer = client.newConsumer(Schema.STRING)
               .topic(topic)
               .subscriptionName("sub")
               .receiverQueueSize(1)
                .subscribe();
      while (true) {
                Message<String> msg = consumer.receive();
                 consumer.acknowledge(msg);
                 Thread.sleep(100);
            }
    
    ```
2. Root Cause:
    - The SnapshotCache updates too aggressively
    - When advancedMarkDeletePosition executes, valid cache entries are frequently unavailable
    - Current eviction strategy doesn't account for periodic synchronization needs
  https://github.com/apache/pulsar/blob/7be22eb2b23057bd5e09c361a43d6ccdcc0c8afd/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCache.java#L44C4-L59C6

### Modifications
1. Cache Update Strategy:
    - modified the cache to maintain mapping relationships for remote clusters.
2. Eviction Policy Enhancement:
    - When cache reaches capacity (maxSnapshotToCache):
        - Allow subsequent snapshots to be added through periodic dynamic adjustment
        - The latest snapshot is used to replace the intermediate snapshot of the cache, and the update becomes slower as the difference between the latest snapshot time and the Mark Delete Position time increases.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
