### PR TITLE
[fix][broker]Avoid read a entry that entry id is -1 when calling getLastMessagePublishTime

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4632,7 +4632,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         try {
             Position lastPosition = ledger.getLastConfirmedEntry();
-            if (lastPosition == null || lastPosition.getEntryId() < 0) {
+            if (lastPosition == null || lastPosition.getEntryId() < 0
+                    || !ledger.getLedgersInfo().containsKey(lastPosition.getLedgerId())) {
                 future.complete(0L);
                 return future;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4632,7 +4632,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         try {
             Position lastPosition = ledger.getLastConfirmedEntry();
-            if (lastPosition == null) {
+            if (lastPosition == null || lastPosition.getEntryId() < 0) {
                 future.complete(0L);
                 return future;
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -4056,6 +4056,17 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testTopicCreationAndLastPublishTimestampsIfNoEntries() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName("persistent://" + defaultNamespace + "/tp");
+        admin.topics().createNonPartitionedTopic(topic);
+        TopicStats stats = admin.topics().getStats(topic);
+        assertTrue(stats.getTopicCreationTimeStamp() > 0);
+        assertEquals(stats.getLastPublishTimeStamp(), 0);
+        // cleanup.
+        admin.topics().delete(topic, false);
+    }
+
+    @Test
     public void testTopicCreationAndLastPublishTimestamps() throws Exception {
         final String topicName = "timestamp-test-topic";
         final String partitionedTopicName = "timestamp-test-partitioned-topic";


### PR DESCRIPTION
### Motivation

**Background**
The method `Persisetent topic  -> getLastMessagePublishTime` will call `read entry(LAC)`, but the variable LAC(managedLedger.lastConfirmedPosition) will be set to `x: -1` when a topic has no entries, see also: https://github.com/apache/pulsar/blob/v4.0.5/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L601

**Issue**
Run the new test `testTopicCreationAndLastPublishTimestampsIfNoEntries`, and you will get such following logs, but it will not fail, because there is a failure catchup here: https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java#L4657-L4659

The logs will continuously print when generates metrics.

```java
public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
    log.warn("[{}] Failed to read last entry for publish time", topic, exception);
    future.complete(0L);
}
```

```
2025-07-30T00:14:25,915 - INFO  - [broker-topic-workers-OrderedExecutor-3-0:RequestLog] - 127.0.0.1 - - [30/Jul/2025:00:14:25 +0800] "PUT /admin/v2/persistent/prop-xyz-d4409f8c-8384-49b3-be96-7b832bc578f4/ns1/tp-340ac909-d194-401c-b2b3-fb628c43c345 HTTP/1.1" 204 0 "-" "Pulsar-Java-v4.1.0-SNAPSHOT" 471
2025-07-30T00:14:25,933 - ERROR - [PulsarTestContext-executor-OrderedExecutor-0-0:ManagedLedgerImpl] - Unknown exception for ManagedLedgerException.
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:359) ~[?:?]
	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at org.apache.bookkeeper.client.PulsarMockReadHandle.lambda$readAsync$0(PulsarMockReadHandle.java:63) ~[classes/:4.17.2]
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:373) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?]
2025-07-30T00:14:25,936 - WARN  - [PulsarTestContext-executor-OrderedExecutor-0-0:PersistentTopic] - [persistent://prop-xyz-d4409f8c-8384-49b3-be96-7b832bc578f4/ns1/tp-340ac909-d194-401c-b2b3-fb628c43c345] Failed to read last entry for publish time
org.apache.bookkeeper.mledger.ManagedLedgerException: Other exception
Caused by: java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:359) ~[?:?]
	at java.base/java.util.ArrayList.get(ArrayList.java:427) ~[?:?]
	at org.apache.bookkeeper.client.PulsarMockReadHandle.lambda$readAsync$0(PulsarMockReadHandle.java:63) ~[classes/:4.17.2]
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:373) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?]
```


### Modifications

Fix the issue

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
