### PR TITLE
[improve][io] Add support for the complete KinesisProducerConfiguration in KinesisSinkConfig

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -108,6 +108,13 @@
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
 
+    <!-- add utils to fix jackson parsing issue -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>utils</artifactId>
+      <version>2.22.12</version>
+    </dependency>
+
     <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -245,7 +245,7 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
 
     @FieldDoc(
             defaultValue = "",
-            help = "Extra KinesisProducerConfiguration parameters. See https://javadoc.io/static/com.amazonaws/amazon-kinesis-producer/0.14.0/index.html?com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.html for all the available parameters."
+            help = "Extra KinesisProducerConfiguration parameters. See https://javadoc.io/static/com.amazonaws/amazon-kinesis-producer/0.15.2/index.html?com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.html for all the available parameters."
                     + "Parameters that are explicitly set take preference over extra config.")
     private Map<String, String> extraKinesisProducerConfig = new HashMap<>();
 

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.io.kinesis;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +55,9 @@ public class KinesisSinkConfigTest {
                 "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
         assertEquals(config.getExtraKinesisProducerConfig(), expectedExtraKinesisProducerConfig,
                 "ExtraKinesisProducerConfiguration Maps should match exactly");
+        KinesisProducerConfiguration kinesisProducerConfiguration = KinesisSinkConfig
+                .loadExtraKinesisProducerConfig(config.getExtraKinesisProducerConfig());
+        assertEquals(kinesisProducerConfiguration.getCredentialsRefreshDelay(), 6000);
     }
 
     @Test

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
@@ -37,6 +37,11 @@ public class KinesisSinkConfigTest {
         map.put("awsKinesisStreamName", "my-stream");
         map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
 
+        Map<String, String> expectedExtraKinesisProducerConfig = new HashMap<> ();
+        expectedExtraKinesisProducerConfig.put("credentialsRefreshDelay", "6000");
+        expectedExtraKinesisProducerConfig.put("logLevel", "debug");
+        map.put("extraKinesisProducerConfig", expectedExtraKinesisProducerConfig);
+
         SinkContext sinkContext = Mockito.mock(SinkContext.class);
         KinesisSinkConfig config = KinesisSinkConfig.load(map, sinkContext);
 
@@ -46,6 +51,8 @@ public class KinesisSinkConfigTest {
         assertEquals(config.getAwsKinesisStreamName(), "my-stream");
         assertEquals(config.getAwsCredentialPluginParam(),
                 "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        assertEquals(config.getExtraKinesisProducerConfig(), expectedExtraKinesisProducerConfig,
+                "ExtraKinesisProducerConfiguration Maps should match exactly");
     }
 
     @Test

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.kinesis;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import java.io.IOException;
 import java.util.HashMap;


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24422

<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
The Apache Pulsar KinesisSink utilises the KinesisProducer from the KPL. The KPL provides a comprehensive set of configuration parameters through its KinesisProducerConfiguration class.

In the current KinesisSink implementation, most of these parameters such as collectionMaxCount, collectionMaxSize, connectTimeout, maxConnections, and minConnections—are not configurable. This restricts users' ability to optimise the sink's performance, or meet network and operational requirements potentially affecting throughput, latency, and resource utilisation.

### Modifications

<!-- Describe the modifications you've done. -->

- Added the following KPL configuration parameters directly into the KinesisSink configuration.

| Parameter | Description |
|--------|--------|
| collectionMaxCount | Maximum number of items to pack into an PutRecords request. |
| collectionMaxSize | Maximum amount of data to send with a PutRecords request. |
| connectTimeout | Timeout (milliseconds) for establishing TLS connections. |
| credentialsRefreshDelay | How often to refresh credentials (in milliseconds). |
| maxConnections | Maximum number of connections to open to the backend. | 
| minConnections | Minimum number of connections to keep open to the backend | 
| rateLimit | Limits the maximum allowed put rate for a shard, as a percentage of the backend limits. | 
| recordTtl | Set a time-to-live on records (milliseconds). | 
| requestTimeout | The maximum total time (milliseconds) allowed for a HTTP request | 

- Introduce an Optional Hashmap for Additional Configuration (extraKinesisProducerConfiguration), which accepts a hashmap of key-value pairs corresponding to any other KPL configuration parameters not directly exposed. This ensures users retain full control over the KinesisProducer's behavior without overloading the primary sink configuration interface.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
  - *Will be updated*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
https://github.com/cognitree/pulsar/pull/25
<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
