### PR TITLE
[fix][client]TopicListWatcher not closed when calling PatternMultiTopicsConsumerImpl.closeAsync() method

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
@@ -73,7 +73,7 @@ public class PatternConsumerUpdateQueue {
 
     private volatile long lastRecheckTaskStartingTimestamp = 0;
 
-    private volatile boolean closed;
+    private boolean closed;
 
     public PatternConsumerUpdateQueue(PatternMultiTopicsConsumerImpl patternConsumer) {
         this(patternConsumer, patternConsumer.topicsChangeListener);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
@@ -73,7 +73,7 @@ public class PatternConsumerUpdateQueue {
 
     private volatile long lastRecheckTaskStartingTimestamp = 0;
 
-    private boolean closed;
+    private volatile boolean closed;
 
     public PatternConsumerUpdateQueue(PatternMultiTopicsConsumerImpl patternConsumer) {
         this(patternConsumer, patternConsumer.topicsChangeListener);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -385,14 +385,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
             timeout.cancel();
             recheckPatternTimeout = null;
         }
-        CompletableFuture<Void> topicListWatcherCloseFuture =
-                watcherFuture.isCompletedExceptionally() ? CompletableFuture.completedFuture(null)
-                        : watcherFuture.thenCompose(
-                        topicListWatcher -> topicListWatcher != null ? topicListWatcher.closeAsync()
-                                : CompletableFuture.completedFuture(null));
-        CompletableFuture<Void> runningTaskCancelCloseFuture =
-                updateTaskQueue.cancelAllAndWaitForTheRunningTask().thenCompose(__ -> super.closeAsync());
-        return FutureUtil.waitForAll(Lists.newArrayList(topicListWatcherCloseFuture, runningTaskCancelCloseFuture));
+        return watcherFuture.thenCompose(TopicListWatcher::closeAsync).exceptionally(t -> null)
+                .thenCompose(__ -> updateTaskQueue.cancelAllAndWaitForTheRunningTask()).exceptionally(t -> null)
+                .thenCompose(__ -> super.closeAsync());
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Motivation

In PatternMultiTopicsConsumerImpl, if watcherFuture is not done, the closeAsync() method will not close TopicListWatcher.
https://github.com/apache/pulsar/blob/2e6a8eb1f200ca687064058a101963713b896fe2/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java#L388-L395

### Modifications

Re-write the closeAsync() method to make sure TopicListWatcher is closed. See file changes.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, see PatternMultiTopicsConsumerImplTest.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

