### PR TITLE
[fix][client] Fix issue in auto releasing of idle connection with topics pattern consumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/MultiBrokerBaseTest.java
@@ -50,6 +50,11 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
         additionalBrokersSetup();
         pulsarResourcesSetup();
+        additionalSetup();
+    }
+
+    protected void additionalSetup() throws Exception {
+        // override this method to add any additional setup logic
     }
 
     protected void pulsarResourcesSetup() throws PulsarAdminException {
@@ -91,7 +96,16 @@ public abstract class MultiBrokerBaseTest extends MockedPulsarServiceBaseTest {
     @Override
     public final void cleanup() throws Exception {
         additionalBrokersCleanup();
+        try {
+            additionalCleanup();
+        } catch (Exception e) {
+            log.warn("Exception during additional cleanup", e);
+        }
         super.internalCleanup();
+    }
+
+    protected void additionalCleanup() throws Exception {
+        // override this method to add any additional cleanup logic
     }
 
     protected void additionalBrokersCleanup() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
@@ -39,7 +39,7 @@ import org.apache.pulsar.client.api.transaction.Transaction;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 
-public class AutoCloseUselessClientConSupports extends MultiBrokerBaseTest {
+public abstract class AutoCloseUselessClientConSupports extends MultiBrokerBaseTest {
 
     protected static final int BROKER_COUNT = 5;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTopicsPatternConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTopicsPatternConsumerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.testng.annotations.Test;
+
+@Test
+public class AutoCloseUselessClientConTopicsPatternConsumerTest extends AutoCloseUselessClientConSupports {
+    private static final String TOPIC_NAME = BrokerTestUtil.newUniqueName("pattern_");
+    private static final String TOPIC_FULL_NAME = "persistent://public/default/" + TOPIC_NAME;
+    private static final String TOPIC_PATTERN = "persistent://public/default/pattern_.*";
+
+    @Override
+    protected void pulsarResourcesSetup() throws PulsarAdminException {
+        super.pulsarResourcesSetup();
+        admin.topics().createNonPartitionedTopic(TOPIC_FULL_NAME);
+    }
+
+    @Test
+    public void testConnectionAutoReleaseWhileUsingTopicsPatternConsumer() throws Exception {
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder()
+                .serviceUrl(lookupUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .connectionsPerBroker(Integer.MAX_VALUE);
+        AtomicInteger connectionCreationCounter = new AtomicInteger(0);
+        PulsarClientImpl pulsarClient = InjectedClientCnxClientBuilder.create(clientBuilder, (conf, eventLoopGroup) -> {
+            connectionCreationCounter.incrementAndGet();
+            return new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup);
+        });
+
+        @Cleanup
+        Consumer consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topicsPattern(TOPIC_PATTERN)
+                .isAckReceiptEnabled(true)
+                .subscriptionName("my-subscription-x")
+                .subscribe();
+        @Cleanup
+        Producer producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(TOPIC_NAME)
+                .create();
+
+        Consumer consumer2 = pulsarClient.newConsumer(Schema.BYTES)
+                .topicsPattern(TOPIC_PATTERN)
+                .subscriptionName("my-subscription-y")
+                .subscribe();
+
+        // check that there are more than 3 connections
+        // at least 3 connections are required:
+        // 1 for "producer", 1 for "consumer", and 1 for the topic watcher of "consumer"
+        // additional connections will be created for the second consumer and its topic watcher
+        // there's also a connection for topic lookup
+        assertThat(pulsarClient.getCnxPool().getPoolSize()).isGreaterThan(3);
+
+        int connectionsCreatedBefore = connectionCreationCounter.get();
+
+        // trigger releasing of unused client connections
+        trigReleaseConnection(pulsarClient);
+
+        // close consumer2 that creates an extra connection due to connectionsPerBroker set to Integer.MAX_VALUE
+        consumer2.close();
+
+        // trigger releasing of unused client connections
+        trigReleaseConnection(pulsarClient);
+
+        // verify that the number of connections is 3 now, which is the expected number of connections
+        assertThat(pulsarClient.getCnxPool().getPoolSize()).isEqualTo(3);
+
+        // Ensure all things still works
+        ensureProducerAndConsumerWorks(producer, consumer);
+
+        // Verify that the number of connections did not increase after the work was completed
+        assertThat(pulsarClient.getCnxPool().getPoolSize()).isEqualTo(3);
+
+        assertThat(connectionCreationCounter.get())
+                .as("No new connections should be created after releasing unused connections since that would "
+                        + "mean that an used connection was released.")
+                .isEqualTo(connectionsCreatedBefore);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -1508,6 +1508,9 @@ public class ClientCnx extends PulsarHandler {
         if (!transactionMetaStoreHandlers.isEmpty()) {
             return false;
         }
+        if (!topicListWatchers.isEmpty()) {
+            return false;
+        }
         return true;
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxIdleStateTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxIdleStateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertTrue;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+public class ClientCnxIdleStateTest {
+
+    @Test
+    public void testShouldNotReleaseConnectionIfIdleCheckFails() throws InterruptedException {
+        ClientCnx clientCnx = mock(ClientCnx.class);
+        ClientCnxIdleState idleState = new ClientCnxIdleState(clientCnx);
+        int maxIdleSeconds = 1;
+
+        // initially, return true for idle check
+        doReturn(true).when(clientCnx).idleCheck();
+
+        // do the first idle detection
+        idleState.doIdleDetect(maxIdleSeconds);
+
+        // the state should be IDLE since the idle check passed
+        assertTrue(idleState.isIdle());
+
+        // Wait for more than maxIdleSeconds
+        Thread.sleep(TimeUnit.SECONDS.toMillis(maxIdleSeconds) + 1);
+
+        // now return false for idle check
+        doReturn(false).when(clientCnx).idleCheck();
+
+        // do the second idle detection
+        idleState.doIdleDetect(maxIdleSeconds);
+
+        // the state should now be USING since the idle check failed
+        assertTrue(idleState.isUsing());
+
+        // verify that idleCheck was called twice
+        verify(clientCnx, times(2)).idleCheck();
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -290,6 +290,17 @@ public class ClientCnxTest {
     }
 
     @Test
+    public void testIdleCheckWithTopicListWatcher() {
+        ClientCnx cnx =
+                new ClientCnx(InstrumentProvider.NOOP, new ClientConfigurationData(), mock(EventLoopGroup.class));
+        // idle check should return true initially
+        assertTrue(cnx.idleCheck());
+        cnx.registerTopicListWatcher(0, mock(TopicListWatcher.class));
+        // idle check should now return false since there's a registered watcher
+        assertFalse(cnx.idleCheck());
+    }
+
+    @Test
     public void testNoWatchersWhenNoServerSupport() {
         withConnection("testNoWatchersWhenNoServerSupport", cnx -> {
             cnx.handleConnected(new CommandConnected()

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConProxyTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
+import org.apache.pulsar.proxy.server.ProxyConfiguration;
+import org.apache.pulsar.proxy.server.ProxyService;
+import org.testng.annotations.Test;
+
+@Test
+public class AutoCloseUselessClientConProxyTest extends AutoCloseUselessClientConSupports {
+    private static final String TOPIC_NAME = BrokerTestUtil.newUniqueName("pattern_");
+    private static final String TOPIC_FULL_NAME = "persistent://public/default/" + TOPIC_NAME;
+    private static final String TOPIC_PATTERN = "persistent://public/default/pattern_.*";
+    private ProxyService proxyService;
+    private ProxyConfiguration proxyConfig;
+    private PulsarClient proxiedClient;
+    private AtomicInteger connectionCreationCounter = new AtomicInteger(0);
+
+    @Override
+    protected void additionalSetup() throws Exception {
+        proxyConfig = new ProxyConfiguration();
+        proxyConfig.setServicePort(Optional.ofNullable(0));
+        proxyConfig.setBrokerProxyAllowedTargetPorts("*");
+        proxyConfig.setMetadataStoreUrl("dummy");
+        proxyConfig.setClusterName(configClusterName);
+        startProxyService();
+        // use the same port for subsequent restarts
+        proxyConfig.setServicePort(proxyService.getListenPort());
+
+        ClientBuilderImpl clientBuilder = (ClientBuilderImpl) PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:" + proxyService.getListenPort().get())
+                .connectionsPerBroker(Integer.MAX_VALUE) // effectively uses a different connection for each usage
+                .statsInterval(0, TimeUnit.SECONDS);
+        proxiedClient = InjectedClientCnxClientBuilder.create(clientBuilder, (conf, eventLoopGroup) -> {
+            connectionCreationCounter.incrementAndGet();
+            return new ClientCnx(InstrumentProvider.NOOP, conf, eventLoopGroup);
+        });
+        registerCloseable(proxiedClient);
+    }
+
+    private void startProxyService() throws Exception {
+        proxyService = BrokerTestUtil.spyWithoutRecordingInvocations(new ProxyService(proxyConfig,
+                new AuthenticationService(PulsarConfigurationLoader.convertFrom(proxyConfig)),
+                AuthenticationDisabled.INSTANCE));
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeper))).when(proxyService).createLocalMetadataStore();
+        doReturn(registerCloseable(new ZKMetadataStore(mockZooKeeperGlobal))).when(proxyService)
+                .createConfigurationMetadataStore();
+        proxyService.start();
+        registerCloseable(proxyService);
+    }
+
+    @Override
+    protected void pulsarResourcesSetup() throws PulsarAdminException {
+        super.pulsarResourcesSetup();
+        admin.topics().createNonPartitionedTopic(TOPIC_FULL_NAME);
+    }
+
+    @Test
+    public void testConnectionAutoReleaseWhileUsingTopicsPatternConsumerAndProxy() throws Exception {
+        PulsarClientImpl pulsarClient = (PulsarClientImpl) proxiedClient;
+        @Cleanup
+        Consumer consumer = pulsarClient.newConsumer(Schema.BYTES)
+                .topicsPattern(TOPIC_PATTERN)
+                .isAckReceiptEnabled(true)
+                .subscriptionName("my-subscription-x")
+                .subscribe();
+        @Cleanup
+        Producer producer = pulsarClient.newProducer(Schema.BYTES)
+                .topic(TOPIC_NAME)
+                .create();
+
+        Consumer consumer2 = pulsarClient.newConsumer(Schema.BYTES)
+                .topicsPattern(TOPIC_PATTERN)
+                .subscriptionName("my-subscription-y")
+                .subscribe();
+
+        int poolSizeAfterCreatingConsumersAndProducer = pulsarClient.getCnxPool().getPoolSize();
+        // check that there are more than 3 connections
+        // at least 3 connections are required:
+        // 1 for "producer", 1 for "consumer", and 1 for the topic watcher of "consumer"
+        // additional connections will be created for the second consumer and its topic watcher
+        // there's also a connection for topic lookup
+        assertThat(poolSizeAfterCreatingConsumersAndProducer).isGreaterThan(3);
+
+        int connectionsCreatedBefore = connectionCreationCounter.get();
+
+        // trigger releasing of unused client connections
+        trigReleaseConnection(pulsarClient);
+
+        // verify that the number of connections is still more than 3, but less than the pool size after creating
+        // consumers and producer
+        // since the lookup connection to the proxy should be closed now
+        assertThat(pulsarClient.getCnxPool().getPoolSize())
+                .isGreaterThan(3)
+                .isLessThan(poolSizeAfterCreatingConsumersAndProducer);
+
+        // close consumer2 that creates an extra connection due to connectionsPerBroker set to Integer.MAX_VALUE
+        consumer2.close();
+
+        // trigger releasing of unused client connections
+        trigReleaseConnection(pulsarClient);
+
+        // verify that the number of connections is 3 now, which is the expected number of connections
+        assertThat(pulsarClient.getCnxPool().getPoolSize()).isEqualTo(3);
+
+        // Ensure all things still works
+        ensureProducerAndConsumerWorks(producer, consumer);
+
+        // Verify that the number of connections did not increase after the work was completed
+        assertThat(pulsarClient.getCnxPool().getPoolSize()).isEqualTo(3);
+
+        assertThat(connectionCreationCounter.get())
+                .as("No new connections should be created after releasing unused connections since that would "
+                        + "mean that an used connection was released.")
+                .isEqualTo(connectionsCreatedBefore);
+    }
+}


### PR DESCRIPTION
### Motivation

["PIP-165 Auto release client useless connections"](https://github.com/apache/pulsar/issues/15516) added a solution that closes unused idling connections. The idle check doesn't consider topic watchers created by a topics pattern (regex) consumer. The impact of this is that connections would get frequently closed and immediately reconnected when topics pattern consumers are used and when the topic watcher is the only resource using the connection.

While reviewing the code, another possible race condition was observed in the solution due lack of usage of volatile for ClientCnxIdleState's idleMarkTime field. The field gets mutated and read in different threads in certain cases.
There was also a concern that a currently used connection could get released under a race condition. That's why this PR adds another check before the ClientCnxIdleState can move from IDLE to RELEASING.

### Modifications

- fix the ClientCnx idleCheck method
  - check topic list watchers
- make ClientCnxIdleState's idleMarkTime field volatile
- add extra idleCheck in ClientCnxIdleState's doIdleDetect before the state can change from IDLE to RELEASING, switch to USING if the connection is getting used.
- adds test coverage at different levels. There are also tests for the usage of Pulsar Proxy + multiple brokers.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->