### PR TITLE
[improve][client] Terminate consumer.receive() when consumer is closed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4142,7 +4142,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     @Test(timeOut = 100000)
     public void consumerReceiveThrowExceptionWhenConsumerClose() throws Exception {
-        @Cleanup
         Consumer<byte[]> consumer = pulsarClient
                 .newConsumer()
                 .topic("persistent://my-property/my-ns/my-topic2")
@@ -4166,6 +4165,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 () -> consumer.receive()
         )
                 .isInstanceOf(PulsarClientException.class)
+                .hasMessage("java.lang.InterruptedException: Queue is terminated")
                 .hasCauseInstanceOf(InterruptedException.class);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4165,8 +4165,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertThatThrownBy(
                 () -> consumer.receive()
         )
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Queue is terminated");
+                .isInstanceOf(PulsarClientException.class)
+                .hasMessage("java.lang.InterruptedException: Queue is terminated");
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4166,7 +4166,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 () -> consumer.receive()
         )
                 .isInstanceOf(PulsarClientException.class)
-                .hasMessage("java.lang.InterruptedException: Queue is terminated");
+                .hasCauseInstanceOf(InterruptedException.class);
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -423,7 +423,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         producer.close();
     }
 
-    @Test
+    @Test(timeOut = 30000)
     public void testZeroQueueGetExceptionWhenReceiveBatchMessage() throws PulsarClientException {
 
         int batchMessageDelayMs = 100;
@@ -440,12 +440,13 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
 
         Producer<byte[]> producer = producerBuilder.create();
 
-
+        // send a batch message to trigger zeroQueueConsumer to close
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.sendAsync(message.getBytes());
         }
 
+        // when zeroQueueConsumer receive a batch message, it will close and receive method will throw exception
         assertThatThrownBy(
                 consumer::receive
         )

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -450,8 +450,8 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         assertThatThrownBy(
                 consumer::receive
         )
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Queue is terminated");
+                .isInstanceOf(PulsarClientException.class)
+                .hasMessage("java.lang.InterruptedException: Queue is terminated");
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -451,7 +451,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
                 consumer::receive
         )
                 .isInstanceOf(PulsarClientException.class)
-                .hasMessage("java.lang.InterruptedException: Queue is terminated");
+                .hasCauseInstanceOf(InterruptedException.class);
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -451,6 +451,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
                 consumer::receive
         )
                 .isInstanceOf(PulsarClientException.class)
+                .hasMessage("java.lang.InterruptedException: Queue is terminated")
                 .hasCauseInstanceOf(InterruptedException.class);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1246,6 +1246,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (poolMessages) {
             releasePooledMessagesAndStopAcceptNew();
         }
+        incomingMessages.terminate();
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1243,22 +1243,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
         negativeAcksTracker.close();
         stats.getStatTimeout().ifPresent(Timeout::cancel);
-        processIncomingMessagesWhenClose();
-    }
-
-    /**
-     * when consumer is closed.we should
-     * 1. terminate incomingMessages queue
-     * 2. If enabled pooled messages, we should release the messages after closing consumer and stop accept the new
-     * messages.
-     */
-    private void processIncomingMessagesWhenClose() {
-        if (poolMessages) {
-            incomingMessages.terminate(message -> message.release());
-            clearIncomingMessages();
-        } else {
-            incomingMessages.terminate(null);
-        }
+        //terminate incomingMessages queue, stop accept the new messages and waking up blocked thread.
+        incomingMessages.terminate(Message::release);
+        clearIncomingMessages();
     }
 
     void activeConsumerChanged(boolean isActive) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -223,6 +223,9 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
                 if (timeoutNanos <= 0) {
                     return null;
                 }
+                if (terminated) {
+                    throw new IllegalStateException("Queue is terminated");
+                }
 
                 timeoutNanos = isNotEmpty.awaitNanos(timeoutNanos);
             }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -447,7 +447,7 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
         // Signal waiting consumer threads to prevent indefinite blocking after termination
         headLock.lock();
         try {
-            isNotEmpty.signal();
+            isNotEmpty.signalAll();
         } finally {
             headLock.unlock();
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -428,7 +428,8 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
     }
 
     /**
-     * Make the queue not accept new items and waking up blocked consume.if there are still new data trying to enter the queue, it will be handed
+     * Make the queue not accept new items and waking up blocked consume.
+     * if there are still new data trying to enter the queue, it will be handed
      * by {@param itemAfterTerminatedHandler}.
      */
     public void terminate(@Nullable Consumer<T> itemAfterTerminatedHandler) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueue.java
@@ -224,7 +224,7 @@ public class GrowableArrayBlockingQueue<T> extends AbstractQueue<T> implements B
                     return null;
                 }
                 if (terminated) {
-                    throw new InterruptedException("Queue is terminated");
+                    return null;
                 }
 
                 timeoutNanos = isNotEmpty.awaitNanos(timeoutNanos);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueueTest.java
@@ -208,6 +208,117 @@ public class GrowableArrayBlockingQueueTest {
         latch.await();
     }
 
