### PR TITLE
[fix][client] Fix potential NPE in TypedMessageBuilderImpl

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -80,7 +80,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
                     return null;
                 }
             }).orElseGet(() -> {
-                EncodeData encodeData = schema.encode(producer.topic, value);
+                EncodeData encodeData = schema.encode(getTopic(), value);
                 content = ByteBuffer.wrap(encodeData.data());
                 if (encodeData.hasSchemaId()) {
                     msgMetadata.setSchemaId(encodeData.schemaId());
@@ -275,7 +275,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
 
     public Message<T> getMessage() {
         beforeSend();
-        return MessageImpl.create(msgMetadata, content, schema, producer != null ? producer.getTopic() : null);
+        return MessageImpl.create(msgMetadata, content, schema, getTopic());
     }
 
     public long getPublishTime() {
@@ -314,7 +314,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
         EncodeData keyEncoded = null;
         // set key as the message key
         if (keyValue.getKey() != null) {
-            keyEncoded = keyValueSchema.getKeySchema().encode(producer.topic, keyValue.getKey());
+            keyEncoded = keyValueSchema.getKeySchema().encode(getTopic(), keyValue.getKey());
             msgMetadata.setPartitionKey(Base64.getEncoder().encodeToString(keyEncoded.data()));
             msgMetadata.setPartitionKeyB64Encoded(true);
         } else {
@@ -324,7 +324,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
         EncodeData valueEncoded = null;
         // set value as the payload
         if (keyValue.getValue() != null) {
-            valueEncoded = keyValueSchema.getValueSchema().encode(producer.topic, keyValue.getValue());
+            valueEncoded = keyValueSchema.getValueSchema().encode(getTopic(), keyValue.getValue());
             content = ByteBuffer.wrap(valueEncoded.data());
         } else {
             msgMetadata.setNullValue(true);
@@ -337,4 +337,9 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
             msgMetadata.setSchemaId(schemaId);
         }
     }
+
+    private String getTopic() {
+        return producer != null ? producer.getTopic() : null;
+    }
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -272,4 +272,13 @@ public class TypedMessageBuilderImplTest {
         }
     }
 
+    @Test
+    public void testGetMessageWithNullProducer() {
+        TypedMessageBuilderImpl<byte[]> builder = new TypedMessageBuilderImpl<>(null, Schema.BYTES);
+        var data = "test".getBytes();
+        builder.value(data);
+        var message = builder.getMessage();
+        assertEquals(message.getValue(), data);
+    }
+
 }


### PR DESCRIPTION
### Motivation

The PIP-420 introduced a new method to encode payload; it requires the topic name, but in some cases, the producer in `TypedMessageBuilderImpl` may be null, which will lead to an NPE issue.

### Modifications

Add a null check while getting the topic name in `TypedMessageBuilderImpl`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
