### PR TITLE
[improve][build] Bump org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -51,7 +51,7 @@
     <log4j2.version>2.23.1</log4j2.version>
     <slf4j.version>2.0.13</slf4j.version>
     <testng.version>7.7.1</testng.version>
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,7 +293,7 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-collections4-4.4.jar
     - org.apache.commons-commons-compress-1.27.1.jar
     - org.apache.commons-commons-configuration2-2.12.0.jar
-    - org.apache.commons-commons-lang3-3.17.0.jar
+    - org.apache.commons-commons-lang3-3.18.0.jar
     - org.apache.commons-commons-text-1.13.1.jar
  * Netty
     - io.netty-netty-buffer-4.1.122.Final.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -343,7 +343,7 @@ The Apache Software License, Version 2.0
     - commons-codec-1.18.0.jar
     - commons-io-2.19.0.jar
     - commons-logging-1.2.jar
-    - commons-lang3-3.17.0.jar
+    - commons-lang3-3.18.0.jar
     - commons-text-1.13.1.jar
     - commons-compress-1.27.1.jar
     - commons-beanutils-1.11.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@ flexible messaging model and an intuitive client API.</description>
     <confluent.version>7.8.2</confluent.version>
     <aircompressor.version>0.27</aircompressor.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
-    <commons-lang3.version>3.17.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-io.version>2.19.0</commons-io.version>
     <commons-codec.version>1.18.0</commons-codec.version>


### PR DESCRIPTION
## Summary
- Upgrade Apache Commons Lang3 dependency from version 3.17.0 to 3.18.0
- Update version references in main pom.xml and buildtools/pom.xml
- Update corresponding jar names in LICENSE.bin.txt files

## Test plan
- [x] Verify build passes with new dependency version using `mvn install -Pcore-modules,-main -DskipTests`
- [x] Confirm all version references are updated consistently across the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)