+    /**
+     * test that multi-threads calling take(), and then terminate the queue, these threads will be properly interrupted.
+     */
+    @Test(timeOut = 10000)
+    public void testTakeBlockingThreadsTermination() throws InterruptedException {
+        GrowableArrayBlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(2);
+        int threadCount = 10;
+        CountDownLatch terminateCompletedLatch = new CountDownLatch(threadCount);
+        CountDownLatch allThreadReadyLatch = new CountDownLatch(threadCount);
+        AtomicInteger interruptedThreadCount = new AtomicInteger(0);
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    allThreadReadyLatch.countDown();
+                    queue.take();
+                    fail("thread should have been interrupted");
+                } catch (InterruptedException e) {
+                    // Expected interruption, record and notify
+                    terminateCompletedLatch.countDown();
+                    interruptedThreadCount.incrementAndGet();
+                }
+            }).start();
+        }
+        // all threads should be ready in at most 1 second
+        assertTrue(allThreadReadyLatch.await(1, TimeUnit.SECONDS));
+        // Terminate the queue - this should interrupt all threads blocked on take()
+        queue.terminate(null);
+        // all threads should be interrupted in at most 1 second
+        assertTrue(terminateCompletedLatch.await(1, TimeUnit.SECONDS));
+        // Verify all threads were properly interrupted
+        assertEquals(interruptedThreadCount.get(), threadCount);
+    }
+
+    /**
+     * test that multi-threads calling poll(), and then terminate the queue,
+     * these threads will be terminated by return null value.
+     */
+    @Test(timeOut = 10000)
+    public void testPollBlockingThreadsTermination() throws InterruptedException {
+        GrowableArrayBlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(2);
+        int threadCount = 10;
+        CountDownLatch terminateCompletedLatch = new CountDownLatch(threadCount);
+        CountDownLatch allThreadReadyLatch = new CountDownLatch(threadCount);
+        AtomicInteger terminateThreadCount = new AtomicInteger(0);
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                try {
+                    allThreadReadyLatch.countDown();
+                    // poll message at a very long timeout, so it will keep pending
+                    Integer poll = queue.poll(1, TimeUnit.HOURS);
+                    // should return a null value if queue is terminated
+                    assertNull(poll);
+                    terminateCompletedLatch.countDown();
+                    terminateThreadCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }).start();
+        }
+        // all threads should be ready in at most 1 second
+        assertTrue(allThreadReadyLatch.await(1, TimeUnit.SECONDS));
+        // Terminate the queue - this should make all threads return null value
+        queue.terminate(null);
+        // all threads should be terminated in at most 1 second
+        assertTrue(terminateCompletedLatch.await(1, TimeUnit.SECONDS));
+        assertEquals(terminateThreadCount.get(), threadCount);
+    }
+
+    /**
+     * test that multi-threads calling take() and poll() mix, and then terminate the queue,
+     * the queue will signal all these threads properly.
+     */
+    @Test(timeOut = 10000)
+    public void testPollTakeMixBlockingThreadsTermination() throws InterruptedException {
+        GrowableArrayBlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(2);
+        int threadCount = 10;
+        CountDownLatch terminateCompletedLatch = new CountDownLatch(threadCount);
+        CountDownLatch allThreadReadyLatch = new CountDownLatch(threadCount);
+        AtomicInteger terminateThreadCount = new AtomicInteger(0);
+        for (int i = 0; i < threadCount; i++) {
+            int finalI = i;
+            new Thread(() -> {
+                allThreadReadyLatch.countDown();
+                if (finalI % 2 == 0) {
+                    try {
+                        queue.take();
+                    } catch (InterruptedException e) {
+                        terminateCompletedLatch.countDown();
+                        terminateThreadCount.incrementAndGet();
+                    }
+                } else {
+                    try {
+                        Integer poll = queue.poll(1, TimeUnit.HOURS);
+                        assertNull(poll);
+                        terminateCompletedLatch.countDown();
+                        terminateThreadCount.incrementAndGet();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }).start();
+        }
+        // all threads should be ready in at most 1 second
+        assertTrue(allThreadReadyLatch.await(1, TimeUnit.SECONDS));
+        // Terminate the queue - this should make all threads return null value
+        queue.terminate(null);
+        // all threads should be terminated in at most 1 second
+        assertTrue(terminateCompletedLatch.await(1, TimeUnit.SECONDS));
+        assertEquals(terminateThreadCount.get(), threadCount);
+    }
+
     @Test
     public void removeTest() {
         BlockingQueue<Integer> queue = new GrowableArrayBlockingQueue<>(4);


### PR DESCRIPTION
### Motivation
Currently, when `consumer.receive()` is called, it blocks indefinitely even when the consumer is being closed. This can lead to threads hanging indefinitely in applications that need to gracefully shutdown consumers. The issue can be reproduced with:
``` java
Thread thread = new Thread(() -> {
    try {
        // sleep 0.1 second to close consumer to ensure consumer.receive() is triggerd
        Thread.sleep(1000);
        consumer.close();
    } catch (Exception e) {
        throw new RuntimeException(e);
    }
});
thread.start();
// hangs forever
consumer.receive();
```
in fact, this could happen in many scenario as long as ```consumer.receive()``` called before ```consumer.close()```

**so, this PR aims to ensure that `consumer.receive()` will immediately throw an `IllegalStateException` when the consumer is being closed, providing clear feedback and preventing thread hangs**
### Modifications
1.Added termination handling in GrowableArrayBlockingQueue to:

- Check termination flag in take() and poll() methods

- Throw IllegalStateException with "Queue is terminated" message when terminated

2.Modified ```ConsumerImpl.closeConsumerTasks()``` to terminate the incoming message queue

3.Added tests covering:

- Regular consumer close during receive()

- Zero queue size consumer receives a batchMessage and another thread close consuer

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.
*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/15

