### PR TITLE
[fix][build] Add missing <name> to submodules

### DIFF
--- a/pulsar-broker-auth-athenz/pom.xml
+++ b/pulsar-broker-auth-athenz/pom.xml
@@ -32,6 +32,7 @@
   <artifactId>pulsar-broker-auth-athenz</artifactId>
   <packaging>jar</packaging>
   <description>Athenz authentication plugin for broker</description>
+  <name>Pulsar Broker Auth Athenz</name>
 
   <dependencies>
 

--- a/pulsar-broker-auth-oidc/pom.xml
+++ b/pulsar-broker-auth-oidc/pom.xml
@@ -32,6 +32,7 @@
   <artifactId>pulsar-broker-auth-oidc</artifactId>
   <packaging>jar</packaging>
   <description>Open ID Connect authentication plugin for broker</description>
+  <name>Pulsar Broker Auth OIDC</name>
 
   <properties>
     <jsonwebtoken.version>0.11.5</jsonwebtoken.version>

--- a/pulsar-broker-auth-sasl/pom.xml
+++ b/pulsar-broker-auth-sasl/pom.xml
@@ -32,6 +32,7 @@
   <artifactId>pulsar-broker-auth-sasl</artifactId>
   <packaging>jar</packaging>
   <description>SASL authentication plugin for broker</description>
+  <name>Pulsar Broker Auth SASL</name>
 
   <dependencies>
 

--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -31,6 +31,7 @@
 
   <artifactId>pulsar-broker-common</artifactId>
   <description>Common classes used in multiple broker modules</description>
+  <name>Pulsar Broker Common</name>
 
   <dependencies>
     <dependency>

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -31,6 +31,7 @@
   <artifactId>pulsar-client-auth-athenz</artifactId>
   <packaging>jar</packaging>
   <description>Athenz authentication plugin for java client</description>
+  <name>Pulsar Client Auth Athenz</name>
 
   <dependencies>
 

--- a/pulsar-client-auth-sasl/pom.xml
+++ b/pulsar-client-auth-sasl/pom.xml
@@ -31,6 +31,7 @@
   <artifactId>pulsar-client-auth-sasl</artifactId>
   <packaging>jar</packaging>
   <description>SASL authentication plugin for java client</description>
+  <name>Pulsar Client Auth SASL</name>
 
   <dependencies>
 

--- a/pulsar-client-messagecrypto-bc/pom.xml
+++ b/pulsar-client-messagecrypto-bc/pom.xml
@@ -31,6 +31,7 @@
   <artifactId>pulsar-client-messagecrypto-bc</artifactId>
   <packaging>jar</packaging>
   <description>Message crypto for End to End encryption with BouncyCastleProvider</description>
+  <name>Pulsar Client Messagecrypto BC</name>
 
   <dependencies>
     <dependency>

--- a/pulsar-config-validation/pom.xml
+++ b/pulsar-config-validation/pom.xml
@@ -31,6 +31,7 @@
 
     <artifactId>pulsar-config-validation</artifactId>
     <description>Annotation based config validation for Pulsar</description>
+    <name>Pulsar Config Validation</name>
 
     <dependencies>
         <dependency>

--- a/pulsar-opentelemetry/pom.xml
+++ b/pulsar-opentelemetry/pom.xml
@@ -31,6 +31,7 @@
 
   <artifactId>pulsar-opentelemetry</artifactId>
   <description>OpenTelemetry Integration</description>
+  <name>Pulsar OpenTelemetry</name>
 
   <dependencies>
     <!-- OpenTelemetry dependencies -->


### PR DESCRIPTION
### Motivation

Some Maven submodules lack the `<name>` element in their `pom.xml` files.
This causes issues during Sonatype releases, where project metadata must be complete and descriptive for all modules.

```
"errors": {
    "pkg:maven/com.ascentstream.pulsar/pulsar-client-auth-sasl@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-config-validation@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-broker-auth-sasl@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-client-messagecrypto-bc@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-client-auth-athenz@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-broker-auth-athenz@2.10.7.14": [
      "Project name is missing"
    ],
    "pkg:maven/com.ascentstream.pulsar/pulsar-broker-common@2.10.7.14": [
      "Project name is missing"
    ]
  }
```

### Modifications

- Added missing <name> to submodules.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->