### PR TITLE
[improve][io] Upgrade AWS SDK v1 & v2, Kinesis KPL and KPC versions

### DIFF
--- a/docker/kinesis-producer-alpine/Dockerfile
+++ b/docker/kinesis-producer-alpine/Dockerfile
@@ -23,7 +23,7 @@ ARG ALPINE_VERSION=3.21
 
 # Build stage
 FROM alpine:$ALPINE_VERSION AS kinesis-producer-build
-ENV KINESIS_PRODUCER_LIB_VERSION=0.15.12
+ENV KINESIS_PRODUCER_LIB_VERSION=1.0.4
 
 # Install build dependencies
 RUN apk update && apk add --no-cache \

--- a/docker/kinesis-producer-alpine/README.md
+++ b/docker/kinesis-producer-alpine/README.md
@@ -32,7 +32,7 @@ This image only needs to be re-created when we want to upgrade to a newer versio
 2. Rebuild the image and push it to Docker Hub:
 ```
 IMAGE=apachepulsar/pulsar-io-kinesis-sink-kinesis_producer
-KINESIS_PRODUCER_VERSION=0.15.12
+KINESIS_PRODUCER_VERSION=1.0.4
 docker buildx build --platform=linux/amd64,linux/arm64 \
  -t "$IMAGE:$KINESIS_PRODUCER_VERSION" -t "$IMAGE:${KINESIS_PRODUCER_VERSION}-$(date -I)" \
  . --push

--- a/docker/kinesis-producer-alpine/build-alpine.sh
+++ b/docker/kinesis-producer-alpine/build-alpine.sh
@@ -20,13 +20,25 @@
 
 set -e
 set -x
+SILENT="n"
+
+silence() {
+  if [ -n "$SILENT" ]; then
+    "$@" >/dev/null
+  else
+    "$@"
+  fi
+}
+
+BOOST_VERSION="1.88.0"
+BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.76.0 to 1_76_0
+PROTOBUF_VERSION="21.12"
+AWS_SDK_CPP_VERSION="1.11.615"
+
+LIB_BOOST="https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"
+LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz"
 
 INSTALL_DIR=/build/third_party
-AWS_SDK_CPP_VERSION="1.11.420"
-PROTOBUF_VERSION="3.11.4"
-BOOST_VERSION="1.76.0"
-BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}"
-
 # Create install directory
 mkdir -p $INSTALL_DIR
 
@@ -39,61 +51,67 @@ export LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH"
 
 cd $INSTALL_DIR
 
-# Build protobuf
-if [ ! -d "protobuf-${PROTOBUF_VERSION}" ]; then
-  curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz
-  tar xf protobuf-all-${PROTOBUF_VERSION}.tar.gz
-  rm protobuf-all-${PROTOBUF_VERSION}.tar.gz
+SED="sed -i"
+CMAKE=$(which cmake3 &>/dev/null && echo "cmake3 " || echo "cmake")
+function _curl {
+  curl -L "$@"
+}
 
-  cd protobuf-${PROTOBUF_VERSION}
-  ./configure --prefix=${INSTALL_DIR} \
-    --disable-shared \
-    CFLAGS="-fPIC" \
-    CXXFLAGS="-fPIC ${CXXFLAGS}" \
-    --with-pic
-  make -j4
-  make install
-  cd ..
-fi
+function conf {
+  silence ./configure \
+    --prefix="$INSTALL_DIR" \
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
+    LDFLAGS="$LDFLAGS" \
+    CXXFLAGS="$CXXFLAGS" \
+    C_INCLUDE_PATH="$C_INCLUDE_PATH" \
+    "$@"
+}
 
-# Build Boost
+# Boost C++ Libraries
 if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
-  curl -LO https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
-  tar xf boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
-  rm boost_${BOOST_VERSION_UNDERSCORED}.tar.gz
+  _curl "$LIB_BOOST" >boost.tgz
+  tar xf boost.tgz
+  rm boost.tgz
 
   cd boost_${BOOST_VERSION_UNDERSCORED}
 
-  BOOST_LIBS="regex,thread,log,system,random,filesystem,chrono,atomic,date_time,program_options,test"
+  LIBS="atomic,chrono,log,system,test,random,regex,thread,filesystem"
+  OPTS="-j 8 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
 
-  ./bootstrap.sh --with-libraries=$BOOST_LIBS --with-toolset=gcc
-
-  ./b2 \
-    -j4 \
-    variant=release \
-    link=static \
-    threading=multi \
-    runtime-link=static \
-    --prefix=${INSTALL_DIR} \
-    cxxflags="-fPIC ${CXXFLAGS}" \
-    install
+  silence ./bootstrap.sh --with-libraries="$LIBS" --with-toolset=gcc
+  silence ./b2 toolset=gcc $OPTS
 
   cd ..
 fi
 
-# Download and build AWS SDK
+# Google Protocol Buffers
+if [ ! -d "protobuf-${PROTOBUF_VERSION}" ]; then
+  _curl "$LIB_PROTOBUF" >protobuf.tgz
+  tar xf protobuf.tgz
+  rm protobuf.tgz
+
+  cd protobuf-${PROTOBUF_VERSION}
+  silence conf --enable-shared=no
+  silence make -j 4
+  silence make install
+
+  cd ..
+fi
+
+# AWS C++ SDK
 if [ ! -d "aws-sdk-cpp" ]; then
-  git clone --depth 1 --branch ${AWS_SDK_CPP_VERSION} https://github.com/awslabs/aws-sdk-cpp.git aws-sdk-cpp
+  git clone https://github.com/awslabs/aws-sdk-cpp.git aws-sdk-cpp
   pushd aws-sdk-cpp
-  git config submodule.fetchJobs 8
-  git submodule update --init --depth 1 --recursive
+  git checkout ${AWS_SDK_CPP_VERSION}
+  git submodule update --init --recursive
   popd
 
   rm -rf aws-sdk-cpp-build
   mkdir aws-sdk-cpp-build
+
   cd aws-sdk-cpp-build
 
-  cmake \
+  silence $CMAKE \
     -DBUILD_ONLY="kinesis;monitoring;sts" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DSTATIC_LINKING=1 \
@@ -105,16 +123,20 @@ if [ ! -d "aws-sdk-cpp" ]; then
     -DCMAKE_FIND_FRAMEWORK=LAST \
     -DENABLE_TESTING="OFF" \
     ../aws-sdk-cpp
-  make -j4
-  make install
+  silence make -j8
+  silence make install
+
   cd ..
+
 fi
+
+cd ..
 
 # Build the native kinesis producer
 cd /build/amazon-kinesis-producer
 ln -fs ../third_party
-cmake -DCMAKE_PREFIX_PATH="$INSTALL_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
-make -j4
+$CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+make -j8
 
 FINAL_DIR=/opt/amazon-kinesis-producer
 # copy the binary

--- a/docker/kinesis-producer-alpine/build-alpine.sh
+++ b/docker/kinesis-producer-alpine/build-alpine.sh
@@ -76,7 +76,7 @@ if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
   cd boost_${BOOST_VERSION_UNDERSCORED}
 
   LIBS="atomic,chrono,log,system,test,random,regex,thread,filesystem"
-  OPTS="-j 4 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
+  OPTS="--build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
 
   silence ./bootstrap.sh --with-libraries="$LIBS" --with-toolset=gcc
   silence ./b2 toolset=gcc $OPTS

--- a/docker/kinesis-producer-alpine/build-alpine.sh
+++ b/docker/kinesis-producer-alpine/build-alpine.sh
@@ -76,7 +76,7 @@ if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
   cd boost_${BOOST_VERSION_UNDERSCORED}
 
   LIBS="atomic,chrono,log,system,test,random,regex,thread,filesystem"
-  OPTS="-j 8 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
+  OPTS="-j 4 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
 
   silence ./bootstrap.sh --with-libraries="$LIBS" --with-toolset=gcc
   silence ./b2 toolset=gcc $OPTS
@@ -123,7 +123,7 @@ if [ ! -d "aws-sdk-cpp" ]; then
     -DCMAKE_FIND_FRAMEWORK=LAST \
     -DENABLE_TESTING="OFF" \
     ../aws-sdk-cpp
-  silence make -j8
+  silence make -j4
   silence make install
 
   cd ..
@@ -136,7 +136,7 @@ cd ..
 cd /build/amazon-kinesis-producer
 ln -fs ../third_party
 $CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
-make -j8
+make -j4
 
 FINAL_DIR=/opt/amazon-kinesis-producer
 # copy the binary

--- a/docker/kinesis-producer-alpine/kinesis_producer_alpine.patch
+++ b/docker/kinesis-producer-alpine/kinesis_producer_alpine.patch
@@ -1,10 +1,9 @@
-From 96ba2eb7145363586529e6c770dcc0920bf04ac2 Mon Sep 17 00:00:00 2001
+From 76518befa2b3b79931044267722feecfe1465d19 Mon Sep 17 00:00:00 2001
 From: Lari Hotari <lhotari@users.noreply.github.com>
-Date: Wed, 18 Dec 2024 17:16:02 +0200
-Subject: [PATCH] Adapt build for Alpine, fix issue with NULL_BACKTRACE support
+Date: Fri, 22 Aug 2025 21:25:49 +0300
+Subject: [PATCH] [PATCH] Adapt build for Alpine, fix issue with NULL_BACKTRACE
+ support
 
-- also use dynamic linking to some libraries (zlib, openssl, libz, libcurl, libcrypto)
-  to reduce binary size
 ---
  CMakeLists.txt                        | 20 +++++++++++---------
  aws/utils/backtrace/bsd_backtrace.cc  |  2 +-
@@ -14,18 +13,24 @@ Subject: [PATCH] Adapt build for Alpine, fix issue with NULL_BACKTRACE support
  5 files changed, 15 insertions(+), 16 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2dd7084..2ba47e6 100644
+index 8803f5c..6152b3d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -213,22 +213,24 @@ set(STATIC_LIBS
-         boost_chrono)
+@@ -213,8 +213,10 @@ set(STATIC_LIBS
  
+ find_package(Protobuf REQUIRED)
  find_package(Threads)
 -find_package(ZLIB)
 +find_package(ZLIB REQUIRED)
  find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring sts)
 +find_package(OpenSSL REQUIRED)
 +find_package(CURL REQUIRED)
+ 
+ # Specify the output directory for generated protobuf files
+ set(PROTO_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aws/kinesis/protobuf/)
+@@ -239,19 +241,19 @@ foreach(proto ${PROTO_FILES})
+     )
+ endforeach()
  
 -add_library(LibCrypto STATIC IMPORTED)
 -set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcrypto.a)
@@ -123,5 +128,5 @@ index b58ab0e..f483c77 100644
  #include <cstring>
  #include <cstdint>
 -- 
-2.47.1
+2.51.0
 

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -82,7 +82,7 @@
       <!-- include the docker image only when docker profile is active -->
       <properties>
         <!-- reference to the image built from docker/kinesis-producer-alpine/Dockerfile -->
-        <PULSAR_IO_KINESIS_KPL_IMAGE>apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:0.15.12</PULSAR_IO_KINESIS_KPL_IMAGE>
+        <PULSAR_IO_KINESIS_KPL_IMAGE>apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:1.0.4</PULSAR_IO_KINESIS_KPL_IMAGE>
       </properties>
       <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@ flexible messaging model and an intuitive client API.</description>
     <kafka-client.version>3.9.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.638</aws-sdk.version>
+    <aws-sdk2.version>2.32.28</aws-sdk2.version>
     <avro.version>1.12.0</avro.version>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
@@ -1358,6 +1359,14 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
         <version>${aws-sdk.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws-sdk2.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@ flexible messaging model and an intuitive client API.</description>
     <aerospike-client.version>4.5.0</aerospike-client.version>
     <kafka-client.version>3.9.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
-    <aws-sdk.version>1.12.638</aws-sdk.version>
+    <aws-sdk.version>1.12.788</aws-sdk.version>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
     <avro.version>1.12.0</avro.version>
     <joda.version>2.10.10</joda.version>

--- a/pulsar-io/aws/pom.xml
+++ b/pulsar-io/aws/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.10.56</version>
     </dependency>
 	<!-- /aws dependencies -->
 

--- a/pulsar-io/kinesis-kpl-shaded/pom.xml
+++ b/pulsar-io/kinesis-kpl-shaded/pom.xml
@@ -1,0 +1,149 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pulsar</groupId>
+    <artifactId>pulsar</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>pulsar-io-kinesis-kpl-shaded</artifactId>
+  <name>Pulsar IO :: Kinesis KPL Shaded</name>
+
+  <!--
+  There's a need to shade the protobuf-java dependency in the AWS Kinesis Producer Library (KPL)
+  since it conflicts at runtime with Pulsar Functions GRPC protobuf-java version.
+  -->
+
+  <properties>
+    <amazon-kinesis-producer.version>1.0.4</amazon-kinesis-producer.version>
+    <protobuf-java.version>4.29.0</protobuf-java.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- enforce protobuf-java version that is compatible with KPL 1.0.x -->
+      <!-- see https://github.com/awslabs/amazon-kinesis-producer/blob/v1.0.4/java/amazon-kinesis-producer/pom.xml#L20 -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf-java.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>software.amazon.kinesis</groupId>
+      <artifactId>amazon-kinesis-producer</artifactId>
+      <version>${amazon-kinesis-producer.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>${project.artifactId}-${project.version}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-shade-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                  <type>jar</type>
+                  <classifier>shaded</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <minimizeJar>false</minimizeJar>
+              <artifactSet>
+                <includes>
+                  <include>software.amazon.kinesis:amazon-kinesis-producer</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                </includes>
+                <excludes>
+                  <!-- This is required for execute shade multiple times without clean -->
+                  <exclude>org.apache.pulsar:pulsar-io-kinesis-kpl-shaded</exclude>
+                </excludes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>org.apache.pulsar.io.kinesis.shaded.com.google.protobuf</shadedPattern>
+                </relocation>
+              </relocations>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/maven/${project.groupId}/${project.artifactId}/pom.xml</resource>
+                  <file>${project.basedir}/dependency-reduced-pom.xml</file>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -32,8 +32,6 @@
 
   <properties>
     <amazon-kinesis-client.version>3.1.2</amazon-kinesis-client.version>
-    <amazon-kinesis-producer.version>1.0.4</amazon-kinesis-producer.version>
-    <protobuf-java.version>4.29.0</protobuf-java.version>
     <json-flattener.version>0.13.0</json-flattener.version>
     <flatbuffers-java.version>1.9.0</flatbuffers-java.version>
     <jaxb-api.version>2.3.0</jaxb-api.version>
@@ -47,19 +45,16 @@
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-client.version}</version>
       </dependency>
-      <!-- enforce protobuf-java version that is compatible with KPL 1.0.x -->
-      <!-- see https://github.com/awslabs/amazon-kinesis-producer/blob/v1.0.4/java/amazon-kinesis-producer/pom.xml#L20 -->
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-bom</artifactId>
-        <version>${protobuf-java.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-io-kinesis-kpl-shaded</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-io-common</artifactId>
@@ -107,11 +102,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
@@ -146,11 +136,6 @@
       <version>${amazon-kinesis-client.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>software.amazon.kinesis</groupId>
-      <artifactId>amazon-kinesis-producer</artifactId>
-      <version>${amazon-kinesis-producer.version}</version>
-    </dependency>
     <!-- /kinesis dependencies -->
 
     <dependency>
@@ -191,6 +176,11 @@
       <plugin>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/amazon-kinesis-producer-*.jar</exclude>
+          </excludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <amazon-kinesis-client.version>2.2.8</amazon-kinesis-client.version>
-    <amazon-kinesis-producer.version>0.15.12</amazon-kinesis-producer.version>
+    <amazon-kinesis-producer.version>1.0.4</amazon-kinesis-producer.version>
     <json-flattener.version>0.13.0</json-flattener.version>
     <flatbuffers-java.version>1.9.0</flatbuffers-java.version>
     <jaxb-api.version>2.3.0</jaxb-api.version>
@@ -133,7 +133,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.amazonaws</groupId>
+      <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
       <version>${amazon-kinesis-producer.version}</version>
     </dependency>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pulsar</groupId>
@@ -31,8 +31,9 @@
   <name>Pulsar IO :: Kinesis</name>
 
   <properties>
-    <amazon-kinesis-client.version>2.2.8</amazon-kinesis-client.version>
+    <amazon-kinesis-client.version>3.1.2</amazon-kinesis-client.version>
     <amazon-kinesis-producer.version>1.0.4</amazon-kinesis-producer.version>
+    <protobuf-java.version>4.29.0</protobuf-java.version>
     <json-flattener.version>0.13.0</json-flattener.version>
     <flatbuffers-java.version>1.9.0</flatbuffers-java.version>
     <jaxb-api.version>2.3.0</jaxb-api.version>
@@ -45,6 +46,15 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-client.version}</version>
+      </dependency>
+      <!-- enforce protobuf-java version that is compatible with KPL 1.0.x -->
+      <!-- see https://github.com/awslabs/amazon-kinesis-producer/blob/v1.0.4/java/amazon-kinesis-producer/pom.xml#L20 -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf-java.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -97,6 +107,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
@@ -123,7 +138,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.22.12</version>
     </dependency>
 
     <dependency>
@@ -137,7 +151,7 @@
       <artifactId>amazon-kinesis-producer</artifactId>
       <version>${amazon-kinesis-producer.version}</version>
     </dependency>
-	<!-- /kinesis dependencies -->
+    <!-- /kinesis dependencies -->
 
     <dependency>
       <groupId>com.google.flatbuffers</groupId>

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -22,11 +22,6 @@ import static com.google.common.util.concurrent.Futures.addCallback;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration.ThreadingModel;
-import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,6 +51,12 @@ import org.apache.pulsar.io.core.annotations.IOType;
 import org.apache.pulsar.io.kinesis.KinesisSinkConfig.MessageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration.ThreadingModel;
+import software.amazon.kinesis.producer.UserRecordFailedException;
+import software.amazon.kinesis.producer.UserRecordResult;
 
 /**
  * A Kinesis sink which can be configured by {@link KinesisSinkConfig}.
@@ -191,10 +192,10 @@ public class KinesisSink extends AbstractAwsConnector implements Sink<GenericObj
                 && kinesisSinkConfig.getSkipCertificateValidation()) {
             kinesisConfig.setVerifyCertificate(false);
         }
-        AWSCredentialsProvider credentialsProvider = createCredentialProvider(
+        AwsCredentialsProvider credentialsProvider = createCredentialProvider(
                 kinesisSinkConfig.getAwsCredentialPluginName(),
                 kinesisSinkConfig.getAwsCredentialPluginParam())
-            .getCredentialProvider();
+            .getV2CredentialsProvider();
         kinesisConfig.setCredentialsProvider(credentialsProvider);
         kinesisConfig.setNativeExecutable(StringUtils.trimToEmpty(kinesisSinkConfig.getNativeExecutable()));
         kinesisConfig.setAggregationEnabled(kinesisSinkConfig.isAggregationEnabled());

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.io.kinesis;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.Serializable;
@@ -31,6 +30,7 @@ import lombok.EqualsAndHashCode;
 import org.apache.pulsar.io.common.IOConfigUtils;
 import org.apache.pulsar.io.core.SinkContext;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -245,7 +245,7 @@ public class KinesisSinkConfig extends BaseKinesisConfig implements Serializable
 
     @FieldDoc(
             defaultValue = "",
-            help = "Extra KinesisProducerConfiguration parameters. See https://javadoc.io/static/com.amazonaws/amazon-kinesis-producer/0.15.2/index.html?com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.html for all the available parameters."
+            help = "Extra KinesisProducerConfiguration parameters. See https://javadoc.io/static/software.amazon.kinesis/amazon-kinesis-producer/1.0.4/software/amazon/kinesis/producer/KinesisProducerConfiguration.html for all the available parameters."
                     + "Parameters that are explicitly set take preference over extra config.")
     private Map<String, String> extraKinesisProducerConfig = new HashMap<>();
 

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkConfigTest.java
@@ -20,13 +20,13 @@ package org.apache.pulsar.io.kinesis;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.io.core.SinkContext;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
 
 public class KinesisSinkConfigTest {
 

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -56,6 +56,7 @@
         <module>kafka</module>
         <module>rabbitmq</module>
         <module>kinesis</module>
+        <module>kinesis-kpl-shaded</module>
         <module>hdfs3</module>
         <module>jdbc</module>
         <module>data-generator</module>
@@ -93,6 +94,7 @@
         <module>http</module>
         <module>rabbitmq</module>
         <module>kinesis</module>
+        <module>kinesis-kpl-shaded</module>
         <module>hdfs3</module>
         <module>jdbc</module>
         <module>data-generator</module>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-client</artifactId>
-      <version>2.2.8</version>
+      <version>3.1.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Motivation

[AWS Blog: Announcing end-of-support for Amazon Kinesis Client Library 1.x and Amazon Kinesis Producer Library 0.x effective January 30, 2026](https://aws.amazon.com/blogs/big-data/announcing-end-of-support-for-amazon-kinesis-client-library-1-x-and-amazon-kinesis-producer-library-0-x-effective-january-30-2026/)

### Modifications

* Upgrade AWS Kinesis Producer Library to 1.0.4 version 
* Upgrade AWS Kinesis Consumer Library to 3.1.2 version
* Resolve AWS SDK v2 library version conflicts that emerged after KPL 1.0.4 upgrade by aligning all versions with AWS SDK v2 bom. Set the version to latest 2.32.28
* For consistency, upgrade AWS SDK v1 library version to latest 1.12.788
* Shade AWS Kinesis Producer Library's Java library partially since it depends on protobuf-java 4.29.0 which is incompatible with Pulsar Functions instance protobuf-java version that is used in grpc communications.
  * Classloaders aren't isolated and without shading protobuf-java 4.29.0, there isn't a way to get the AWS 1.0.4 KPL Java library to work.
* Upgrade AWS Kinesis Producer Library native library build for Alpine
  * Library will be pushed [to Docker Hub](https://hub.docker.com/r/apachepulsar/pulsar-io-kinesis-sink-kinesis_producer/tags) at `apachepulsar/pulsar-io-kinesis-sink-kinesis_producer:1.0.4`
  * The KPL binary in the docker image is used in [pulsar-all docker image builds](https://github.com/apache/pulsar/blob/f2709bc823c7d048065dfb3d2845e47bcb0e3e0f/docker/pulsar-all/Dockerfile#L37-L41)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->