### PR TITLE
[fix][doc]fix typo in Message and RawMessage

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -102,11 +102,11 @@ public interface Message<T> {
 
     /**
      * Get the event time associated with this message. It is typically set by the applications via
-     * {@link MessageBuilder#setEventTime(long)}.
+     * {@link TypedMessageBuilder#eventTime(long)}.
      *
      * <p>If there isn't any event time associated with this event, it will return 0.
      *
-     * @see MessageBuilder#setEventTime(long)
+     * @see TypedMessageBuilder#eventTime(long)
      * @since 1.20.0
      * @return the message event time or 0 if event time wasn't set
      */
@@ -114,10 +114,10 @@ public interface Message<T> {
 
     /**
      * Get the sequence id associated with this message. It is typically set by the applications via
-     * {@link MessageBuilder#setSequenceId(long)}.
+     * {@link TypedMessageBuilder#sequenceId(long)}.
      *
      * @return sequence id associated with this message.
-     * @see MessageBuilder#setEventTime(long)
+     * @see TypedMessageBuilder#sequenceId(long)
      * @since 1.22.0
      */
     long getSequenceId();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/raw/RawMessage.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.api.raw;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 
 /**
  * View of a message that exposes the internal direct-memory buffer for more efficient processing.
@@ -72,7 +73,7 @@ public interface RawMessage {
 
     /**
      * Get the event time associated with this message. It is typically set by the applications via
-     * {@link MessageBuilder#setEventTime(long)}.
+     * {@link TypedMessageBuilder#eventTime(long)}.
      *
      * <p>If there isn't any event time associated with this event, it will return 0.
      */
@@ -80,10 +81,10 @@ public interface RawMessage {
 
     /**
      * Get the sequence id associated with this message. It is typically set by the applications via
-     * {@link MessageBuilder#setSequenceId(long)}.
+     * {@link TypedMessageBuilder#sequenceId(long)}.
      *
      * @return sequence id associated with this message.
-     * @see MessageBuilder#setEventTime(long)
+     * @see TypedMessageBuilder#sequenceId(long)
      */
     long getSequenceId();
 


### PR DESCRIPTION
### Motivation
fix typo in Message and RawMessage.
here's the current typo like below:

![typoErro](https://github.com/user-attachments/assets/7af1493a-c5d9-45e9-8b53-9b6331b6b497)

### Modifications

fix typo

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:https://github.com/3pacccccc/pulsar/pull/9