### PR TITLE
[fix][broker] Once the cluster is configured incorrectly, the broker maintains the incorrect cluster configuration even if you removed it

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -808,6 +808,12 @@ public class BrokerService implements Closeable {
                 return CompletableFuture.completedFuture(null);
             }
             return client.closeAsync();
+        }).thenCompose(__ -> {
+            PulsarAdmin pulsarAdmin = clusterAdmins.remove(clusterName);
+            if (pulsarAdmin != null) {
+                pulsarAdmin.close();
+            }
+            return CompletableFuture.completedFuture(null);
         });
     }
 


### PR DESCRIPTION
### Motivation

**Reproduce steps**
- Create a remote cluster with an incorrect auth-param.
- Call `pulsar-admin topics set-replication-clusters <clusters> <topic>`, which will trigger the creation of an Internal PulsarAdmin Object in the broker's memory.
- Remove the cluster that contains incorrect `auth-params`
- Recreate the cluster with the correct info
- Issue: the broker still maintains a PulsarAdmin with an incorrect `auth-params` that we set the first time

### Modifications

- Close and remove the PulsarAdmin Object of the remote cluster when removing clusters

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x