### PR TITLE
[fix] Don't use ForkJoinPool when using CompletableFuture.thenXXXAsync

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -218,7 +218,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
@@ -243,7 +243,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
@@ -325,7 +325,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/MetadataStoreCacheLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/MetadataStoreCacheLoader.java
@@ -63,7 +63,7 @@ public class MetadataStoreCacheLoader implements Closeable {
     public void init() throws Exception {
         loadReportResources.getStore().registerListener((n) -> {
             if (LOADBALANCE_BROKERS_ROOT.equals(n.getPath()) && NotificationType.ChildrenChanged.equals(n.getType())) {
-                loadReportResources.getChildrenAsync(LOADBALANCE_BROKERS_ROOT).thenApplyAsync((brokerNodes)->{
+                loadReportResources.getChildrenAsync(LOADBALANCE_BROKERS_ROOT).thenApplyAsync(brokerNodes -> {
                     updateBrokerList(brokerNodes).thenRun(() -> {
                         log.info("Successfully updated broker info {}", brokerNodes);
                     }).exceptionally(ex -> {
@@ -71,7 +71,7 @@ public class MetadataStoreCacheLoader implements Closeable {
                         return null;
                     });
                     return null;
-                }).exceptionally(ex -> {
+                }, orderedExecutor.chooseThread()).exceptionally(ex -> {
                     log.warn("Error updating broker info after broker list changed", ex);
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -307,11 +307,13 @@ public class PersistentTopicsBase extends AdminResource {
                         for (int i = 0; i < numPartitions; i++) {
                             TopicName topicNamePartition = topicName.getPartition(i);
                             future = future.thenComposeAsync(unused ->
-                                    getAuthorizationService().revokePermissionAsync(topicNamePartition, role));
+                                    getAuthorizationService().revokePermissionAsync(topicNamePartition, role),
+                                    pulsar().getOrderedExecutor().chooseThread(role));
                         }
                     }
                     return future.thenComposeAsync(unused ->
-                                    getAuthorizationService().revokePermissionAsync(topicName, role))
+                                    getAuthorizationService().revokePermissionAsync(topicName, role),
+                                    pulsar().getOrderedExecutor().chooseThread(role))
                                  .thenAccept(unused -> asyncResponse.resume(Response.noContent().build()));
                 })
                 ).exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -638,7 +638,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                         Set<String> candidateBrokers = availableBrokerCandidates.keySet();
                         return getBrokerSelectionStrategy().select(candidateBrokers, bundle, context);
                     });
-                });
+                }, pulsar.getOrderedExecutor().chooseThread(bundle.toString()));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -331,7 +331,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 return getTopicPoliciesAsync(topicName, type);
             }
             return CompletableFuture.completedFuture(p.getRight());
-        });
+        }, pulsarService.getOrderedExecutor().chooseThread(topicName.toString()));
     }
 
     public void addOwnedNamespaceBundleAsync(NamespaceBundle namespaceBundle) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClient.java
@@ -174,7 +174,7 @@ public class PulsarRegistrationClient implements RegistrationClient {
                         return waitForAll(bookieInfoUpdated)
                                 .thenApply(___ -> bookieIds);
                     }
-                })
+                }, executor)
                 .thenApply(s -> new Versioned<>(s, Version.NEW));
     }
 

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -127,7 +127,7 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
                         }
                     };
                 return FutureUtils.value(entries);
-            }).whenCompleteAsync((res, exception) -> {
+            }, bk.executor).whenCompleteAsync((res, exception) -> {
                     if (exception != null) {
                         cb.readComplete(PulsarMockBookKeeper.getExceptionCode(exception),
                                 PulsarMockLedgerHandle.this, null, ctx);

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
@@ -70,7 +70,7 @@ class PulsarMockReadHandle implements ReadHandle {
                         ledgerEntries);
             }
             return FutureUtils.value(ledgerEntries);
-        });
+        }, bk.executor);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Currently, in some cases when don't pass an executor to `CompletableFuture`.`thenComposeAsync/thenApplyAsync/thenAcceptAsync`, which will use `ForkJoinPool.commonPool`.

Which maybe lead to 3 problems:
1. `ForkJoinPool.commonPool` is managed by JVM, it is out of Pulsar manage.
2. The default thread num of `ForkJoinPool.commonPool` is `Math.max(1, Runtime.getRuntime().availableProcessors() - 1)`, if the broker is in heavy workload, it's not enough.
3. The callback methods can be executed in different thread everytime when we call `thenComposeAsync/thenApplyAsync/thenAcceptAsync`, it maybe lead to potential thread safety issue.


### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
