### PR TITLE
[feat][pip] PIP-419: Support consumer message filter on broker-side for specific subscription

### DIFF
--- a/pip/pip-419.md
+++ b/pip/pip-419.md
@@ -163,7 +163,7 @@ public class ConsumerExample {
 
 ### Public API
 
-1. Add an optional config `filterExpression` in `ConsumerBuilder`
+1. Add an optional config `filterExpression` in [ConsumerBuilder](https://github.com/apache/pulsar/blob/965ef5c14c93ca896ef4c8f34520066285fcf047/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java)
 
 ```java
 ConsumerBuilder<T> filterExpression(FilterExpression filterExpression);

--- a/pip/pip-419.md
+++ b/pip/pip-419.md
@@ -1,0 +1,184 @@
+# 消息过滤
+
+# PIP-419: Support consumer message filter on broker-side for specific subscription
+
+Implementation PR: 
+
+# Background knowledge
+
+In my company, we developed a centralized message broker service, which starts multiple subscriptions to consume messages from multiple topics, and then forwards them to business clients after certain processing. Our users have message filtering requirements, that is, when messages are written to topics with different tags, multiple different subscriptions will be started when consuming, and each subscription will only consume messages with the tags it cares about.
+
+What we are doing is replacing all RocketMQ with Pulsar,  but I found that consumers cannot filter messages based on certain message tags or properties, just like [message filtering](https://rocketmq.apache.org/docs/featureBehavior/07messagefilter) in RocketMQ.
+
+From the user's perspective, when using a Pulsar Consumer, we have two main options to consume messages:
+
+1. Pull mode, by calling `consumer.receive()`(or `consumer.receiveAsync()`)
+
+```java
+public class ConsumerExample {
+    public static void main(String[] args) throws PulsarClientException {
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .build();
+        Consumer<Long> consumer = pulsarClient.newConsumer(Schema.INT64)
+                .topic("persistent://public/default/my-topic")
+                .subscriptionName("my-subscription")
+                .subscribe();
+        do {
+            Message<Long> message = consumer.receive();
+            consumer.acknowledge(message);
+        } while (true);
+
+    }
+}
+
+```
+
+1. Push mode, by registering a `MessageListener` interface, when building the Consumer.
+
+```java
+public class ConsumerExample {
+    public static void main(String[] args) throws PulsarClientException {
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .build();
+        Consumer<Long> consumer = pulsarClient.newConsumer(Schema.INT64)
+                .topic("persistent://public/default/my-topic")
+                .subscriptionName("my-subscription2")
+                .messageListener((consumer, message) -> {
+                    // process message
+                    consumer.acknowledgeAsync(message);
+                })
+                .subscribe();
+    }
+}
+
+```
+
+However, I found that they do not have similar message filtering configurations, which means that a subscription will receive all messages from a topic and then filter them at the business layer if necessary. These meaningless messages may cause a lot of bandwidth waste. **Therefore, I think it is very meaningful to implement message filtering on the pulsar broker side.**
+
+# Motivation
+
+As [Background knowledge](https://www.notion.so/1f38504c2b898043982ce46d7d903c64?pvs=21) mentioned, implement message filtering on the pulsar broker side, enrich the pulsar ecosystem, save bandwidth, and help RocketMQ users switch to Pulsar more smoothly. And, I've noticed two similar PRshttps://github.com/apache/pulsar/pull/8544 and https://github.com/apache/pulsar/pull/7629, but neither was approved, so I want to try to get this work implemented.
+
+# Goals
+
+1. **Implement message filtering on the pulsar broker side.**
+
+## In Scope
+
+If this PIP is accepted, it will help users to easily filter messages when consumption. 
+
+# Detailed Design
+
+## Design & Implementation Details
+
+**The general idea is to filter based on the properties of the message at pulsar broker.** 
+
+In the following scenario, the producer adds two properties, messageType and messageSource, when writing messages. For example:
+
+```java
+ // message1
+ TypedMessageBuilder<byte[]> messageBuilder1 = producer.newMessage();
+ messageBuilder1.property("messageType", "file");
+ messageBuilder1.property("messageSource", "QQ");
+ 
+  // message2
+ TypedMessageBuilder<byte[]> messageBuilder2 = producer.newMessage();
+ messageBuilder2.property("messageType", "audio");
+ messageBuilder2.property("messageSource", "wechat");
+```
+
+If a subscription only wants to consume *audio* messages from w*echat*, how should it be implemented? 
+
+We can implement message filtering logic on pulsar broker at `org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer`
+
+![image.png](%E6%B6%88%E6%81%AF%E8%BF%87%E6%BB%A4%201f38504c2b898043982ce46d7d903c64/image.png)
+
+The filtering engine can choose the following two solutions. **In general, I prefer the SQL-92 solution, which should have better performance. Groovy may have slightly worse performance due to its dynamic characteristics.**
+
+### Solution 1 SQL-92
+
+Message filtering using [SQL-92](https://en.wikipedia.org/wiki/SQL-92) syntax mentioned in https://github.com/apache/pulsar/pull/8544#issuecomment-1064619792
+
+We can write the following SQL expression to filter messages, the pseudo code is as follow:
+
+```java
+// The filter expression passed by the pulsar consumer client to the pulsar broker
+String sql = "messageSource='wechat' AND messageType='audio'"
+
+// The pulsar broker uses the expression passed by the client to filter the messages and returns the messages that meet the conditions to the client.
+List filtedMessages = messages.stream()
+                    .filter(message -> {
+                        return SQL92Expression.evaluate(message)
+                    })
+                    .collect(Collectors.toList());
+```
+
+### Solution 2 Groovy
+
+> [Groovy](https://groovy-lang.org/) is a JVM-based object-oriented programming language under Apache. It can be used for object-oriented programming and can also be used as a pure scripting language to call Groovy scripts in Java.
+> 
+
+We can write the following Groovy expression to filter messages, the pseudo code is as follows:
+
+```java
+// The filter expression passed by the pulsar consumer client to the pulsar broker
+String groovyExpression = "it.properties.messageType.equals('audio') && it.properties.messageSource.equals('wechat')"
+
+// The pulsar broker uses the expression passed by the client to filter the messages and returns the messages that meet the conditions to the client.
+GroovyShell shell = new GroovyShell();
+Script script = shell.parse("return " + groovyExpression);
+List filtedMessages = messages.stream()
+                    .filter(message -> {
+                        binding.setVariable("it", message);
+                        script.setBinding(binding);
+                        return (Boolean) script.run();
+                    })
+                    .collect(Collectors.toList());
+```
+
+### Usage Example
+
+```java
+public class ConsumerExample {
+    public static void main(String[] args) throws PulsarClientException {
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650")
+                .build();
+        Consumer<Long> consumer = pulsarClient.newConsumer(Schema.INT64)
+                .topic("persistent://public/default/my-topic")
+                .subscriptionName("my-subscription")
+                .filterExpression(new FilterExpression("messageSource='wechat' AND messageType='audio'", FilterExpressionType.SQL92))
+                //.filterExpression(new FilterExpression("it.properties.messageType.equals('audio') && it.properties.messageSource.equals('wechat')", FilterExpressionType.Groovy))
+                .subscribe();
+                
+        do {
+            Message<Long> message = consumer.receive(); // just receive messages that meet the filter rules.
+            consumer.acknowledge(message);
+        } while (true);
+
+    }
+}
+
+```
+
+## Public-facing Changes
+
+### Public API
+
+1. Add an optional config `filterExpression` in `ConsumerBuilder`
+
+```java
+ConsumerBuilder<T> filterExpression(FilterExpression filterExpression);
+
+```
+
+# Backward & Forward Compatibility
+
+You can do upgrading or reverting normally, no specified steps are needed to do.
+
+# Links
+
+- Mailing List discussion thread:
+- Mailing List voting thread:

--- a/pip/pip-419.md
+++ b/pip/pip-419.md
@@ -89,7 +89,7 @@ In the following scenario, the producer adds two properties, messageType and mes
 
 If a subscription only wants to consume *audio* messages from w*echat*, how should it be implemented? 
 
-We can implement message filtering logic on pulsar broker at `org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer`
+We can implement message filtering logic on pulsar broker at [org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer](https://github.com/apache/pulsar/blob/965ef5c14c93ca896ef4c8f34520066285fcf047/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L108)
 
 ![image](https://github.com/user-attachments/assets/10eea512-1181-42f1-af9c-83dea5bf565e)
 

--- a/pip/pip-419.md
+++ b/pip/pip-419.md
@@ -73,7 +73,7 @@ If this PIP is accepted, it will help users to easily filter messages when consu
 
 **The general idea is to filter based on the properties of the message at pulsar broker.** 
 
-In the following scenario, the producer adds two properties, messageType and messageSource, when writing messages. For example:
+In the following scenario, the producer adds two properties, `messageType` and `messageSource`, when writing messages. For example:
 
 ```java
  // message1
@@ -90,8 +90,6 @@ In the following scenario, the producer adds two properties, messageType and mes
 If a subscription only wants to consume *audio* messages from w*echat*, how should it be implemented? 
 
 We can implement message filtering logic on pulsar broker at [org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer](https://github.com/apache/pulsar/blob/965ef5c14c93ca896ef4c8f34520066285fcf047/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java#L108)
-
-![image](https://github.com/user-attachments/assets/10eea512-1181-42f1-af9c-83dea5bf565e)
 
 The filtering engine can choose the following two solutions. **In general, I prefer the SQL-92 solution, which should have better performance. Groovy may have slightly worse performance due to its dynamic characteristics.**
 

--- a/pip/pip-419.md
+++ b/pip/pip-419.md
@@ -1,5 +1,3 @@
-# 消息过滤
-
 # PIP-419: Support consumer message filter on broker-side for specific subscription
 
 Implementation PR: 
@@ -59,7 +57,7 @@ However, I found that they do not have similar message filtering configurations,
 
 # Motivation
 
-As [Background knowledge](https://www.notion.so/1f38504c2b898043982ce46d7d903c64?pvs=21) mentioned, implement message filtering on the pulsar broker side, enrich the pulsar ecosystem, save bandwidth, and help RocketMQ users switch to Pulsar more smoothly. And, I've noticed two similar PRshttps://github.com/apache/pulsar/pull/8544 and https://github.com/apache/pulsar/pull/7629, but neither was approved, so I want to try to get this work implemented.
+As [Background knowledge](#background-knowledge) mentioned, implement message filtering on the pulsar broker side, enrich the pulsar ecosystem, save bandwidth, and help RocketMQ users switch to Pulsar more smoothly. And, I've noticed two similar PRs https://github.com/apache/pulsar/pull/8544 and https://github.com/apache/pulsar/pull/7629, but neither was approved, so I want to try to get this work implemented.
 
 # Goals
 
@@ -93,7 +91,7 @@ If a subscription only wants to consume *audio* messages from w*echat*, how shou
 
 We can implement message filtering logic on pulsar broker at `org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer`
 
-![image.png](%E6%B6%88%E6%81%AF%E8%BF%87%E6%BB%A4%201f38504c2b898043982ce46d7d903c64/image.png)
+![image](https://github.com/user-attachments/assets/10eea512-1181-42f1-af9c-83dea5bf565e)
 
 The filtering engine can choose the following two solutions. **In general, I prefer the SQL-92 solution, which should have better performance. Groovy may have slightly worse performance due to its dynamic characteristics.**
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: https://github.com/apache/pulsar/pull/8544
https://github.com/apache/pulsar/pull/7629

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
Currently, Pulsar does not have the ability to filter messages by subscription, this pip try to implement message filtering on the pulsar broker side, enrich the pulsar ecosystem, save bandwidth, and help RocketMQ users switch to Pulsar more smoothly. And, I've noticed two similar PRs https://github.com/apache/pulsar/pull/8544 and https://github.com/apache/pulsar/pull/7629, but neither was approved, so I want to try to get this work implemented.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/AuroraTwinkle/pulsar/pull/6
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
