### PR TITLE
[improve][admin] Expose per ledger props to PersistentTopic.getInternalStats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4577,6 +4577,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                 }
                             }
                         }
+                        if (li.getPropertiesCount() > 0) {
+                            Map<String, String> properties = new HashMap<>(li.getPropertiesCount());
+                            for (MLDataFormats.KeyValue kv : li.getPropertiesList()) {
+                                properties.put(kv.getKey(), kv.getValue());
+                            }
+                            info.properties = properties;
+                        }
                         stats.ledgers.add(info);
                     });
                     statFuture.complete(stats);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -24,11 +24,13 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.net.URL;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ServerErrorException;
 
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -42,6 +44,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.CursorStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.slf4j.Logger;
@@ -123,11 +126,23 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         }
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        ManagedLedger ledger = topic.getManagedLedger();
+        long firstLedgerId = ledger.getLedgersInfo().firstKey();
+        ledger.asyncAddLedgerProperty(firstLedgerId, "foo", "bar").get();
+
         PersistentTopicInternalStats internalStats = topic.getInternalStats(true).get();
         assertNotNull(internalStats.ledgers.get(0).metadata);
         // For the mock test, the default ensembles is ["192.0.2.1:1234","192.0.2.2:1234","192.0.2.3:1234"]
         // The registered bookie ID is 192.168.1.1:5000
         assertTrue(internalStats.ledgers.get(0).underReplicated);
+
+        for (ManagedLedgerInternalStats.LedgerInfo ledgerInfo : internalStats.ledgers) {
+            if (ledgerInfo.ledgerId == firstLedgerId) {
+                Map<String, String> properties = ledgerInfo.properties;
+                assertNotNull(properties);
+                assertEquals(properties.get("foo"), "bar");
+            }
+        }
 
         CursorStats cursor = internalStats.cursors.get(subscriptionName);
         assertEquals(cursor.numberOfEntriesSinceFirstNotAckedMessage, numberOfMsgs);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -81,6 +81,7 @@ public class ManagedLedgerInternalStats {
         public boolean offloaded;
         public String metadata;
         public boolean underReplicated;
+        public Map<String, String> properties;
     }
 
     /**


### PR DESCRIPTION
### Motivation

In https://github.com/apache/pulsar/pull/24076, we introduced per-ledger properties to ML, it should be exposed to internalStats to help track potential issue.

### Modifications

Expose per ledger props to PersistentTopic.getInternalStats

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
