### PR TITLE
[fix][broker] fix CheckConnectionStatus  disconnected 

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1028,9 +1028,11 @@ maxConcurrentHttpRequests=1024
 # Metadata service uri that bookkeeper is used for loading corresponding metadata driver
 # and resolving its metadata service location.
 # This value can be fetched using `bookkeeper shell whatisinstanceid` command in BookKeeper cluster.
-# For example: zk+hierarchical://localhost:2181/ledgers
+# For example: zk+hierarchical://localhost:2181
 # The metadata service uri list can also be semicolon separated values like below:
-# zk+hierarchical://zk1:2181;zk2:2181;zk3:2181/ledgers
+# zk+hierarchical://zk1:2181;zk2:2181;zk3:2181
+# or
+# metadata-store:zk:localhost:2181  If we set -Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver -Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver
 bookkeeperMetadataServiceUri=
 
 # Authentication plugin to use when connecting to bookies

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1028,9 +1028,9 @@ maxConcurrentHttpRequests=1024
 # Metadata service uri that bookkeeper is used for loading corresponding metadata driver
 # and resolving its metadata service location.
 # This value can be fetched using `bookkeeper shell whatisinstanceid` command in BookKeeper cluster.
-# For example: zk+hierarchical://localhost:2181
+# For example: zk+hierarchical://localhost:2181/ledgers
 # The metadata service uri list can also be semicolon separated values like below:
-# zk+hierarchical://zk1:2181;zk2:2181;zk3:2181
+# zk+hierarchical://zk1:2181;zk2:2181;zk3:2181/ledgers
 # or
 # metadata-store:zk:localhost:2181  If we set -Dbookkeeper.metadata.bookie.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver -Dbookkeeper.metadata.client.drivers=org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver
 bookkeeperMetadataServiceUri=

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -126,6 +126,7 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setBusyWaitEnabled(conf.isEnableBusyWait());
         bkConf.setNumWorkerThreads(conf.getBookkeeperClientNumWorkerThreads());
         bkConf.setThrottleValue(conf.getBookkeeperClientThrottleValue());
+        bkConf.setZkTimeout((int) conf.getMetadataStoreSessionTimeoutMillis());
         bkConf.setAddEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setReadEntryTimeout((int) conf.getBookkeeperClientTimeoutInSeconds());
         bkConf.setSpeculativeReadTimeout(conf.getBookkeeperClientSpeculativeReadTimeoutInMillis());


### PR DESCRIPTION
### Motivation

I found there is problem related to bk's zktimeout config, the default bk zktimeout of bk is 10s, but 
We caculate tickTimeMillis  =  zktimeout/15. 

https://github.com/apache/pulsar/blob/277835a65dd586de941b7d0ad448843b7b5589a4/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java#L63

In below future.get, always timeout.
https://github.com/apache/pulsar/blob/277835a65dd586de941b7d0ad448843b7b5589a4/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java#L108-L112

We should support set bk zktimeut by 
 bkConf.setZkTimeout((int) conf.getMetadataStoreSessionTimeoutMillis());


### Modifications

bkConf.setZkTimeout((int) conf.getMetadataStoreSessionTimeoutMillis());

### Verifying this change


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
