### PR TITLE
[improve][broker] Add managedCursor/LedgerInfoCompressionType settings to broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1302,6 +1302,29 @@ managedLedgerMaxReadsInFlightSizeInMB=0
 # MetadataStore.
 managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 
+# ManagedCursorInfo compression type, option values (NONE, LZ4, ZLIB, ZSTD, SNAPPY).
+# If value is NONE, then save the ManagedCursorInfo bytes data directly without compression.
+# Using compression reduces the size of persistent cursor (subscription) metadata. This enables using a higher
+# managedLedgerMaxUnackedRangesToPersistInMetadataStore value and reduces the overall metadata stored in
+# the metadata store such as ZooKeeper.
+managedCursorInfoCompressionType=NONE
+
+# ManagedCursorInfo compression size threshold (bytes), only compress metadata when origin size more then this value.
+# 0 means compression will always apply.
+managedCursorInfoCompressionThresholdInBytes=16384
+
+# ManagedLedgerInfo compression type, option values (NONE, LZ4, ZLIB, ZSTD, SNAPPY).
+# If value is invalid or NONE, then save the ManagedLedgerInfo bytes data directly without compression.
+# Using compression reduces the size of the persistent topic metadata. When a topic contains a large number of
+# individual ledgers in BookKeeper or tiered storage, compression helps prevent the metadata size from exceeding
+# the maximum size of a metadata store entry (ZNode in ZooKeeper). This also reduces the overall metadata stored
+# in the metadata store such as ZooKeeper.
+managedLedgerInfoCompressionType=NONE
+
+# ManagedLedgerInfo compression size threshold (bytes), only compress metadata when origin size more then this value.
+# 0 means compression will always apply.
+managedLedgerInfoCompressionThresholdInBytes=16384
+
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -832,6 +832,29 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # MetadataStore.
 managedLedgerMaxUnackedRangesToPersistInMetadataStore=1000
 
+# ManagedCursorInfo compression type, option values (NONE, LZ4, ZLIB, ZSTD, SNAPPY).
+# If value is NONE, then save the ManagedCursorInfo bytes data directly without compression.
+# Using compression reduces the size of persistent cursor (subscription) metadata. This enables using a higher
+# managedLedgerMaxUnackedRangesToPersistInMetadataStore value and reduces the overall metadata stored in
+# the metadata store such as ZooKeeper.
+managedCursorInfoCompressionType=NONE
+
+# ManagedCursorInfo compression size threshold (bytes), only compress metadata when origin size more then this value.
+# 0 means compression will always apply.
+managedCursorInfoCompressionThresholdInBytes=16384
+
+# ManagedLedgerInfo compression type, option values (NONE, LZ4, ZLIB, ZSTD, SNAPPY).
+# If value is invalid or NONE, then save the ManagedLedgerInfo bytes data directly without compression.
+# Using compression reduces the size of the persistent topic metadata. When a topic contains a large number of
+# individual ledgers in BookKeeper or tiered storage, compression helps prevent the metadata size from exceeding
+# the maximum size of a metadata store entry (ZNode in ZooKeeper). This also reduces the overall metadata stored
+# in the metadata store such as ZooKeeper.
+managedLedgerInfoCompressionType=NONE
+
+# ManagedLedgerInfo compression size threshold (bytes), only compress metadata when origin size more then this value.
+# 0 means compression will always apply.
+managedLedgerInfoCompressionThresholdInBytes=16384
+
 # Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false


### PR DESCRIPTION
### Motivation

To reduce the size of ZNodes, there's ManagedCursorInfo compression which was introduced in [PIP-146](https://github.com/apache/pulsar/issues/14529). ManagedLedgerInfo compression was introduced earlier, in PR #11490.
ManagedCursorInfo compression can enable using a higher `managedLedgerMaxUnackedRangesToPersist` and `managedLedgerMaxUnackedRangesToPersistInMetadataStore` settings.
ManagedLedgerInfo compression is required for a very large amount of BookKeeper or tiered storage ledgers for a single topic.  Both settings reduce the size of metadata storage which will reduce overall ZooKeeper memory usage. After enabling compression, existing entries won't be compressed until they are modified.

### Modifications

- add the settings to `broker.conf` and `standalone.conf` so that it's easier to enable the settings. Without settings in `broker.conf`, it's necessary to use `PULSAR_PREFIX_` syntax with Pulsar's Helm chart and docker image when using the `apply-config-from-env.py` solution that is used to apply environment variables to `broker.conf`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->