### PR TITLE
[fix][prox]Pulsar Proxy OOM because forget to clear topic name cache

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -39,6 +39,14 @@ brokerServiceURLTLS=
 brokerWebServiceURL=
 brokerWebServiceURLTLS=
 
+# Max capacity of the topic name cache. -1 means unlimited cache; 0 means broker will clear all cache
+# per "maxSecondsToClearTopicNameCache", it does not mean broker will not cache TopicName.
+topicNameCacheMaxCapacity=100000
+
+# A Specifies the minimum number of seconds that the topic name stays in memory, to avoid clear cache frequently when
+# there are too many topics are in use.
+maxSecondsToClearTopicNameCache=7200
+
 # If function workers are setup in a separate cluster, configure the following 2 settings. This url should point to
 # the discovery service provider of the function workers cluster, and does not support multi urls yet.
 functionWorkerWebServiceURL=

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -92,6 +92,14 @@ maxHttpServerConnections=2048
 # Max concurrent web requests
 maxConcurrentHttpRequests=1024
 
+# Max capacity of the topic name cache. -1 means unlimited cache; 0 means broker will clear all cache
+# per "maxSecondsToClearTopicNameCache", it does not mean broker will not cache TopicName.
+topicNameCacheMaxCapacity=100000
+
+# A Specifies the minimum number of seconds that the topic name stays in memory, to avoid clear cache frequently when
+# there are too many topics are in use.
+maxSecondsToClearTopicNameCache=7200
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -651,6 +651,7 @@ public class BrokerService implements Closeable {
             maxSecondsToClearTopicNameCache,
             maxSecondsToClearTopicNameCache,
             TimeUnit.SECONDS);
+        TopicName.setEvictCacheByScheduledTask(true);
     }
 
     protected void startStatsUpdater(int statsUpdateInitialDelayInSecs, int statsUpdateFrequencyInSecs) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -174,6 +174,21 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private boolean zooKeeperAllowReadOnlyOperations;
 
     @FieldContext(
+            dynamic = true,
+            category = CATEGORY_SERVER,
+            doc = "Max capacity of the topic name cache. -1 means unlimited cache; 0 means broker will clear all cache"
+                    + " per maxSecondsToClearTopicNameCache, it does not mean broker will not cache TopicName."
+    )
+    private int topicNameCacheMaxCapacity = 100_000;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "A Specifies the minimum number of seconds that the topic name stays in memory, to avoid clear cache"
+                    + " frequently when there are too many topics are in use."
+    )
+    private int maxSecondsToClearTopicNameCache = 3600 * 2;
+
+    @FieldContext(
         category = CATEGORY_BROKER_DISCOVERY,
         doc = "If does not set metadataStoreUrl or configurationMetadataStoreUrl, this url should point to the"
                 + " discovery service provider."

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -73,6 +73,8 @@ public class ProxyConfigurationTest {
             printWriter.println("zookeeperSessionTimeoutMs=60");
             printWriter.println("zooKeeperCacheExpirySeconds=500");
             printWriter.println("httpMaxRequestHeaderSize=1234");
+            printWriter.println("topicNameCacheMaxCapacity=20000");
+            printWriter.println("maxSecondsToClearTopicNameCache=1800");
         }
         testConfigFile.deleteOnExit();
         InputStream stream = new FileInputStream(testConfigFile);
@@ -81,6 +83,8 @@ public class ProxyConfigurationTest {
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
         assertEquals(serviceConfig.getHttpMaxRequestHeaderSize(), 1234);
+        assertEquals(serviceConfig.getTopicNameCacheMaxCapacity(), 20000);
+        assertEquals(serviceConfig.getMaxSecondsToClearTopicNameCache(), 1800);
 
         testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {
@@ -91,6 +95,8 @@ public class ProxyConfigurationTest {
             printWriter.println("metadataStoreCacheExpirySeconds=500");
             printWriter.println("zooKeeperSessionTimeoutMillis=-1");
             printWriter.println("zooKeeperCacheExpirySeconds=-1");
+            printWriter.println("topicNameCacheMaxCapacity=200");
+            printWriter.println("maxSecondsToClearTopicNameCache=900");
         }
         testConfigFile.deleteOnExit();
         stream = new FileInputStream(testConfigFile);
@@ -98,6 +104,8 @@ public class ProxyConfigurationTest {
         stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 60);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 500);
+        assertEquals(serviceConfig.getTopicNameCacheMaxCapacity(), 200);
+        assertEquals(serviceConfig.getMaxSecondsToClearTopicNameCache(), 900);
 
         testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {
@@ -108,6 +116,8 @@ public class ProxyConfigurationTest {
             printWriter.println("metadataStoreCacheExpirySeconds=30");
             printWriter.println("zookeeperSessionTimeoutMs=100");
             printWriter.println("zooKeeperCacheExpirySeconds=300");
+            printWriter.println("topicNameCacheMaxCapacity=100");
+            printWriter.println("maxSecondsToClearTopicNameCache=100");
         }
         testConfigFile.deleteOnExit();
         stream = new FileInputStream(testConfigFile);
@@ -115,6 +125,8 @@ public class ProxyConfigurationTest {
         stream.close();
         assertEquals(serviceConfig.getMetadataStoreSessionTimeoutMillis(), 100);
         assertEquals(serviceConfig.getMetadataStoreCacheExpirySeconds(), 300);
+        assertEquals(serviceConfig.getTopicNameCacheMaxCapacity(), 100);
+        assertEquals(serviceConfig.getMaxSecondsToClearTopicNameCache(), 100);
     }
 
 


### PR DESCRIPTION
Fixes #24445

Main Issue: #24445

### Motivation

PR https://github.com/apache/pulsar/pull/23052 fixed the issue caused by creating TopicName and adding items into the queue of TopicName Cache.

Issue: PR added a clarification for Pulsar Broker, but forgot to add the clarification for Pulsar Proxy, Pulsar WebSocket Service, and Pulsar Client.

### Modifications

- Pulsar Proxy and Pulsar WebSocket Service: to add a scheduled task to clear the cache
- Pulsar Client: clear cache when its capacity reaches `10_000`, which is the same value as the original behavior before https://github.com/apache/pulsar/pull/23052  

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
