### PR TITLE
[improve][test] Add test for retrieving bookie metrics via HTTP

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BookkeeperInstallWithHttpServerEnabledTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/bookkeeper/BookkeeperInstallWithHttpServerEnabledTest.java
@@ -81,4 +81,14 @@ public class BookkeeperInstallWithHttpServerEnabledTest extends PulsarClusterTes
         assertEquals(result.getExitCode(), 0);
         assertEquals(result.getStdout(), "OK\n");
     }
+
+    @Test
+    public void testGetBookieMetrics() throws Exception {
+        ContainerExecResult result = pulsarCluster.getAnyBookie().execCmd(
+                PulsarCluster.CURL,
+                "-X",
+                "GET",
+                "http://localhost:8000/metrics");
+        assertEquals(result.getExitCode(), 0);
+    }
 }


### PR DESCRIPTION
### Motivation

When the Prometheus library versions differ between the broker and the bookkeeper, it may cause compatibility issues that prevent us from retrieving metrics from the bookie.

### Modifications

- Added `testGetBookieMetrics` to verify that bookie metrics can be fetched successfully, ensuring compatibility across Prometheus versions.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->