### PR TITLE
[fix][build] propose wagon-ssh-external version

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -63,7 +63,6 @@
     <mockito.version>5.17.0</mockito.version>
     <byte-buddy.version>1.15.11</byte-buddy.version>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
-
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
       --add-opens java.base/jdk.internal.loader=ALL-UNNAMED


### PR DESCRIPTION
Motivation

we has proposed wagon-ssh.external version in pulsar-bom/pom.xml. so we should popose in all place.  when we replace jar version, it  is easy. 

 Modifications
proposed wagon-ssh.external version

Documentation

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

Matching PR in forked repository

PR in forked repository: 
