### PR TITLE
[fix][io] Fix kinesis avro bytes handling

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/json/JsonConverter.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/json/JsonConverter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -78,11 +79,13 @@ public class JsonConverter {
             case BOOLEAN:
                 return jsonNodeFactory.booleanNode((Boolean) value);
             case BYTES:
+                byte[] bytes = new byte[((ByteBuffer) value).remaining()];
+                ((ByteBuffer) value).get(bytes);
                 // Workaround for https://github.com/wnameless/json-flattener/issues/91
                 if (convertBytesToString) {
-                    return jsonNodeFactory.textNode(Base64.getEncoder().encodeToString((byte[]) value));
+                    return jsonNodeFactory.textNode(Base64.getEncoder().encodeToString(bytes));
                 }
-                return jsonNodeFactory.binaryNode((byte[]) value);
+                return jsonNodeFactory.binaryNode(bytes);
             case FIXED:
                 // Workaround for https://github.com/wnameless/json-flattener/issues/91
                 if (convertBytesToString) {

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
@@ -30,7 +30,6 @@ import com.google.gson.Gson;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
@@ -279,6 +279,7 @@ public class UtilsTest {
         RecordSchemaBuilder udtSchemaBuilder = SchemaBuilder.record("type1");
         udtSchemaBuilder.field("a").type(SchemaType.STRING).optional().defaultValue(null);
         udtSchemaBuilder.field("b").type(SchemaType.BOOLEAN).optional().defaultValue(null);
+        udtSchemaBuilder.field("c").type(SchemaType.BYTES).optional().defaultValue(null);
         udtSchemaBuilder.field("d").type(SchemaType.DOUBLE).optional().defaultValue(null);
         udtSchemaBuilder.field("f").type(SchemaType.FLOAT).optional().defaultValue(null);
         udtSchemaBuilder.field("i").type(SchemaType.INT32).optional().defaultValue(null);
@@ -293,8 +294,9 @@ public class UtilsTest {
                 .set("e", udtGenericSchema.newRecordBuilder()
                         .set("a", "a")
                         .set("b", true)
-                        .set("d", 1.0)
-                        .set("f", 1.0f)
+                        .set("c", ByteBuffer.wrap("10".getBytes(StandardCharsets.UTF_8)))
+                        .set("d", 0.5)
+                        .set("f", 0.25f)
                         .set("i", 1)
                         .set("l", 10L)
                         .build())
@@ -303,7 +305,7 @@ public class UtilsTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("prop-key", "prop-value");
 
-        Record<GenericObject> genericObjectRecord = new Record<GenericObject>() {
+        Record<GenericObject> genericObjectRecord = new Record<>() {
             @Override
             public Optional<String> getTopicName() {
                 return Optional.of("data-ks1.table1");
@@ -321,7 +323,8 @@ public class UtilsTest {
 
             @Override
             public GenericObject getValue() {
-                return valueGenericRecord;
+                // Ensure the record in encoded amd decoded correctly
+                return valueSchema.decode(valueSchema.encode(valueGenericRecord));
             }
 
             @Override
@@ -339,7 +342,7 @@ public class UtilsTest {
         String json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, false);
 
         assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\",\"payload\":{\"c\":\"1\","
-                + "\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":10}},"
+                + "\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"c\":\"MTA=\",\"d\":0.5,\"f\":0.25,\"i\":1,\"l\":10}},"
                 + "\"properties\":{\"prop-key\":\"prop-value\"},\"eventTime\":1648502845803}");
     }
 
@@ -369,18 +372,15 @@ public class UtilsTest {
         valueSchemaBuilder.field("e", udtGenericSchema).type(schemaType).optional().defaultValue(null);
         GenericSchema<GenericRecord> valueSchema = Schema.generic(valueSchemaBuilder.build(schemaType));
 
-        byte[] bytes = "10".getBytes(StandardCharsets.UTF_8);
         GenericRecord valueGenericRecord = valueSchema.newRecordBuilder()
                 .set("c", "1")
                 .set("d", 1)
                 .set("e", udtGenericSchema.newRecordBuilder()
                         .set("a", "a")
                         .set("b", true)
-                        // There's a bug in json-flattener that doesn't handle byte[] fields correctly.
-                        // But since we use AUTO_CONSUME, we won't get byte[] fields for JSON schema anyway.
-                        .set("c", schemaType == SchemaType.AVRO ? bytes : Base64.getEncoder().encodeToString(bytes))
-                        .set("d", 1.0)
-                        .set("f", 1.0f)
+                        .set("c", ByteBuffer.wrap("10".getBytes(StandardCharsets.UTF_8)))
+                        .set("d", 0.5)
+                        .set("f", 0.25f)
                         .set("i", 1)
                         .set("l", 10L)
                         .build())
@@ -398,7 +398,7 @@ public class UtilsTest {
 
             @Override
             public Object getNativeObject() {
-                return keyValue;
+                return keyValueSchema.decode(keyValueSchema.encode(keyValue));
             }
         };
 
@@ -441,15 +441,15 @@ public class UtilsTest {
         String json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, false);
 
         assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
-                + "\"payload\":{\"value\":{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"c\":\"MTA=\",\"d\":1.0,"
-                + "\"f\":1.0,\"i\":1,\"l\":10}},\"key\":{\"a\":\"1\",\"b\":1}},"
+                + "\"payload\":{\"value\":{\"c\":\"1\",\"d\":1,\"e\":{\"a\":\"a\",\"b\":true,\"c\":\"MTA=\",\"d\":0.5,"
+                + "\"f\":0.25,\"i\":1,\"l\":10}},\"key\":{\"a\":\"1\",\"b\":1}},"
                 + "\"properties\":{\"prop-key\":\"prop-value\"},\"eventTime\":1648502845803}");
 
         json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, true);
 
         assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\",\"payload.value.c\":\"1\","
                 + "\"payload.value.d\":1,\"payload.value.e.a\":\"a\",\"payload.value.e.b\":true,"
-                + "\"payload.value.e.c\":\"MTA=\",\"payload.value.e.d\":1.0,\"payload.value.e.f\":1.0,"
+                + "\"payload.value.e.c\":\"MTA=\",\"payload.value.e.d\":0.5,\"payload.value.e.f\":0.25,"
                 + "\"payload.value.e.i\":1,\"payload.value.e.l\":10,\"payload.key.a\":\"1\",\"payload.key.b\":1,"
                 + "\"properties.prop-key\":\"prop-value\",\"eventTime\":1648502845803}");
     }
@@ -476,7 +476,7 @@ public class UtilsTest {
 
             @Override
             public Object getNativeObject() {
-                return keyValue;
+                return keyValueSchema.decode(keyValueSchema.encode(keyValue));
             }
         };
 

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/json/JsonConverterTests.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/json/JsonConverterTests.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -71,7 +72,7 @@ public class JsonConverterTests {
         genericRecord.put("l", 1L);
         genericRecord.put("i", 1);
         genericRecord.put("b", true);
-        genericRecord.put("bb", "10".getBytes(StandardCharsets.UTF_8));
+        genericRecord.put("bb", ByteBuffer.wrap("10".getBytes(StandardCharsets.UTF_8)));
         genericRecord.put("d", 10.0);
         genericRecord.put("f", 10.0f);
         genericRecord.put("s", "toto");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sinks/KinesisSinkTester.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -156,13 +157,15 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
                         "f2_" + i,
                         Arrays.asList(i, i +1),
                         new HashSet<>(Arrays.asList((long) i)),
-                        ImmutableMap.of("map1_k_" + i, "map1_kv_" + i));
+                        ImmutableMap.of("map1_k_" + i, "map1_kv_" + i),
+                        ("key_bytes_" + i).getBytes(StandardCharsets.UTF_8));
                 final SimplePojo valuePojo = new SimplePojo(
                         String.valueOf(i),
                         "v2_" + i,
                         Arrays.asList(i, i +1),
                         new HashSet<>(Arrays.asList((long) i)),
-                        ImmutableMap.of("map1_v_" + i, "map1_vv_" + i));
+                        ImmutableMap.of("map1_v_" + i, "map1_vv_" + i),
+                        ("value_bytes_" + i).getBytes(StandardCharsets.UTF_8));
                 producer.newMessage()
                         .value(new KeyValue<>(keyPojo, valuePojo))
                         .send();
