### PR TITLE
[fix][broker] Fix wrong backlog age metrics when the mark delete position point to a deleted ledger

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3651,7 +3651,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         Position oldestMarkDeletePosition = oldestMarkDeleteCursorInfo.getPosition();
         OldestPositionInfo lastOldestPositionInfo = oldestPositionInfo;
         if (lastOldestPositionInfo != null
-            && oldestMarkDeletePosition.compareTo(lastOldestPositionInfo.getOldestCursorMarkDeletePosition()) == 0) {
+            && oldestMarkDeletePosition.compareTo(lastOldestPositionInfo.getOldestCursorMarkDeletePosition()) == 0
+            && oldestMarkDeletePosition.compareTo(ledger.getFirstPosition()) >= 0) {
             // Same position, but the cursor causing it has changed?
             if (!lastOldestPositionInfo.getCursorName().equals(oldestMarkDeleteCursorInfo.getCursor().getName())) {
                 updateResultIfNewer(new OldestPositionInfo(
@@ -3779,6 +3780,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo
                 markDeletePositionLedgerInfo = ledger.getLedgerInfo(markDeletePosition.getLedgerId()).get();
+
+        // If markDeletePositionLedgerInfo is null (ledger no longer exists due to retention/cleanup),
+        // use the next valid position instead to get a meaningful timestamp
+        if (markDeletePositionLedgerInfo == null) {
+            Position nextValidPosition = ledger.getNextValidPosition(markDeletePosition);
+            markDeletePositionLedgerInfo = ledger.getLedgerInfo(nextValidPosition.getLedgerId()).get();
+            markDeletePosition = nextValidPosition;
+        }
 
         org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo positionToCheckLedgerInfo =
                 markDeletePositionLedgerInfo;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
@@ -51,7 +52,6 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
     }
 
     protected void doInitConf() throws Exception {
-        this.conf.setPreciseTimeBasedBacklogQuotaCheck(true);
         this.conf.setManagedLedgerMaxEntriesPerLedger(2);
         this.conf.setManagedLedgerMaxLedgerRolloverTimeMinutes(10);
         this.conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
@@ -106,6 +106,48 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
         // Verify: "persistentTopic.estimatedTimeBasedBacklogQuotaCheck" will not get a NullPointerException.
         Position oldestPosition = ml.getCursors().getCursorWithOldestPosition().getPosition();
         persistentTopic.estimatedTimeBasedBacklogQuotaCheck(oldestPosition);
+
+        p1.close();
+        c1.close();
+        admin.topics().delete(tp, false);
+    }
+
+    @Test
+    public void testEstimatedTimeBasedBacklogQuotaCheckWithTopicUnloading() throws Exception {
+        final String tp = BrokerTestUtil.newUniqueName("public/default/tp-with-topic-unloading");
+        admin.topics().createNonPartitionedTopic(tp);
+
+        Consumer<byte[]> c1 = pulsarClient.newConsumer().topic(tp).subscriptionName("s1").subscribe();
+        Producer<byte[]> p1 = pulsarClient.newProducer().topic(tp).create();
+
+        byte[] content = new byte[]{1};
+        for (int i = 0; i < 10; i++) {
+            p1.send(content);
+        }
+
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(tp, false).join().get();
+
+        Awaitility.await().untilAsserted(() -> {
+            admin.brokers().backlogQuotaCheck();
+            assertTrue(persistentTopic.getBestEffortOldestUnacknowledgedMessageAgeSeconds() > 0);
+        });
+
+        for (int i = 0; i < 10; i++) {
+            c1.acknowledge(c1.receive());
+        }
+
+        Awaitility.await().untilAsserted(() -> assertEquals(persistentTopic.getBacklogSize(), 0));
+        admin.topics().unload(tp);
+        for (int i = 0; i < 10; i++) {
+            p1.send(content);
+        }
+
+        PersistentTopic persistentTopicNew = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(tp, false).join().get();
+        Awaitility.await().untilAsserted(() -> {
+            admin.brokers().backlogQuotaCheck();
+            assertTrue(persistentTopicNew.getBestEffortOldestUnacknowledgedMessageAgeSeconds() > 0);
+        });
 
         p1.close();
         c1.close();


### PR DESCRIPTION
### Motivation

The mark delete position may point to ledgers that have been cleaned up/deleted. This causes:

 1. pulsar_storage_backlog_age_seconds metric returns -1 instead of actual backlog age after topic unloading
 2. Prometheus monitoring shows incorrect backlog age for lagged subscriptions

You can use the newly added test to reproduce the issue.

### Verifying this change

Added new test

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
