### PR TITLE
[improve][build] Increase maven resolver's sync context timeout

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Xss1500k
+-Xss1500k -Daether.syncContext.named.time=300


### PR DESCRIPTION
### Motivation

During CI builds, especially when building Docker images or specific modules, Maven occasionally fails with:
```
Error:  Could not acquire lock(s)
Error:  java.lang.IllegalStateException: Could not acquire lock(s)
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error: Process completed with exit code 1.
```

This occurs even in concurrent(`-T 1C`) builds because Maven's default lock wait time (30 seconds) can be insufficient in some CI environments. Increasing the lock wait time prevents these intermittent failures.

### Modifications

- Added the JVM option `-Daether.syncContext.named.time=300` to increase the maximum lock wait time to 5 minutes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->