### PR TITLE
[improve][test] Refactor the way way pulsar-io-debezium-oracle nar file is patched when building the test image

### DIFF
--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -27,6 +27,29 @@ RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go && go install ./...
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...
 
+
+# patch Oracle Debezium Connector nar file to include Oracle JDBC dependencies
+FROM $PULSAR_ALL_IMAGE as oracle-jdbc-builder
+
+USER root
+WORKDIR /
+
+RUN OJDBC_VERSION="19.3.0.0" && \
+    OJDBC_BASE_URL="https://repo1.maven.org/maven2/com/oracle/ojdbc" && \
+    DEPS_DIR="META-INF/bundled-dependencies" && \
+    OJDBC_ARTIFACTS="ojdbc8 ucp oraclepki osdt_cert osdt_core simplefan orai18n xdb xmlparserv2" && \
+    cd / && rm -rf "$DEPS_DIR" && mkdir -p "$DEPS_DIR" && \
+    cd "$DEPS_DIR" && \
+    for ojdbc_artifact in $OJDBC_ARTIFACTS; do \
+        ojdbc_jar_file="${ojdbc_artifact}-${OJDBC_VERSION}.jar" && \
+        ojdbc_download_url="${OJDBC_BASE_URL}/${ojdbc_artifact}/${OJDBC_VERSION}/${ojdbc_jar_file}" && \
+        echo "Downloading $ojdbc_jar_file from $ojdbc_download_url" && \
+        curl -sSL --retry 5 --retry-delay 1 --retry-max-time 30 "${ojdbc_download_url}" -o "${ojdbc_jar_file}" && \
+        [ -f "${ojdbc_jar_file}" ] || (echo "Failed to download ${ojdbc_jar_file}" && exit 1); \
+    done && \
+    cd / && \
+    jar uvf /pulsar/connectors/pulsar-io-debezium-oracle-*.nar $DEPS_DIR/*.jar >&2
+
 ########################################
 ###### Main image build
 ########################################
@@ -77,19 +100,8 @@ COPY target/certificate-authority /pulsar/certificate-authority/
 # copy broker plugins
 COPY target/plugins/ /pulsar/examples/
 
-# download Oracle JDBC driver for Oracle Debezium Connector tests
-RUN mkdir -p META-INF/bundled-dependencies
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar -o ojdbc8-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/ucp/19.3.0.0/ucp-19.3.0.0.jar -o ucp-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/oraclepki/19.3.0.0/oraclepki-19.3.0.0.jar -o oraclepki-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/osdt_cert/19.3.0.0/osdt_cert-19.3.0.0.jar -o osdt_cert-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/osdt_core/19.3.0.0/osdt_core-19.3.0.0.jar -o osdt_core-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/simplefan/19.3.0.0/simplefan-19.3.0.0.jar -o simplefan-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/orai18n/19.3.0.0/orai18n-19.3.0.0.jar -o orai18n-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/xdb/19.3.0.0/xdb-19.3.0.0.jar -o xdb-19.3.0.0.jar
-RUN cd META-INF/bundled-dependencies && curl -sSL https://search.maven.org/remotecontent?filepath=com/oracle/ojdbc/xmlparserv2/19.3.0.0/xmlparserv2-19.3.0.0.jar -o xmlparserv2-19.3.0.0.jar
-
-RUN jar uf connectors/pulsar-io-debezium-oracle-*.nar META-INF/bundled-dependencies/ojdbc8-19.3.0.0.jar META-INF/bundled-dependencies/ucp-19.3.0.0.jar META-INF/bundled-dependencies/oraclepki-19.3.0.0.jar META-INF/bundled-dependencies/osdt_cert-19.3.0.0.jar META-INF/bundled-dependencies/osdt_core-19.3.0.0.jar META-INF/bundled-dependencies/simplefan-19.3.0.0.jar META-INF/bundled-dependencies/orai18n-19.3.0.0.jar META-INF/bundled-dependencies/xdb-19.3.0.0.jar META-INF/bundled-dependencies/xmlparserv2-19.3.0.0.jar
+# Copy patched Oracle Debezium Connector nar file which includes Oracle JDBC dependencies
+COPY --from=oracle-jdbc-builder /pulsar/connectors/pulsar-io-debezium-oracle-*.nar /pulsar/connectors/
 
 # Fix permissions for filesystem offloader
 RUN mkdir -p pulsar


### PR DESCRIPTION
### Motivation

"CI Flaky - System - Pulsar IO - Oracle" in Pulsar CI sometimes fails due to dependency download failing when the pulsar-io-debezium-oracle nar file was patched. Since the image is built in a previous step, it's hard to investigate the issue.

### Modifications

Refactor the way way pulsar-io-debezium-oracle nar file is patched when building the test image

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->