### PR TITLE
[fix][broker] expose consumer name for partitioned topic stats

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -3334,8 +3334,6 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         topicStats.getPublishers().forEach(p -> assertTrue(p.isSupportsPartialProducer()));
     }
 
-
-
     @Test(dataProvider = "topicType")
     public void testPartitionedStatsAggregationByProducerNamePerPartition(String topicType) throws Exception {
         restartClusterIfReused();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -155,6 +155,7 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.drainingHashes = stats.drainingHashes;
         this.keyHashRanges = stats.keyHashRanges;
         this.keyHashRangeArrays = stats.keyHashRangeArrays;
+        this.consumerName = stats.consumerName;
         return this;
     }
 


### PR DESCRIPTION
### Motivation

Expose the consumer name for partitioned topic stats

### Modifications

- Add consumerName for `ConsumerStatsImpl`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->