### PR TITLE
[fix][proxy] Fix default value of connectionMaxIdleSeconds in Pulsar Proxy

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -734,6 +734,8 @@ public class ProxyConnection extends PulsarHandler {
         ProxyConfiguration proxyConfig = service.getConfiguration();
         initialConf.setServiceUrl(
                 proxyConfig.isTlsEnabledWithBroker() ? service.getServiceUrlTls() : service.getServiceUrl());
+        /** The proxy service does not need to automatically clean up idling connections, so set to false. **/
+        initialConf.setConnectionMaxIdleSeconds(-1);
 
         // Apply all arbitrary configuration. This must be called before setting any fields annotated as
         // @Secret on the ClientConfigurationData object because of the way they are serialized.
@@ -742,8 +744,6 @@ public class ProxyConnection extends PulsarHandler {
                 .filterAndMapProperties(proxyConfig.getProperties(), "brokerClient_");
         ClientConfigurationData clientConf = ConfigurationDataUtils
                 .loadData(overrides, initialConf, ClientConfigurationData.class);
-        /** The proxy service does not need to automatically clean up invalid connections, so set false. **/
-        initialConf.setConnectionMaxIdleSeconds(-1);
         clientConf.setAuthentication(this.getClientAuthentication());
         if (proxyConfig.isTlsEnabledWithBroker()) {
             clientConf.setUseTls(true);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -41,6 +41,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.avro.reflect.Nullable;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -178,6 +180,34 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         for (int i = 0; i < 10; i++) {
             producer.send("test".getBytes());
         }
+    }
+
+    @Test
+    public void testProxyConnectionClientConfig() throws Exception {
+        @Cleanup
+        PulsarClient client = PulsarClient.builder().serviceUrl(proxyService.getServiceUrl())
+                .build();
+
+        @Cleanup
+        Producer<byte[]> producer = client.newProducer()
+                .topic("persistent://sample/test/local/producer-topic2")
+                .create();
+
+        MutableBoolean found = new MutableBoolean(false);
+        proxyService.getClientCnxs().forEach(proxyConnection -> {
+            if (proxyConnection.getConnectionPool() != null) {
+                try {
+                    found.setTrue();
+                    assertEquals(-1,
+                            FieldUtils.readDeclaredField(proxyConnection.getConnectionPool(),
+                                    "connectionMaxIdleSeconds",
+                                    true));
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        assertTrue(found.isTrue(), "No proxy connection found with connectionMaxIdleSeconds set to -1");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The configuration code added in #16165 intends to set the default value of connectionMaxIdleSeconds in Pulsar Proxy to -1. This is not the case. The effective value is 60 since the value is set after the object is no longer used.

https://github.com/apache/pulsar/blob/08caff42b71e619b66094df6b3bcaeb1eba1e97a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java#L745-L746

full method code:

https://github.com/apache/pulsar/blob/08caff42b71e619b66094df6b3bcaeb1eba1e97a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java#L732-L767

### Modifications

- move the line of code a few lines earlier so that it gets used
- add a test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->