### PR TITLE
[fix][ml] Enhance OpFindNewest to support skip non-recoverable data

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -196,9 +196,8 @@ class OpFindNewest implements ReadEntryCallback {
                 callback.findEntryComplete(lastMatchedPosition, OpFindNewest.this.ctx);
                 return;
             } catch (Exception e) {
-                log.error("[{}] Failed to skip non-recoverable data at position {}: {}", ledger.getName(),
-                    searchPosition, e.getMessage(), e);
-                callback.findEntryFailed(new ManagedLedgerException("Failed to skip non-recoverable data", e),
+                callback.findEntryFailed(
+                    new ManagedLedgerException("Failed to skip non-recoverable data during search position", e),
                     Optional.ofNullable(searchPosition), OpFindNewest.this.ctx);
                 return;
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -101,8 +101,6 @@ class OpFindNewest implements ReadEntryCallback {
                 state = State.checkLast;
                 searchPosition = ledger.getPositionAfterN(searchPosition, max, PositionBound.startExcluded);
                 Position lastPosition = ledger.getLastPosition();
-                searchPosition =
-                        ledger.getPositionAfterN(searchPosition, max, PositionBound.startExcluded);
                 if (lastPosition.compareTo(searchPosition) < 0) {
                     if (log.isDebugEnabled()) {
                         log.debug("first position {} matches, last should be {}, but moving to lastPos {}", position,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -153,7 +153,7 @@ class OpFindNewest implements ReadEntryCallback {
                 searchPosition, state);
             checkArgument(state == State.checkFirst || state == State.checkLast || state == State.searching);
             if (state == State.checkFirst) {
-                // If we failed to read the first entry, try next valid ledger
+                // If we failed to read the first entry, try next valid position
                 Position nextPosition = findNextValidPosition(searchPosition, exception);
                 if (nextPosition != null && nextPosition.getEntryId() != -1) {
                     long numberOfEntries =
@@ -181,7 +181,7 @@ class OpFindNewest implements ReadEntryCallback {
                     find();
                     return;
                 } else {
-                    // If we can't find next valid position, try previous ledger's last entry
+                    // If we can't find next valid position, try previous valid position
                     Position prevPosition = findPreviousValidPosition(searchPosition, exception);
                     if (prevPosition != null && prevPosition.getEntryId() != -1) {
                         searchPosition = prevPosition;
@@ -212,7 +212,7 @@ class OpFindNewest implements ReadEntryCallback {
         if (prevPosition.getEntryId() != -1) {
             var minPosition = ledger.getPositionAfterN(startPosition, min, PositionBound.startExcluded);
             if (minPosition.compareTo(prevPosition) > 0) {
-                // If the prev position is out of the min position, an invalid position is returned
+                // If the previous position is out of the min position, an invalid position is returned
                 prevPosition = null;
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -466,16 +466,16 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < totalEntries; i++) {
             ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
         }
-        // {0、1、2、3、4} (0) 3 x
-        // {5、6、7、8、9} (1) 4
-        // {10、11、12、13、14} (2) 5
-        // {15、16、17、18、19} (3) 6
-        // {20、21、22、23、24} (4) 7 x
-        // {25、26、27、28、29} (5) 8 x
-        // {30、31、32、33、34} (6) 9
-        // {35、36、37、38、39} (7) 10
-        // {40、41、42、43、44} (8) 11
-        // {45、46、47、48、49} (9) 12 x
+        // {0,1,2,3,4} (0) 3 x
+        // {5,6,7,8,9} (1) 4
+        // {10,11,12,13,14} (2) 5
+        // {15,16,17,18,19} (3) 6
+        // {20,21,22,23,24} (4) 7 x
+        // {25,26,27,28,29} (5) 8 x
+        // {30,31,32,33,34} (6) 9
+        // {35,36,37,38,39} (7) 10
+        // {40,41,42,43,44} (8) 11
+        // {45,46,47,48,49} (9) 12 x
         Awaitility.await().untilAsserted(() ->
                 assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
 
@@ -529,16 +529,16 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < totalEntries; i++) {
             ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
         }
-        // {0、1、2、3、4} (0) 3 x
-        // {5、6、7、8、9} (1) 4
-        // {10、11、12、13、14} (2) 5
-        // {15、16、17、18、19} (3) 6
-        // {20、21、22、23、24} (4) 7 x
-        // {25、26、27、28、29} (5) 8 x
-        // {30、31、32、33、34} (6) 9
-        // {35、36、37、38、39} (7) 10
-        // {40、41、42、43、44} (8) 11
-        // {45、46、47、48、49} (9) 12 x
+        // {0,1,2,3,4} (0) 3 x
+        // {5,6,7,8,9} (1) 4
+        // {10,11,12,13,14} (2) 5
+        // {15,16,17,18,19} (3) 6
+        // {20,21,22,23,24} (4) 7 x
+        // {25,26,27,28,29} (5) 8 x
+        // {30,31,32,33,34} (6) 9
+        // {35,36,37,38,39} (7) 10
+        // {40,41,42,43,44} (8) 11
+        // {45,46,47,48,49} (9) 12 x
         Awaitility.await().untilAsserted(() ->
                 assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -67,6 +68,9 @@ import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonito
 import org.apache.pulsar.broker.service.persistent.PersistentMessageFinder;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ResetCursorData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
@@ -81,6 +85,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
+@Slf4j
 public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
 
     public static byte[] createMessageWrittenToLedger(String msg) {
@@ -144,7 +149,12 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
     }
 
     CompletableFuture<Void> findMessage(final Result result, final ManagedCursor c1, final long timestamp) {
-        PersistentMessageFinder messageFinder = new PersistentMessageFinder("topicname", c1, 0);
+        return findMessage(result, c1, timestamp, 0);
+    }
+
+    CompletableFuture<Void> findMessage(final Result result, final ManagedCursor c1, final long timestamp,
+                                        int ledgerCloseTimestampMaxClockSkewMillis) {
+        PersistentMessageFinder messageFinder = new PersistentMessageFinder("topicname", c1, ledgerCloseTimestampMaxClockSkewMillis);
 
         final CompletableFuture<Void> future = new CompletableFuture<>();
         messageFinder.findMessages(timestamp, new AsyncCallbacks.FindEntryCallback() {
@@ -437,6 +447,153 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         ledger.close();
         factory.shutdown();
 
+    }
+
+    public void testFindMessageWithTimestampAutoSkipNonRecoverable() throws Exception {
+
+        final String ledgerAndCursorName = "testFindMessageWithTimestampAutoSkipNonRecoverable";
+        final int entriesPerLedger = 5;
+        final int totalEntries = 50;
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setRetentionSizeInMB(10);
+        config.setMaxEntriesPerLedger(entriesPerLedger);
+        config.setRetentionTime(1, TimeUnit.HOURS);
+        config.setAutoSkipNonRecoverableData(true);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(ledgerAndCursorName, config);
+
+        long initTimeMillis = System.currentTimeMillis();
+        for (int i = 0; i < totalEntries; i++) {
+            ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
+        }
+        // {0、1、2、3、4} (0) 3 x
+        // {5、6、7、8、9} (1) 4
+        // {10、11、12、13、14} (2) 5
+        // {15、16、17、18、19} (3) 6
+        // {20、21、22、23、24} (4) 7 x
+        // {25、26、27、28、29} (5) 8 x
+        // {30、31、32、33、34} (6) 9
+        // {35、36、37、38、39} (7) 10
+        // {40、41、42、43、44} (8) 11
+        // {45、46、47、48、49} (9) 12 x
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
+
+        List<LedgerInfo> ledgers = ledger.getLedgersInfoAsList();
+        LedgerInfo lastLedgerInfo = ledgers.get(ledgers.size() - 1);
+        // The `lastLedgerInfo` should be newly opened, and it does not contain any entries.
+        // Please refer to: https://github.com/apache/pulsar/pull/22034
+        assertEquals(lastLedgerInfo.getEntries(), 0);
+        assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
+
+        bkc.deleteLedger(ledgers.get(0).getLedgerId());
+        bkc.deleteLedger(ledgers.get(4).getLedgerId());
+        bkc.deleteLedger(ledgers.get(5).getLedgerId());
+        bkc.deleteLedger(ledgers.get(9).getLedgerId());
+
+        MessageId messageId = findMessageIdByPublishTime(initTimeMillis + 17, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(3).getLedgerId(), 2, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 27, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(4).getLedgerId(), 0, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 43, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(8).getLedgerId(), 3, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 48, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(9).getLedgerId(), 0, -1));
+
+        ledger.close();
+        factory.shutdown();
+    }
+
+    public void testFindMessageByCursorWithTimestampAutoSkipNonRecoverable() throws Exception {
+
+        final String ledgerAndCursorName = "testFindMessageByCursorWithTimestampAutoSkipNonRecoverable";
+        final int entriesPerLedger = 5;
+        final int totalEntries = 50;
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setRetentionSizeInMB(10);
+        config.setMaxEntriesPerLedger(entriesPerLedger);
+        config.setRetentionTime(1, TimeUnit.HOURS);
+        config.setAutoSkipNonRecoverableData(true);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(ledgerAndCursorName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor(ledgerAndCursorName);
+
+        long initTimeMillis = System.currentTimeMillis();
+        for (int i = 0; i < totalEntries; i++) {
+            ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
+        }
+        // {0、1、2、3、4} (0) 3 x
+        // {5、6、7、8、9} (1) 4
+        // {10、11、12、13、14} (2) 5
+        // {15、16、17、18、19} (3) 6
+        // {20、21、22、23、24} (4) 7 x
+        // {25、26、27、28、29} (5) 8 x
+        // {30、31、32、33、34} (6) 9
+        // {35、36、37、38、39} (7) 10
+        // {40、41、42、43、44} (8) 11
+        // {45、46、47、48、49} (9) 12 x
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
+
+        List<LedgerInfo> ledgers = ledger.getLedgersInfoAsList();
+        LedgerInfo lastLedgerInfo = ledgers.get(ledgers.size() - 1);
+        // The `lastLedgerInfo` should be newly opened, and it does not contain any entries.
+        // Please refer to: https://github.com/apache/pulsar/pull/22034
+        assertEquals(lastLedgerInfo.getEntries(), 0);
+        assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
+
+        bkc.deleteLedger(ledgers.get(0).getLedgerId());
+        bkc.deleteLedger(ledgers.get(4).getLedgerId());
+        bkc.deleteLedger(ledgers.get(5).getLedgerId());
+        bkc.deleteLedger(ledgers.get(9).getLedgerId());
+        Result result = new Result();
+
+        findMessage(result, cursor, initTimeMillis + 17, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(3).getLedgerId(), 1));
+
+        result = new Result();
+        findMessage(result, cursor, initTimeMillis + 27, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(3).getLedgerId(), 4));
+
+        result = new Result();
+        findMessage(result, cursor, initTimeMillis + 43, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(8).getLedgerId(), 2));
+
+        ledger.close();
+        factory.shutdown();
+    }
+
+    private CompletableFuture<MessageId> findMessageIdByPublishTime(long timestamp, ManagedLedger managedLedger) {
+        return managedLedger.asyncFindPosition(entry -> {
+            try {
+                long entryTimestamp = Commands.getEntryTimestamp(entry.getDataBuffer());
+                return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
+            } catch (Exception e) {
+                log.error("Error deserializing message for message position find", e);
+            } finally {
+                entry.release();
+            }
+            return false;
+        }).thenApply(position -> {
+            if (position == null) {
+                return null;
+            } else {
+                return new MessageIdImpl(position.getLedgerId(), position.getEntryId(), -1);
+            }
+        });
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -580,8 +580,6 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             Thread.sleep(10);
         }
 
-        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).get().get();
-
         Map<Long, MessageIdImpl> timestampToMessageId = new HashMap<>();
         List<Long> ledgerIds = new ArrayList<>();
         @Cleanup
@@ -610,7 +608,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             log.info("delete ledger: {}", deletedLedgerId);
         }
 
-        restartBroker();
+        admin.topics().unload(topicName);
 
         @Cleanup
         org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
@@ -625,7 +623,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         final int lastNonRecoverableEntryNums = 5;
 
         for (int i = 0; i < timestamps.length - lastNonRecoverableEntryNums; i++) {
-            MessageIdImpl nextValidMessageId = (MessageIdImpl) timestampToMessageId.get(timestamps[i]);
+            MessageIdImpl nextValidMessageId = timestampToMessageId.get(timestamps[i]);
             int l = i;
             while (nextValidMessageId == null) {
                 nextValidMessageId = timestampToMessageId.get(timestamps[l++]);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +47,7 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.commons.lang3.ArraySorter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -88,6 +90,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         conf.setManagedLedgerMaxEntriesPerLedger(10);
         conf.setDefaultRetentionSizeInMB(100);
         conf.setDefaultRetentionTimeInMinutes(100);
+        conf.setAutoSkipNonRecoverableData(true);
         super.baseSetup();
     }
 
@@ -560,6 +563,78 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             Position readPosition = cursor.getReadPosition();
             Assert.assertEquals(readPosition.getLedgerId(), messageId.getLedgerId());
             Assert.assertEquals(readPosition.getEntryId(), messageId.getEntryId());
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testSeekByTimestampWithSkipNonRecoverableData() throws Exception {
+        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestampWithSkipNonRecoverableData";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
+
+        @Cleanup
+        Producer<String> producer =
+            pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        for (int i = 0; i < 55; i++) {
+            producer.send(("message-" + i));
+            Thread.sleep(10);
+        }
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).get().get();
+
+        Map<Long, MessageIdImpl> timestampToMessageId = new HashMap<>();
+        List<Long> ledgerIds = new ArrayList<>();
+        @Cleanup
+        Reader<String> reader =
+            pulsarClient.newReader(Schema.STRING).topic(topicName).startMessageId(MessageId.earliest).create();
+        while (reader.hasMessageAvailable()) {
+            Message<String> message = reader.readNext();
+            log.info("message: {} ----- {}", message.getMessageId(), message.getPublishTime());
+            timestampToMessageId.put(message.getPublishTime(), (MessageIdImpl) message.getMessageId());
+            long ledgerId = ((MessageIdImpl) message.getMessageId()).getLedgerId();
+            if (!ledgerIds.contains(ledgerId)) {
+                ledgerIds.add(ledgerId);
+            }
+        }
+
+        Assert.assertEquals(timestampToMessageId.size(), 55);
+
+        LinkedHashSet<Long> deletedLedgerIds = new LinkedHashSet<>();
+        deletedLedgerIds.add(ledgerIds.get(0));
+        deletedLedgerIds.add(ledgerIds.get(ledgerIds.size() - 1));
+        int mid = ledgerIds.size() / 2;
+        deletedLedgerIds.add(ledgerIds.get(mid));
+
+        for (Long deletedLedgerId : deletedLedgerIds) {
+            pulsar.getBookKeeperClient().deleteLedger(deletedLedgerId);
+            log.info("delete ledger: {}", deletedLedgerId);
+        }
+
+        restartBroker();
+
+        @Cleanup
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+            .receiverQueueSize(0)
+            .topic(topicName).subscriptionName("my-sub")
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        long[] timestamps = timestampToMessageId.keySet().stream().mapToLong(Long::longValue).toArray();
+        ArraySorter.sort(timestamps);
+
+        timestampToMessageId.values().removeIf(messageId -> deletedLedgerIds.contains(messageId.getLedgerId()));
+
+        for (int i = 0; i < timestamps.length - 5; i++) {
+            MessageIdImpl nextValidMessageId = (MessageIdImpl) timestampToMessageId.get(timestamps[i]);
+            int l = i;
+            while (nextValidMessageId == null) {
+                nextValidMessageId = timestampToMessageId.get(timestamps[l++]);
+            }
+
+            consumer.seek(timestamps[i]);
+            Message<String> receive = consumer.receive();
+
+            MessageIdImpl msgId = (MessageIdImpl) receive.getMessageId();
+            Assert.assertEquals(msgId.getLedgerId(), nextValidMessageId.getLedgerId());
+            Assert.assertEquals(msgId.getEntryId(), nextValidMessageId.getEntryId());
         }
     }
 


### PR DESCRIPTION


### Motivation

When some ledgers are not offloaded successfully, they will be removed from the metadata store so that seek by timestamp might fail.

```
Error opening ledger for reading at position 4098289:438 - org.apache.bookkeeper.mledger.ManagedLedgerException$LedgerNotExistException: No such ledger exists on Metadata Server

```
skipNonRecoverableData is true, but it does not handle the seek case. The workaround is to see by message id.

### Modifications

When `skipNonRecoverableData` is true, OpFindNewest can auto skip non-recoverable data.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
