### PR TITLE
[fix][broker][branch-4.0] Revert "[improve][broker] Reduce memory occupation of the delayed message queue (#23611)"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -20,12 +20,6 @@ package org.apache.pulsar.broker.delayed;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.Timer;
-import it.unimi.dsi.fastutil.longs.Long2ObjectAVLTreeMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectSortedMap;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
 import java.time.Clock;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -35,15 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
-import org.roaringbitmap.longlong.Roaring64Bitmap;
+import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
 
 @Slf4j
 public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker {
 
-    // timestamp -> ledgerId -> entryId
-    // AVL tree -> OpenHashMap -> RoaringBitmap
-    protected final Long2ObjectSortedMap<Long2ObjectMap<Roaring64Bitmap>>
-            delayedMessageMap = new Long2ObjectAVLTreeMap<>();
+    protected final TripleLongPriorityQueue priorityQueue = new TripleLongPriorityQueue();
 
     // If we detect that all messages have fixed delay time, such that the delivery is
     // always going to be in FIFO order, then we can avoid pulling all the messages in
@@ -61,9 +52,6 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     // Track whether we have seen all messages with fixed delay so far.
     private boolean messagesHaveFixedDelay = true;
 
-    // The bit count to trim to reduce memory occupation.
-    private final int timestampPrecisionBitCnt;
-
     InMemoryDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher, Timer timer,
                                    long tickTimeMillis,
                                    boolean isDelayedDeliveryDeliverAtTimeStrict,
@@ -78,35 +66,6 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                                           long fixedDelayDetectionLookahead) {
         super(dispatcher, timer, tickTimeMillis, clock, isDelayedDeliveryDeliverAtTimeStrict);
         this.fixedDelayDetectionLookahead = fixedDelayDetectionLookahead;
-        this.timestampPrecisionBitCnt = calculateTimestampPrecisionBitCnt(tickTimeMillis);
-    }
-
-    /**
-     * The tick time is used to determine the precision of the delivery time. As the redelivery time
-     * is not accurate, we can bucket the delivery time and group multiple message ids into the same
-     * bucket to reduce the memory usage. THe default value is 1 second, which means we accept 1 second
-     * deviation for the delivery time, so that we can trim the lower 9 bits of the delivery time, because
-     * 2**9ms = 512ms < 1s, 2**10ms = 1024ms > 1s.
-     * @param tickTimeMillis
-     * @return
-     */
-    private static int calculateTimestampPrecisionBitCnt(long tickTimeMillis) {
-        int bitCnt = 0;
-        while (tickTimeMillis > 0) {
-            tickTimeMillis >>= 1;
-            bitCnt++;
-        }
-        return bitCnt > 0 ? bitCnt - 1 : 0;
-    }
-
-    /**
-     * trim the lower bits of the timestamp to reduce the memory usage.
-     * @param timestamp
-     * @param bits
-     * @return
-     */
-    private static long trimLowerBit(long timestamp, int bits) {
-        return timestamp & (-1L << bits);
     }
 
     @Override
@@ -121,10 +80,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                     deliverAt - clock.millis());
         }
 
-        long timestamp = trimLowerBit(deliverAt, timestampPrecisionBitCnt);
-        delayedMessageMap.computeIfAbsent(timestamp, k -> new Long2ObjectOpenHashMap<>())
-                .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap())
-                .add(entryId);
+        priorityQueue.add(deliverAt, ledgerId, entryId);
         updateTimer();
 
         checkAndUpdateHighest(deliverAt);
