### PR TITLE
[fix][io] Fix Kinesis checkpoint mechanism to prevent data duplication

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
@@ -132,7 +132,7 @@ public class KinesisRecordProcessor implements ShardRecordProcessor {
                     checkpointExecutor.schedule(this::triggerCheckpoint, checkpointInterval, TimeUnit.MILLISECONDS);
                 }
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.error("Error while triggering checkpoint for shard {}. Terminating.", kinesisShardId, e);
             sourceContext.fatal(e);
         }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessor.java
@@ -20,6 +20,11 @@ package org.apache.pulsar.io.kinesis;
 
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.io.core.SourceContext;
@@ -39,120 +44,178 @@ import software.amazon.kinesis.retrieval.KinesisClientRecord;
 @Slf4j
 public class KinesisRecordProcessor implements ShardRecordProcessor {
 
+    private record CheckpointSequenceNumber(String sequenceNumber, long subSequenceNumber) {}
+
     private final int numRetries;
     private final long checkpointInterval;
     private final long backoffTime;
-
     private final LinkedBlockingQueue<KinesisRecord> queue;
     private final SourceContext sourceContext;
     private final Set<String> propertiesToInclude;
-
-    private long nextCheckpointTimeInNanos;
+    private final ScheduledExecutorService checkpointExecutor;
+    private final AtomicReference<RecordProcessorCheckpointer> checkpointerRef = new AtomicReference<>();
+    private final AtomicBoolean isCheckpointing = new AtomicBoolean(false);
     private String kinesisShardId;
-    private volatile String sequenceNumberToCheckpoint = null;
-    private String lastCheckpointedSequenceNumber = null;
+    private final AtomicInteger numRecordsInFlight = new AtomicInteger(0);
+
+    private volatile CheckpointSequenceNumber sequenceNumberNeedToCheckpoint = null;
+    private volatile CheckpointSequenceNumber lastCheckpointSequenceNumber = null;
 
     public KinesisRecordProcessor(LinkedBlockingQueue<KinesisRecord> queue, KinesisSourceConfig config,
-                                  SourceContext sourceContext) {
+                                  SourceContext sourceContext, ScheduledExecutorService checkpointExecutor) {
         this.queue = queue;
         this.checkpointInterval = config.getCheckpointInterval();
         this.numRetries = config.getNumRetries();
         this.backoffTime = config.getBackoffTime();
         this.propertiesToInclude = config.getPropertiesToInclude();
         this.sourceContext = sourceContext;
+        this.checkpointExecutor = checkpointExecutor;
     }
 
-    private void checkpoint(RecordProcessorCheckpointer checkpointer, String sequenceNumber) {
-        log.info("Checkpointing shard {} at sequence number {}", kinesisShardId, sequenceNumber);
-        for (int i = 0; i < numRetries; i++) {
-            try {
-                checkpointer.checkpoint(sequenceNumber);
-                lastCheckpointedSequenceNumber = sequenceNumber;
-                break;
-            } catch (ShutdownException se) {
-                log.info("Caught shutdown exception, skipping checkpoint.", se);
-                sourceContext.fatal(se);
-                break;
-            } catch (InvalidStateException e) {
-                log.error("Cannot save checkpoint to the DynamoDB table.", e);
+    private void tryCheckpointWithRetry(RecordProcessorCheckpointer checkpointer,
+                                        CheckpointSequenceNumber checkpoint, int attempt) {
+        try {
+            log.info("Attempting checkpoint {}/{} for shard {} at {}. In-flight records: {}",
+                    attempt, numRetries, kinesisShardId, checkpoint, numRecordsInFlight.get());
+            checkpointer.checkpoint(checkpoint.sequenceNumber(), checkpoint.subSequenceNumber());
+            lastCheckpointSequenceNumber = checkpoint;
+            log.info("Successfully checkpointed shard {} at {}", kinesisShardId, checkpoint);
+            isCheckpointing.set(false);
+            checkpointExecutor.schedule(this::triggerCheckpoint, checkpointInterval, TimeUnit.MILLISECONDS);
+        } catch (ShutdownException | InvalidStateException e) {
+            log.error("Caught a non-retryable exception for shard {} during checkpoint at {}. Terminating.",
+                    kinesisShardId, checkpoint, e);
+            sourceContext.fatal(e);
+        } catch (ThrottlingException | KinesisClientLibDependencyException e) {
+            if (attempt >= numRetries) {
+                log.error("Checkpoint for shard {} failed after {} attempts at {}. Terminating.",
+                        kinesisShardId, numRetries, checkpoint, e);
                 sourceContext.fatal(e);
-                break;
-            } catch (ThrottlingException | KinesisClientLibDependencyException e) {
-                if (i >= (numRetries - 1)) {
-                    log.error("Checkpoint failed after {} attempts.", (i + 1), e);
-                    sourceContext.fatal(e);
-                    break;
-                }
-            }
-
-            try {
-                Thread.sleep(backoffTime);
-            } catch (InterruptedException e) {
-                log.debug("Interrupted sleep", e);
+            } else {
+                log.warn("Throttling/Dependency error on checkpoint for shard {} at {}. Scheduling retry {} "
+                                + "after {}ms.", kinesisShardId, checkpoint, attempt + 1, backoffTime);
+                checkpointExecutor.schedule(() -> tryCheckpointWithRetry(checkpointer, checkpoint, attempt + 1),
+                        backoffTime, TimeUnit.MILLISECONDS);
             }
         }
     }
 
-    public void updateSequenceNumberToCheckpoint(String sequenceNumber) {
-        this.sequenceNumberToCheckpoint = sequenceNumber;
+    public void updateSequenceNumberToCheckpoint(String sequenceNumber, long subSequenceNumber) {
+        CheckpointSequenceNumber newCheckpoint = new CheckpointSequenceNumber(sequenceNumber, subSequenceNumber);
+        log.debug("{} Updating sequence number to checkpoint {}", kinesisShardId, newCheckpoint);
+        this.sequenceNumberNeedToCheckpoint = newCheckpoint;
+        this.numRecordsInFlight.decrementAndGet();
     }
 
     public void failed() {
+        numRecordsInFlight.decrementAndGet();
         sourceContext.fatal(new PulsarClientException("Failed to process Kinesis records due send to pulsar topic"));
     }
 
     @Override
     public void initialize(InitializationInput initializationInput) {
         kinesisShardId = initializationInput.shardId();
-        log.info("Initializing KinesisRecordProcessor for shard {}. Config: checkpointInterval={}ms, numRetries={}, "
-                        + "backoffTime={}ms, propertiesToInclude={}",
-                kinesisShardId, checkpointInterval, numRetries, backoffTime, propertiesToInclude);
-        nextCheckpointTimeInNanos = System.nanoTime() + checkpointInterval;
+        log.info("Initializing KinesisRecordProcessor for shard {}, extendedSequenceNumber: {}, pendingCheckSeq: {}",
+                kinesisShardId, initializationInput.extendedSequenceNumber(),
+                initializationInput.pendingCheckpointSequenceNumber());
+        checkpointExecutor.schedule(this::triggerCheckpoint, checkpointInterval, TimeUnit.MILLISECONDS);
+    }
+
+    private void triggerCheckpoint() {
+        if (isCheckpointing.compareAndSet(false, true)) {
+            final RecordProcessorCheckpointer checkpointer = checkpointerRef.get();
+            final CheckpointSequenceNumber currentCheckpoint = this.sequenceNumberNeedToCheckpoint;
+
+            if (checkpointer != null && currentCheckpoint != null && !currentCheckpoint.equals(
+                    lastCheckpointSequenceNumber)) {
+                tryCheckpointWithRetry(checkpointer, currentCheckpoint, 1);
+            } else {
+                isCheckpointing.set(false);
+                checkpointExecutor.schedule(this::triggerCheckpoint, checkpointInterval, TimeUnit.MILLISECONDS);
+            }
+        }
     }
 
     @Override
     public void processRecords(ProcessRecordsInput processRecordsInput) {
+        this.checkpointerRef.set(processRecordsInput.checkpointer());
         log.info("Processing {} records from {}", processRecordsInput.records().size(), kinesisShardId);
         long millisBehindLatest = processRecordsInput.millisBehindLatest();
 
         for (KinesisClientRecord record : processRecordsInput.records()) {
             try {
+                log.debug("Add record with sequence number {}:{} to queue for shard {}.",
+                        record.sequenceNumber(), record.subSequenceNumber(), kinesisShardId);
+                numRecordsInFlight.incrementAndGet();
                 queue.put(new KinesisRecord(record, this.kinesisShardId, millisBehindLatest,
                         propertiesToInclude, this));
-            } catch (InterruptedException e) {
-                log.warn("unable to create KinesisRecord ", e);
+            } catch (Exception e) {
+                numRecordsInFlight.decrementAndGet();
+                log.error("Unable to create and queue KinesisRecord for shard {}.", kinesisShardId, e);
+                sourceContext.fatal(e);
             }
-        }
-
-        // Checkpoint once every checkpoint interval.
-        if (System.nanoTime() > nextCheckpointTimeInNanos) {
-            if (sequenceNumberToCheckpoint != null
-                    && !sequenceNumberToCheckpoint.equals(lastCheckpointedSequenceNumber)) {
-                checkpoint(processRecordsInput.checkpointer(), sequenceNumberToCheckpoint);
-            }
-            nextCheckpointTimeInNanos = System.nanoTime() + checkpointInterval;
         }
     }
 
     @Override
     public void leaseLost(LeaseLostInput leaseLostInput) {
-        log.info("Lease lost for shard {} lastCheckPointedSequenceNumber {}, will terminate soon.",
-                kinesisShardId, lastCheckpointedSequenceNumber);
+        log.info("Lease lost for shard {}. Last checkpointed at {}.", kinesisShardId, lastCheckpointSequenceNumber);
+    }
+
+    private void finalizeAndCheckpoint(RecordProcessorCheckpointer checkpointer, boolean isShardEnd) {
+        boolean processedInTime = false;
+        log.info("Waiting up to {}s for {} in-flight records on shard {}.", numRetries,
+                numRecordsInFlight.get(), kinesisShardId);
+        try {
+            for (int i = 0; i < numRetries; i++) {
+                if (numRecordsInFlight.get() == 0) {
+                    processedInTime = true;
+                    break;
+                }
+                Thread.sleep(2000L);
+            }
+        } catch (Exception e) {
+            log.warn("Error while waiting for in-flight records on shard {}.", kinesisShardId, e);
+        }
+
+        try {
+            if (processedInTime && isShardEnd) {
+                log.info("All records processed for shard {}. Performing SHARD_END checkpoint.", kinesisShardId);
+                for (int i = 0; i < numRetries; i++) {
+                    try {
+                        checkpointer.checkpoint();
+                        log.info("Successfully checkpointed shard {} at SHARD_END.", kinesisShardId);
+                        return;
+                    } catch (ThrottlingException | KinesisClientLibDependencyException ex) {
+                        if (i >= numRetries - 1) {
+                            throw ex;
+                        }
+                        Thread.sleep(backoffTime);
+                    }
+                }
+            } else {
+                log.warn("Not all records for shard {} were processed or not a shard end. "
+                                + "Performing best-effort checkpoint.", kinesisShardId);
+                final CheckpointSequenceNumber finalCheckpoint = this.sequenceNumberNeedToCheckpoint;
+                if (finalCheckpoint != null) {
+                    checkpointer.checkpoint(finalCheckpoint.sequenceNumber(), finalCheckpoint.subSequenceNumber());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to perform final checkpoint for shard {}. Data may be reprocessed.", kinesisShardId, e);
+            sourceContext.fatal(e);
+        }
     }
 
     @Override
     public void shardEnded(ShardEndedInput shardEndedInput) {
-        log.info("Reached end of shard {}, will checkpoint.", kinesisShardId);
-        if (sequenceNumberToCheckpoint != null) {
-            checkpoint(shardEndedInput.checkpointer(), sequenceNumberToCheckpoint);
-        }
+        log.info("Reached end of shard {}, starting final checkpoint process.", kinesisShardId);
+        finalizeAndCheckpoint(shardEndedInput.checkpointer(), true);
     }
 
     @Override
     public void shutdownRequested(ShutdownRequestedInput shutdownRequestedInput) {
-        log.info("Shutdown requested for record processor on shard {}, will checkpoint.", kinesisShardId);
-        if (sequenceNumberToCheckpoint != null) {
-            checkpoint(shutdownRequestedInput.checkpointer(), sequenceNumberToCheckpoint);
-        }
+        log.info("Shutdown requested for shard {}, starting final checkpoint process.", kinesisShardId);
+        finalizeAndCheckpoint(shutdownRequestedInput.checkpointer(), false);
     }
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisRecordProcessorFactory.java
@@ -19,25 +19,29 @@
 package org.apache.pulsar.io.kinesis;
 
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import org.apache.pulsar.io.core.SourceContext;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 
 public class KinesisRecordProcessorFactory implements ShardRecordProcessorFactory {
-
     private final LinkedBlockingQueue<KinesisRecord> queue;
-    private final KinesisSourceConfig config;
+    private final KinesisSourceConfig kinesisSourceConfig;
     private final SourceContext sourceContext;
+    private final ScheduledExecutorService checkpointExecutor;
+
     public KinesisRecordProcessorFactory(LinkedBlockingQueue<KinesisRecord> queue,
                                          KinesisSourceConfig kinesisSourceConfig,
-                                         SourceContext sourceContext) {
+                                         SourceContext sourceContext,
+                                         ScheduledExecutorService checkpointExecutor) {
         this.queue = queue;
-        this.config = kinesisSourceConfig;
+        this.kinesisSourceConfig = kinesisSourceConfig;
         this.sourceContext = sourceContext;
+        this.checkpointExecutor = checkpointExecutor;
     }
 
     @Override
     public ShardRecordProcessor shardRecordProcessor() {
-        return new KinesisRecordProcessor(queue, config, sourceContext);
+        return new KinesisRecordProcessor(queue, kinesisSourceConfig, sourceContext, checkpointExecutor);
     }
 }

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSource.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSource.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pulsar.io.kinesis;
 
-import java.net.InetAddress;
 import java.util.Map;
-import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.io.aws.AbstractAwsConnector;
 import org.apache.pulsar.io.aws.AwsCredentialProviderPlugin;
@@ -55,25 +56,23 @@ public class KinesisSource extends AbstractAwsConnector implements Source<byte[]
     private Scheduler scheduler;
     private Thread schedulerThread;
     private Throwable threadEx;
-
-
-    @Override
-    public void close() throws Exception {
-        scheduler.shutdown();
-    }
+    private ScheduledExecutorService checkpointExecutor;
 
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         this.kinesisSourceConfig = KinesisSourceConfig.load(config, sourceContext);
         queue = new LinkedBlockingQueue<>(kinesisSourceConfig.getReceiveQueueSize());
-        workerId = InetAddress.getLocalHost().getCanonicalHostName() + ":" + UUID.randomUUID();
+        workerId = String.valueOf(sourceContext.getInstanceId());
+
+        this.checkpointExecutor = Executors.newSingleThreadScheduledExecutor();
 
         AwsCredentialProviderPlugin credentialsProvider = createCredentialProvider(
                 kinesisSourceConfig.getAwsCredentialPluginName(),
                 kinesisSourceConfig.getAwsCredentialPluginParam());
 
         KinesisAsyncClient kClient = kinesisSourceConfig.buildKinesisAsyncClient(credentialsProvider);
-        recordProcessorFactory = new KinesisRecordProcessorFactory(queue, kinesisSourceConfig, sourceContext);
+        recordProcessorFactory = new KinesisRecordProcessorFactory(queue, kinesisSourceConfig,
+                sourceContext, checkpointExecutor);
         configsBuilder = new ConfigsBuilder(kinesisSourceConfig.getAwsKinesisStreamName(),
                                             kinesisSourceConfig.getApplicationName(),
                                             kClient,
@@ -122,4 +121,17 @@ public class KinesisSource extends AbstractAwsConnector implements Source<byte[]
         }
     }
 
+    @Override
+    public void close() throws Exception {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+        if (schedulerThread != null) {
+            schedulerThread.join(30000L);
+        }
+        if (checkpointExecutor != null) {
+            checkpointExecutor.shutdownNow();
+            checkpointExecutor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

The Kinesis Source connector had several critical issues in its checkpointing mechanism that could lead to data loss, data duplication, or stalled processing.

1.  **Incorrect `shardEnded` Handling**: The connector did not correctly implement the `ShardRecordProcessor#shardEnded` method. It checkpointed at a specific sequence number instead of the required `SHARD_END` marker, which can cause the entire stream processing to stall during Kinesis resharding events. Reference: [Developing KCL 2.x Consumers in Java - shardEnded](https://docs.aws.amazon.com/streams/latest/dev/develop-kcl-consumers-java.html#kcl-java-interface-shardrecordprocessor)
2.  **Unreliable Periodic Checkpoints**: The periodic checkpoint logic was tied to the `processRecords` method. This is unreliable in Kinesis's Enhanced Fan-Out (push) mode, where this method is not called on idle streams, preventing timely checkpoints.
3.  **Inaccurate Checkpoints for Aggregated Records**: The logic did not account for KPL aggregation, ignoring the `subSequenceNumber`. This caused the reprocessing of entire aggregated batches upon failure, leading to significant data duplication.
4.  **Unstable Worker ID**: The `workerId` was generated with a random UUID, causing KCL to treat every restart as a new worker and ignore existing checkpoints, leading to consistent data reprocessing.



### Modifications

This PR overhauls the Kinesis Source connector's checkpointing and record processing logic for correctness and robustness.

1.  **Stable Worker ID**:
    - The `workerId` is now generated from the stable `sourceContext.getInstanceId()` instead of a random UUID. This is critical for ensuring KCL can recognize a restarted processor and correctly resume from its last checkpoint.

2.  **Independent Checkpoint Scheduler**:
    - Introduced a `ScheduledExecutorService` in `KinesisSource` to drive periodic checkpoints, completely decoupling it from the `processRecords` message flow. This ensures timely checkpoints in both Polling and Enhanced Fan-Out modes.
    - The new scheduler uses a non-blocking, asynchronous retry mechanism with backoff for `ThrottlingException`.

3.  **Precise Checkpointing with `subSequenceNumber`**:
    - The connector now correctly handles de-aggregated records from the Kinesis Producer Library (KPL) by checkpointing both the `sequenceNumber` and `subSequenceNumber`.
    - An immutable `CheckpointSequenceNumber` record was introduced to atomically and safely manage the checkpoint state across threads.

4.  **Robust `shardEnded` and `shutdownRequested` Handling**:
    - Implemented a blocking `waitForInFlightRecords` helper with a timeout to ensure all queued records are processed before a final checkpoint.
    - `shardEnded` now correctly performs a `SHARD_END` checkpoint (with retries) on success and a best-effort checkpoint on timeout, fully complying with the KCL contract.

5.  **Concurrency and Safety Fixes**:
    - Fixed a race condition in `processRecords` by ensuring the in-flight record counter is incremented **before** a record is enqueued.
    - Replaced the shared `static CharsetDecoder` in `KinesisRecord` with a thread-safe call to prevent an `IllegalStateException`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

The entire `KinesisRecordProcessorTest` suite was overhauled to support testing the new asynchronous, scheduled checkpointing logic. The new tests verify:
- The asynchronous scheduler correctly triggers checkpoints after records are acknowledged.
- The checkpoint logic correctly advances only to a newer `CheckpointSequenceNumber`.
- The `shardEnded` method correctly performs a `SHARD_END` checkpoint on the success path.
- The `shardEnded` and `shutdownRequested` methods correctly time out and perform best-effort checkpoints on the failure path.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

A dedicated `ScheduledExecutorService` has been introduced in `KinesisSource` to manage checkpointing asynchronously. Additionally, the `shardEnded` and `shutdownRequested` methods now block the KCL thread for a short period to wait for in-flight messages.

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: ```