### PR TITLE
[fix][test] Fix flaky NegativeAcksTest.testNegativeAcksWithBackoff

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -240,6 +240,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
                 .enableBatching(batching)
+                .batchingMaxPublishDelay(30, TimeUnit.SECONDS)
                 .create();
 
         Set<String> sentMessages = new HashSet<>();
@@ -259,7 +260,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
             Message<String> msg = null;
             for (int j = 0; j < N; j++) {
                 msg = consumer.receive();
-                log.info("Received message {}", msg.getValue());
+                log.info("Received msgId: {}, message {}", msg.getMessageId(), msg.getValue());
                 if (!batching) {
                     consumer.negativeAcknowledge(msg);
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -259,7 +259,8 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         for (int i = 0; i < redeliverCount; i++) {
             Message<String> msg = null;
             for (int j = 0; j < N; j++) {
-                msg = consumer.receive();
+                msg = consumer.receive(10, TimeUnit.SECONDS);
+                assertNotNull(msg);
                 log.info("Received msgId: {}, message {}", msg.getMessageId(), msg.getValue());
                 if (!batching) {
                     consumer.negativeAcknowledge(msg);
@@ -276,7 +277,8 @@ public class NegativeAcksTest extends ProducerConsumerBase {
 
         // All the messages should be received again
         for (int i = 0; i < N; i++) {
-            Message<String> msg = consumer.receive();
+            Message<String> msg = consumer.receive(10, TimeUnit.SECONDS);
+            assertNotNull(msg);
             receivedMessages.add(msg.getValue());
             consumer.acknowledge(msg);
         }


### PR DESCRIPTION
### Motivation
![Clipboard_Screenshot_1747985208](https://github.com/user-attachments/assets/e2c25dee-b50e-4d2b-8cc7-f15dea78928e)


This test sometimes blocks at `consumer.receive()` at line 261. The problem is introduced in this PR https://github.com/apache/pulsar/pull/23986. For batch sending scenarios, the current way of creating producers cannot guarantee that all messages are sent out in one batch. Therefore, for batch messages, executing `consumer。negativeAcknowledge` only once is not enough.



### Modifications 
By adding `batchingMaxPublishDelay` when creating the producer, all messages are guaranteed to be sent together.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->