### PR TITLE
[fix][ml]Received more than once callback when calling cursor.delete

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -5290,6 +5290,34 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testCallbackTimes() throws Exception {
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("testCallbackTimes");
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ml.openCursor("c1");
+        Position position1 = ml.addEntry(new byte[1]);
+        Position position2 = ml.addEntry(new byte[2]);
+        AtomicInteger executedCallbackTimes = new AtomicInteger();
+        cursor.asyncDelete(Arrays.asList(position1, position2), new DeleteCallback() {
+            @Override
+            public void deleteComplete(Object ctx) {
+                executedCallbackTimes.incrementAndGet();
+            }
+
+            @Override
+            public void deleteFailed(ManagedLedgerException exception, Object ctx) {
+                executedCallbackTimes.incrementAndGet();
+            }
+        }, new Object());
+        // Verify that the executed count of callback is "1".
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(executedCallbackTimes.get() > 0);
+        });
+        Thread.sleep(2000);
+        assertEquals(executedCallbackTimes.get(), 1);
+        // cleanup.
+        ml.delete();
+    }
+
+    @Test
     void testForceCursorRecovery() throws Exception {
         TestPulsarMockBookKeeper bk = new TestPulsarMockBookKeeper(executor);
         factory.shutdown();


### PR DESCRIPTION
### Motivation

**About cursor deleting, there are two cases**
- `scenario-A`: Acked nothing, because all positions have been acknowledged before.
- `scenario-B`: Acked some position, then it will try to `mark-deleted`.
  - `scenario-B1`:  Acked some positions, but `individualDeletedMessages` became empty after combining ranges in the method `setAcknowledgedPosition`, 
  - `scenario-B2`: Acked some positions, and `individualDeletedMessages` was still not empty.

**Triggering callbacks**
- Regarding the `scenario-A`, Cursor will skip calling `mark-deleted`, because it is meaningless.
- Regarding the `scenario-B`, Cursor will call `mark-deleted`, which will trigger a `callback`.

**Issue**
Regarding the `scenario-B1`, the Cursor triggers twice the callbacks.
- The first time: calls the callback if `individualDeletedMessages` is empty. https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2479

```java
boolean empty = individualDeletedMessages.isEmpty();
if (empty) {
    callback.deleteComplete(ctx);
}
```
- The first time: calls the callback after calling `mark-deleted`. https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2499

```java
internalAsyncMarkDelete(newMarkDeletePosition, properties, new MarkDeleteCallback() {
        @Override
        public void markDeleteComplete(Object ctx) {
            callback.deleteComplete(ctx);
        }
}
```

### Modifications

To confirm the scenario matches `scenario-A`, rather than confirming `individualDeletedMessages.isEmpty`, use a specific variable to record it.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x