### PR TITLE
[fix][ml] Cursor ignores the position that has an empty ack-set if disabled deletionAtBatchIndexLevelEnabled

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2390,7 +2390,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     continue;
                 }
                 long[] ackSet = AckSetStateUtil.getAckSetArrayOrNull(position);
-                if (ackSet == null) {
+                if (ackSet == null || ackSet.length == 0) {
                     if (batchDeletedIndexes != null) {
                         batchDeletedIndexes.remove(position);
                     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -5192,6 +5192,21 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testDeleteBatchedMessageWithEmptyAckSet() throws Exception {
+        ManagedLedgerConfig managedLedgerConfig = new ManagedLedgerConfig();
+        managedLedgerConfig.setDeletionAtBatchIndexLevelEnabled(false);
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("testDeleteBatchedMessageWithEmptyAckSet",
+            managedLedgerConfig);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ml.openCursor("c1");
+        Position position = ml.addEntry(new byte[1]);
+        Position positionWithEmptyAckSet =
+                AckSetStateUtil.createPositionWithAckSet(position.getLedgerId(), position.getEntryId(), new long[]{});
+        cursor.delete(positionWithEmptyAckSet);
+        assertEquals(cursor.markDeletePosition, position);
+        ml.delete();
+    }
+
+    @Test
     public void testEstimateEntryCountBySize() throws Exception {
         final String mlName = "ml-" + UUID.randomUUID().toString().replaceAll("-", "");
         ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open(mlName);


### PR DESCRIPTION
### Motivation

After disabling `deletionAtBatchIndexLevelEnabled`, `ManagedCursorImpl` ignores positions that have an empty `ackSet` when calling `cursor.delete`, which leads to the caller acknowledging nothing.

And the Transaction task will acknowledge positions that have an empty `ackSet` after all single messages of a batch were acknowledged, 

- https://github.com/apache/pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/PositionAckSetUtil.java#L52 
```java
    public static void andAckSet(Position currentPosition, Position otherPosition) {
        if (currentPosition == null || otherPosition == null) {
            return;
        }
        AckSetState currentAckSetState = AckSetStateUtil.getAckSetState(currentPosition);
        AckSetState otherAckSetState = AckSetStateUtil.getAckSetState(otherPosition);
        // The ackSet will be an empty long array after the latest single message of a batch was acked.
        currentAckSetState.setAckSet(andAckSet(currentAckSetState.getAckSet(), otherAckSetState.getAckSet()));
    }
```

- https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java#L804

```java
private void handleIndividualAck(TxnID txnID, List<MutablePair<Position, Integer>> positions) {
     ...
     if (pendingAckMessageForCurrentTxn.containsKey(position)) {
          PositionAckSetUtil.andAckSet(pendingAckMessageForCurrentTxn.get(position), position);
      }
     ...
}
```

### Modifications

Fix the bug

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
