### PR TITLE
[improve][build] Upgrade Caffeine from 2.9.1 to 3.2.1

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -260,7 +260,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.17.2.jar
      - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.17.2.jar
      - com.fasterxml.jackson.module-jackson-module-parameter-names-2.17.2.jar
- * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
+ * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.14.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.51.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -324,7 +324,7 @@ The Apache Software License, Version 2.0
      - jackson-datatype-jdk8-2.17.2.jar
      - jackson-datatype-jsr310-2.17.2.jar
      - jackson-module-parameter-names-2.17.2.jar
- * Caffeine -- caffeine-2.9.1.jar
+ * Caffeine -- caffeine-3.2.1.jar
  * simpleclient_caffeine-0.16.0.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
-    <caffeine.version>2.9.1</caffeine.version>
+    <caffeine.version>3.2.1</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
     <jline.version>2.14.6</jline.version>
     <jline3.version>3.21.0</jline3.version>


### PR DESCRIPTION
## Summary

This PR upgrades the Caffeine caching library from version 2.9.1 to 3.2.1 to benefit from the latest features and performance improvements.

### Changes Made
- Updated `caffeine.version` from 2.9.1 to 3.2.1 in the main pom.xml
- Updated LICENSE.bin.txt files to reflect the new Caffeine version

🤖 Generated with [Claude Code](https://claude.ai/code)