### PR TITLE
[fix][client] fix ArrayIndexOutOfBoundsException in SameAuthParamsLookupAutoClusterFailover

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -113,7 +113,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         });
         Assert.assertTrue(checkStatesFuture1.join());
 
-        // Test failover 0 --> 3.
+        // Test failover 0 --> 2.
         pulsar1.close();
         Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
             CompletableFuture<Boolean> checkStatesFuture2 = new CompletableFuture<>();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -133,7 +133,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
     }
 
     private int findFailoverTo() {
-        for (int i = currentPulsarServiceIndex + 1; i <= pulsarServiceUrlArray.length; i++) {
+        for (int i = currentPulsarServiceIndex + 1; i < pulsarServiceUrlArray.length; i++) {
             if (probeAvailable(i)) {
                 return i;
             }


### PR DESCRIPTION
Fixes #24526

### Motivation

As reported in issue #24526, this is a flaky test caused by an array index out of bounds exception in findFailoverTo(), which leads to the failover logic failing. As a result, the test conditions can never be met, eventually causing a timeout.

### Modifications

- Fixed the array index out of bounds issue in SameAuthParamsLookupAutoClusterFailover.findFailoverTo() .
- Corrected the comment for SameAuthParamsLookupAutoClusterFailoverTest.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
