### PR TITLE
[fix][test] Fix flaky MultiTopicsReaderTest.testMultiNonPartitionedTopicWithRollbackDuration

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MultiTopicsReaderTest.java
@@ -629,6 +629,7 @@ public class MultiTopicsReaderTest extends MockedPulsarServiceBaseTest {
     void shouldSupportCancellingReadNextAsync() throws Exception {
         String topic = "persistent://my-property/my-ns/my-reader-topic" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
+        @Cleanup
         MultiTopicsReaderImpl<byte[]> reader = (MultiTopicsReaderImpl<byte[]>) pulsarClient.newReader()
                 .topic(topic)
                 .startMessageId(MessageId.earliest)


### PR DESCRIPTION
### Motivation
![image](https://github.com/user-attachments/assets/ddd6e926-b4c4-438f-9c9a-2b8407fcbd09)


The root cause of this problem is that the `reader` is not cleaned up in the unit test `shouldSupportCancellingReadNextAsync`


### Modifications
Add @Cleanup on `reader` in test `shouldSupportCancellingReadNextAsync`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->