### PR TITLE
[fix][cli] Fix pulsar-shell cannot produce message with quotes and space

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.shell.config.FileConfigStore;
 import org.jline.console.impl.SystemRegistryImpl;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Parser;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
@@ -290,7 +291,7 @@ public class PulsarShell {
 
                 @Override
                 public List<String> parseLine(String line) {
-                    return reader.getParser().parse(line, 0).words();
+                    return reader.getParser().parse(line, 0, Parser.ParseContext.SPLIT_LINE).words();
                 }
             };
         }, () -> terminal);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.client.cli.CmdProduce;
 import org.jline.reader.EndOfFileException;
+import org.jline.reader.Parser;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.LineReaderImpl;
 import org.jline.terminal.Terminal;
@@ -82,7 +83,7 @@ public class PulsarShellTest {
 
         @Override
         public List<String> parseLine(String line) {
-            return getParser().parse(line, 0).words();
+            return getParser().parse(line, 0, Parser.ParseContext.SPLIT_LINE).words();
         }
     }
 
@@ -148,7 +149,7 @@ public class PulsarShellTest {
         final Properties props = new Properties();
         props.setProperty("webServiceUrl", "http://localhost:8080");
         linereader.addCmd("admin topics create my-topic --metadata a=b ");
-        linereader.addCmd("client produce -m msg my-topic");
+        linereader.addCmd("client produce -m \"hello pulsar\" my-topic");
         linereader.addCmd("quit");
         final TestPulsarShell testPulsarShell = new TestPulsarShell(new String[]{}, props, pulsarAdmin);
         testPulsarShell.run((a) -> linereader, () -> terminal);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/shell/PulsarShellTest.java
@@ -149,12 +149,13 @@ public class PulsarShellTest {
         final Properties props = new Properties();
         props.setProperty("webServiceUrl", "http://localhost:8080");
         linereader.addCmd("admin topics create my-topic --metadata a=b ");
+        linereader.addCmd("client produce -m msg my-topic");
         linereader.addCmd("client produce -m \"hello pulsar\" my-topic");
         linereader.addCmd("quit");
         final TestPulsarShell testPulsarShell = new TestPulsarShell(new String[]{}, props, pulsarAdmin);
         testPulsarShell.run((a) -> linereader, () -> terminal);
         verify(topics).createNonPartitionedTopic(eq("persistent://public/default/my-topic"), any(Map.class));
-        verify(testPulsarShell.cmdProduceHolder.get()).call();
+        verify(testPulsarShell.cmdProduceHolder.get(), times(2)).call();
         assertEquals((int) testPulsarShell.exitCode, 0);
 
     }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24319

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
The `InteractiveLineReader` cannot `parseLine("client produce -m \"hello\ pulsar\" my-topic")` correctly. The result will not retain quotes. 


### Modifications

change the following code from

```

                public List<String> parseLine(String line) {
                    return reader.getParser().parse(line, 0).words();
                }
```

to

```
                public List<String> parseLine(String line) {
                    return reader.getParser().parse(line, 0, Parser.ParseContext.SPLIT_LINE).words();
                }
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change added tests and can be verified as follows:

  - *org.apache.pulsar.shell.PulsarShellTest#testInteractiveMode*


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
