### PR TITLE
[improve][pip] PIP-437: Adding Transaction Support to Pulsar Functions Through Auto-Transaction Wrapping

### DIFF
--- a/pip/pip-437.md
+++ b/pip/pip-437.md
@@ -1,0 +1,572 @@
+# PIP-437: Adding Transaction Support to Pulsar Functions Through Auto-Transaction Wrapping
+
+# Background knowledge
+
+Apache Pulsar transactions enable atomic operations across multiple topics, allowing producers to send messages and consumers to acknowledge messages as a single unit
+of work. This provides the foundation for exactly-once processing semantics in streaming applications.
+
+## Transaction Architecture
+
+Pulsar's transaction system consists of four key components:
+
+1. **Transaction Coordinator (TC)**: A broker module that manages transaction lifecycles, allocates transaction IDs, and orchestrates the commit/abort process.
+
+2. **Transaction Log**: A persistent topic storing transaction metadata and state changes, enabling recovery after failures.
+
+3. **Transaction Buffer**: Temporarily stores messages produced within transactions, making them visible to consumers only after commit.
+
+4. **Pending Acknowledge State**: Tracks message acknowledgments within transactions, preventing conflicts between competing transactions.
+
+## Transaction Lifecycle
+
+Transactions follow a defined lifecycle:
+
+1. **OPEN**: Client obtains a transaction ID from the Transaction Coordinator.
+2. **PRODUCING/ACKNOWLEDGING**: Client registers topic partitions/subscriptions with the TC, then produces/acknowledges messages within the transaction.
+3. **COMMITTING/ABORTING**: Client requests to end the transaction, TC begins two-phase commit.
+4. **COMMITTED/ABORTED**: After processing all partitions, TC finalizes the transaction state.
+5. **TIMED_OUT**: Transactions exceeding their timeout are automatically aborted.
+
+## Transaction Guarantees
+
+Pulsar transactions provide:
+- Atomic writes across multiple topics
+- Conditional acknowledgment to prevent duplicate processing by "zombie" instances
+- Visibility control ensuring consumers only see committed transaction messages
+- Support for exactly-once processing in consume-transform-produce patterns
+
+# Motivation
+
+Currently, Pulsar Functions cannot publish to multiple topics transactionally, which is a significant limitation for use cases requiring atomic multi-topic
+publishing. For instance, if a function processes an input message and needs to publish related updates to several output topics, there's no guarantee that all
+operations will succeed atomically.
+
+This limitation prevents building robust stream processing applications that require exactly-once semantics across multiple input and output topics. Without
+transaction support in Functions, developers must implement their own error handling and retry mechanisms, which can be complex and error-prone.
+
+Adding transaction support to Pulsar Functions would finally ensure message processing atomicity.
+
+# Goals
+
+## In Scope
+
+1. Enable automatic transaction support for Pulsar Functions through configuration
+2. Allow Functions to publish messages to multiple topics within a single transaction
+3. Support transactional acknowledgment of input messages
+4. Ensure transactions are committed only if message processing completes successfully
+5. Provide transaction timeout configuration for Functions
+
+## Out of Scope
+
+1. Exposing explicit transaction management APIs in the Functions interface
+2. Supporting multi-function transactions (transactions spanning multiple function invocations)
+3. Adding transaction support to Pulsar IO connectors
+4. Changes to the Function interface itself
+
+# High Level Design
+
+The proposed solution introduces automatic transaction wrapping for Pulsar Functions through configuration settings. When enabled, each function execution will be
+automatically wrapped in a transaction without requiring code changes to the function implementation.
+
+The general flow will be:
+1. Function is configured with `autoTransactionsEnabled: true`
+2. When a message arrives, the function runtime creates a new transaction
+3. The function processes the message with an enhanced Context that uses the transaction
+4. Any output messages are published using the transaction
+5. Input message acknowledgment is performed within the transaction
+6. If the function completes successfully, the transaction is committed
+7. If the function throws an exception, the transaction is aborted
+
+This approach provides transaction support in a way that is transparent to function implementers, requiring only configuration changes rather than code changes.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+### Configuration Classes
+
+First, we need to extend `FunctionConfig` to include transaction-related settings:
+
+```java
+public class FunctionConfig {
+    // Whether to automatically wrap each function call in a transaction
+    private boolean autoTransactionsEnabled = false;
+
+    // Default transaction timeout in milliseconds
+    private long transactionTimeoutMs = 60000;
+
+    // Getters and setters
+    public boolean isAutoTransactionsEnabled() {
+        return autoTransactionsEnabled;
+    }
+
+    public void setAutoTransactionsEnabled(boolean autoTransactionsEnabled) {
+        this.autoTransactionsEnabled = autoTransactionsEnabled;
+    }
+
+    public long getTransactionTimeoutMs() {
+        return transactionTimeoutMs;
+    }
+
+    public void setTransactionTimeoutMs(long transactionTimeoutMs) {
+        this.transactionTimeoutMs = transactionTimeoutMs;
+    }
+}
+```
+
+We also need to update the protobuf definition for FunctionDetails to include these fields:
+
+```java
+message FunctionDetails {
+    // Other existing fields...
+
+    // Whether to automatically wrap function execution in a transaction
+    bool autoTransactionsEnabled = X;
+
+    // Default transaction timeout in milliseconds
+    int64 transactionTimeoutMs = Y;
+}
+```
+
+### Modifications to ContextImpl
+
+The ContextImpl class needs to be updated to track the current transaction:
+
+```java
+class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
+    // Existing fields...
+
+    private Transaction currentTransaction;
+
+    // Existing methods...
+
+    public void setCurrentTransaction(Transaction transaction) {
+        this.currentTransaction = transaction;
+    }
+
+    public Transaction getCurrentTransaction() {
+        return currentTransaction;
+    }
+
+    @Override
+    public <T> CompletableFuture<Void> publish(String topicName, T object) {
+        if (currentTransaction != null) {
+            try {
+                return newOutputMessage(topicName, null)
+                    .value(object)
+                    .sendAsync(currentTransaction)
+                    .thenApply(msgId -> null);
+            } catch (PulsarClientException e) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                future.completeExceptionally(e);
+                return future;
+            }
+        } else {
+            // Use existing implementation
+            return publish(topicName, object, "");
+        }
+    }
+
+    @Override
+    public <T> TypedMessageBuilder<T> newOutputMessage(String topicName, Schema<T> schema)
+            throws PulsarClientException {
+        MessageBuilderImpl<T> messageBuilder = new MessageBuilderImpl<>();
+        TypedMessageBuilder<T> typedMessageBuilder;
+        Producer<T> producer = getProducer(topicName, schema);
+
+        if (schema != null) {
+            typedMessageBuilder = producer.newMessage(schema);
+        } else {
+            typedMessageBuilder = producer.newMessage();
+        }
+
+        // If there's an active transaction, associate the message with it
+        if (currentTransaction != null) {
+            typedMessageBuilder = typedMessageBuilder.sendTransaction(currentTransaction);
+        }
+
+        messageBuilder.setUnderlyingBuilder(typedMessageBuilder);
+        return messageBuilder;
+    }
+
+    @Override
+    public Record<?> getCurrentRecord() {
+        Record<?> record = super.getCurrentRecord();
+        if (record != null && currentTransaction != null) {
+            return new TransactionalRecordWrapper<>(record, currentTransaction);
+        }
+        return record;
+    }
+}
+```
+
+### TransactionalRecordWrapper Implementation
+
+```java
+public class TransactionalRecordWrapper<T> implements Record<T> {
+    private final Record<T> delegate;
+    private final Transaction transaction;
+    private static final Logger log = LoggerFactory.getLogger(TransactionalRecordWrapper.class);
+
+    public TransactionalRecordWrapper(Record<T> delegate, Transaction transaction) {
+        this.delegate = delegate;
+        this.transaction = transaction;
+    }
+
+    @Override
+    public void ack() {
+        if (transaction != null && delegate instanceof PulsarRecord) {
+            PulsarRecord<?> pulsarRecord = (PulsarRecord<?>) delegate;
+            pulsarRecord.getConsumer().ifPresent(consumer -> {
+                try {
+                    consumer.acknowledgeAsync(pulsarRecord.getMessageId(), transaction);
+                } catch (Exception e) {
+                    log.error("Failed to transactionally acknowledge message", e);
+                    delegate.fail();
+                }
+            });
+        } else {
+            // Fall back to non-transactional ack
+            delegate.ack();
+        }
+    }
+
+    @Override
+    public void fail() {
+        delegate.fail();
+    }
+
+    // Delegate all other methods to the wrapped record
+    @Override
+    public Optional<String> getKey() {
+        return delegate.getKey();
+    }
+
+    @Override
+    public T getValue() {
+        return delegate.getValue();
+    }
+
+    @Override
+    public Optional<Long> getEventTime() {
+        return delegate.getEventTime();
+    }
+
+    @Override
+    public Optional<String> getPartitionId() {
+        return delegate.getPartitionId();
+    }
+
+    @Override
+    public Optional<String> getTopicName() {
+        return delegate.getTopicName();
+    }
+
+    @Override
+    public Schema<T> getSchema() {
+        return delegate.getSchema();
+    }
+
+    @Override
+    public Optional<Long> getRecordSequence() {
+        return delegate.getRecordSequence();
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return delegate.getProperties();
+    }
+}
+```
+
+### Modifications to JavaInstanceRunnable
+
+The JavaInstanceRunnable class needs to be updated to handle auto transactions:
+
+```java
+public class JavaInstanceRunnable implements AutoCloseable, Runnable {
+    // Existing fields...
+
+    @Override
+    public void run() {
+        try {
+            setup();
+
+            while (true) {
+                currentRecord = readInput();
+
+                // increment number of records received from source
+                stats.incrTotalReceived();
+
+                // If auto transactions are enabled, wrap the function execution in a transaction
+                if (instanceConfig.getFunctionDetails().getAutoTransactionsEnabled()) {
+                    processWithTransaction();
+                } else {
+                    processNormally();
+                }
+
+                if (deathException != null) {
+                    throw deathException;
+                }
+            }
+        } catch (Throwable t) {
+            // Existing error handling...
+        } finally {
+            close();
+        }
+    }
+
+    private void processNormally() {
+        // Existing logic for non-transactional execution
+        Thread currentThread = Thread.currentThread();
+        Consumer<Throwable> asyncErrorHandler = throwable -> currentThread.interrupt();
+
+        // set last invocation time
+        stats.setLastInvocation(System.currentTimeMillis());
+
+        // start time for process latency stat
+        stats.processTimeStart();
+
+        // process the message
+        Thread.currentThread().setContextClassLoader(functionClassLoader);
+        JavaExecutionResult result = javaInstance.handleMessage(
+                currentRecord,
+                currentRecord.getValue(),
+                this::handleResult,
+                asyncErrorHandler);
+        Thread.currentThread().setContextClassLoader(instanceClassLoader);
+
+        // register end time
+        stats.processTimeEnd();
+
+        if (result != null) {
+            // process the synchronous results
+            handleResult(currentRecord, result);
+        }
+    }
+
+    private void processWithTransaction() {
+        Transaction txn = null;
+        JavaExecutionResult result = null;
+        boolean success = false;
+
+        try {
+            // Create a new transaction
+            long timeoutMs = instanceConfig.getFunctionDetails().getTransactionTimeoutMs();
+            if (timeoutMs <= 0) {
+                timeoutMs = 60000; // Default to 60 seconds if not specified
+            }
+
+            txn = client.newTransaction()
+                .withTransactionTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+                .build().get();
+
+            // Associate transaction with current execution context
+            ContextImpl context = (ContextImpl) javaInstance.getContext();
+            context.setCurrentTransaction(txn);
+
+            // set last invocation time
+            stats.setLastInvocation(System.currentTimeMillis());
+
+            // start time for process latency stat
+            stats.processTimeStart();
+
+            // Process the message with the transaction context
+            Thread.currentThread().setContextClassLoader(functionClassLoader);
+            result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
+            Thread.currentThread().setContextClassLoader(instanceClassLoader);
+
+            // register end time
+            stats.processTimeEnd();
+
+            // Check result
+            if (result.getUserException() == null) {
+                // If processing succeeded and there was output, it's already sent
+                // with the transaction, just commit the transaction
+                txn.commit().get();
+                success = true;
+
+                // Increment total successfully processed
+                stats.incrTotalProcessedSuccessfully();
+            } else {
+                // If user exception occurred, abort the transaction
+                txn.abort().get();
+
+                // Log and track user exception
+                Throwable t = result.getUserException();
+                log.warn("Encountered exception when processing message {}", currentRecord, t);
+                stats.incrUserExceptions(t);
+                currentRecord.fail();
+            }
+        } catch (Exception e) {
+            // If an error occurred, try to abort the transaction
+            if (txn != null && !success) {
+                try {
+                    txn.abort().get();
+                } catch (Exception abortEx) {
+                    log.error("Failed to abort transaction", abortEx);
+                }
+            }
+
+            log.error("Error processing message with transaction", e);
+            stats.incrSystemExceptions(e);
+            currentRecord.fail();
+        } finally {
+            // Clean up the transaction context
+            ContextImpl context = (ContextImpl) javaInstance.getContext();
+            context.setCurrentTransaction(null);
+        }
+    }
+
+    private void handleResult(Record<?> srcRecord, JavaExecutionResult result) throws Exception {
+        // Only used for non-transactional execution
+        if (result.getUserException() != null) {
+            // Handle user exception...
+            Throwable t = result.getUserException();
+            log.warn("Encountered exception when processing message {}", srcRecord, t);
+            stats.incrUserExceptions(t);
+            srcRecord.fail();
+        } else {
+            if (result.getResult() != null) {
+                sendOutputMessage(srcRecord, result.getResult());
+            } else {
+                // Handle null result case
+                if (!instanceConfig.getFunctionDetails().getAutoAck() ||
+                    instanceConfig.getFunctionDetails().getProcessingGuarantees() !=
+                    org.apache.pulsar.functions.proto.Function.ProcessingGuarantees.ATMOST_ONCE) {
+                    srcRecord.ack();
+                }
+            }
+            // increment total successfully processed
+            stats.incrTotalProcessedSuccessfully();
+        }
+    }
+
+    // Existing methods...
+}
+```
+
+# Public-facing Changes
+
+## Configuration
+
+Two new configuration options will be added to the FunctionConfig:
+
+1. `autoTransactionsEnabled` (boolean): When set to true, each function execution will be automatically wrapped in a transaction. Default: false.
+2. `transactionTimeoutMs` (long): The timeout in milliseconds for transactions created by the function. Default: 60000 (60 seconds).
+
+## CLI
+
+The Pulsar Admin CLI will be updated to support these new configuration options:
+
+```bash
+$ pulsar-admin functions create \
+  --auto-transactions-enabled true \
+  --transaction-timeout-ms 30000 \
+  ... other options ...
+```
+
+Similarly, the CLI will support updating these options with the update command.
+
+# Metrics
+
+The following new metrics will be added to track transaction usage in functions:
+
+1. `pulsar_function_txn_created_total`: Counter tracking the total number of transactions created by functions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+2. `pulsar_function_txn_committed_total`: Counter tracking successfully committed transactions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+3. `pulsar_function_txn_aborted_total`: Counter tracking aborted transactions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+4. `pulsar_function_txn_timeout_total`: Counter tracking transactions that timed out
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+5. `pulsar_function_txn_latency`: Histogram of transaction duration from creation to commit/abort
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Milliseconds
+
+# Monitoring
+
+To monitor the transaction functionality in Pulsar Functions, users should:
+
+1. Monitor the transaction metrics mentioned above to track transaction usage and success/failure rates.
+2. Set up alerts for high transaction abort rates or timeouts, which may indicate issues with function processing or transaction configuration.
+3. Monitor function processing latency metrics to ensure that using transactions doesn't introduce unacceptable overhead.
+4. Set up alerts for transaction timeout occurrences, which might indicate that the configured timeout is too low for the function's processing time.
+5. Configure appropriate logging levels to capture transaction-related errors for debugging.
+
+Example alert thresholds:
+- Transaction abort rate > 5% over 5 minutes
+- Transaction timeout rate > 1% over 5 minutes
+- Transaction duration approaching timeout value (e.g., > 80% of configured timeout)
+
+# Security Considerations
+
+The proposed transaction support doesn't introduce new security concerns as it builds on top of existing Pulsar transaction mechanisms. All security aspects of
+transactions, including authentication and authorization, are inherited from the Pulsar client's transaction implementation.
+
+Functions will only be able to create transactions and operate on topics they already have permission to access. No additional permissions are required beyond what's
+already needed for the function to operate.
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+The proposed changes are backward compatible with existing Pulsar Functions:
+
+1. The new transaction-related configuration options default to disabled (autoTransactionsEnabled=false).
+2. Existing functions will continue to operate without transaction support unless explicitly configured.
+3. The Function interface remains unchanged, so existing function implementations will work with transaction support when enabled.
+
+To enable transaction support for existing functions:
+
+1. Ensure transactions are enabled at the broker level.
+2. Update the function configuration to set autoTransactionsEnabled=true and optionally configure transactionTimeoutMs.
+3. Restart or update the function to apply the new configuration.
+
+## Downgrade / Rollback
+
+To roll back to a version without transaction support:
+
+1. Update function configuration to disable transactions (autoTransactionsEnabled=false).
+2. Restart or update the function to apply the configuration change.
+3. If downgrading Pulsar itself, no special steps are needed for functions; they will simply operate without transaction support.
+
+## Pulsar Upgrade & Downgrade/Rollback Considerations
+
+1. Transactions created by functions in one cluster will not span to other clusters; they are local to the cluster where the function executes.
+2. Functions running in different clusters should each be configured for transaction support independently.
+3. During rolling upgrades, ensure that transaction-enabled functions are only deployed to clusters that support transactions.
+4. When downgrading, first disable transactions in function configurations before downgrading the clusters.
+
+# Alternatives
+
+## Explicit Transaction API
+
+Instead of automatic transaction wrapping, we could expose explicit transaction APIs in the Context interface:
+
+```java
+Transaction newTransaction();
+void commitTransaction(Transaction txn);
+void abortTransaction(Transaction txn);
+```
+This approach gives function authors more control but requires code changes to use transactions. We rejected this approach to keep the programming model simpler
+and avoid breaking the Function interface.
+
+# General Notes
+
+The implementation of transaction support in Pulsar Functions should be considered a stepping stone toward a more comprehensive exactly-once processing model for
+Pulsar's stream processing capabilities. Future work may include Transaction support in Pulsar IO connectors.
+
+# Links
+
+- https://github.com/apache/pulsar/issues/24588
+- https://pulsar.apache.org/docs/txn-why/
+- https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn


### PR DESCRIPTION
### Motivation

  This PIP proposes extending Pulsar Functions with configuration-based automatic transaction support to enable exactly-once processing semantics. Currently, Pulsar
  Functions cannot publish to multiple topics transactionally, which is a significant limitation for use cases requiring atomic multi-topic operations.

  ### Modifications

  The implementation will allow functions to atomically process input messages and publish to multiple output topics within a single transaction without requiring code
  changes to the function implementation. This will be achieved through:

  - Adding transaction configuration options to FunctionConfig
  - Modifying JavaInstanceRunnable to support auto-transactions
  - Enhancing ContextImpl to track and use transactions
  - Adding metrics for monitoring transaction usage in functions

  ### Verifying this change

  - [ ] Make sure that the change passes the CI checks.

  This change will add tests and can be verified through:
  - Unit tests for transaction-enabled function execution
  - Integration tests for end-to-end transaction processing

  ### Does this pull request potentially affect one of the following parts:

  - [x] The public API
  - [x] The metrics

  ### Documentation

  - [ ] `doc-required` <!-- Will update docs after implementation -->
