### PR TITLE
[fix][test] fix flaky GrowableArrayBlockingQueueTest.testPollBlockingThreadsTermination

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4191,8 +4191,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                     consumer.receive();
                     fail("thread should have been interrupted");
                 } catch (PulsarClientException e) {
-                    terminateCompletedLatch.countDown();
                     interruptedThreadCount.incrementAndGet();
+                    terminateCompletedLatch.countDown();
                 }
             }).start();
         }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueueTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/GrowableArrayBlockingQueueTest.java
@@ -226,8 +226,8 @@ public class GrowableArrayBlockingQueueTest {
                     fail("thread should have been interrupted");
                 } catch (InterruptedException e) {
                     // Expected interruption, record and notify
-                    terminateCompletedLatch.countDown();
                     interruptedThreadCount.incrementAndGet();
+                    terminateCompletedLatch.countDown();
                 }
             }).start();
         }
@@ -260,8 +260,8 @@ public class GrowableArrayBlockingQueueTest {
                     Integer poll = queue.poll(1, TimeUnit.HOURS);
                     // should return a null value if queue is terminated
                     assertNull(poll);
-                    terminateCompletedLatch.countDown();
                     terminateThreadCount.incrementAndGet();
+                    terminateCompletedLatch.countDown();
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
@@ -295,15 +295,15 @@ public class GrowableArrayBlockingQueueTest {
                     try {
                         queue.take();
                     } catch (InterruptedException e) {
-                        terminateCompletedLatch.countDown();
                         terminateThreadCount.incrementAndGet();
+                        terminateCompletedLatch.countDown();
                     }
                 } else {
                     try {
                         Integer poll = queue.poll(1, TimeUnit.HOURS);
                         assertNull(poll);
-                        terminateCompletedLatch.countDown();
                         terminateThreadCount.incrementAndGet();
+                        terminateCompletedLatch.countDown();
                     } catch (InterruptedException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24575

### Modifications
This PR fixes the flaky test caused by incorrect operation order between ```countDown()``` and shared variable updates in https://github.com/apache/pulsar/pull/24550.
### Verifying this change

- [x] Make sure that the change passes the CI checks.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/19
