### PR TITLE
[improve][pip] PIP-439: Adding Transaction Support to Pulsar Functions Through Managed Transaction Wrapping

### DIFF
--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -1,4 +1,4 @@
-# PIP-439: Adding Transaction Support to Pulsar Functions Through Auto-Transaction Wrapping
+# PIP-439: Adding Transaction Support to Pulsar Functions Through Managed Transaction Wrapping
 
 # Background knowledge
 
@@ -70,6 +70,8 @@ Adding transaction support to Pulsar Functions would finally ensure message proc
 3. Support transactional acknowledgment of input messages
 4. Ensure transactions are committed only if message processing completes successfully
 5. Provide transaction timeout configuration for Functions
+6. Add transaction support for async functions
+7. Handling multiple transactions in batches to improve performance, added in a later phase of implementation
 
 ## Out of Scope
 
@@ -110,6 +112,8 @@ public enum TransactionMode {
 public class TransactionConfig {
   private TransactionMode transactionMode = TransactionMode.OFF;
   private Long transactionTimeoutMs = 60000L;
+  private Integer transactionBatchingMaxEntries = 1;
+  private Long transactionBatchingQuietPeriodMs = 100L;
 
   // Getters and setters...
 }
@@ -133,6 +137,8 @@ message TransactionSpec {
   }
   TransactionMode transactionMode = 1;
   int64 transactionTimeoutMs = 2;
+  int64 transactionBatchingMaxEntries = 3;
+  int64 transactionBatchingQuietPeriodMs = 4;
 }
 
 message FunctionDetails {
@@ -141,46 +147,18 @@ message FunctionDetails {
 }
 ```
 
-### Modifications to Context Interface
+### Modifications to ContextImpl
 
-We will update the Context interface to expose the current transaction:
-
-```java
-public interface Context {
-      // Existing methods...
-
-    /**
-     * Returns the current transaction if function is running in managed transaction mode.
-     *
-     * <p>IMPORTANT: This method is not async-safe. When writing asynchronous functions that
-     * return CompletableFuture and need to use the transaction inside callbacks or chained
-     * operations, you must store a reference to the transaction locally before returning the future:
-     *
-     * <pre>{@code
-     * public CompletableFuture<String> process(String input, Context context) {
-     *     // Store transaction reference locally before async operations
-     *     Transaction txn = context.getCurrentTransaction();
-     *
-     *     return someAsyncOperation()
-     *         .thenApply(result -> {
-     *             // Use the locally stored transaction reference
-     *             // instead of calling context.getCurrentTransaction() here
-     *               return "processed";
-     *         });
-     * }
-     * }</pre>
-     *
-     * @return the current transaction, or null if transactions are disabled
-     */
-    Transaction getCurrentTransaction();
-}
-```
 
 ```java
 class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
     // Existing fields...
 
-    private Transaction currentTransaction;
+    // Finds the proper transaction to tie to current function execution (sync/async)
+    private Transaction getManagedTransaction() {
+
+        // implementation...
+    }
 
     // Existing methods...
 
@@ -189,23 +167,19 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     }
 
     @Override
