### PR TITLE
[fix][broker]Fix dirty reading of namespace level offload thresholds

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -125,11 +125,14 @@ import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationDataImpl;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationPolicyUnloadScope;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
+import org.apache.pulsar.common.policies.data.OffloadPolicies;
+import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
@@ -4039,6 +4042,54 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
         Assert.assertTrue(permissions11.isEmpty());
         Assert.assertTrue(permissions22.isEmpty());
+    }
+
+    @Test
+    public void testOverridesNamespaceOffloadThreshold() throws Exception {
+        String namespace = BrokerTestUtil.newUniqueName(this.defaultTenant + "/ns");
+        String topic = BrokerTestUtil.newUniqueName("persistent://" + namespace + "/tp");
+        admin.namespaces().createNamespace(namespace);
+        admin.topics().createNonPartitionedTopic(topic);
+        admin.topicPolicies().setDispatchRate(topic, DispatchRate.builder().dispatchThrottlingRateInMsg(1).build());
+        // assert we get -1 which indicates it will fall back to default
+        assertEquals(admin.namespaces().getOffloadThreshold(namespace), -1);
+        assertEquals(admin.namespaces().getOffloadThresholdInSeconds(namespace), -1);
+        // Set namespace level offloading threshold.
+        long m1 = 1024 * 1024;
+        long h1 = 1000 * 3600;
+        OffloadPoliciesImpl policies = OffloadPoliciesImpl.builder()
+                .managedLedgerOffloadDriver("S3")
+                .s3ManagedLedgerOffloadBucket("bucket-1")
+                .managedLedgerOffloadThresholdInBytes(m1)
+                .managedLedgerOffloadThresholdInSeconds(h1)
+                .build();
+        admin.namespaces().setOffloadPolicies(namespace, policies);
+        OffloadPolicies policies1 = admin.namespaces().getOffloadPolicies(namespace);
+        assertEquals(policies1.getManagedLedgerOffloadThresholdInBytes(), m1);
+        assertEquals(policies1.getManagedLedgerOffloadThresholdInSeconds(), h1);
+
+        long m2 = 2 * 1024 * 1024L;
+        long h2 = 2 * 1000 * 3600;
+        admin.namespaces().setOffloadThreshold(namespace, m2);
+        admin.namespaces().setOffloadThresholdInSeconds(namespace, h2);
+        OffloadPolicies policies2 = admin.namespaces().getOffloadPolicies(namespace);
+        assertEquals(policies2.getManagedLedgerOffloadThresholdInBytes(), m2);
+        assertEquals(policies2.getManagedLedgerOffloadThresholdInSeconds(), h2);
+        OffloadPolicies policies3 = admin.topicPolicies().getOffloadPolicies(topic, true);
+        assertEquals(policies3.getManagedLedgerOffloadThresholdInBytes(), m2);
+        assertEquals(policies3.getManagedLedgerOffloadThresholdInSeconds(), h2);
+
+        admin.namespaces().removeOffloadPolicies(namespace);
+        OffloadPolicies policies4 = admin.namespaces().getOffloadPolicies(namespace);
+        assertTrue(policies4 == null);
+        assertEquals(admin.namespaces().getOffloadThreshold(namespace), -1);
+        assertEquals(admin.namespaces().getOffloadThresholdInSeconds(namespace), -1);
+        OffloadPolicies policies5 = admin.topicPolicies().getOffloadPolicies(topic, true);
+        assertTrue(policies5 == null);
+
+        // cleanup.
+        admin.topics().delete(topic);
+        admin.namespaces().deleteNamespace(namespace);
     }
 
     @Test


### PR DESCRIPTION
### Motivation


**Background**
- The oldest behaviour of offload settings: Pulsar only supports setting Broker-level offload policies and namespace-level thresholds. and handle namespace-level thresholds by the following fields:
  - `{@link Policies#offload_deletion_lag_ms}`
  - `{@link Policies#offload_threshold}`
  - `{@link Policies#offload_threshold_in_seconds}`
- After https://github.com/apache/pulsar/pull/6183, Pulsar supports namespace-level policies, which were supported by `{@link Policies#offload_policies}`. And the thresholds were moved to the following fields:
  - `{@link Policies#offload_policies} -> {@link OffloadPoliciesImpl#getManagedLedgerOffloadDeletionLagInMillis}`
  - ` {@link Policies#offload_policies} -> {@link OffloadPoliciesImpl#getManagedLedgerOffloadThresholdInBytes}`
  - `{@link Policies#offload_policies} -> {@link OffloadPoliciesImpl#getManagedLedgerOffloadThresholdInSeconds}`
- https://github.com/apache/pulsar/pull/6422 made setting offload thresholds(`{@link Policies#offload_deletion_lag_ms}`, `{@link Policies#offload_threshold}`, `{@link Policies#offload_threshold_in_seconds}`) affect namespace policies(`{@link Policies#offload_policies} `)
- But neither mechanisms work well together

**The issue we encountered**, Thanks @horizonzy for investigating the issue

```
> pulsar-admin topicPolicies get-offload-policies <topic>
null

> more conf/broker.conf | grep -i "managedLedgerOffload"
managedLedgerOffloadDeletionLagMs=63072000000
managedLedgerOffloadAutoTriggerSizeThresholdBytes=-1
managedLedgerOffloadThresholdInSeconds=-1

> pulsar-admin namespaces get-offload-threshold <namespace>
offloadThresholdInBytes: 0
offloadThresholdInSeconds: -1

> pulsar-admin topicPolicies get-offload-policies <topic> -ap
{
  ...
  "managedLedgerOffloadThresholdInSeconds" : -1,
  "managedLedgerOffloadThresholdInBytes" : -1,
}
```

- How to reproduce the issue
  - create namespace-level offload policies
  - set namespace-level offload policies thresholds
  - remove namespace-level offload policies
  - get topic-level offload policies with `-ap`, you will get a dirty view

### Modifications

To make the offload policies compatible with the old policies, use the old policies' threshold(`{@link Policies#offload_deletion_lag_ms}`, `{@link Policies#offload_threshold}`, `{@link Policies#offload_threshold_in_seconds}`) if the new policies(`{@link Policies#offload_policies} `) are not set. Once the new fields are set, the old fields will be removed.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
