### PR TITLE
[fix][test] Fix flaky SimpleBrokerStartTest.testNoNICSpeed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleBrokerStartTest.java
@@ -103,12 +103,7 @@ public class SimpleBrokerStartTest {
         if (!hasNicSpeeds) {
             @Cleanup
             PulsarService pulsarService = new PulsarService(config);
-            try {
-                pulsarService.start();
-                fail("unexpected behaviour");
-            } catch (PulsarServerException ex) {
-                assertTrue(ex.getCause() instanceof IllegalStateException);
-            }
+            pulsarService.start();
         }
     }
 


### PR DESCRIPTION
### Motivation
![Clipboard_Screenshot_1750078979](https://github.com/user-attachments/assets/0c0ddcac-70e3-451b-9203-08686897f821)

In PR https://github.com/apache/pulsar/pull/21409, the check for NicSpeed ​​has been removed, so it can start normally and will not throw PulsarServerException when without NicSpeeds. Therefore, the unit test should modify the logic to be compatible.

### Modifications 
Modify the logic checked in the unit test to be compatible with the PR https://github.com/apache/pulsar/pull/21409.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->