### PR TITLE
fix: add missing managedLedgerForceRecovery broker configuration field

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1360,6 +1360,10 @@ managedLedgerInfoCompressionThresholdInBytes=16384
 # corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 autoSkipNonRecoverableData=false
 
+# Whether to allow brokers to forcefully load topics by skipping ledger failures to avoid topic unavailability and 
+# perform auto repairs of the topics.
+managedLedgerForceRecovery=false
+
 # Whether to recover cursors lazily when trying to recover a managed ledger backing a persistent topic.
 # It can improve write availability of topics.
 # The caveat is now when recovered ledger is ready to write we're not sure if all old consumers last mark


### PR DESCRIPTION
Main Issue: #21759

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #21752 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

`managedLedgerForceRecovery` is a broker configuration field, that can be set dynamically but it is missing when we want it to be set statically through broker configuration and applied when the application/container starts.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
