### PR TITLE
[fix][client] Retry for unknown exceptions when creating a producer or consumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -289,7 +289,7 @@ public class ConnectionPool implements AutoCloseable {
             }
             // Try use exists connection.
             if (clientCnx.getIdleState().tryMarkUsingAndClearIdleTime()) {
-                return CompletableFuture.supplyAsync(() -> clientCnx, clientCnx.ctx().executor());
+                return CompletableFuture.completedFuture(clientCnx);
             } else {
                 // If connection already release, create a new one.
                 pool.remove(key, completableFuture);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -974,12 +974,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     cnx.sendRequestWithId(cmd, closeRequestId);
                 }
 
+                final boolean retriable = PulsarClientException.isRetriableError(e.getCause());
+                final boolean unrecoverable = isUnrecoverableError(e.getCause());
                 if (e.getCause() instanceof PulsarClientException
-                        && PulsarClientException.isRetriableError(e.getCause())
-                        && !isUnrecoverableError(e.getCause())
+                        && retriable
+                        && !unrecoverable
                         && System.currentTimeMillis() < SUBSCRIBE_DEADLINE_UPDATER.get(ConsumerImpl.this)) {
                     future.completeExceptionally(e.getCause());
-                } else if (!subscribeFuture.isDone()) {
+                } else if (!subscribeFuture.isDone() && !retriable) {
                     // unable to create new consumer, fail operation
                     setState(State.Failed);
                     final Throwable throwable = PulsarClientException.wrap(e, String.format("Failed to subscribe the "
@@ -990,7 +992,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     closeConsumerTasks();
                     subscribeFuture.completeExceptionally(throwable);
                     client.cleanupConsumer(this);
-                } else if (isUnrecoverableError(e.getCause())) {
+                } else if (unrecoverable) {
                     closeWhenReceivedUnrecoverableError(e.getCause(), cnx);
                 } else {
                     // consumer was subscribed and connected but we got some error, keep trying

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2037,8 +2037,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 closeProducerTasks();
                 client.cleanupProducer(this);
             } else if (producerCreatedFuture.isDone() || (
-                    cause instanceof PulsarClientException
-                            && PulsarClientException.isRetriableError(cause)
+                            PulsarClientException.isRetriableError(cause)
                             && System.currentTimeMillis() < PRODUCER_DEADLINE_UPDATER.get(ProducerImpl.this)
             )) {
                 // Either we had already created the producer once (producerCreatedFuture.isDone()) or we are

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -19,11 +19,13 @@
 package org.apache.pulsar.common.protocol;
 
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
+import lombok.Setter;
 import org.apache.pulsar.common.api.proto.CommandPing;
 import org.apache.pulsar.common.api.proto.CommandPong;
 import org.apache.pulsar.common.api.proto.ProtocolVersion;
@@ -37,6 +39,8 @@ import org.slf4j.LoggerFactory;
  * parameter instance lifecycle.
  */
 public abstract class PulsarHandler extends PulsarDecoder {
+    @VisibleForTesting
+    @Setter
     protected ChannelHandlerContext ctx;
     protected SocketAddress remoteAddress;
     private int remoteEndpointProtocolVersion = ProtocolVersion.v0.getValue();


### PR DESCRIPTION
### Motivation

There are several methods that get a connection from the `ConnectionPool`.
1. `ConnectionPool#getConnection(ServiceNameResolver)`
    It's only used in `BinaryProtoLookupService`. The callbacks are all executed in `PulsarClientImpl#lookupExecutorProvider`: a single thread executor whose thread name starts with `pulsar-client-lookup`.
2. `ConnectionPool#getConnection(InetSocketAddress)`
    It's called by the 1st method directly. Besides, it's only called by `BinaryProtoLookupService#findBroker`, which also uses `PulsarClientImpl#lookupExecutorProvider` to execute the callback.
3. `ConnectionPool#getConnection(InetSocketAddress logicalAddress, InetSocketAddress physicalAddress, int randomKey)`
    It's called by the 2nd method directly. Besides, it's only called by the 4th method.
4. `PulsarClientImpl#getConnection(InetSocketAddress, InetSocketAddress, int)`
    It's called in `ConnectionHandler#grabCnx` to establish a connection between broker and client (producer, consumer or reader). The callback calls `connectionOpened` or `handleConnectionError` without switching to another executor.
5. Other methods in `PulsarClientImpl`
    Including:
    - `getConnectionToServiceUrl`
    - `getConnection(String, int)`
    - `getConnection(String, String)`
    They all call the 4th method in the callback of `LookupService#getBroker` and only used in `grabCnx`.

To solve a race condition caused by the fact that socket is closed in Netty's I/O thread while `connectionOpened` that sends the command is executed in another thread, #23499 completes the future of `ConnectionPool#getConnection` in Netty's' I/O thread as well. However, this adds an additional thread switching for all usages in method 1 above, which is not necessary.

I found this issue when I found a producer creation was blocked forever due to a deadlock in `sendAsync`'s callback, which is executed in Netty's I/O thread. When checking the heap dump, I found `ClientCnx#pendingRequests` was empty, which means `client.getCnxPool().getConnection(socketAddress)` never complete, see https://github.com/apache/pulsar/blob/1e57827b33395a2124593d95fa7641ee5e125d9b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java#L218

Though even if without the change, other response processing will still be blocked because the I/O thread is blocked. It's very confusing when reviewing the heap dump:
- `BinaryProtoLookupService#partitionedMetadataInProgress` is not empty
- `ClientCnx#pendingRequests` is empty (the only connection in the pool)

<img width="877" height="253" alt="image" src="https://github.com/user-attachments/assets/ca3cbbb8-9110-4697-b3c9-72c4b61c19d1" />

<img width="678" height="336" alt="image" src="https://github.com/user-attachments/assets/be1dc242-d6e3-41ad-92df-8336500653db" />

Actually, the root cause of the issue described in #23499 is that the `StacklessClosedChannelException` is treated as an exception cannot be retried. However, all network exceptions should be retried. Hence, this PR proposed a different solution to retry for such errors. Technically, only a few known exceptions should be treated as not retriable, e.g. `AuthorizationException`. Other known or unknown exceptions should be retried.

It's not guaranteed that `writeAndFlush` will always succeed. For example, if the code reaches here: https://github.com/apache/pulsar/blob/d2728253c666f7d4bd4f111356f3b97663603b6a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L1062

The future of `ClientCnx#sendRequestWithId` could fail with an exception that is not `PulsarClientException`.

### Modifications

Revert the change in #23499 and retry for retriable exception even if it's not `PulsarClientException`. Improve `SimpleProduceConsumeIoTest` to cover consumer creation as well. Since this test only covers a very limited case, add `testUnknownRpcExceptionFor*` tests that inject failure on the 1st `writeAndFlush` in `connectionOpened`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: