### PR TITLE
[fix][broker]Fix deadlock when compaction and topic deletion execute concurrently

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl.ENTRY_LATENCY_BUCKETS_USEC;
 import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -114,6 +115,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
 
     protected final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
+    @VisibleForTesting
+    @Getter
     protected volatile boolean isFenced;
 
     protected final HierarchyTopicPolicies topicPolicies;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -270,6 +270,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private volatile double lastUpdatedAvgPublishRateInMsg = 0;
     private volatile double lastUpdatedAvgPublishRateInByte = 0;
 
+    @Getter
     private volatile boolean isClosingOrDeleting = false;
 
     private ScheduledFuture<?> fencedTopicMonitoringTask = null;
@@ -1510,6 +1511,28 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
 
             fenceTopicToCloseOrDelete(); // Avoid clients reconnections while deleting
+            // Wait compaction to avoid a deadlock below:
+            // 1. thread-compaction : create a raw reader.
+            // 2. thread-topic-deleting : mark topic as deleting, and disconnect clients that includes compaction
+            //      reader.
+            // 3. thread-compaction: the raw reader attempts to reconnect due to the disconnection in step "2-1".
+            // 4. thread-topic-deleting: unsubscribe all subscriptions, which contains "__compaction".
+            // 5. thread-topic-deleting: deleting "__compaction" cursor will wait for the in-progress compaction task.
+            // 6. thread-compaction: the raw read can not connect successfully anymore because the topic was marked as
+            //    "fenced && isDeleting".
+            // 7. deadlock: "thread-topic-deleting" waiting for compaction task being finished, thread-compaction
+            //    continuously reconnects.
+            // To solve the issue, let "thread-topic-deleting" release the fencing&deleting state, wait for the
+            // compaction task being finished. Since "thread-topic-deleting" never release "lock.writeLock", the broker
+            // will not trigger a new compaction task.
+            if (currentCompaction != null && !currentCompaction.isDone()) {
+                unfenceTopicToResume();
+                return currentCompaction
+                    .thenCompose(__ -> delete(failIfHasSubscriptions, failIfHasBacklogs, closeIfClientsConnected))
+                    .whenComplete((__, ex) -> {
+                        lock.writeLock().unlock();
+                    });
+            }
             // Mark the progress of close to prevent close calling concurrently.
             this.closeFutures =
                     new CloseFutures(new CompletableFuture(), new CompletableFuture(), new CompletableFuture());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
@@ -33,23 +33,24 @@ public interface RawReader {
      */
 
     static CompletableFuture<RawReader> create(PulsarClient client, String topic, String subscription) {
-        return create(client, topic, subscription, true);
+        return create(client, topic, subscription, true, true);
     }
 
     static CompletableFuture<RawReader> create(PulsarClient client, String topic, String subscription,
-                                               boolean createTopicIfDoesNotExist) {
+                                               boolean createTopicIfDoesNotExist, boolean retryOnRecoverableErrors) {
         CompletableFuture<Consumer<byte[]>> future = new CompletableFuture<>();
         RawReader r =
-                new RawReaderImpl((PulsarClientImpl) client, topic, subscription, future, createTopicIfDoesNotExist);
+                new RawReaderImpl((PulsarClientImpl) client, topic, subscription, future, createTopicIfDoesNotExist,
+                        retryOnRecoverableErrors);
         return future.thenApply(__ -> r);
     }
 
     static CompletableFuture<RawReader> create(PulsarClient client,
                                                ConsumerConfigurationData<byte[]> consumerConfiguration,
-                                               boolean createTopicIfDoesNotExist) {
+                                               boolean createTopicIfDoesNotExist, boolean retryOnRecoverableErrors) {
         CompletableFuture<Consumer<byte[]>> future = new CompletableFuture<>();
         RawReader r = new RawReaderImpl((PulsarClientImpl) client,
-                consumerConfiguration, future, createTopicIfDoesNotExist);
+                consumerConfiguration, future, createTopicIfDoesNotExist, retryOnRecoverableErrors);
         return future.thenApply(__ -> r);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
@@ -135,6 +136,13 @@ public class RawReaderImpl implements RawReader {
             );
             incomingRawMessages = new GrowableArrayBlockingQueue<>();
             pendingRawReceives = new ConcurrentLinkedQueue<>();
+        }
+
+        protected boolean isUnrecoverableError(Throwable t) {
+            if (t instanceof PulsarClientException.ServiceNotReadyException) {
+                return false;
+            }
+            return super.isUnrecoverableError(t);
         }
 
         void tryCompletePending() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
