### PR TITLE
[fix][transaction] Fix deadlock when loading transaction buffer snapshot

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -301,6 +301,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     private TransactionPendingAckStoreProvider transactionPendingAckStoreProvider;
     private final ExecutorProvider transactionExecutorProvider;
+    private final ExecutorProvider transactionSnapshotRecoverExecutorProvider;
     private final MonotonicClock monotonicClock;
     private String brokerId;
     private final CompletableFuture<Void> readyForIncomingRequestsFuture = new CompletableFuture<>();
@@ -371,8 +372,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         if (config.isTransactionCoordinatorEnabled()) {
             this.transactionExecutorProvider = new ExecutorProvider(this.getConfiguration()
                     .getNumTransactionReplayThreadPoolSize(), "pulsar-transaction-executor");
+            this.transactionSnapshotRecoverExecutorProvider = new ExecutorProvider(this.getConfiguration()
+                    .getNumTransactionReplayThreadPoolSize(), "pulsar-transaction-snapshot-recover");
         } else {
             this.transactionExecutorProvider = null;
+            this.transactionSnapshotRecoverExecutorProvider = null;
         }
 
         this.ioEventLoopGroup = EventLoopUtil.newEventLoopGroup(config.getNumIOThreads(), config.isEnableBusyWait(),
@@ -660,6 +664,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             if (transactionExecutorProvider != null) {
                 transactionExecutorProvider.shutdownNow();
+            }
+            if (transactionSnapshotRecoverExecutorProvider != null) {
+                transactionSnapshotRecoverExecutorProvider.shutdownNow();
             }
             if (transactionTimer != null) {
                 transactionTimer.stop();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -87,7 +87,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     public CompletableFuture<Position> recoverFromSnapshot() {
         final var future = new CompletableFuture<Position>();
         final var pulsar = topic.getBrokerService().getPulsar();
-        pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
+        pulsar.getTransactionSnapshotRecoverExecutorProvider().getExecutor(this).execute(() -> {
             try {
                 final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
                         .getTableView().readLatest(topic.getName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -228,7 +228,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     public CompletableFuture<Position> recoverFromSnapshot() {
         final var pulsar = topic.getBrokerService().getPulsar();
         final var future = new CompletableFuture<Position>();
-        pulsar.getTransactionExecutorProvider().getExecutor(this).execute(() -> {
+        pulsar.getTransactionSnapshotRecoverExecutorProvider().getExecutor(this).execute(() -> {
             try {
                 final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
                         .getTxnBufferSnapshotIndexService().getTableView().readLatest(topic.getName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
@@ -58,6 +58,16 @@ public class TableView<T> {
     }
 
     public T readLatest(String topic) throws Exception {
+        try {
+            return internalReadLatest(topic);
+        } catch (Exception e) {
+            final var namespace = TopicName.get(topic).getNamespaceObject();
+            readers.remove(namespace);
+            throw e;
+        }
+    }
+
+    private T internalReadLatest(String topic) throws Exception {
         final var reader = getReader(topic);
         while (wait(reader.hasMoreEventsAsync(), "has more events")) {
             final var msg = wait(reader.readNextAsync(), "read message");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/SimpleCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/SimpleCache.java
@@ -41,7 +41,7 @@ public class SimpleCache<K, V> {
 
         boolean tryExpire() {
             if (System.currentTimeMillis() >= deadlineMs) {
-                expireCallback.accept(value);
+                cancel();
                 return true;
             } else {
                 return false;
@@ -50,6 +50,10 @@ public class SimpleCache<K, V> {
 
         void updateDeadline() {
             deadlineMs = System.currentTimeMillis() + timeoutMs;
+        }
+
+        void cancel() {
+            expireCallback.accept(value);
         }
     }
 
@@ -79,5 +83,15 @@ public class SimpleCache<K, V> {
         newValue.updateDeadline();
         cache.put(key, newValue);
         return newValue.value;
+    }
+
+    public void remove(final K key) {
+        final ExpirableValue<V> value;
+        synchronized (this) {
+            value = cache.remove(key);
+        }
+        if (value != null) {
+            value.cancel();
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -178,7 +178,9 @@ public class TransactionTest extends TransactionTestBase {
 
     @BeforeClass
     protected void setup() throws Exception {
-       setUpBase(NUM_BROKERS, NUM_PARTITIONS, NAMESPACE1 + "/test", 0);
+        // Use a single transaction thread to reproduce possible deadlock easily
+        conf.setNumTransactionReplayThreadPoolSize(1);
+        setUpBase(NUM_BROKERS, NUM_PARTITIONS, NAMESPACE1 + "/test", 0);
     }
 
     @AfterClass(alwaysRun = true)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -180,6 +180,7 @@ public class TransactionTest extends TransactionTestBase {
     protected void setup() throws Exception {
         // Use a single transaction thread to reproduce possible deadlock easily
         conf.setNumTransactionReplayThreadPoolSize(1);
+        conf.setManagedLedgerNumSchedulerThreads(1);
         setUpBase(NUM_BROKERS, NUM_PARTITIONS, NAMESPACE1 + "/test", 0);
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/1376

### Motivation

https://github.com/apache/pulsar/pull/23062 introduces a possible deadlock. `transactionExecutorProvider` is actually used by two different places:
- `TopicTransactionBuffer`
- `PendingAckHandleImpl`

https://github.com/apache/pulsar/blob/e0d7faa087f7ae6895f139b89ef333c8211f71d3/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java#L244

https://github.com/apache/pulsar/blob/e0d7faa087f7ae6895f139b89ef333c8211f71d3/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java#L175

The future of `PendingAckHandleImpl` is completed in this executor, while the executor might be executing the blocking snapshot replay task. When there is only 1 thread in `transactionExecutorProvider`, the reader requires the dispatcher for messages, while the `PendingAckHandleImpl` object cannot complete its future because the `transaction-executor` thread is occupied.

There is another bug that when the reader fails with a non-retriable error, it will still exist in the cache at least for 60 seconds. See https://github.com/apache/pulsar/blob/e0d7faa087f7ae6895f139b89ef333c8211f71d3/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java#L45

### Modifications

Reduce `numTransactionReplayThreadPoolSize` and `managedLedgerNumSchedulerThreads` to 1. After that, `TransactionTest` will always fail at `testCreateTransactionSystemTopic` when creating a consumer

There are two major fixes:
1. Add a separated executor service for the blocking snapshot replay task.
2. Record the exception when the consumer's state becomes `Fail` and fail the `getLastMessageId` RPC immediately after that. In `TableView#readLatest`, remove the reader from cache if `readToLatest` fail.

With the 1st fix, `testCreateTransactionSystemTopic` will succeed but `TransactionTest` will still fail in `testDeleteNamespace`. It's because the previous `testCreateTransactionSystemTopic` recreated the `tnx/ns1` namespace but the reader will keep reconnecting with `Fail` state to get the last message id. The 2nd fix will fix it.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
