### PR TITLE
[fix][broker]fix flaky test testReplicatorsInflightTaskListIsEmptyAfterReplicationFinished

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -80,6 +80,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.InjectedClientCnxClientBuilder;
 import org.apache.pulsar.client.api.Message;
@@ -1665,7 +1666,11 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         final String subscriptionName = "s1";
         admin2.topics().createNonPartitionedTopic(topicName);
         admin2.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
-        admin1.topics().createNonPartitionedTopic(topicName);
+        try {
+            admin1.topics().createNonPartitionedTopic(topicName);
+        } catch (PulsarAdminException.ConflictException e) {
+            // Maybe the topic has been created by the replicator.
+        }
         admin1.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
 
         // Publish messages.


### PR DESCRIPTION
Fixes #24583


### Motivation & Modifications

fix the flaky test `testReplicatorsInflightTaskListIsEmptyAfterReplicationFinished`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x