### PR TITLE
[fix][misc] Exclude commons-configuration2 and commons-beanutils in pulsar-common

### DIFF
--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -122,11 +122,33 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-common-allocator</artifactId>
+      <exclusions>
+        <!-- Exclude dependencies that are not needed in Pulsar, https://github.com/apache/bookkeeper/issues/4647 -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-configuration2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>cpu-affinity</artifactId>
+      <exclusions>
+        <!-- Exclude dependencies that are not needed in Pulsar, https://github.com/apache/bookkeeper/issues/4647 -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-configuration2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -146,6 +168,15 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
+        </exclusion>
+        <!-- Exclude dependencies that are not needed in Pulsar, https://github.com/apache/bookkeeper/issues/4647 -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-configuration2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Fixes #24611

### Motivation

See #24611 and https://github.com/apache/bookkeeper/issues/4647

### Modifications

Exclude commons-configuration2 and commons-beanutils in pulsar-common for bookkeeper library dependencies since they aren't needed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->