### PR TITLE
[fix][sec] Upgrade to Netty 4.1.124.Final to address CVE-2025-55163

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -55,7 +55,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.122.Final</netty.version>
+    <netty.version>4.1.124.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>33.4.8-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -295,26 +295,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.18.0.jar
     - org.apache.commons-commons-text-1.13.1.jar
  * Netty
-    - io.netty-netty-buffer-4.1.122.Final.jar
-    - io.netty-netty-codec-4.1.122.Final.jar
-    - io.netty-netty-codec-dns-4.1.122.Final.jar
-    - io.netty-netty-codec-http-4.1.122.Final.jar
-    - io.netty-netty-codec-http2-4.1.122.Final.jar
-    - io.netty-netty-codec-socks-4.1.122.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.122.Final.jar
-    - io.netty-netty-common-4.1.122.Final.jar
-    - io.netty-netty-handler-4.1.122.Final.jar
-    - io.netty-netty-handler-proxy-4.1.122.Final.jar
-    - io.netty-netty-resolver-4.1.122.Final.jar
-    - io.netty-netty-resolver-dns-4.1.122.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.122.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.122.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.122.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.122.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.122.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.122.Final.jar
+    - io.netty-netty-buffer-4.1.124.Final.jar
+    - io.netty-netty-codec-4.1.124.Final.jar
+    - io.netty-netty-codec-dns-4.1.124.Final.jar
+    - io.netty-netty-codec-http-4.1.124.Final.jar
+    - io.netty-netty-codec-http2-4.1.124.Final.jar
+    - io.netty-netty-codec-socks-4.1.124.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.124.Final.jar
+    - io.netty-netty-common-4.1.124.Final.jar
+    - io.netty-netty-handler-4.1.124.Final.jar
+    - io.netty-netty-handler-proxy-4.1.124.Final.jar
+    - io.netty-netty-resolver-4.1.124.Final.jar
+    - io.netty-netty-resolver-dns-4.1.124.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.124.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.124.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.124.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.124.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.124.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.124.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.124.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.124.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.72.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -350,22 +350,22 @@ The Apache Software License, Version 2.0
     - commons-collections-3.2.2.jar
     - commons-configuration2-2.12.0.jar
  * Netty
-    - netty-buffer-4.1.122.Final.jar
-    - netty-codec-4.1.122.Final.jar
-    - netty-codec-dns-4.1.122.Final.jar
-    - netty-codec-http-4.1.122.Final.jar
-    - netty-codec-socks-4.1.122.Final.jar
-    - netty-codec-haproxy-4.1.122.Final.jar
-    - netty-common-4.1.122.Final.jar
-    - netty-handler-4.1.122.Final.jar
-    - netty-handler-proxy-4.1.122.Final.jar
-    - netty-resolver-4.1.122.Final.jar
-    - netty-resolver-dns-4.1.122.Final.jar
-    - netty-transport-4.1.122.Final.jar
-    - netty-transport-classes-epoll-4.1.122.Final.jar
-    - netty-transport-native-epoll-4.1.122.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.122.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.122.Final.jar
+    - netty-buffer-4.1.124.Final.jar
+    - netty-codec-4.1.124.Final.jar
+    - netty-codec-dns-4.1.124.Final.jar
+    - netty-codec-http-4.1.124.Final.jar
+    - netty-codec-socks-4.1.124.Final.jar
+    - netty-codec-haproxy-4.1.124.Final.jar
+    - netty-common-4.1.124.Final.jar
+    - netty-handler-4.1.124.Final.jar
+    - netty-handler-proxy-4.1.124.Final.jar
+    - netty-resolver-4.1.124.Final.jar
+    - netty-resolver-dns-4.1.124.Final.jar
+    - netty-transport-4.1.124.Final.jar
+    - netty-transport-classes-epoll-4.1.124.Final.jar
+    - netty-transport-native-epoll-4.1.124.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.124.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.124.Final.jar
     - netty-tcnative-boringssl-static-2.0.72.Final.jar
     - netty-tcnative-boringssl-static-2.0.72.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.72.Final-linux-x86_64.jar
@@ -376,9 +376,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.122.Final.jar
-    - netty-resolver-dns-native-macos-4.1.122.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.122.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.124.Final.jar
+    - netty-resolver-dns-native-macos-4.1.124.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.124.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.122.Final</netty.version>
+    <netty.version>4.1.124.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>9.4.57.v20241219</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
### Motivation

Netty 4.1.124.Final contains a fix for moderate level CVE-2025-55163
- [Netty 4.1.124.Final release notes](https://netty.io/news/2025/08/13/4-1-124-Final.html)
- [Netty 4.1.123.Final release notes](https://netty.io/news/2025/07/16/4-1-123-Final.html)

### Modifications

- Upgrade Netty version to 4.1.124.Final

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->