### PR TITLE
[fix][broker] Fix Broker OOM due to too many waiting cursors and reuse a recycled OpReadEntry incorrectly

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1053,8 +1053,8 @@ public class ManagedCursorImpl implements ManagedCursor {
                             op.readPosition);
                 }
 
-                // Check again for new entries after the configured time, then if still no entries are available register
-                // to be notified
+                // Check again for new entries after the configured time, then if still no entries are available
+                // register to be notified.
                 if (getConfig().getNewEntriesCheckDelayInMillis() > 0) {
                     delayCheckForNewEntriesTask = new DelayCheckForNewEntriesTask(op, callback, ctx);
                 } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -157,10 +158,17 @@ public class ManagedCursorImpl implements ManagedCursor {
             MarkDeleteEntry.class, "lastMarkDeleteEntry");
     protected volatile MarkDeleteEntry lastMarkDeleteEntry;
 
+    /** Protects the method "asyncReadEntriesWithSkipOrWait" and "cancelPendingReadRequest" runs concurrently. **/
+    private final Object pendingReadOpMutex = new Object();
+    /**
+     *  'ManagedLedger.notifyCursors' relies on this CAS to avoid using "pendingReadOpMutex" to guarantee thread-safety,
+     *  which improved the performance of publishing messages.
+     */
     protected static final AtomicReferenceFieldUpdater<ManagedCursorImpl, OpReadEntry> WAITING_READ_OP_UPDATER =
         AtomicReferenceFieldUpdater.newUpdater(ManagedCursorImpl.class, OpReadEntry.class, "waitingReadOp");
     @SuppressWarnings("unused")
     private volatile OpReadEntry waitingReadOp = null;
+    private volatile DelayCheckForNewEntriesTask delayCheckForNewEntriesTask;
 
     public static final int FALSE = 0;
     public static final int TRUE = 1;