@@ -222,8 +225,12 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
             JsonNode payload = READER.readTree(data).at("/payload");
             String i = payload.at("/value/field1").asText();
             assertEquals(payload.at("/value/field2").asText(), "v2_" + i);
+            assertEquals(payload.at("/value/bytes").asText(),
+                    Base64.getEncoder().encodeToString(("value_bytes_" + i).getBytes(StandardCharsets.UTF_8)));
             assertEquals(payload.at("/key/field1").asText(), "f1_" + i);
             assertEquals(payload.at("/key/field2").asText(), "f2_" + i);
+            assertEquals(payload.at("/key/bytes").asText(),
+                    Base64.getEncoder().encodeToString(("key_bytes_" + i).getBytes(StandardCharsets.UTF_8)));
             actualKvs.put(i, i);
         } else {
             actualKvs.put(partitionKey, data);
@@ -271,6 +278,7 @@ public class KinesisSinkTester extends SinkTester<LocalStackContainer> {
         private List<Integer> list1;
         private Set<Long> set1;
         private Map<String, String> map1;
+        private byte[] bytes;
     }
 
     @Override


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

AVRO uses `ByteBuffer` for schema BYTES.
In the Kinesis sink, when converting AVRO record to JSON, we get 
```
2025-05-16T19:16:09.142923400Z java.lang.ClassCastException: class java.nio.HeapByteBuffer cannot be cast to class [B (java.nio.HeapByteBuffer and [B are in module java.base of loader 'bootstrap')
2025-05-16T19:16:09.142932060Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:80) ~[?:?]
2025-05-16T19:16:09.142933540Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:119) ~[?:?]
2025-05-16T19:16:09.142934623Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:54) ~[?:?]
2025-05-16T19:16:09.142935763Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:113) ~[?:?]
2025-05-16T19:16:09.142936847Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:119) ~[?:?]
2025-05-16T19:16:09.142938214Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:105) ~[?:?]
2025-05-16T19:16:09.142939866Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:119) ~[?:?]
2025-05-16T19:16:09.142941409Z 	at org.apache.pulsar.io.kinesis.json.JsonConverter.toJson(JsonConverter.java:54) ~[?:?]
2025-05-16T19:16:09.142956643Z 	at org.apache.pulsar.io.kinesis.Utils.toJsonSerializable(Utils.java:265) ~[?:?]
2025-05-16T19:16:09.142958964Z 	at org.apache.pulsar.io.kinesis.Utils.toJsonSerializable(Utils.java:260) ~[?:?]
2025-05-16T19:16:09.142961420Z 	at org.apache.pulsar.io.kinesis.Utils.serializeRecordToJsonExpandingValue(Utils.java:225) ~[?:?]
2025-05-16T19:16:09.142962967Z 	at org.apache.pulsar.io.kinesis.KinesisSink.createKinesisMessage(KinesisSink.java:308) ~[?:?]
2025-05-16T19:16:09.142964593Z 	at org.apache.pulsar.io.kinesis.KinesisSink.write(KinesisSink.java:134) ~[?:?]
2025-05-16T19:16:09.142966767Z 	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.sendOutputMessage(JavaInstanceRunnable.java:447) ~[com.datastax.oss-pulsar-functions-instance-3.1.4.8.jar:3.1.4.8]
2025-05-16T19:16:09.142968398Z 	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.handleResult(JavaInstanceRunnable.java:409) ~[com.datastax.oss-pulsar-functions-instance-3.1.4.8.jar:3.1.4.8]
2025-05-16T19:16:09.142970014Z 	at org.apache.pulsar.functions.instance.JavaInstanceRunnable.run(JavaInstanceRunnable.java:349) ~[com.datastax.oss-pulsar-functions-instance-3.1.4.8.jar:3.1.4.8]
2025-05-16T19:16:09.142972314Z 	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```
Because in `JsonConverter::toJson`, we do
```java
            case BYTES:
                // Workaround for https://github.com/wnameless/json-flattener/issues/91
                if (convertBytesToString) {
                    return jsonNodeFactory.textNode(Base64.getEncoder().encodeToString((byte[]) value));
                }
                return jsonNodeFactory.binaryNode((byte[]) value);
```
and `value` is a `ByteBuffer`.

### Modifications

* Handle the value as a `ByteBuffer` in `JsonConverter::toJson`
* In unit tests, ensure that the record is correct for the schema codec.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cbornet/pulsar/pull/19

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
