### PR TITLE
[fix][test] Fix flaky PulsarBrokerStatsClientTest.testTopicInternalStats

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -133,6 +133,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         assertTrue(cursor.active);
 
         producer.close();
+        // Call close to ensure that all acknowledge requests are executed.
         consumer.close();
 
         topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -130,14 +130,20 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         assertTrue(internalStats.ledgers.get(0).underReplicated);
 
         CursorStats cursor = internalStats.cursors.get(subscriptionName);
+        assertTrue(cursor.active);
+
+        producer.close();
+        consumer.close();
+
+        topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+        internalStats = topic.getInternalStats(true).get();
+        cursor = internalStats.cursors.get(subscriptionName);
         assertEquals(cursor.numberOfEntriesSinceFirstNotAckedMessage, numberOfMsgs);
         assertTrue(cursor.totalNonContiguousDeletedMessagesRange > 0
                 && (cursor.totalNonContiguousDeletedMessagesRange) < numberOfMsgs / 2);
         assertFalse(cursor.subscriptionHavePendingRead);
         assertFalse(cursor.subscriptionHavePendingReplayRead);
-        assertTrue(cursor.active);
-        producer.close();
-        consumer.close();
+        assertFalse(cursor.active);
         log.info("-- Exiting {} test --", methodName);
     }
 


### PR DESCRIPTION
### Motivation
<img width="1398" alt="Clipboard_Screenshot_1747912362" src="https://github.com/user-attachments/assets/d0f22d06-2a35-4e3f-b642-5cff6dd950c8" />


This unit test `assertTrue(cursor.totalNonContiguousDeletedMessagesRange > 0 && (cursor.totalNonContiguousDeletedMessagesRange) < numberOfMsgs / 2)` reports an error because the consumer's acknowledge method is implemented one-way and the server may not have processed the ack request yet before `topic.getInternalStats` , so `totalNonContiguousDeletedMessagesRange` is sometimes equal to 0.
https://github.com/apache/pulsar/blob/bdf6277456db9df1618adcd07b588f3a94714796/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java#L616

At the same time, `assertFalse(cursor.subscriptionHavePendingRead)` sometimes goes wrong unless we close the consumer first.



### Modifications 
Optimize assert logic to ensure the robustness of unit tests.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->