### PR TITLE
[improve][broker] Add logging when MetadataStoreTableViewImpl cache and tableview are out of sync (ExtensibleLoadManagerImpl only)

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/tableview/impl/MetadataStoreTableViewImpl.java
@@ -405,7 +405,15 @@ public class MetadataStoreTableViewImpl<T> implements MetadataStoreTableView<T> 
     }
 
     public T get(String key) {
-        return data.get(key);
+
+        var cached = cache.getIfCached(getPath(key));
+        // Added this logging to print warn any discrepancy between cache and tableview
+        var val = immutableData.get(key);
+        if (!Objects.equals(cached.orElse(null), val)) {
+            log.warn("cache and tableview are out of sync on item key={} value={} cached={}. Prolonged inconsistency "
+                    + "may require broker restart to mitigate the issue.", key, val, cached);
+        }
+        return val;
     }
 
     public CompletableFuture<Void> put(String key, T value) {


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

https://github.com/apache/pulsar/pull/24478 introduced tableview refresh logic when a metadata session is reestablished.  For better debugging, we better print warn log in case the cache and tableview record are out-of-sync(not expected)

### Modifications

- added warn logs when the cache and tableview record in MetadataStoreTableViewImpl are out-of-sync 
- minor bug fix in the test code

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
