### PR TITLE
[improve][build] Add Async Profiler integration for integration tests

### DIFF
--- a/build/build_java_test_image.sh
+++ b/build/build_java_test_image.sh
@@ -21,5 +21,5 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_DIR/.."
 mvn -am -pl tests/docker-images/java-test-image -Pcore-modules,-main,integrationTests,docker \
-  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dlicense.skip=true \
+  -Dmaven.test.skip=true -DskipSourceReleaseAssembly=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Dlicense.skip=true \
   "$@" install

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ManualTestUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ManualTestUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.testng.SkipException;
+
+public class ManualTestUtil {
+
+    public static void skipManualTestIfNotEnabled() {
+        if (!BooleanUtils.toBoolean(System.getenv("ENABLE_MANUAL_TEST")) && !isRunningInIntelliJ()) {
+            throw new SkipException("This test requires setting ENABLE_MANUAL_TEST=true environment variable.");
+        }
+    }
+
+    public static boolean isRunningInIntelliJ() {
+        // Check for IntelliJ-specific system properties
+        return System.getProperty("idea.test.cyclic.buffer.size") != null
+                || System.getProperty("java.class.path", "").contains("idea_rt.jar");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3108,6 +3108,16 @@ flexible messaging model and an intuitive client API.</description>
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- This profile is used in addition to -PtestAsyncProfiler to profile created exceptions
+      This works only on Linux.
+      -->
+      <id>testAsyncProfilerExceptions</id>
+      <properties>
+        <test.asyncprofiler.opts>event=Java_java_lang_Throwable_fillInStackTrace,tree,reverse</test.asyncprofiler.opts>
+        <test.asyncprofiler.outputformat>html</test.asyncprofiler.outputformat>
+      </properties>
+    </profile>
     <!-- profile that redirects log4j logs to a file -->
     <profile>
       <id>testLoggingToFile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3078,12 +3078,14 @@ flexible messaging model and an intuitive client API.</description>
         -->
         <test.asyncprofiler.event>itimer</test.asyncprofiler.event>
         <!-- Assumes Async Profiler 4.1+ to be installed, which supports "all" option -->
-        <test.asyncprofiler.opts>event=${test.asyncprofiler.event},all,jfrsync=profile</test.asyncprofiler.opts>
+        <!-- See https://github.com/async-profiler/async-profiler/blob/v4.1/src/arguments.cpp#L45 for supported options -->
+        <test.asyncprofiler.opts>event=${test.asyncprofiler.event},all,alloc=2m,jfrsync=profile</test.asyncprofiler.opts>
+        <test.asyncprofiler.outputformat>jfr</test.asyncprofiler.outputformat>
         <test.asyncprofiler.args>
           -XX:+UnlockDiagnosticVMOptions
           -XX:+DebugNonSafepoints
           -Xms${testMaxHeapSize} -XX:+AlwaysPreTouch
-          -agentpath:${env.LIBASYNCPROFILER_PATH}=start,${test.asyncprofiler.opts},jfr,file=${pulsar.basedir}/target/test_profile_${maven.build.timestamp}_${surefire.forkNumber}_%p.jfr
+          -agentpath:${env.LIBASYNCPROFILER_PATH}=start,${test.asyncprofiler.opts},quiet,file=${pulsar.basedir}/target/test_profile_${git.commit.id.abbrev}_${maven.build.timestamp}_${surefire.forkNumber}_%p.${test.asyncprofiler.outputformat}
           -Dpulsar.test.logging.appender=FILE
           -Dpulsar.test.logging.file=target/test_${maven.build.timestamp}_${surefire.forkNumber}.log
         </test.asyncprofiler.args>
@@ -3092,6 +3094,19 @@ flexible messaging model and an intuitive client API.</description>
         <redirectTestOutputToFile>false</redirectTestOutputToFile>
         <test.netty.leakdetection.args></test.netty.leakdetection.args>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+              <injectAllReactorProjects>true</injectAllReactorProjects>
+              <skipPoms>false</skipPoms>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <!-- profile that redirects log4j logs to a file -->
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@ flexible messaging model and an intuitive client API.</description>
     <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
     <!-- surefire.version is defined in apache parent pom -->
     <!-- it is used for surefire, failsafe and surefire-report plugins -->
-    <surefire.version>3.1.0</surefire.version>
+    <surefire.version>3.5.3</surefire.version>
     <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/AbstractBrokerEntryCacheMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/AbstractBrokerEntryCacheMultiBrokerTest.java
@@ -36,7 +36,6 @@ import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.pulsar.broker.MultiBrokerTestZKBaseTest;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
@@ -46,7 +45,7 @@ import org.apache.pulsar.client.api.SizeUnit;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
-import org.testng.SkipException;
+import org.apache.pulsar.tests.ManualTestUtil;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -140,15 +139,7 @@ public abstract class AbstractBrokerEntryCacheMultiBrokerTest extends MultiBroke
 
     @Override
     protected void beforeSetup() {
-        if (!BooleanUtils.toBoolean(System.getenv("ENABLE_MANUAL_TEST")) && !isRunningInIntelliJ()) {
-            throw new SkipException("This test requires setting ENABLE_MANUAL_TEST=true environment variable.");
-        }
-    }
-
-    static boolean isRunningInIntelliJ() {
-        // Check for IntelliJ-specific system properties
-        return System.getProperty("idea.test.cyclic.buffer.size") != null
-                || System.getProperty("java.class.path", "").contains("idea_rt.jar");
+        ManualTestUtil.skipManualTestIfNotEnabled();
     }
 
     @Override

--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -42,3 +42,15 @@ COPY target/java-test-functions.jar /pulsar/examples/
 
 # copy buildtools.jar to /pulsar/lib so that org.apache.pulsar.tests.ExtendedNettyLeakDetector can be used
 COPY target/buildtools.jar /pulsar/lib/
+
+ARG INSTALL_ASYNC_PROFILER=false
+# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.1 to /opt/async-profiler
+RUN if [ "${INSTALL_ASYNC_PROFILER}" = "true" ]; then \
+    mkdir -p /opt/async-profiler \
+    && cd /opt/async-profiler \
+    && curl -L \
+    "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
+    | tar -zxvf - --strip-components=1; \
+    else \
+    echo "async-profiler installation skipped"; \
+    fi

--- a/tests/docker-images/java-test-image/pom.xml
+++ b/tests/docker-images/java-test-image/pom.xml
@@ -38,18 +38,15 @@
           <name>integrationTests</name>
         </property>
       </activation>
+      <properties>
+        <docker.install.asyncprofiler>false</docker.install.asyncprofiler>
+      </properties>
       <dependencies>
         <dependency>
-          <groupId>org.apache.pulsar.tests</groupId>
-          <artifactId>java-test-functions</artifactId>
-          <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
           <groupId>org.apache.pulsar</groupId>
-          <artifactId>pulsar-server-distribution</artifactId>
+          <artifactId>pulsar-docker-image</artifactId>
           <version>${project.parent.version}</version>
-          <classifier>bin</classifier>
-          <type>tar.gz</type>
+          <type>pom</type>
           <scope>provided</scope>
           <exclusions>
             <exclusion>
@@ -57,6 +54,11 @@
               <artifactId>*</artifactId>
             </exclusion>
           </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.pulsar.tests</groupId>
+          <artifactId>java-test-functions</artifactId>
+          <version>${project.parent.version}</version>
         </dependency>
       </dependencies>
       <build>
@@ -161,6 +163,7 @@
                       <build>
                         <args>
                           <PULSAR_IMAGE>${docker.organization}/${docker.image}:${project.version}-${git.commit.id.abbrev}</PULSAR_IMAGE>
+                          <INSTALL_ASYNC_PROFILER>${docker.install.asyncprofiler}</INSTALL_ASYNC_PROFILER>
                         </args>
                         <contextDir>${project.basedir}</contextDir>
                         <noCache>true</noCache>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -107,4 +107,16 @@ COPY --from=oracle-jdbc-builder /pulsar/connectors/pulsar-io-debezium-oracle-*.n
 RUN mkdir -p pulsar
 RUN chmod g+rwx pulsar
 
+ARG INSTALL_ASYNC_PROFILER=false
+# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.1 to /opt/async-profiler
+RUN if [ "${INSTALL_ASYNC_PROFILER}" = "true" ]; then \
+    mkdir -p /opt/async-profiler \
+    && cd /opt/async-profiler \
+    && curl -L \
+    "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
+    | tar -zxvf - --strip-components=1; \
+    else \
+    echo "async-profiler installation skipped"; \
+    fi \
+
 CMD bash

--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/bookie.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M -XX:MaxDirectMemorySize=512M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar bookie
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/broker.conf
+++ b/tests/docker-images/latest-version-image/conf/broker.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/broker.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx150M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar broker
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/functions_worker.conf
+++ b/tests/docker-images/latest-version-image/conf/functions_worker.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/functions_worker.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx150M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar functions-worker
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/global-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/global-zk.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/global-zk.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar configuration-store
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/local-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/local-zk.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/local-zk.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx128M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar zookeeper
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/proxy.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx150M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar proxy
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/conf/websocket.conf
+++ b/tests/docker-images/latest-version-image/conf/websocket.conf
@@ -22,7 +22,6 @@ autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/pulsar-websocket.log
 directory=/pulsar
-environment=PULSAR_MEM="-Xmx150M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError",PULSAR_GC="-XX:+UseZGC"
 command=/pulsar/bin/pulsar websocket
 user=pulsar
 stopwaitsecs=15

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -38,6 +38,9 @@
           <name>integrationTests</name>
         </property>
       </activation>
+      <properties>
+        <docker.install.asyncprofiler>false</docker.install.asyncprofiler>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.pulsar.tests</groupId>
@@ -166,6 +169,7 @@
                         <contextDir>${project.basedir}</contextDir>
                         <args>
                           <PULSAR_ALL_IMAGE>${docker.organization}/${docker.image}-all:${project.version}-${git.commit.id.abbrev}</PULSAR_ALL_IMAGE>
+                          <INSTALL_ASYNC_PROFILER>${docker.install.asyncprofiler}</INSTALL_ASYNC_PROFILER>
                         </args>
                         <noCache>true</noCache>
                         <buildx>

--- a/tests/docker-images/latest-version-image/scripts/func-lib.sh
+++ b/tests/docker-images/latest-version-image/scripts/func-lib.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+set -o pipefail
+
+function run_pulsar_component() {
+  local component=$1
+  local supervisord_component=$2
+  local maxMem=$3
+  local additionalMemParam=$4
+  export PULSAR_MEM="${PULSAR_MEM:-"-Xmx${maxMem} ${additionalMemParam} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError"}"
+  export PULSAR_GC="${PULSAR_GC:-"-XX:+UseZGC"}"
+
+  bin/apply-config-from-env.py conf/${component}.conf
+  bin/apply-config-from-env.py conf/pulsar_env.sh
+
+  if [[ "$component" == "functions_worker" ]]; then
+    bin/apply-config-from-env.py conf/client.conf
+    bin/gen-yml-from-env.py conf/functions_worker.yml
+  fi
+
+  if [[ "${supervisord_component}" == "global-zk" ]]; then
+    bin/generate-zookeeper-config.sh conf/global_zookeeper.conf
+  elif [[ "${supervisord_component}" == "local-zk" ]]; then
+    bin/generate-zookeeper-config.sh conf/zookeeper.conf
+  fi
+
+  if [ -z "$NO_AUTOSTART" ]; then
+      sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/${supervisord_component}.conf
+  fi
+
+  exec /usr/bin/supervisord -c /etc/supervisord.conf
+}

--- a/tests/docker-images/latest-version-image/scripts/run-bookie.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-bookie.sh
@@ -18,16 +18,10 @@
 # under the License.
 #
 
+source bin/func-lib.sh
+
 # sets dbStorage_writeCacheMaxSizeMb and dbStorage_readAheadCacheMaxSizeMb if not already defined
 export dbStorage_writeCacheMaxSizeMb="${dbStorage_writeCacheMaxSizeMb:-16}"
 export dbStorage_readAheadCacheMaxSizeMb="${dbStorage_readAheadCacheMaxSizeMb:-16}"
 
-bin/apply-config-from-env.py conf/bookkeeper.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh
-
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/bookie.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
-
+run_pulsar_component bookkeeper bookie 128M -XX:MaxDirectMemorySize=512M

--- a/tests/docker-images/latest-version-image/scripts/run-broker.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-broker.sh
@@ -18,12 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/broker.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/broker.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
-
+run_pulsar_component broker broker 150M

--- a/tests/docker-images/latest-version-image/scripts/run-functions-worker.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-functions-worker.sh
@@ -18,13 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/client.conf && \
-    bin/gen-yml-from-env.py conf/functions_worker.yml && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/functions_worker.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
-
+run_pulsar_component functions_worker functions_worker 150M

--- a/tests/docker-images/latest-version-image/scripts/run-global-zk.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-global-zk.sh
@@ -18,12 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/zookeeper.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh && \
-    bin/generate-zookeeper-config.sh conf/global_zookeeper.conf
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/global-zk.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+run_pulsar_component zookeeper global-zk 128M

--- a/tests/docker-images/latest-version-image/scripts/run-local-zk.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-local-zk.sh
@@ -18,12 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/zookeeper.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh && \
-    bin/generate-zookeeper-config.sh conf/zookeeper.conf
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/local-zk.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+run_pulsar_component zookeeper local-zk 128M

--- a/tests/docker-images/latest-version-image/scripts/run-proxy.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-proxy.sh
@@ -18,11 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/proxy.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/proxy.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+run_pulsar_component proxy proxy 150M

--- a/tests/docker-images/latest-version-image/scripts/run-standalone.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-standalone.sh
@@ -18,4 +18,7 @@
 # under the License.
 #
 
+export PULSAR_MEM="${PULSAR_MEM:-"-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError"}"
+export PULSAR_GC="${PULSAR_GC:-"-XX:+UseZGC"}"
+
 bin/pulsar standalone

--- a/tests/docker-images/latest-version-image/scripts/run-websocket.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-websocket.sh
@@ -18,11 +18,6 @@
 # under the License.
 #
 
-bin/apply-config-from-env.py conf/websocket.conf && \
-    bin/apply-config-from-env.py conf/pulsar_env.sh
+source bin/func-lib.sh
 
-if [ -z "$NO_AUTOSTART" ]; then
-    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/websocket.conf
-fi
-
-exec /usr/bin/supervisord -c /etc/supervisord.conf
+run_pulsar_component websocket websocket 150M

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -353,6 +353,19 @@
       </build>
     </profile>
     <profile>
+      <!--
+      This profile is used in addition to the Integration Tests Async Profiler support to profile created exceptions
+      Check the org.apache.pulsar.tests.integration.profiling.PulsarProfilingTest example for how to profile int tests.
+      Profiling of exceptions requires that perf events have been enabled on the docker host. PulsarProfilingTest
+      contains instructions.
+      -->
+      <id>inttestAsyncProfilerExceptions</id>
+      <properties>
+        <inttest.asyncprofiler.opts>event=Java_java_lang_Throwable_fillInStackTrace,tree,reverse</inttest.asyncprofiler.opts>
+        <inttest.asyncprofiler.outputformat>html</inttest.asyncprofiler.outputformat>
+      </properties>
+    </profile>
+    <profile>
       <id>apache-release</id>
       <build>
         <plugins>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -305,13 +305,17 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
-              -Dconfluent.version=${confluent.version} -Djacoco.version=${jacoco-maven-plugin.version}
-              -Dintegrationtest.coverage.enabled=${integrationtest.coverage.enabled} -Dintegrationtest.coverage.dir=${integrationtest.coverage.dir}
-              -Dinttest.asyncprofiler.opts=${inttest.asyncprofiler.opts} -Dinttest.asyncprofiler.outputformat=${inttest.asyncprofiler.outputformat}
-              -Dinttest.asyncprofiler.dir=${inttest.asyncprofiler.dir}
-              -Dmaven.build.timestamp=${maven.build.timestamp} -Dgit.commit.id.abbrev=${git.commit.id.abbrev}
               ${test.additional.args}
               </argLine>
+              <systemPropertyVariables>
+                <confluent.version>${confluent.version}</confluent.version>
+                <jacoco.version>${jacoco-maven-plugin.version}</jacoco.version>
+                <integrationtest.coverage.enabled>${integrationtest.coverage.enabled}</integrationtest.coverage.enabled>
+                <integrationtest.coverage.dir>${integrationtest.coverage.dir}</integrationtest.coverage.dir>
+                <inttest.asyncprofiler.opts>${inttest.asyncprofiler.opts}</inttest.asyncprofiler.opts>
+                <inttest.asyncprofiler.outputformat>${inttest.asyncprofiler.outputformat}</inttest.asyncprofiler.outputformat>
+                <inttest.asyncprofiler.dir>${inttest.asyncprofiler.dir}</inttest.asyncprofiler.dir>
+              </systemPropertyVariables>
               <skipTests>false</skipTests>
               <suiteXmlFiles>
                 <file>src/test/resources/${integrationTestSuiteFile}</file>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <integrationTestSuiteFile>pulsar.xml</integrationTestSuiteFile>
     <mongo-reactivestreams.version>4.1.2</mongo-reactivestreams.version>
+    <inttest.asyncprofiler.opts>event=cpu,lock=1ms,alloc=2m,jfrsync=profile</inttest.asyncprofiler.opts>
+    <inttest.asyncprofiler.outputformat>jfr</inttest.asyncprofiler.outputformat>
+    <inttest.asyncprofiler.dir></inttest.asyncprofiler.dir>
   </properties>
 
   <dependencies>
@@ -304,6 +307,9 @@
               <argLine>${testJacocoAgentArgument} -XX:+ExitOnOutOfMemoryError -Xmx1G -XX:MaxDirectMemorySize=1G
               -Dconfluent.version=${confluent.version} -Djacoco.version=${jacoco-maven-plugin.version}
               -Dintegrationtest.coverage.enabled=${integrationtest.coverage.enabled} -Dintegrationtest.coverage.dir=${integrationtest.coverage.dir}
+              -Dinttest.asyncprofiler.opts=${inttest.asyncprofiler.opts} -Dinttest.asyncprofiler.outputformat=${inttest.asyncprofiler.outputformat}
+              -Dinttest.asyncprofiler.dir=${inttest.asyncprofiler.dir}
+              -Dmaven.build.timestamp=${maven.build.timestamp} -Dgit.commit.id.abbrev=${git.commit.id.abbrev}
               ${test.additional.args}
               </argLine>
               <skipTests>false</skipTests>
@@ -333,6 +339,15 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <configuration>
+              <skip>false</skip>
+              <injectAllReactorProjects>true</injectAllReactorProjects>
+              <skipPoms>false</skipPoms>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -51,7 +51,7 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
         String existingValue = getEnvMap().get(key);
         if (existingValue == null) {
             addEnv(key, value);
-        } else {
+        } else if (!existingValue.contains(value)) {
             addEnv(key, existingValue + " " + value);
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -379,7 +379,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
         sb.append(",file=/profiles/inttest_profile_").append(System.getProperty("git.commit.id.abbrev", ""));
         sb.append("_").append(System.getProperty("maven.build.timestamp", "").replace(' ', '_'));
         sb.append("_").append(getContainerName());
-        sb.append("_").append("%p.").append(System.getProperty("inttest.asyncprofiler.outputformat"));
+        sb.append("_").append("%p.").append(System.getProperty("inttest.asyncprofiler.outputformat", "jfr"));
         initializePulsarExtraOpts();
         appendToEnv("PULSAR_EXTRA_OPTS", "-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints " + sb);
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pulsar.tests.integration.profiling;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.tests.ManualTestUtil;
@@ -32,22 +35,39 @@ import org.testcontainers.containers.GenericContainer;
 import org.testng.annotations.Test;
 
 /**
- * Test profiling.
+ * Sample test that profiles the broker side with Async Profiler.
  *
  * Example usage:
+ * # This has been tested on Mac with Orbstack (https://orbstack.dev/) docker
+ * # compile apachepulsar/java-test-image with async profiler
  * ./build/build_java_test_image.sh -Ddocker.install.asyncprofiler=true
+ * # set environment variables
  * export PULSAR_TEST_IMAGE_NAME=apachepulsar/java-test-image:latest
  * export NETTY_LEAK_DETECTION=off
  * export ENABLE_MANUAL_TEST=true
+ * # compile integration test dependencies
  * mvn -am -pl tests/integration -DskipTests install
- * mvn -DintegrationTests -pl tests/integration -Dtest=PulsarProfilingTest -DredirectTestOutputToFile=false test
+ * # enable perf events for profiling and tune it
+ * docker run --rm -it --privileged --cap-add SYS_ADMIN --security-opt seccomp=unconfined \
+ *   alpine sh -c "echo 1 > /proc/sys/kernel/perf_event_paranoid \
+ *   && echo 0 > /proc/sys/kernel/kptr_restrict \
+ *   && echo 1024 > /proc/sys/kernel/perf_event_max_stack \
+ *   && echo 2048 > /proc/sys/kernel/perf_event_mlock_kb"
+ * # run the test
+ * mvn -DintegrationTests -pl tests/integration -Dtest=PulsarProfilingTest -DtestRetryCount=0 \
+ *   -DredirectTestOutputToFile=false test
+ * By default, the .jfr files will go into tests/integration/target
+ * You can use jfrconv from async profiler to convert them into html flamegraphs or use other tools such
+ * as Eclipse Mission Control (https://adoptium.net/jmc) or IntelliJ to open them.
  */
 @Slf4j
 public class PulsarProfilingTest extends PulsarTestSuite {
     private static final String DEFAULT_PULSAR_MEM = "-Xms512m -Xmx1g";
 
+    // A container that runs pulsar-perf, arguments are currently hard-coded since this is an example
     static class PulsarPerfContainer extends GenericContainer<PulsarPerfContainer> {
         private final String brokerHostname;
+        private final long numberOfMessages = 100_000_000;
 
         public PulsarPerfContainer(String clusterName,
                                    String brokerHostname,
@@ -67,7 +87,7 @@ public class PulsarProfilingTest extends PulsarTestSuite {
                     "/pulsar/bin/pulsar-perf", "consume", topicName,
                     "-u", "pulsar://" + brokerHostname + ":6650",
                     "-st", "Shared",
-                    "-m", "1000000");
+                    "-m", String.valueOf(numberOfMessages), "-ml", "200M");
         }
 
         public CompletableFuture<Long> produce(String topicName) throws Exception {
@@ -75,7 +95,9 @@ public class PulsarProfilingTest extends PulsarTestSuite {
                     "/pulsar/bin/pulsar-perf", "produce", topicName,
                     "-u", "pulsar://" + brokerHostname + ":6650",
                     "-au", "http://" + brokerHostname + ":8080",
-                    "-r", "1000000", "-m", "1000100");
+                    "-r", String.valueOf(Integer.MAX_VALUE), // max-rate
+                    "-s", "8192", // 8kB message size
+                    "-m", String.valueOf(numberOfMessages), "-ml", "200M");
         }
     }
 
@@ -89,24 +111,88 @@ public class PulsarProfilingTest extends PulsarTestSuite {
     }
 
     @Override
+    public void tearDownCluster() throws Exception {
+        if (perfConsume != null) {
+            perfConsume.stop();
+            perfConsume = null;
+        }
+        if (perfProduce != null) {
+            perfProduce.stop();
+            perfProduce = null;
+        }
+        super.tearDownCluster();
+    }
+
+    @Override
     protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(String clusterName,
         PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
+
+        // Enable profiling on the broker
         specBuilder.profileBroker(true);
+
+        // Only run one broker so that all load goes to a single broker
+        specBuilder.numBrokers(1);
+        // Have 3 bookies to reduce bottleneck on bookie
+        specBuilder.numBookies(3);
+        // no need for proxy
+        specBuilder.numProxies(0);
+
+        // Increase memory for brokers and configure more aggressive rollover
+        specBuilder.brokerEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM,
+                "managedLedgerMinLedgerRolloverTimeMinutes", "1",
+                "managedLedgerMaxLedgerRolloverTimeMinutes", "5",
+                "managedLedgerMaxSizePerLedgerMbytes", "512",
+                "managedLedgerDefaultEnsembleSize", "1",
+                "managedLedgerDefaultWriteQuorum", "1",
+                "managedLedgerDefaultAckQuorum", "1"
+        ));
+
+        // Increase memory for bookkeepers and make compaction run more often
+        Map<String, String> bkEnv = new HashMap<>();
+        bkEnv.put("PULSAR_MEM", DEFAULT_PULSAR_MEM);
+        bkEnv.put("dbStorage_writeCacheMaxSizeMb", "64");
+        bkEnv.put("dbStorage_readAheadCacheMaxSizeMb", "96");
+        bkEnv.put("journalMaxSizeMB", "256");
+        bkEnv.put("journalSyncData", "false");
+        bkEnv.put("majorCompactionInterval", "300");
+        bkEnv.put("minorCompactionInterval", "30");
+        bkEnv.put("compactionRateByEntries", "20000");
+        bkEnv.put("gcWaitTime", "30000");
+        bkEnv.put("isForceGCAllowWhenNoSpace", "true");
+        bkEnv.put("diskUsageLwmThreshold", "0.75");
+        bkEnv.put("diskCheckInterval", "60");
+        specBuilder.bookkeeperEnvs(bkEnv);
+
+        // Create pulsar-perf containers
         String brokerHostname = clusterName + "-pulsar-broker-0";
         perfProduce = new PulsarPerfContainer(clusterName, brokerHostname, "perf-produce");
         perfConsume = new PulsarPerfContainer(clusterName, brokerHostname, "perf-consume");
-        specBuilder.externalServices(Map.of("pulsar-produce", perfProduce, "pulsar-consume", perfConsume));
-        specBuilder.brokerEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM));
-        specBuilder.bookkeeperEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM));
+        specBuilder.externalServices(Map.of(
+                "pulsar-produce", perfProduce,
+                "pulsar-consume", perfConsume
+        ));
+
         return specBuilder;
     }
 
