### PR TITLE
[fix][misc] Fix topics pattern consumer backwards compatibility

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -733,6 +733,16 @@ enableBrokerSideSubscriptionPatternEvaluation=true
 # Longer patterns are rejected to avoid patterns that are crafted to overload the broker.
 subscriptionPatternMaxLength=50
 
+# The regular expression implementation to use for topic pattern matching.
+# RE2J_WITH_JDK_FALLBACK is the default. It uses the RE2J implementation and falls back to
+# the JDK implementation for backwards compatibility reasons when the pattern compilation fails
+# with the RE2/j library.
+# RE2J is more performant but does not support all regex features (e.g. negative lookaheads).
+# JDK uses the standard Java regex implementation which supports all features but can be slower.
+# Bad or malicious regex patterns requiring extensive backtracing could cause high resource usage
+# with RE2J_WITH_JDK_FALLBACK or JDK implementations.
+topicsPatternRegexImplementation=RE2J_WITH_JDK_FALLBACK
+
 ### --- Authentication --- ###
 # Role names that are treated as "proxy roles". If the broker sees a request with
 #role as proxyRoles - it will demand to see a valid original principal.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -386,6 +386,16 @@ enableBrokerSideSubscriptionPatternEvaluation=true
 # Longer patterns are rejected to avoid patterns that are crafted to overload the broker.
 subscriptionPatternMaxLength=50
 
+# The regular expression implementation to use for topic pattern matching.
+# RE2J_WITH_JDK_FALLBACK is the default. It uses the RE2J implementation and falls back to
+# the JDK implementation for backwards compatibility reasons when the pattern compilation fails
+# with the RE2/j library.
+# RE2J is more performant but does not support all regex features (e.g. negative lookaheads).
+# JDK uses the standard Java regex implementation which supports all features but can be slower.
+# Bad or malicious regex patterns requiring extensive backtracing could cause high resource usage
+# with RE2J_WITH_JDK_FALLBACK or JDK implementations.
+topicsPatternRegexImplementation=RE2J_WITH_JDK_FALLBACK
+
 ### --- Metadata Store --- ###
 
 # Whether we should enable metadata operations batching

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -51,6 +51,7 @@ import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.sasl.SaslConstants;
+import org.apache.pulsar.common.topics.TopicsPattern;
 import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
 import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
@@ -1568,6 +1569,20 @@ public class ServiceConfiguration implements PulsarConfiguration {
                     + "# 2. Allowed alphanumeric (a-zA-Z_0-9) and these special chars -=:. for topic name.\n"
                     + "# NOTE: This flag will be removed in some major releases in the future.\n")
     private boolean strictTopicNameEnabled = false;
+
+    @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "The regular expression implementation to use for topic pattern matching. \n"
+                    + "RE2J_WITH_JDK_FALLBACK is the default. It uses the RE2J implementation and falls back to "
+                    + "the JDK implementation for backwards compatibility reasons when the pattern compilation fails "
+                    + "with the RE2/j library.\n"
+                    + "RE2J is more performant but does not support all regex features (e.g. negative lookaheads). \n"
+                    + "JDK uses the standard Java regex implementation which supports all features but can be slower.\n"
+                    + "Bad or malicious regex patterns requiring extensive backtracing could cause high resource usage "
+                    + "with RE2J_WITH_JDK_FALLBACK or JDK implementations."
+    )
+    private TopicsPattern.RegexImplementation topicsPatternRegexImplementation =
+            TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK;
 
     @FieldContext(
             category = CATEGORY_SCHEMA,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListServiceTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import com.google.re2j.Pattern;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +38,7 @@ import org.apache.pulsar.common.api.proto.CommandWatchTopicListClose;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.topics.TopicList;
+import org.apache.pulsar.common.topics.TopicsPattern;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -50,6 +50,8 @@ public class TopicListServiceTest {
     private CompletableFuture<List<String>> topicListFuture;
     private Semaphore lookupSemaphore;
     private TopicResources topicResources;
+    private final TopicsPattern.RegexImplementation topicsPatternImplementation =
+            TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK;
 
     @BeforeMethod(alwaysRun = true)
     public void setup() throws Exception {
@@ -80,8 +82,8 @@ public class TopicListServiceTest {
                 NamespaceName.get("tenant/ns"),
                 13,
                 7,
-                Pattern.compile("persistent://tenant/ns/topic\\d"),
-                null,
+                "persistent://tenant/ns/topic\\d",
+                topicsPatternImplementation, null,
                 lookupSemaphore);
         List<String> topics = Collections.singletonList("persistent://tenant/ns/topic1");
         String hash = TopicList.calculateHash(topics);
@@ -98,8 +100,8 @@ public class TopicListServiceTest {
                 NamespaceName.get("tenant/ns"),
                 13,
                 7,
-                Pattern.compile("persistent://tenant/ns/topic\\d"),
-                null,
+                "persistent://tenant/ns/topic\\d",
+                topicsPatternImplementation, null,
                 lookupSemaphore);
         topicListFuture.completeExceptionally(new PulsarServerException("Error"));
         Assert.assertEquals(1, lookupSemaphore.availablePermits());
@@ -114,8 +116,8 @@ public class TopicListServiceTest {
                 NamespaceName.get("tenant/ns"),
                 13,
                 7,
-                Pattern.compile("persistent://tenant/ns/topic\\d"),
-                null,
+                "persistent://tenant/ns/topic\\d",
+                topicsPatternImplementation, null,
                 lookupSemaphore);
         List<String> topics = Collections.singletonList("persistent://tenant/ns/topic1");
         topicListFuture.complete(topics);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListWatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicListWatcherTest.java
@@ -21,11 +21,12 @@ package org.apache.pulsar.broker.service;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import com.google.re2j.Pattern;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.pulsar.common.topics.TopicList;
+import org.apache.pulsar.common.topics.TopicsPattern;
+import org.apache.pulsar.common.topics.TopicsPatternFactory;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -40,7 +41,8 @@ public class TopicListWatcherTest {
     );
 
     private static final long ID = 7;
-    private static final Pattern PATTERN = Pattern.compile("tenant/ns/topic\\d+");
+    private static final TopicsPattern PATTERN =
+            TopicsPatternFactory.create("tenant/ns/topic\\d+", TopicsPattern.RegexImplementation.RE2J);
 
 
     private TopicListService topicListService;
@@ -98,5 +100,4 @@ public class TopicListWatcherTest {
                 Arrays.asList("persistent://tenant/ns/topic1", "persistent://tenant/ns/topic2"),
                 watcher.getMatchingTopics());
     }
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
@@ -204,7 +204,7 @@ public class PatternTopicsConsumerImplAuthTest extends ProducerConsumerBase {
         assertTrue(consumer.getTopic().startsWith(PatternMultiTopicsConsumerImpl.DUMMY_TOPIC_NAME_PREFIX));
 
         // 4. verify consumer
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         List<String> topics = ((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions();
         List<ConsumerImpl<byte[]>> consumers = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplTest.java
@@ -227,7 +227,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         });
 
         // 4. verify consumer get methods, to get right number of partitions and topics.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         List<String> topics = ((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions();
         List<ConsumerImpl<byte[]>> consumers = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
 
@@ -311,7 +311,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         });
 
         // 4. verify consumer get methods, to get right number of partitions and topics.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         List<String> topics = ((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions();
         List<ConsumerImpl<byte[]>> consumers = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
 
@@ -394,7 +394,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         });
 
         // 4. verify consumer get methods, to get right number of partitions and topics.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         List<String> topics = ((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions();
         List<ConsumerImpl<byte[]>> consumers = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
 