@@ -56,7 +56,7 @@ public abstract class Compactor {
     }
 
     public CompletableFuture<Long> compact(String topic) {
-        return RawReader.create(pulsar, topic, COMPACTION_SUBSCRIPTION, false).thenComposeAsync(
+        return RawReader.create(pulsar, topic, COMPACTION_SUBSCRIPTION, false, false).thenComposeAsync(
                 this::compactAndCloseReader, scheduler);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerCloseTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.testng.Assert.assertTrue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -76,7 +81,7 @@ public class ConsumerCloseTest extends ProducerConsumerBase {
                         .subscribe();
                 Assert.fail("Should have thrown an exception");
             } catch (PulsarClientException e) {
-                Assert.assertTrue(e.getCause() instanceof InterruptedException);
+                assertTrue(e.getCause() instanceof InterruptedException);
             }
         });
         startConsumer.start();
@@ -87,5 +92,40 @@ public class ConsumerCloseTest extends ProducerConsumerBase {
         Awaitility.await().ignoreExceptions().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             Assert.assertEquals(clientImpl.consumersCount(), 0);
         });
+    }
+
+    @Test
+    public void testReceiveWillDoneAfterClosedConsumer() throws Exception {
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        String subName = "test-sub";
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.topics().createSubscription(tpName, subName, MessageId.earliest);
+        ConsumerImpl<byte[]> consumer =
+                (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(tpName).subscriptionName(subName).subscribe();
+        CompletableFuture<Message<byte[]>> future = consumer.receiveAsync();
+        consumer.close();
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(future.isDone());
+        });
+    }
+
+    @Test
+    public void testReceiveWillDoneAfterTopicDeleted() throws Exception {
+        String namespace = "public/default";
+        admin.namespaces().setAutoTopicCreation(namespace, AutoTopicCreationOverride.builder()
+                .allowAutoTopicCreation(false).build());
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        String subName = "test-sub";
+        admin.topics().createNonPartitionedTopic(tpName);
+        admin.topics().createSubscription(tpName, subName, MessageId.earliest);
+        ConsumerImpl<byte[]> consumer =
+                (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(tpName).subscriptionName(subName).subscribe();
+        CompletableFuture<Message<byte[]>> future = consumer.receiveAsync();
+        admin.topics().delete(tpName, true);
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(future.isDone());
+        });
+        // cleanup.
+        admin.namespaces().removeAutoTopicCreation(namespace);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -27,12 +27,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -44,6 +49,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -54,12 +60,17 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.awaitility.Awaitility;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pulsar.client.impl.RawReaderImpl.DEFAULT_RECEIVER_QUEUE_SIZE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 @Test(groups = "broker-impl")
 @Slf4j
@@ -215,7 +226,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         consumerConfiguration.setReadCompacted(true);
         consumerConfiguration.setSubscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
         consumerConfiguration.setAckReceiptEnabled(true);
-        RawReader reader = RawReader.create(pulsarClient, consumerConfiguration, true).get();
+        RawReader reader = RawReader.create(pulsarClient, consumerConfiguration, true, true).get();
 
         MessageId lastMessageId = reader.getLastMessageIdAsync().get();
         while (true) {
@@ -547,11 +558,62 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         String topic2 = "persistent://my-property/my-ns/" + BrokerTestUtil.newUniqueName("reader");
         try {
-            reader = RawReader.create(pulsarClient, topic2, subscription, false).get();
+            reader = RawReader.create(pulsarClient, topic2, subscription, false, true).get();
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getCause() instanceof PulsarClientException.TopicDoesNotExistException);
         }
         reader.closeAsync().join();
