### PR TITLE
[fix][broker] fix bk configuration bookkeeperMetadataServiceUri 

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1031,6 +1031,8 @@ maxConcurrentHttpRequests=1024
 # For example: zk+hierarchical://localhost:2181/ledgers
 # The metadata service uri list can also be semicolon separated values like below:
 # zk+hierarchical://zk1:2181;zk2:2181;zk3:2181/ledgers
+# or
+# metadata-store:zk:localhost:2181/ledgers If we set -Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver -Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver
 bookkeeperMetadataServiceUri=
 
 # Authentication plugin to use when connecting to bookies

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -306,7 +306,8 @@ public class PulsarClusterMetadataSetup {
         if (arguments.existingBkMetadataServiceUri == null && arguments.bookieMetadataServiceUri == null) {
             ServerConfiguration bkConf = new ServerConfiguration();
             bkConf.setListDelimiterHandler(new DisabledListDelimiterHandler());
-            bkConf.setMetadataServiceUri("metadata-store:" + arguments.metadataStoreUrl);
+            bkConf.setMetadataServiceUri("metadata-store:" + arguments.metadataStoreUrl
+                    + BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH);
             bkConf.setZkTimeout(arguments.zkSessionTimeoutMillis);
             // only format if /ledgers doesn't exist
             if (!localStore.exists(BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH).get()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -126,6 +126,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setBusyWaitEnabled(conf.isEnableBusyWait());
         bkConf.setNumWorkerThreads(conf.getBookkeeperClientNumWorkerThreads());
         bkConf.setThrottleValue(conf.getBookkeeperClientThrottleValue());
+        bkConf.setZkTimeout((int) conf.getMetadataStoreSessionTimeoutMillis());
         bkConf.setAddEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setReadEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setSpeculativeReadTimeout(conf.getBookkeeperClientSpeculativeReadTimeoutInMillis());

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -113,10 +113,11 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
 
         String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
         String bookkeeperMetadataServiceUri;
-        if (provider == "ZooKeeper" || provider == "MockZookeeper") {
+        if (provider.equalsIgnoreCase("ZooKeeper")
+                || provider.equalsIgnoreCase("MockZookeeper")) {
             bookkeeperMetadataServiceUri =  "metadata-store:zk:" + urlSupplier.get() + ledgersRoot;
         }  else {
-            bookkeeperMetadataServiceUri =  "metadata-store:" + urlSupplier.get() + ledgersRoot;
+            bookkeeperMetadataServiceUri =  urlSupplier.get() + ledgersRoot;
         }
         ClientConfiguration baseClientConf = TestBKConfiguration.newClientConfiguration();
         baseClientConf.setMetadataServiceUri(bookkeeperMetadataServiceUri);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -106,7 +106,8 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
     }
 
     @Test(dataProvider = "impl")
-    public void testGetWritableBookiesByMetadataClientDriver(String provider, Supplier<String> urlSupplier) throws Exception {
+    public void testGetWritableBookiesByMetadataClientDriver(String provider, Supplier<String> urlSupplier)
+            throws Exception {
         System.setProperty("bookkeeper.metadata.bookie.drivers", PulsarMetadataBookieDriver.class.getName());
         System.setProperty("bookkeeper.metadata.client.drivers", PulsarMetadataClientDriver.class.getName());
 


### PR DESCRIPTION
### Motivation
The issue occurs when configuring 
bookkeeperMetadataServiceUri=metadata-store:zk:zk1:2181/ledgers along with enabling:

text
-Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver  
-Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver  
Root Cause Analysis
The problem arises in AbstractMetadataDriver when creating MetadataStoreExtended. Specifically:

The resolveLedgersRootPath() method has a bug in path parsing.

When using ZooKeeper (ZK), the connection string typically includes a double slash (//) (e.g., zk://metadata-store:2181/ledgers), which ensures URI.getPath() correctly returns /ledgers.

However, Pulsar’s metadata service connection string (metadata-store:zk:metadata-store:2181/ledgers) lacks the // prefix, causing URI.getPath() to incorrectly parse the ledger root path, defaulting to /ledgers regardless of the configured path.

```
URI metadataServiceUri = URI.create(metadataServiceUriStr);
String path = metadataServiceUri.getPath();
return path == null ? BookKeeperConstants.DEFAULT_ZK_LEDGERS_ROOT_PATH : path;
```

### Modifications
The fix should ensure proper path resolution regardless of the connection string format. Possible approaches:

Normalize the connection string before parsing (e.g., ensure // is present for consistency).

Improve resolveLedgersRootPath() to handle both formats (with or without //).

Example: Extract the path segment after the last : or / if the URI parsing fails.

Explicitly enforce a default /ledgers fallback only when path extraction fails.

### Verifying this change



### Does this pull request potentially affect one of the following parts:



- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/gaozhangmin/pulsar/tree/fix_resolveLedgersRootPath
