### PR TITLE
[fix][sec] Upgrade bouncycastle bcpkix-fips version to 1.79 to address CVE-2025-8916

### DIFF
--- a/bouncy-castle/bc/LICENSE
+++ b/bouncy-castle/bc/LICENSE
@@ -205,5 +205,5 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.81.jar
     - org.bouncycastle-bcprov-jdk18on-1.78.1.jar

--- a/bouncy-castle/bc/pom.xml
+++ b/bouncy-castle/bc/pom.xml
@@ -42,13 +42,11 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
     </dependency>
   </dependencies>
 

--- a/bouncy-castle/bcfips/LICENSE
+++ b/bouncy-castle/bcfips/LICENSE
@@ -205,5 +205,5 @@
 This projects includes binary packages with the following licenses:
 Bouncy Castle License
  * Bouncy Castle -- licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-fips-1.0.1.jar
-    - org.bouncycastle-bc-fips-1.0.1.jar
+    - org.bouncycastle-bcpkix-fips-1.0.7.jar
+    - org.bouncycastle-bc-fips-1.0.2.6.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -619,9 +619,9 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.81.jar
     - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
-    - org.bouncycastle-bcutil-jdk18on-1.78.1.jar
+    - org.bouncycastle-bcutil-jdk18on-1.81.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -471,9 +471,9 @@ Creative Commons Attribution License
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.78.1.jar
+    - bcpkix-jdk18on-1.81.jar
     - bcprov-jdk18on-1.78.1.jar
-    - bcutil-jdk18on-1.78.1.jar
+    - bcutil-jdk18on-1.81.jar
 
 ------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,9 +196,12 @@ flexible messaging model and an intuitive client API.</description>
     <slf4j.version>2.0.13</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <bouncycastle.version>1.78.1</bouncycastle.version>
+    <!-- bouncycastle dependencies aren't necessarily aligned -->
+    <bouncycastle.bcprov-jdk18on.version>1.78.1</bouncycastle.bcprov-jdk18on.version>
+    <bouncycastle.bcpkix-jdk18on.version>1.81</bouncycastle.bcpkix-jdk18on.version>
+    <bouncycastle.bcprov-ext-jdk18on.version>1.78.1</bouncycastle.bcprov-ext-jdk18on.version>
     <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
-    <bouncycastle.bc-fips.version>1.0.2.5</bouncycastle.bc-fips.version>
+    <bouncycastle.bc-fips.version>1.0.2.6</bouncycastle.bc-fips.version>
     <jackson.version>2.17.2</jackson.version>
     <fastutil.version>8.5.14</fastutil.version>
     <reflections.version>0.10.2</reflections.version>
@@ -1012,13 +1015,19 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>${bouncycastle.version}</version>
+        <version>${bouncycastle.bcprov-jdk18on.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
-        <version>${bouncycastle.version}</version>
+        <version>${bouncycastle.bcpkix-jdk18on.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-ext-jdk18on</artifactId>
+        <version>${bouncycastle.bcprov-ext-jdk18on.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation & Modifications

Upgrade bouncycastle version to 1.79 to address CVE-2025-8916.

Since all bouncycastle libraries don't have aligned version numbers, the pom.xml has been modified so that different versions can be specified.

This CVE also applies to the `org.bouncycastle:bcpkix-fips` dependency, but there's no 1.0.8 version available yet. That will be upgraded in another PR when the fix is available.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->