+    }
+
+    @Test(timeOut = 60000)
+    public void testReconnectsWhenServiceNotReady() throws Exception {
+        String topic = "persistent://my-property/my-ns/" + BrokerTestUtil.newUniqueName("reader");
+        String subscriptionName = "s1";
+        admin.topics().createNonPartitionedTopic(topic);
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
+
+        // Inject a delay event for topic close, which leads to that the raw-reader will get a ServiceNotReady error,
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).get().get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedCursor compactionCursor = ml.openCursor(subscriptionName);
+        ManagedCursor spyCompactionCursor = spy(compactionCursor);
+        CountDownLatch delayCloseCursorSignal = new CountDownLatch(1);
+        Answer answer = new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                delayCloseCursorSignal.await();
+                return invocationOnMock.callRealMethod();
+            }
+        };
+        doAnswer(answer).when(spyCompactionCursor).asyncClose(any(AsyncCallbacks.CloseCallback.class), any());
+        ml.getCursors().removeCursor(subscriptionName);
+        ml.getCursors().add(spyCompactionCursor, ml.getLastConfirmedEntry());
+
+        // Unload topic after reader is connected.
+        // The topic state comes to "fenced", then RawReader will get a ServiceNotReady error,
+        CompletableFuture<RawMessage> msgFuture = reader.readNextAsync();
+        CompletableFuture<Void> unloadFuture = admin.topics().unloadAsync(topic);
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertTrue(persistentTopic.isFenced());
+        });
+
+        // Verify: RasReader reconnected after that the unloading is finished, and it can consume successfully.
+        delayCloseCursorSignal.countDown();
+        unloadFuture.get();
+        MessageIdImpl msgIdSent = (MessageIdImpl) producer.send("msg");
+        RawMessage rawMessage = msgFuture.get();
+        Assert.assertNotNull(rawMessage);
+        MessageIdImpl msgIdReceived = (MessageIdImpl) rawMessage.getMessageId();
+        Assert.assertEquals(msgIdSent.getLedgerId(), msgIdReceived.getLedgerId());
+        Assert.assertEquals(msgIdSent.getEntryId(), msgIdReceived.getEntryId());
+
+        // cleanup.
+        rawMessage.close();;
+        producer.close();
+        reader.closeAsync().get();
+        admin.topics().delete(topic, false);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -20,7 +20,11 @@ package org.apache.pulsar.compaction;
 
 import static org.apache.pulsar.broker.BrokerTestUtil.newUniqueName;
 import static org.apache.pulsar.broker.BrokerTestUtil.spyWithoutRecordingInvocations;
+import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -60,9 +64,11 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.api.OpenBuilder;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -101,6 +107,8 @@ import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -2318,6 +2326,67 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         consumer.close();
         producer.close();
+    }
+
+    @Test(timeOut = 120 * 1000)
+    public void testConcurrentCompactionAndTopicDelete() throws Exception {
+        final String topicName = newUniqueName("persistent://my-tenant/my-ns/tp");
+        admin.topics().createNonPartitionedTopic(topicName);
+        // Load up the topic.
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+
+        // Inject a reading delay to the compaction task,
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        ManagedCursor compactionCursor = ml.openCursor(COMPACTION_SUBSCRIPTION);
+        ManagedCursor spyCompactionCursor = spy(compactionCursor);
+        CountDownLatch delayReadSignal = new CountDownLatch(1);
+        Answer answer = new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                log.info("===> Compaction reading is stuck");
+                delayReadSignal.await();
+                log.info("===> Compaction reading finished");
+                return invocationOnMock.callRealMethod();
+            }
+        };
+        doAnswer(answer).when(spyCompactionCursor).asyncReadEntries(anyInt(),
+                any(AsyncCallbacks.ReadEntriesCallback.class), any(), any(Position.class));
+        doAnswer(answer).when(spyCompactionCursor).asyncReadEntries(anyInt(), anyLong(),
+                any(AsyncCallbacks.ReadEntriesCallback.class), any(), any(Position.class));
+        doAnswer(answer).when(spyCompactionCursor).asyncReadEntriesOrWait(anyInt(), anyLong(),
+                any(AsyncCallbacks.ReadEntriesCallback.class), any(), any(Position.class));
+        ml.getCursors().removeCursor(COMPACTION_SUBSCRIPTION);
+        ml.getCursors().add(spyCompactionCursor, ml.getLastConfirmedEntry());
+
+        // Trigger a compaction task.
+        for (int i = 0; i < 2000; i++) {
+            producer.newMessage().key(String.valueOf(i)).value(String.valueOf(i)).send();
+        }
+        ConsumerImpl<String> consumer = (ConsumerImpl<String>) pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName).readCompacted(true).subscriptionName("s1")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscribe();
+        persistentTopic.triggerCompaction();
+        Awaitility.await().untilAsserted(() -> {
+           assertEquals(persistentTopic.getSubscriptions().get(COMPACTION_SUBSCRIPTION).getConsumers().size(), 1);
+        });
+
+        // Since we injected a delay reading, the compaction task started and not finish yet.
+        // Call topic deletion, they two tasks are concurrently executed.
+        producer.close();
+        consumer.close();
+        CompletableFuture<Void> deleteTopicFuture = persistentTopic.deleteForcefully();
+
+        // Remove the injection after 3s.
+        Thread.sleep(3000);
+        delayReadSignal.countDown();
+
+        // Verify: topic deletion is successfully executed.
+        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(deleteTopicFuture.isDone());
+        });
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -2345,9 +2345,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         Answer answer = new Answer() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                log.info("===> Compaction reading is stuck");
                 delayReadSignal.await();
