### PR TITLE
[improve][cli] Make pulsar-perf termination more responsive by using Thread interrupt status

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -259,6 +259,9 @@ public class PerformanceClient extends CmdBase {
                     }
                 } catch (Exception e) {
                     log.error("Authentication plugin error: " + e.getMessage());
+                    if (e instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
             }
 
@@ -272,6 +275,9 @@ public class PerformanceClient extends CmdBase {
                 return;
             } catch (Exception e1) {
                 log.error("Fail in starting client[{}]", e1.getMessage());
+                if (e1 instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 return;
             }
 
@@ -288,7 +294,7 @@ public class PerformanceClient extends CmdBase {
                 long testEndTime = startTime + (long) (this.testTime * 1e9);
                 // Send messages on all topics/producers
                 long totalSent = 0;
-                while (true) {
+                while (!Thread.currentThread().isInterrupted()) {
                     for (String topic : producersMap.keySet()) {
                         if (this.testTime > 0 && System.nanoTime() > testEndTime) {
                             log.info("------------- DONE (reached the maximum duration: [{} seconds] of production) "
@@ -352,10 +358,11 @@ public class PerformanceClient extends CmdBase {
         histogramLogWriter.outputLogFormatVersion();
         histogramLogWriter.outputLegend();
 
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 break;
             }
 
@@ -399,6 +406,9 @@ public class PerformanceClient extends CmdBase {
             Class clz = classLoader.loadClass(formatterClass);
             return (IMessageFormatter) clz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             return null;
         }
     }
@@ -408,11 +418,12 @@ public class PerformanceClient extends CmdBase {
         loadArguments();
         PerfClientUtils.printJVMInformation(log);
         long start = System.nanoTime();
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
             printAggregatedThroughput(start);
             printAggregatedStats();
-        }));
+        });
         runPerformanceTest();
+        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
     }
 
     private class Tuple {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/proxy/socket/client/PerformanceClient.java
@@ -259,7 +259,7 @@ public class PerformanceClient extends CmdBase {
                     }
                 } catch (Exception e) {
                     log.error("Authentication plugin error: " + e.getMessage());
-                    if (e instanceof InterruptedException) {
+                    if (PerfClientUtils.hasInterruptedException(e)) {
                         Thread.currentThread().interrupt();
                     }
                 }
@@ -275,7 +275,7 @@ public class PerformanceClient extends CmdBase {
                 return;
             } catch (Exception e1) {
                 log.error("Fail in starting client[{}]", e1.getMessage());
-                if (e1 instanceof InterruptedException) {
+                if (PerfClientUtils.hasInterruptedException(e1)) {
                     Thread.currentThread().interrupt();
                 }
                 return;
@@ -406,7 +406,7 @@ public class PerformanceClient extends CmdBase {
             Class clz = classLoader.loadClass(formatterClass);
             return (IMessageFormatter) clz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
-            if (e instanceof InterruptedException) {
+            if (PerfClientUtils.hasInterruptedException(e)) {
                 Thread.currentThread().interrupt();
             }
             return null;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/BrokerMonitor.java
@@ -472,7 +472,7 @@ public class BrokerMonitor extends CmdBase {
         try {
             final BrokerWatcher brokerWatcher = new BrokerWatcher(zkClient);
             brokerWatcher.updateBrokers(BROKER_ROOT);
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 Thread.sleep(GLOBAL_STATS_PRINT_PERIOD_MILLIS);
                 printGlobalData();
             }
@@ -538,7 +538,7 @@ public class BrokerMonitor extends CmdBase {
 
     private void startBrokerLoadDataStoreMonitor() {
         try {
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 Thread.sleep(GLOBAL_STATS_PRINT_PERIOD_MILLIS);
                 printBrokerLoadDataStore();
             }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -125,7 +125,7 @@ public class LoadSimulationClient extends CmdBase{
         // messages continue to be sent after broker
         // restarts occur.
         private Producer<byte[]> getNewProducer() throws Exception {
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 try {
                     return client.newProducer()
                                 .topic(topic)
@@ -136,6 +136,7 @@ public class LoadSimulationClient extends CmdBase{
                     Thread.sleep(10000);
                 }
             }
+            throw new InterruptedException();
         }
 
         private class MutableBoolean {
@@ -151,6 +152,9 @@ public class LoadSimulationClient extends CmdBase{
                     // Unset the well flag in the case of an exception so we can
                     // try to get a new Producer.
                     wellnessFlag.value = false;
+                    if (e instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
                     return null;
                 };
                 while (!stop.get() && wellnessFlag.value) {
@@ -345,7 +349,7 @@ public class LoadSimulationClient extends CmdBase{
     public void start() throws Exception {
         final ServerSocket serverSocket = new ServerSocket(port);
 
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             // Technically, two controllers can be connected simultaneously, but
             // non-sequential handling of commands
             // has not been tested or considered and is not recommended.

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationClient.java
@@ -152,7 +152,7 @@ public class LoadSimulationClient extends CmdBase{
                     // Unset the well flag in the case of an exception so we can
                     // try to get a new Producer.
                     wellnessFlag.value = false;
-                    if (e instanceof InterruptedException) {
+                    if (PerfClientUtils.hasInterruptedException(e)) {
                         Thread.currentThread().interrupt();
                     }
                     return null;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/LoadSimulationController.java
@@ -523,7 +523,7 @@ public class LoadSimulationController extends CmdBase{
             // This controller will now stream rate changes from the given ZK.
             // Users wishing to stop this should Ctrl + C and use another
             // Controller to send new commands.
-            while (true) {}
+            Thread.currentThread().join();
         }
     }
 
@@ -677,7 +677,7 @@ public class LoadSimulationController extends CmdBase{
      */
     public void start() throws Exception {
         BufferedReader inReader = new BufferedReader(new InputStreamReader(System.in));
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             // Print the very simple prompt.
             System.out.println();
             System.out.print("> ");

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -304,7 +304,7 @@ public class ManagedLedgerWriter extends CmdBase{
                         }
                     }
                 } catch (Throwable t) {
-                    if (t instanceof InterruptedException) {
+                    if (PerfClientUtils.hasInterruptedException(t)) {
                         Thread.currentThread().interrupt();
                     } else {
                         log.error("Got error", t);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -304,7 +304,11 @@ public class ManagedLedgerWriter extends CmdBase{
                         }
                     }
                 } catch (Throwable t) {
-                    log.error("Got error", t);
+                    if (t instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    } else {
+                        log.error("Got error", t);
+                    }
                 }
             });
         }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -69,9 +69,6 @@ import picocli.CommandLine.Spec;
 @Command(name = "managed-ledger", description = "Write directly on managed-ledgers")
 public class ManagedLedgerWriter extends CmdBase{
 
-    private static final ExecutorService executor = Executors
-            .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-managed-ledger-exec"));
-
     private static final LongAdder messagesSent = new LongAdder();
     private static final LongAdder bytesSent = new LongAdder();
     private static final LongAdder totalMessagesSent = new LongAdder();
@@ -220,7 +217,10 @@ public class ManagedLedgerWriter extends CmdBase{
         log.info("Created {} managed ledgers", managedLedgers.size());
 
         long start = System.nanoTime();
+        ExecutorService executor = Executors
+                .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-managed-ledger-exec"));
         Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
+            executor.shutdownNow();
             printAggregatedThroughput(start);
             printAggregatedStats();
         });

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -136,4 +136,28 @@ public class PerfClientUtils {
         return pulsarAdminBuilder;
     }
 
+    /**
+     * This is used to register a shutdown hook that will be called when the JVM exits.
+     * @param runnable the runnable to run on shutdown
+     * @return the thread that was registered as a shutdown hook
+     */
+    public static Thread addShutdownHook(Runnable runnable) {
+        Thread shutdownHookThread = new Thread(runnable, "perf-client-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHookThread);
+        return shutdownHookThread;
+    }
+
+    /**
+     * This is used to remove a previously registered shutdown hook and run it immediately.
+     * This is useful at least for tests when there are multiple instances of the classes
+     * in the JVM. It will also prevent resource leaks when test code isn't relying on the JVM
+     * exit to clean up resources.
+     * @param shutdownHookThread the shutdown hook thread to remove and run
+     * @throws InterruptedException if the thread is interrupted while waiting for it to finish
+     */
+    public static void removeAndRunShutdownHook(Thread shutdownHookThread) throws InterruptedException {
+        Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
+        shutdownHookThread.start();
+        shutdownHookThread.join();
+    }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -192,4 +192,27 @@ public class PerfClientUtils {
             }
         }
     }
+
+    /**
+     * Check if the throwable or any of its causes is an InterruptedException.
+     *
+     * @param throwable the throwable to check
+     * @return true if the throwable or any of its causes is an InterruptedException, false otherwise
+     */
+    public static boolean hasInterruptedException(Throwable throwable) {
+        if (throwable == null) {
+            return false;
+        }
+        if (throwable instanceof InterruptedException) {
+            return true;
+        }
+        Throwable cause = throwable.getCause();
+        while (cause != null) {
+            if (cause instanceof InterruptedException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerfClientUtils.java
@@ -158,9 +158,17 @@ public class PerfClientUtils {
      * @throws InterruptedException if the thread is interrupted while waiting for it to finish
      */
     public static void removeAndRunShutdownHook(Thread shutdownHookThread) throws InterruptedException {
-        Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
-        shutdownHookThread.start();
-        shutdownHookThread.join();
+        // clear interrupted status and restore later
+        boolean wasInterrupted = Thread.currentThread().interrupted();
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
+            shutdownHookThread.start();
+            shutdownHookThread.join();
+        } finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -524,8 +524,7 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 }
             }
         }
-
-        pulsarClient.close();
+        PerfClientUtils.closeClient(pulsarClient);
         PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -654,6 +654,10 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
                         if (ex.getCause() instanceof ArrayIndexOutOfBoundsException) {
                             return null;
                         }
+                        // Ignore the exception when the producer is closed
+                        if (ex.getCause() instanceof PulsarClientException.AlreadyClosedException) {
+                            return null;
+                        }
                         log.warn("Write message error with exception", ex);
                         messagesFailed.increment();
                         if (this.exitOnFailure) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -726,7 +726,11 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
                 }
             }
         } catch (Throwable t) {
-            log.error("Got error", t);
+            if (t instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            } else {
+                log.error("Got error", t);
+            }
         } finally {
             if (!produceEnough) {
                 doneLatch.countDown();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -81,10 +81,6 @@ import picocli.CommandLine.TypeConversionException;
  */
 @Command(name = "produce", description = "Test pulsar producer performance.")
 public class PerformanceProducer extends PerformanceTopicListArguments{
-
-    private static final ExecutorService executor = Executors
-            .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-producer-exec"));
-
     private static final LongAdder messagesSent = new LongAdder();
     private static final LongAdder messagesFailed = new LongAdder();
     private static final LongAdder bytesSent = new LongAdder();
@@ -288,8 +284,10 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
 
         long start = System.nanoTime();
 
+        ExecutorService executor = Executors
+                .newCachedThreadPool(new DefaultThreadFactory("pulsar-perf-producer-exec"));
         Thread shutdownHookThread = PerfClientUtils.addShutdownHook(() -> {
-            executorShutdownNow();
+            executorShutdownNow(executor);
             printAggregatedThroughput(start);
             printAggregatedStats();
         });
@@ -422,7 +420,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
         super("produce");
     }
 
-    private static void executorShutdownNow() {
+    private static void executorShutdownNow(ExecutorService executor) {
         executor.shutdownNow();
         try {
             if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -735,13 +735,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
             if (!produceEnough) {
                 doneLatch.countDown();
             }
-            if (null != client) {
-                try {
-                    client.close();
-                } catch (PulsarClientException e) {
-                    log.error("Failed to close test client", e);
-                }
-            }
+            PerfClientUtils.closeClient(client);
         }
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -213,7 +213,7 @@ public class PerformanceReader extends PerformanceTopicListArguments {
             oldTime = now;
         }
 
-        pulsarClient.close();
+        PerfClientUtils.closeClient(pulsarClient);
         PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
     }
     private static void printAggregatedThroughput(long start) {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
+import static org.apache.pulsar.testclient.PerfClientUtils.addShutdownHook;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.util.concurrent.RateLimiter;
@@ -163,10 +164,10 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         log.info("Start reading from {} topics", this.numTopics);
 
         final long start = System.nanoTime();
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+        Thread shutdownHookThread = addShutdownHook(() -> {
             printAggregatedThroughput(start);
             printAggregatedStats();
-        }));
+        });
 
         if (this.testTime > 0) {
             TimerTask timoutTask = new TimerTask() {
@@ -184,10 +185,11 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         long oldTime = System.nanoTime();
         Histogram reportHistogram = null;
 
-        while (true) {
+        while (!Thread.currentThread().isInterrupted()) {
             try {
                 Thread.sleep(10000);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 break;
             }
 
@@ -212,6 +214,7 @@ public class PerformanceReader extends PerformanceTopicListArguments {
         }
 
         pulsarClient.close();
+        PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
     }
     private static void printAggregatedThroughput(long start) {
         double elapsed = (System.nanoTime() - start) / 1e9;

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -213,7 +213,8 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
         ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(this)
                 .enableTransaction(!this.isDisableTransaction);
 
-        try (PulsarClient client = clientBuilder.build()) {
+        PulsarClient client = clientBuilder.build();
+        try {
 
             ExecutorService executorService = new ThreadPoolExecutor(this.numTestThreads,
                     this.numTestThreads,
@@ -540,6 +541,8 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
             }
 
             PerfClientUtils.removeAndRunShutdownHook(shutdownHookThread);
+        } finally {
+            PerfClientUtils.closeClient(client);
         }
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -259,9 +259,10 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                             atomicReference = new AtomicReference<>(null);
                         }
                     } catch (Exception e) {
-                        log.error("Failed to build Producer/Consumer with exception : ", e);
-                        if (e instanceof InterruptedException) {
+                        if (PerfClientUtils.hasInterruptedException(e)) {
                             Thread.currentThread().interrupt();
+                        } else {
+                            log.error("Failed to build Producer/Consumer with exception : ", e);
                         }
                         executorService.shutdownNow();
                         PerfClientUtils.exit(1);
@@ -314,11 +315,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                                     messageAckCumulativeRecorder.recordValue(latencyMicros);
                                                     numMessagesAckSuccess.increment();
                                                 }).exceptionally(exception -> {
-                                                    if (exception.getCause() instanceof InterruptedException) {
+                                                    if (PerfClientUtils.hasInterruptedException(exception)) {
                                                         Thread.currentThread().interrupt();
-                                                        if (!executing.get()) {
-                                                            return null;
-                                                        }
+                                                        return null;
                                                     }
                                                     log.error(
                                                             "Ack message failed with transaction {} throw exception",
@@ -334,11 +333,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                             messageAckCumulativeRecorder.recordValue(latencyMicros);
                                             numMessagesAckSuccess.increment();
                                         }).exceptionally(exception -> {
-                                            if (exception.getCause() instanceof InterruptedException) {
+                                            if (PerfClientUtils.hasInterruptedException(exception)) {
                                                 Thread.currentThread().interrupt();
-                                                if (!executing.get()) {
-                                                    return null;
-                                                }
+                                                return null;
                                             }
                                             log.error(
                                                     "Ack message failed with transaction {} throw exception",
@@ -363,11 +360,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                                 messageSendRCumulativeRecorder.recordValue(latencyMicros);
                                                 numMessagesSendSuccess.increment();
                                             }).exceptionally(exception -> {
-                                                if (exception.getCause() instanceof InterruptedException) {
+                                                if (PerfClientUtils.hasInterruptedException(exception)) {
                                                     Thread.currentThread().interrupt();
-                                                    if (!executing.get()) {
-                                                        return null;
-                                                    }
+                                                    return null;
                                                 }
                                                 // Ignore the exception when the producer is closed
                                                 if (exception.getCause()
@@ -388,11 +383,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                                 messageSendRCumulativeRecorder.recordValue(latencyMicros);
                                                 numMessagesSendSuccess.increment();
                                             }).exceptionally(exception -> {
-                                                if (exception.getCause() instanceof InterruptedException) {
+                                                if (PerfClientUtils.hasInterruptedException(exception)) {
                                                     Thread.currentThread().interrupt();
-                                                    if (!executing.get()) {
-                                                        return null;
-                                                    }
+                                                    return null;
                                                 }
                                                 // Ignore the exception when the producer is closed
                                                 if (exception.getCause()
@@ -417,11 +410,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                             numTxnOpSuccess.increment();
                                             totalNumEndTxnOpSuccess.increment();
                                         }).exceptionally(exception -> {
-                                            if (exception.getCause() instanceof InterruptedException) {
+                                            if (PerfClientUtils.hasInterruptedException(exception)) {
                                                 Thread.currentThread().interrupt();
-                                                if (!executing.get()) {
-                                                    return null;
-                                                }
+                                                return null;
                                             }
                                             log.error("Commit transaction {} failed with exception",
                                                     transaction.getTxnID().toString(),
@@ -434,11 +425,9 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                     numTxnOpSuccess.increment();
                                     totalNumEndTxnOpSuccess.increment();
                                 }).exceptionally(exception -> {
-                                    if (exception.getCause() instanceof InterruptedException) {
+                                    if (PerfClientUtils.hasInterruptedException(exception)) {
                                         Thread.currentThread().interrupt();
-                                        if (!executing.get()) {
-                                            return null;
-                                        }
+                                        return null;
                                     }
                                     log.error("Commit transaction {} failed with exception",
                                             transaction.getTxnID().toString(),
@@ -457,14 +446,12 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                     totalNumTxnOpenTxnSuccess.increment();
                                     break;
                                 } catch (Exception throwable) {
-                                    if (throwable instanceof InterruptedException) {
+                                    if (PerfClientUtils.hasInterruptedException(throwable)) {
                                         Thread.currentThread().interrupt();
-                                        if (!executing.get()) {
-                                            break;
-                                        }
+                                    } else {
+                                        log.error("Failed to new transaction with exception: ", throwable);
+                                        totalNumTxnOpenTxnFail.increment();
                                     }
-                                    log.error("Failed to new transaction with exception: ", throwable);
-                                    totalNumTxnOpenTxnFail.increment();
                                 }
                             }
                         } else {

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceTransaction.java
@@ -368,6 +368,11 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                                         return null;
                                                     }
                                                 }
+                                                // Ignore the exception when the producer is closed
+                                                if (exception.getCause()
+                                                        instanceof PulsarClientException.AlreadyClosedException) {
+                                                    return null;
+                                                }
                                                 log.error("Send transaction message failed with exception : ",
                                                         exception);
                                                 numMessagesSendFailed.increment();
@@ -387,6 +392,11 @@ public class PerformanceTransaction extends PerformanceBaseArguments{
                                                     if (!executing.get()) {
                                                         return null;
                                                     }
+                                                }
+                                                // Ignore the exception when the producer is closed
+                                                if (exception.getCause()
+                                                        instanceof PulsarClientException.AlreadyClosedException) {
+                                                    return null;
                                                 }
                                                 log.error("Send message failed with exception : ", exception);
                                                 numMessagesSendFailed.increment();

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -227,9 +227,10 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
             }
         });
         thread.start();
-        thread.join();
-        Message<byte[]> message = consumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> message = consumer.receive(15, TimeUnit.SECONDS);
         assertNotNull(message);
+        thread.interrupt();
+        thread.join();
         consumer.close();
     }
 

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -217,7 +217,7 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         String topic = testTopic + UUID.randomUUID().toString();
         String args = String.format(argString, topic, pulsar.getBrokerServiceUrl(), pulsar.getWebServiceAddress());
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
-                .subscriptionType(SubscriptionType.Key_Shared).subscribe();
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         Thread thread = new Thread(() -> {
             try {
                 PerformanceProducer producer = new PerformanceProducer();

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -218,19 +218,18 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         String args = String.format(argString, topic, pulsar.getBrokerServiceUrl(), pulsar.getWebServiceAddress());
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
                 .subscriptionType(SubscriptionType.Key_Shared).subscribe();
-        new Thread(() -> {
+        Thread thread = new Thread(() -> {
             try {
                 PerformanceProducer producer = new PerformanceProducer();
                 producer.run(args.split(" "));
             } catch (Exception e) {
                 log.error("Failed to start perf producer");
             }
-        }).start();
-        Awaitility.await()
-                .untilAsserted(() -> {
-                    Message<byte[]> message = consumer.receive(3, TimeUnit.SECONDS);
-                    assertNotNull(message);
-                });
+        });
+        thread.start();
+        thread.join();
+        Message<byte[]> message = consumer.receive(3, TimeUnit.SECONDS);
+        assertNotNull(message);
         consumer.close();
     }
 


### PR DESCRIPTION
### Motivation

Terminating pulsar-perf with CTRL-C could take a while. There's also a similar problem in some test cases that I came across while fixing test resource leaks.

### Modifications

- replace `while(true)` loops with `while(!Thread.currentThread().isInterrupted())` 
- properly propagate Thread interrupted information after catching exceptions
- fix issue in tests related to runtime hook resource leaks
  - when the execution completes successfully, remove the shutdown hook and run it without waiting for JVM exit

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->