### PR TITLE
[fix][ml]Revert a behavior change of releasing idle offloaded ledger handle: only release idle BlobStoreBackedReadHandle

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2753,7 +2753,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     ReadHandle readHandle = ledger.join();
                     if (readHandle instanceof OffloadedLedgerHandle offloadedLedgerHandle) {
                         int pendingRead = offloadedLedgerHandle.getPendingRead();
-                        if (pendingRead == 0) {
+                        long lastAccessTimestamp = offloadedLedgerHandle.lastAccessTimestamp();
+                        if (lastAccessTimestamp >= 0 && pendingRead == 0) {
                             long delta = now - offloadedLedgerHandle.lastAccessTimestamp();
                             if (delta >= inactiveOffloadedLedgerEvictionTimeMs) {
                                 log.info("[{}] Offloaded ledger {} can be released ({} ms elapsed since last access)",

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -135,8 +135,8 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle, OffloadedLedge
         // is better.
         PENDING_READ_UPDATER.incrementAndGet(this);
         promise.whenComplete((__, ex) -> {
-            PENDING_READ_UPDATER.decrementAndGet(BlobStoreBackedReadHandleImpl.this);
             lastAccessTimestamp = System.currentTimeMillis();
+            PENDING_READ_UPDATER.decrementAndGet(BlobStoreBackedReadHandleImpl.this);
         });
         executor.execute(() -> {
             if (state == State.Closed) {


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/24381 changed the behavior below:
- original: Pulsar only releases the offloaded ledger handle that is  typed `BlobStoreBackedReadHandle`
- after #24381, Pulsar will release the offloaded ledger handle immediately if its type is not `BlobStoreBackedReadHandle`, because the method `lastAccessTimestamp()` always returns `-1` if its type is not `BlobStoreBackedReadHandle`

### Modifications
- Revert the behavior change.
- Modify `lastAccessTimestamp` first, and modify `pendingReading` second, to avoid getting a new `pendingReading` and an older `lastAccessTimestamp`, which leads to an incorrect ledger handle invalidation.

### Potential issue

The following issue still exists. I will push a new PR to fix it in the future.

| time/thread | release idle ledger handle | `ledgerHandle.readAsync` |
| --- | --- | --- |
| 1 | Ledger handle has been idle for a long time |
| 2 | Start to release ledger handle |
| 3 | | a new reading request comes in |
| 4 | closed ledger handle |
| 5 | | get a ledger closed error |


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
