### PR TITLE
[fix][broker] Fix NPE when getting delayed delivery policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -976,7 +976,8 @@ public class PersistentTopicsBase extends AdminResource {
             .thenApply(op -> {
                 TopicPolicies policies = op.orElseGet(TopicPolicies::new);
                 DelayedDeliveryPolicies delayedDeliveryPolicies = null;
-                if (policies.isDelayedDeliveryEnabledSet() && policies.isDelayedDeliveryTickTimeMillisSet()) {
+                if (policies.isDelayedDeliveryEnabledSet() && policies.isDelayedDeliveryTickTimeMillisSet()
+                        && policies.isDelayedDeliveryMaxDelayInMillisSet()) {
                     delayedDeliveryPolicies = DelayedDeliveryPolicies.builder()
                             .tickTime(policies.getDelayedDeliveryTickTimeMillis())
                             .active(policies.getDelayedDeliveryEnabled())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -976,13 +976,14 @@ public class PersistentTopicsBase extends AdminResource {
             .thenApply(op -> {
                 TopicPolicies policies = op.orElseGet(TopicPolicies::new);
                 DelayedDeliveryPolicies delayedDeliveryPolicies = null;
-                if (policies.isDelayedDeliveryEnabledSet() && policies.isDelayedDeliveryTickTimeMillisSet()
-                        && policies.isDelayedDeliveryMaxDelayInMillisSet()) {
-                    delayedDeliveryPolicies = DelayedDeliveryPolicies.builder()
+                if (policies.isDelayedDeliveryEnabledSet() && policies.isDelayedDeliveryTickTimeMillisSet()) {
+                    DelayedDeliveryPolicies.Builder builder = DelayedDeliveryPolicies.builder()
                             .tickTime(policies.getDelayedDeliveryTickTimeMillis())
-                            .active(policies.getDelayedDeliveryEnabled())
-                            .maxDeliveryDelayInMillis(policies.getDelayedDeliveryMaxDelayInMillis())
-                            .build();
+                            .active(policies.getDelayedDeliveryEnabled());
+                    if (policies.isDelayedDeliveryMaxDelayInMillisSet()) {
+                        builder.maxDeliveryDelayInMillis(policies.getDelayedDeliveryMaxDelayInMillis());
+                    }
+                    delayedDeliveryPolicies = builder.build();
                 }
                 if (delayedDeliveryPolicies == null && applied) {
                     delayedDeliveryPolicies = getNamespacePolicies(namespaceName).delayed_delivery_policies;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -128,6 +128,10 @@ public class TopicPolicies {
         return delayedDeliveryEnabled != null;
     }
 
+    public boolean isDelayedDeliveryMaxDelayInMillisSet(){
+        return delayedDeliveryMaxDelayInMillis != null;
+    }
+
     public boolean isMaxUnackedMessagesOnSubscriptionSet() {
         return maxUnackedMessagesOnSubscription != null;
     }


### PR DESCRIPTION
### Motivation

Fix NPE which introduced by https://github.com/apache/pulsar/pull/21798.

The issue was happened when upgrading the old version cluster to 3.3.0 or later version.
Withe the old version broker, the delayed delivery policy was persistent to the system topic without `delayedDeliveryMaxDelayInMillis` but the new version broker try to convert null to a long value.

```
 --- An unexpected error occurred in the server ---

Message: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.pulsar.common.policies.data.TopicPolicies.getDelayedDeliveryMaxDelayInMillis()" is null

Stacktrace:

java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.pulsar.common.policies.data.TopicPolicies.getDelayedDeliveryMaxDelayInMillis()" is null
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalGetDelayedDeliveryPolicies$103(PersistentTopicsBase.java:983)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)


Reason:
 --- An unexpected error occurred in the server ---

Message: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.pulsar.common.policies.data.TopicPolicies.getDelayedDeliveryMaxDelayInMillis()" is null

Stacktrace:

java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.pulsar.common.policies.data.TopicPolicies.getDelayedDeliveryMaxDelayInMillis()" is null
	at org.apache.pulsar.broker.admin.impl.PersistentTopicsBase.lambda$internalGetDelayedDeliveryPolicies$103(PersistentTopicsBase.java:983)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