@@ -492,7 +492,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         });
 
         // 4. verify consumer get methods, to get right number of partitions and topics.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         List<String> topics = ((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions();
         List<ConsumerImpl<byte[]>> consumers = ((PatternMultiTopicsConsumerImpl<byte[]>) consumer).getConsumers();
 
@@ -569,7 +569,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         });
 
         // 3. verify consumer get methods, to get 5 number of partitions and topics.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 5);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 5);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 2);
@@ -593,7 +593,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 5. verify consumer get methods, to get number of partitions and topics, value 6=1+2+3.
         Awaitility.await().untilAsserted(() -> {
-            assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+            assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 6);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 6);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 2);
@@ -665,7 +665,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 2. verify consumer get methods. There is no need to trigger discovery, because the broker will push the
         // changes to update(CommandWatchTopicUpdate).
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         Awaitility.await().untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 4);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 4);
@@ -704,7 +704,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         admin.topics().createPartitionedTopic(topicName, 4);
 
         // 2. verify broker will push the changes to update(CommandWatchTopicUpdate).
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 4);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 4);
@@ -761,7 +761,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         Producer<byte[]> producer2 = pulsarClient.newProducer().topic(topicName2).create();
 
         // 3. verify will update the partitions and consumers
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         Awaitility.await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 8);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 8);
@@ -825,7 +825,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         }
 
         // 2. verify consumer can subscribe the topic.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         Awaitility.await().untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 1);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 1);
@@ -883,7 +883,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
 
         // 2. verify consumer can subscribe the topic.
         // Since the minimum value of `patternAutoDiscoveryPeriod` is 60s, we set the test timeout to a triple value.
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         Awaitility.await().atMost(Duration.ofMinutes(3)).untilAsserted(() -> {
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 1);
             assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 1);
@@ -980,7 +980,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         assertTrue(consumer instanceof PatternMultiTopicsConsumerImpl);
 
         // 4. verify consumer get methods, to get 6 number of partitions and topics: 6=1+2+3
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 6);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 6);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 2);
@@ -1095,7 +1095,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         assertTrue(consumer instanceof PatternMultiTopicsConsumerImpl);
 
         // 4. verify consumer get methods, to get 0 number of partitions and topics: 6=1+2+3
-        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().pattern());
+        assertSame(pattern.pattern(), ((PatternMultiTopicsConsumerImpl<?>) consumer).getPattern().inputPattern());
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitions().size(), 6);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getConsumers().size(), 6);
         assertEquals(((PatternMultiTopicsConsumerImpl<?>) consumer).getPartitionedTopics().size(), 2);
