### PR TITLE
[fix][ml] Fix ManagedCursorImpl.individualDeletedMessages concurrent issue

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -641,6 +641,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
             recoverIndividualDeletedMessages(positionInfo.getIndividualDeletedMessagesList());
         } else if (positionInfo.getIndividualDeletedMessageRangesCount() > 0) {
+            lock.writeLock().lock();
             List<LongListMap> rangeList = positionInfo.getIndividualDeletedMessageRangesList();
             try {
                 Map<Long, long[]> rangeMap = rangeList.stream().collect(Collectors.toMap(LongListMap::getKey,
@@ -664,6 +665,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             } catch (Exception e) {
                 log.warn("[{}]-{} Failed to recover individualDeletedMessages from serialized data", ledger.getName(),
                         name, e);
+            } finally {
+                lock.writeLock().unlock();
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3260,9 +3260,12 @@ public class ManagedCursorImpl implements ManagedCursor {
          */
         if (getConfig().isUnackedRangesOpenCacheSetEnabled() && getConfig().isPersistIndividualAckAsLongArray()) {
             try {
+                lock.readLock().lock();
                 internalRanges = individualDeletedMessages.toRanges(getConfig().getMaxUnackedRangesToPersist());
             } catch (Exception e) {
                 log.warn("[{}]-{} Failed to serialize individualDeletedMessages", ledger.getName(), name, e);
+            } finally {
+                lock.readLock().unlock();
             }
         }
         if (internalRanges != null && !internalRanges.isEmpty()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3259,8 +3259,8 @@ public class ManagedCursorImpl implements ManagedCursor {
          * and deserialization error.
          */
         if (getConfig().isUnackedRangesOpenCacheSetEnabled() && getConfig().isPersistIndividualAckAsLongArray()) {
+            lock.readLock().lock();
             try {
-                lock.readLock().lock();
                 internalRanges = individualDeletedMessages.toRanges(getConfig().getMaxUnackedRangesToPersist());
             } catch (Exception e) {
                 log.warn("[{}]-{} Failed to serialize individualDeletedMessages", ledger.getName(), name, e);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -641,8 +641,8 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (positionInfo.getIndividualDeletedMessagesCount() > 0) {
             recoverIndividualDeletedMessages(positionInfo.getIndividualDeletedMessagesList());
         } else if (positionInfo.getIndividualDeletedMessageRangesCount() > 0) {
-            lock.writeLock().lock();
             List<LongListMap> rangeList = positionInfo.getIndividualDeletedMessageRangesList();
+            lock.writeLock().lock();
             try {
                 Map<Long, long[]> rangeMap = rangeList.stream().collect(Collectors.toMap(LongListMap::getKey,
                         list -> list.getValuesList().stream().mapToLong(i -> i).toArray()));


### PR DESCRIPTION
### Motivation

Fix ManagedCursorImpl.individualDeletedMessages concurrent issue.

```txt
2025-05-22T13:16:55,588 - INFO  - [PulsarTestContext-executor-OrderedExecutor-0-0:PulsarMockBookKeeper] - Creating ledger 6
2025-05-22T13:16:55,592 - WARN  - [PulsarTestContext-executor-OrderedExecutor-0-0:ManagedCursorImpl] - [my-property/my-ns/persistent/my-topic1]-my-subscriber-name Failed to serialize individualDeletedMessages
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at org.roaringbitmap.ArrayContainer.copyBitmapTo(ArrayContainer.java:1136) ~[RoaringBitmap-1.2.0.jar:?]
	at org.roaringbitmap.BitSetUtil.toLongArray(BitSetUtil.java:94) ~[RoaringBitmap-1.2.0.jar:?]
	at org.roaringbitmap.RoaringBitSet.toLongArray(RoaringBitSet.java:216) ~[RoaringBitmap-1.2.0.jar:?]
	at org.apache.pulsar.common.util.collections.OpenLongPairRangeSet.lambda$toRanges$5(OpenLongPairRangeSet.java:266) ~[classes/:?]
	at java.base/java.util.concurrent.ConcurrentSkipListMap.forEach(ConcurrentSkipListMap.java:3030) ~[?:?]
	at org.apache.pulsar.common.util.collections.OpenLongPairRangeSet.toRanges(OpenLongPairRangeSet.java:262) ~[classes/:?]
	at org.apache.bookkeeper.mledger.impl.RangeSetWrapper.toRanges(RangeSetWrapper.java:151) ~[classes/:?]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.persistPositionToLedger(ManagedCursorImpl.java:3263) ~[classes/:?]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.lambda$createNewMetadataLedger$37(ManagedCursorImpl.java:3067) ~[classes/:?]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire$$$capture(CompletableFuture.java:718) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.lambda$doCreateNewMetadataLedger$39(ManagedCursorImpl.java:3115) ~[classes/:?]
```

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
