### PR TITLE
[improve][broker] PIP427:Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2056,7 +2056,9 @@ public class BrokerService implements Closeable {
                 }
             }
 
-            managedLedgerConfig.setThrottleMarkDelete(persistencePolicies.getManagedLedgerMaxMarkDeleteRate());
+            managedLedgerConfig.setThrottleMarkDelete(persistencePolicies.getManagedLedgerMaxMarkDeleteRate() >= 0
+                    ? persistencePolicies.getManagedLedgerMaxMarkDeleteRate()
+                    : serviceConfig.getManagedLedgerDefaultMarkDeleteRateLimit());
             managedLedgerConfig.setDigestType(serviceConfig.getManagedLedgerDigestType());
             managedLedgerConfig.setPassword(serviceConfig.getManagedLedgerPassword());
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
@@ -33,7 +33,7 @@ public class PersistencePolicies {
     private String managedLedgerStorageClassName;
 
     public PersistencePolicies() {
-        this(2, 2, 2, 0.0, null);
+        this(2, 2, 2, -1, null);
     }
 
     public PersistencePolicies(int bookkeeperEnsemble, int bookkeeperWriteQuorum, int bookkeeperAckQuorum,

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1376,8 +1376,8 @@ public class CmdNamespaces extends CmdBase {
 
         @Option(names = { "-r",
                 "--ml-mark-delete-max-rate" },
-                description = "Throttling rate of mark-delete operation " +
-                        "(0 means no throttle, -1 means unset which will use the default configuration from broker)")
+                description = "Throttling rate of mark-delete operation "
+                        + "(0 means no throttle, -1 means unset which will use the default configuration from broker)")
         private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "-c",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1376,8 +1376,9 @@ public class CmdNamespaces extends CmdBase {
 
         @Option(names = { "-r",
                 "--ml-mark-delete-max-rate" },
-                description = "Throttling rate of mark-delete operation (0 means no throttle)")
-        private double managedLedgerMaxMarkDeleteRate = 0;
+                description = "Throttling rate of mark-delete operation " +
+                        "(0 means no throttle, -1 means unset which will use the default configuration from broker)")
+        private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "-c",
                 "--ml-storage-class" },
@@ -1390,9 +1391,6 @@ public class CmdNamespaces extends CmdBase {
             if (bookkeeperEnsemble <= 0 || bookkeeperWriteQuorum <= 0 || bookkeeperAckQuorum <= 0) {
                 throw new ParameterException("[--bookkeeper-ensemble], [--bookkeeper-write-quorum] "
                         + "and [--bookkeeper-ack-quorum] must greater than 0.");
-            }
-            if (managedLedgerMaxMarkDeleteRate < 0) {
-                throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getAdmin().namespaces().setPersistence(namespace, new PersistencePolicies(bookkeeperEnsemble,
                     bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1188,9 +1188,12 @@ public class CmdTopicPolicies extends CmdBase {
                 description = "Number of acks (guaranteed copies) to wait for each entry")
         private int bookkeeperAckQuorum = 2;
 
-        @Option(names = { "-r", "--ml-mark-delete-max-rate" },
-                description = "Throttling rate of mark-delete operation (0 means no throttle)")
-        private double managedLedgerMaxMarkDeleteRate = 0;
+        @Option(names = { "-r",
+                "--ml-mark-delete-max-rate" },
+                description = "Throttling rate of mark-delete operation " +
+                        "(0 means no throttle, -1 means unset which will use " +
+                        "the configuration from namespace or broker)")
+        private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "--global", "-g" }, description = "Whether to set this policy globally. "
                 + "If set to true, the policy will be replicate to other clusters asynchronously", arity = "0")
@@ -1207,9 +1210,6 @@ public class CmdTopicPolicies extends CmdBase {
             if (bookkeeperEnsemble <= 0 || bookkeeperWriteQuorum <= 0 || bookkeeperAckQuorum <= 0) {
                 throw new ParameterException("[--bookkeeper-ensemble], [--bookkeeper-write-quorum] "
                         + "and [--bookkeeper-ack-quorum] must greater than 0.");
-            }
-            if (managedLedgerMaxMarkDeleteRate < 0) {
-                throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getTopicPolicies(isGlobal).setPersistence(persistentTopic, new PersistencePolicies(bookkeeperEnsemble,
                     bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1190,9 +1190,9 @@ public class CmdTopicPolicies extends CmdBase {
 
         @Option(names = { "-r",
                 "--ml-mark-delete-max-rate" },
-                description = "Throttling rate of mark-delete operation " +
-                        "(0 means no throttle, -1 means unset which will use " +
-                        "the configuration from namespace or broker)")
+                description = "Throttling rate of mark-delete operation "
+                        + "(0 means no throttle, -1 means unset which will use "
+                        + "the configuration from namespace or broker)")
         private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "--global", "-g" }, description = "Whether to set this policy globally. "

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -2152,9 +2152,9 @@ public class CmdTopics extends CmdBase {
         private int bookkeeperAckQuorum = 2;
 
         @Option(names = { "-r",
-                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation "
-                + "(0 means no throttle)")
-        private double managedLedgerMaxMarkDeleteRate = 0;
+                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation " +
+                "(0 means no throttle, -1 means unset which will use the configuration from namespace or broker)")
+        private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "-c",
                 "--ml-storage-class" },
@@ -2167,9 +2167,6 @@ public class CmdTopics extends CmdBase {
             if (bookkeeperEnsemble <= 0 || bookkeeperWriteQuorum <= 0 || bookkeeperAckQuorum <= 0) {
                 throw new ParameterException("[--bookkeeper-ensemble], [--bookkeeper-write-quorum] "
                         + "and [--bookkeeper-ack-quorum] must greater than 0.");
-            }
-            if (managedLedgerMaxMarkDeleteRate < 0) {
-                throw new ParameterException("[--ml-mark-delete-max-rate] cannot less than 0.");
             }
             getTopics().setPersistence(persistentTopic, new PersistencePolicies(bookkeeperEnsemble,
                     bookkeeperWriteQuorum, bookkeeperAckQuorum, managedLedgerMaxMarkDeleteRate,
@@ -2509,7 +2506,7 @@ public class CmdTopics extends CmdBase {
 
         @Option(names = { "--dispatch-rate-period",
             "-dt" }, description = "dispatch-rate-period in second type"
-                + " (default 1 second will be overwrite if not passed)")
+                + "(default 1 second will be overwrite if not passed)")
         private int dispatchRatePeriodSec = 1;
 
         @Option(names = { "--relative-to-publish-rate",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -2152,8 +2152,8 @@ public class CmdTopics extends CmdBase {
         private int bookkeeperAckQuorum = 2;
 
         @Option(names = { "-r",
-                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation " +
-                "(0 means no throttle, -1 means unset which will use the configuration from namespace or broker)")
+                "--ml-mark-delete-max-rate" }, description = "Throttling rate of mark-delete operation "
+                + "(0 means no throttle, -1 means unset which will use the configuration from namespace or broker)")
         private double managedLedgerMaxMarkDeleteRate = -1;
 
         @Option(names = { "-c",

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/CmdTopicPoliciesTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/CmdTopicPoliciesTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.TopicPolicies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.testng.annotations.Test;
 
 public class CmdTopicPoliciesTest {
@@ -43,5 +44,101 @@ public class CmdTopicPoliciesTest {
 
         verify(topicPolicies, times(1)).setRetention("persistent://public/default/topic",
                 new RetentionPolicies(200 * 24 * 60, 2 * 1024 * 1024));
+    }
+
+    @Test
+    public void testSetPersistenceWithDefaultMarkDeleteRate() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(anyBoolean())).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test that the default value is now -1 (unset) instead of 0
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -1.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithNegativeMarkDeleteRate() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(anyBoolean())).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test that negative values are now allowed (previously would throw exception)
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r -5.0".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -5.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithZeroMarkDeleteRate() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(anyBoolean())).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test that zero is still allowed
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r 0".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, 0.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithPositiveMarkDeleteRate() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(anyBoolean())).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test that positive values still work
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r 10.5".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, 10.5, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithUnsetMarkDeleteRate() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(anyBoolean())).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test explicitly setting to -1 (unset)
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r -1".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -1.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithGlobalFlag() throws Exception {
+        TopicPolicies topicPolicies = mock(TopicPolicies.class);
+
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.topicPolicies(true)).thenReturn(topicPolicies);
+
+        CmdTopicPolicies cmd = new CmdTopicPolicies(() -> admin);
+
+        // Test with global flag
+        cmd.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r -1 -g".split("\\s+"));
+
+        verify(topicPolicies, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -1.0, null));
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats.LedgerInfo;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -266,5 +267,45 @@ public class TestCmdTopics {
         cmdTopics.run("set-retention public/default/topic -s 2T -t 200d".split("\\s+"));
         verify(mockTopics, times(1)).setRetention("persistent://public/default/topic",
                 new RetentionPolicies(200 * 24 * 60, 2 * 1024 * 1024));
+    }
+
+    @Test
+    public void testSetPersistenceWithDefaultMarkDeleteRate() throws Exception {
+        // Test that the default value is now -1 (unset) instead of 0
+        cmdTopics.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2".split("\\s+"));
+        verify(mockTopics, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -1.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithNegativeMarkDeleteRate() throws Exception {
+        // Test that negative values are now allowed (previously would throw exception)
+        cmdTopics.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r -5.0".split("\\s+"));
+        verify(mockTopics, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -5.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithZeroMarkDeleteRate() throws Exception {
+        // Test that zero is still allowed
+        cmdTopics.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r 0".split("\\s+"));
+        verify(mockTopics, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, 0.0, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithPositiveMarkDeleteRate() throws Exception {
+        // Test that positive values still work
+        cmdTopics.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r 10.5".split("\\s+"));
+        verify(mockTopics, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, 10.5, null));
+    }
+
+    @Test
+    public void testSetPersistenceWithUnsetMarkDeleteRate() throws Exception {
+        // Test explicitly setting to -1 (unset)
+        cmdTopics.run("set-persistence persistent://public/default/topic -e 2 -w 2 -a 2 -r -1".split("\\s+"));
+        verify(mockTopics, times(1)).setPersistence("persistent://public/default/topic", 
+                new PersistencePolicies(2, 2, 2, -1.0, null));
     }
 }


### PR DESCRIPTION
### Motivation

Implementation of pip-427 #24425

### Modifications

- Adjusted the logic in BrokerService to set the throttle mark delete rate based on persistence policies, allowing for a fallback to the broker's default rate when necessary.
- Added comprehensive unit tests to validate the behavior of namespace and topic-level persistence policies, ensuring correct application of the managed ledger max mark delete rate.
- Updated CLI commands to accept a default value of -1 for the mark delete rate, indicating that it should use the broker's default configuration.
- Enhanced test coverage for CLI commands to verify the handling of various mark delete rate scenarios, including negative and zero values.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->