### PR TITLE
[fix][ci] Fix code coverage metrics in Pulsar CI

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -51,11 +51,12 @@ runs:
     - name: "Upload to Codecov (attempt #1)"
       id: codecov-upload-1
       if: steps.repo-check.outputs.passed == 'true'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       continue-on-error: true
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
     - name: "Wait 15 seconds before next attempt"
       if: steps.codecov-upload-1.outcome == 'failure'
@@ -64,11 +65,12 @@ runs:
     - name: "Upload to Codecov (attempt #2)"
       id: codecov-upload-2
       if: steps.codecov-upload-1.outcome == 'failure'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       continue-on-error: true
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
     - name: "Wait 60 seconds before next attempt"
       if: steps.codecov-upload-2.outcome == 'failure'
@@ -77,12 +79,13 @@ runs:
     - name: "Upload to Codecov (attempt #3)"
       id: codecov-upload-3
       if: steps.codecov-upload-2.outcome == 'failure'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       # fail on last attempt
       continue-on-error: false
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
     - name: "Show link to Codecov report"
       shell: bash

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -28,6 +28,10 @@ inputs:
   flags:
     # see https://github.com/codecov/codecov-action#arguments
     description: 'Flag the upload to group coverage metrics. Multiple flags are separated by a comma.'
+  token:
+    description: 'Codecov token to use for uploading coverage metrics.'
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -56,7 +60,7 @@ runs:
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}
         verbose: true
     - name: "Wait 15 seconds before next attempt"
       if: steps.codecov-upload-1.outcome == 'failure'
@@ -70,7 +74,7 @@ runs:
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}
         verbose: true
     - name: "Wait 60 seconds before next attempt"
       if: steps.codecov-upload-2.outcome == 'failure'
@@ -85,7 +89,7 @@ runs:
       with:
         flags: ${{ inputs.flags }}
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ inputs.token }}
         verbose: true
     - name: "Show link to Codecov report"
       shell: bash

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -272,6 +272,7 @@ jobs:
         continue-on-error: true
         with:
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Surefire reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -472,6 +472,7 @@ jobs:
         uses: ./.github/actions/upload-coverage
         with:
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Delete coverage files from build artifacts
         run: |
@@ -829,6 +830,7 @@ jobs:
         uses: ./.github/actions/upload-coverage
         with:
           flags: inttests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Delete coverage files from build artifacts
         run: |
@@ -1226,6 +1228,7 @@ jobs:
         uses: ./.github/actions/upload-coverage
         with:
           flags: systests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Delete coverage files from build artifacts
         run: |


### PR DESCRIPTION
### Motivation

Codecov metrics have been broken for Pulsar CI since the scheduled master branch build cannot upload metrics without a token. This PR passes the token provided in secrets to the Codecov action. The `CODECOV_TOKEN` secret has been added to `apache/pulsar` repository. This token is only used for `apache/pulsar` branch builds. For PR branch builds, uploads haven't been a problem and that could happen without a token or with the user provided token.

Additional information:
The `CODECOV_TOKEN` secret was added to `apache/pulsar` at https://github.com/apache/pulsar/settings/secrets/actions. The token value is available at https://app.codecov.io/gh/apache/pulsar/config/general for apache/pulsar committers after using GitHub login to login to Codecov.

### Modifications

- upgrade to v5 of https://github.com/codecov/codecov-action
- pass secrets.CODECOV_TOKEN to the action

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->