### PR TITLE
[fix][ml] Fix asyncReadEntries might never complete if empty entries are read from BK

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -110,6 +110,7 @@ import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,8 +173,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                     ManagedLedgerFactoryConfig config)
             throws Exception {
         this(metadataStore, new DefaultBkFactory(bkClientConfiguration),
-                true /* isBookkeeperManaged */, config, NullStatsLogger.INSTANCE, OpenTelemetry.noop(),
-                factory -> new RangeEntryCacheManagerImpl(factory, factory.scheduledExecutor, OpenTelemetry.noop()));
+                true /* isBookkeeperManaged */, config, NullStatsLogger.INSTANCE, OpenTelemetry.noop(), null);
     }
 
     public ManagedLedgerFactoryImpl(MetadataStoreExtended metadataStore, BookKeeper bookKeeper)
@@ -189,7 +189,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
     @VisibleForTesting
     public ManagedLedgerFactoryImpl(MetadataStoreExtended metadataStore, BookKeeper bookKeeper,
-                                    Function<ManagedLedgerFactoryImpl, EntryCacheManager> entryCacheManagerCreator)
+                                    @Nullable Function<ManagedLedgerFactoryImpl, EntryCacheManager>
+                                            entryCacheManagerCreator)
             throws Exception {
         this(metadataStore, __ -> CompletableFuture.completedFuture(bookKeeper), false,
                 new ManagedLedgerFactoryConfig(), NullStatsLogger.INSTANCE, OpenTelemetry.noop(),
@@ -209,8 +210,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                     OpenTelemetry openTelemetry)
             throws Exception {
         this(metadataStore, bookKeeperGroupFactory, false /* isBookkeeperManaged */,
-                config, statsLogger, openTelemetry, factory -> new RangeEntryCacheManagerImpl(factory,
-                        factory.scheduledExecutor, openTelemetry));
+                config, statsLogger, openTelemetry, null);
     }
 
     private ManagedLedgerFactoryImpl(MetadataStoreExtended metadataStore,
@@ -219,7 +219,8 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                      ManagedLedgerFactoryConfig config,
                                      StatsLogger statsLogger,
                                      OpenTelemetry openTelemetry,
-                                     Function<ManagedLedgerFactoryImpl, EntryCacheManager> entryCacheManagerCreator)
+                                     @Nullable Function<ManagedLedgerFactoryImpl, EntryCacheManager>
+                                             entryCacheManagerCreator)
             throws Exception {
         MetadataCompressionConfig compressionConfigForManagedLedgerInfo =
                 config.getCompressionConfigForManagedLedgerInfo();
@@ -242,7 +243,11 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                 compressionConfigForManagedCursorInfo);
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
-        this.entryCacheManager = entryCacheManagerCreator.apply(this);
+        if (entryCacheManagerCreator == null) {
+            this.entryCacheManager = new RangeEntryCacheManagerImpl(this, scheduledExecutor, openTelemetry);
+        } else {
+            this.entryCacheManager = entryCacheManagerCreator.apply(this);
+        }
         this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
                 0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2245,8 +2245,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             // If all messages in [firstEntry...lastEntry] are filter out,
             // then manual call internalReadEntriesComplete to advance read position.
             if (firstValidEntry == -1L) {
-                opReadEntry.internalReadEntriesComplete(Collections.emptyList(), opReadEntry.ctx,
-                        PositionFactory.create(ledger.getId(), lastEntry));
+                final var nextReadPosition = PositionFactory.create(ledger.getId(), lastEntry).getNext();
+                opReadEntry.updateReadPosition(nextReadPosition);
+                opReadEntry.checkReadCompletion();
                 return;
             }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -68,6 +68,7 @@ class OpReadEntry implements ReadEntriesCallback {
 
     private void internalReadEntriesComplete(List<Entry> returnedEntries) {
         if (returnedEntries.isEmpty()) {
+            log.warn("[{}] Read no entries unexpectedly", this);
             checkReadCompletion();
             return;
         }
@@ -243,8 +244,17 @@ class OpReadEntry implements ReadEntriesCallback {
     @Override
     public String toString() {
         final var cursor = this.cursor;
+        final var readPosition = this.readPosition;
+        final var nextReadPosition = this.nextReadPosition;
+        final var entries = this.entries;
+        final var maxPosition = this.maxPosition;
+        final var count = this.count;
         if (cursor != null) {
-            return cursor.ledger.getName() + ":" + cursor.getName();
+            return cursor.ledger.getName() + " " + cursor.getName() + "{ readPosition: "
+                    + (readPosition != null ? readPosition : "(null)") + ", nextReadPosition: "
+                    + (nextReadPosition != null ? nextReadPosition : "(null)") + ", maxPosition: "
+                    + (maxPosition != null ? maxPosition : "(null)") + ", entries count: "
+                    + (entries != null ? entries.size() : "(null)") + ", count: " + count + " }";
         } else {
             return "(null)";
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -223,10 +223,9 @@ class OpReadEntry implements ReadEntriesCallback {
         cursor.ledger.getExecutor().execute(() -> {
             try {
                 callback.readEntriesComplete(entries, ctx);
+                recycle();
             } catch (Throwable throwable) {
                 log.error("[{}] readEntriesComplete failed (last position: {})", this, lastEntryPosition(), throwable);
-            } finally {
-                recycle();
             }
         });
     }
@@ -235,10 +234,9 @@ class OpReadEntry implements ReadEntriesCallback {
         try {
             callback.readEntriesFailed(e, ctx);
             cursor.ledger.mbean.recordReadEntriesError();
+            recycle();
         } catch (Throwable throwable) {
             log.error("[{}] readEntriesFailed failed (exception: {})", this, e.getMessage(), throwable);
-        } finally {
-            recycle();
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -74,10 +74,9 @@ class OpReadEntry implements ReadEntriesCallback {
         // Filter the returned entries for individual deleted messages
         int entriesCount = returnedEntries.size();
         long entriesSize = 0;
-        for (final var returnedEntry : returnedEntries) {
-            entriesSize += returnedEntry.getLength();
+        for (int i = 0; i < entriesCount; i++) {
+            entriesSize += returnedEntries.get(i).getLength();
         }
-        final var lastPosition = returnedEntries.get(returnedEntries.size() - 1).getPosition();
         cursor.updateReadStats(entriesCount, entriesSize);
 
         if (log.isDebugEnabled()) {
@@ -89,6 +88,7 @@ class OpReadEntry implements ReadEntriesCallback {
         entries.addAll(filteredEntries);
 
         // if entries have been filtered out then try to skip reading of already deletedMessages in that range
+        final var lastPosition = returnedEntries.get(entriesCount - 1).getPosition();
         final Position nexReadPosition = entriesCount != filteredEntries.size()
                 ? cursor.getNextAvailablePosition(lastPosition) : lastPosition.getNext();
         updateReadPosition(nexReadPosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -84,11 +84,12 @@ class OpReadEntry implements ReadEntriesCallback {
                     cursor.ledger.getName(), cursor.getName(), returnedEntries.size(), entries.size(), count);
         }
 
+        // Entries might be released after `filterReadEntries`, so retrieve the last position before that
+        final var lastPosition = returnedEntries.get(entriesCount - 1).getPosition();
         final var filteredEntries = cursor.filterReadEntries(returnedEntries);
         entries.addAll(filteredEntries);
 
         // if entries have been filtered out then try to skip reading of already deletedMessages in that range
-        final var lastPosition = returnedEntries.get(entriesCount - 1).getPosition();
         final Position nexReadPosition = entriesCount != filteredEntries.size()
                 ? cursor.getNextAvailablePosition(lastPosition) : lastPosition.getNext();
         updateReadPosition(nexReadPosition);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -440,8 +440,9 @@ public class RangeEntryCacheImpl implements EntryCache {
      * @param shouldCacheEntry if we should put the entry into the cache
      * @return a handle to the operation
      */
-    CompletableFuture<List<EntryImpl>> readFromStorage(ReadHandle lh,
-                                                       long firstEntry, long lastEntry, boolean shouldCacheEntry) {
+    @VisibleForTesting
+    protected CompletableFuture<List<EntryImpl>> readFromStorage(ReadHandle lh, long firstEntry, long lastEntry,
+                                                                 boolean shouldCacheEntry) {
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;
         CompletableFuture<List<EntryImpl>> readResult = ReadEntryUtils.readAsync(ml, lh, firstEntry, lastEntry)
                 .thenApply(

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -18,17 +18,22 @@
  */
 package org.apache.bookkeeper.test;
 
+import io.opentelemetry.api.OpenTelemetry;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import lombok.SneakyThrows;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.impl.cache.EntryCache;
+import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheManagerImpl;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
@@ -57,6 +62,7 @@ public abstract class MockedBookKeeperTestCase {
     protected ExecutorService cachedExecutor;
 
     protected FaultInjectionMetadataStore metadataStore;
+    private Function<ManagedLedgerImpl, EntryCache> entryCacheCreator = null;
 
     public MockedBookKeeperTestCase() {
         // By default start a 3 bookies cluster
@@ -84,7 +90,17 @@ public abstract class MockedBookKeeperTestCase {
 
         ManagedLedgerFactoryConfig managedLedgerFactoryConfig = new ManagedLedgerFactoryConfig();
         initManagedLedgerFactoryConfig(managedLedgerFactoryConfig);
-        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        factory = new ManagedLedgerFactoryImpl(metadataStore, bkc, __ -> new RangeEntryCacheManagerImpl(__,
+                __.getScheduledExecutor(), OpenTelemetry.noop()) {
+
+            @Override
+            public EntryCache getEntryCache(ManagedLedgerImpl ml) {
+                if (entryCacheCreator != null) {
+                    return entryCacheCreator.apply(ml);
+                }
+                return super.getEntryCache(ml);
+            }
+        });
 
         setUpTestCase();
     }
@@ -163,5 +179,9 @@ public abstract class MockedBookKeeperTestCase {
 
     protected void stopMetadataStore() {
         metadataStore.setAlwaysFail(new MetadataStoreException("failed"));
+    }
+
+    protected void setEntryCacheCreator(Function<ManagedLedgerImpl, EntryCache> entryCacheCreator) {
+        this.entryCacheCreator = entryCacheCreator;
     }
 }


### PR DESCRIPTION
Main Issue: #24497

### Motivation

When the `OpReadEntry#readEntriesComplete` is triggered by `RangeEntryCacheImpl#readFromStorage` with an empty list of entries, NPE will happen here: https://github.com/apache/pulsar/blob/bc5b933c0015beec8bb1907273c630730cffc853/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java#L95

Then `updateReadPosition` and `checkReadCompletion` will be skipped, where the result is very similar to https://github.com/apache/pulsar/issues/24497#issuecomment-3073740788
- The callback of `asyncReadEntries` will never complete
- The `entriesReadCount` will be updated but the `readPosition` won't
- `pendingReadOps` will not be reduced to 0

Unfortunately, from the existing analysis, the issue of 24497 might not be caused by this bug, but this NPE is still possible.

### Modifications

Remove the confusing `lastPosition` argument in `internalReadEntriesComplete`. It's only set when all entries have been filtered out and it needs to reset the `readPosition` in `ManagedLedgerImpl#internalReadFromLedger`. It can be replaced by a simple combination of `updateReadPosition` and `checkReadCompletion`.

In `internalReadEntriesComplete`, just call `checkReadCompletion` when no entries are read to trigger another round of read.

In addition, catch exceptions when triggering user-provided callback and print logs with better information. Without this change, the exception will be caught by `SingleThreadTask#safeRunTask` and the log will be `Error while running task:` that does not have description for a specific cursor or read position.

### Verifying this change

Make `EntryCache` configurable in tests add add `testReadNoEntries` to verify that the `asyncReadEntries` will eventually succeed even if one read operation returns an empty entry list.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: