### PR TITLE
[fix][build] Ensure that buildtools is Java 8 compatible and fix remaining compatibility issue

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -46,6 +46,7 @@
     <project.build.outputTimestamp>2024-10-14T13:32:50Z</project.build.outputTimestamp>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <surefire.version>3.1.0</surefire.version>
     <log4j2.version>2.23.1</log4j2.version>
     <slf4j.version>2.0.13</slf4j.version>

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadLeakDetectorListener.java
@@ -102,7 +102,7 @@ public class ThreadLeakDetectorListener extends BetweenTestClassesListenerAdapte
     private static String firstTestClassName(List<ITestClass> testClasses) {
         return testClasses.stream()
                 .findFirst()
-                .orElseThrow()
+                .get()
                 .getRealClass().getName();
     }
 


### PR DESCRIPTION
### Motivation

Recent changes broke running tests in IntelliJ since IntelliJ enforces Java 8 compatibility for buildtools module.
The maven build didn't contain the needed `<maven.compiler.release>8</maven.compiler.release>` setting in buildtools module.

### Modifications

- add `<maven.compiler.release>8</maven.compiler.release>`
- fix the single compatibility issue

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->