### PR TITLE
[fix][io][branch-3.0]Pulsar-SQL: Fix classcast ex when decode decimal value

### DIFF
--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
@@ -348,7 +348,7 @@ public class PulsarJsonFieldDecoder
                 jsonNode = (JsonNode) value;
             } else {
                 throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED,
-                        format("decimal object of '%s' as '%s' for column '%s' cann't convert to JsonNode",
+                        format("decimal object of '%s' as '%s' for column '%s' cannot be converted to JsonNode",
                                 value.getClass(), type, columnName));
             }
             String textValue = jsonNode.isValueNode() ? jsonNode.asText() : jsonNode.toString();

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
@@ -29,8 +29,8 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.DecimalNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
@@ -342,8 +342,8 @@ public class PulsarJsonFieldDecoder
                 blockBuilder = type.createBlockBuilder(null, 1);
             }
 
-            assert value instanceof DecimalNode;
-            final DecimalNode node = (DecimalNode) value;
+            assert value instanceof ValueNode;
+            final ValueNode node = (ValueNode) value;
             // For decimalType, need to eliminate the decimal point,
             // and give it to trino to set the decimal point
             type.writeObject(blockBuilder, Int128.valueOf(node.asText().replace(".", "")));

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/decoder/json/PulsarJsonFieldDecoder.java
@@ -30,7 +30,6 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;


### PR DESCRIPTION
### Motivation

![Screenshot 2025-05-20 at 11 48 56](https://github.com/user-attachments/assets/6537913c-3ced-46ea-b493-d1d899ac35a2)


The original implementation of decoding was introduced by #15687, The implementation is as follows

```java
String textValue = value.isValueNode() ? value.asText() : value.toString();
if (type instanceof DecimalType) {
    textValue = textValue.replace(".", "");
    BigInteger bigInteger = new BigInteger(textValue);
    return Decimals.encodeUnscaledValue(bigInteger);
}
```

#20016 introduced a break change, which added a classcast from `object` to `DecimalNode`, The implementation was changed to as follows

```java
// value is typed "Object", the actual type is a JsonNode
final DecimalNode node = (DecimalNode) value;
type.writeObject(blockBuilder, Int128.valueOf(node.asText().replace(".", "")));
```

### Modifications

Revert the implementation to the original.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
