### PR TITLE
[fix][broker]Fix flaky test PartitionCreationTest.testCreateMissedPartitions

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
@@ -135,15 +135,9 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         // simulate partitioned topic without partitions
         pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
                 .createPartitionedTopicAsync(TopicName.get(topic),
-                new PartitionedTopicMetadata(numPartitions));
-        Consumer<byte[]> consumer = null;
-        try {
-            consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1")
-                    .subscribeAsync().get(3, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            //ok here, consumer will create failed with 'Topic does not exist'
-        }
-        Assert.assertNull(consumer);
+                new PartitionedTopicMetadata(numPartitions)).join();
+        Assert.assertEquals(admin.topics().getList("public/default").stream()
+            .filter(tp -> TopicName.get(topic).getPartitionedTopicName().endsWith(topic)).toList().size(), 0);
         if (useRestApi) {
             admin.topics().createMissedPartitions(topic);
         } else {
@@ -152,7 +146,7 @@ public class PartitionCreationTest extends ProducerConsumerBase {
                 admin.topics().createNonPartitionedTopic(topicName.getPartition(i).toString());
             }
         }
-        consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe();
         Assert.assertNotNull(consumer);
         Assert.assertTrue(consumer instanceof MultiTopicsConsumerImpl);
         Assert.assertEquals(((MultiTopicsConsumerImpl) consumer).getConsumers().size(), 3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.common.naming.TopicDomain;


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/24651 changed the behaviour, which allows creating partitions if the partitioned topic metadata exists. Then the test `PartitionCreationTest.testCreateMissedPartitions` is not suitable anymore.

It can pass when merging #24651 because the test has another issue: it calls `createPartitionedTopicAsync`, but never waits for it to be finished, which leads to the next check passing because the creation may not have completed.

### Modifications

Improve the test

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