-                log.info("===> Compaction reading finished");
                 return invocationOnMock.callRealMethod();
             }
         };

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -363,6 +363,17 @@ public class PulsarClientException extends IOException {
     }
 
     /**
+     * Relates to server-side errors:
+     *  ServiceUnitNotReadyException, TopicFencedException and SubscriptionFencedException.
+     */
+    public static class ServiceNotReadyException extends LookupException {
+
+        public ServiceNotReadyException(String msg) {
+            super(msg);
+        }
+    }
+
+    /**
      * Connect exception thrown by Pulsar client.
      */
     public static class ConnectException extends PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -1353,7 +1353,7 @@ public class ClientCnx extends PulsarHandler {
         case PersistenceError:
             return new PulsarClientException.BrokerPersistenceException(errorMsg);
         case ServiceNotReady:
-            return new PulsarClientException.LookupException(errorMsg);
+            return new PulsarClientException.ServiceNotReadyException(errorMsg);
         case TooManyRequests:
             return new PulsarClientException.TooManyRequestsException(errorMsg);
         case ProducerBlockedQuotaExceededError:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -64,7 +64,8 @@ public class ConnectionHandler {
          * @apiNote If the returned future is completed exceptionally, reconnectLater will be called.
          */
         CompletableFuture<Void> connectionOpened(ClientCnx cnx);
-        default void connectionFailed(PulsarClientException e) {
+        default boolean connectionFailed(PulsarClientException e) {
+            return true;
         }
     }
 
@@ -142,22 +143,24 @@ public class ConnectionHandler {
     }
 
     private Void handleConnectionError(Throwable exception) {
+        boolean toRetry = true;
         try {
             log.warn("[{}] [{}] Error connecting to broker: {}",
                     state.topic, state.getHandlerName(), exception.getMessage());
             if (exception instanceof PulsarClientException) {
-                connection.connectionFailed((PulsarClientException) exception);
+                toRetry = connection.connectionFailed((PulsarClientException) exception);
             } else if (exception.getCause() instanceof PulsarClientException) {
-                connection.connectionFailed((PulsarClientException) exception.getCause());
+                toRetry = connection.connectionFailed((PulsarClientException) exception.getCause());
             } else {
-                connection.connectionFailed(new PulsarClientException(exception));
+                toRetry = connection.connectionFailed(new PulsarClientException(exception));
             }
         } catch (Throwable throwable) {
             log.error("[{}] [{}] Unexpected exception after the connection",
                     state.topic, state.getHandlerName(), throwable);
         }
-
-        reconnectLater(exception);
+        if (toRetry) {
+            reconnectLater(exception);
+        }
         return null;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -64,6 +64,13 @@ public class ConnectionHandler {
          * @apiNote If the returned future is completed exceptionally, reconnectLater will be called.
          */
         CompletableFuture<Void> connectionOpened(ClientCnx cnx);
+
+        /**
+         *
+         * @param e What error happened when tries to get a connection
+         * @return If "true", the connection handler will retry to get a connection, otherwise, it stops to get a new
+         * connection. If it returns "false", you should release resources that consumers/producers occupied.
+         */
         default boolean connectionFailed(PulsarClientException e) {
             return true;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1002,7 +1002,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     protected boolean isUnrecoverableError(Throwable t) {
-        return !(t instanceof TopicDoesNotExistException) && !(t instanceof IllegalStateException);
+        // TopicDoesNotExistException: topic has been deleted.
+        // NotFoundException: topic has been deleted.
+        // IllegalStateException: consumer has been closed.
+        return (t instanceof TopicDoesNotExistException) || (t instanceof IllegalStateException)
+                || (t instanceof PulsarClientException.NotFoundException);
     }
 
     protected void closeWhenReceivedUnrecoverableError(Throwable t, ClientCnx cnx) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -985,18 +985,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                             + "with subscription name %s when connecting to the broker",
                                     topicName.toString(), subscription)));
                     client.cleanupConsumer(this);
-                } else if (e.getCause() instanceof TopicDoesNotExistException) {
-                    // The topic was deleted after the consumer was created, and we're
-                    // not allowed to recreate the topic. This can happen in few cases:
-                    //  * Regex consumer getting error after topic gets deleted
-                    //  * Regular consumer after topic is manually delete and with
-                    //    auto-topic-creation set to false
-                    // No more retries are needed in this case.
-                    setState(State.Failed);
-                    closeConsumerTasks();
-                    client.cleanupConsumer(this);
-                    log.warn("[{}][{}] Closed consumer because topic does not exist anymore {}",
-                            topic, subscription, cnx.channel().remoteAddress());
+                } else if (isUnrecoverableError(e.getCause())) {
+                    closeWhenReceivedUnrecoverableError(e.getCause(), cnx);
                 } else {
                     // consumer was subscribed and connected but we got some error, keep trying
                     future.completeExceptionally(e.getCause());
@@ -1009,6 +999,30 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             });
         }
         return future;
