### PR TITLE
[fix][broker][branch-4.0]Can not access topic policies if topic partitions have not been created

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -761,7 +761,8 @@ public abstract class AdminResource extends PulsarWebResource {
                     if (persistentResourceCreated) {
                         return CompletableFuture.completedFuture(true);
                     }
-                    return getPartitionedTopicMetadataAsync(TopicName.get(topicName.getPartitionedTopicName()), true, false).thenApply(metadata -> {
+                    return getPartitionedTopicMetadataAsync(TopicName.get(topicName.getPartitionedTopicName()), true,
+                            false).thenApply(metadata -> {
                         return metadata.partitions > topicName.getPartitionIndex();
                     });
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -761,10 +761,14 @@ public abstract class AdminResource extends PulsarWebResource {
                     if (persistentResourceCreated) {
                         return CompletableFuture.completedFuture(true);
                     }
-                    return getPartitionedTopicMetadataAsync(TopicName.get(topicName.getPartitionedTopicName()), true,
-                            false).thenApply(metadata -> {
-                        return metadata.partitions > topicName.getPartitionIndex();
-                    });
+                    return pulsar().getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                        .getPartitionedTopicMetadataAsync(TopicName.get(topicName.getPartitionedTopicName()), false)
+                        .thenApply(optMetadata -> {
+                            if (optMetadata.isEmpty()) {
+                                return false;
+                            }
+                            return optMetadata.get().partitions > topicName.getPartitionIndex();
+                        });
                 });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1538,6 +1538,20 @@ public class ReplicatorTest extends ReplicatorTestBase {
         for (int i = 0; i < numPartitions; i++) {
             expectedTopicList.add(pt.getPartition(i).toString());
         }
+        PersistentTopic partition0 = (PersistentTopic) pulsar1.getBrokerService()
+                .getTopic(TopicName.get(persistentPartitionedTopic).getPartition(0).toString(), false)
+                .join().get();
+        PersistentTopic partition1 = (PersistentTopic) pulsar1.getBrokerService()
+                .getTopic(TopicName.get(persistentPartitionedTopic).getPartition(1).toString(), false)
+                .join().get();
+        PersistentTopic partition2 = (PersistentTopic) pulsar1.getBrokerService()
+                .getTopic(TopicName.get(persistentPartitionedTopic).getPartition(2).toString(), false)
+                .join().get();
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(partition0.getReplicators().size() >= 2);
+            assertTrue(partition1.getReplicators().size() >= 2);
+            assertTrue(partition2.getReplicators().size() >= 2);
+        });
 
         checkListContainExpectedTopic(admin1, namespace, expectedTopicList);
         checkListContainExpectedTopic(admin2, namespace, expectedTopicList);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionCreationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -100,6 +101,20 @@ public class PartitionCreationTest extends ProducerConsumerBase {
         final String topic = domain.value() + "://public/default/"
                 + "testCreateConsumerForNonPartitionedTopicWhenEnableTopicAutoCreation";
         Assert.assertNotNull(pulsarClient.newConsumer().topic(topic).subscriptionName("sub-1").subscribe());
+    }
+
+    @Test
+    public void testGetPoliciesIfPartitionsNotCreated() throws Exception {
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/tp");
+        int numPartitions = 3;
+        // simulate partitioned topic without partitions
+        pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+                .createPartitionedTopicAsync(TopicName.get(topic),
+                        new PartitionedTopicMetadata(numPartitions)).join();
+        // Verify: the command will not get an topic not found error.
+        admin.topics().getReplicationClusters(topic, true);
+        // cleanup.
+        admin.topics().deletePartitionedTopic(topic);
     }
 
     @Test(timeOut = 60000)


### PR DESCRIPTION
### Motivation

To reproduce the issue:
- Create a partitioned topic with 2 partitions
- All partitions are deleted because the feature `brokerDeleteInactiveTopicsEnabled` is `true`
- Try to get the topic-level policies; you will get a Topic not found error

The master branch does not have the issue because #24225 have fixed it [here](https://github.com/apache/pulsar/pull/24225/files#diff-6902810fd24ff29ec34052bcc6a0de36d76107649148d945b80ec2be888e9042L734-R778)

### Modifications

fix the issue

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x