### PR TITLE
[fix][test]fix flaky ZeroQueueSizeTest.testZeroQueueGetExceptionWhenReceiveBatchMessage 

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4151,9 +4151,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     @Test(timeOut = 100000)
     public void consumerReceiveThrowExceptionWhenConsumerClose() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/my-topic-");
         Consumer<byte[]> consumer = pulsarClient
                 .newConsumer()
-                .topic("persistent://my-property/my-ns/my-topic2")
+                .topic(topic)
                 .receiverQueueSize(10)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("my-sub")
@@ -4181,9 +4182,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
     @Test(timeOut = 100000)
     public void multiThreadConsumerReceiveThrowExceptionWhenConsumerClose() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://my-property/my-ns/my-topic-");
         Consumer<byte[]> consumer = pulsarClient
                 .newConsumer()
-                .topic("persistent://my-property/my-ns/my-topic2")
+                .topic(topic)
                 .receiverQueueSize(10)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionName("my-sub")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ZeroQueueSizeTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
@@ -430,13 +431,14 @@ public class ZeroQueueSizeTest extends BrokerTestBase {
     @Test(timeOut = 30000)
     public void testZeroQueueGetExceptionWhenReceiveBatchMessage() throws PulsarClientException {
 
-        int batchMessageDelayMs = 100;
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://prop-xyz/use/ns-abc/topic1")
+        final String topic = BrokerTestUtil.newUniqueName(
+                "persistent://prop/ns-abc/testZeroQueueGetExceptionWhenReceiveBatchMessage-");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic)
                 .subscriptionName("my-subscriber-name").subscriptionType(SubscriptionType.Shared).receiverQueueSize(0)
                 .subscribe();
 
         ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://prop-xyz/use/ns-abc/topic1")
+                .topic(topic)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition);
 
         producerBuilder.enableBatching(true)


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24629
### Motivation
```ZeroQueueSizeTest.testZeroQueueGetExceptionWhenReceiveBatchMessage``` use same topicName(```persistent://prop-xyz/use/ns-abc/topic1```) as ```ZeroQueueSizeTest.testFailedZeroQueueSizeBatchMessage```, Since ```testFailedZeroQueueSizeBatchMessage``` sends some non-batch messages, it interferes with this test's behavior.
### Modifications
changing tests which using same topicName to use unique topicName:
- ```ZeroQueueSizeTest#testZeroQueueGetExceptionWhenReceiveBatchMessage```
- ```SimpleProducerConsumerTest#consumerReceiveThrowExceptionWhenConsumerClose```
- ```SimpleProducerConsumerTest#multiThreadConsumerReceiveThrowExceptionWhenConsumerClose```
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/23