@@ -149,8 +105,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
      */
     @Override
     public boolean hasMessageAvailable() {
-        boolean hasMessageAvailable = !delayedMessageMap.isEmpty()
-                && delayedMessageMap.firstLongKey() <= getCutoffTime();
+        boolean hasMessageAvailable = !priorityQueue.isEmpty() && priorityQueue.peekN1() <= getCutoffTime();
         if (!hasMessageAvailable) {
             updateTimer();
         }
@@ -166,49 +121,25 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
         NavigableSet<Position> positions = new TreeSet<>();
         long cutoffTime = getCutoffTime();
 
-        while (n > 0 && !delayedMessageMap.isEmpty()) {
-            long timestamp = delayedMessageMap.firstLongKey();
+        while (n > 0 && !priorityQueue.isEmpty()) {
+            long timestamp = priorityQueue.peekN1();
             if (timestamp > cutoffTime) {
                 break;
             }
 
-            LongSet ledgerIdToDelete = new LongOpenHashSet();
-            Long2ObjectMap<Roaring64Bitmap> ledgerMap = delayedMessageMap.get(timestamp);
-            for (Long2ObjectMap.Entry<Roaring64Bitmap> ledgerEntry : ledgerMap.long2ObjectEntrySet()) {
-                long ledgerId = ledgerEntry.getLongKey();
-                Roaring64Bitmap entryIds = ledgerEntry.getValue();
-                int cardinality = (int) entryIds.getLongCardinality();
-                if (cardinality <= n) {
-                    entryIds.forEach(entryId -> {
-                        positions.add(PositionFactory.create(ledgerId, entryId));
-                    });
-                    n -= cardinality;
-                    ledgerIdToDelete.add(ledgerId);
-                } else {
-                    long[] entryIdsArray = entryIds.toArray();
-                    for (int i = 0; i < n; i++) {
-                        positions.add(PositionFactory.create(ledgerId, entryIdsArray[i]));
-                        entryIds.removeLong(entryIdsArray[i]);
-                    }
-                    n = 0;
-                }
-                if (n <= 0) {
-                    break;
-                }
-            }
-            for (long ledgerId : ledgerIdToDelete) {
-                ledgerMap.remove(ledgerId);
-            }
-            if (ledgerMap.isEmpty()) {
-                delayedMessageMap.remove(timestamp);
-            }
+            long ledgerId = priorityQueue.peekN2();
+            long entryId = priorityQueue.peekN3();
+            positions.add(PositionFactory.create(ledgerId, entryId));
+
+            priorityQueue.pop();
+            --n;
         }
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Get scheduled messages - found {}", dispatcher.getName(), positions.size());
         }
 
-        if (delayedMessageMap.isEmpty()) {
+        if (priorityQueue.isEmpty()) {
             // Reset to initial state
             highestDeliveryTimeTracked = 0;
             messagesHaveFixedDelay = true;
@@ -220,33 +151,24 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
 
     @Override
     public CompletableFuture<Void> clear() {
-        this.delayedMessageMap.clear();
+        this.priorityQueue.clear();
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public long getNumberOfDelayedMessages() {
-        return delayedMessageMap.values().stream().mapToLong(
-                ledgerMap -> ledgerMap.values().stream().mapToLong(
-                        Roaring64Bitmap::getLongCardinality).sum()).sum();
+        return priorityQueue.size();
     }
 
-    /**
-     * This method rely on Roaring64Bitmap::getLongSizeInBytes to calculate the memory usage of the buffer.
-     * The memory usage of the buffer is not accurate, because Roaring64Bitmap::getLongSizeInBytes will
-     * overestimate the memory usage of the buffer a lot.
-     * @return the memory usage of the buffer
-     */
     @Override
     public long getBufferMemoryUsage() {
-        return delayedMessageMap.values().stream().mapToLong(
-                ledgerMap -> ledgerMap.values().stream().mapToLong(
-                        Roaring64Bitmap::getLongSizeInBytes).sum()).sum();
+        return priorityQueue.bytesCapacity();
     }
 
     @Override
     public void close() {
         super.close();
+        priorityQueue.close();
     }
 
     @Override
@@ -259,6 +181,6 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     }
 
     protected long nextDeliveryTime() {
-        return delayedMessageMap.firstLongKey();
+        return priorityQueue.peekN1();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -93,7 +93,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             false, 0)
             }};
             case "testAddMessageWithStrictDelay" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 100, clock,
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterNowBeforeTickTimeFrequencyWithStrict" -> new Object[][]{{
@@ -101,7 +101,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterNowAfterTickTimeFrequencyWithStrict" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 100000, clock,
                             true, 0)
             }};
             case "testAddMessageWithDeliverAtTimeAfterFullTickTimeWithStrict" -> new Object[][]{{
@@ -109,7 +109,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                             true, 0)
             }};
             case "testWithFixedDelays", "testWithMixedDelays","testWithNoDelays" -> new Object[][]{{
-                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 8, clock,
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 500, clock,
                             true, 100)
             }};
             default -> new Object[][]{{
@@ -232,7 +232,7 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                     return;
                 }
                 try {
-                    this.delayedMessageMap.firstLongKey();
+                    this.priorityQueue.peekN1();
                 } catch (Exception e) {
                     e.printStackTrace();
                     exceptions[0] = e;


### PR DESCRIPTION
### Motivation

- Revert: https://github.com/apache/pulsar/pull/23611
- Mailing list discussion: https://lists.apache.org/thread/3dc1c3n7d0tmwm8974qh9w771jzgy6f6

#### Reason for Revert:

This PR has introduced a significant performance regression in the Pulsar broker.
The attached flame graph visually demonstrates increased CPU utilization and time 
spent in the code paths related to DelayedDeliveryTracker and stream operations.

While the intention was to optimize memory usage, the current implementation 
appears to have an adverse effect on CPU performance, leading to overall degraded 
broker throughput and increased latency.

#### Impact:

This regression is impacting the stability and performance of our Pulsar clusters, 
especially when you have large-scale delayed messages. Reverting the change will 
allow us to restore the previous performance characteristics while we investigate 
a more robust and performant solution for DelayedDeliveryTracker memory optimization.

#### Root Cause:

https://github.com/apache/pulsar/pull/23611/files#diff-f159b4e262ff6213bba19d20e6dc01d07ea8c19f4675524e4ceb1470f456e8fcR229-R231
Here is the change that caused this issue. Each message added to the
DelayedMessageTracker will call `getNumberOfDelayedMessages()` method
which will iterate the map defined in InMemoryDelayedDeliveryTracker

```
protected final Long2ObjectSortedMap<Long2ObjectSortedMap<Roaring64Bitmap>>
delayedMessageMap = new Long2ObjectAVLTreeMap<>();
```

#### More contexts:

Flamegraph:
![delayed-tracker-flamegraph](https://github.com/user-attachments/assets/de4601be-deb5-4120-acee-643cec3eb8b2)

Jstack:
```
"broker-topic-workers-OrderedExecutor-1-0" #51 [95] prio=5 os_prio=0 cpu=1678706.57ms elapsed=15712.43s tid=0x00007fa0da32b820 nid=95 runnable  [0x00007fa0d6c00000]
   java.lang.Thread.State: RUNNABLE
        at java.util.stream.AbstractPipeline.wrapSink(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.reduce(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.sum(java.base@21.0.7/Unknown Source)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.lambda$getNumberOfDelayedMessages$3(InMemoryDelayedDeliveryTracker.java:231)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker$$Lambda/0x0000000100e73078.applyAsLong(Unknown Source)
        at java.util.stream.ReferencePipeline$5$1.accept(java.base@21.0.7/Unknown Source)
        at java.util.Iterator.forEachRemaining(java.base@21.0.7/Unknown Source)
        at it.unimi.dsi.fastutil.objects.ObjectSpliterators$SpliteratorFromIterator.forEachRemaining(ObjectSpliterators.java:1158)
        at java.util.stream.AbstractPipeline.copyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.reduce(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.sum(java.base@21.0.7/Unknown Source)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.getNumberOfDelayedMessages(InMemoryDelayedDeliveryTracker.java:231)
        at org.apache.pulsar.broker.delayed.AbstractDelayedDeliveryTracker.updateTimer(AbstractDelayedDeliveryTracker.java:91)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.addMessage(InMemoryDelayedDeliveryTracker.java:128)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.trackDelayedDelivery(PersistentDispatcherMultipleConsumers.java:1314)
        - locked <0x00000000c21d88b8> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.AbstractBaseDispatcher.filterEntriesForConsumer(AbstractBaseDispatcher.java:228)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.trySendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:864)
        - locked <0x00000000c21d88b8> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.sendMessagesToConsumers(PersistentDispatcherMultipleConsumers.java:769)
        - eliminated <0x00000000c21d88b8> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.handleSendingMessagesAndReadingMore(PersistentDispatcherMultipleConsumers.java:729)
        - locked <0x00000000c21d88b8> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$readEntriesComplete$9(PersistentDispatcherMultipleConsumers.java:719)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers$$Lambda/0x0000000100c0f440.run(Unknown Source)
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128)
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:99)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.runWith(java.base@21.0.7/Unknown Source)
        at java.lang.Thread.run(java.base@21.0.7/Unknown Source)

"broker-topic-workers-OrderedExecutor-2-0" #52 [96] prio=5 os_prio=0 cpu=1797445.47ms elapsed=15712.43s tid=0x00007fa0d9419fc0 nid=96 runnable  [0x00007fa0d6aff000]
   java.lang.Thread.State: RUNNABLE
        at java.util.stream.AbstractPipeline.copyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.reduce(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.sum(java.base@21.0.7/Unknown Source)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.lambda$getNumberOfDelayedMessages$3(InMemoryDelayedDeliveryTracker.java:231)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker$$Lambda/0x0000000100e73078.applyAsLong(Unknown Source)
        at java.util.stream.ReferencePipeline$5$1.accept(java.base@21.0.7/Unknown Source)
        at java.util.Iterator.forEachRemaining(java.base@21.0.7/Unknown Source)
        at it.unimi.dsi.fastutil.objects.ObjectSpliterators$SpliteratorFromIterator.forEachRemaining(ObjectSpliterators.java:1158)
        at java.util.stream.AbstractPipeline.copyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.7/Unknown Source)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(java.base@21.0.7/Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.reduce(java.base@21.0.7/Unknown Source)
        at java.util.stream.LongPipeline.sum(java.base@21.0.7/Unknown Source)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.getNumberOfDelayedMessages(InMemoryDelayedDeliveryTracker.java:231)
        at org.apache.pulsar.broker.delayed.AbstractDelayedDeliveryTracker.updateTimer(AbstractDelayedDeliveryTracker.java:91)
        at org.apache.pulsar.broker.delayed.InMemoryDelayedDeliveryTracker.getScheduledMessages(InMemoryDelayedDeliveryTracker.java:217)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.getMessagesToReplayNow(PersistentDispatcherMultipleConsumers.java:1327)
        - locked <0x00000000b8cd7968> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.readMoreEntries(PersistentDispatcherMultipleConsumers.java:386)
        - locked <0x00000000b8cd7968> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.handleSendingMessagesAndReadingMore(PersistentDispatcherMultipleConsumers.java:743)
        - locked <0x00000000b8cd7968> (a org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$readEntriesComplete$9(PersistentDispatcherMultipleConsumers.java:719)
        at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers$$Lambda/0x0000000100c0f440.run(Unknown Source)
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128)
        at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:99)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.runWith(java.base@21.0.7/Unknown Source)
        at java.lang.Thread.run(java.base@21.0.7/Unknown Source)
```

### Modifications

Revert PR #23611 and the related PR #24035

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->