### PR TITLE
[fix][broker] Ignore metadata changes when broker is not in the Started state

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2532,9 +2532,19 @@ public class BrokerService implements Closeable {
 
 
     private void handleMetadataChanges(Notification n) {
-        if (!pulsar.isRunning()) {
+        if (pulsar.getState() != PulsarService.State.Started) {
+            String brokerId;
+            try {
+                brokerId = pulsar.getBrokerId();
+            } catch (Exception ex) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to get brokerId", ex);
+                }
+                // If broker is not running, we cannot get brokerId.
+                brokerId = "unknown";
+            }
             // Ignore metadata changes when broker is not running
-            log.info("Ignoring metadata change since broker is not running (id={}, state={}) {}", pulsar.getBrokerId(),
+            log.info("Ignoring metadata change since broker is not running (id={}, state={}) {}", brokerId,
                     pulsar.getState(), n);
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24312

### Motivation

The `brokerId` was previously initialized in the `start` method, after the `BrokerService` had already started. This could lead to a `NullPointerException` if the `brokerId` is accessed during the early stages of startup. 

### Modifications

- Only handle the metadata changes when broker is fully started. 
- Failed to retrieve `brokerId`, please fall back to `unknown`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->