### PR TITLE
[fix][test] Fix more ByteBuf resource leaks in tests, part 4

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3324,7 +3324,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         List<OpAddEntry> oldOps = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             OpAddEntry op = OpAddEntry.createNoRetainBuffer(ledger,
-                    ByteBufAllocator.DEFAULT.buffer(128).retain(), null, null, new AtomicBoolean());
+                    ByteBufAllocator.DEFAULT.buffer(128), null, null, new AtomicBoolean());
             if (i > 4) {
                 op.setLedger(mock(LedgerHandle.class));
             }
@@ -3341,6 +3341,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             } else {
                 Assert.assertSame(oldOp, newOp);
             }
+            oldOp.getData().release();
         }
     }
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/TripleLongPriorityQueueTest.java
@@ -190,6 +190,7 @@ public class TripleLongPriorityQueueTest {
         // Trigger shrinking
         pq.clear();
         capacity = scaleCapacity - (int)(scaleCapacity * 0.5f * 0.9f);
+        pq.close();
     }
 
     private void triggerScaleOut(int initialCapacity, TripleLongPriorityQueue pq) {

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderStreamingTest.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
@@ -97,6 +98,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testHappyCase() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -107,6 +109,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         long beginLedger = 0;
         long beginEntry = 0;
         log.error("try begin offload");
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, new HashMap<>()).get();
         //Segment should closed because size in bytes full
@@ -123,6 +126,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testReadAndWrite() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -136,6 +140,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -159,7 +164,9 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setUidMsb(uuid.getMostSignificantBits())
                         .setComplete(true).setEndEntryId(9).build());
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        @Cleanup
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -172,6 +179,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testReadAndWriteAcrossLedger() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "2000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -185,6 +193,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -216,7 +225,9 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setUidMsb(uuid.getMostSignificantBits())
                         .setComplete(true).setEndEntryId(9).build());
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        @Cleanup
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -226,7 +237,9 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
             assertEquals(storedData, entryBytes);
         }
 
+        @Cleanup
         final ReadHandle readHandle2 = offloader.readOffloaded(1, contextBuilder.build(), driverMeta).get();
+        @Cleanup
         final LedgerEntries ledgerEntries2 = readHandle2.readAsync(0, 9).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries2) {
@@ -239,11 +252,13 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testReadAndWriteAcrossSegment() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_ROLLOVER_TIME_SEC, "600");
         }});
+        @Cleanup
         LedgerOffloader offloader2 = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -258,6 +273,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -276,6 +292,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         assertEquals(offloadResult.endEntry, 9);
 
         //Segment should closed because size in bytes full
