### PR TITLE
[improve] Upgrade pulsar-client-python to 3.7.0 in Docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -105,28 +105,11 @@ RUN apk add --no-cache \
 RUN apk upgrade --no-cache
 
 # Python dependencies
-
-# The grpcio@1.59.3 is installed by apk, and Pulsar-client@3.4.0 requires grpcio>=1.60.0, which causes the grocio to be reinstalled by pip.
-# If pip cannot find the grpcio wheel that the doesn't match the OS, the grpcio will be compiled locally.
-# Once https://github.com/apache/pulsar-client-python/pull/211 is released, keep only the pulsar-client[all] and kazoo dependencies, and remove comments.
 ARG PULSAR_CLIENT_PYTHON_VERSION
-RUN echo -e "\
-#pulsar-client[all]==${PULSAR_CLIENT_PYTHON_VERSION}\n\
-pulsar-client==${PULSAR_CLIENT_PYTHON_VERSION}\n\
-# Zookeeper\n\
-kazoo\n\
-# functions\n\
-protobuf>=3.6.1,<=3.20.3\n\
-grpcio>=1.59.3\n\
-apache-bookkeeper-client>=4.16.1\n\
-prometheus_client\n\
-ratelimit\n\
-# avro\n\
-fastavro>=1.9.2\n\
-" > /requirements.txt
-
-RUN pip3 install --break-system-packages --no-cache-dir --only-binary grpcio -r /requirements.txt
-RUN rm /requirements.txt
+RUN pip3 install --break-system-packages --no-cache-dir \
+    --only-binary grpcio \
+    pulsar-client[all]==${PULSAR_CLIENT_PYTHON_VERSION} \
+    kazoo
 
 COPY --from=jvm /opt/jvm /opt/jvm
 ENV JAVA_HOME=/opt/jvm

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ flexible messaging model and an intuitive client API.</description>
     <pulsar.broker.compiler.release>${maven.compiler.target}</pulsar.broker.compiler.release>
     <pulsar.client.compiler.release>8</pulsar.client.compiler.release>
 
-    <pulsar.client.python.version>3.5.0</pulsar.client.python.version>
+    <pulsar.client.python.version>3.7.0</pulsar.client.python.version>
 
     <IMAGE_JDK_MAJOR_VERSION>21</IMAGE_JDK_MAJOR_VERSION>
 


### PR DESCRIPTION
### Motivation

Upgrade pulsar-client-python from 3.5.0 to 3.7.0 to get recent fixes.

### Modifications

- Upgrade pulsar-client-python to 3.7.0
- remove previous workaround #22733 for arm64 build, since https://github.com/apache/pulsar-client-python/pull/211 is included in pulsar-client-python 3.7.0
- keep `--only-binary grpcio` option so that grpc package doesn't get built from source and would fail the build if a suitable version isn't available
- simplify installation since requirements.txt file isn't needed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->