### PR TITLE
[improve][pip] PIP-438: add namespace topics limit metric

### DIFF
--- a/pip/pip-438.md
+++ b/pip/pip-438.md
@@ -67,5 +67,5 @@ No impact on geo-replication. Clusters can be upgraded independently.
 
 # Links
 
-* Mailing List discussion thread: [To be updated]
+* Mailing List discussion thread: https://lists.apache.org/thread/c3r2v2bhmtf82b0h1ff2pqc8wnosp7b8
 * Mailing List voting thread: [To be updated]

--- a/pip/pip-438.md
+++ b/pip/pip-438.md
@@ -1,0 +1,71 @@
+# PIP-437: Add namespace topics limit metric
+
+# Background knowledge
+
+Pulsar namespaces can be configured with a maximum number of topics. When this limit is reached, producers fail to create new topics. Currently, operators lack visibility into namespace topic limits through metrics.
+
+# Motivation
+
+Operators cannot proactively monitor namespace capacity because there's no metric exposing the configured topic limit. This leads to reactive troubleshooting when producers start failing.
+
+# Goals
+
+## In Scope
+
+- Add `pulsar_namespace_max_topics_limit` metric exposing the configured maximum topics limit for each namespace
+- Include cluster and namespace labels for correlation with existing topic count metrics
+
+## Out of Scope
+
+# High Level Design
+
+Add a new gauge metric that exposes the configured maximum topics limit for each namespace. It will be calculated on
+each export of metrics.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+- Create method `getNamespaceTopicLimit` method in `NamespaceStatsAggregator`, fetching from namespace policies their 
+  max topics limit, falling back to the default value set in the broker configuration
+- Create method `printNamespaceTopicLimitStats` in `NamespaceStatsAggregator` to print the configured limit for each
+  namespace
+
+## Public-facing Changes
+
+- **Metric name**: `pulsar_namespace_max_topics_limit`
+- **Description**: Maximum number of topics allowed in the namespace
+- **Labels**: `cluster` (cluster name), `namespace` 
+- **Type**: Gauge
+
+# Monitoring
+
+Enables namespace saturation monitoring by comparing with existing topic count metrics:
+- Saturation: `(pulsar_topics_count / pulsar_namespace_max_topics_limit) * 100`
+
+# Security Considerations
+
+No new security concerns. Exposes configuration data already accessible via admin API to authorized users.
+
+# Backward & Forward Compatibility
+
+## Upgrade
+No special steps required. Metric available immediately after upgrade.
+
+## Downgrade / Rollback
+No issues. Metric simply disappears on rollback.
+
+## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
+
+No impact on geo-replication. Clusters can be upgraded independently.
+
+# Alternatives
+
+1. **Enhance existing metrics**: Rejected to avoid breaking existing monitoring
+2. **Admin API only**: Rejected due to poor integration with monitoring workflows
+
+
+# Links
+
+* Mailing List discussion thread: [To be updated]
+* Mailing List voting thread: [To be updated]


### PR DESCRIPTION
### Motivation

We recently came with an issue where namespaces were reaching their limits, errors are lifted to producers and cannot be fixed by them (need either to delete topics or increase namespace limit). This PR creates a new metric to give topics limit for each namespace loaded in a broker. It will allow to correlate the current topic count (already existing metric) and the limit to determine the saturation of a namespace.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository
