### PR TITLE
[fix][broker] Remove consumer from cache if closed before creation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -49,6 +49,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class ConsumerClosedException extends BrokerServiceException {
+        public ConsumerClosedException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class ProducerBusyException extends BrokerServiceException {
         public ProducerBusyException(String msg) {
             super(msg);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -2236,6 +2236,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // create operation will complete, the new consumer will be discarded.
             log.info("[{}] Closed consumer before its creation was completed. consumerId={}",
                      remoteAddress, consumerId);
+            consumers.remove(consumerId, consumerFuture);
             commandSender.sendSuccessResponse(requestId);
             return;
         }
@@ -2243,6 +2244,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (consumerFuture.isCompletedExceptionally()) {
             log.info("[{}] Closed consumer that already failed to be created. consumerId={}",
                      remoteAddress, consumerId);
+            consumers.remove(consumerId, consumerFuture);
             commandSender.sendSuccessResponse(requestId);
             return;
         }


### PR DESCRIPTION
### Motivation

When a consumer sends a subscribe command and then immediately sends a close command while the subscription is still in progress, the broker logs messages like:
```
2025-08-15T14:42:52,889+0800 [pulsar-io-4-40] INFO  org.apache.pulsar.broker.service.ServerCnx - [/10.184.74.6:44058] Closing consumer: consumerId=13296
2025-08-15T14:42:52,889+0800 [pulsar-io-4-40] INFO  org.apache.pulsar.broker.service.ServerCnx - [/10.184.74.6:44058] Closed consumer before its creation was completed. consumerId=13296
2025-08-15T14:42:53,258+0800 [pulsar-io-4-40] WARN  org.apache.pulsar.broker.service.ServerCnx - [/10.184.74.6:44058][persistent://public/10000/__change_events-partition-0][multiTopicsReader-f3f7fd855d] A failed consumer with id is already present on the connection, consumerId=13296
```

This happens because the consumer remains in the connection's cache even after it is closed before the subscription is fully established. As a result, any new subscription attempt with the same consumer ID fails with `A failed consumer with id is already present on the connection.`

This regression was introduced by [#22283](https://github.com/apache/pulsar/pull/22283).

### Modifications

- Remove consumer from cache if closed before creation in the `handleCloseConsumer`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
