### PR TITLE
[fix][client] Close orphan producer or consumer when the creation is interrupted

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientInterruptTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientInterruptTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.intercept.MockBrokerInterceptor;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Producer;
+import org.apache.pulsar.broker.service.ServerCnx;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.TopicName;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-impl")
+public class ClientInterruptTest extends ProducerConsumerBase {
+
+    private final CreationInterceptor interceptor = new CreationInterceptor();
+    private int index = 0;
+    private PulsarClientImpl client;
+    private String topic;
+    private ExecutorService executor;
+    private CompletableFuture<Void> delayTriggered;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+        client = (PulsarClientImpl) PulsarClient.builder().serviceUrl(pulsar.getBrokerServiceUrl()).build();
+        pulsar.getBrokerService().setInterceptor(interceptor);
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @BeforeMethod
+    public void setupTopic() {
+        interceptor.numConsumerCreated.set(0);
+        interceptor.numProducerCreated.set(0);
+        executor = Executors.newCachedThreadPool();
+        TopicName topicName = TopicName.get("test-topic-" + index++);
+        topic = topicName.toString();
+
+        final var mlPath = BrokerService.MANAGED_LEDGER_PATH_ZNODE + "/" + topicName.getPersistenceNamingEncoding();
+        delayTriggered = new CompletableFuture<>();
+        mockZooKeeper.delay(1000L, (op, path) -> {
+            final var result = path.equals(mlPath);
+            if (result) {
+                log.info("Injected delay for {} {}", op, path);
+                delayTriggered.complete(null);
+            }
+            return result;
+        });
+    }
+
+    @AfterMethod(alwaysRun = true, timeOut = 10000)
+    public void cleanupTopic() {
+        executor.shutdown();
+    }
+
+    @Test(timeOut = 10000)
+    public void testCreateProducer() throws Exception {
+        testCreateInterrupt("producer", () -> client.newProducer().topic(topic).create());
+    }
+
+    @Test(timeOut = 10000)
+    public void testSubscribe() throws Exception {
+        testCreateInterrupt("consumer", () -> client.newConsumer().topic(topic).subscriptionName("sub")
+                .subscribe());
+    }
+
+    @Test(timeOut = 10000)
+    public void testCreateReader() throws Exception {
+        testCreateInterrupt("reader", () -> client.newReader().topic(topic).startMessageId(MessageId.earliest)
+                .create());
+    }
+
+    private void testCreateInterrupt(String name, PulsarClientSyncTask task) throws Exception {
+        final var exception = new AtomicReference<PulsarClientException>();
+        final var threadInterrupted = new CompletableFuture<Boolean>();
+        final var future = executor.submit(() -> {
+            try {
+                task.run();
+                exception.set(new PulsarClientException("Task " + name + " succeeded"));
+            } catch (PulsarClientException e) {
+                exception.set(e);
+            }
+
+            try {
+                Thread.sleep(1);
+                threadInterrupted.complete(false);
+            } catch (InterruptedException __) {
+                threadInterrupted.complete(true);
+            }
+        });
+        delayTriggered.get();
+        future.cancel(true);
+
+        Awaitility.await().untilAsserted(() -> assertNotNull(exception.get()));
+        assertTrue(exception.get().getCause() instanceof InterruptedException);
+
+        Awaitility.await().untilAsserted(() -> assertTrue(pulsar.getBrokerService().getTopics().containsKey(topic)));
+        final var persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get()
+                .orElseThrow();
+
+        if (name.equals("producer")) {
+            Awaitility.await().untilAsserted(() -> assertEquals(interceptor.numProducerCreated.get(), 1));
+            // Verify the created producer will eventually be closed
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(persistentTopic.getProducers().size(), 0);
+                assertEquals(client.producersCount(), 0);
+            });
+        } else {
+            Awaitility.await().untilAsserted(() -> assertEquals(interceptor.numConsumerCreated.get(), 1));
+            // Verify the created consumer will eventually be closed
+            Awaitility.await().untilAsserted(() -> {
+                persistentTopic.getSubscriptions().values().forEach(subscription ->
+                        assertTrue(subscription.getConsumers().isEmpty()));
+                assertEquals(client.consumersCount(), 0);
+            });
+        }
+        // The thread's interrupt state should not be set, it's the caller's responsibility to set the interrupt state
+        // if necessary when catching the `PulsarClientException` that wraps an `InterruptedException`
+        assertFalse(threadInterrupted.get());
+    }
+
+    private interface PulsarClientSyncTask {
+
+        void run() throws PulsarClientException;
+    }
+
+
+    private static class CreationInterceptor extends MockBrokerInterceptor  {
+
+        final AtomicInteger numProducerCreated = new AtomicInteger(0);
+        final AtomicInteger numConsumerCreated = new AtomicInteger(0);
+
+        @Override
+        public void producerCreated(ServerCnx cnx, Producer producer, Map<String, String> metadata) {
+            numProducerCreated.incrementAndGet();
+        }
+
+        @Override
+        public void consumerCreated(ServerCnx cnx, Consumer consumer, Map<String, String> metadata) {
+            numConsumerCreated.incrementAndGet();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerCloseTest.java
@@ -20,19 +20,13 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertTrue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,47 +46,6 @@ public class ConsumerCloseTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
-    }
-
-    @Test
-    public void testInterruptedWhenCreateConsumer() throws InterruptedException {
-
-        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
-        String subName = "test-sub";
-        String mlCursorPath = BrokerService.MANAGED_LEDGER_PATH_ZNODE + "/"
-                + TopicName.get(tpName).getPersistenceNamingEncoding() + "/" + subName;
-
-        // Make create cursor delay 1s
-        CountDownLatch topicLoadLatch = new CountDownLatch(1);
-        for (int i = 0; i < 5; i++) {
-            mockZooKeeper.delay(1000, (op, path) -> {
-                if (mlCursorPath.equals(path)) {
-                    topicLoadLatch.countDown();
-                    return true;
-                }
-                return false;
-            });
-        }
-
-        Thread startConsumer = new Thread(() -> {
-            try {
-                pulsarClient.newConsumer()
-                        .topic(tpName)
-                        .subscriptionName(subName)
-                        .subscribe();
-                Assert.fail("Should have thrown an exception");
-            } catch (PulsarClientException e) {
-                assertTrue(e.getCause() instanceof InterruptedException);
-            }
-        });
-        startConsumer.start();
-        topicLoadLatch.await();
-        startConsumer.interrupt();
-
-        PulsarClientImpl clientImpl = (PulsarClientImpl) pulsarClient;
-        Awaitility.await().ignoreExceptions().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
-            Assert.assertEquals(clientImpl.consumersCount(), 0);
-        });
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -84,7 +84,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public Producer<T> create() throws PulsarClientException {
         try {
-            return createAsync().get();
+            return FutureUtil.wait(createAsync(), Producer::closeAsync);
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -73,7 +73,7 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     @Override
     public Reader<T> create() throws PulsarClientException {
         try {
-            return createAsync().get();
+            return FutureUtil.wait(createAsync(), Reader::closeAsync);
         } catch (Exception e) {
             throw PulsarClientException.unwrap(e);
         }


### PR DESCRIPTION
### Motivation

The producer or reader creation has the same issue like what https://github.com/apache/pulsar/pull/24100 fixes for consumer: when the thread is interrupted, the returned future will complete exceptionally with the wrapped `InterruptedException`, but the asynchronous creation will continue in the background.

### Modifications

- Add a common `FutureUtils.wait` method to call a callback on the completed result.
- Apply the method above to the creation of producer, consumer and reader.
- Add `ClientInterruptTest` to cover the fixes above and remove duplicated `ConsumerCloseTest#testInterruptedWhenCreateConsumer`.

It should be noted that the complicated fix approach of https://github.com/apache/pulsar/pull/24100 is replaced by the solution in this PR.

This PR also reverts the change that the thread interrupt state is set, which should be the caller's responsibility to do that. This is actually a wrong behavior for many existing synchronous APIs.

Without this change, the 2nd creation of the consumer in the code snippet will fail when the 1st creation is interrupted:

```java
try {
    @Cleanup final var consumer = client.newConsumer().topic("tp").subscriptionName("sub")
            .subscribe();
    fail();
} catch (PulsarClientException e) {
    assertTrue(e.getCause() instanceof InterruptedException);
}
try {
    @Cleanup final var consumer = client.newConsumer().topic("another-tp").subscriptionName("sub")
            .subscribe();
} catch (PulsarClientException e) {
    fail();
}
```

If we want to make the 2nd call fail, the caller should handle the `InterruptException` like:

```java
} catch (PulsarClientException e) {
    if (e.getCause() instanceof InterruptedException) {
        Thread.currentThread().interrupt();
    }
}
```

In short,
- Before https://github.com/apache/pulsar/pull/24100, after the creation of producer, consumer or reader is interrupted, the thread interrupt flag won't be set.
- After https://github.com/apache/pulsar/pull/24100, after the creation of consumer is interrupted, the thread interrupt flag will be set.
- After this PR, after the creation of producer, consumer or reader is interrupted, the thread interrupt flag won't be set.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
