### PR TITLE
[improve] Change PersistentMessageFinder's fields modifier to reuse in plugins

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
@@ -49,7 +49,7 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
     protected static final int TRUE = 1;
     @SuppressWarnings("unused")
     protected volatile int messageFindInProgress = FALSE;
-    protected static final AtomicIntegerFieldUpdater<PersistentMessageFinder> messageFindInProgressUpdater =
+    protected static final AtomicIntegerFieldUpdater<PersistentMessageFinder> MESSAGE_FIND_IN_PROGRESS =
             AtomicIntegerFieldUpdater
                     .newUpdater(PersistentMessageFinder.class, "messageFindInProgress");
 
@@ -61,7 +61,7 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
     }
 
     public void findMessages(final long timestamp, AsyncCallbacks.FindEntryCallback callback) {
-        if (messageFindInProgressUpdater.compareAndSet(this, FALSE, TRUE)) {
+        if (MESSAGE_FIND_IN_PROGRESS.compareAndSet(this, FALSE, TRUE)) {
             this.timestamp = timestamp;
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Starting message position find at timestamp {}", subName, timestamp);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
@@ -39,17 +39,17 @@ import org.slf4j.LoggerFactory;
  * given a timestamp find the first message (position) (published) at or before the timestamp.
  */
 public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback {
-    private final ManagedCursor cursor;
-    private final String subName;
-    private final int ledgerCloseTimestampMaxClockSkewMillis;
-    private final String topicName;
-    private long timestamp = 0;
+    protected final ManagedCursor cursor;
+    protected final String subName;
+    protected final int ledgerCloseTimestampMaxClockSkewMillis;
+    protected final String topicName;
+    protected long timestamp = 0;
 
-    private static final int FALSE = 0;
-    private static final int TRUE = 1;
+    protected static final int FALSE = 0;
+    protected static final int TRUE = 1;
     @SuppressWarnings("unused")
-    private volatile int messageFindInProgress = FALSE;
-    private static final AtomicIntegerFieldUpdater<PersistentMessageFinder> messageFindInProgressUpdater =
+    protected volatile int messageFindInProgress = FALSE;
+    protected static final AtomicIntegerFieldUpdater<PersistentMessageFinder> messageFindInProgressUpdater =
             AtomicIntegerFieldUpdater
                     .newUpdater(PersistentMessageFinder.class, "messageFindInProgress");
 


### PR DESCRIPTION
### Motivation

Change PersistentMessageFinder's fields modifier to protected, so we can reuse/rewrite the class in protocolhandlers, such as KoP.

### Modifications

Change PersistentMessageFinder's fields modifier to protected.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
