### PR TITLE
[fix][client]Prevent ZeroQueueConsumer from receiving batch messages when using MessagePayloadProcessor

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -605,12 +605,15 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
                 .messagePayloadProcessor(new MessagePayloadProcessor() {
                                              @Override
                                              public <T> void process(MessagePayload payload,
-                                                                     MessagePayloadContext context, Schema<T> schema,
-                                                                     java.util.function.Consumer<Message<T>> messageConsumer) throws Exception {
+                                                             MessagePayloadContext context, Schema<T> schema,
+                                                             java.util.function.Consumer<Message<T>> messageConsumer) {
                                                  if (context.isBatch()) {
                                                      final int numMessages = context.getNumMessages();
                                                      for (int i = 0; i < numMessages; i++) {
-                                                         messageConsumer.accept(context.getMessageAt(i, numMessages, payload, true, schema));
+                                                         messageConsumer.
+                                                                 accept(context.getMessageAt(i, numMessages,
+                                                                         payload, true, schema)
+                                                                 );
                                                      }
                                                  } else {
                                                      messageConsumer.accept(context.asSingleMessage(payload, schema));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -38,7 +38,11 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
+import org.apache.pulsar.client.api.MessagePayload;
+import org.apache.pulsar.client.api.MessagePayloadContext;
+import org.apache.pulsar.client.api.MessagePayloadProcessor;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -363,6 +367,7 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
             .ackTimeout(1, TimeUnit.SECONDS)
             .messageListener((MessageListener<Integer>) (c, msg) -> {
                 try {
+                    System.out.println("----receive data : " + msg.getData());
                     receivedMessages.add(msg.getValue());
                 } finally {
                     latch.countDown();
@@ -577,5 +582,66 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
         for (int i = 0; i < numMessages; i++) {
             assertEquals(receivedMessages.get(i).intValue(), i);
         }
+    }
+
+    @Test(timeOut = 30000)
+    public void testZeroQueueSizeConsumerWithPayloadProcessorReceiveBatchMessage() throws Exception {
+        String key = "payloadProcessorReceiveBatchMessage";
+
+        // 1. Config
+        final String topicName = "persistent://prop/use/ns-abc/topic-" + key;
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final String messagePredicate = "my-message-" + key + "-";
+
+        // 2. Create Producer
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batchingMaxMessages(5)
+                .enableBatching(true)
+                .create();
+
+        // 3. Create Consumer
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic(topicName)
+                .messagePayloadProcessor(new MessagePayloadProcessor() {
+                                             @Override
+                                             public <T> void process(MessagePayload payload,
+                                                                     MessagePayloadContext context, Schema<T> schema,
+                                                                     java.util.function.Consumer<Message<T>> messageConsumer) throws Exception {
+                                                 if (context.isBatch()) {
+                                                     final int numMessages = context.getNumMessages();
+                                                     for (int i = 0; i < numMessages; i++) {
+                                                         messageConsumer.accept(context.getMessageAt(i, numMessages, payload, true, schema));
+                                                     }
+                                                 } else {
+                                                     messageConsumer.accept(context.asSingleMessage(payload, schema));
+                                                 }
+                                             }
+                                         }
+                )
+                .subscriptionName(subscriptionName)
+                .receiverQueueSize(0)
+                .subscribe();
+
+        ArrayList<CompletableFuture<MessageId>> futures = new ArrayList<>();
+        // 3. producer publish batch-messages
+        for (int i = 0; i < totalMessages; i++) {
+            String message = messagePredicate + i;
+            futures.add(producer.sendAsync(message.getBytes()));
+        }
+        producer.flush();
+
+        // ensure all messages are sent as batch messages
+        for (CompletableFuture<MessageId> future : futures) {
+            assertTrue(future.get() instanceof BatchMessageIdImpl);
+        }
+
+        // 4. consumer should throw PulsarClientException when call method receive()
+        assertThatThrownBy(
+                consumer::receive
+        )
+                .isInstanceOf(PulsarClientException.class)
+                .hasMessage("java.lang.InterruptedException: Queue is terminated")
+                .hasCauseInstanceOf(InterruptedException.class);
+        producer.close();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1396,7 +1396,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         final AtomicInteger skippedMessages = new AtomicInteger(0);
         if (this instanceof ZeroQueueConsumerImpl<T> && entryContext.isBatch()) {
             this.receiveIndividualMessagesFromBatch(brokerEntryMetadata,
-                messageMetadata,redeliveryCount, ackSet, byteBuf, null, null, consumerEpoch, false);
+                messageMetadata, redeliveryCount, ackSet, byteBuf, null, null, consumerEpoch, false);
             return;
         }
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1394,6 +1394,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         final MessagePayloadContextImpl entryContext = MessagePayloadContextImpl.get(
                 brokerEntryMetadata, messageMetadata, messageId, this, redeliveryCount, ackSet, consumerEpoch);
         final AtomicInteger skippedMessages = new AtomicInteger(0);
+        if (this instanceof ZeroQueueConsumerImpl<T> && entryContext.isBatch()) {
+            this.receiveIndividualMessagesFromBatch(brokerEntryMetadata,
+                    messageMetadata,redeliveryCount, ackSet, byteBuf, null, null, consumerEpoch, false);
+            return;
+        }
         try {
             conf.getPayloadProcessor().process(payload, entryContext, schema, message -> {
                 if (message != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1396,7 +1396,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         final AtomicInteger skippedMessages = new AtomicInteger(0);
         if (this instanceof ZeroQueueConsumerImpl<T> && entryContext.isBatch()) {
             this.receiveIndividualMessagesFromBatch(brokerEntryMetadata,
-                    messageMetadata,redeliveryCount, ackSet, byteBuf, null, null, consumerEpoch, false);
+                messageMetadata,redeliveryCount, ackSet, byteBuf, null, null, consumerEpoch, false);
             return;
         }
         try {


### PR DESCRIPTION
### Motivation
Currently, `ZeroQueueConsumerImpl` with `MessagePayloadProcessor` enabled can incorrectly receive batch messages when it shouldn't. This occurs because:

1. The message payload processor processes batch messages before checking if the consumer is a zero-queue consumer
2. This behavior contradicts the expected behavior of zero-queue consumers which should not buffer any messages

The issue can be reproduced when:
- Using a `MessagePayloadProcessor` that processes batch messages

### Modifications
1. Added early check in `processPayloadByProcessor` to detect zero-queue consumers receiving batch messages
2. For zero-queue consumers with batch messages, bypass the payload processor and directly use `receiveIndividualMessagesFromBatch`
3. Added new test case `testZeroQueueSizeConsumerWithPayloadProcessorReceiveBatchMessage` to verify the fix

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/20

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
