### PR TITLE
[fix][broker]User topic failed to delete after removed cluster because of failed delete data from transaction buffer topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -410,6 +410,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         TopicName topicName = TopicName.get(topic);
         if (brokerService.getPulsar().getConfiguration().isTransactionCoordinatorEnabled()
                 && !isEventSystemTopic(topicName)
+                && !SystemTopicNames.isTransactionInternalName(topicName)
+                && !SystemTopicNames.isTransactionBufferOrPendingAckSystemTopicName(topicName)
                 && !NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())
                 && !ExtensibleLoadManagerImpl.isInternalTopic(topic)) {
             this.transactionBuffer = brokerService.getPulsar()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -75,6 +75,10 @@ public class SystemTopic extends PersistentTopic {
         if (SystemTopicNames.isTopicPoliciesSystemTopic(topic)) {
             return super.checkReplication();
         }
+        // Since the txn system topic is not allowed to access anymore, we should delete data.
+        if (SystemTopicNames.isTransactionBufferOrPendingAckSystemTopicName(TopicName.get(topic))) {
+            return super.removeTopicIfLocalClusterNotAllowed().thenAccept(__ -> {});
+        }
         return CompletableFuture.completedFuture(null);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
@@ -65,10 +65,7 @@ public class NamespaceEventsSystemTopicFactory {
                 pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topicName);
         CompletableFuture<Boolean> partition0Exists =
                 pulsar.getPulsarResources().getTopicResources().persistentTopicExists(topicName.getPartition(0));
-        return nonPartitionedExists.thenCombine(partition0Exists, (a, b) -> {
-            System.out.println("===> a: " + a + ", b: " + b);
-            return a | b;
-        });
+        return nonPartitionedExists.thenCombine(partition0Exists, (a, b) -> a | b);
     }
 
     public <T> TransactionBufferSnapshotBaseSystemTopicClient<T> createTransactionBufferSystemTopicClient(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -115,7 +115,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
         NamespaceName namespaceName = TopicName.get(topic.getName()).getNamespaceObject();
         PulsarService pulsar = topic.getBrokerService().getPulsar();
         return NamespaceEventsSystemTopicFactory.checkSystemTopicExists(
-                    namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT,pulsar)
+                    namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT, pulsar)
             .thenCompose(exists -> {
                 if (exists) {
                     return this.takeSnapshotWriter.getFuture().thenCompose(writer -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -25,12 +25,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.commons.collections4.map.LinkedMap;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.metadata.AbortTxnMetadata;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
 import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.events.EventType;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 
@@ -108,11 +112,20 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
 
     @Override
     public CompletableFuture<Void> clearAbortedTxnSnapshot() {
-        return this.takeSnapshotWriter.getFuture().thenCompose(writer -> {
-            TransactionBufferSnapshot snapshot = new TransactionBufferSnapshot();
-            snapshot.setTopicName(topic.getName());
-            return writer.deleteAsync(snapshot.getTopicName(), snapshot);
-        }).thenRun(() -> log.info("[{}] Successes to delete the aborted transaction snapshot", this.topic));
+        NamespaceName namespaceName = TopicName.get(topic.getName()).getNamespaceObject();
+        PulsarService pulsar = topic.getBrokerService().getPulsar();
+        return NamespaceEventsSystemTopicFactory.checkSystemTopicExists(
+                    namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT,pulsar)
+            .thenCompose(exists -> {
+                if (exists) {
+                    return this.takeSnapshotWriter.getFuture().thenCompose(writer -> {
+                        TransactionBufferSnapshot snapshot = new TransactionBufferSnapshot();
+                        snapshot.setTopicName(topic.getName());
+                        return writer.deleteAsync(snapshot.getTopicName(), snapshot);
+                    }).thenRun(() -> log.info("[{}] Successes to delete the aborted transaction snapshot", this.topic));
+                }
+                return CompletableFuture.completedFuture(null);
+            });
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -42,9 +42,11 @@ import org.apache.bookkeeper.mledger.ReadOnlyManagedLedger;
 import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService.ReferenceCountedWriter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
 import org.apache.pulsar.broker.systopic.SystemTopicClient;
 import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
 import org.apache.pulsar.broker.transaction.buffer.metadata.TransactionBufferSnapshot;
@@ -57,6 +59,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.events.EventType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -730,12 +733,28 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         }
 
         private CompletableFuture<Void> clearSnapshotSegmentAndIndexes() {
-            CompletableFuture<Void> res = persistentWorker.clearAllSnapshotSegments()
-                    .thenCompose((ignore) -> snapshotIndexWriter.getFuture()
-                            .thenCompose(indexesWriter -> indexesWriter.writeAsync(topic.getName(), null)))
-                    .thenRun(() ->
-                            log.debug("Successes to clear the snapshot segment and indexes for the topic [{}]",
-                                    topic.getName()));
+            NamespaceName namespaceName = TopicName.get(topic.getName()).getNamespaceObject();
+            PulsarService pulsar = topic.getBrokerService().getPulsar();
+            CompletableFuture<Void> deleteSegmentFuture = NamespaceEventsSystemTopicFactory.checkSystemTopicExists(
+                            namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS,pulsar)
+                    .thenCompose(exists -> {
+                        if (exists) {
+                            return persistentWorker.clearAllSnapshotSegments();
+                        }
+                        return CompletableFuture.completedFuture(null);
+                    });
+            CompletableFuture<Void> res = deleteSegmentFuture.thenCompose(ignore ->
+                    NamespaceEventsSystemTopicFactory.checkSystemTopicExists(
+                            namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT_INDEXES, pulsar)
+                    .thenCompose(exists -> {
+                        if (exists) {
+                            return snapshotIndexWriter.getFuture()
+                                .thenCompose(writer -> writer.writeAsync(topic.getName(), null))
+                                .thenRun(() -> log.debug("Successes to clear the snapshot segment and indexes for"
+                                        + " the topic [{}]", topic.getName()));
+                        }
+                        return CompletableFuture.completedFuture(null);
+                    }));
             res.exceptionally(e -> {
                 log.error("Failed to clear the snapshot segment and indexes for the topic [{}]",
                         topic.getName(), e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -736,7 +736,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
             NamespaceName namespaceName = TopicName.get(topic.getName()).getNamespaceObject();
             PulsarService pulsar = topic.getBrokerService().getPulsar();
             CompletableFuture<Void> deleteSegmentFuture = NamespaceEventsSystemTopicFactory.checkSystemTopicExists(
-                            namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS,pulsar)
+                            namespaceName, EventType.TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS, pulsar)
                     .thenCompose(exists -> {
                         if (exists) {
                             return persistentWorker.clearAllSnapshotSegments();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -43,6 +44,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -65,7 +68,14 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         super.cleanup();
     }
 
-    @Test(enabled = false)
+    protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
+                                     LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
+        super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
+        config.setTransactionCoordinatorEnabled(true);
+    }
+
+
+        @Test(enabled = false)
     public void testReplicatorProducerStatInTopic() throws Exception {
         super.testReplicatorProducerStatInTopic();
     }
@@ -484,7 +494,7 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         // The topics under the namespace of the cluster-1 will be deleted.
         // Verify the result.
         admin1.namespaces().setNamespaceReplicationClusters(ns1, new HashSet<>(Arrays.asList(cluster2)));
-        Awaitility.await().atMost(Duration.ofSeconds(60)).ignoreExceptions().untilAsserted(() -> {
+        Awaitility.await().atMost(Duration.ofSeconds(120)).ignoreExceptions().untilAsserted(() -> {
             Map<String, CompletableFuture<Optional<Topic>>> tps = pulsar1.getBrokerService().getTopics();
             assertFalse(tps.containsKey(topic));
             assertFalse(tps.containsKey(topicChangeEvents));

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/SystemTopicNames.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/SystemTopicNames.java
@@ -89,10 +89,21 @@ public class SystemTopicNames {
         return TopicName.getPartitionedTopicName(topic).getLocalName().equals(NAMESPACE_EVENTS_LOCAL_NAME);
     }
 
+    /**
+     * These topics can not be created manually by users.
+     */
     public static boolean isTransactionInternalName(TopicName topicName) {
         String topic = topicName.toString();
         return topic.startsWith(TRANSACTION_COORDINATOR_ASSIGN.toString())
                 || topic.startsWith(TRANSACTION_COORDINATOR_LOG.toString())
+                || topic.endsWith(PENDING_ACK_STORE_SUFFIX);
+    }
+
+    public static boolean isTransactionBufferOrPendingAckSystemTopicName(TopicName topicName) {
+        String topic = topicName.getPartitionedTopicName();
+        return topic.endsWith(TRANSACTION_BUFFER_SNAPSHOT.toString())
+                || topic.endsWith(TRANSACTION_BUFFER_SNAPSHOT_SEGMENTS.toString())
+                || topic.endsWith(TRANSACTION_BUFFER_SNAPSHOT_INDEXES)
                 || topic.endsWith(PENDING_ACK_STORE_SUFFIX);
     }
 


### PR DESCRIPTION
### Motivation

#### Background
- Users may start 2 clusters with the Geo-Replication feature with Global ZK
- Users want to hire one cluster, so remove the cluster from `namespace-level replicatedClusters`
  - Broker will remove the topics because the cluster was removed.
- Issue occurs:
  - User topics can not be deleted anymore, because the operation `delete data from transaction buffer` can not be executed successfully anymore, and will get an error "Namespace missing local cluster name in clusters list". Because the topic `__transaction_buffer_snapshot` can not be accessed anymore since the cluster was removed.
  - The task `topic.checkReplication` and other operations will retry again and again, as a result, the broker will crash of OOM  


### Modifications
- Do not create the transaction buffer component for transaction system topics.
- Remove the system topic `__transaction_buffer_snapshot` if it is not allowed to be accessed(removed current cluster from `allowed cluster`)
- Skip removing topic-level policies if the system topic `__transaction_buffer_snapshot` has been deleted.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
