### PR TITLE
[improve][build] Use org.apache.nifi:nifi-nar-maven-plugin:2.1.0 with skipDocGeneration=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2972,6 +2972,46 @@ flexible messaging model and an intuitive client API.</description>
     </profile>
 
     <profile>
+      <id>jdk21</id>
+      <activation>
+        <jdk>21</jdk>
+      </activation>
+      <properties>
+        <!-- nifi-nar-maven-plugin >= 2.0.0 require Java 21+ -->
+        <nifi-nar-maven-plugin.version>2.1.0</nifi-nar-maven-plugin.version>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.nifi</groupId>
+              <artifactId>nifi-nar-maven-plugin</artifactId>
+              <version>${nifi-nar-maven-plugin.version}</version>
+              <extensions>true</extensions>
+              <configuration>
+                <!--
+                skips nifi nar specific doc generation which isn't used for Pulsar nar files
+                see https://github.com/apache/nifi-maven/pull/35
+                -->
+                <skipDocGeneration>true</skipDocGeneration>
+                <finalName>${project.artifactId}-${project.version}</finalName>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>default-nar</id>
+                  <phase>${narPluginPhase}</phase>
+                  <goals>
+                    <goal>nar</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
       <id>jdk24</id>
       <activation>
         <jdk>24</jdk>


### PR DESCRIPTION
### Motivation

The nifi-nar-maven-plugin will generate NiFi specific documentation when the NAR file is created. Pulsar doesn't use this documentation and it's a waste of resources to attempt to generate the documentation which is a heavy classloading and scanning process.

Since org.apache.nifi:nifi-nar-maven-plugin:2.0.0, it has been possible to skip the documentation generation, thanks to @nicoloboschi's PR https://github.com/apache/nifi-maven/pull/35. The challenge with nifi-nar-maven-plugin 2.0.0+ version is that it requires Java 21+. This PR solves that challenge.

### Modifications

- Configure the build to use org.apache.nifi:nifi-nar-maven-plugin:2.1.0 with skipDocGeneration=true when the build JVM is Java 21+

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->