+    }
+
+    protected boolean isUnrecoverableError(Throwable t) {
+        return !(t instanceof TopicDoesNotExistException) && !(t instanceof IllegalStateException);
+    }
+
+    protected void closeWhenReceivedUnrecoverableError(Throwable t, ClientCnx cnx) {
+        // The topic was deleted after the consumer was created, and we're
+        // not allowed to recreate the topic. This can happen in few cases:
+        //  * Regex consumer getting error after topic gets deleted
+        //  * Regular consumer after topic is manually delete and with
+        //    auto-topic-creation set to false
+        // No more retries are needed in this case.
+        final String cnxStr = cnx == null ? "null" : String.valueOf(cnx.channel().remoteAddress());
+        log.warn("[{}][{}] {} Closed consumer because get an error that does not support to retry: {} {}",
+                topic, subscription, cnxStr, t.getClass().getName(), t.getMessage());
+        closeAsync().whenComplete((__, ex) -> {
+            if (ex == null) {
+                setState(State.Failed);
+                return;
+            }
+            log.error("[{}][{}] {} Failed to close consumer after got an error that does not support to retry: {} {}",
+                topic, subscription, cnxStr, t.getClass().getName(), t.getMessage());
+        });
     }
 
     protected void consumerIsReconnectedToBroker(ClientCnx cnx, int currentQueueSize) {
@@ -1091,7 +1105,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     @Override
-    public void connectionFailed(PulsarClientException exception) {
+    public boolean connectionFailed(PulsarClientException exception) {
         boolean nonRetriableError = !PulsarClientException.isRetriableError(exception);
         boolean timeout = System.currentTimeMillis() > lookupDeadline;
         if (nonRetriableError || timeout) {
@@ -1107,10 +1121,18 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 closeConsumerTasks();
                 deregisterFromClientCnx();
                 client.cleanupConsumer(this);
+                return false;
+            } else {
+                Throwable actError = FutureUtil.unwrapCompletionException(exception);
+                if (isUnrecoverableError(actError)) {
+                    closeWhenReceivedUnrecoverableError(actError, null);
+                    return false;
+                }
             }
         } else {
             previousExceptionCount.incrementAndGet();
         }
+        return true;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -974,6 +974,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
                 if (e.getCause() instanceof PulsarClientException
                         && PulsarClientException.isRetriableError(e.getCause())
+                        && !isUnrecoverableError(e.getCause())
                         && System.currentTimeMillis() < SUBSCRIBE_DEADLINE_UPDATER.get(ConsumerImpl.this)) {
                     future.completeExceptionally(e.getCause());
                 } else if (!subscribeFuture.isDone()) {
@@ -1001,6 +1002,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         return future;
     }
 
+    /***
+     * Different consumer implementation can define its additional unrecoverable error.
+     */
     protected boolean isUnrecoverableError(Throwable t) {
         // TopicDoesNotExistException: topic has been deleted.
         // NotFoundException: topic has been deleted.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
@@ -98,6 +98,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
                 log.info("[{}] Watcher creation failed for {} with non-retriable error {}",
                         topic, name, exception.getMessage());
                 deregisterFromClientCnx();
+                return false;
             }
         } else {
             previousExceptionCount.incrementAndGet();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
@@ -89,7 +89,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
     }
 
     @Override
-    public void connectionFailed(PulsarClientException exception) {
+    public boolean connectionFailed(PulsarClientException exception) {
         boolean nonRetriableError = !PulsarClientException.isRetriableError(exception);
         if (nonRetriableError) {
             exception.setPreviousExceptionCount(previousExceptionCount);
@@ -102,6 +102,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
         } else {
             previousExceptionCount.incrementAndGet();
         }
+        return true;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -136,6 +136,7 @@ public class TransactionMetaStoreHandler extends HandlerState
                             + "timeout", transactionCoordinatorId, exception);
                 }
                 setState(State.Failed);
+                return false;
             }
         } else {
             previousExceptionCount.getAndIncrement();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -122,7 +122,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     @Override
-    public void connectionFailed(PulsarClientException exception) {
+    public boolean connectionFailed(PulsarClientException exception) {
         boolean nonRetriableError = !PulsarClientException.isRetriableError(exception);
         boolean timeout = System.currentTimeMillis() > lookupDeadline;
         if (nonRetriableError || timeout) {
@@ -140,6 +140,7 @@ public class TransactionMetaStoreHandler extends HandlerState
         } else {
             previousExceptionCount.getAndIncrement();
         }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
### Motivation



#### **Issue 1**: deadlock when compaction and topic deletion execute concurrently
Reproduction steps of the deadlock( see also the new test `testConcurrentCompactionAndTopicDelete` )
1. `thread-compaction`: create a raw reader.
2. `thread-topic-deleting`: mark the topic as deleted and disconnect clients, including the compaction reader.
3. `thread-compaction`: The raw reader attempts to reconnect due to the disconnection in step "2-1".
4. `thread-topic-deleting`: unsubscribe all subscriptions that contain "__compaction".
5. `thread-topic-deleting`: deleting "__compaction" cursor will wait for the in-progress compaction task.
6. `thread-compaction`: the raw read can not connect successfully anymore because the topic was marked as  "fenced && isDeleting".
7. `deadlock`: "thread-topic-deleting" waiting for compaction task being finished, thread-compaction continuously reconnects.

Note:
- If the `thread-compaction` is stuck when the first phase of compaction calling `reader.readNextAsync()` at step 6, the deadlock can be solved after `{brokerServiceCompactionPhaseOneLoopTimeInSeconds)` seconds
- But regarding other scenarios, such as `reader.getLastMessageIdAsync`... the deadlock will persist forever.
 
You can reproduce the issue by the new test `testConcurrentCompactionAndTopicDelete`

---

#### **Issue 2-1**: The responded compostable future of `Consumer.receiveAsync()` never complete if the topic is deleted

**Background**: 
- Enabling `topic auto creation`: Client triggers a new topic creation if users delete a topic with `-f`.
- Disabling `topic auto creation`: Client stops retrying reconnection and sets the consumer's state to `Failed`.
- Issue: regarding the scenario "Disabling topic-auto-creation", the client set the consumer's state to `Failed`, but it does not trigger a completion for the pending receive requests, leading to the pending receive future never completing. See https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L988-L999

```java
setState(State.Failed);
closeConsumerTasks();
client.cleanupConsumer(this);
// Issue: it should call "failPendingReceive()" also
```

You can reproduce the issue by the new test `testReceiveWillDoneAfterTopicDeleted`


#### **Issue 2-2**: resource leak that contains a dead letter producer and a retry letter producer.
Regarding `issue 2-1`, the client also forgot to release the related dead letter producer and the retry letter producer, which also caused a resource leak. Since there are other issues that prevent the new test from passing, I will write a separate PR to add the test to cover this case, which also contains another fix.

---

#### **Issue 3**: Even though the client received a `TopicNotFound` error, it continuously retries.
Root cause: Pulsar client prevents retrying when it receives a `TopicNotFound` error from the `Subscribe` command, but the `TopicNotFound` can also be received from the process `get broker connections of the target topic`.

You can reproduce the issue by the new test `testReceiveWillDoneAfterTopicDeleted`

---

### Modifications

- Regarding issue 1 - a deadlock error, closes the RawReader if the compaction task received a ServiceNotReady error, which happens when a topic/subscription is fenced, or the topic/namespace is loading/unloading. Since the RawReader is an internal API, this change is safe.
- Regarding issue 2 - consumer forgets to complete the pending read request when it stops reconnecting, calls `consumer.close()` instead of calling a part of the stats modifying, which is more complete.
- Regarding issue 3 - continues to reconnect even though it received a TopicNotFound error, stops reconnecting after receiving an unrecovered error from grabbing new connections, and closes consumers/producers.

---

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

---

### Matching PR in forked repository

PR in forked repository: x
