### PR TITLE
[fix][io] Make record properties configurable for kinesis source

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSourceConfig.java
@@ -22,8 +22,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
@@ -130,6 +134,16 @@ public class KinesisSourceConfig extends BaseKinesisConfig implements Serializab
     )
     private boolean useEnhancedFanOut = true;
 
+    @FieldDoc(required = false,
+            defaultValue = "kinesis.arrival.timestamp,kinesis.encryption.type,kinesis.partition.key,"
+                    + "kinesis.sequence.number,kinesis.shard.id,kinesis.millis.behind.latest",
+            help = "A comma-separated list of Kinesis metadata properties to include in the Pulsar message properties."
+                    + " The supported properties are: kinesis.arrival.timestamp, kinesis.encryption.type, "
+                    + "kinesis.partition.key, kinesis.sequence.number, kinesis.shard.id, kinesis.millis.behind.latest")
+    private String kinesisRecordProperties = "kinesis.arrival.timestamp,kinesis.encryption.type,"
+            + "kinesis.partition.key,kinesis.sequence.number,kinesis.shard.id,kinesis.millis.behind.latest";
+    private transient Set<String> propertiesToInclude;
+
     public static KinesisSourceConfig load(Map<String, Object> config, SourceContext sourceContext) {
         KinesisSourceConfig kinesisSourceConfig = IOConfigUtils.loadWithSecrets(config,
                 KinesisSourceConfig.class, sourceContext);
@@ -142,6 +156,15 @@ public class KinesisSourceConfig extends BaseKinesisConfig implements Serializab
         if (kinesisSourceConfig.getInitialPositionInStream() == InitialPositionInStream.AT_TIMESTAMP) {
             checkArgument((kinesisSourceConfig.getStartAtTime() != null),
                     "When initialPositionInStream is AT_TIMESTAMP, startAtTime must be specified");
+        }
+        if (isNotBlank(kinesisSourceConfig.getKinesisRecordProperties())) {
+            Set<String> properties = Arrays.stream(kinesisSourceConfig.getKinesisRecordProperties().split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet());
+            kinesisSourceConfig.setPropertiesToInclude(properties);
+        } else {
+            kinesisSourceConfig.setPropertiesToInclude(Collections.emptySet());
         }
         return kinesisSourceConfig;
     }

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisRecordTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisRecordTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.kinesis.model.EncryptionType;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+public class KinesisRecordTest {
+
+    private KinesisClientRecord mockRecord;
+    private final String shardId = "shard-001";
+    private final long millisBehindLatest = 12345L;
+    private final String partitionKey = "test-key";
+    private final String sequenceNumber = "seq-123";
+    private final Instant arrivalTimestamp = Instant.now();
+
+    @BeforeMethod
+    public void setup() {
+        mockRecord = Mockito.mock(KinesisClientRecord.class);
+        when(mockRecord.partitionKey()).thenReturn(partitionKey);
+        when(mockRecord.sequenceNumber()).thenReturn(sequenceNumber);
+        when(mockRecord.approximateArrivalTimestamp()).thenReturn(arrivalTimestamp);
+        when(mockRecord.encryptionType()).thenReturn(EncryptionType.NONE);
+        when(mockRecord.data()).thenReturn(ByteBuffer.wrap("test-data".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testAllPropertiesIncluded() {
+        Set<String> propertiesToInclude = new HashSet<>(Arrays.asList(
+                KinesisRecord.ARRIVAL_TIMESTAMP,
+                KinesisRecord.ENCRYPTION_TYPE,
+                KinesisRecord.PARTITION_KEY,
+                KinesisRecord.SEQUENCE_NUMBER,
+                KinesisRecord.SHARD_ID,
+                KinesisRecord.MILLIS_BEHIND_LATEST
+        ));
+
+        KinesisRecord kinesisRecord = new KinesisRecord(mockRecord, shardId, millisBehindLatest, propertiesToInclude);
+        Map<String, String> properties = kinesisRecord.getProperties();
+
+        assertEquals(properties.size(), 6);
+        assertEquals(properties.get(KinesisRecord.SHARD_ID), shardId);
+        assertEquals(properties.get(KinesisRecord.MILLIS_BEHIND_LATEST), String.valueOf(millisBehindLatest));
+        assertEquals(properties.get(KinesisRecord.PARTITION_KEY), partitionKey);
+        assertEquals(properties.get(KinesisRecord.SEQUENCE_NUMBER), sequenceNumber);
+        assertEquals(properties.get(KinesisRecord.ARRIVAL_TIMESTAMP), arrivalTimestamp.toString());
+        assertEquals(properties.get(KinesisRecord.ENCRYPTION_TYPE), EncryptionType.NONE.toString());
+    }
+
+    @Test
+    public void testSomePropertiesIncluded() {
+        Set<String> propertiesToInclude = new HashSet<>(Arrays.asList(
+                KinesisRecord.SHARD_ID,
+                KinesisRecord.SEQUENCE_NUMBER
+        ));
+
+        KinesisRecord kinesisRecord = new KinesisRecord(mockRecord, shardId, millisBehindLatest, propertiesToInclude);
+        Map<String, String> properties = kinesisRecord.getProperties();
+
+        assertEquals(properties.size(), 2);
+        assertTrue(properties.containsKey(KinesisRecord.SHARD_ID));
+        assertTrue(properties.containsKey(KinesisRecord.SEQUENCE_NUMBER));
+
+        assertFalse(properties.containsKey(KinesisRecord.PARTITION_KEY));
+        assertFalse(properties.containsKey(KinesisRecord.ARRIVAL_TIMESTAMP));
+        assertFalse(properties.containsKey(KinesisRecord.ENCRYPTION_TYPE));
+        assertFalse(properties.containsKey(KinesisRecord.MILLIS_BEHIND_LATEST));
+    }
+
+    @Test
+    public void testNoPropertiesIncluded() {
+        Set<String> propertiesToInclude = Collections.emptySet();
+
+        KinesisRecord kinesisRecord = new KinesisRecord(mockRecord, shardId, millisBehindLatest, propertiesToInclude);
+        Map<String, String> properties = kinesisRecord.getProperties();
+
+        assertTrue(properties.isEmpty());
+    }
+}

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSourceConfigTests.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.io.kinesis;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -28,7 +29,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.Set;
 import org.apache.pulsar.io.core.SourceContext;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -159,5 +160,54 @@ public class KinesisSourceConfigTests {
         map.put("awsCredentialPluginParam",
                 "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
         KinesisSourceConfig.load(map, Mockito.mock(SourceContext.class));
+    }
+
+    @Test
+    public final void propertiesDefaultTest() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("awsRegion", "us-west-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        KinesisSourceConfig config = KinesisSourceConfig.load(map, sourceContext);
+
+        Set<String> properties = config.getPropertiesToInclude();
+        assertEquals(properties.size(), 6);
+        assertTrue(properties.contains("kinesis.shard.id"));
+        assertTrue(properties.contains("kinesis.sequence.number"));
+    }
+
+    @Test
+    public final void propertiesCustomTest() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("awsRegion", "us-west-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        // Set custom properties, note the extra whitespace to test trim()
+        map.put("kinesisRecordProperties", "kinesis.shard.id, kinesis.partition.key ");
+
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        KinesisSourceConfig config = KinesisSourceConfig.load(map, sourceContext);
+
+        Set<String> properties = config.getPropertiesToInclude();
+        assertEquals(properties.size(), 2);
+        assertTrue(properties.contains("kinesis.shard.id"));
+        assertTrue(properties.contains("kinesis.partition.key"));
+    }
+
+    @Test
+    public final void propertiesEmptyTest() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("awsRegion", "us-west-1");
+        map.put("awsKinesisStreamName", "my-stream");
+        map.put("awsCredentialPluginParam", "{\"accessKey\":\"myKey\",\"secretKey\":\"my-Secret\"}");
+        map.put("kinesisRecordProperties", "");
+
+        SourceContext sourceContext = Mockito.mock(SourceContext.class);
+        KinesisSourceConfig config = KinesisSourceConfig.load(map, sourceContext);
+
+        Set<String> properties = config.getPropertiesToInclude();
+        assertTrue(properties.isEmpty());
     }
 }


### PR DESCRIPTION
### Motivation

The Kinesis source connector's handling of metadata properties was rigid and contained a critical bug.

- Properties were not configurable: Users could not select which Kinesis metadata properties to include in Pulsar messages. This forced all properties to be included, which could be inefficient in terms of message size.

- Key Collision Bug: A bug was discovered where all property keys were defined as an empty string (""), causing a key collision that resulted in the loss of all metadata except for the last one set (sequenceNumber).

This PR fixes these issues by introducing a configuration to control which properties are included, which also resolves the underlying bug.

### Modifications

- Added a new configuration, kinesisRecordProperties, to KinesisSourceConfig.java. This allows users to provide a comma-separated list of properties to include.
- The default value retains all previously available properties to ensure backward compatibility.
- As part of making the properties configurable, the empty string constants in KinesisRecord.java were replaced with unique, descriptive keys (e.g., "kinesis.arrival.timestamp"), fixing the data loss bug.

### Verifying this change
- Add unit test to covert this change

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