+        @Cleanup
         OffloadHandle offloadHandle2 = offloader2
                 .streamingOffload(ml, uuid2, beginLedger, 10, driverMeta).get();
         for (int i = 0; i < 10; i++) {
@@ -301,7 +318,9 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setComplete(true).setEndEntryId(19).build()
         );
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
+        @Cleanup
         final LedgerEntries ledgerEntries = readHandle.readAsync(0, 19).get();
 
         for (LedgerEntry ledgerEntry : ledgerEntries) {
@@ -314,6 +333,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testRandomRead() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -333,6 +353,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -351,6 +372,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         assertEquals(offloadResult.endEntry, 9);
 
         //Segment should closed because size in bytes full
+        @Cleanup
         OffloadHandle offloadHandle2 = offloader2
                 .streamingOffload(ml, uuid2, beginLedger, 10, driverMeta).get();
         for (int i = 0; i < 10; i++) {
@@ -376,6 +398,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setComplete(true).setEndEntryId(19).build()
         );
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
 
         for (int i = 0; i <= 19; i++) {
@@ -387,6 +410,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                 begin = end;
                 end = temp;
             }
+            @Cleanup
             final LedgerEntries ledgerEntries = readHandle.readAsync(begin, end).get();
             for (LedgerEntry ledgerEntry : ledgerEntries) {
                 final EntryImpl storedEntry = (EntryImpl) entries.get((int) ledgerEntry.getEntryId());
@@ -399,6 +423,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testInvalidEntryIds() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -412,6 +437,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -435,6 +461,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setUidMsb(uuid.getMostSignificantBits())
                         .setComplete(true).setEndEntryId(9).build());
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
         try {
             readHandle.read(-1, -1);
@@ -451,6 +478,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
 
     @Test
     public void testReadNotExistLedger() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader(new HashMap<String, String>() {{
             put(TieredStorageConfiguration.MAX_OFFLOAD_SEGMENT_SIZE_IN_BYTES, "1000");
             put(config.getKeys(TieredStorageConfiguration.METADATA_FIELD_MAX_BLOCK_SIZE).get(0), "5242880");
@@ -464,6 +492,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
         Map<String, String> driverMeta = new HashMap<String, String>() {{
             put(TieredStorageConfiguration.METADATA_FIELD_BUCKET, BUCKET);
         }};
+        @Cleanup
         OffloadHandle offloadHandle = offloader
                 .streamingOffload(ml, uuid, beginLedger, beginEntry, driverMeta).get();
 
@@ -487,6 +516,7 @@ public class BlobStoreManagedLedgerOffloaderStreamingTest extends BlobStoreManag
                         .setUidMsb(uuid.getMostSignificantBits())
                         .setComplete(true).setEndEntryId(9).build());
 
+        @Cleanup
         final ReadHandle readHandle = offloader.readOffloaded(0, contextBuilder.build(), driverMeta).get();
 
         // delete blob(ledger)

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.Cleanup;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
@@ -113,6 +114,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test(timeOut = 600000)  // 10 minutes.
     public void testHappyCase() throws Exception {
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
         offloader.offload(buildReadHandle(), UUID.randomUUID(), new HashMap<>()).get();
     }
@@ -125,6 +127,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             return;
         }
 
+        @Cleanup
         LedgerOffloader offloader = getOffloader("some-non-existant-bucket-name");
         try {
             offloader.offload(buildReadHandle(), UUID.randomUUID(), new HashMap<>()).get();
@@ -137,12 +140,15 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test(timeOut = 600000)  // 10 minutes.
     public void testOffloadAndRead() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
@@ -167,7 +173,9 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test(timeOut = 60000)
     public void testReadHandlerState() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
@@ -176,14 +184,17 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         BlobStoreBackedReadHandleImpl toTest = (BlobStoreBackedReadHandleImpl) offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
         Assert.assertEquals(toTest.getState(), BlobStoreBackedReadHandleImpl.State.Opened);
-        toTest.read(0, 1);
+        @Cleanup
+        LedgerEntries ledgerEntries = toTest.read(0, 1);
         toTest.close();
         Assert.assertEquals(toTest.getState(), BlobStoreBackedReadHandleImpl.State.Closed);
     }
 
     @Test(timeOut = 600000)  // 10 minutes.
     public void testOffloadAndReadMetrics() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
@@ -193,6 +204,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         extraMap.put("ManagedLedgerName", managedLegerName);
         offloader.offload(toWrite, uuid, extraMap).get();
 
+        @Cleanup
         LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) this.offloaderStats;
 
         assertEquals(offloaderStats.getOffloadError(topic), 0);
@@ -203,7 +215,9 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         Map<String, String> map = new HashMap<>();
         map.putAll(offloader.getOffloadDriverMetadata());
         map.put("ManagedLedgerName", managedLegerName);
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, map).get();
+        @Cleanup
         LedgerEntries toTestEntries = toTest.read(0, toTest.getLastAddConfirmed());
         Iterator<LedgerEntry> toTestIter = toTestEntries.iterator();
         while (toTestIter.hasNext()) {
@@ -218,6 +232,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testOffloadFailInitDataBlockUpload() throws Exception {
+        @Cleanup
         ReadHandle readHandle = buildReadHandle();
         UUID uuid = UUID.randomUUID();
         String failureString = "fail InitDataBlockUpload";
@@ -230,6 +245,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 .doThrow(new RuntimeException(failureString))
                 .when(spiedBlobStore).initiateMultipartUpload(any(), any(), any());
 
+            @Cleanup
             BlobStoreManagedLedgerOffloader offloader = getOffloader(spiedBlobStore);
             offloader.offload(readHandle, uuid, new HashMap<>()).get();
             Assert.fail("Should throw exception when initiateMultipartUpload");
@@ -243,6 +259,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testOffloadFailDataBlockPartUpload() throws Exception {
+        @Cleanup
         ReadHandle readHandle = buildReadHandle();
         UUID uuid = UUID.randomUUID();
         String failureString = "fail DataBlockPartUpload";
@@ -255,6 +272,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 .doThrow(new RuntimeException(failureString))
                 .when(spiedBlobStore).uploadMultipartPart(any(), anyInt(), any());
 
+            @Cleanup
             BlobStoreManagedLedgerOffloader offloader = getOffloader(spiedBlobStore);
             offloader.offload(readHandle, uuid, new HashMap<>()).get();
             Assert.fail("Should throw exception for when uploadPart");
@@ -268,6 +286,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testOffloadFailDataBlockUploadComplete() throws Exception {
+        @Cleanup
         ReadHandle readHandle = buildReadHandle();
         UUID uuid = UUID.randomUUID();
         String failureString = "fail DataBlockUploadComplete";
@@ -282,6 +301,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 .doNothing()
                 .when(spiedBlobStore).abortMultipartUpload(any());
 
+            @Cleanup
             BlobStoreManagedLedgerOffloader offloader = getOffloader(spiedBlobStore);
             offloader.offload(readHandle, uuid, new HashMap<>()).get();
 
@@ -297,6 +317,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testOffloadFailPutIndexBlock() throws Exception {
+        @Cleanup
         ReadHandle readHandle = buildReadHandle();
         UUID uuid = UUID.randomUUID();
         String failureString = "fail putObject";
@@ -308,6 +329,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
                 .doThrow(new RuntimeException(failureString))
                 .when(spiedBlobStore).putBlob(any(), any());
 
+            @Cleanup
             BlobStoreManagedLedgerOffloader offloader = getOffloader(spiedBlobStore);
             offloader.offload(readHandle, uuid, new HashMap<>()).get();
 
@@ -323,6 +345,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test(timeOut = 600000)
     public void testOffloadReadRandomAccess() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
         long[][] randomAccesses = new long[10][2];
         Random r = new Random(0);
@@ -338,11 +361,13 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             randomAccesses[i][1] = second;
         }
 
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
@@ -369,11 +394,14 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testOffloadReadInvalidEntryIds() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
@@ -392,9 +420,11 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testDeleteOffloaded() throws Exception {
+        @Cleanup
         ReadHandle readHandle = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
         UUID uuid = UUID.randomUUID();
 
+        @Cleanup
         BlobStoreManagedLedgerOffloader offloader = getOffloader();
 
         // verify object exist after offload
@@ -411,6 +441,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
     @Test
     public void testDeleteOffloadedFail() throws Exception {
         String failureString = "fail deleteOffloaded";
+        @Cleanup
         ReadHandle readHandle = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
         UUID uuid = UUID.randomUUID();
 
@@ -420,6 +451,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
             .doThrow(new RuntimeException(failureString))
             .when(spiedBlobStore).removeBlobs(any(), any());
 
+        @Cleanup
         BlobStoreManagedLedgerOffloader offloader = getOffloader(spiedBlobStore);
 
         try {
@@ -451,6 +483,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
         Mockito.doReturn(1234L).when(readHandle).getId();
 
         UUID uuid = UUID.randomUUID();
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         try {
@@ -463,6 +496,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testReadUnknownDataVersion() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
         BlobStoreManagedLedgerOffloader offloader = getOffloader();
 
@@ -502,6 +536,7 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testReadUnknownIndexVersion() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
         BlobStoreManagedLedgerOffloader offloader = getOffloader();
 
@@ -539,17 +574,22 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testReadEOFException() throws Throwable {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
-        toTest.readAsync(0, toTest.getLastAddConfirmed()).get();
+        @Cleanup
+        LedgerEntries ledgerEntries = toTest.readAsync(0, toTest.getLastAddConfirmed()).get();
 
         try {
-            toTest.readAsync(0, 0).get();
+            @Cleanup
+            LedgerEntries ledgerEntries2 = toTest.readAsync(0, 0).get();
         } catch (Exception e) {
             Assert.fail("Get unexpected exception when reading entries", e);
         }
@@ -557,7 +597,9 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test(timeOut = 600000)  // 10 minutes.
     public void testScanLedgers() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
@@ -585,15 +627,19 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testReadWithAClosedLedgerHandler() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 1);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
+        @Cleanup
         ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
         long lac = toTest.getLastAddConfirmed();
-        toTest.readAsync(0, lac).get();
+        @Cleanup
+        LedgerEntries ledgerEntries = toTest.readAsync(0, lac).get();
         toTest.closeAsync().get();
         try {
             toTest.readAsync(0, lac).get();
@@ -608,11 +654,14 @@ public class BlobStoreManagedLedgerOffloaderTest extends BlobStoreManagedLedgerO
 
     @Test
     public void testReadNotExistLedger() throws Exception {
+        @Cleanup
         ReadHandle toWrite = buildReadHandle(DEFAULT_BLOCK_SIZE, 3);
+        @Cleanup
         LedgerOffloader offloader = getOffloader();
 
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
+        @Cleanup
         ReadHandle offloadRead = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         assertEquals(offloadRead.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 


### PR DESCRIPTION
### Motivation

Fixing Netty ByteBuf leaks in test code is needed for executing the plan explained in [Enhancing Pulsar CI with Netty leak detection and reporting](https://lists.apache.org/thread/fh63hg31womzr64bc7djv3sovgcx6z99). The Pulsar CI Netty leak detection and reporting solution was added in #24272.

While working on this PR, I found a real production code issue. That is fixed in a separate PR, #24331.

### Modifications

- Fix ByteBuf leaks in these tests
  - ManagedLedgerTest
  - TripleLongPriorityQueueTest
  - BlobStoreManagedLedgerOffloaderStreamingTest
  - BlobStoreManagedLedgerOffloaderTest

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->