### PR TITLE
[fix][broker] Fix ManagedCursor state management race conditions and lifecycle issues

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -193,6 +193,7 @@ public class ManagedLedgerException extends Exception {
     }
 
     public static class ConcurrentWaitCallbackException extends ManagedLedgerException {
+
         public ConcurrentWaitCallbackException() {
             super("We can only have a single waiting callback");
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -198,12 +198,6 @@ public class ManagedLedgerException extends Exception {
         }
     }
 
-    public static class CursorDeactivatedWaitCallbackException extends ManagedLedgerException {
-        public CursorDeactivatedWaitCallbackException() {
-            super("Cursor is deactivated without cancelling pending request, cannot wait for callback");
-        }
-    }
-
     public static class OffloadReadHandleClosedException extends ManagedLedgerException {
 
         public OffloadReadHandleClosedException() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -193,9 +193,14 @@ public class ManagedLedgerException extends Exception {
     }
 
     public static class ConcurrentWaitCallbackException extends ManagedLedgerException {
-
         public ConcurrentWaitCallbackException() {
             super("We can only have a single waiting callback");
+        }
+    }
+
+    public static class CursorDeactivatedWaitCallbackException extends ManagedLedgerException {
+        public CursorDeactivatedWaitCallbackException() {
+            super("Cursor is deactivated without cancelling pending request, cannot wait for callback");
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -227,7 +227,9 @@ public class ManagedCursorImpl implements ManagedCursor {
     // active state cache in ManagedCursor. It should be in sync with the state in activeCursors in ManagedLedger.
     private volatile boolean isActive = false;
 
+    // This is a lock used to update the registration state of the cursor in the managed ledger.
     private Object waitingRegistrationLock = new Object();
+    // This is used to track if the cursor is waiting for registration in the managed ledger.
     boolean waitingRegistered = false;
 
     class MarkDeleteEntry {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1205,7 +1205,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         if (op != null) {
             op.recycle();
         }
-        return op != null;
+        return op != null && op != OpReadEntry.WAITING_READ_OP_FOR_CLOSED_CURSOR;
     }
 
     public boolean hasPendingReadRequest() {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3640,7 +3640,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private void asyncDeleteCursorLedger(int retry) {
         State previousState = changeStateIfNotDeletingOrDeleted(State.Deleting);
         if (previousState == State.Deleted) {
-            log.warn("[{}-{}] Cursor ledger is already deleting or deleted. state=", ledger.getName(), name, state);
+            log.warn("[{}-{}] Cursor ledger is already deleting or deleted. state={}", ledger.getName(), name, state);
             return;
         }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -3638,6 +3638,8 @@ public class ManagedCursorImpl implements ManagedCursor {
         closeWaitingCursor();
 
         if (cursorLedger == null) {
+            log.warn("[{}-{}] There's no cursor ledger available for deletion.", ledger.getName(), name);
+            state = State.DeletingFailed;
             return;
         }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1436,7 +1436,6 @@ public class ManagedCursorImpl implements ManagedCursor {
     @Override
     public void setInactive() {
         if (isActive) {
-            cancelWaitingCursorsWhenDeactivated();
             ledger.deactivateCursor(this);
             isActive = false;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -228,7 +228,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private volatile boolean isActive = false;
 
     // This is a lock used to update the registration state of the cursor in the managed ledger.
-    private Object waitingRegistrationLock = new Object();
+    private final Object waitingRegistrationLock = new Object();
     // This is used to track if the cursor is waiting for registration in the managed ledger.
     boolean waitingRegistered = false;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -809,6 +809,13 @@ public class ManagedCursorImpl implements ManagedCursor {
         changeStateIfNotClosed(State.NoLedger);
     }
 
+    /**
+     * Change the state of the cursor if it is not already considered closed.
+     * This is to prevent invalid state transitions when the cursor is already closed.
+     *
+     * @param newState The new state to set
+     * @return The previous state of the cursor
+     */
     private State changeStateIfNotClosed(State newState) {
         return STATE_UPDATER.getAndUpdate(this, current -> {
             if (current.isClosed()) {
@@ -818,6 +825,13 @@ public class ManagedCursorImpl implements ManagedCursor {
         });
     }
 
+    /**
+     * Change the state of the cursor if it is not already Deleting or Deleted.
+     * This is to prevent invalid state transitions when the cursor is already being deleted or has been deleted.
+     *
+     * @param newState The new state to set
+     * @return The previous state of the cursor
+     */
     State changeStateIfNotDeletingOrDeleted(State newState) {
         return STATE_UPDATER.getAndUpdate(this, current -> {
             if (current.isDeletingOrDeleted()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1078,10 +1078,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         // If the cursor is active, we need to deactivate it first
         cursor.setInactive();
-        // Set the state to closing to avoid any new writes
-        ManagedCursorImpl.State previousState =
-                cursor.changeStateIfNotDeletingOrDeleted(ManagedCursorImpl.State.Deleting);
-        if (previousState.isDeletingOrDeleted()) {
+        // Set the state to deleting (which is a closed state) to avoid any new writes
+        ManagedCursorImpl.State beforeChangingState = cursor.changeStateToDeletingIfNotDeleted();
+        if (beforeChangingState.isDeletingOrDeleted()) {
             log.warn("[{}] [{}] Cursor is already being deleted or has been deleted.", name, consumerName);
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1081,7 +1081,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         // Set the state to closing to avoid any new writes
         ManagedCursorImpl.State previousState =
                 cursor.changeStateIfNotDeletingOrDeleted(ManagedCursorImpl.State.Deleting);
-        if (previousState.isDeletion()) {
+        if (previousState.isDeletingOrDeleted()) {
             log.warn("[{}] [{}] Cursor is already being deleted or has been deleted.", name, consumerName);
             return;
         }
@@ -1102,7 +1102,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
             @Override
             public void operationFailed(MetaStoreException e) {
-                handleBadVersion(e);
+                cursor.getAndSetState(ManagedCursorImpl.State.DeletingFailed);
                 callback.deleteCursorFailed(e, ctx);
             }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -114,6 +114,7 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
     public void asyncClose(CloseCallback callback, Object ctx) {
         STATE_UPDATER.set(this, State.Closed);
         closeWaitingCursor();
+        setInactive();
         callback.closeComplete(ctx);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorImpl.java
@@ -113,6 +113,7 @@ public class NonDurableCursorImpl extends ManagedCursorImpl {
     @Override
     public void asyncClose(CloseCallback callback, Object ctx) {
         STATE_UPDATER.set(this, State.Closed);
+        closeWaitingCursor();
         callback.closeComplete(ctx);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -61,6 +61,7 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
     public void asyncClose(final AsyncCallbacks.CloseCallback callback, final Object ctx) {
         state = State.Closed;
         closeWaitingCursor();
+        setInactive();
         callback.closeComplete(ctx);
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -60,6 +60,7 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
     @Override
     public void asyncClose(final AsyncCallbacks.CloseCallback callback, final Object ctx) {
         state = State.Closed;
+        closeWaitingCursor();
         callback.closeComplete(ctx);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -355,11 +355,14 @@ public class PersistentSubscription extends AbstractSubscription {
         if (dispatcher != null && dispatcher.getConsumers().isEmpty()) {
             deactivateCursor();
             // Remove the cursor from the waiting cursors list.
-            // For durable cursors, we should *not* cancel the pending read. This is because internally,
-            // in the dispatcher implementations, there is a "havePendingRead" flag that is not reset. If the pending
-            // read is cancelled, the dispatcher will not continue reading from the managed ledger when a new
-            // consumer is added to the dispatcher since based on the "havePendingRead" state, it will continue to
-            // expect that a read is pending and will not submit a new read.
+            // For durable cursors, we should *not* cancel the pending read with cursor.cancelPendingReadRequest.
+            // This is because internally, in the dispatcher implementations, there is a "havePendingRead" flag
+            // that is not reset. If the pending read is cancelled, the dispatcher will not continue reading from
+            // the managed ledger when a new consumer is added to the dispatcher since based on the "havePendingRead"
+            // state, it will continue to expect that a read is pending and will not submit a new read.
+            // For non-durable cursors, there's no difference since the cursor is not expected to be used again.
+
+            // remove waiting cursor from the managed ledger, this applies to both durable and non-durable cursors.
             topic.getManagedLedger().removeWaitingCursor(cursor);
 
             if (!cursor.isDurable()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -383,12 +383,15 @@ public class PersistentSubscription extends AbstractSubscription {
                         if (!isResetCursor) {
                             try {
                                 topic.getManagedLedger().deleteCursor(cursor.getName());
+                                topic.getManagedLedger().removeWaitingCursor(cursor);
                             } catch (InterruptedException | ManagedLedgerException e) {
                                 log.warn("[{}] [{}] Failed to remove non durable cursor", topic.getName(), subName, e);
                             }
                         }
                     }, topic.getBrokerService().pulsar().getExecutor());
                 });
+            } else {
+                topic.getManagedLedger().removeWaitingCursor(cursor);
             }
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -59,7 +59,6 @@ import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.Entry;
-import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedException;
 import org.apache.bookkeeper.mledger.Position;
@@ -1046,7 +1045,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 15000)
+    @Test(timeOut = 30000)
     public void testCloseReplicatorStartProducer() throws Exception {
         TopicName dest = TopicName.get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns1/closeCursor"));
         // Producer on r1
@@ -1063,33 +1062,30 @@ public class ReplicatorTest extends ReplicatorTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
         PersistentReplicator replicator = (PersistentReplicator) topic.getPersistentReplicator("r2");
 
+        // check that the replicator producer is not null
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(replicator.getProducer());
+        });
+
         // close the cursor
-        Field cursorField = PersistentReplicator.class.getDeclaredField("cursor");
-        cursorField.setAccessible(true);
-        ManagedCursor cursor = (ManagedCursor) cursorField.get(replicator);
-        cursor.close();
-        // try to read entries
+        replicator.getCursor().close();
+
+        // try to produce entries
         producer1.produce(10);
 
+        // attempt to read entries directly from replicator cursor
         try {
-            cursor.readEntriesOrWait(10);
+            replicator.getCursor().readEntriesOrWait(10);
             fail("It should have failed");
         } catch (Exception e) {
             assertEquals(e.getClass(), CursorAlreadyClosedException.class);
         }
 
-        // replicator-readException: cursorAlreadyClosed
-        replicator.readEntriesFailed(new CursorAlreadyClosedException("Cursor already closed exception"), null);
-
         // wait replicator producer to be closed
-        Thread.sleep(100);
-
-        // Replicator producer must be closed
-        Field producerField = AbstractReplicator.class.getDeclaredField("producer");
-        producerField.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        ProducerImpl<byte[]> replicatorProducer = (ProducerImpl<byte[]>) producerField.get(replicator);
-        assertNull(replicatorProducer);
+        // Replicator producer must be null after the producer has been closed
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(replicator.getProducer());
+        });
     }
 
     @Test(timeOut = 30000)


### PR DESCRIPTION
Fixes #24566

### Motivation

The test `ReplicatorTest.testCloseReplicatorStartProducer` was consistently failing due to critical issues introduced in PR #24551. Investigation (shared in https://github.com/apache/pulsar/issues/24566#issuecomment-3119993989 by @3pacccccc ) revealed that the changes led to infinite recursive calls in `ManagedCursorImpl#cancelPendingReadRequest`, causing broker instability and test failures.

The root cause was improper state management for pending read operations, particularly when:
- Multiple threads attempt to cancel pending read requests concurrently
- Cursors are closed while read operations are pending
- OpReadEntry instances are recycled and reused incorrectly
- Cursor state transitions occur without proper synchronization
- Cursor deletion and closure operations race with active read operations

### Modifications

This PR addresses the state management issues through several key changes:

#### Core Synchronization Fixes

1. **Reverted problematic synchronization approach**: Removed the complex `pendingReadOpMutex` and `DelayCheckForNewEntriesTask` implementation added in #24551 that caused infinite recursion, returning to a more robust compare-and-swap based solution.

2. **Added operation ID tracking**: Introduced an `id` field to `OpReadEntry` instances to prevent recycled operations from being processed incorrectly. This ensures that only the correct operation instance is handled when checking for new entries.

3. **Improved atomic state transitions**: Enhanced the CAS (Compare-And-Swap) operations using `getAndUpdate()` with lambda functions that verify both the operation instance and its ID before making state changes:
   ```java
                OpReadEntry waitingReadOpItem = WAITING_READ_OP_UPDATER.getAndUpdate(this,
                        current -> {
                            if (current == op && current.id == opReadId) {
                                // update the value to null to cancel the waiting read op
                                return null;
                            } else {
                                // keep the current waiting read op value
                                return current;
                            }
                        });
                // If the waiting read op was the same as the one we are trying to cancel, it means that it was now
                // cleared from the waitingReadOp field and therefore "cancelled"
                if (waitingReadOpItem == op && waitingReadOpItem.id == opReadId) {
                    if (log.isDebugEnabled()) {
                        log.debug("[{}] [{}] Cancelled notification and scheduled read at {}", ledger.getName(),
                                name, op.readPosition);
                    }
                    PENDING_READ_OPS_UPDATER.incrementAndGet(this);
                    ledger.asyncReadEntries(op);
   ```

#### Enhanced State Management System

4. **Comprehensive state model enhancement**: Significantly expanded the cursor `State` enum with:
   - New states: `Deleting`, `Deleted`, `DeletingFailed` for better deletion lifecycle tracking
   - Added `closedState` boolean field and `isClosed()` method for more robust state checking
   - Added `isDeletingOrDeleted()` method for deletion state validation
   - Enhanced state constructor to properly categorize closed vs. open states

5. **Thread-safe state transition methods**: Implemented atomic state transition utilities:
   - `changeStateIfNotClosed()` - prevents state changes on closed cursors
   - `changeStateIfNotDeletingOrDeleted()` - prevents state changes on deleting/deleted cursors
   - Enhanced `trySetStateToClosing()` with atomic operations

#### Cursor Lifecycle Management

6. **Proper cursor closure handling**: Added comprehensive cursor closure logic:
   - `closeWaitingCursor()` - handles normal cursor closure scenarios
   - `cancelWaitingCursorsWhenDeactivated()` - handles cursor deactivation scenarios
   - `internalCloseWaitingCursor()` - unified internal implementation with exception supplier pattern
   - Added sentinel value (`WAITING_READ_OP_FOR_CLOSED_CURSOR`) to handle closed cursor scenarios

7. **Enhanced cursor deactivation**: Updated `setInactive()` to properly cancel waiting cursors when deactivated, preventing orphaned read operations.

8. **Robust deletion lifecycle**: Improved `asyncDeleteCursorLedger()` with:
   - Proper state transitions through deletion lifecycle
   - Enhanced retry logic with backoff for failed deletions
   - Better error handling and state recovery for deletion failures
   - Prevention of duplicate deletion attempts

#### Exception Handling Improvements

9. **New exception types**: Added `CursorDeactivatedWaitCallbackException` for better error propagation when cursors are deactivated without properly cancelling pending requests.

10. **Enhanced error propagation**: Improved error handling throughout the cursor lifecycle to ensure proper cleanup and user notification.

#### Managed Ledger Integration

11. **Enhanced cursor deletion in ManagedLedgerImpl**: Improved `asyncDeleteCursor()` with:
    - Proper state checking before deletion attempts
    - Separate handling for durable vs. non-durable cursors
    - Better error recovery and state management
    - Prevention of concurrent deletion attempts

12. **Enhanced waiting cursor registration**: Implemented thread-safe registration/deregistration of waiting cursors to prevent race conditions when adding or removing cursors from the waiting list, with improved debug logging.

#### Specialized Cursor Implementation Updates

13. **Non-durable cursor improvements**: Updated `NonDurableCursorImpl.asyncClose()` to properly close waiting cursors and set inactive state.

14. **Read-only cursor improvements**: Updated `ReadOnlyCursorImpl.asyncClose()` with the same proper cleanup logic.

#### Misc refactoring in ManagedCursorImpl

15. In the previous code, the `state` field was sometimes read directly and sometimes with `STATE_UPDATER.get`. Similarly, it was sometimes set directly and mostly with `STATE_UPDATER.set`. There's no need to use `STATE_UPDATER.get` and `STATE_UPDATER.set`. The volatile `state` field can be read and set directly without `STATE_UPDATER`. 
`STATE_UPDATER` is only needed for CAS operations on the `state` field.

### Key Technical Improvements

- **Eliminated infinite recursion**: The previous implementation could enter infinite recursive calls in `cancelPendingReadRequest()`, which is now resolved
- **Thread-safe operation lifecycle**: OpReadEntry instances are properly tracked through their lifecycle to prevent use-after-recycle scenarios
- **Comprehensive state management**: New state model provides better visibility and control over cursor lifecycle
- **Enhanced error handling**: Cursor closure and deletion events now properly propagate appropriate exceptions to pending operations
- **Performance optimization**: Reduced lock contention by using atomic operations instead of synchronized blocks where possible
- **Improved debugging**: Added comprehensive debug logging for cursor registration/deregistration operations
- **Robust deletion handling**: Deletion operations now properly handle failures, retries, and state recovery

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, specifically:
- `ReplicatorTest.testCloseReplicatorStartProducer` - verifies proper cleanup when replicator cursors are closed
- `FailoverSubscriptionTest.testWaitingCursorsCountAfterSwitchingActiveConsumers` - verifies that each cursor doesn't get added more than once into ManagedLedgerImpl's waiting cursors list
- Existing managed ledger tests that exercise concurrent read operations
- Integration tests that stress-test cursor state management under load
- Tests covering cursor deletion and state transitions

The modifications also include timeout adjustments for the test to account for the improved error handling paths.

### Impact Assessment

This change affects:
- **Threading model**: Improved thread safety in cursor state management with atomic state transitions
- **Error handling**: Better propagation of cursor closure and deactivation exceptions
- **Performance**: Reduced lock contention in high-throughput scenarios through atomic operations
- **Lifecycle management**: More robust cursor deletion and closure handling
- **State consistency**: Enhanced state model prevents invalid state transitions
- **Resource cleanup**: Better cleanup of waiting cursors and pending operations

The changes are backward compatible and do not affect public APIs or configuration defaults.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->