### PR TITLE
[improve][pip] PIP-427: Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration

### DIFF
--- a/pip/pip-427 Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration.md
+++ b/pip/pip-427 Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration.md
@@ -77,5 +77,5 @@ And the change will not affect any existing namespaces.
 <!--
 Updated afterwards
 -->
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/j9vx6zkkgnz08sfgp14swylb8wv6djzs
 * Mailing List voting thread:


### PR DESCRIPTION
### Motivation

Currently, the pulsar-admin namespaces set-persistence command implicitly resets the mark-delete rate to 0 (unlimited) if the --ml-mark-delete-max-rate flag is omitted when changing other policies. This behavior can cause unexpected high load on BookKeeper and acts as a "footgun" for operators.

This PR added the PIP by making the default behavior safer and more intuitive, aligning it with the broker's own configuration.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
