### PR TITLE
[fix][io] Acknowledge RabbitMQ message after processing the message successfully

### DIFF
--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -96,11 +96,23 @@ public class RabbitMQSource extends PushSource<byte[]> {
         @Override
         public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
                 throws IOException {
-            source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body));
             long deliveryTag = envelope.getDeliveryTag();
-            // positively acknowledge all deliveries up to this delivery tag to reduce network traffic
-            // since manual message acknowledgments are turned on by default
-            this.getChannel().basicAck(deliveryTag, true);
+            source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body, () -> {
+                // positively acknowledge all deliveries up to this delivery tag to reduce network traffic
+                // since manual message acknowledgments are turned on by default
+                try {
+                    this.getChannel().basicAck(deliveryTag, true);
+                } catch (IOException e) {
+                    logger.error("Error while acknowledging envelope {}.", envelope, e);
+                }
+            }, () -> {
+                // negatively acknowledge this delivery tag to RabbitMQ
+                try {
+                    this.getChannel().basicNack(deliveryTag, false, true);
+                } catch (IOException e) {
+                    logger.error("Error while negatively acknowledging envelope {}.", envelope, e);
+                }
+            }));
         }
     }
 
@@ -108,5 +120,17 @@ public class RabbitMQSource extends PushSource<byte[]> {
     private static class RabbitMQRecord implements Record<byte[]> {
         private final Optional<String> key;
         private final byte[] value;
+        private final Runnable ackFunction;
+        private final Runnable nackFunction;
+
+        @Override
+        public void ack() {
+            ackFunction.run();
+        }
+
+        @Override
+        public void fail() {
+            nackFunction.run();
+        }
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -98,10 +98,9 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 throws IOException {
             long deliveryTag = envelope.getDeliveryTag();
             source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body, () -> {
-                // positively acknowledge all deliveries up to this delivery tag to reduce network traffic
-                // since manual message acknowledgments are turned on by default
+                // acknowledge this delivery tag to RabbitMQ
                 try {
-                    this.getChannel().basicAck(deliveryTag, true);
+                    this.getChannel().basicAck(deliveryTag, false);
                 } catch (IOException e) {
                     logger.error("Error while acknowledging envelope {}.", envelope, e);
                 }


### PR DESCRIPTION
Fixes #24353

### Motivation

See #24346 

### Modifications

- add `ackFunction` and `failFunction` to the internal `RabbitMQRecord` class and use these functions in the `ack` and `fail` implementations of the `Record` interface.

- switch to use individual acks towards RabbitMQ since there's no benefit of using "multi" acks when every message will get acked in any case

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->