### PR TITLE
[improve][misc] Optimize topic list hashing so that potentially large String allocation is avoided

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicListTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicListTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import com.google.re2j.Pattern;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -100,10 +101,16 @@ public class TopicListTest {
         String hash1 = TopicList.calculateHash(Arrays.asList(topicName3, topicName2, topicName1));
         String hash2 = TopicList.calculateHash(Arrays.asList(topicName1, topicName3, topicName2));
         assertEquals(hash1, hash2, "Hash must not depend on order of topics in the list");
+        assertEquals(hash1, "90d4a04a", "Hash must be equal to the expected value");
 
         String hash3 = TopicList.calculateHash(Arrays.asList(topicName1, topicName2));
         assertNotEquals(hash1, hash3, "Different list must have different hashes");
 
+        String hash4 = TopicList.calculateHash(Arrays.asList(topicName1));
+        assertEquals(hash4, "0d0602ed", "Hash must be equal to the expected value");
+
+        String hash5 = TopicList.calculateHash(Collections.emptyList());
+        assertEquals(hash5, "00000000", "Hash of empty list must be 0");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Pulsar's regular expression pattern-based consumers rely on hashing topic listings for a namespace. The hash for all topics in the namespace is calculated in multiple locations throughout the solution. For example, whenever a new topic is added or deleted, the hash will be recalculated for all topics in the namespace.

The current hash calculation implementation concatenates all topics into a single String instance, which is then passed to the hash calculation. This approach is suboptimal since the Guava Hashing API provides a way to calculate hashes of individual items. The current implementation causes unnecessary large java.lang.String and byte[] allocations. In the optimized version, no new java.lang.String instances are allocated, and the byte[] allocation consists of small allocations for each individual String instance (the topic name).

### Modifications

- Optimize topic list hashing by using the Guava Hashing API's Hasher, where individual items can be passed to hash calculation
- Add tests that ensure the modified hash calculation produces the same result as the previous implementation

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->