### PR TITLE
[improve][misc] Upgrade RE2/J to 1.8

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -512,7 +512,7 @@ The Apache Software License, Version 2.0
     - com.google.http-client-google-http-client-gson-1.41.0.jar
     - com.google.http-client-google-http-client-1.41.0.jar
     - com.google.auto.value-auto-value-annotations-1.11.0.jar
-    - com.google.re2j-re2j-1.7.jar
+    - com.google.re2j-re2j-1.8.jar
   * Jetcd - shaded
   * IPAddress
     - com.github.seancfoley-ipaddress-5.5.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -419,7 +419,7 @@ The Apache Software License, Version 2.0
   * Apache Avro
     - avro-1.11.4.jar
     - avro-protobuf-1.11.4.jar
- * RE2j -- re2j-1.7.jar
+ * RE2j -- re2j-1.8.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar
  * RoaringBitmap -- RoaringBitmap-1.2.0.jar
  * Fastutil -- fastutil-8.5.14.jar

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@ flexible messaging model and an intuitive client API.</description>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
     <opentelemetry.semconv.version>1.29.0-alpha</opentelemetry.semconv.version>
     <picocli.version>4.7.5</picocli.version>
-    <re2j.version>1.7</re2j.version>
+    <re2j.version>1.8</re2j.version>
     <completable-futures.version>0.3.6</completable-futures.version>
     <failsafe.version>3.3.2</failsafe.version>
 


### PR DESCRIPTION
### Motivation

RE2/J is used in topics pattern consumers on the broker side to match topics. There's a newer version 1.8 available that comes with some bug fixes and optimizations.
Release notes: https://github.com/google/re2j/releases/tag/re2j-1.8

### Modifications

Upgrade RE2/J library from 1.7 to 1.8

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->