### PR TITLE
[improve][doc] Clarify geo-replication cluster removal behavior for shared vs separate configuration stores

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -438,7 +438,9 @@ public class Namespaces extends NamespacesBase {
 
     @POST
     @Path("/{property}/{cluster}/{namespace}/replication")
-    @ApiOperation(hidden = true, value = "Set the replication clusters for a namespace.")
+    @ApiOperation(hidden = true, value = "Set the replication clusters for a namespace. "
+            + "When removing a cluster: with shared configuration store, data will be deleted from the removed cluster; "
+            + "with separate configuration store, only replication stops but data is preserved.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
             @ApiResponse(code = 409, message = "Peer-cluster can't be part of replication-cluster"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -456,7 +456,9 @@ public class Namespaces extends NamespacesBase {
 
     @POST
     @Path("/{tenant}/{namespace}/replication")
-    @ApiOperation(value = "Set the replication clusters for a namespace.")
+    @ApiOperation(value = "Set the replication clusters for a namespace. "
+            + "When removing a cluster: with shared configuration store, data will be deleted from the removed cluster; "
+            + "with separate configuration store, only replication stops but data is preserved.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2392,7 +2392,9 @@ public class PersistentTopics extends PersistentTopicsBase {
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/replication")
-    @ApiOperation(value = "Set the replication clusters for a topic.")
+    @ApiOperation(value = "Set the replication clusters for a topic. "
+            + "When removing a cluster: with shared configuration store, topic data will be deleted from the removed cluster; "
+            + "with separate configuration store, only replication stops but topic data is preserved.")
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "Operation successful"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -853,10 +853,10 @@ public interface Namespaces {
      * <p/>
      * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
      * <ul>
-     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data 
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data
      *     from the removed cluster.</li>
-     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
-     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the 
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the
+     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the
      *     removed cluster, but existing data on the removed cluster is preserved.</li>
      * </ul>
      * <p/>
@@ -889,10 +889,10 @@ public interface Namespaces {
      * <p/>
      * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
      * <ul>
-     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data 
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data
      *     from the removed cluster.</li>
-     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
-     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the 
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the
+     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the
      *     removed cluster, but existing data on the removed cluster is preserved.</li>
      * </ul>
      * <p/>

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -851,6 +851,15 @@ public interface Namespaces {
     /**
      * Set the replication clusters for a namespace.
      * <p/>
+     * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
+     * <ul>
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data 
+     *     from the removed cluster.</li>
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
+     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the 
+     *     removed cluster, but existing data on the removed cluster is preserved.</li>
+     * </ul>
+     * <p/>
      * Request example:
      *
      * <pre>
@@ -877,6 +886,15 @@ public interface Namespaces {
 
     /**
      * Set the replication clusters for a namespace asynchronously.
+     * <p/>
+     * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
+     * <ul>
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the data 
+     *     from the removed cluster.</li>
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
+     *     operating cluster's behavior. Geo-replication stops from the operating cluster to the 
+     *     removed cluster, but existing data on the removed cluster is preserved.</li>
+     * </ul>
      * <p/>
      * Request example:
      *

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4371,6 +4371,15 @@ public interface Topics {
 
     /**
      * Set the replication clusters for the topic.
+     * <p/>
+     * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
+     * <ul>
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data 
+     *     from the removed cluster.</li>
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
+     *     operating cluster's behavior. Replication stops from the operating cluster to the 
+     *     removed cluster, but existing topic data on the removed cluster is preserved.</li>
+     * </ul>
      *
      * @param topic
      * @param clusterIds
@@ -4381,6 +4390,15 @@ public interface Topics {
 
     /**
      * Set the replication clusters for the topic asynchronously.
+     * <p/>
+     * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
+     * <ul>
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data 
+     *     from the removed cluster.</li>
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
+     *     operating cluster's behavior. Replication stops from the operating cluster to the 
+     *     removed cluster, but existing topic data on the removed cluster is preserved.</li>
+     * </ul>
      *
      * @param topic
      * @param clusterIds

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4374,10 +4374,10 @@ public interface Topics {
      * <p/>
      * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
      * <ul>
-     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data 
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data
      *     from the removed cluster.</li>
-     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
-     *     operating cluster's behavior. Replication stops from the operating cluster to the 
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the
+     *     operating cluster's behavior. Replication stops from the operating cluster to the
      *     removed cluster, but existing topic data on the removed cluster is preserved.</li>
      * </ul>
      *
@@ -4393,10 +4393,10 @@ public interface Topics {
      * <p/>
      * When removing a cluster from the replication list, the behavior depends on your configuration store setup:
      * <ul>
-     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data 
+     * <li><b>Shared Configuration Store</b>: Removing a cluster from replication will delete the topic data
      *     from the removed cluster.</li>
-     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the 
-     *     operating cluster's behavior. Replication stops from the operating cluster to the 
+     * <li><b>Separate Configuration Store</b>: Removing a cluster from replication only affects the
+     *     operating cluster's behavior. Replication stops from the operating cluster to the
      *     removed cluster, but existing topic data on the removed cluster is preserved.</li>
      * </ul>
      *

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -316,7 +316,9 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
-    @Command(description = "Set replication clusters for a namespace")
+    @Command(description = "Set replication clusters for a namespace. "
+            + "When removing a cluster: with shared configuration store, data will be deleted from the removed cluster; "
+            + "with separate configuration store, only replication stops but data is preserved.")
     private class SetReplicationClusters extends CliCommand {
         @Parameters(description = "tenant/namespace", arity = "1")
         private String namespaceName;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1999,7 +1999,9 @@ public class CmdTopicPolicies extends CmdBase {
     }
 
     @Command(description = "Set the replication clusters for a topic, global policy will be copied to the remote"
-            + " cluster if you enabled namespace level replication.")
+            + " cluster if you enabled namespace level replication. "
+            + "When removing a cluster: with shared configuration store, topic data will be deleted from the removed cluster; "
+            + "with separate configuration store, only replication stops but topic data is preserved.")
     private class SetReplicationClusters extends CliCommand {
         @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
         private String topicName;


### PR DESCRIPTION
## Summary
Updated Java API and CLI documentation to clarify the different behaviors when removing a cluster from namespace replication based on configuration store setup.

## Motivation
Users were confused about what happens when removing a cluster from geo-replication. The behavior is significantly different between shared and separate configuration store setups, but this wasn't documented.

## Changes
- **Java API (`Namespaces.java`)**: Updated `setNamespaceReplicationClusters()` and `setNamespaceReplicationClustersAsync()` documentation
- **CLI (`CmdNamespaces.java`)**: Updated `set-clusters` command description

## Behavioral Clarification
### Shared Configuration Store
- When removing a cluster from replication: **Data will be deleted from the removed cluster** to maintain consistency across the shared configuration

### Separate Configuration Store  
- When removing a cluster from replication: **Only replication stops from the operating cluster** to the removed cluster, but existing data on the removed cluster is preserved

## Test plan
- [x] Documentation changes only - no functional code changes
- [x] Verified existing tests still pass
- [x] Updated both sync and async API documentation consistently
- [x] Updated CLI help text to match API documentation

## Documentation

- [x] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->