### PR TITLE
[fix][io] Ensure infinite retention for Debezium history topic

### DIFF
--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -158,6 +158,10 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         ddlParser.parse(ddl, tables3);
         assertEquals(3, tables3.size());
 
+        // trim topic
+        admin.topics().unload(topicName);
+        admin.topics().trimTopic(topicName);
+
         // Stop the history (which should stop the producer) ...
         history.stop();
         history = new PulsarDatabaseHistory();
@@ -258,8 +262,9 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         assertTrue(history.exists());
         try (Reader<String> ignored = history.createHistoryReader()) {
             List<String> subscriptions = admin.topics().getSubscriptions(topicName);
-            assertEquals(subscriptions.size(), 1);
+            assertEquals(subscriptions.size(), 2);
             assertTrue(subscriptions.contains("my-subscription"));
+            assertTrue(subscriptions.contains(PulsarDatabaseHistory.DURABLE_SUB_NAME));
         } catch (Exception e) {
             fail("Failed to create history reader");
         }


### PR DESCRIPTION
### Motivation

The Debezium DatabaseHistory mechanism requires a complete and immutable log of all DDL changes to correctly reconstruct table schemas upon connector restart. The current PulsarDatabaseHistory implementation stores this history in a Pulsar topic but does not enforce a retention policy.


### Modifications
Create a durable subscription and never receive/ack message to make sure history topic data is retained.  The data is actually very small. Additionally, we can also flexibly control this subscription's cursor to fix or skip some history data.


### Verifying this change
- You can reproduce this issue by testing: `PulsarDatabaseHistoryTest`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
