### PR TITLE
[fix][broker] Fix exclusive producer creation when last shared producer closes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1099,7 +1099,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         // decrement usage only if this was a valid producer close
         USAGE_COUNT_UPDATER.decrementAndGet(this);
         // this conditional check is an optimization so we don't have acquire the write lock
-        // and execute following routine if there are no exclusive producers or there is no producer but still got waitingExclusiveProducers to call
+        // and execute following routine if there are no exclusive producers
+        // or there is no producer but still got waitingExclusiveProducers to call
         if (hasExclusiveProducer || (producers.size() == 0 && !waitingExclusiveProducers.isEmpty())) {
             lock.writeLock().lock();
             try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1099,8 +1099,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         // decrement usage only if this was a valid producer close
         USAGE_COUNT_UPDATER.decrementAndGet(this);
         // this conditional check is an optimization so we don't have acquire the write lock
-        // and execute following routine if there are no exclusive producers
-        if (hasExclusiveProducer) {
+        // and execute following routine if there are no exclusive producers or there is no producer but still got waitingExclusiveProducers to call
+        if (hasExclusiveProducer || (producers.size() == 0 && !waitingExclusiveProducers.isEmpty())) {
             lock.writeLock().lock();
             try {
                 hasExclusiveProducer = false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -1098,10 +1098,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected void handleProducerRemoved(Producer producer) {
         // decrement usage only if this was a valid producer close
         USAGE_COUNT_UPDATER.decrementAndGet(this);
-        // this conditional check is an optimization so we don't have acquire the write lock
-        // and execute following routine if there are no exclusive producers
-        // or there is no producer but still got waitingExclusiveProducers to call
-        if (hasExclusiveProducer || (producers.size() == 0 && !waitingExclusiveProducers.isEmpty())) {
+        // this conditional check is an optimization so we only need to acquire the write lock
+        // and execute following routine when:
+        // 1. If there was an exclusive producer before.
+        // 2. If this was the last producer closed and there are waiting exclusive producers
+        if (hasExclusiveProducer || (producers.isEmpty() && !waitingExclusiveProducers.isEmpty())) {
             lock.writeLock().lock();
             try {
                 hasExclusiveProducer = false;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -266,6 +266,7 @@ public class ExclusiveProducerTest extends BrokerTestBase {
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
             assertTrue(p3Future.isDone());
         });
+        p3Future.get().close();
     }
 
     @Test(dataProvider = "topics")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -242,6 +242,33 @@ public class ExclusiveProducerTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "topics")
+    public void testSharedProducerCloseWithWaitForExclusiveProducer(String type, boolean partitioned) throws Exception {
+        String topic = newTopic(type, partitioned);
+        Producer<String> p1 = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .accessMode(ProducerAccessMode.Shared)
+                .create();
+        Producer<String> p2 = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .accessMode(ProducerAccessMode.Shared)
+                .create();
+        CompletableFuture<Producer<String>> p3Future = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .accessMode(ProducerAccessMode.WaitForExclusive)
+                .createAsync();
+        // sleep 1 second to make sure p1, p2, p3Future are added to broker producers and waitingExclusiveProducers
+        Thread.sleep(1000L);
+        // now p3Future is still pending because p1,p2 are active in shared mode.
+        assertFalse(p3Future.isDone());
+        p1.close();
+        p2.close();
+        // close p1,p2 and p3Future should be done and return a producer.
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(p3Future.isDone());
+        });
+    }
+
+    @Test(dataProvider = "topics")
     public void existingSharedProducer(String type, boolean partitioned) throws Exception {
         String topic = newTopic(type, partitioned);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -265,6 +265,7 @@ public class ExclusiveProducerTest extends BrokerTestBase {
         // close p1,p2 and p3Future should be done and return a producer.
         Awaitility.await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
             assertTrue(p3Future.isDone());
+            assertTrue(p3Future.get().isConnected());
         });
         p3Future.get().close();
     }


### PR DESCRIPTION
### Motivation

When a producer in `WaitForExclusive` mode is created while shared producers exist on a topic, it fails to become active even after all shared producers are closed. This occurs because the broker doesn't properly check for waiting exclusive producers when the last shared producer is removed.

Steps to reproduce:
1. Create a producer with Shared mode
2. Create a producer with WaitForExclusive mode
3. Close the first producer
4. The exclusive producer never gets created

### Modifications

- Modified the condition in `handleProducerRemoved()` to also check for waiting exclusive producers when the last producer is removed
- Added test case to verify the fix

### Verifying this change

- [x] Make sure that the change passes the CI checks.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/13

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
