### PR TITLE
[improve][build] Disable javadoc build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2252,6 +2252,7 @@ flexible messaging model and an intuitive client API.</description>
           <configuration>
             <doclint>none</doclint>
             <notimestamp>true</notimestamp>
+            <failOnError>false</failOnError>
           </configuration>
         </plugin>
         <plugin>
@@ -2485,6 +2486,7 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <doclint>none</doclint>
+              <failOnError>false</failOnError>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
### Motivation

Maven Central requires javadoc JARs, but strict Javadoc checks can fail the build. Disabling `failOnError` ensures minor Javadoc issues don't block the deploy process：
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.5.0:jar (attach-javadocs) on project pulsar-broker: MavenReportException: Error while generating Javadoc: 
Error:  Exit code: 1
Error:  /home/ubuntu/actions-runner/_work/***-ci/***-ci/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java:89: error: cannot find symbol
Error:  import org.apache.pulsar.broker.event.data.ProducerConnectEventData.ProducerConnectEventDataBuilder;
Error:                                                                     ^
Error:    symbol:   class ProducerConnectEventDataBuilder
Error:    location: class ProducerConnectEventData
Error:  /home/ubuntu/actions-runner/_work/***-ci/***-ci/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java:164: error: cannot find symbol
Error:          private final EventContext.EventContextBuilder builder;
Error:                                    ^
Error:    symbol:   class EventContextBuilder
Error:    location: class EventContext
Error: [ERROR] 2 errors
Error:  Command line was: /home/ubuntu/actions-runner/_work/_tool/Java_Temurin-Hotspot_jdk/17.0.14-7/x64/bin/javadoc @options @packages
Error:  
Error:  Refer to the generated Javadoc files in '/home/ubuntu/actions-runner/_work/***-ci/***-ci/pulsar/pulsar-broker/target/apidocs' dir.
Error:  -> [Help 1]
```

### Modifications

- Added `<failOnError>false</failOnError>` to maven-javadoc-plugin configuration

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->