### PR TITLE
[fix][ci] Fix "Could not acquire lock(s)" error in MacOS build in CI

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -1438,9 +1438,16 @@ jobs:
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
-
       - name: build package
-        run: mvn -B clean package -DskipTests -T 1C -ntp
+        run: |
+          # needs workaround for https://issues.apache.org/jira/browse/MNG-7868
+          # https://github.com/apache/maven/issues/9049
+          mvn -Daether.connector.basic.threads=8 \
+              -Daether.metadataResolver.threads=8 \
+              -Daether.syncContext.named.time=120 \
+              -Daether.syncContext.named.factory=file-lock \
+              -Daether.syncContext.named.nameMapper=file-gav \
+              -B clean package -DskipTests -T 1C -ntp
 
   codeql:
     name: Run CodeQL Analysis


### PR DESCRIPTION
### Motivation

Sometimes the MacOS build in CI will fail multiple times in a row.
```
Error:  Could not acquire lock(s)
Error:  java.lang.IllegalStateException: Could not acquire lock(s)
```
(example in https://github.com/apache/pulsar/actions/runs/17216365004/job/48853507321#step:6:9028)

### Modifications

It appears that this is a Maven bug, https://github.com/apache/maven/issues/9049.
One of the workaround documented in this comment: https://github.com/apache/maven/issues/9049#issuecomment-3043838144 . This workaround is added to the Pulsar CI build.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->