### PR TITLE
[improve][ml] Improve cache insert performance by removing exists check since it's already covered by putIfAbsent

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java
@@ -139,12 +139,6 @@ public class RangeEntryCacheImpl implements EntryCache {
                     entryLength);
         }
 
-        Position position = entry.getPosition();
-        if (entries.exists(position)) {
-            // If the entry is already in the cache, don't insert it again
-            return false;
-        }
-
         ByteBuf cachedData;
         if (copyEntries) {
             cachedData = copyEntry(entry);
@@ -156,6 +150,7 @@ public class RangeEntryCacheImpl implements EntryCache {
             cachedData = entry.getDataBuffer().retain();
         }
 
+        Position position = entry.getPosition();
         ReferenceCountedEntry cacheEntry =
                 EntryImpl.createWithRetainedDuplicate(position, cachedData, entry.getReadCountHandler());
         cachedData.release();


### PR DESCRIPTION
### Motivation

While profiling Pulsar with PulsarProfilingTest, I noticed that a significant part of CPU of an insert to the cache is spent in the existence check. The case where the entry might already be in the cache is already covered by putIfAbsent and it is very rare after the PendingReadsManager solution was introduced to de-duplicate reads.

### Modifications

- remove the exists check before inserting to cache

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->