### PR TITLE
[fix][broker] Add guard to prevent concurrent snapshot creation with warning log by ReplicationSubscriptionController

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
@@ -91,6 +92,8 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
             .help("Counter of timed out snapshots").register();
 
     private final OpenTelemetryReplicatedSubscriptionStats stats;
+
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     public ReplicatedSubscriptionsController(PersistentTopic topic, String localCluster) {
         this.topic = topic;
@@ -219,61 +222,70 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     }
 
     private void startNewSnapshot() {
-        cleanupTimedOutSnapshots();
-
-        if (lastCompletedSnapshotStartTime == 0 && !pendingSnapshots.isEmpty()) {
-            // 1. If the remote cluster has disabled subscription replication or there's an incorrect config,
-            //    it will not respond to SNAPSHOT_REQUEST. Therefore, lastCompletedSnapshotStartTime will remain 0,
-            //    making it unnecessary to resend the request.
-            // 2. This approach prevents sending additional SNAPSHOT_REQUEST to both local_topic and remote_topic.
-            // 3. Since it's uncertain when the remote cluster will enable subscription replication,
-            //    the timeout mechanism of pendingSnapshots is used to ensure retries.
-            //
-            // In other words, when hit this case, The frequency of sending SNAPSHOT_REQUEST
-            // will use `replicatedSubscriptionsSnapshotTimeoutSeconds`.
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] PendingSnapshot exists but has never succeeded. "
-                        + "Skipping snapshot creation until pending snapshot timeout.", topic.getName());
-            }
+        if (!isRunning.compareAndSet(false, true)) {
+            log.warn("[{}] Snapshot already in progress. Skipping new snapshot.", topic.getName());
             return;
         }
 
-        if (topic.getLastMaxReadPositionMovedForwardTimestamp() < lastCompletedSnapshotStartTime
-                || topic.getLastMaxReadPositionMovedForwardTimestamp() == 0) {
-            // There was no message written since the last snapshot, we can skip creating a new snapshot
-            if (log.isDebugEnabled()) {
+        try {
+            cleanupTimedOutSnapshots();
+
+            if (lastCompletedSnapshotStartTime == 0 && !pendingSnapshots.isEmpty()) {
+                // 1. If the remote cluster has disabled subscription replication or there's an incorrect config,
+                //    it will not respond to SNAPSHOT_REQUEST. Therefore, lastCompletedSnapshotStartTime will remain 0,
+                //    making it unnecessary to resend the request.
+                // 2. This approach prevents sending additional SNAPSHOT_REQUEST to both local_topic and remote_topic.
+                // 3. Since it's uncertain when the remote cluster will enable subscription replication,
+                //    the timeout mechanism of pendingSnapshots is used to ensure retries.
+                //
+                // In other words, when hit this case, The frequency of sending SNAPSHOT_REQUEST
+                // will use `replicatedSubscriptionsSnapshotTimeoutSeconds`.
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] PendingSnapshot exists but has never succeeded. "
+                            + "Skipping snapshot creation until pending snapshot timeout.", topic.getName());
+                }
+                return;
+            }
+
+            if (topic.getLastMaxReadPositionMovedForwardTimestamp() < lastCompletedSnapshotStartTime
+                    || topic.getLastMaxReadPositionMovedForwardTimestamp() == 0) {
+                // There was no message written since the last snapshot, we can skip creating a new snapshot
+                if (log.isDebugEnabled()) {
                 log.debug("[{}] There is no new data in topic. Skipping snapshot creation.", topic.getName());
+                }
+                return;
             }
-            return;
-        }
 
-        MutableBoolean anyReplicatorDisconnected = new MutableBoolean();
-        topic.getReplicators().forEach((cluster, replicator) -> {
-            if (!replicator.isConnected()) {
-                anyReplicatorDisconnected.setTrue();
-            }
-        });
+            MutableBoolean anyReplicatorDisconnected = new MutableBoolean();
+            topic.getReplicators().forEach((cluster, replicator) -> {
+                if (!replicator.isConnected()) {
+                    anyReplicatorDisconnected.setTrue();
+                }
+            });
 
-        if (anyReplicatorDisconnected.isTrue()) {
-            // Do not attempt to create snapshot when some of the clusters are not reachable
-            if (log.isDebugEnabled()) {
+            if (anyReplicatorDisconnected.isTrue()) {
+                // Do not attempt to create snapshot when some of the clusters are not reachable
+                if (log.isDebugEnabled()) {
                 log.debug("[{}] Do not attempt to create snapshot when some of the clusters are not reachable.",
                         topic.getName());
+                }
+                return;
             }
-            return;
-        }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Starting snapshot creation.", topic.getName());
-        }
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Starting snapshot creation.", topic.getName());
+            }
 
-        pendingSnapshotsMetric.inc();
-        stats.recordSnapshotStarted();
-        ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(this,
-                topic.getReplicators().keySet(), topic.getBrokerService().pulsar().getConfiguration(),
-                Clock.systemUTC());
-        pendingSnapshots.put(builder.getSnapshotId(), builder);
-        builder.start();
+            pendingSnapshotsMetric.inc();
+            stats.recordSnapshotStarted();
+            ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(this,
+                    topic.getReplicators().keySet(), topic.getBrokerService().pulsar().getConfiguration(), Clock.systemUTC());
+            pendingSnapshots.put(builder.getSnapshotId(), builder);
+            builder.start();
+
+        } finally {
+            isRunning.set(false);
+        }
     }
 
     public Optional<String> getLastCompletedSnapshotId() {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24422

<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Replicated subscription snapshot creation is scheduled at a fixed interval. There is a risk of initiating overlapping snapshot tasks in slow environments with small interval.

While `lastCompletedSnapshotStartTime` already prevents redundant snapshot creation when no new data is present, it does not safeguard against concurrent execution if a previous snapshot is still in progress.

### Modifications

<!-- Describe the modifications you've done. -->

- Introduced an AtomicBoolean `isRunning` to guard the `startNewSnapshot()` method and prevent concurrent executions.
- Added a warning log when a new snapshot is skipped due to one already in progress.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
  - *Will be updated*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
