### PR TITLE
[improve][test] Remove EntryCacheCreator from ManagedLedgerFactoryImpl

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -440,9 +440,8 @@ public class RangeEntryCacheImpl implements EntryCache {
      * @param shouldCacheEntry if we should put the entry into the cache
      * @return a handle to the operation
      */
-    @VisibleForTesting
-    protected CompletableFuture<List<EntryImpl>> readFromStorage(ReadHandle lh, long firstEntry, long lastEntry,
-                                                                 boolean shouldCacheEntry) {
+    CompletableFuture<List<EntryImpl>> readFromStorage(ReadHandle lh,
+                                                       long firstEntry, long lastEntry, boolean shouldCacheEntry) {
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;
         CompletableFuture<List<EntryImpl>> readResult = ReadEntryUtils.readAsync(ml, lh, firstEntry, lastEntry)
                 .thenApply(

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -47,6 +47,7 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +80,8 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
+import org.apache.bookkeeper.client.PulsarMockReadHandleInterceptor;
+import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -100,12 +103,11 @@ import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.ScanOutcome;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.VoidCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
-import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl;
-import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheManagerImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.apache.commons.collections.iterators.EmptyIterator;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.IntRange;
@@ -139,7 +141,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
     @AfterMethod
     public void afterMethod() {
-        setEntryCacheCreator(null);
+        bkc.setReadHandleInterceptor(null);
     }
 
     @Test
@@ -5413,16 +5415,32 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     @Test(timeOut = 10000)
     public void testReadNoEntries() throws Exception {
         final var firstRead = new AtomicBoolean(true);
-        setEntryCacheCreator(ml -> new RangeEntryCacheImpl((RangeEntryCacheManagerImpl) factory.getEntryCacheManager(),
-                ml, factory.getConfig().isCopyEntriesInCache()) {
-
+        bkc.setReadHandleInterceptor(new PulsarMockReadHandleInterceptor() {
             @Override
-            protected CompletableFuture<List<EntryImpl>> readFromStorage(ReadHandle lh, long firstEntry, long lastEntry,
-                                                                         boolean shouldCacheEntry) {
+            public CompletableFuture<LedgerEntries> interceptReadAsync(long ledgerId, long firstEntry, long lastEntry,
+                                                                       LedgerEntries entries) {
                 if (firstRead.compareAndSet(true, false)) {
-                    return CompletableFuture.completedFuture(List.of());
+                    // LedgerEntriesImpl doesn't allow empty entries list.
+                    // Implementing a dummy LedgerEntries that returns an empty list.
+                    return CompletableFuture.completedFuture(new LedgerEntries() {
+                        @Override
+                        public org.apache.bookkeeper.client.api.LedgerEntry getEntry(long entryId) {
+                            return null;
+                        }
+
+                        @Override
+                        public Iterator<org.apache.bookkeeper.client.api.LedgerEntry> iterator() {
+                            return EmptyIterator.INSTANCE;
+                        }
+
+                        @Override
+                        public void close() {
+
+                        }
+                    });
+                } else {
+                    return CompletableFuture.completedFuture(entries);
                 }
-                return super.readFromStorage(lh, firstEntry, lastEntry, shouldCacheEntry);
             }
         });
         final var ml = factory.open("testReadNoEntries");


### PR DESCRIPTION
### Motivation

In PR #24515, a change was made to ManagedLedgerFactoryImpl for testing the changes by adding a new parameter "EntryCacheCreator" to ManagedLedgerFactoryImpl. This conflicts with #24363 changes and one of the conflicts is that the EntryCache instance isn't designed to be instantiated on it's own and I'd like to keep the implementation details in package protected classes. There would be unnecessary complexity just to support this particular testing use cases.
There's already a way to test such changes with the PulsarMockReadHandleInterceptor which is supported by PulsarMockBookKeeper. This is why adding the "EntryCacheCreator" is not necessary.

### Modifications

- revert the changes to add "EntryCacheCreator" to ManagedLedgerFactoryImpl. 
- migrate the test added in #24515 to use PulsarMockReadHandleInterceptor

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->