### PR TITLE
[improve][broker] add namespace topics limit metric

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopicMetrics;
 import org.apache.pulsar.broker.service.persistent.PersistentTopicMetrics.BacklogQuotaMetrics;
 import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusLabels;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentSubscriptionStatsImpl;
@@ -83,6 +84,7 @@ public class NamespaceStatsAggregator {
         Optional<CompactorMXBean> compactorMXBean = getCompactorMXBean(pulsar);
         LongAdder topicsCount = new LongAdder();
         Map<String, Long> localNamespaceTopicCount = new HashMap<>();
+        Map<String, Integer> localNamespaceTopicLimit = new HashMap<>();
         pulsar.getBrokerService().getMultiLayerTopicsMap().forEach((namespace, bundlesMap) -> {
             namespaceStats.reset();
             topicsCount.reset();
@@ -105,6 +107,10 @@ public class NamespaceStatsAggregator {
                 }
             }));
 
+            if (localNamespaceTopicLimit.containsKey(namespace)) {
+                localNamespaceTopicLimit.put(namespace, getNamespaceTopicLimit(pulsar, namespace));
+            }
+
             if (!includeTopicMetrics) {
                 // Only include namespace level stats if we don't have the per-topic, otherwise we're going to
                 // report the same data twice, and it will make the aggregation difficult
@@ -118,12 +124,27 @@ public class NamespaceStatsAggregator {
             printTopicsCountStats(stream, localNamespaceTopicCount, cluster);
         }
 
+        printNamespaceTopicLimitStats(stream, localNamespaceTopicLimit, cluster);
+
         printBrokerStats(stream, cluster, brokerStats);
     }
 
     private static Optional<CompactorMXBean> getCompactorMXBean(PulsarService pulsar) {
         Compactor compactor = pulsar.getNullableCompactor();
         return Optional.ofNullable(compactor).map(Compactor::getStats);
+    }
+
+    private static int getNamespaceTopicLimit(PulsarService pulsar, String namespace) {
+        try {
+            return pulsar.getPulsarResources().getNamespaceResources()
+                    .getPoliciesAsync(NamespaceName.get(namespace))
+                    .thenApply(optoptPolicies -> optoptPolicies.map(p -> p.max_topics_per_namespace)
+                            .orElse(pulsar.getConfig().getMaxTopicsPerNamespace()))
+                    .get();
+        } catch (Exception e) {
+            log.warn("Failed to get namespace policies for namespace {}", namespace, e);
+            return pulsar.getConfig().getMaxTopicsPerNamespace();
+        }
     }
 
     private static void aggregateTopicStats(TopicStats stats, SubscriptionStatsImpl subscriptionStats,
@@ -392,7 +413,18 @@ public class NamespaceStatsAggregator {
     private static void printTopicsCountStats(PrometheusMetricStreams stream, Map<String, Long> namespaceTopicsCount,
                                               String cluster) {
         namespaceTopicsCount.forEach(
-                (ns, topicCount) -> writeMetric(stream, "pulsar_topics_count", topicCount, cluster, ns)
+                (ns, topicCount) -> {
+                    writeMetric(stream, "pulsar_topics_count", topicCount, cluster, ns);
+                }
+        );
+    }
+
+    private static void printNamespaceTopicLimitStats(PrometheusMetricStreams stream,
+                                                      Map<String, Integer> namespaceTopicsLimit, String cluster) {
+        namespaceTopicsLimit.forEach(
+                (ns, maxTopicsLimit) -> {
+                    writeMetric(stream, "pulsar_namespace_max_topics_limit", maxTopicsLimit, cluster, ns);
+                }
         );
     }
 
@@ -580,7 +612,6 @@ public class NamespaceStatsAggregator {
         String[] labels = new String[]{"cluster", cluster, "namespace", namespace};
         stream.writeSample(metricName, value, labels);
     }
-
 
 
     private static void writeReplicationStat(PrometheusMetricStreams stream, String metricName,


### PR DESCRIPTION
### Motivation

We recently came with an issue where namespaces were reaching their limits, errors are lifted to producers and cannot be fixed by them (need either to delete topics or increase namespace limit). This PR creates a new metric to give topics limit for each namespace loaded in a broker. It will allow to correlate the current topic count (already existing metric) and the limit to determine the saturation of a namespace. 

### Modifications

* Implement metric `pulsar_namespace_max_topics_limit` (labels are cluster and namespace)

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
