### PR TITLE
[improve][broker]Improve the log when encountered in-flight read limitation

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -179,7 +179,9 @@ public class InflightReadsLimiter implements AutoCloseable {
             if (queuedHandles.size() >= maxReadsInFlightAcquireQueueSize) {
                 log.warn("Failed to queue handle for acquiring permits: {}, creationTime: {}, remainingBytes:{},"
                     + " maxReadsInFlightAcquireQueueSize:{}, pending-queue-size: {}, please increase broker"
-                    + " config managedLedgerMaxReadsInFlightPermitsAcquireQueueSize",
+                    + " config managedLedgerMaxReadsInFlightPermitsAcquireQueueSize and confirm the configuration of"
+                    + " managedLedgerMaxReadsInFlightSizeInMB and"
+                    + " managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis are suitable.",
                     permits, handle.creationTime, remainingBytes, maxReadsInFlightAcquireQueueSize, queuedHandles.size());
                 return Optional.of(new Handle(0, handle.creationTime, false));
             } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -182,7 +182,8 @@ public class InflightReadsLimiter implements AutoCloseable {
                     + " config managedLedgerMaxReadsInFlightPermitsAcquireQueueSize and confirm the configuration of"
                     + " managedLedgerMaxReadsInFlightSizeInMB and"
                     + " managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis are suitable.",
-                    permits, handle.creationTime, remainingBytes, maxReadsInFlightAcquireQueueSize, queuedHandles.size());
+                    permits, handle.creationTime, remainingBytes, maxReadsInFlightAcquireQueueSize,
+                    queuedHandles.size());
                 return Optional.of(new Handle(0, handle.creationTime, false));
             } else {
                 queuedHandles.offer(new QueuedHandle(handle, callback));

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -177,8 +177,10 @@ public class InflightReadsLimiter implements AutoCloseable {
             return Optional.of(new Handle(maxReadsInFlightSize, handle.creationTime, true));
         } else {
             if (queuedHandles.size() >= maxReadsInFlightAcquireQueueSize) {
-                log.warn("Failed to queue handle for acquiring permits: {}, creationTime: {}, remainingBytes:{}",
-                        permits, handle.creationTime, remainingBytes);
+                log.warn("Failed to queue handle for acquiring permits: {}, creationTime: {}, remainingBytes:{},"
+                    + " maxReadsInFlightAcquireQueueSize:{}, pending-queue-size: {}, please increase broker"
+                    + " config managedLedgerMaxReadsInFlightPermitsAcquireQueueSize",
+                    permits, handle.creationTime, remainingBytes, maxReadsInFlightAcquireQueueSize, queuedHandles.size());
                 return Optional.of(new Handle(0, handle.creationTime, false));
             } else {
                 queuedHandles.offer(new QueuedHandle(handle, callback));
@@ -223,15 +225,17 @@ public class InflightReadsLimiter implements AutoCloseable {
     }
 
     private void handleTimeout(QueuedHandle queuedHandle) {
-        if (log.isDebugEnabled()) {
-            log.debug("timed out queued permits: {}, creationTime: {}, remainingBytes:{}",
-                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes);
-        }
+        log.warn("timed out queued permits: {}, creationTime: {}, remainingBytes:{}, acquireTimeoutMillis: {}. Please"
+                + " review whether the BK read requests is fast enough or broker config"
+                + " managedLedgerMaxReadsInFlightSizeInMB and managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis"
+                + " are suitable",
+                queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes, acquireTimeoutMillis);
         try {
             queuedHandle.callback.accept(new Handle(0, queuedHandle.handle.creationTime, false));
         } catch (Exception e) {
-            log.error("Error in callback of timed out queued permits: {}, creationTime: {}, remainingBytes:{}",
-                    queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes, e);
+            log.error("Error in callback of timed out queued permits: {}, creationTime: {}, remainingBytes:{},"
+                + " acquireTimeoutMillis: {}",
+                queuedHandle.handle.permits, queuedHandle.handle.creationTime, remainingBytes, acquireTimeoutMillis, e);
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -339,7 +339,6 @@ public class RangeEntryCacheImpl implements EntryCache {
                             + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
                             + "managedLedgerMaxReadsInFlightSizeInMB)", lh.getId(), getName(),
                     estimatedReadSize, numberOfEntries);
-            log.warn(message);
             originalCallback.readEntriesFailed(new ManagedLedgerException.TooManyRequestsException(message), ctx);
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -332,14 +332,12 @@ public class RangeEntryCacheImpl implements EntryCache {
                                                final ReadEntriesCallback originalCallback, Object ctx,
                                                InflightReadsLimiter.Handle handle, long estimatedReadSize) {
         if (!handle.success()) {
-            String message = String.format(
-                    "Couldn't acquire enough permits on the max reads in flight limiter to read from ledger "
-                            + "%d, %s, estimated read size %d bytes for %d entries (check "
-                            + "managedLedgerMaxReadsInFlightSizeInMB, "
-                            + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
-                            + "managedLedgerMaxReadsInFlightPermitsAcquireQueueSize)", lh.getId(), getName(),
-                    estimatedReadSize, numberOfEntries);
-            log.error(message);
+            String message = String.format("Couldn't acquire enough permits on the max reads in flight limiter to read"
+                + " from ledger %d, %s, estimated read size %d bytes for %d entries. because the pending read requests"
+                + " queue is full, please increase the broker config"
+                + " managedLedgerMaxReadsInFlightPermitsAcquireQueueSize.",
+                lh.getId(), getName(), estimatedReadSize, numberOfEntries);
+            log.warn(message);
             originalCallback.readEntriesFailed(new ManagedLedgerException.TooManyRequestsException(message), ctx);
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -332,11 +332,13 @@ public class RangeEntryCacheImpl implements EntryCache {
                                                final ReadEntriesCallback originalCallback, Object ctx,
                                                InflightReadsLimiter.Handle handle, long estimatedReadSize) {
         if (!handle.success()) {
-            String message = String.format("Couldn't acquire enough permits on the max reads in flight limiter to read"
-                + " from ledger %d, %s, estimated read size %d bytes for %d entries. because the pending read requests"
-                + " queue is full, please increase the broker config"
-                + " managedLedgerMaxReadsInFlightPermitsAcquireQueueSize.",
-                lh.getId(), getName(), estimatedReadSize, numberOfEntries);
+            String message = String.format(
+                    "Couldn't acquire enough permits on the max reads in flight limiter to read from ledger "
+                            + "%d, %s, estimated read size %d bytes for %d entries (check "
+                            + "managedLedgerMaxReadsInFlightPermitsAcquireQueueSize (direct config), "
+                            + "managedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis and "
+                            + "managedLedgerMaxReadsInFlightSizeInMB)", lh.getId(), getName(),
+                    estimatedReadSize, numberOfEntries);
             log.warn(message);
             originalCallback.readEntriesFailed(new ManagedLedgerException.TooManyRequestsException(message), ctx);
             return;


### PR DESCRIPTION
### Motivation & Modifications

- When reaching the pending read queue size limitation
  - Highlight the config `managedLedgerMaxReadsInFlightPermitsAcquireQueueSize` when the broker reaches the limitation that the pending read queue is full.
  - Instead of printing an error-level log,  print a warning-level log.
- Additional print queue size and the limit threshold when the pending read queue is full
- Print warning-level log if reached in-flight messages size is reached, instead of debug-level.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x