### PR TITLE
[improve][broker]Part-2 Add Admin API to delete topic policies

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyTestUtils.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicPolicyTestUtils.java
@@ -48,6 +48,14 @@ public class TopicPolicyTestUtils {
                 .orElse(null);
     }
 
+    public static TopicPolicies getTopicPolicies(TopicPoliciesService topicPoliciesService, TopicName topicName,
+             boolean global) throws ExecutionException, InterruptedException {
+        TopicPoliciesService.GetType getType = global ? TopicPoliciesService.GetType.GLOBAL_ONLY
+                : TopicPoliciesService.GetType.LOCAL_ONLY;
+        return topicPoliciesService.getTopicPoliciesAsync(topicName, getType).get()
+                .orElse(null);
+    }
+
     public static TopicPolicies getLocalTopicPolicies(TopicPoliciesService topicPoliciesService, TopicName topicName)
             throws ExecutionException, InterruptedException {
         return topicPoliciesService.getTopicPoliciesAsync(topicName, TopicPoliciesService.GetType.LOCAL_ONLY).get()

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
@@ -1936,7 +1936,18 @@ public interface TopicPolicies {
      */
     CompletableFuture<Void> setReplicationClusters(String topic, List<String> clusterIds);
 
+    /**
+     * get the replication clusters for the topic.
+     */
     Set<String> getReplicationClusters(String topic, boolean applied) throws PulsarAdminException;
 
+    /**
+     * get the replication clusters for the topic.
+     */
     void removeReplicationClusters(String topic) throws PulsarAdminException;
+
+    /**
+     * Delete topic policies, it works even if the topic has been deleted.
+     */
+    void deleteTopicPolicies(String topic) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -1312,6 +1312,17 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
         return asyncDeleteRequest(path);
     }
 
+    @Override
+    public void deleteTopicPolicies(String topic) throws PulsarAdminException {
+        sync(() -> deleteTopicPoliciesAsync(topic));
+    }
+
+    public CompletableFuture<Void> deleteTopicPoliciesAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "policies");
+        return asyncDeleteRequest(path);
+    }
+
     /*
      * returns topic name with encoded Local Name
      */

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -60,7 +60,7 @@ public class CmdTopicPolicies extends CmdBase {
 
     public CmdTopicPolicies(Supplier<PulsarAdmin> admin) {
         super("topicPolicies", admin);
-
+        addCommand("delete", new DeletePolicies());
         addCommand("get-message-ttl", new GetMessageTTL());
         addCommand("set-message-ttl", new SetMessageTTL());
         addCommand("remove-message-ttl", new RemoveMessageTTL());
@@ -2055,6 +2055,20 @@ public class CmdTopicPolicies extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
             getTopicPolicies(isGlobal).removeReplicationClusters(persistentTopic);
+        }
+    }
+
+    @Command(description = "Remove the all policies for a topic, it will not remove policies from the remote"
+            + "cluster")
+    private class DeletePolicies extends CliCommand {
+
+        @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
+        private String topicName;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(topicName);
+            getTopicPolicies(false).deleteTopicPolicies(persistentTopic);
         }
     }
 


### PR DESCRIPTION
### Motivation

See the [PIP-422](https://github.com/apache/pulsar/blob/master/pip/pip-422.md)
- https://github.com/apache/pulsar/pull/24368

```
pulsar-admin topicPolicies delete <topic>
```

### Modifications
- Add Admin API to delete topic policies


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