@@ -1188,7 +1188,7 @@ public class PatternTopicsConsumerImplTest extends ProducerConsumerBase {
         PatternMultiTopicsConsumerImpl<String> consumerImpl = (PatternMultiTopicsConsumerImpl<String>) consumer;
 
         // 4. verify consumer get methods
-        assertSame(consumerImpl.getPattern().pattern(), pattern.pattern());
+        assertSame(consumerImpl.getPattern().inputPattern(), pattern.pattern());
         assertEquals(consumerImpl.getPartitionedTopics().size(), 0);
 
         producer1.send("msg-1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
+import org.apache.pulsar.common.topics.TopicsPattern;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-naming")
@@ -412,5 +413,23 @@ public class ServiceConfigurationTest {
         conf = PulsarConfigurationLoader.create(new ByteArrayInputStream(confFile.getBytes()),
                 ServiceConfiguration.class);
         assertEquals(conf.lookupProperties(), Map.of("lookup.key2", "value2"));
+    }
+
+    @Test
+    public void testTopicsPatternRegexImplementationOptions() throws IOException {
+        ServiceConfiguration conf = loadConfString("topicsPatternRegexImplementation=RE2J_WITH_JDK_FALLBACK");
+        assertEquals(conf.getTopicsPatternRegexImplementation(),
+                TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
+        conf = loadConfString("topicsPatternRegexImplementation=JDK");
+        assertEquals(conf.getTopicsPatternRegexImplementation(),
+                TopicsPattern.RegexImplementation.JDK);
+        conf = loadConfString("topicsPatternRegexImplementation=RE2J");
+        assertEquals(conf.getTopicsPatternRegexImplementation(),
+                TopicsPattern.RegexImplementation.RE2J);
+    }
+
+    private static ServiceConfiguration loadConfString(String confString) throws IOException {
+        return PulsarConfigurationLoader.create(new ByteArrayInputStream(confString.getBytes(StandardCharsets.UTF_8)),
+                ServiceConfiguration.class);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -126,7 +126,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     }
 
     CompletableFuture<Void> recheckTopicsChange() {
-        String pattern = topicsPattern.pattern();
+        String pattern = topicsPattern.inputPattern();
         final int epoch = recheckPatternEpoch.incrementAndGet();
         return client.getLookup().getTopicsUnderNamespace(namespaceName, subscriptionMode, pattern, topicsHash)
             .thenCompose(getTopicsResult -> {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -18,10 +18,8 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.google.re2j.Pattern;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
@@ -44,12 +42,13 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.topics.TopicList;
+import org.apache.pulsar.common.topics.TopicsPattern;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T> implements TimerTask {
-    private final Pattern topicsPattern;
+    private final TopicsPattern topicsPattern;
     final TopicsChangedListener topicsChangeListener;
     private final Mode subscriptionMode;
     private final CompletableFuture<TopicListWatcher> watcherFuture = new CompletableFuture<>();
@@ -66,7 +65,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
     /***
      * @param topicsPattern The regexp for the topic name(not contains partition suffix).
      */
-    public PatternMultiTopicsConsumerImpl(Pattern topicsPattern,
+    public PatternMultiTopicsConsumerImpl(TopicsPattern topicsPattern,
                                           String topicsHash,
                                           PulsarClientImpl client,
                                           ConsumerConfigurationData<T> conf,
@@ -80,11 +79,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         this.topicsPattern = topicsPattern;
         this.topicsHash = topicsHash;
         this.subscriptionMode = subscriptionMode;
-
-        if (this.namespaceName == null) {
-            this.namespaceName = getNameSpaceFromPattern(topicsPattern);
-        }
-        checkArgument(getNameSpaceFromPattern(topicsPattern).toString().equals(this.namespaceName.toString()));
+        this.namespaceName = topicsPattern.namespace();
 
         this.topicsChangeListener = new PatternTopicsChangedListener();
         this.updateTaskQueue = new PatternConsumerUpdateQueue(this);
@@ -107,10 +102,6 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
             this.recheckPatternTimeout = client.timer().newTimeout(
                     this, Math.max(1, conf.getPatternAutoDiscoveryPeriod()), TimeUnit.SECONDS);
         }
-    }
-
-    public static NamespaceName getNameSpaceFromPattern(Pattern pattern) {
-        return TopicName.get(pattern.pattern()).getNamespaceObject();
     }
 
     /**
@@ -168,7 +159,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
             });
     }
 
-    static CompletableFuture<Void> updateSubscriptions(Pattern topicsPattern,
+    static CompletableFuture<Void> updateSubscriptions(TopicsPattern topicsPattern,
                                                        java.util.function.Consumer<String> topicsHashSetter,
                                                        GetTopicsResult getTopicsResult,
                                                        TopicsChangedListener topicsChangedListener,
@@ -198,7 +189,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         return FutureUtil.waitForAll(Collections.unmodifiableList(listenersCallback));
     }
 
-    public Pattern getPattern() {
+    public TopicsPattern getPattern() {
         return this.topicsPattern;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.re2j.Pattern;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
@@ -91,6 +90,8 @@ import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.topics.TopicList;
+import org.apache.pulsar.common.topics.TopicsPattern;
+import org.apache.pulsar.common.topics.TopicsPatternFactory;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.BackoffBuilder;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -638,7 +639,7 @@ public class PulsarClientImpl implements PulsarClient {
         Mode subscriptionMode = convertRegexSubscriptionMode(conf.getRegexSubscriptionMode());
         TopicName destination = TopicName.get(regex);
         NamespaceName namespaceName = destination.getNamespaceObject();
-        Pattern pattern = Pattern.compile(conf.getTopicsPattern().pattern());
+        TopicsPattern pattern = TopicsPatternFactory.create(conf.getTopicsPattern());
 
         CompletableFuture<Consumer<T>> consumerSubscribedFuture = new CompletableFuture<>();
         lookup.getTopicsUnderNamespace(namespaceName, subscriptionMode, regex, null)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.re2j.Pattern;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +29,7 @@ import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicUpdate;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.protocol.Commands;
+import org.apache.pulsar.common.topics.TopicsPattern;
 import org.apache.pulsar.common.util.BackoffBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +45,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
     private final PatternConsumerUpdateQueue patternConsumerUpdateQueue;
     private final String name;
     private final ConnectionHandler connectionHandler;
-    private final Pattern topicsPattern;
+    private final TopicsPattern topicsPattern;
     private final long watcherId;
     private volatile long createWatcherDeadline = 0;
     private final NamespaceName namespace;
@@ -63,11 +63,11 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
      * @param topicsPattern The regexp for the topic name(not contains partition suffix).
      */
     public TopicListWatcher(PatternConsumerUpdateQueue patternConsumerUpdateQueue,
-                            PulsarClientImpl client, Pattern topicsPattern, long watcherId,
+                            PulsarClientImpl client, TopicsPattern topicsPattern, long watcherId,
                             NamespaceName namespace, String topicsHash,
                             CompletableFuture<TopicListWatcher> watcherFuture,
                             Runnable recheckTopicsChangeAfterReconnect) {
-        super(client, topicsPattern.pattern());
+        super(client, topicsPattern.topicLookupNameForTopicListWatcherPlacement());
         this.patternConsumerUpdateQueue = patternConsumerUpdateQueue;
         this.name = "Watcher(" + topicsPattern + ")";
         this.connectionHandler = new ConnectionHandler(this,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
@@ -131,7 +131,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
         synchronized (this) {
             setClientCnx(cnx);
             BaseCommand watchRequest = Commands.newWatchTopicList(requestId, watcherId, namespace.toString(),
-                            topicsPattern.pattern(), topicsHash);
+                            topicsPattern.inputPattern(), topicsHash);
 
             cnx.newWatchTopicList(watchRequest, requestId)
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImplTest.java
@@ -24,12 +24,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import com.google.common.collect.Sets;
-import com.google.re2j.Pattern;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import org.apache.pulsar.common.lookup.GetTopicsResult;
+import org.apache.pulsar.common.topics.TopicsPatternFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -52,7 +53,7 @@ public class PatternMultiTopicsConsumerImplTest {
     @Test
     public void testChangedUnfilteredResponse() {
         PatternMultiTopicsConsumerImpl.updateSubscriptions(
-                Pattern.compile("tenant/my-ns/name-.*"),
+                TopicsPatternFactory.create(Pattern.compile("tenant/my-ns/name-.*")),
                 mockTopicsHashSetter,
                 new GetTopicsResult(Arrays.asList(
                         "persistent://tenant/my-ns/name-1",
@@ -71,7 +72,7 @@ public class PatternMultiTopicsConsumerImplTest {
     @Test
     public void testChangedFilteredResponse() {
         PatternMultiTopicsConsumerImpl.updateSubscriptions(
-                Pattern.compile("tenant/my-ns/name-.*"),
+                TopicsPatternFactory.create(Pattern.compile("tenant/my-ns/name-.*")),
                 mockTopicsHashSetter,
                 new GetTopicsResult(Arrays.asList(
                         "persistent://tenant/my-ns/name-0",
@@ -90,7 +91,7 @@ public class PatternMultiTopicsConsumerImplTest {
     @Test
     public void testUnchangedResponse() {
         PatternMultiTopicsConsumerImpl.updateSubscriptions(
-                Pattern.compile("tenant/my-ns/name-.*"),
+                TopicsPatternFactory.create(Pattern.compile("tenant/my-ns/name-.*")),
                 mockTopicsHashSetter,
                 new GetTopicsResult(Arrays.asList(
                         "persistent://tenant/my-ns/name-0",

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicListWatcherTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicListWatcherTest.java
@@ -27,12 +27,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
-import com.google.re2j.Pattern;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 import lombok.Cleanup;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.impl.PatternMultiTopicsConsumerImpl.TopicsChangedListener;
@@ -41,6 +41,7 @@ import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicUpdate;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.topics.TopicsPatternFactory;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -67,7 +68,7 @@ public class TopicListWatcherTest {
         Timer timer = new HashedWheelTimer();
         when(client.timer()).thenReturn(timer);
         String topic = "persistent://tenant/ns/topic\\d+";
-        when(client.getConnection(topic, 0)).
+        when(client.getConnection(anyString(), anyInt())).
                 thenReturn(clientCnxFuture.thenApply(clientCnx -> Pair.of(clientCnx, false)));
         when(client.getConnection(any(), any(), anyInt())).thenReturn(clientCnxFuture);
         when(connectionPool.getConnection(any(), any(), anyInt())).thenReturn(clientCnxFuture);
@@ -82,7 +83,7 @@ public class TopicListWatcherTest {
 
         watcherFuture = new CompletableFuture<>();
         watcher = new TopicListWatcher(queue, client,
-                Pattern.compile(topic), 7,
+                TopicsPatternFactory.create(Pattern.compile(topic)), 7,
                 NamespaceName.get("tenant/ns"), null, watcherFuture, () -> {});
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/GetTopicsResult.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/GetTopicsResult.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.common.lookup;
 
-import com.google.re2j.Pattern;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,6 +29,7 @@ import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace;
 import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespaceResponse;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.topics.TopicList;
+import org.apache.pulsar.common.topics.TopicsPattern;
 
 /***
  * A value object.
@@ -123,7 +123,7 @@ public class GetTopicsResult {
         }
     }
 
-    public GetTopicsResult filterTopics(Pattern topicsPattern) {
+    public GetTopicsResult filterTopics(TopicsPattern topicsPattern) {
         List<String> topicsFiltered = TopicList.filterTopics(getTopics(), topicsPattern);
         // If nothing changed.
         if (topicsFiltered.equals(getTopics())) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/JDKTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/JDKTopicsPattern.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import java.util.regex.Pattern;
+
+class JDKTopicsPattern implements TopicsPattern {
+    private final Pattern pattern;
+
+    public JDKTopicsPattern(String regex) {
+        this.pattern = Pattern.compile(regex);
+    }
+
+    public JDKTopicsPattern(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public boolean matches(String topicName) {
+        return pattern.matcher(topicName).matches();
+    }
+
+    @Override
+    public String pattern() {
+        return pattern.pattern();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/JDKTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/JDKTopicsPattern.java
@@ -21,14 +21,17 @@ package org.apache.pulsar.common.topics;
 import java.util.regex.Pattern;
 
 class JDKTopicsPattern implements TopicsPattern {
+    private final String inputPattern;
     private final Pattern pattern;
 
-    public JDKTopicsPattern(String regex) {
-        this.pattern = Pattern.compile(regex);
+    public JDKTopicsPattern(String inputPattern, String regexWithoutTopicDomainScheme) {
+        this.inputPattern = inputPattern;
+        this.pattern = Pattern.compile(regexWithoutTopicDomainScheme);
     }
 
     public JDKTopicsPattern(Pattern pattern) {
         this.pattern = pattern;
+        this.inputPattern = pattern.pattern();
     }
 
     @Override
@@ -37,7 +40,7 @@ class JDKTopicsPattern implements TopicsPattern {
     }
 
     @Override
-    public String pattern() {
-        return pattern.pattern();
+    public String inputPattern() {
+        return inputPattern;
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/MatchAllTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/MatchAllTopicsPattern.java
@@ -32,7 +32,7 @@ class MatchAllTopicsPattern implements TopicsPattern {
     }
 
     @Override
-    public String pattern() {
+    public String inputPattern() {
         return ALL_TOPICS_PATTERN;
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/MatchAllTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/MatchAllTopicsPattern.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import static org.apache.pulsar.common.topics.TopicList.ALL_TOPICS_PATTERN;
+
+class MatchAllTopicsPattern implements TopicsPattern {
+    public static final MatchAllTopicsPattern INSTANCE = new MatchAllTopicsPattern();
+
+    private MatchAllTopicsPattern() {
+        // Private constructor to prevent instantiation
+    }
+
+    public boolean matches(String topicName) {
+        return true; // Matches all topic names
+    }
+
+    @Override
+    public String pattern() {
+        return ALL_TOPICS_PATTERN;
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/RE2JTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/RE2JTopicsPattern.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import com.google.re2j.Pattern;
+
+class RE2JTopicsPattern implements TopicsPattern {
+    private final Pattern pattern;
+
+    public RE2JTopicsPattern(String regex) {
+        this.pattern = Pattern.compile(regex);
+    }
+
+    @Override
+    public boolean matches(String topicName) {
+        return pattern.matcher(topicName).matches();
+    }
+
+    @Override
+    public String pattern() {
+        return pattern.pattern();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/RE2JTopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/RE2JTopicsPattern.java
@@ -21,10 +21,12 @@ package org.apache.pulsar.common.topics;
 import com.google.re2j.Pattern;
 
 class RE2JTopicsPattern implements TopicsPattern {
+    private final String inputPattern;
     private final Pattern pattern;
 
-    public RE2JTopicsPattern(String regex) {
-        this.pattern = Pattern.compile(regex);
+    public RE2JTopicsPattern(String inputPattern, String regexWithoutTopicDomainScheme) {
+        this.inputPattern = inputPattern;
+        this.pattern = Pattern.compile(regexWithoutTopicDomainScheme);
     }
 
     @Override
@@ -33,7 +35,7 @@ class RE2JTopicsPattern implements TopicsPattern {
     }
 
     @Override
-    public String pattern() {
-        return pattern.pattern();
+    public String inputPattern() {
+        return inputPattern;
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPattern.java
@@ -49,11 +49,13 @@ public interface TopicsPattern {
     boolean matches(String topicNameWithoutDomainSchemePrefix);
 
     /**
-     * Returns the regex pattern used by this TopicsPattern.
+     * Returns the original regex pattern used by this TopicsPattern passed as input.
+     * The internal implementation modifies the pattern to remove the possible topic domain scheme
+     * (e.g., "persistent://") since in matching the topic name, the domain scheme is ignored.
      *
      * @return the regex pattern as a string
      */
-    String pattern();
+    String inputPattern();
 
     /**
      * Returns the namespace associated with this TopicsPattern.
@@ -62,7 +64,7 @@ public interface TopicsPattern {
      * @return the NamespaceName associated with this TopicsPattern
      */
     default NamespaceName namespace() {
-        return TopicName.get(pattern()).getNamespaceObject();
+        return TopicName.get(inputPattern()).getNamespaceObject();
     }
 
     /**
@@ -77,6 +79,6 @@ public interface TopicsPattern {
         // By default, return the pattern itself since it is sufficient for a topic lookup.
         // Currently Pulsar doesn't limit the characters used in the topic name part of the pattern, but this would
         // be a good place to apply any sanitization if needed in the future.
-        return pattern();
+        return inputPattern();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPattern.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPattern.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * Interface for matching topic names against a pattern.
+ * Implementations can use different regex libraries such as RE2J or standard JDK.
+ * There's also an option to use RE2J with JDK fallback.
+ */
+public interface TopicsPattern {
+    /**
+     * The regex implementation type used by the TopicsPattern.
+     * RE2J is a fast regex engine that is suitable for high-performance applications.
+     * JDK uses the standard Java regex engine.
+     * RE2J_WITH_JDK_FALLBACK uses RE2J but falls back to JDK if RE2J fails to compile the pattern.
+     */
+    enum RegexImplementation {
+        RE2J,
+        JDK,
+        RE2J_WITH_JDK_FALLBACK
+    }
+
+    /**
+     * Evaluates the pattern for the given topic name which is expected to be
+     * passed without the domain scheme prefix in the format "tenant/namespace/topic".
+     *
+     * @param topicNameWithoutDomainSchemePrefix the topic name to match
+     * @return true if the topic matches the pattern, false otherwise
+     */
+    boolean matches(String topicNameWithoutDomainSchemePrefix);
+
+    /**
+     * Returns the regex pattern used by this TopicsPattern.
+     *
+     * @return the regex pattern as a string
+     */
+    String pattern();
+
+    /**
+     * Returns the namespace associated with this TopicsPattern.
+     * This is typically used to determine the namespace context for the pattern.
+     *
+     * @return the NamespaceName associated with this TopicsPattern
+     */
+    default NamespaceName namespace() {
+        return TopicName.get(pattern()).getNamespaceObject();
+    }
+
+    /**
+     * The Topic watcher instance will be created on the broker based on a lookup for the topic name
+     * returned by this method. The placement reuses topic lookup so that the Pulsar load balancer can
+     * place the topic watcher on different brokers based on load without having to implement another load balancing
+     * solution for topic watchers.
+     *
+     * @return the topic lookup name for topic watcher placement
+     */
+    default String topicLookupNameForTopicListWatcherPlacement() {
+        // By default, return the pattern itself since it is sufficient for a topic lookup.
+        // Currently Pulsar doesn't limit the characters used in the topic name part of the pattern, but this would
+        // be a good place to apply any sanitization if needed in the future.
+        return pattern();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPatternFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicsPatternFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Factory class for creating instances of TopicsPattern based on different regex implementations.
+ * It supports JDK regex, RE2J regex, and a fallback mechanism for RE2J with JDK.
+ */
+@UtilityClass
+@Slf4j
+public class TopicsPatternFactory {
+    /**
+     * Creates a TopicsPattern from a JDK Pattern.
+     * If the pattern contains the topic domain scheme, it will be removed and a RE2J_WITH_JDK_FALLBACK implementation
+     * will be used. If the pattern does not contain the topic domain scheme, the input JDK Pattern instance will be
+     * used to evaluate topic name matches.
+     * The Pulsar Java Client will use this method to create a TopicsPattern from a JDK Pattern.
+     *
+     * @param jdkPattern the JDK Pattern to create the TopicsPattern from
+     * @return a TopicsPattern instance
+     */
+    public static TopicsPattern create(Pattern jdkPattern) {
+        String currentRegex = jdkPattern.pattern();
+        String removedTopicDomainScheme = TopicList.removeTopicDomainScheme(currentRegex);
+        // If the regex pattern is already without the topic domain scheme, we can directly create a JDKTopicsPattern
+        if (currentRegex.equals(removedTopicDomainScheme)) {
+            return new JDKTopicsPattern(jdkPattern);
+        } else {
+            // If the regex pattern contains the topic domain scheme, we remove it and create a TopicsPattern
+            // using RE2J_WITH_JDK_FALLBACK
+            return internalCreate(removedTopicDomainScheme, TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
+        }
+    }
+
+    /**
+     * Creates a TopicsPattern from a regex string, using the specified regex implementation.
+     * The Pulsar Broker will use this method to create a TopicsPattern from a regex string. The implementation
+     * is configured in the broker configuration file with the `topicsPatternRegexImplementation` property.
+     *
+     * @param regex the regex string to create the TopicsPattern from
+     * @param implementation the regex implementation to use (RE2J, JDK, or RE2J_WITH_JDK_FALLBACK)
+     * @return a TopicsPattern instance
+     */
+    public static TopicsPattern create(String regex, TopicsPattern.RegexImplementation implementation) {
+        return internalCreate(TopicList.removeTopicDomainScheme(regex), implementation);
+    }
+
+    /**
+     * Creates a TopicsPattern that matches all topics.
+     *
+     * @return a TopicsPattern instance that matches all topics
+     */
+    public static TopicsPattern matchAll() {
+        return MatchAllTopicsPattern.INSTANCE;
+    }
+
+    private static TopicsPattern internalCreate(String regex, TopicsPattern.RegexImplementation implementation) {
+        if (TopicList.ALL_TOPICS_PATTERN.equals(regex)) {
+            return matchAll();
+        }
+        switch (implementation) {
+            case RE2J:
+                return new RE2JTopicsPattern(regex);
+            case JDK:
+                return new JDKTopicsPattern(regex);
+            case RE2J_WITH_JDK_FALLBACK:
+                try {
+                    return new RE2JTopicsPattern(regex);
+                } catch (com.google.re2j.PatternSyntaxException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Failed to compile regex pattern '{}' with RE2J, fallback to JDK", regex, e);
+                    }
+                    // Fallback to JDK implementation if RE2J fails
+                    return new JDKTopicsPattern(regex);
+                }
+            default:
+                throw new IllegalArgumentException("Unknown RegexImplementation: " + implementation);
+        }
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicListTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicListTest.java
@@ -18,17 +18,17 @@
  */
 package org.apache.pulsar.common.topics;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
-import com.google.re2j.Pattern;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.regex.Pattern;
 import org.testng.annotations.Test;
 
 public class TopicListTest {
@@ -44,12 +44,11 @@ public class TopicListTest {
 
         Pattern pattern1 = Pattern.compile("persistent://my-property/my-ns/pattern-topic.*");
         List<String> result1 = TopicList.filterTopics(topicsNames, pattern1);
-        assertTrue(result1.size() == 2 && result1.contains(topicName1) && result1.contains(topicName2));
+        assertThat(result1).containsExactly(topicName1, topicName2);
 
         Pattern pattern2 = Pattern.compile("persistent://my-property/my-ns/.*");
         List<String> result2 = TopicList.filterTopics(topicsNames, pattern2);
-        assertTrue(result2.size() == 4
-                && Stream.of(topicName1, topicName2, topicName3, topicName4).allMatch(result2::contains));
+        assertThat(result2).containsExactly(topicName1, topicName2, topicName3, topicName4);
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternFactoryTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternFactoryTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import com.google.re2j.PatternSyntaxException;
+import java.util.regex.Pattern;
+import org.testng.annotations.Test;
+
+public class TopicsPatternFactoryTest {
+    public static final String DEFAULT_TOPICS_PATTERN = "tenant/namespace/test-topic-.*";
+    public static final String DEFAULT_TOPICS_PATTERN_WITH_DOMAIN = "persistent://" + DEFAULT_TOPICS_PATTERN;
+
+    @Test
+    public void testCreateWithJdkPattern() {
+        Pattern jdkPattern = Pattern.compile(DEFAULT_TOPICS_PATTERN);
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(jdkPattern);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    private static void assertTopicsPattern(TopicsPattern topicsPattern) {
+        assertNotNull(topicsPattern);
+        assertEquals(topicsPattern.pattern(), "tenant/namespace/test-topic-.*");
+        assertTopicsPatternMatches(topicsPattern);
+    }
+
+    private static void assertTopicsPatternMatches(TopicsPattern topicsPattern) {
+        assertTrue(topicsPattern.matches("tenant/namespace/test-topic-1"));
+        assertTrue(topicsPattern.matches("tenant/namespace/test-topic-abc"));
+        assertFalse(topicsPattern.matches("tenant/namespace/other-topic"));
+    }
+
+    @Test
+    public void testCreateWithJdkPatternContainingTopicDomainScheme() {
+        Pattern jdkPattern = Pattern.compile(DEFAULT_TOPICS_PATTERN_WITH_DOMAIN);
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(jdkPattern);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    @Test
+    public void testCreateWithStringAndRE2JImplementation() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
+                TopicsPattern.RegexImplementation.RE2J);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    @Test
+    public void testCreateWithStringAndJDKImplementation() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
+                TopicsPattern.RegexImplementation.JDK);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    @Test
+    public void testCreateWithStringAndRE2JWithJDKFallbackImplementation() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
+                TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    @Test
+    public void testCreateWithStringContainingTopicDomainScheme() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN_WITH_DOMAIN,
+                TopicsPattern.RegexImplementation.JDK);
+        assertTopicsPattern(topicsPattern);
+    }
+
+    @Test
+    public void testCreateWithAllTopicsPattern() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(".*",
+                TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
+        assertNotNull(topicsPattern);
+        assertTrue(topicsPattern.matches("tenant/namespace/any-topic"));
+        assertTrue(topicsPattern.matches("tenant/namespace/test-topic-1"));
+        assertTrue(topicsPattern.matches(""));
+    }
+
+    @Test
+    public void testMatchAll() {
+        TopicsPattern topicsPattern = TopicsPatternFactory.matchAll();
+        assertNotNull(topicsPattern);
+        assertTrue(topicsPattern.matches("tenant/namespace/any-topic"));
+        assertTrue(topicsPattern.matches("tenant/namespace/test-topic-1"));
+        assertTrue(topicsPattern.matches(""));
+        assertTrue(topicsPattern.matches("tenant/namespace/very-long-topic-name"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testCreateWithInvalidImplementation() {
+        TopicsPatternFactory.create(null, TopicsPattern.RegexImplementation.JDK);
+    }
+
+    @Test
+    public void testRE2JFallbackToJDK() {
+        // example of excluding topics that start with "test2-" or "test3-" or "other-", but require that the topic
+        // name ends with "-topic" or "-topic-" and any suffix
+        // This regex cannot be parsed by RE2J, so it should fall back to JDK regex
+        String complexRegex = "tenant/namespace/(?!(test2|test3|other)-).+-topic(-.*)?";
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(complexRegex,
+                TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
+        assertNotNull(topicsPattern);
+        assertTopicsPatternMatches(topicsPattern);
+        assertTrue(topicsPattern.matches("tenant/namespace/any-topic"));
+        assertFalse(topicsPattern.matches("tenant/namespace/test2-topic"));
+        assertFalse(topicsPattern.matches("tenant/namespace/test3-topic"));
+        assertTrue(topicsPattern.matches("tenant/namespace/test4-topic"));
+        assertTrue(topicsPattern.matches("tenant/namespace/test20-topic"));
+    }
+
+    @Test(expectedExceptions = PatternSyntaxException.class)
+    public void testRE2JParsingFailure() {
+        String complexRegex = "tenant/namespace/(?!(test2|test3|other)-).+-topic(-.*)?";
+        TopicsPattern topicsPattern = TopicsPatternFactory.create(complexRegex,
+                TopicsPattern.RegexImplementation.RE2J);
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternFactoryTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternFactoryTest.java
@@ -34,12 +34,13 @@ public class TopicsPatternFactoryTest {
     public void testCreateWithJdkPattern() {
         Pattern jdkPattern = Pattern.compile(DEFAULT_TOPICS_PATTERN);
         TopicsPattern topicsPattern = TopicsPatternFactory.create(jdkPattern);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, false);
     }
 
-    private static void assertTopicsPattern(TopicsPattern topicsPattern) {
+    private static void assertTopicsPattern(TopicsPattern topicsPattern, boolean inputIncludesDomainScheme) {
         assertNotNull(topicsPattern);
-        assertEquals(topicsPattern.pattern(), "tenant/namespace/test-topic-.*");
+        assertEquals(topicsPattern.inputPattern(),
+                inputIncludesDomainScheme ? DEFAULT_TOPICS_PATTERN_WITH_DOMAIN : DEFAULT_TOPICS_PATTERN);
         assertTopicsPatternMatches(topicsPattern);
     }
 
@@ -53,35 +54,35 @@ public class TopicsPatternFactoryTest {
     public void testCreateWithJdkPatternContainingTopicDomainScheme() {
         Pattern jdkPattern = Pattern.compile(DEFAULT_TOPICS_PATTERN_WITH_DOMAIN);
         TopicsPattern topicsPattern = TopicsPatternFactory.create(jdkPattern);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, true);
     }
 
     @Test
     public void testCreateWithStringAndRE2JImplementation() {
         TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
                 TopicsPattern.RegexImplementation.RE2J);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, false);
     }
 
     @Test
     public void testCreateWithStringAndJDKImplementation() {
         TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
                 TopicsPattern.RegexImplementation.JDK);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, false);
     }
 
     @Test
     public void testCreateWithStringAndRE2JWithJDKFallbackImplementation() {
         TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN,
                 TopicsPattern.RegexImplementation.RE2J_WITH_JDK_FALLBACK);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, false);
     }
 
     @Test
     public void testCreateWithStringContainingTopicDomainScheme() {
         TopicsPattern topicsPattern = TopicsPatternFactory.create(DEFAULT_TOPICS_PATTERN_WITH_DOMAIN,
                 TopicsPattern.RegexImplementation.JDK);
-        assertTopicsPattern(topicsPattern);
+        assertTopicsPattern(topicsPattern, true);
     }
 
     @Test

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/topics/TopicsPatternTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.topics;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import java.util.regex.Pattern;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.Test;
+
+public class TopicsPatternTest {
+
+    @Test
+    public void testNamespace() {
+        TopicsPattern pattern = TopicsPatternFactory.create(Pattern.compile("tenant/namespace/topic-.*"));
+        NamespaceName namespace = pattern.namespace();
+        assertEquals(namespace.getTenant(), "tenant");
+        assertEquals(namespace.getLocalName(), "namespace");
+        assertEquals(namespace.toString(), "tenant/namespace");
+
+        // Test with a standard topic pattern
+        TopicsPattern domainPrefixPattern =
+                TopicsPatternFactory.create(Pattern.compile("persistent://tenant/namespace/topic-.*"));
+        NamespaceName namespace2 = pattern.namespace();
+        assertEquals(namespace.getTenant(), "tenant");
+        assertEquals(namespace.getLocalName(), "namespace");
+        assertEquals(namespace.toString(), "tenant/namespace");
+
+        // Test with a more complex topic pattern
+        TopicsPattern complexPattern =
+                TopicsPatternFactory.create(Pattern.compile("persistent://my-tenant/my-namespace/prefix-.*-suffix"));
+        NamespaceName complexNamespace = complexPattern.namespace();
+        assertEquals(complexNamespace.getTenant(), "my-tenant");
+        assertEquals(complexNamespace.getLocalName(), "my-namespace");
+        assertEquals(complexNamespace.toString(), "my-tenant/my-namespace");
+
+        // Test with non-persistent topic pattern
+        TopicsPattern nonPersistentPattern =
+                TopicsPatternFactory.create(Pattern.compile("non-persistent://test-tenant/test-namespace/.*"));
+        NamespaceName nonPersistentNamespace = nonPersistentPattern.namespace();
+        assertEquals(nonPersistentNamespace.getTenant(), "test-tenant");
+        assertEquals(nonPersistentNamespace.getLocalName(), "test-namespace");
+        assertEquals(nonPersistentNamespace.toString(), "test-tenant/test-namespace");
+    }
+
+    @Test
+    public void testTopicLookupNameForTopicListWatcherPlacement() {
+        TopicsPattern pattern =
+                TopicsPatternFactory.create(Pattern.compile("persistent://tenant/namespace/topic-.*(\\d+)?"));
+        String lookupName = pattern.topicLookupNameForTopicListWatcherPlacement();
+        assertNotNull(lookupName);
+        TopicName lookupTopicName = TopicName.get(lookupName);
+        assertEquals(lookupTopicName.getTenant(), "tenant");
+        assertEquals(lookupTopicName.getNamespacePortion(), "namespace");
+        assertEquals(lookupTopicName.getLocalName(), "topic-.*(\\d+)?");
+    }
+}


### PR DESCRIPTION
## Motivation

PR #22829 introduced a breaking change by switching the regular expression library from JDK's `java.util.regex.Pattern` to RE2/J in the topics pattern consumer implementation. This change breaks backwards compatibility with advanced regular expressions that rely on features not supported by RE2/J.

**Problem**: RE2/J does not support certain regex features by design, such as negative lookaheads. A common use case is subscribing to all topics except those with specific prefixes. For example, the pattern `persistent://public/default/(?!(test2|test3|test4)-).+` should subscribe to all topics in the `public/default` namespace that don't start with `test2-`, `test3-`, or `test4-`.

**Current Behavior**: In Pulsar 4.0.x, this pattern fails with:
```
org.apache.pulsar.shade.com.google.re2j.PatternSyntaxException: error parsing regexp: invalid or unsupported Perl syntax: `(?!`
```

## Modifications

This PR introduces a configurable solution that maintains backwards compatibility while allowing users to choose their preferred regex implementation:

### 1. New TopicsPattern Interface
- Encapsulates topics pattern usage into a specific interface `TopicsPattern`
- Provides methods used by both client and broker for topics pattern consumers
- Abstracts the underlying regex implementation

### 2. Broker Configuration Option
Added `topicsPatternRegexImplementation` configuration with three options:

- **`RE2J_WITH_JDK_FALLBACK`** (default): Uses RE2J implementation with automatic fallback to JDK when pattern compilation fails with RE2/J. Provides backwards compatibility while maintaining performance for simple patterns.

- **`RE2J`**: Uses only the RE2J implementation. More performant but doesn't support all regex features (e.g., negative lookaheads). Recommended for security-conscious deployments to prevent regex DoS attacks.

- **`JDK`**: Uses the standard Java regex implementation. Supports all regex features but can be slower and potentially vulnerable to regex DoS attacks with malicious patterns.

### 3. Implementation Classes
- `RE2JTopicsPattern`: High-performance RE2J implementation
- `JDKTopicsPattern`: Full-featured JDK implementation  
- `MatchAllTopicsPattern`: Optimized implementation for `.*` patterns
- `TopicsPatternFactory`: Creates appropriate implementation based on configuration

### 4. Client Compatibility
- Maintains full backwards compatibility for Java client users
- Existing `Pattern.compile()` usage continues to work seamlessly
- The public Java client API hasn't changed although technically public methods have been modified

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->