### PR TITLE
[improve][broker]Find the target position at most once, during expiring messages for a topic, even though there are many subscriptions

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpFindNewest.java
@@ -250,6 +250,9 @@ class OpFindNewest implements ReadEntryCallback {
         return nextPosition;
     }
 
+    /**
+     * Find the largest entry that matches the given predicate.
+     */
     public void find() {
         if (cursor != null ? cursor.hasMoreEntries(searchPosition) : ledger.hasMoreEntries(searchPosition)) {
             ledger.asyncReadEntry(searchPosition, this, null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MessageExpirer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MessageExpirer.java
@@ -25,9 +25,19 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 @InterfaceStability.Evolving
 public interface MessageExpirer {
 
+    /**
+     * Mark delete the largest position that is less than the {@param position}.
+     */
     boolean expireMessages(Position position);
 
+    /**
+     * Mark delete the largest message that publish timestamp is less than the result of the expression
+     * "{@link System#currentTimeMillis - {@param messageTTLInSeconds})".
+     */
     boolean expireMessages(int messageTTLInSeconds);
 
+    /**
+     * Async implementation of {@link #expireMessages(int)}.
+     */
     CompletableFuture<Boolean> expireMessagesAsync(int messageTTLInSeconds);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MessageExpirer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MessageExpirer.java
@@ -26,7 +26,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 public interface MessageExpirer {
 
     /**
-     * Mark delete the largest position that is less than the {@param position}.
+     * Mark delete the largest position that is less than or equals the {@param position}.
      */
     boolean expireMessages(Position position);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -148,7 +148,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                     ml.getOptionalLedgerInfo(messagePosition.getLedgerId());
             if (ledgerInfoOptional.isPresent()) {
                 if (messagePosition.getEntryId() >= 0
-                        && ledgerInfoOptional.get().getEntries() -1 >= messagePosition.getEntryId()) {
+                        && ledgerInfoOptional.get().getEntries() - 1 >= messagePosition.getEntryId()) {
                     findEntryComplete(messagePosition, null);
                     return true;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.LedgerNotExistExcept
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NonRecoverableLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.broker.service.MessageExpirer;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -140,6 +141,15 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
     public boolean expireMessages(Position messagePosition) {
         // If it's beyond last position of this topic, do nothing.
         Position topicLastPosition = this.topic.getLastPosition();
+        ManagedLedger managedLedger = cursor.getManagedLedger();
+        if (managedLedger instanceof ManagedLedgerImpl ml) {
+            Position positionToExpire = ml.getPreviousPosition(messagePosition);
+            if (positionToExpire.getEntryId() >= 0) {
+                findEntryComplete(positionToExpire, null);
+            }
+            return true;
+        }
+
         if (topicLastPosition.compareTo(messagePosition) < 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{}] Ignore expire-message scheduled task, given position {} is beyond "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -149,7 +149,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
             }
             return true;
         }
-
+        // Fallback to the slower solution if the managed ledger is not an instance of ManagedLedgerImpl.
         if (topicLastPosition.compareTo(messagePosition) < 0) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{}] Ignore expire-message scheduled task, given position {} is beyond "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2181,10 +2181,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         && (additionalSystemCursorNames.isEmpty()
                         || !additionalSystemCursorNames.contains(sub.getName()))) {
                     // The variable "position" is to mark delete position.
-                    // The method "expireMessages(position)" will mark delete the previous position of the given
-                    // position.
-                    // So we give it a next valid position.
-                    sub.expireMessages(PositionFactory.create(position.getLedgerId(), position.getEntryId() + 1));
+                    // Regarding the method "expireMessages(position)", it will mark delete the target position if the
+                    // position is valid, otherwise, it mark deletes the previous valid position.
+                    // So we give it the position to be mark deleted.
+                    sub.expireMessages(position);
                 }
             });
             replicators.forEach((__, replicator)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2180,7 +2180,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (!isCompactionSubscription(sub.getName())
                         && (additionalSystemCursorNames.isEmpty()
                         || !additionalSystemCursorNames.contains(sub.getName()))) {
-                    sub.expireMessages(position);
+                    // The variable "position" is to mark delete position.
+                    // The method "expireMessages(position)" will mark delete the previous position of the given
+                    // position.
+                    // So we give it a next valid position.
+                    sub.expireMessages(PositionFactory.create(position.getLedgerId(), position.getEntryId() + 1));
                 }
             });
             replicators.forEach((__, replicator)

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
@@ -149,7 +149,7 @@ public class PersistentMessageExpiryMonitorTest extends ProducerConsumerBase {
     }
 
     /***
-     * Confirm the anti-concurrency mechanism "expirationCheckInProgressUpdater" works.
+     * Verify finding position task only executes once for multiple subscriptions of a topic.
      */
     @Test
     void testTopicExpireMessages() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
@@ -169,6 +169,7 @@ public class PersistentMessageExpiryMonitorTest extends ProducerConsumerBase {
         // Trigger 3 ledgers creation.
         producer.send("1");
         producer.send("2");
+        producer.send("3");
         producer.send("4");
         producer.send("5");
         Assert.assertEquals(3, ml.getLedgersInfo().size());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -1119,12 +1119,12 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         rolloverPerIntervalStats();
         assertEquals(subRef.getNumberOfEntriesInBacklog(false), numMsgs);
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(messageTTLSecs));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(messageTTLSecs - 1));
         runMessageExpiryCheck();
 
         assertEquals(subRef.getNumberOfEntriesInBacklog(false), numMsgs);
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(messageTTLSecs / 2));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1 + messageTTLSecs / 2));
         runMessageExpiryCheck();
 
         assertEquals(subRef.getNumberOfEntriesInBacklog(false), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -817,11 +817,14 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         p2.close();
         // Let the message expire
         for (String topic : topicList) {
+            // The TTL value can not be set to a negative value, the mininum value is 1.
             PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
                     .getTopicIfExists(topic).get().get();
-            persistentTopic.getBrokerService().getPulsar().getConfiguration().setTtlDurationDefaultInSeconds(-1);
-            persistentTopic.getHierarchyTopicPolicies().getMessageTTLInSeconds().updateBrokerValue(-1);
+            persistentTopic.getBrokerService().getPulsar().getConfiguration().setTtlDurationDefaultInSeconds(1);
+            persistentTopic.getHierarchyTopicPolicies().getMessageTTLInSeconds().updateBrokerValue(1);
         }
+        // Wait 2 seconds to expire message.
+        Thread.sleep(2000);
         pulsar.getBrokerService().forEachTopic(Topic::checkMessageExpiry);
         //wait for checkMessageExpiry
         PersistentSubscription sub = (PersistentSubscription)


### PR DESCRIPTION
### Motivation

#### 1. Instead of finding the target position for each subscription, search the target position once, and expire messages for each subscription.
**Background**: The steps of expiry of a topic
- Call expiry for each subscription
  - The subscription finds the target position, then calls mark deleting for the cursor
- Call expiry for each replicator
  - The replicator finds the target position, then calls mark deleting for the cursor

So the task calls for finding the target position many times when a topic expires. But the finding position operation is really expensive

#### 2. Improve the method `expireMessages(Position)`

The previous steps of expiring messages by position:
- Search the target position with a binary search
- Expire messages by the target position.

It costs a lot, we can simplify the steps by `managedLedger.getPreviousPosition(x)`

### Modifications

Since all of the tasks that find the target position that relates to the same topic will get the same result, we can call the finding operation at most once, during expiring messages for a topic

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x