### PR TITLE
[fix][client] NPE in MultiTopicsConsumerImpl.negativeAcknowledge

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -571,6 +571,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public void negativeAcknowledge(MessageId messageId) {
+        if (getState() != State.Ready) {
+            log.warn("[{}] [{}] Cannot negative acknowledge message {} - consumer is not ready (state: {})",
+                    topic, subscription, messageId, getState());
+            return;
+        }
         checkArgument(messageId instanceof TopicMessageId);
         ConsumerImpl<T> consumer = consumers.get(((TopicMessageId) messageId).getOwnerTopic());
         consumer.negativeAcknowledge(messageId);
@@ -579,6 +584,11 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public void negativeAcknowledge(Message<?> message) {
+        if (getState() != State.Ready) {
+            log.warn("[{}] [{}] Cannot negative acknowledge message {} - consumer is not ready (state: {})",
+                    topic, subscription, message.getMessageId(), getState());
+            return;
+        }
         MessageId messageId = message.getMessageId();
         checkArgument(messageId instanceof TopicMessageId);
         ConsumerImpl<T> consumer = consumers.get(((TopicMessageId) messageId).getOwnerTopic());


### PR DESCRIPTION
### Issue Description (on version 3.0.10)

  - Location: MultiTopicsConsumerImpl.java:581 in the negativeAcknowledge(Message<?> message) method
  - Error: java.lang.NullPointerException
  - Root Cause: Race condition between closeAsync() and negativeAcknowledge() methods

  Technical Details

  What was happening:
  1. closeAsync() sets consumer state to Closing/Closed and calls cleanupMultiConsumer()
  2. cleanupMultiConsumer() sets unAckedMessageTracker = null (line 685)
  3. Concurrently, negativeAcknowledge() methods were still being called
  4. These methods accessed unAckedMessageTracker.remove(messageId) without checking if it was null
  5. This caused NullPointerException at line 581

  Race condition timeline:
  Thread 1: closeAsync() → setState(Closed) → cleanupMultiConsumer() → unAckedMessageTracker = null
  Thread 2: negativeAcknowledge() → unAckedMessageTracker.remove() → NPE!

The original stacktrace:

```
  Stacktrace:
  java.lang.NullPointerException: null
  class java.lang.NullPointerException: null
      at
  org.apache.pulsar.client.impl.MultiTopicsConsumerImpl.negativeAcknowledge(MultiTopicsConsumerImpl.java:581)
      at com.company.pulsar.FutureAsyncHandler.negativeAcknowledgeAsync(FutureAsyncHandler.scala:98)
      at com.company.pulsar.FutureAsyncHandler.negativeAcknowledgeAsync(FutureAsyncHandler.scala:25)
      at com.company.pulsar.consumer.DefaultConsumer.negativeAcknowledgeAsync(Consumer.scala:135)
      at com.company.pulsar.consumer.PulsarCommittableSourceGraphStage$CommittableMessageImpl.nack(CommittableSour
  ce.scala:134)
      at com.company.pulsar.PulsarTracer$TracedCommittableMessage.$anonfun$nack$1(PulsarTracer.scala:127)
      at com.company.pulsar.PulsarTracer$TracedCommittableMessage.$anonfun$wrapReply$1(PulsarTracer.scala:112)
      at com.company.domainapi.tracer.TraceFactory.$anonfun$decoratedOrigFn$1(TraceFactory.scala:93)
      at com.company.tracer.TraceFactoryImpl.buildSpanAroundFuture(TraceFactoryImpl.scala:197)
      at com.company.tracer.TraceFactoryImpl.$anonfun$tracedFt$1(TraceFactoryImpl.scala:123)
      at com.company.domainapi.tracer.TraceFactory.wrapChildCreation(TraceFactory.scala:161)
      at com.company.domainapi.tracer.TraceFactory.wrapChildCreation$(TraceFactory.scala:150)
      at com.company.tracer.TraceFactoryImpl.wrapChildCreation(TraceFactoryImpl.scala:29)
      at com.company.tracer.TraceFactoryImpl.tracedFt(TraceFactoryImpl.scala:123)
      at com.company.tracer.SpanTrace.childFt(BaseTrace.scala:121)
      at com.company.pulsar.PulsarTracer$TracedCommittableMessage.wrapReply(PulsarTracer.scala:108)
      at com.company.pulsar.PulsarTracer$TracedCommittableMessage.nack(PulsarTracer.scala:127)
      at com.company.pulsar.PulsarConsumerService$anonfun$nestedInanonfun$enqueueAndStartTask$3$1.applyOrElse(Puls
  arConsumerService.scala:749)
      at com.company.pulsar.PulsarConsumerService$anonfun$nestedInanonfun$enqueueAndStartTask$3$1.applyOrElse(Puls
  arConsumerService.scala:746)
      at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:490)
      at org.apache.pekko.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:73)
      at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:110)
      at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
      at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
      at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:110)
      at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)
      at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurato
  r.scala:57)
      at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
      at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
      at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
      at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
      at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```

### Modification

Make negativeAcknowledge return immediately if the consumer is not Ready instead of throwing exceptions for the follow reasons

- Throwing exception will break the API since we didn't declare the PulsarClientException for the method signature.
- If the consumer gets closed, all the unacked messages will be redelivered automatically. Users don't need to care about the failures of negativeAcknowledge() in this case.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->