### PR TITLE
[improve][test] Improve integration test profiling test example

### DIFF
--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -26,7 +26,7 @@ USER root
 COPY target/scripts /pulsar/bin
 RUN chmod a+rx /pulsar/bin/*
 
-RUN apk add --no-cache supervisor
+RUN apk add --no-cache supervisor jq
 
 RUN mkdir -p /var/log/pulsar \
     && mkdir -p /var/run/supervisor/ \

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -62,7 +62,7 @@ FROM $PULSAR_ALL_IMAGE
 # However, any processes exec'ing into the containers will run as root, by default.
 USER root
 
-RUN apk add --no-cache supervisor procps curl
+RUN apk add --no-cache supervisor procps curl jq
 
 RUN mkdir -p /var/log/pulsar && mkdir -p /var/run/supervisor/
 

--- a/tests/docker-images/latest-version-image/conf/supervisord.conf
+++ b/tests/docker-images/latest-version-image/conf/supervisord.conf
@@ -26,6 +26,7 @@ loglevel=info
 pidfile=/var/run/supervisord.pid
 minfds=1024
 minprocs=200
+user=root
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.sock

--- a/tests/docker-images/latest-version-image/scripts/run-standalone.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-standalone.sh
@@ -18,7 +18,8 @@
 # under the License.
 #
 
-export PULSAR_MEM="${PULSAR_MEM:-"-Xmx512M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/pulsar -XX:+ExitOnOutOfMemoryError"}"
-export PULSAR_GC="${PULSAR_GC:-"-XX:+UseZGC"}"
+source /pulsar/bin/func-lib.sh
+
+set_pulsar_mem 512M
 
 bin/pulsar standalone

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -44,7 +44,6 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     @Override
     protected void configure() {
         super.configure();
-        addEnv("MALLOC_ARENA_MAX", "1");
     }
 
     protected void appendToEnv(String key, String value) {


### PR DESCRIPTION
### Motivation & Modifications

A previous PR #24688 added an example test for profiling integration tests with Async Profiler.

Improvements:
- collecting more details from the `pulsar-perf produce` and `pulsar-perf consume` containers
  - store the latency histogram to the `tests/integration/target` directory
  - store stdout & stderr to a log file in the same directory
  - gracefully shutdown the containers so that the latency histogram files don't get truncated
- collect topic stats and internal stats in pretty printed JSON to stdout and to files stored in `tests/integration/target`
- collect broker metrics and store to `tests/integration/target`
  - metrics can be used to validate PIP-430 in this test so that all reads come from the cache in the tailing read scenario setup with `pulsar-perf consume` and `pulsar perf produce`
- switch to use smaller message size without batching to stress test PIP-430 changes
- configure `dispatcherMaxReadBatchSize` to `1000` in broker to get past issue #24695
  - this PR can be used to reduce issue #24695 by commenting out the setting
- improve integration test startup scripts
  - fix an issue with invalid replacements in `conf/pulsar_env.sh`
  - always add parameters to capture heap dumps on OOME
- install `jq` to test container images so that it can be used in pretty printing topic stats retrieved with `curl`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
