### PR TITLE
[improve][broker] Enable concurrent processing of pending read Entries to avoid duplicate Reads

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/PendingReadsManager.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl.cache;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
 import io.prometheus.client.Counter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -268,7 +269,7 @@ public class PendingReadsManager {
 
         // this method isn't synchronized since that could lead to deadlocks
         private void readEntriesComplete(List<ReadEntriesCallbackWithContext> callbacks,
-                                                List<EntryImpl> entriesToReturn) {
+                                         List<EntryImpl> entriesToReturn) {
             if (callbacks.size() == 1) {
                 ReadEntriesCallbackWithContext first = callbacks.get(0);
                 if (first.startEntry == key.startEntry
@@ -338,117 +339,67 @@ public class PendingReadsManager {
             FindPendingReadOutcome findBestCandidateOutcome = findPendingRead(key,
                     pendingReadsForLedger, createdByThisThread);
             PendingRead pendingRead = findBestCandidateOutcome.pendingRead;
+
             if (findBestCandidateOutcome.needsAdditionalReads()) {
-                AsyncCallbacks.ReadEntriesCallback wrappedCallback = new AsyncCallbacks.ReadEntriesCallback() {
-                    @Override
-                    public void readEntriesComplete(List<Entry> entries, Object ctx) {
-                        PendingReadKey missingOnLeft = findBestCandidateOutcome.missingOnLeft;
-                        PendingReadKey missingOnRight = findBestCandidateOutcome.missingOnRight;
-                        if (missingOnRight != null && missingOnLeft != null) {
-                            AsyncCallbacks.ReadEntriesCallback readFromLeftCallback =
-                                    new AsyncCallbacks.ReadEntriesCallback() {
-                                @Override
-                                public void readEntriesComplete(List<Entry> entriesFromLeft, Object dummyCtx1) {
-                                    AsyncCallbacks.ReadEntriesCallback readFromRightCallback =
-                                            new AsyncCallbacks.ReadEntriesCallback() {
-                                        @Override
-                                        public void readEntriesComplete(List<Entry> entriesFromRight,
-                                                                        Object dummyCtx2) {
-                                            List<Entry> finalResult =
-                                                    new ArrayList<>(entriesFromLeft.size()
-                                                            + entries.size() + entriesFromRight.size());
-                                            finalResult.addAll(entriesFromLeft);
-                                            finalResult.addAll(entries);
-                                            finalResult.addAll(entriesFromRight);
-                                            callback.readEntriesComplete(finalResult, ctx);
-                                        }
-
-                                        @Override
-                                        public void readEntriesFailed(ManagedLedgerException exception,
-                                                                      Object dummyCtx3) {
-                                            entries.forEach(Entry::release);
-                                            entriesFromLeft.forEach(Entry::release);
-                                            callback.readEntriesFailed(exception, ctx);
-                                        }
-                                    };
-                                    rangeEntryCache.asyncReadEntry0(lh,
-                                            missingOnRight.startEntry, missingOnRight.endEntry,
-                                            shouldCacheEntry, readFromRightCallback, null, false);
-                                }
-
-                                @Override
-                                public void readEntriesFailed(ManagedLedgerException exception, Object dummyCtx4) {
-                                    entries.forEach(Entry::release);
-                                    callback.readEntriesFailed(exception, ctx);
-                                }
-                            };
-                            rangeEntryCache.asyncReadEntry0(lh, missingOnLeft.startEntry, missingOnLeft.endEntry,
-                                    shouldCacheEntry, readFromLeftCallback, null, false);
-                        } else if (missingOnLeft != null) {
-                            AsyncCallbacks.ReadEntriesCallback readFromLeftCallback =
-                                    new AsyncCallbacks.ReadEntriesCallback() {
-
-                                        @Override
-                                        public void readEntriesComplete(List<Entry> entriesFromLeft,
-                                                                        Object dummyCtx5) {
-                                            List<Entry> finalResult =
-                                                    new ArrayList<>(entriesFromLeft.size() + entries.size());
-                                            finalResult.addAll(entriesFromLeft);
-                                            finalResult.addAll(entries);
-                                            callback.readEntriesComplete(finalResult, ctx);
-                                        }
-
-                                        @Override
-                                        public void readEntriesFailed(ManagedLedgerException exception,
-                                                                      Object dummyCtx6) {
-                                            entries.forEach(Entry::release);
-                                            callback.readEntriesFailed(exception, ctx);
-                                        }
-                                    };
-                            rangeEntryCache.asyncReadEntry0(lh, missingOnLeft.startEntry, missingOnLeft.endEntry,
-                                    shouldCacheEntry, readFromLeftCallback, null, false);
-                        } else if (missingOnRight != null) {
-                            AsyncCallbacks.ReadEntriesCallback readFromRightCallback =
-                                    new AsyncCallbacks.ReadEntriesCallback() {
-
-                                        @Override
-                                        public void readEntriesComplete(List<Entry> entriesFromRight,
-                                                                        Object dummyCtx7) {
-                                            List<Entry> finalResult =
-                                                    new ArrayList<>(entriesFromRight.size() + entries.size());
-                                            finalResult.addAll(entries);
-                                            finalResult.addAll(entriesFromRight);
-                                            callback.readEntriesComplete(finalResult, ctx);
-                                        }
-
-                                        @Override
-                                        public void readEntriesFailed(ManagedLedgerException exception,
-                                                                      Object dummyCtx8) {
-                                            entries.forEach(Entry::release);
-                                            callback.readEntriesFailed(exception, ctx);
-                                        }
-                                    };
-                            rangeEntryCache.asyncReadEntry0(lh, missingOnRight.startEntry, missingOnRight.endEntry,
-                                    shouldCacheEntry, readFromRightCallback, null, false);
-                        }
-                    }
-
-                    @Override
-                    public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                        callback.readEntriesFailed(exception, ctx);
-                    }
-                };
-                listenerAdded = pendingRead.addListener(wrappedCallback, ctx, key.startEntry, key.endEntry);
+                CompletableFuture<List<Entry>> readFromMidFuture = new CompletableFuture<>();
+                ReadEntriesCallback presentReadCallback = new ReadEntriesCallback(readFromMidFuture);
+                listenerAdded = pendingRead.addListener(presentReadCallback, ctx, key.startEntry, key.endEntry);
+                if (!listenerAdded) {
+                    continue;
+                }
+                CompletableFuture<List<Entry>> readFromLeftFuture =
+                        recursiveReadMissingEntriesAsync(lh, shouldCacheEntry, findBestCandidateOutcome.missingOnLeft);
+                CompletableFuture<List<Entry>> readFromRightFuture =
+                        recursiveReadMissingEntriesAsync(lh, shouldCacheEntry, findBestCandidateOutcome.missingOnRight);
+                readFromLeftFuture
+                        .thenCombine(readFromMidFuture, (left, mid) -> {
+                            List<Entry> result = new ArrayList<>(left);
+                            result.addAll(mid);
+                            return result;
+                        })
+                        .thenCombine(readFromRightFuture, (combined, right) -> {
+                            combined.addAll(right);
+                            return combined;
+                        })
+                        .whenComplete((finalResult, e) -> {
+                            if (e != null) {
+                                callback.readEntriesFailed(createManagedLedgerException(e), ctx);
+                                releaseEntriesSafely(readFromLeftFuture);
+                                releaseEntriesSafely(readFromMidFuture);
+                                releaseEntriesSafely(readFromRightFuture);
+                            } else {
+                                callback.readEntriesComplete(finalResult, ctx);
+                            }
+                        });
             } else {
                 listenerAdded = pendingRead.addListener(callback, ctx, key.startEntry, key.endEntry);
             }
-
 
             if (createdByThisThread.get()) {
                 CompletableFuture<List<EntryImpl>> readResult = rangeEntryCache.readFromStorage(lh, firstEntry,
                         lastEntry, shouldCacheEntry);
                 pendingRead.attach(readResult);
             }
+        }
+    }
+
+    private CompletableFuture<List<Entry>> recursiveReadMissingEntriesAsync(ReadHandle lh, boolean shouldCacheEntry,
+                                                                            PendingReadKey missingKey) {
+        CompletableFuture<List<Entry>> future;
+        if (missingKey != null) {
+            future = new CompletableFuture<>();
+            ReadEntriesCallback callback = new ReadEntriesCallback(future);
+            rangeEntryCache.asyncReadEntry0(lh, missingKey.startEntry, missingKey.endEntry,
+                    shouldCacheEntry, callback, null, false);
+        } else {
+            future = CompletableFuture.completedFuture(Collections.emptyList());
+        }
+        return future;
+    }
+
+    private void releaseEntriesSafely(CompletableFuture<List<Entry>> future) {
+        if (!future.isCompletedExceptionally()) {
+            future.thenAccept(entries -> entries.forEach(Entry::release));
         }
     }
 
@@ -459,5 +410,24 @@ public class PendingReadsManager {
 
     void invalidateLedger(long id) {
         cachedPendingReads.remove(id);
+    }
+
+    static class ReadEntriesCallback implements AsyncCallbacks.ReadEntriesCallback {
+
+        private final CompletableFuture<List<Entry>> completableFuture;
+
+        public ReadEntriesCallback(CompletableFuture<List<Entry>> completableFuture) {
+            this.completableFuture = completableFuture;
+        }
+
+        @Override
+        public void readEntriesComplete(List<Entry> entries, Object ctx) {
+            completableFuture.complete(entries);
+        }
+
+        @Override
+        public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+            completableFuture.completeExceptionally(exception);
+        }
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

When I read source code about "skip send duplicate read to BK", I found it's not concurrent. 
Firstly, it would be faster if it's concurrrent. Secondly, it may still send duplicate read to BK.
For example:

1. read  [10, 70]
2. read [80, 100]
3. read [10, 100]

The third read will be splitted into [10,70], [71, 79], [80, 100]. The three reads will be performed in sequence. If [80, 100] pending reads is done before [10, 70] , there will be another [80, 100] read send to BookKeeper later.  At the same time, it will be faster if we send [71, 79] read to BK earlier.


<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

I have add three futures in `org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager.PendingRead#readEntriesComplete`. Each future
will read a  range of entry concurrently. At last aggregate all the results of future.

### Verifying this change

- [X] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

