### PR TITLE
[fix][sec] Upgrade Kafka connector and clients version to 3.9.1 to address CVE-2025-27818

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.5.0</aerospike-client.version>
-    <kafka-client.version>3.9.0</kafka-client.version>
+    <kafka-client.version>3.9.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.638</aws-sdk.version>
     <avro.version>1.11.4</avro.version>
@@ -252,7 +252,7 @@ flexible messaging model and an intuitive client API.</description>
     <guava.version>33.4.8-jre</guava.version>
     <jcip.version>1.0</jcip.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
-    <confluent.version>7.8.2</confluent.version>
+    <confluent.version>7.9.2</confluent.version>
     <aircompressor.version>0.27</aircompressor.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -38,6 +38,17 @@
     <jaxb-api.version>2.3.0</jaxb-api.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <!-- enforce kafka client version that gets pulled transitively -->
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka-client.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
### Motivation

Kafka clients before 3.9.1 include CVE-2025-27818. Kafka clients are used in Pulsar IO Connectors.

### Modifications

- upgrade Kafka clients version to 3.9.1
- set the Confluent Platform version to 7.9.x so that it matches Kafka 3.9.x as explained in https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility
- Apache Pulsar IO Connectors include ASL 2.0 licensed dependencies from Confluent Platform:
  - io.confluent:kafka-connect-avro-converter
  - io.confluent:kafka-schema-registry-client
  - io.confluent:kafka-avro-serializer

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->