### PR TITLE
[improve][test] Default-enable bk http in test setup

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarCluster.java
@@ -210,7 +210,8 @@ public class PulsarCluster {
                             .withEnv("PULSAR_PREFIX_diskUsageLwmThreshold", "0.97")
                             .withEnv("nettyMaxFrameSizeBytes", String.valueOf(spec.maxMessageSize))
                             .withEnv("ledgerDirectories", "data/bookkeeper/" + name + "/ledgers")
-                            .withEnv("journalDirectory", "data/bookkeeper/" + name + "/journal");
+                            .withEnv("journalDirectory", "data/bookkeeper/" + name + "/journal")
+                            .withEnv("httpServerEnabled", "true");
                     if (spec.bookkeeperEnvs != null) {
                         bookieContainer.withEnv(spec.bookkeeperEnvs);
                     }


### PR DESCRIPTION
### Motivation

bk http is an important feature. During bk upgrades, the http server may stop working unexpectedly.
A similar issue occurred in https://github.com/apache/pulsar/pull/20070, which didn't include tests to cover bk http functionality.

### Modifications

- Enabled bk http by default in the test configuration to ensure the http server is started and functional.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->