-    public Transaction getCurrentTransaction() {
-        return currentTransaction;
-    }
-
-    @Override
     public <T> TypedMessageBuilder<T> newOutputMessage(String topicName, Schema<T> schema)
           throws PulsarClientException {
       MessageBuilderImpl<T> messageBuilder = new MessageBuilderImpl<>();
       TypedMessageBuilder<T> typedMessageBuilder;
       Producer<T> producer = getProducer(topicName, schema);
+      Transaction managedTransaction = getManagedTransaction(); 
     
       if (currentTransaction != null) {
           if (schema != null) {
               // Uses the new API that supports both schema and transaction
-              typedMessageBuilder = producer.newMessage(schema, currentTransaction);
+              typedMessageBuilder = producer.newMessage(schema, managedTransaction);
           } else {
-              typedMessageBuilder = producer.newMessage(currentTransaction);
+              typedMessageBuilder = producer.newMessage(managedTransaction);
           }
       } else if (schema != null) {
           typedMessageBuilder = producer.newMessage(schema);
@@ -226,8 +200,44 @@ It's important to note that Pulsar Functions supports asynchronous processing, w
 For asynchronous functions:
 1. The transaction is created at the beginning of message processing, just like for synchronous functions
 2. When the function returns a `CompletableFuture`, the transaction is maintained until the future completes
+ - Any Context-related operations inside of the returned 'CompletableFuture' objects are tied to the correct transaction
 3. When the future completes successfully, the transaction is committed
 4. If the future completes exceptionally, the transaction is aborted
+
+## Batch Processing of Transactions
+
+To optimize performance and reduce the overhead on the Transaction Coordinator, this proposal introduces transaction batching.
+Transaction batching allows multiple incoming messages to be processed within the same transaction, reducing the total number of
+transactions created.
+
+## Transaction Batching Concept
+
+Transaction batching is distinct from Pulsar's message batching. While message batching combines multiple messages into a single "batch
+message" for efficient network transfer, transaction batching processes multiple incoming messages (or batch messages) within the scope
+of a single transaction.
+
+Key benefits of transaction batching include:
+1. **Reduced Load on Transaction Coordinator**: Fewer transactions means less coordination overhead
+2. **Improved Throughput**: Higher message processing capacity with lower per-message overhead
+3. **Optimized Resource Usage**: Better utilization of transaction resources
+4. **Consistent Performance at Scale**: Maintains performance characteristics under high load
+
+### Transaction Batching Parameters
+
+Transaction batching is controlled by two main parameters:
+
+1. **`transactionBatchingMaxEntries`**: The maximum number of entries (incoming messages or batch messages) to process within a single
+transaction before committing it and starting a new one.
+ - An "entry" refers to an incoming batch message which could itself contain multiple individual messages
+ - Default: 1 (recommended minimum to ensure batch index acknowledgment state doesn't span transactions)
+ - Setting this to higher values increases throughput but may impact latency
+
+2. **`transactionBatchingQuietPeriodMs`**: The maximum amount of time to wait for additional messages before committing a transaction if
+`transactionBatchingMaxEntries` is not reached.
+ - Default: 100ms
+ - This parameter handles scenarios where message flow isn't continuous
+ - When the quiet period elapses without new messages arriving, the current transaction is committed
+
 
 # Public-facing Changes
 
@@ -239,11 +249,26 @@ Transaction support will be configured using the new TransactionConfig class:
 TransactionConfig txnConfig = new TransactionConfig();
 txnConfig.setTransactionMode(TransactionMode.MANAGED);
 txnConfig.setTransactionTimeoutMs(30000L); // 30 seconds
+txnConfig.setTransactionBatchingMaxEntries(10); // Process up to 10 entries per transaction
+txnConfig.setTransactionBatchingQuietPeriodMs(50L); // Commit after 50ms of inactivity
 
 FunctionConfig functionConfig = new FunctionConfig();
 functionConfig.setTransaction(txnConfig);
 // Other configuration...
 ```
+
+The Functions worker configuration will include a setting to en-/disable `pulsar_function_txn_latency`:
+
+```yaml
+# Transaction metrics configuration
+transactionMetrics:
+  # Enable/disable specific transaction metrics individually
+  enabledMetrics:
+    txnLatency: false          # Transaction duration histograms (high cardinality)
+    # ... disable any future metric deemed as too expensive to enable per default
+```
+
+
 
 ## CLI
 
@@ -253,6 +278,8 @@ The Pulsar Admin CLI will be updated to support these new configuration options:
 $ pulsar-admin functions create \
   --auto-transactions-enabled true \
   --transaction-timeout-ms 30000 \
+  --transaction-batching-max-entries 10 \
+  --transaction-batching-quiet-period-ms 50 \
   ... other options ...
 ```
 
@@ -278,9 +305,23 @@ The following new metrics will be added to track transaction usage in functions:
  - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
  - Unit: Count
 
-5. `pulsar_function_txn_latency`: Histogram of transaction duration from creation to commit/abort
+5. `pulsar_function_txn_latency`: Histogram of transaction duration from creation to commit/abort (configurable in functions worker)
  - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
  - Unit: Milliseconds
+ - turned off by default to avoid adding too much volume and will be configurable in the functions worker
+
+6. `pulsar_function_txn_batch_size`: Histogram of transaction batch sizes (number of entries processed per transaction)
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+7. `pulsar_function_txn_batch_commit_reason`: Counter tracking transaction batch commits by reason
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`, `reason` ("max_entries", "quiet_period",
+"function_close")
+ - Unit: Count
+
+8. `pulsar_function_txn_entries_per_second`: Gauge tracking the rate of entries processed in transactions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Entries/second
 
 # Monitoring
 
@@ -365,6 +406,6 @@ Pulsar's stream processing capabilities. Future work may include Transaction sup
 # Links
 
 - https://github.com/apache/pulsar/issues/24588
-- https://pulsar.apache.org/docs/txn-why/
-- https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn
-
+- [Pulsar transactions](https://pulsar.apache.org/docs/txn-why/)
+- [Kickoff Discussion](https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn)
+- [PIP Discussion](https://lists.apache.org/thread/ztvxg5d2w526ov0w9c9l66tgpfogtvph)

--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -230,11 +230,13 @@ Transaction batching is controlled by two main parameters:
 transaction before committing it and starting a new one.
  - An "entry" refers to an incoming batch message which could itself contain multiple individual messages
  - Default: 1 (recommended minimum to ensure batch index acknowledgment state doesn't span transactions)
+ - Setting this to **0 disables** transaction batching!
  - Setting this to higher values increases throughput but may impact latency
+
 
 2. **`transactionBatchingQuietPeriodMs`**: The maximum amount of time to wait for additional messages before committing a transaction if
 `transactionBatchingMaxEntries` is not reached.
- - Default: 100ms
+ - Default: 1ms (matching the Pulsar Client producer's default `batchingMaxPublishDelay` value)
  - This parameter handles scenarios where message flow isn't continuous
  - When the quiet period elapses without new messages arriving, the current transaction is committed
 
@@ -250,7 +252,7 @@ TransactionConfig txnConfig = new TransactionConfig();
 txnConfig.setTransactionMode(TransactionMode.MANAGED);
 txnConfig.setTransactionTimeoutMs(30000L); // 30 seconds
 txnConfig.setTransactionBatchingMaxEntries(10); // Process up to 10 entries per transaction
-txnConfig.setTransactionBatchingQuietPeriodMs(50L); // Commit after 50ms of inactivity
+txnConfig.setTransactionBatchingQuietPeriodMs(1L); // Commit after 1ms of inactivity
 
 FunctionConfig functionConfig = new FunctionConfig();
 functionConfig.setTransaction(txnConfig);
@@ -278,7 +280,7 @@ $ pulsar-admin functions create \
   --auto-transactions-enabled true \
   --transaction-timeout-ms 30000 \
   --transaction-batching-max-entries 10 \
-  --transaction-batching-quiet-period-ms 50 \
+  --transaction-batching-quiet-period-ms 1 \
   ... other options ...
 ```
 

--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -408,5 +408,6 @@ Pulsar's stream processing capabilities. Future work may include Transaction sup
 
 - https://github.com/apache/pulsar/issues/24588
 - [Pulsar transactions](https://pulsar.apache.org/docs/txn-why/)
-- [Kickoff Discussion](https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn)
-- [PIP Discussion](https://lists.apache.org/thread/ztvxg5d2w526ov0w9c9l66tgpfogtvph)
+- [Mailing List Kickoff Discussion Thread](https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn)
+- [Mailing List PIP Discussion Thread](https://lists.apache.org/thread/ztvxg5d2w526ov0w9c9l66tgpfogtvph)
+- [Mailing List PIP Voting Thread](https://lists.apache.org/thread/8g43xgv8d0p3m918c9zrpwn81p4lh9d4)

--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -1,0 +1,573 @@
+# PIP-439: Adding Transaction Support to Pulsar Functions Through Auto-Transaction Wrapping
+
+# Background knowledge
+
+Apache Pulsar transactions enable atomic operations across multiple topics, allowing producers to send messages and consumers to acknowledge messages as a single unit
+of work. This provides the foundation for exactly-once processing semantics in streaming applications.
+
+## Transaction Architecture
+
+Pulsar's transaction system consists of four key components:
+
+1. **Transaction Coordinator (TC)**: A broker module that manages transaction lifecycles, allocates transaction IDs, and orchestrates the commit/abort process.
+
+2. **Transaction Log**: A persistent topic storing transaction metadata and state changes, enabling recovery after failures.
+
+3. **Transaction Buffer**: Temporarily stores messages produced within transactions, making them visible to consumers only after commit.
+
+4. **Pending Acknowledge State**: Tracks message acknowledgments within transactions, preventing conflicts between competing transactions.
+
+## Transaction Lifecycle
+
+Transactions follow a defined lifecycle:
+
+1. **OPEN**: Client obtains a transaction ID from the Transaction Coordinator.
+2. **PRODUCING/ACKNOWLEDGING**: Client registers topic partitions/subscriptions with the TC, then produces/acknowledges messages within the transaction.
+3. **COMMITTING/ABORTING**: Client requests to end the transaction, TC begins two-phase commit.
+4. **COMMITTED/ABORTED**: After processing all partitions, TC finalizes the transaction state.
+5. **TIMED_OUT**: Transactions exceeding their timeout are automatically aborted.
+
+## Transaction Guarantees
+
+Pulsar transactions provide:
+- Atomic writes across multiple topics
+- Conditional acknowledgment to prevent duplicate processing by "zombie" instances
+- Visibility control ensuring consumers only see committed transaction messages
+- Support for exactly-once processing in consume-transform-produce patterns
+
+# Motivation
+
+Currently, Pulsar Functions cannot publish to multiple topics transactionally, which is a significant limitation for use cases requiring atomic multi-topic
+publishing. For instance, if a function processes an input message and needs to publish related updates to several output topics, there's no guarantee that all
+operations will succeed atomically.
+
+This limitation prevents building robust stream processing applications that require exactly-once semantics across multiple input and output topics. Without
+transaction support in Functions, developers must implement their own error handling and retry mechanisms, which can be complex and error-prone.
+
+Adding transaction support to Pulsar Functions would finally ensure message processing atomicity.
+
+# Goals
+
+## In Scope
+
+1. Enable automatic transaction support for Pulsar Functions through configuration
+2. Allow Functions to publish messages to multiple topics within a single transaction
+3. Support transactional acknowledgment of input messages
+4. Ensure transactions are committed only if message processing completes successfully
+5. Provide transaction timeout configuration for Functions
+
+## Out of Scope
+
+1. Exposing explicit transaction management APIs in the Functions interface
+2. Supporting multi-function transactions (transactions spanning multiple function invocations)
+3. Adding transaction support to Pulsar IO connectors
+4. Changes to the Function interface itself
+
+# High Level Design
+
+The proposed solution introduces automatic transaction wrapping for Pulsar Functions through configuration settings. When enabled, each function execution will be
+automatically wrapped in a transaction without requiring code changes to the function implementation.
+
+The general flow will be:
+1. Function is configured with `autoTransactionsEnabled: true`
+2. When a message arrives, the function runtime creates a new transaction
+3. The function processes the message with an enhanced Context that uses the transaction
+4. Any output messages are published using the transaction
+5. Input message acknowledgment is performed within the transaction
+6. If the function completes successfully, the transaction is committed
+7. If the function throws an exception, the transaction is aborted
+
+This approach provides transaction support in a way that is transparent to function implementers, requiring only configuration changes rather than code changes.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+### Configuration Classes
+
+First, we need to extend `FunctionConfig` to include transaction-related settings:
+
+```java
+public class FunctionConfig {
+    // Whether to automatically wrap each function call in a transaction
+    private boolean autoTransactionsEnabled = false;
+
+    // Default transaction timeout in milliseconds
+    private long transactionTimeoutMs = 60000;
+
+    // Getters and setters
+    public boolean isAutoTransactionsEnabled() {
+        return autoTransactionsEnabled;
+    }
+
+    public void setAutoTransactionsEnabled(boolean autoTransactionsEnabled) {
+        this.autoTransactionsEnabled = autoTransactionsEnabled;
+    }
+
+    public long getTransactionTimeoutMs() {
+        return transactionTimeoutMs;
+    }
+
+    public void setTransactionTimeoutMs(long transactionTimeoutMs) {
+        this.transactionTimeoutMs = transactionTimeoutMs;
+    }
+}
+```
+
+We also need to update the protobuf definition for FunctionDetails to include these fields:
+
+```java
+message FunctionDetails {
+    // Other existing fields...
+
+    // Whether to automatically wrap function execution in a transaction
+    bool autoTransactionsEnabled = X;
+
+    // Default transaction timeout in milliseconds
+    int64 transactionTimeoutMs = Y;
+}
+```
+
+### Modifications to ContextImpl
+
+The ContextImpl class needs to be updated to track the current transaction:
+
+```java
+class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
+    // Existing fields...
+
+    private Transaction currentTransaction;
+
+    // Existing methods...
+
+    public void setCurrentTransaction(Transaction transaction) {
+        this.currentTransaction = transaction;
+    }
+
+    public Transaction getCurrentTransaction() {
+        return currentTransaction;
+    }
+
+    @Override
+    public <T> CompletableFuture<Void> publish(String topicName, T object) {
+        if (currentTransaction != null) {
+            try {
+                return newOutputMessage(topicName, null)
+                    .value(object)
+                    .sendAsync(currentTransaction)
+                    .thenApply(msgId -> null);
+            } catch (PulsarClientException e) {
+                CompletableFuture<Void> future = new CompletableFuture<>();
+                future.completeExceptionally(e);
+                return future;
+            }
+        } else {
+            // Use existing implementation
+            return publish(topicName, object, "");
+        }
+    }
+
+    @Override
+    public <T> TypedMessageBuilder<T> newOutputMessage(String topicName, Schema<T> schema)
+            throws PulsarClientException {
+        MessageBuilderImpl<T> messageBuilder = new MessageBuilderImpl<>();
+        TypedMessageBuilder<T> typedMessageBuilder;
+        Producer<T> producer = getProducer(topicName, schema);
+
+        if (schema != null) {
+            typedMessageBuilder = producer.newMessage(schema);
+        } else {
+            typedMessageBuilder = producer.newMessage();
+        }
+
+        // If there's an active transaction, associate the message with it
+        if (currentTransaction != null) {
+            typedMessageBuilder = typedMessageBuilder.sendTransaction(currentTransaction);
+        }
+
+        messageBuilder.setUnderlyingBuilder(typedMessageBuilder);
+        return messageBuilder;
+    }
+
+    @Override
+    public Record<?> getCurrentRecord() {
+        Record<?> record = super.getCurrentRecord();
+        if (record != null && currentTransaction != null) {
+            return new TransactionalRecordWrapper<>(record, currentTransaction);
+        }
+        return record;
+    }
+}
+```
+
+### TransactionalRecordWrapper Implementation
+
+```java
+public class TransactionalRecordWrapper<T> implements Record<T> {
+    private final Record<T> delegate;
+    private final Transaction transaction;
+    private static final Logger log = LoggerFactory.getLogger(TransactionalRecordWrapper.class);
+
+    public TransactionalRecordWrapper(Record<T> delegate, Transaction transaction) {
+        this.delegate = delegate;
+        this.transaction = transaction;
+    }
+
+    @Override
+    public void ack() {
+        if (transaction != null && delegate instanceof PulsarRecord) {
+            PulsarRecord<?> pulsarRecord = (PulsarRecord<?>) delegate;
+            pulsarRecord.getConsumer().ifPresent(consumer -> {
+                try {
+                    consumer.acknowledgeAsync(pulsarRecord.getMessageId(), transaction);
+                } catch (Exception e) {
+                    log.error("Failed to transactionally acknowledge message", e);
+                    delegate.fail();
+                }
+            });
+        } else {
+            // Fall back to non-transactional ack
+            delegate.ack();
+        }
+    }
+
+    @Override
+    public void fail() {
+        delegate.fail();
+    }
+
+    // Delegate all other methods to the wrapped record
+    @Override
+    public Optional<String> getKey() {
+        return delegate.getKey();
+    }
+
+    @Override
+    public T getValue() {
+        return delegate.getValue();
+    }
+
+    @Override
+    public Optional<Long> getEventTime() {
+        return delegate.getEventTime();
+    }
+
+    @Override
+    public Optional<String> getPartitionId() {
+        return delegate.getPartitionId();
+    }
+
+    @Override
+    public Optional<String> getTopicName() {
+        return delegate.getTopicName();
+    }
+
+    @Override
+    public Schema<T> getSchema() {
+        return delegate.getSchema();
+    }
+
+    @Override
+    public Optional<Long> getRecordSequence() {
+        return delegate.getRecordSequence();
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return delegate.getProperties();
+    }
+}
+```
+
+### Modifications to JavaInstanceRunnable
+
+The JavaInstanceRunnable class needs to be updated to handle auto transactions:
+
+```java
+public class JavaInstanceRunnable implements AutoCloseable, Runnable {
+    // Existing fields...
+
+    @Override
+    public void run() {
+        try {
+            setup();
+
+            while (true) {
+                currentRecord = readInput();
+
+                // increment number of records received from source
+                stats.incrTotalReceived();
+
+                // If auto transactions are enabled, wrap the function execution in a transaction
+                if (instanceConfig.getFunctionDetails().getAutoTransactionsEnabled()) {
+                    processWithTransaction();
+                } else {
+                    processNormally();
+                }
+
+                if (deathException != null) {
+                    throw deathException;
+                }
+            }
+        } catch (Throwable t) {
+            // Existing error handling...
+        } finally {
+            close();
+        }
+    }
+
+    private void processNormally() {
+        // Existing logic for non-transactional execution
+        Thread currentThread = Thread.currentThread();
+        Consumer<Throwable> asyncErrorHandler = throwable -> currentThread.interrupt();
+
+        // set last invocation time
+        stats.setLastInvocation(System.currentTimeMillis());
+
+        // start time for process latency stat
+        stats.processTimeStart();
+
+        // process the message
+        Thread.currentThread().setContextClassLoader(functionClassLoader);
+        JavaExecutionResult result = javaInstance.handleMessage(
+                currentRecord,
+                currentRecord.getValue(),
+                this::handleResult,
+                asyncErrorHandler);
+        Thread.currentThread().setContextClassLoader(instanceClassLoader);
+
+        // register end time
+        stats.processTimeEnd();
+
+        if (result != null) {
+            // process the synchronous results
+            handleResult(currentRecord, result);
+        }
+    }
+
+    private void processWithTransaction() {
+        Transaction txn = null;
+        JavaExecutionResult result = null;
+        boolean success = false;
+
+        try {
+            // Create a new transaction
+            long timeoutMs = instanceConfig.getFunctionDetails().getTransactionTimeoutMs();
+            if (timeoutMs <= 0) {
+                timeoutMs = 60000; // Default to 60 seconds if not specified
+            }
+
+            txn = client.newTransaction()
+                .withTransactionTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+                .build().get();
+
+            // Associate transaction with current execution context
+            ContextImpl context = (ContextImpl) javaInstance.getContext();
+            context.setCurrentTransaction(txn);
+
+            // set last invocation time
+            stats.setLastInvocation(System.currentTimeMillis());
+
+            // start time for process latency stat
+            stats.processTimeStart();
+
+            // Process the message with the transaction context
+            Thread.currentThread().setContextClassLoader(functionClassLoader);
+            result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
+            Thread.currentThread().setContextClassLoader(instanceClassLoader);
+
+            // register end time
+            stats.processTimeEnd();
+
+            // Check result
+            if (result.getUserException() == null) {
+                // If processing succeeded and there was output, it's already sent
+                // with the transaction, just commit the transaction
+                txn.commit().get();
+                success = true;
+
+                // Increment total successfully processed
+                stats.incrTotalProcessedSuccessfully();
+            } else {
+                // If user exception occurred, abort the transaction
+                txn.abort().get();
+
+                // Log and track user exception
+                Throwable t = result.getUserException();
+                log.warn("Encountered exception when processing message {}", currentRecord, t);
+                stats.incrUserExceptions(t);
+                currentRecord.fail();
+            }
+        } catch (Exception e) {
+            // If an error occurred, try to abort the transaction
+            if (txn != null && !success) {
+                try {
+                    txn.abort().get();
+                } catch (Exception abortEx) {
+                    log.error("Failed to abort transaction", abortEx);
+                }
+            }
+
+            log.error("Error processing message with transaction", e);
+            stats.incrSystemExceptions(e);
+            currentRecord.fail();
+        } finally {
+            // Clean up the transaction context
+            ContextImpl context = (ContextImpl) javaInstance.getContext();
+            context.setCurrentTransaction(null);
+        }
+    }
+
+    private void handleResult(Record<?> srcRecord, JavaExecutionResult result) throws Exception {
+        // Only used for non-transactional execution
+        if (result.getUserException() != null) {
+            // Handle user exception...
+            Throwable t = result.getUserException();
+            log.warn("Encountered exception when processing message {}", srcRecord, t);
+            stats.incrUserExceptions(t);
+            srcRecord.fail();
+        } else {
+            if (result.getResult() != null) {
+                sendOutputMessage(srcRecord, result.getResult());
+            } else {
+                // Handle null result case
+                if (!instanceConfig.getFunctionDetails().getAutoAck() ||
+                    instanceConfig.getFunctionDetails().getProcessingGuarantees() !=
+                    org.apache.pulsar.functions.proto.Function.ProcessingGuarantees.ATMOST_ONCE) {
+                    srcRecord.ack();
+                }
+            }
+            // increment total successfully processed
+            stats.incrTotalProcessedSuccessfully();
+        }
+    }
+
+    // Existing methods...
+}
+```
+
+# Public-facing Changes
+
+## Configuration
+
+Two new configuration options will be added to the FunctionConfig:
+
+1. `autoTransactionsEnabled` (boolean): When set to true, each function execution will be automatically wrapped in a transaction. Default: false.
+2. `transactionTimeoutMs` (long): The timeout in milliseconds for transactions created by the function. Default: 60000 (60 seconds).
+
+## CLI
+
+The Pulsar Admin CLI will be updated to support these new configuration options:
+
+```bash
+$ pulsar-admin functions create \
+  --auto-transactions-enabled true \
+  --transaction-timeout-ms 30000 \
+  ... other options ...
+```
+
+Similarly, the CLI will support updating these options with the update command.
+
+# Metrics
+
+The following new metrics will be added to track transaction usage in functions:
+
+1. `pulsar_function_txn_created_total`: Counter tracking the total number of transactions created by functions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+2. `pulsar_function_txn_committed_total`: Counter tracking successfully committed transactions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+3. `pulsar_function_txn_aborted_total`: Counter tracking aborted transactions
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+4. `pulsar_function_txn_timeout_total`: Counter tracking transactions that timed out
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Count
+
+5. `pulsar_function_txn_latency`: Histogram of transaction duration from creation to commit/abort
+ - Labels: `tenant`, `namespace`, `name` (function name), `instance_id`, `cluster`
+ - Unit: Milliseconds
+
+# Monitoring
+
+To monitor the transaction functionality in Pulsar Functions, users should:
+
+1. Monitor the transaction metrics mentioned above to track transaction usage and success/failure rates.
+2. Set up alerts for high transaction abort rates or timeouts, which may indicate issues with function processing or transaction configuration.
+3. Monitor function processing latency metrics to ensure that using transactions doesn't introduce unacceptable overhead.
+4. Set up alerts for transaction timeout occurrences, which might indicate that the configured timeout is too low for the function's processing time.
+5. Configure appropriate logging levels to capture transaction-related errors for debugging.
+
+Example alert thresholds:
+- Transaction abort rate > 5% over 5 minutes
+- Transaction timeout rate > 1% over 5 minutes
+- Transaction duration approaching timeout value (e.g., > 80% of configured timeout)
+
+# Security Considerations
+
+The proposed transaction support doesn't introduce new security concerns as it builds on top of existing Pulsar transaction mechanisms. All security aspects of
+transactions, including authentication and authorization, are inherited from the Pulsar client's transaction implementation.
+
+Functions will only be able to create transactions and operate on topics they already have permission to access. No additional permissions are required beyond what's
+already needed for the function to operate.
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+The proposed changes are backward compatible with existing Pulsar Functions:
+
+1. The new transaction-related configuration options default to disabled (autoTransactionsEnabled=false).
+2. Existing functions will continue to operate without transaction support unless explicitly configured.
+3. The Function interface remains unchanged, so existing function implementations will work with transaction support when enabled.
+
+To enable transaction support for existing functions:
+
+1. Ensure transactions are enabled at the broker level.
+2. Update the function configuration to set autoTransactionsEnabled=true and optionally configure transactionTimeoutMs.
+3. Restart or update the function to apply the new configuration.
+
+## Downgrade / Rollback
+
+To roll back to a version without transaction support:
+
+1. Update function configuration to disable transactions (autoTransactionsEnabled=false).
+2. Restart or update the function to apply the configuration change.
+3. If downgrading Pulsar itself, no special steps are needed for functions; they will simply operate without transaction support.
+
+## Pulsar Upgrade & Downgrade/Rollback Considerations
+
+1. Transactions created by functions in one cluster will not span to other clusters; they are local to the cluster where the function executes.
+2. Functions running in different clusters should each be configured for transaction support independently.
+3. During rolling upgrades, ensure that transaction-enabled functions are only deployed to clusters that support transactions.
+4. When downgrading, first disable transactions in function configurations before downgrading the clusters.
+
+# Alternatives
+
+## Explicit Transaction API
+
+Instead of automatic transaction wrapping, we could expose explicit transaction APIs in the Context interface:
+
+```java
+Transaction newTransaction();
+void commitTransaction(Transaction txn);
+void abortTransaction(Transaction txn);
+```
+This approach gives function authors more control but requires code changes to use transactions. We rejected this approach to keep the programming model simpler
+and avoid breaking the Function interface.
+
+# General Notes
+
+The implementation of transaction support in Pulsar Functions should be considered a stepping stone toward a more comprehensive exactly-once processing model for
+Pulsar's stream processing capabilities. Future work may include Transaction support in Pulsar IO connectors.
+
+# Links
+
+- https://github.com/apache/pulsar/issues/24588
+- https://pulsar.apache.org/docs/txn-why/
+- https://lists.apache.org/thread/rll8qyovpd7t9v5yxth25qo44zksbgkn
+

--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -35,6 +35,21 @@ Pulsar transactions provide:
 - Visibility control ensuring consumers only see committed transaction messages
 - Support for exactly-once processing in consume-transform-produce patterns
 
+## Pulsar Functions
+
+Pulsar Functions is a lightweight compute framework integrated with Apache Pulsar that
+enables stream processing without managing infrastructure. Key characteristics include:
+ - Simple Programming Model: Functions receive messages, process them, and optionally
+produce output
+ - Processing Patterns: Supports both synchronous and asynchronous message processing
+ - Context Object: Provides access to message metadata, output production, and state
+storage
+ - Integration: Natively integrated with Pulsar's pub-sub messaging system
+ - Deployment: Managed by Pulsar with automatic scaling and fault tolerance
+
+Functions operate on a per-message basis, making them ideal for implementing stream
+processing with exactly-once semantics when combined with transactions.
+
 # Motivation
 
 Currently, Pulsar Functions cannot publish to multiple topics transactionally, which is a significant limitation for use cases requiring atomic multi-topic
@@ -65,11 +80,10 @@ Adding transaction support to Pulsar Functions would finally ensure message proc
 
 # High Level Design
 
-The proposed solution introduces automatic transaction wrapping for Pulsar Functions through configuration settings. When enabled, each function execution will be
-automatically wrapped in a transaction without requiring code changes to the function implementation.
+The proposed solution introduces managed transaction wrapping for Pulsar Functions through configuration settings. When enabled, each function execution will be automatically wrapped in a transaction without requiring code changes to the function implementation.
 
 The general flow will be:
-1. Function is configured with `autoTransactionsEnabled: true`
+1. Function is configured with `transactionMode: MANAGED`
 2. When a message arrives, the function runtime creates a new transaction
 3. The function processes the message with an enhanced Context that uses the transaction
 4. Any output messages are published using the transaction
@@ -85,52 +99,82 @@ This approach provides transaction support in a way that is transparent to funct
 
 ### Configuration Classes
 
-First, we need to extend `FunctionConfig` to include transaction-related settings:
+We will update the FunctionConfig to include transaction-related settings through a new `TransactionConfig` class:
 
 ```java
+public enum TransactionMode {
+  OFF,
+  MANAGED
+}
+
+public class TransactionConfig {
+  private TransactionMode transactionMode = TransactionMode.OFF;
+  private Long transactionTimeoutMs = 60000L;
+
+  // Getters and setters...
+}
+
 public class FunctionConfig {
-    // Whether to automatically wrap each function call in a transaction
-    private boolean autoTransactionsEnabled = false;
+  // Existing fields...
 
-    // Default transaction timeout in milliseconds
-    private long transactionTimeoutMs = 60000;
+  private TransactionConfig transaction = new TransactionConfig();
 
-    // Getters and setters
-    public boolean isAutoTransactionsEnabled() {
-        return autoTransactionsEnabled;
-    }
-
-    public void setAutoTransactionsEnabled(boolean autoTransactionsEnabled) {
-        this.autoTransactionsEnabled = autoTransactionsEnabled;
-    }
-
-    public long getTransactionTimeoutMs() {
-        return transactionTimeoutMs;
-    }
-
-    public void setTransactionTimeoutMs(long transactionTimeoutMs) {
-        this.transactionTimeoutMs = transactionTimeoutMs;
-    }
+  // Getter and setter ...
 }
 ```
 
+```java
 We also need to update the protobuf definition for FunctionDetails to include these fields:
 
-```java
+message TransactionSpec {
+  enum TransactionMode {
+      OFF = 0;
+      MANAGED = 1;
+  }
+  TransactionMode transactionMode = 1;
+  int64 transactionTimeoutMs = 2;
+}
+
 message FunctionDetails {
-    // Other existing fields...
-
-    // Whether to automatically wrap function execution in a transaction
-    bool autoTransactionsEnabled = X;
-
-    // Default transaction timeout in milliseconds
-    int64 transactionTimeoutMs = Y;
+  // Other existing fields...
+  TransactionSpec transaction = 24;
 }
 ```
 
-### Modifications to ContextImpl
+### Modifications to Context Interface
 
-The ContextImpl class needs to be updated to track the current transaction:
+We will update the Context interface to expose the current transaction:
+
+```java
+public interface Context {
+      // Existing methods...
+
+    /**
+     * Returns the current transaction if function is running in managed transaction mode.
+     *
+     * <p>IMPORTANT: This method is not async-safe. When writing asynchronous functions that
+     * return CompletableFuture and need to use the transaction inside callbacks or chained
+     * operations, you must store a reference to the transaction locally before returning the future:
+     *
+     * <pre>{@code
+     * public CompletableFuture<String> process(String input, Context context) {
+     *     // Store transaction reference locally before async operations
+     *     Transaction txn = context.getCurrentTransaction();
+     *
+     *     return someAsyncOperation()
+     *         .thenApply(result -> {
+     *             // Use the locally stored transaction reference
+     *             // instead of calling context.getCurrentTransaction() here
+     *               return "processed";
+     *         });
+     * }
+     * }</pre>
+     *
+     * @return the current transaction, or null if transactions are disabled
+     */
+    Transaction getCurrentTransaction();
+}
+```
 
 ```java
 class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable {
@@ -144,316 +188,62 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         this.currentTransaction = transaction;
     }
 
+    @Override
     public Transaction getCurrentTransaction() {
         return currentTransaction;
     }
 
     @Override
-    public <T> CompletableFuture<Void> publish(String topicName, T object) {
-        if (currentTransaction != null) {
-            try {
-                return newOutputMessage(topicName, null)
-                    .value(object)
-                    .sendAsync(currentTransaction)
-                    .thenApply(msgId -> null);
-            } catch (PulsarClientException e) {
-                CompletableFuture<Void> future = new CompletableFuture<>();
-                future.completeExceptionally(e);
-                return future;
-            }
-        } else {
-            // Use existing implementation
-            return publish(topicName, object, "");
-        }
-    }
-
-    @Override
     public <T> TypedMessageBuilder<T> newOutputMessage(String topicName, Schema<T> schema)
-            throws PulsarClientException {
-        MessageBuilderImpl<T> messageBuilder = new MessageBuilderImpl<>();
-        TypedMessageBuilder<T> typedMessageBuilder;
-        Producer<T> producer = getProducer(topicName, schema);
-
-        if (schema != null) {
-            typedMessageBuilder = producer.newMessage(schema);
-        } else {
-            typedMessageBuilder = producer.newMessage();
-        }
-
-        // If there's an active transaction, associate the message with it
-        if (currentTransaction != null) {
-            typedMessageBuilder = typedMessageBuilder.sendTransaction(currentTransaction);
-        }
-
-        messageBuilder.setUnderlyingBuilder(typedMessageBuilder);
-        return messageBuilder;
-    }
-
-    @Override
-    public Record<?> getCurrentRecord() {
-        Record<?> record = super.getCurrentRecord();
-        if (record != null && currentTransaction != null) {
-            return new TransactionalRecordWrapper<>(record, currentTransaction);
-        }
-        return record;
+          throws PulsarClientException {
+      MessageBuilderImpl<T> messageBuilder = new MessageBuilderImpl<>();
+      TypedMessageBuilder<T> typedMessageBuilder;
+      Producer<T> producer = getProducer(topicName, schema);
+    
+      if (currentTransaction != null) {
+          if (schema != null) {
+              // Uses the new API that supports both schema and transaction
+              typedMessageBuilder = producer.newMessage(schema, currentTransaction);
+          } else {
+              typedMessageBuilder = producer.newMessage(currentTransaction);
+          }
+      } else if (schema != null) {
+          typedMessageBuilder = producer.newMessage(schema);
+      } else {
+          typedMessageBuilder = producer.newMessage();
+      }
+    
+      messageBuilder.setUnderlyingBuilder(typedMessageBuilder);
+      return messageBuilder;
     }
 }
 ```
 
-### TransactionalRecordWrapper Implementation
+## Asynchronous Functions Support
 
-```java
-public class TransactionalRecordWrapper<T> implements Record<T> {
-    private final Record<T> delegate;
-    private final Transaction transaction;
-    private static final Logger log = LoggerFactory.getLogger(TransactionalRecordWrapper.class);
+It's important to note that Pulsar Functions supports asynchronous processing, where functions can return `CompletableFuture` objects. This proposal ensures that transaction support works seamlessly with both synchronous and asynchronous functions.
 
-    public TransactionalRecordWrapper(Record<T> delegate, Transaction transaction) {
-        this.delegate = delegate;
-        this.transaction = transaction;
-    }
-
-    @Override
-    public void ack() {
-        if (transaction != null && delegate instanceof PulsarRecord) {
-            PulsarRecord<?> pulsarRecord = (PulsarRecord<?>) delegate;
-            pulsarRecord.getConsumer().ifPresent(consumer -> {
-                try {
-                    consumer.acknowledgeAsync(pulsarRecord.getMessageId(), transaction);
-                } catch (Exception e) {
-                    log.error("Failed to transactionally acknowledge message", e);
-                    delegate.fail();
-                }
-            });
-        } else {
-            // Fall back to non-transactional ack
-            delegate.ack();
-        }
-    }
-
-    @Override
-    public void fail() {
-        delegate.fail();
-    }
-
-    // Delegate all other methods to the wrapped record
-    @Override
-    public Optional<String> getKey() {
-        return delegate.getKey();
-    }
-
-    @Override
-    public T getValue() {
-        return delegate.getValue();
-    }
-
-    @Override
-    public Optional<Long> getEventTime() {
-        return delegate.getEventTime();
-    }
-
-    @Override
-    public Optional<String> getPartitionId() {
-        return delegate.getPartitionId();
-    }
-
-    @Override
-    public Optional<String> getTopicName() {
-        return delegate.getTopicName();
-    }
-
-    @Override
-    public Schema<T> getSchema() {
-        return delegate.getSchema();
-    }
-
-    @Override
-    public Optional<Long> getRecordSequence() {
-        return delegate.getRecordSequence();
-    }
-
-    @Override
-    public Map<String, String> getProperties() {
-        return delegate.getProperties();
-    }
-}
-```
-
-### Modifications to JavaInstanceRunnable
-
-The JavaInstanceRunnable class needs to be updated to handle auto transactions:
-
-```java
-public class JavaInstanceRunnable implements AutoCloseable, Runnable {
-    // Existing fields...
-
-    @Override
-    public void run() {
-        try {
-            setup();
-
-            while (true) {
-                currentRecord = readInput();
-
-                // increment number of records received from source
-                stats.incrTotalReceived();
-
-                // If auto transactions are enabled, wrap the function execution in a transaction
-                if (instanceConfig.getFunctionDetails().getAutoTransactionsEnabled()) {
-                    processWithTransaction();
-                } else {
-                    processNormally();
-                }
-
-                if (deathException != null) {
-                    throw deathException;
-                }
-            }
-        } catch (Throwable t) {
-            // Existing error handling...
-        } finally {
-            close();
-        }
-    }
-
-    private void processNormally() {
-        // Existing logic for non-transactional execution
-        Thread currentThread = Thread.currentThread();
-        Consumer<Throwable> asyncErrorHandler = throwable -> currentThread.interrupt();
-
-        // set last invocation time
-        stats.setLastInvocation(System.currentTimeMillis());
-
-        // start time for process latency stat
-        stats.processTimeStart();
-
-        // process the message
-        Thread.currentThread().setContextClassLoader(functionClassLoader);
-        JavaExecutionResult result = javaInstance.handleMessage(
-                currentRecord,
-                currentRecord.getValue(),
-                this::handleResult,
-                asyncErrorHandler);
-        Thread.currentThread().setContextClassLoader(instanceClassLoader);
-
-        // register end time
-        stats.processTimeEnd();
-
-        if (result != null) {
-            // process the synchronous results
-            handleResult(currentRecord, result);
-        }
-    }
-
-    private void processWithTransaction() {
-        Transaction txn = null;
-        JavaExecutionResult result = null;
-        boolean success = false;
-
-        try {
-            // Create a new transaction
-            long timeoutMs = instanceConfig.getFunctionDetails().getTransactionTimeoutMs();
-            if (timeoutMs <= 0) {
-                timeoutMs = 60000; // Default to 60 seconds if not specified
-            }
-
-            txn = client.newTransaction()
-                .withTransactionTimeout(timeoutMs, TimeUnit.MILLISECONDS)
-                .build().get();
-
-            // Associate transaction with current execution context
-            ContextImpl context = (ContextImpl) javaInstance.getContext();
-            context.setCurrentTransaction(txn);
-
-            // set last invocation time
-            stats.setLastInvocation(System.currentTimeMillis());
-
-            // start time for process latency stat
-            stats.processTimeStart();
-
-            // Process the message with the transaction context
-            Thread.currentThread().setContextClassLoader(functionClassLoader);
-            result = javaInstance.handleMessage(currentRecord, currentRecord.getValue());
-            Thread.currentThread().setContextClassLoader(instanceClassLoader);
-
-            // register end time
-            stats.processTimeEnd();
-
-            // Check result
-            if (result.getUserException() == null) {
-                // If processing succeeded and there was output, it's already sent
-                // with the transaction, just commit the transaction
-                txn.commit().get();
-                success = true;
-
-                // Increment total successfully processed
-                stats.incrTotalProcessedSuccessfully();
-            } else {
-                // If user exception occurred, abort the transaction
-                txn.abort().get();
-
-                // Log and track user exception
-                Throwable t = result.getUserException();
-                log.warn("Encountered exception when processing message {}", currentRecord, t);
-                stats.incrUserExceptions(t);
-                currentRecord.fail();
-            }
-        } catch (Exception e) {
-            // If an error occurred, try to abort the transaction
-            if (txn != null && !success) {
-                try {
-                    txn.abort().get();
-                } catch (Exception abortEx) {
-                    log.error("Failed to abort transaction", abortEx);
-                }
-            }
-
-            log.error("Error processing message with transaction", e);
-            stats.incrSystemExceptions(e);
-            currentRecord.fail();
-        } finally {
-            // Clean up the transaction context
-            ContextImpl context = (ContextImpl) javaInstance.getContext();
-            context.setCurrentTransaction(null);
-        }
-    }
-
-    private void handleResult(Record<?> srcRecord, JavaExecutionResult result) throws Exception {
-        // Only used for non-transactional execution
-        if (result.getUserException() != null) {
-            // Handle user exception...
-            Throwable t = result.getUserException();
-            log.warn("Encountered exception when processing message {}", srcRecord, t);
-            stats.incrUserExceptions(t);
-            srcRecord.fail();
-        } else {
-            if (result.getResult() != null) {
-                sendOutputMessage(srcRecord, result.getResult());
-            } else {
-                // Handle null result case
-                if (!instanceConfig.getFunctionDetails().getAutoAck() ||
-                    instanceConfig.getFunctionDetails().getProcessingGuarantees() !=
-                    org.apache.pulsar.functions.proto.Function.ProcessingGuarantees.ATMOST_ONCE) {
-                    srcRecord.ack();
-                }
-            }
-            // increment total successfully processed
-            stats.incrTotalProcessedSuccessfully();
-        }
-    }
-
-    // Existing methods...
-}
-```
+For asynchronous functions:
+1. The transaction is created at the beginning of message processing, just like for synchronous functions
+2. When the function returns a `CompletableFuture`, the transaction is maintained until the future completes
+3. When the future completes successfully, the transaction is committed
+4. If the future completes exceptionally, the transaction is aborted
 
 # Public-facing Changes
 
 ## Configuration
 
-Two new configuration options will be added to the FunctionConfig:
+Transaction support will be configured using the new TransactionConfig class:
 
-1. `autoTransactionsEnabled` (boolean): When set to true, each function execution will be automatically wrapped in a transaction. Default: false.
-2. `transactionTimeoutMs` (long): The timeout in milliseconds for transactions created by the function. Default: 60000 (60 seconds).
+```java
+TransactionConfig txnConfig = new TransactionConfig();
+txnConfig.setTransactionMode(TransactionMode.MANAGED);
+txnConfig.setTransactionTimeoutMs(30000L); // 30 seconds
+
+FunctionConfig functionConfig = new FunctionConfig();
+functionConfig.setTransaction(txnConfig);
+// Other configuration...
+```
 
 ## CLI
 
@@ -512,8 +302,7 @@ Example alert thresholds:
 The proposed transaction support doesn't introduce new security concerns as it builds on top of existing Pulsar transaction mechanisms. All security aspects of
 transactions, including authentication and authorization, are inherited from the Pulsar client's transaction implementation.
 
-Functions will only be able to create transactions and operate on topics they already have permission to access. No additional permissions are required beyond what's
-already needed for the function to operate.
+Functions will only be able to create transactions and operate on topics they already have permission to access. No additional permissions are required beyond what's already needed for the function to operate.
 
 # Backward & Forward Compatibility
 
@@ -521,23 +310,31 @@ already needed for the function to operate.
 
 The proposed changes are backward compatible with existing Pulsar Functions:
 
-1. The new transaction-related configuration options default to disabled (autoTransactionsEnabled=false).
-2. Existing functions will continue to operate without transaction support unless explicitly configured.
+1. The new transaction mode defaults to `OFF` so existing functions will continue to operate without transaction support.
+2. Existing functions can enable transaction support by simply updating their configuration.
 3. The Function interface remains unchanged, so existing function implementations will work with transaction support when enabled.
 
 To enable transaction support for existing functions:
 
 1. Ensure transactions are enabled at the broker level.
-2. Update the function configuration to set autoTransactionsEnabled=true and optionally configure transactionTimeoutMs.
+2. Update the function configuration to set `transactionMode: MANAGED` and optionally configure transactionTimeoutMs.
 3. Restart or update the function to apply the new configuration.
 
 ## Downgrade / Rollback
 
-To roll back to a version without transaction support:
 
-1. Update function configuration to disable transactions (autoTransactionsEnabled=false).
-2. Restart or update the function to apply the configuration change.
-3. If downgrading Pulsar itself, no special steps are needed for functions; they will simply operate without transaction support.
+When downgrading to a version that doesn't support the transaction features, several
+steps need to be taken to ensure compatibility:
+
+1. Configuration Reset:
+ - Update all function configurations to set `transactionMode: OFF` before downgrading
+ - If the downgrade target doesn't recognize the transaction configuration fields,
+these fields should be explicitly removed from the function configuration to prevent
+errors
+2. Function Updates:
+ - After downgrading Pulsar, any functions that were using managed transactions must be
+updated or redeployed
+ - This ensures that the runtime configurations are compatible with the older version
 
 ## Pulsar Upgrade & Downgrade/Rollback Considerations
 

--- a/pip/pip-439.md
+++ b/pip/pip-439.md
@@ -263,8 +263,7 @@ The Functions worker configuration will include a setting to en-/disable `pulsar
 # Transaction metrics configuration
 transactionMetrics:
   # Enable/disable specific transaction metrics individually
-  enabledMetrics:
-    txnLatency: false          # Transaction duration histograms (high cardinality)
+  txnLatency: false          # Transaction duration histograms (high cardinality)
     # ... disable any future metric deemed as too expensive to enable per default
 ```
 


### PR DESCRIPTION
# Motivation

This PIP proposes extending Pulsar Functions with configuration-based automatic/managed transaction support to enable exactly-once processing semantics. Currently, Pulsar Functions cannot publish to multiple topics transactionally, which is a significant limitation for use cases requiring atomic multi-topic operations.
  
### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] Dependencies (add or upgrade a dependency)
- [X] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [X] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [X] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