@@ -1033,26 +1041,81 @@ public class ManagedCursorImpl implements ManagedCursor {
             OpReadEntry op = OpReadEntry.create(this, readPosition, numberOfEntriesToRead, callback,
                     ctx, maxPosition, skipCondition);
 
-            if (!WAITING_READ_OP_UPDATER.compareAndSet(this, null, op)) {
-                op.recycle();
-                callback.readEntriesFailed(new ManagedLedgerException.ConcurrentWaitCallbackException(), ctx);
+            synchronized (pendingReadOpMutex) {
+                if (!WAITING_READ_OP_UPDATER.compareAndSet(this, null, op)) {
+                    op.recycle();
+                    callback.readEntriesFailed(new ManagedLedgerException.ConcurrentWaitCallbackException(), ctx);
+                    return;
+                }
+
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] [{}] Deferring retry of read at position {}", ledger.getName(), name,
+                            op.readPosition);
+                }
+
+                // Check again for new entries after the configured time, then if still no entries are available register
+                // to be notified
+                if (getConfig().getNewEntriesCheckDelayInMillis() > 0) {
+                    delayCheckForNewEntriesTask = new DelayCheckForNewEntriesTask(op, callback, ctx);
+                } else {
+                    // If there's no delay, check directly from the same thread
+                    checkForNewEntries(op, callback, ctx);
+                }
+            }
+        }
+    }
+
+    private class DelayCheckForNewEntriesTask implements Runnable {
+
+        private final OpReadEntry op;
+        private final ReadEntriesCallback callback;
+        private final Object ctx;
+        private ScheduledFuture<?> scheduledFuture;
+        /**
+         * 0: init
+         * 1: running
+         * 2: cancelled
+         * 3: done
+         */
+        private final AtomicInteger state = new AtomicInteger();
+
+        public DelayCheckForNewEntriesTask(OpReadEntry op, ReadEntriesCallback callback, Object ctx) {
+            this.op = op;
+            this.callback = callback;
+            this.ctx = ctx;
+            start();
+        }
+
+        private void start() {
+            scheduledFuture = ledger.getScheduledExecutor().schedule(this,
+                    getConfig().getNewEntriesCheckDelayInMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public void run() {
+            if (!state.compareAndSet(0, 1)) {
                 return;
             }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Deferring retry of read at position {}", ledger.getName(), name, op.readPosition);
-            }
-
-            // Check again for new entries after the configured time, then if still no entries are available register
-            // to be notified
-            if (getConfig().getNewEntriesCheckDelayInMillis() > 0) {
-                ledger.getScheduledExecutor()
-                        .schedule(() -> checkForNewEntries(op, callback, ctx),
-                                getConfig().getNewEntriesCheckDelayInMillis(), TimeUnit.MILLISECONDS);
-            } else {
-                // If there's no delay, check directly from the same thread
+            synchronized (pendingReadOpMutex) {
                 checkForNewEntries(op, callback, ctx);
+                state.compareAndSet(1, 3);
             }
+        }
+
+        public boolean isDone() {
+            return state.get() == 3;
+        }
+
+        public boolean cancel() {
+            // Not all implementations of Executor guarantee that the Runnable will be no long be executed after a
+            // successful cancel, such as Guava MoreExecutors, see also https://github.com/google/guava/blob
+            // /v32.1.2/guava/src/com/google/common/util/concurrent/MoreExecutors.java#L709.
+            // The current task gurantees.
+            if (state.compareAndSet(0, 2)) {
+                scheduledFuture.cancel(false);
+                return true;
+            }
+            return false;
         }
     }
 
@@ -1089,16 +1152,16 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
                 // Try to cancel the notification request
                 if (WAITING_READ_OP_UPDATER.compareAndSet(this, op, null)) {
+                    ledger.removeWaitingCursor(this);
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] [{}] Cancelled notification and scheduled read at {}", ledger.getName(),
-                                name, op.readPosition);
+                            name, op.readPosition);
                     }
                     PENDING_READ_OPS_UPDATER.incrementAndGet(this);
                     ledger.asyncReadEntries(op);
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] notification was already cancelled", ledger.getName(), name);
-                    }
+                    log.info("[{}] [{}] notification that new entries added was already be called, skipped the curren"
+                        + "t new entry checking", ledger.getName(), name);
                 }
             } else if (ledger.isTerminated()) {
                 // At this point we registered for notification and still there were no more available
@@ -1121,11 +1184,49 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (log.isDebugEnabled()) {
             log.debug("[{}] [{}] Cancel pending read request", ledger.getName(), name);
         }
-        final OpReadEntry op = WAITING_READ_OP_UPDATER.getAndSet(this, null);
-        if (op != null) {
-            op.recycle();
+        synchronized (pendingReadOpMutex) {
+            final OpReadEntry op = WAITING_READ_OP_UPDATER.get(this);
+            // Case 1: the pending read has executed, or there is no pending read.
+            if (op == null) {
+                return false;
+            }
+            Function<Boolean, Boolean> clearWaitingReadOp = removeWaitingCursor -> {
+                if (WAITING_READ_OP_UPDATER.compareAndSet(this, op,null)) {
+                    if (removeWaitingCursor) {
+                        ledger.removeWaitingCursor(this);
+                    }
+                    op.recycle();
+                    return true;
+                } else {
+                    // Managed ledger has noticed that new entries was added.
+                    if (WAITING_READ_OP_UPDATER.get(this) == null) {
+                        return false;
+                    }
+                    // It will never occur, it means the lock "pendingReadOpMutex" does not work as expected, which
+                    // allowed other thread to modify the "waitingReadOp" concurrently.
+                    // The waitingReadOp has been modified to other instance, which will never occur.
+                    log.warn("[{}] [{}] Cancel pending request encountered an unexpected error, the lock"
+                        + " \"pendingReadOpMutex\" does not work as expected, which allowed other"
+                        + " thread to modify the \"waitingReadOp\" concurrently..", ledger.getName(), name);
+                    return cancelPendingReadRequest();
+                }
+            };
+            // There is a pending read,
+            // Case 2: delayCheckForNewEntriesTask can be cancelled, no need to remove cursor from "ml.waitingCursors",
+            //         because it has not added successfully yet.
+            if (delayCheckForNewEntriesTask != null && delayCheckForNewEntriesTask.cancel()) {
+                return clearWaitingReadOp.apply(false);
+            }
+            // Case 3: managedLedgerNewEntriesCheckDelayInMillis is "0".
+            // Case 4: delayCheckForNewEntriesTask has done, which has added cursor into "ml.waitingCursors".
+            if (delayCheckForNewEntriesTask == null || delayCheckForNewEntriesTask.isDone()) {
+                return clearWaitingReadOp.apply(true);
+            }
+            // Case 5: delayCheckForNewEntriesTask is running, but not done, which only occurs at a corner case. It
+            // only happens when the task is starting. Calling "cancelPendingReadRequest" here will release the lock
+            // "pendingReadOpMutex" and let the task go ahead.
+            return cancelPendingReadRequest();
         }
-        return op != null;
     }
 
     public boolean hasPendingReadRequest() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1062,6 +1062,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         } else if (!cursor.isDurable()) {
             cursor.setState(ManagedCursorImpl.State.Closed);
+            cursor.cancelPendingReadRequest();
             cursors.removeCursor(consumerName);
             deactivateCursorByName(consumerName);
             callback.deleteCursorComplete(ctx);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -383,15 +383,12 @@ public class PersistentSubscription extends AbstractSubscription {
                         if (!isResetCursor) {
                             try {
                                 topic.getManagedLedger().deleteCursor(cursor.getName());
-                                topic.getManagedLedger().removeWaitingCursor(cursor);
                             } catch (InterruptedException | ManagedLedgerException e) {
                                 log.warn("[{}] [{}] Failed to remove non durable cursor", topic.getName(), subName, e);
                             }
                         }
                     }, topic.getBrokerService().pulsar().getExecutor());
                 });
