### PR TITLE
[improve][ml]Release idle offloaded read handle only the ref count is 0

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerHandle.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/OffloadedLedgerHandle.java
@@ -26,4 +26,8 @@ public interface OffloadedLedgerHandle {
     default long lastAccessTimestamp() {
         return -1;
     }
+
+    default int getPendingRead() {
+        return 0;
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2751,10 +2751,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             ledgerCache.forEach((ledgerId, ledger) -> {
                 if (ledger.isDone() && !ledger.isCompletedExceptionally()) {
                     ReadHandle readHandle = ledger.join();
-                    if (readHandle instanceof OffloadedLedgerHandle) {
-                        long lastAccessTimestamp = ((OffloadedLedgerHandle) readHandle).lastAccessTimestamp();
-                        if (lastAccessTimestamp >= 0) {
-                            long delta = now - lastAccessTimestamp;
+                    if (readHandle instanceof OffloadedLedgerHandle offloadedLedgerHandle) {
+                        int pendingRead = offloadedLedgerHandle.getPendingRead();
+                        if (pendingRead == 0) {
+                            long delta = now - offloadedLedgerHandle.lastAccessTimestamp();
                             if (delta >= inactiveOffloadedLedgerEvictionTimeMs) {
                                 log.info("[{}] Offloaded ledger {} can be released ({} ms elapsed since last access)",
                                         name, ledgerId, delta);
@@ -2764,6 +2764,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                         "[{}] Offloaded ledger {} cannot be released ({} ms elapsed since last access)",
                                         name, ledgerId, delta);
                             }
+                        } else if (pendingRead < 0) {
+                            log.error("[{}] Offloaded ledger {} went to a wrong state because its pending read is a"
+                                + " negative value {}. Please raise an issue to https://github.com/apache/pulsar", name,
+                                ledgerId, pendingRead);
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/19783 introduced a feature: release idle offloaded ledger handle to release the direct memory occupied. But it left a potential issue, which has been discussed [here](https://github.com/apache/pulsar/pull/19783#discussion_r2086201906), and it can happen this way

| time/thread | release idle ledger handle | `ledgerHandle.readAsync` |
| --- | --- | --- |
| 1 | | `touch()`, update `lastAccessTimestamp` |
| 2 | | append the reading request into `executor.queue` |
| 3 | | the `executor` is very busy, leading to delayed executions of `ledgerHandle.readAsync` |
| 4 | Check how long the ledger handle has been idled |
| 5 | release the ledger handle |
| 6 | | `ledgerHandle.readAsync` execute eventually, but the ledger handle has been closed |

Since users can modify the threshold of marking the ledger handle as `idle` by the configuration `managedLedgerInactiveOffloadedLedgerEvictionTimeSeconds`, it may increase the probability of the issue happening

### Modifications

- Added a ref count named `pendingRead` to record how many pending reading requests are in progress, Pulsar release ledger handle when `pendingRead` is `0,` and has idled for enough time
- Instead of updating "lastAccessTimestamp" when a reading is starting, update it when a reading task is finished


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
