### PR TITLE
[fix][broker]Broker OOM because ServerCnx handling too many pending write, when the client can not handle response quick enough

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -920,6 +920,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_POLICIES,
+        doc = "The maximum number of pending write bytes of per connection when the connection is unwritable because"
+            + " the client can not handle too many response. Using a value of -1, is disabling it."
+    )
+    private int connectionMaxPendingWriteBytes = -1;
+
+    @FieldContext(
+        category = CATEGORY_POLICIES,
         doc = "The maximum number of connections per IP. If it exceeds, new connections are rejected."
     )
     private int brokerMaxConnectionsPerIp = 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -315,6 +315,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         // the null check is a workaround for #13620
         super(pulsar.getBrokerService() != null ? pulsar.getBrokerService().getKeepAliveIntervalSeconds() : 0,
                 TimeUnit.SECONDS);
+        super.maxPendingWriteBytes = pulsar.getConfig().getConnectionMaxPendingWriteBytes();
         this.service = pulsar.getBrokerService();
         this.schemaService = pulsar.getSchemaRegistryService();
         this.listenerName = listenerName;
@@ -437,13 +438,6 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         // complete possible pending connection check future
         if (connectionCheckInProgress != null && !connectionCheckInProgress.isDone()) {
             connectionCheckInProgress.complete(Optional.of(false));
-        }
-    }
-
-    @Override
-    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("Channel writability has changed to: {}", ctx.channel().isWritable());
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerBackPressureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerBackPressureTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-impl")
+public class PatternConsumerBackPressureTest extends MockedPulsarServiceBaseTest {
+
+    @Override
+    @BeforeMethod
+    protected void setup() throws Exception {
+        isTcpLookup = true;
+        conf.setEnableBrokerSideSubscriptionPatternEvaluation(false);
+        super.internalSetup();
+        setupDefaultTenantAndNamespace();
+    }
+
+    @Override
+    @AfterMethod(alwaysRun = true)
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        conf.setConnectionMaxPendingWriteBytes(5 * 1024 * 1024);
+    }
+
+    @Test(timeOut = 60 * 1000)
+    public void testBrokerOOM() throws PulsarAdminException, InterruptedException {
+        final int topicCount = 8192;
+        final int requests = 10_000;
+        final String topicName = UUID.randomUUID().toString();
+        admin.topics().createPartitionedTopic(topicName, topicCount);
+        final ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+
+        final PulsarClientImpl pulsarClientImpl = (PulsarClientImpl) pulsarClient;
+        final AtomicInteger success = new AtomicInteger(0);
+        final CountDownLatch latch = new CountDownLatch(requests);
+        for (int i = 0; i < requests; i++) {
+            executorService.execute(() -> {
+                pulsarClientImpl.getLookup()
+                    .getTopicsUnderNamespace(NamespaceName.get("public", "default"),
+                            CommandGetTopicsOfNamespace.Mode.PERSISTENT, ".*", "")
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            success.incrementAndGet();
+                        }
+                        log.info("latch-count: {}, succeed: {}", latch.getCount(), success.get());
+                        latch.countDown();
+                    });
+            });
+        }
+        latch.await();
+        Assert.assertEquals(success.get(), requests);
+    }
+}


### PR DESCRIPTION
### Motivation

Thanks @mattisonchao for sharing the issue context and the code for reproducing the issue.

- There is a write buffer that Netty provided is `outboundBuffer = io.netty.channel.ChannelOutboundBuffer`, it is used to cache data that should be written out, and batch flush to benefit performance.
- When `ChannelOutboundBuffer` caches too much data, it will mark `channel` as `unwritable`, but it continuously caches the data, if the user continuously calls `channel.write`, eventually it leads to an OOM
- You can reproduce the issue with the new test 

![Screenshot 2025-06-17 at 23 30 03](https://github.com/user-attachments/assets/4b428543-8a60-4624-9e10-1671f0e92b78)


### Modifications

- Add a broker param: `connectionMaxPendingWriteBytes`, pause handling requests when `ChannelOutboundBuffer`'s pending write bytes length is larger than the threshold. Resume when the channel is `writable` again.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x