-    @Test
-    public void profileTest() throws Exception {
+    @Test(timeOut = 600_000)
+    public void runPulsarPerf() throws Exception {
         String topicName = generateTopicName("profiletest", true);
         CompletableFuture<Long> consumeFuture = perfConsume.consume(topicName);
         Thread.sleep(1000);
-        CompletableFuture<Long> produceFuture = perfConsume.produce(topicName);
-        FutureUtil.waitForAll(List.of(consumeFuture, produceFuture)).get();
+        CompletableFuture<Long> produceFuture = perfProduce.produce(topicName);
+        FutureUtil.waitForAll(List.of(consumeFuture, produceFuture))
+                .orTimeout(3, TimeUnit.MINUTES)
+                .exceptionally(t -> {
+                    if (FutureUtil.unwrapCompletionException(t) instanceof TimeoutException) {
+                        // ignore test timeout
+                        log.info("Test timed out, ignoring this in profiling.");
+                        return null;
+                    } else {
+                        log.error("Failed to run pulsar-perf", t);
+                    }
+                    throw FutureUtil.wrapToCompletionException(t);
+                })
+                .get();
     }
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
  *
  * Example usage:
  * # This has been tested on Mac with Orbstack (https://orbstack.dev/) docker
- * # compile apachepulsar/java-test-image with async profiler
+ * # compile apachepulsar/java-test-image with async profiler (add "clean" to ensure a clean build with recent changes)
  * ./build/build_java_test_image.sh -Ddocker.install.asyncprofiler=true
  * # set environment variables
  * export PULSAR_TEST_IMAGE_NAME=apachepulsar/java-test-image:latest

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.profiling;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.tests.ManualTestUtil;
+import org.apache.pulsar.tests.integration.containers.PulsarContainer;
+import org.apache.pulsar.tests.integration.suites.PulsarTestSuite;
+import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
+import org.apache.pulsar.tests.integration.utils.DockerUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testng.annotations.Test;
+
+/**
+ * Test profiling.
+ *
+ * Example usage:
+ * ./build/build_java_test_image.sh -Ddocker.install.asyncprofiler=true
+ * export PULSAR_TEST_IMAGE_NAME=apachepulsar/java-test-image:latest
+ * export NETTY_LEAK_DETECTION=off
+ * export ENABLE_MANUAL_TEST=true
+ * mvn -am -pl tests/integration -DskipTests install
+ * mvn -DintegrationTests -pl tests/integration -Dtest=PulsarProfilingTest -DredirectTestOutputToFile=false test
+ */
+@Slf4j
+public class PulsarProfilingTest extends PulsarTestSuite {
+    private static final String DEFAULT_PULSAR_MEM = "-Xms512m -Xmx1g";
+
+    static class PulsarPerfContainer extends GenericContainer<PulsarPerfContainer> {
+        private final String brokerHostname;
+
+        public PulsarPerfContainer(String clusterName,
+                                   String brokerHostname,
+                                   String hostname) {
+            super(PulsarContainer.DEFAULT_IMAGE_NAME);
+            this.brokerHostname = brokerHostname;
+            withCreateContainerCmdModifier(createContainerCmd -> {
+                createContainerCmd.withHostName(hostname);
+                createContainerCmd.withName(clusterName + "-" + hostname);
+            });
+            withEnv("PULSAR_MEM", DEFAULT_PULSAR_MEM);
+            setCommand("sleep 1000000");
+        }
+
+        public CompletableFuture<Long> consume(String topicName) throws Exception {
+            return DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                    "/pulsar/bin/pulsar-perf", "consume", topicName,
+                    "-u", "pulsar://" + brokerHostname + ":6650",
+                    "-st", "Shared",
+                    "-m", "1000000");
+        }
+
+        public CompletableFuture<Long> produce(String topicName) throws Exception {
+            return DockerUtils.runCommandAsyncWithLogging(getDockerClient(), getContainerId(),
+                    "/pulsar/bin/pulsar-perf", "produce", topicName,
+                    "-u", "pulsar://" + brokerHostname + ":6650",
+                    "-au", "http://" + brokerHostname + ":8080",
+                    "-r", "1000000", "-m", "1000100");
+        }
+    }
+
+    private PulsarPerfContainer perfConsume;
+    private PulsarPerfContainer perfProduce;
+
+    @Override
+    public void setupCluster() throws Exception {
+        ManualTestUtil.skipManualTestIfNotEnabled();
+        super.setupCluster();
+    }
+
+    @Override
+    protected PulsarClusterSpec.PulsarClusterSpecBuilder beforeSetupCluster(String clusterName,
+        PulsarClusterSpec.PulsarClusterSpecBuilder specBuilder) {
+        specBuilder.profileBroker(true);
+        String brokerHostname = clusterName + "-pulsar-broker-0";
+        perfProduce = new PulsarPerfContainer(clusterName, brokerHostname, "perf-produce");
+        perfConsume = new PulsarPerfContainer(clusterName, brokerHostname, "perf-consume");
+        specBuilder.externalServices(Map.of("pulsar-produce", perfProduce, "pulsar-consume", perfConsume));
+        specBuilder.brokerEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM));
+        specBuilder.bookkeeperEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM));
+        return specBuilder;
+    }
+
+    @Test
+    public void profileTest() throws Exception {
+        String topicName = generateTopicName("profiletest", true);
+        CompletableFuture<Long> consumeFuture = perfConsume.consume(topicName);
+        Thread.sleep(1000);
+        CompletableFuture<Long> produceFuture = perfConsume.produce(topicName);
+        FutureUtil.waitForAll(List.of(consumeFuture, produceFuture)).get();
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -63,6 +63,7 @@ import org.testng.annotations.Test;
 @Slf4j
 public class PulsarProfilingTest extends PulsarTestSuite {
     private static final String DEFAULT_PULSAR_MEM = "-Xms512m -Xmx1g";
+    private static final String BROKER_PULSAR_MEM = "-Xms2g -Xmx2g";
 
     // A container that runs pulsar-perf, arguments are currently hard-coded since this is an example
     static class PulsarPerfContainer extends GenericContainer<PulsarPerfContainer> {
@@ -138,7 +139,7 @@ public class PulsarProfilingTest extends PulsarTestSuite {
         specBuilder.numProxies(0);
 
         // Increase memory for brokers and configure more aggressive rollover
-        specBuilder.brokerEnvs(Map.of("PULSAR_MEM", DEFAULT_PULSAR_MEM,
+        specBuilder.brokerEnvs(Map.of("PULSAR_MEM", BROKER_PULSAR_MEM,
                 "managedLedgerMinLedgerRolloverTimeMinutes", "1",
                 "managedLedgerMaxLedgerRolloverTimeMinutes", "5",
                 "managedLedgerMaxSizePerLedgerMbytes", "512",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/topologies/PulsarClusterSpec.java
@@ -199,4 +199,19 @@ public class PulsarClusterSpec {
 
     @Default
     boolean enableOxia = false;
+
+    @Default
+    boolean profileBroker = false;
+
+    @Default
+    boolean profileProxy = false;
+
+    @Default
+    boolean profileFunctionWorker = false;
+
+    @Default
+    boolean profileBookie = false;
+
+    @Default
+    boolean profileZookeeper = false;
 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/utils/DockerUtils.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/utils/DockerUtils.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.tests.integration.utils;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.InspectExecResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
@@ -38,6 +39,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -205,10 +207,7 @@ public class DockerUtils {
                                                                                DockerClient dockerClient,
                                                                                String containerId,
                                                                                String... cmd) {
-        String execId = dockerClient.execCreateCmd(containerId)
-                .withCmd(cmd)
-                .withAttachStderr(true)
-                .withAttachStdout(true)
+        String execId = createExecCreateCmd(dockerClient, containerId, cmd)
                 .withUser(userId)
                 .exec()
                 .getId();
@@ -218,10 +217,7 @@ public class DockerUtils {
     public static CompletableFuture<ContainerExecResult> runCommandAsync(DockerClient dockerClient,
                                                                          String containerId,
                                                                          String... cmd) {
-        String execId = dockerClient.execCreateCmd(containerId)
-                .withCmd(cmd)
-                .withAttachStderr(true)
-                .withAttachStdout(true)
+        String execId = createExecCreateCmd(dockerClient, containerId, cmd)
                 .exec()
                 .getId();
         return runCommandAsync(execId, dockerClient, containerId, cmd);
@@ -294,10 +290,7 @@ public class DockerUtils {
                                                                    String containerId,
                                                                    String... cmd) throws ContainerExecException {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        String execId = dockerClient.execCreateCmd(containerId)
-                .withCmd(cmd)
-                .withAttachStderr(true)
-                .withAttachStdout(true)
+        String execId = createExecCreateCmd(dockerClient, containerId, cmd)
                 .exec()
                 .getId();
         final String containerName = getContainerName(dockerClient, containerId);
@@ -359,10 +352,7 @@ public class DockerUtils {
     public static CompletableFuture<Long> runCommandAsyncWithLogging(DockerClient dockerClient,
                                                                         String containerId, String... cmd) {
         CompletableFuture<Long> future = new CompletableFuture<>();
-        String execId = dockerClient.execCreateCmd(containerId)
-                .withCmd(cmd)
-                .withAttachStderr(true)
-                .withAttachStdout(true)
+        String execId = createExecCreateCmd(dockerClient, containerId, cmd)
                 .exec()
                 .getId();
         final String containerName = getContainerName(dockerClient, containerId);
@@ -398,6 +388,15 @@ public class DockerUtils {
                     }
                 });
         return future;
+    }
+
+    private static ExecCreateCmd createExecCreateCmd(DockerClient dockerClient, String containerId, String[] cmd) {
+        return dockerClient.execCreateCmd(containerId)
+                .withCmd(cmd)
+                .withAttachStderr(true)
+                .withAttachStdout(true)
+                // Clear out PULSAR_EXTRA_OPTS and OPTS so that they don't interfere with the test
+                .withEnv(List.of("PULSAR_EXTRA_OPTS=", "OPTS="));
     }
 
     private static InspectExecResponse waitForExecCmdToFinish(DockerClient dockerClient, String execId) {


### PR DESCRIPTION
### Motivation

Async Profiler is a powerful profiler, but it requires using Linux to get more accurate profiling results. When the main development workflow is on Mac for many like me, I started to wonder if it's possible to set up Async Profiler with the more accurate profiling mode using Docker. I use [OrbStack](https://orbstack.dev/) (instead of Docker Desktop) on Mac to develop Apache Pulsar. I wanted to be able to create simple scenarios that take a few minutes to run and analyze the results with various tools. For example, converting flamegraphs to .html format with various views (such as per-thread CPU flamegraphs, allocation flamegraphs, and lock flamegraphs) and using [Eclipse Mission Control](https://adoptium.net/jmc) to analyze GC events and other details that Async Profiler is able to collect together with Java Flight Recorder in its "jfrsync" mode.

This work extends the Async Profiler support that was added in #24623 for directly profiling unit tests in the same process. The downside of that approach is that there will be too many aspects included, which skew the results and make it not useful for validating the performance of actual production code. It also had the problem that Async Profiler on Mac doesn't support the more accurate CPU profiling modes that Async Profiler supports on Linux. This is explained in https://github.com/async-profiler/async-profiler/blob/master/docs/CpuSamplingEngines.md.

On Mac, it's not possible to profile native methods either, such as profiling the sources of exceptions. With Async Profiler, it's possible to specify `event=Java_java_lang_Throwable_fillInStackTrace,tree,reverse` to profile exception sources. (btw. JFR has also `jdk.JavaExceptionThrow` and `jdk.JavaErrorThrow` events which could be used, but the exception event isn't enabled by default).

### Modifications

- Add changes to inttest Dockerfiles to install async-profiler
- Change build to support running and passing necessary parameters to integration tests for profiling
- Make changes to the PulsarContainer used in integration tests to integrate with Async Profiler and configure the Docker container with necessary privileges and security configuration
- Add a sample test class which profiles a broker while pulsar-perf consume and produce are running

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->