### PR TITLE
[fix][broker]Dispatcher did unnecessary sort for recentlyJoinedConsumers and printed noisy error logs

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
@@ -315,7 +315,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
         PersistentStickyKeyDispatcherMultipleConsumersClassic persistentDispatcher =
                 new PersistentStickyKeyDispatcherMultipleConsumersClassic(
                 topicMock, cursorMock, subscriptionMock, configMock,
-                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT));
+                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT), spyRecentlyJoinedConsumers);
 
         Consumer consumer0 = createMockConsumer();
         when(consumer0.consumerName()).thenReturn("0");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +47,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -294,6 +296,68 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
         Map.Entry<Consumer, Position> entry6 = itr.next();
         assertEquals(entry6.getValue(), PositionFactory.create(6, 1));
         assertEquals(entry6.getKey(), consumer6);
+
+        // cleanup.
+        persistentDispatcher.close();
+    }
+
+    @Test
+    public void testSkipSortRecentlyJoinedConsumersIfNotNeeded() throws Exception {
+        // Inject a sorting counter.
+        LinkedHashMap<Consumer, Position> recentlyJoinedConsumers = new LinkedHashMap<>();
+        LinkedHashMap<Consumer, Position> spyRecentlyJoinedConsumers = spy(recentlyJoinedConsumers);
+        AtomicInteger sortTimes = new AtomicInteger(0);
+        doAnswer(invocationOnMock -> {
+            sortTimes.incrementAndGet();
+            return invocationOnMock.callRealMethod();
+        }).when(spyRecentlyJoinedConsumers).clear();
+
+        PersistentStickyKeyDispatcherMultipleConsumersClassic persistentDispatcher =
+                new PersistentStickyKeyDispatcherMultipleConsumersClassic(
+                topicMock, cursorMock, subscriptionMock, configMock,
+                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT));
+
+        Consumer consumer0 = createMockConsumer();
+        when(consumer0.consumerName()).thenReturn("0");
+        Consumer consumer1 = createMockConsumer();
+        when(consumer0.consumerName()).thenReturn("MzGG2");
+        Consumer consumer2 = createMockConsumer();
+        when(consumer1.consumerName()).thenReturn("rMOYG");
+        Consumer consumer3 = createMockConsumer();
+        when(consumer2.consumerName()).thenReturn("QIleA");
+
+        when(cursorMock.getNumberOfEntriesSinceFirstNotAckedMessage()).thenReturn(100L);
+        when(cursorMock.getMarkDeletedPosition()).thenReturn(PositionFactory.create(-1, -1));
+        persistentDispatcher.addConsumer(consumer0).join();
+
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(1, 1));
+        persistentDispatcher.addConsumer(consumer1).join();
+
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(1, 1));
+        persistentDispatcher.addConsumer(consumer2).join();
+
+        when(cursorMock.getReadPosition()).thenReturn(PositionFactory.create(1, 2));
+        persistentDispatcher.addConsumer(consumer3).join();
+
+        assertEquals(persistentDispatcher.getRecentlyJoinedConsumers().size(), 3);
+
+        Iterator<Map.Entry<Consumer, Position>> itr =
+                persistentDispatcher.getRecentlyJoinedConsumers().entrySet().iterator();
+
+        Map.Entry<Consumer, Position> entry1 = itr.next();
+        assertEquals(entry1.getValue(), PositionFactory.create(1, 1));
+        assertEquals(entry1.getKey(), consumer1);
+
+        Map.Entry<Consumer, Position> entry2 = itr.next();
+        assertEquals(entry2.getValue(), PositionFactory.create(1, 1));
+        assertEquals(entry2.getKey(), consumer2);
+
+        Map.Entry<Consumer, Position> entry3 = itr.next();
+        assertEquals(entry3.getValue(), PositionFactory.create(1, 2));
+        assertEquals(entry3.getKey(), consumer3);
+
+        // Verify: no sorting was executed
+        assertEquals(sortTimes.get(), 0);
 
         // cleanup.
         persistentDispatcher.close();


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23795 improved the method `recentlyJoinedConsumers`: rather than check ordering for all items, just check the latest two because the method will be called after addition for all consumers.

The method `sortRecentlyJoinedConsumersIfNeeded` has a bug; it did an unnecessary sorting for the collection `recentlyJoinedConsumers`, and printed noisy logs `The items in recentlyJoinedConsumers are out-of-order.`

For example:
- there are `3` items: `[1, 2, 3]`
- the first loop:  `posPre` -> `1`
- the second loop: `posPre` -> `null`; `posAfter` -> `2`
- the latest loop: `posPre` -> `3`; Since the variable `posPre` is null , skip to set the variable `posAfter`

```java
        // Record the second latest item.
        Position posPre = null;
        // Record the latest item.
        Position posAfter = null;
        for (Map.Entry<Consumer, Position> entry : recentlyJoinedConsumers.entrySet()) {
            if (posPre == null) {
                posPre = entry.getValue();
            } else {
                posPre = posAfter; // Issue: the variable "posPre" will be set to "null" at the second loop
                posAfter = entry.getValue();
            }
        }
```

### Modifications

Fix the issue.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
