### PR TITLE
[fix][ws] Allow websocket principals to specify originalPrincipal without proxy role

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -489,7 +489,8 @@ public class AuthorizationService {
                 errorMsg = "originalPrincipal cannot be a proxy role.";
             }
         } else if (StringUtils.isNotBlank(originalPrincipal)
-                && !(allowNonProxyPrincipalsToBeEqual && originalPrincipal.equals(authenticatedPrincipal))) {
+                && !(allowNonProxyPrincipalsToBeEqual && originalPrincipal.equals(authenticatedPrincipal))
+                && !isWebsocketPrinciple(originalPrincipal)) {
             errorMsg = "cannot specify originalPrincipal when connecting without valid proxy role.";
         }
         if (errorMsg != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/NonProxyRoleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/NonProxyRoleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.proxy;
+
+import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
+import org.testng.annotations.Test;
+
+/**
+ * Tests WebSocket proxy authentication when the websocket server connects to the broker
+ * using admin token authentication instead of proxy role authentication.
+ */
+@Test(groups = "websocket")
+public class NonProxyRoleTest extends ProxyRoleAuthTest {
+
+    @Override
+    protected WebSocketProxyConfiguration getProxyConfig() {
+        WebSocketProxyConfiguration configuration = super.getProxyConfig();
+        // Configure proxy's internal client to use ADMIN_TOKEN when connecting to broker
+        configuration.setBrokerClientAuthenticationPlugin("org.apache.pulsar.client.impl.auth.AuthenticationToken");
+        configuration.setBrokerClientAuthenticationParameters("token:" + ADMIN_TOKEN);
+        return configuration;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyRoleAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyRoleAuthTest.java
@@ -77,7 +77,7 @@ public class ProxyRoleAuthTest extends ProducerConsumerBase {
     private static final String PROXY_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "websocket_proxy",
             Optional.empty());
     private static final String CLIENT_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "client", Optional.empty());
-    private static final String ADMIN_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "admin", Optional.empty());
+    protected static final String ADMIN_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "admin", Optional.empty());
     private static final String UNAUTHORIZED_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "unauthorized_user",
             Optional.empty());
 


### PR DESCRIPTION
## Summary
- Fixes authorization issue where websocket connections using admin token authentication were incorrectly rejected when specifying an originalPrincipal
- Adds support for websocket principals to use originalPrincipal without requiring proxy role authentication
- Includes comprehensive test coverage for the new behavior

## Changes
- Modified `AuthorizationService.java` to add websocket principal check in authorization logic
- Updated `ProxyRoleAuthTest.java` to make `ADMIN_TOKEN` accessible for test inheritance  
- Added `NonProxyRoleTest.java` to verify websocket proxy authentication without proxy role

## Test plan
- [x] Existing proxy role authentication tests continue to pass
- [x] New NonProxyRoleTest verifies websocket admin token authentication works correctly
- [x] Authorization logic properly handles websocket principals with originalPrincipal

## Document

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->