### PR TITLE
[fix][broker] Fix NPE and annotate nullable return values for ManagedCursorContainer

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -38,6 +38,7 @@ import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A ManagedLedger it's a superset of a BookKeeper ledger concept.
@@ -579,8 +580,9 @@ public interface ManagedLedger {
     /**
      * Get the slowest consumer.
      *
-     * @return the slowest consumer
+     * @return the slowest consumer or null if there is no consumer
      */
+    @Nullable
     ManagedCursor getSlowestConsumer();
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainer.java
@@ -23,12 +23,17 @@ import lombok.experimental.UtilityClass;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains cursors for a ManagedLedger.
  * <p>
  * The goal is to be able to find out the slowest cursor and hence decide which is the oldest ledger we need to keep.
  */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
 public interface ManagedCursorContainer extends Iterable<ManagedCursor> {
     /**
      * Adds a cursor to the container with the specified position.
@@ -45,6 +50,7 @@ public interface ManagedCursorContainer extends Iterable<ManagedCursor> {
      * @param name the name of the cursor
      * @return the ManagedCursor if found, otherwise null
      */
+    @Nullable
     ManagedCursor get(String name);
 
     /**
@@ -63,29 +69,32 @@ public interface ManagedCursorContainer extends Iterable<ManagedCursor> {
      * @param cursor the cursor to update the position for
      * @param newPosition the updated position for the cursor
      * @return a pair of positions, representing the previous slowest cursor and the new slowest cursor (after the
-     *         update).
+     *         update) or null if the cursor does not exist.
      */
     Pair<Position, Position> cursorUpdated(ManagedCursor cursor, Position newPosition);
 
     /**
      * Gets the position of the slowest cursor.
      *
-     * @return the position of the slowest cursor
+     * @return the position of the slowest cursor or null if there is no cursor
      */
+    @Nullable
     Position getSlowestCursorPosition();
 
     /**
      * Gets the slowest cursor.
      *
-     * @return the slowest ManagedCursor
+     * @return the slowest ManagedCursor or null if there is no cursor
      */
+    @Nullable
     ManagedCursor getSlowestCursor();
 
     /**
      * Gets the cursor's {@link CursorInfo} with the oldest position.
      *
-     * @return the CursorInfo containing the cursor and its position
+     * @return the CursorInfo containing the cursor and its position or null if there is no cursor
      */
+    @Nullable
     CursorInfo getCursorWithOldestPosition();
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -219,6 +219,9 @@ public class BacklogQuotaManager {
             try {
                 for (; ; ) {
                     ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
+                    if (slowestConsumer == null) {
+                        break;
+                    }
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2166,7 +2166,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     private void checkMessageExpiryWithSharedPosition(ManagedLedgerImpl ml, int messageTtlInSeconds) {
         // Find the target position at one time, then expire all subscriptions and replicators.
-        ManagedCursor cursor = ml.getCursors().getCursorWithOldestPosition().getCursor();
+        final var cursorWithOldestPosition = ml.getCursors().getCursorWithOldestPosition();
+        if (cursorWithOldestPosition == null) {
+            return;
+        }
+        ManagedCursor cursor = cursorWithOldestPosition.getCursor();
         PersistentMessageFinder finder = new PersistentMessageFinder(topic, cursor, brokerService.getPulsar()
                 .getConfig().getManagedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis());
         // Find the target position.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2168,6 +2168,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         // Find the target position at one time, then expire all subscriptions and replicators.
         final var cursorWithOldestPosition = ml.getCursors().getCursorWithOldestPosition();
         if (cursorWithOldestPosition == null) {
+            // Skip checking message expiry for topics without subscription
             return;
         }
         ManagedCursor cursor = cursorWithOldestPosition.getCursor();


### PR DESCRIPTION
### Motivation

I observed the following NPE when I ran some tests.

```
2025-09-05 10:49:38.826 [pulsar-msg-expiry-monitor-OrderedScheduler-0-0] WARN  org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService - Unexpected throwable from task class com.google.common.util.concurrent.MoreExecutors$ScheduledListeningDecorator$NeverSuccessfulListenableFutureTask: Cannot invoke "org.apache.bookkeeper.mledger.impl.ManagedCursorContainer$CursorInfo.getCursor()" because the return value of "org.apache.bookkeeper.mledger.impl.ManagedCursorContainer.getCursorWithOldestPosition()" is null
java.lang.NullPointerException: Cannot invoke "org.apache.bookkeeper.mledger.impl.ManagedCursorContainer$CursorInfo.getCursor()" because the return value of "org.apache.bookkeeper.mledger.impl.ManagedCursorContainer.getCursorWithOldestPosition()" is null
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.checkMessageExpiryWithSharedPosition(PersistentTopic.java:2169)
```

It's because `getCursorWithOldestPosition` could return null but `checkMessageExpiryWithSharedPosition` does not apply null validation.

### Modifications

Add `@Nullable` annotations to all `ManagedCursorContainer`'s methods of that could return null. Then check all non-test code and add null validation if missed:
1. The `checkMessageExpiryWithSharedPosition` added in https://github.com/apache/pulsar/pull/24622
2. The missed null validation for `getSlowedConsumer` since a very early commit, but not sure why the NPE was never reported

P.S. Using `Optional` might be a better alternative to force users to check null because many developers still ignore warnings. To avoid unnecessary heap allocation and API changes, I didn't change the method signature.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
