### PR TITLE
[fix][broker] Fix matching of topicsPattern for topic names which contain non-ascii characters

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -116,7 +116,7 @@ public class TopicResources {
                 Matcher matcher = entry.getValue().matcher(notification.getPath());
                 if (matcher.matches()) {
                     TopicName topicName = TopicName.get(
-                            matcher.group(2), NamespaceName.get(matcher.group(1)), matcher.group(3));
+                            matcher.group(2), NamespaceName.get(matcher.group(1)), decode(matcher.group(3)));
                     entry.getKey().accept(topicName.toString(), notification.getType());
                 }
             }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
@@ -114,4 +114,13 @@ public class TopicResourcesTest {
         verifyNoMoreInteractions(listener);
     }
 
+    @Test
+    public void testListenerInvokedWithDecodedTopicName() {
+        BiConsumer<String, NotificationType> listener = mock(BiConsumer.class);
+        topicResources.registerPersistentTopicListener(NamespaceName.get("tenant/namespace"), listener);
+        topicResources.handleNotification(new Notification(NotificationType.Created,
+                "/managed-ledgers/tenant/namespace/persistent/topic%3Atest"));
+        verify(listener).accept("persistent://tenant/namespace/topic:test", NotificationType.Created);
+    }
+
 }


### PR DESCRIPTION
Fixes #24182

### Motivation

When using `topicsPattern` consumer, the pattern wouldn't properly match topic names which contain non-ascii characters.

### Modifications

- decode the url encoded persistent topic name before passing it to the listener
- add a unit test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->