-            } else {
-                topic.getManagedLedger().removeWaitingCursor(cursor);
             }
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.testng.Assert.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.awaitility.Awaitility;
+import org.awaitility.reflect.WhiteboxImpl;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-api")
+public class FailoverSubscriptionTest extends ProducerConsumerBase {
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30_000, invocationCount = 5)
+    public void testWaitingCursorsCountAfterSwitchingActiveConsumers() throws Exception {
+        final String tp = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/tp");
+        final String subscription = "s1";
+        admin.topics().createNonPartitionedTopic(tp);
+        admin.topics().createSubscription(tp, subscription, MessageId.earliest);
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(tp, false).join().get();
+        Map<String, ConsumerImpl<byte[]>> consumerMap = new HashMap<>();
+        ConsumerImpl<byte[]> firstConsumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(tp)
+                .subscriptionType(SubscriptionType.Failover).subscriptionName(subscription).subscribe();
+        consumerMap.put(firstConsumer.getConsumerName(), firstConsumer);
+        PersistentDispatcherSingleActiveConsumer dispatcher =
+                (PersistentDispatcherSingleActiveConsumer) topic.getSubscription(subscription).getDispatcher();;
+        for (int i = 0; i < 100; i++) {
+            ConsumerImpl<byte[]> consumerLoop = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(tp)
+                    .subscriptionType(SubscriptionType.Failover).subscriptionName(subscription).subscribe();
+            consumerMap.put(consumerLoop.getConsumerName(), consumerLoop);
+            if (dispatcher != null && dispatcher.getActiveConsumer() != null) {
+                String activeConsumer = dispatcher.getActiveConsumer().consumerName();
+                consumerMap.remove(activeConsumer).close();
+            }
+        }
+
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
+        ConcurrentLinkedQueue<ManagedCursorImpl> waitingCursors =
+                WhiteboxImpl.getInternalState(managedLedger, "waitingCursors");
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(waitingCursors.size(), 1);
+        });
+
+        // cleanup.
+        for (ConsumerImpl<byte[]> consumer : consumerMap.values()) {
+            consumer.close();
+        }
+        admin.topics().delete(tp, false);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
@@ -60,7 +60,7 @@ public class FailoverSubscriptionTest extends ProducerConsumerBase {
                 .subscriptionType(SubscriptionType.Failover).subscriptionName(subscription).subscribe();
         consumerMap.put(firstConsumer.getConsumerName(), firstConsumer);
         PersistentDispatcherSingleActiveConsumer dispatcher =
-                (PersistentDispatcherSingleActiveConsumer) topic.getSubscription(subscription).getDispatcher();;
+                (PersistentDispatcherSingleActiveConsumer) topic.getSubscription(subscription).getDispatcher();
         for (int i = 0; i < 100; i++) {
             ConsumerImpl<byte[]> consumerLoop = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(tp)
                     .subscriptionType(SubscriptionType.Failover).subscriptionName(subscription).subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/FailoverSubscriptionTest.java
@@ -21,16 +21,13 @@ package org.apache.pulsar.client.api;
 import static org.testng.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.awaitility.Awaitility;
-import org.awaitility.reflect.WhiteboxImpl;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -75,10 +72,8 @@ public class FailoverSubscriptionTest extends ProducerConsumerBase {
         }
 
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
-        ConcurrentLinkedQueue<ManagedCursorImpl> waitingCursors =
-                WhiteboxImpl.getInternalState(managedLedger, "waitingCursors");
         Awaitility.await().untilAsserted(() -> {
-            assertEquals(waitingCursors.size(), 1);
+            assertEquals(managedLedger.getWaitingCursorsCount(), 1);
         });
 
         // cleanup.


### PR DESCRIPTION
### Motivation

#### Background

**1. Pending read if no entries to read.**
- Cursor sets itself into `managedledger.waitingCursors` if there are no entries to read.
- Managed ledger triggers `cursor.notifyEntriesAvailable` once new entries were added.

**2, Double-check that it has more entries.**
- The cursor does an additional check if there are no entries to read<sup>[code-1]</sup>.
- The cursor delays the second checking if the configuration `newEntriesCheckDelayInMillis` is larger than `0`<sup>[code-1]</sup>.

**3. The variable waitingReadOp of cursor**
- It used to maintain an `OpReadEntry` to trigger a new read after getting notified that new entries were added.
- It prevents an issue from occurring, where more than one pending read is in progress

**4. The variable waitingCursors of Managed Cursor**
- It maintains the list of cursors that are waiting for new entries.

---

**Issue 1: The same cursor was added to `managedledger.waitingCursors` thousands of times.**
- Configurations
  - subscription type: `Failover`
- Reproduce flow
  - Add consumer(`C1`); it becomes an active consumer.
  - Add consumer(`C2`); C2 becomes the active consumer after a choice by the dispatcher
    - Triggers a `scheduleReadOnActiveConsumer`
    - **(Highlight)** The method `scheduleReadOnActiveConsumer` resets the variable `cursor.waitingReadOp`, but it forgets to remove the cursor from `managedledger.waitingCursors`
    - The issue occurs, which is the same as #22157. You can reproduce the issue with the new test `testWaitingCursorsCountAfterSwitchingActiveConsumers`

<img width="1307" height="879" alt="Screenshot 2025-07-24 at 00 01 32" src="https://github.com/user-attachments/assets/acdce67d-6b95-46d4-91cf-d0dfc1cc52ff" />

---

**Issue 2: Reused a recycled OpReadEntry, which causes repeated delivery and other unexpected issues**
| time | cursor -> read entries | cursor -> cancel pending read | Other tasks |
| --- | --- | --- | --- |
| 1 | has no entries to read |
| 2 | create an `OpReadEntry` and set to `cursor.waitingReadOp` |
| 3 | Schedule a delay task to do the double confirm of whether Managed Ledger has entries to read |
| 4 | The delayed task is waiting to get run |
| 5 | | start to cancel pending read |
| 6 | | clear `cursor.waitingReadOp` |
| 7 | | recycle stored `OpReadEntry`, which was created by the task `read entries` |
| 8 | Run delayed task |
| 9 | | | reused the recycled `OpReadEntry` |
| 10 | Uses the `OpReadEntry` to read entries, but it has been recycled and reused by other tasks |

---

**Issue 3: The method `cursor.checkForNewEntries` forgets to remove cursor from `managedledger.waitingCursors`.**
- `cursor.checkForNewEntries` implements the double-check that checks whether there are entries to read.
- Clear `cursor.waitingReadOp` and trigger a reading if there are entries to read after the first check.
- The method forgot to remove the cursor from `managedledger.waitingCursors` after clearing the variable `cursor.waitingReadOp`

---

- **[code-1]**: https://github.com/apache/pulsar/blob/v4.0.5/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1033-L1052

```java
            if (!WAITING_READ_OP_UPDATER.compareAndSet(this, null, op)) {
                op.recycle();
                callback.readEntriesFailed(new ManagedLedgerException.ConcurrentWaitCallbackException(), ctx);
                return;
            }
            if (getConfig().getNewEntriesCheckDelayInMillis() > 0) {
                ledger.getScheduledExecutor()
                        .schedule(() -> checkForNewEntries(op, callback, ctx),
                                getConfig().getNewEntriesCheckDelayInMillis(), TimeUnit.MILLISECONDS);
            } else {
                // If there's no delay, check directly from the same thread
                checkForNewEntries(op, callback, ctx);
            }
```

- **[code-2]**: https://github.com/apache/pulsar/blob/v4.0.5/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1083-L1099

```java
            if (hasMoreEntries()) {
                if (WAITING_READ_OP_UPDATER.compareAndSet(this, op, null)) {
                    if (log.isDebugEnabled()) {
                        log.debug("[{}] [{}] Cancelled notification and scheduled read at {}", ledger.getName(),
                                name, op.readPosition);
                    }
                    PENDING_READ_OPS_UPDATER.incrementAndGet(this);
                    ledger.asyncReadEntries(op);
                } 
            }
```

### Modifications

- Fix the `3` issues
- Instead of modifying `managedledger.waitingCursors` and `cursor.waitingReadOp` everywhere, Managed Cursor handles the variables itself




### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x