### PR TITLE
[fix][test]fix flaky MessagePayloadProcessorTest.testDefaultProcessor

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/DefaultProcessorWithRefCnt.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/DefaultProcessorWithRefCnt.java
@@ -42,7 +42,7 @@ public class DefaultProcessorWithRefCnt implements MessagePayloadProcessor {
     @Override
     public <T> void process(MessagePayload payload, MessagePayloadContext context, Schema<T> schema,
                             Consumer<Message<T>> messageConsumer) throws Exception {
-        MessagePayloadProcessor.DEFAULT.process(payload, context, schema, messageConsumer);
         totalRefCnt += ((MessagePayloadImpl) payload).getByteBuf().refCnt();
+        MessagePayloadProcessor.DEFAULT.process(payload, context, schema, messageConsumer);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24709
### Motivation
The flakiness occurred because ```Assert.assertEquals(processor.getTotalRefCnt(), 2 * numBatches)```<sup>[1]</sup>  was sometimes executed before ```totalRefCnt += ((MessagePayloadImpl) payload).getByteBuf().refCnt().``` <sup>[2]</sup> This race condition led to inconsistent test results. By updating the reference count first, we ensure the assertion always evaluates correctly.

[1]:https://github.com/apache/pulsar/blob/13e0a7b89c64bb516d66a48b0da5ede3cff0d8e2/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/MessagePayloadProcessorTest.java#L159
[2]:https://github.com/apache/pulsar/blob/f5176e5b693a9d6adbd3606ada8a24e394ab2ce7/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/DefaultProcessorWithRefCnt.java#L45
[3]:https://github.com/apache/pulsar/blob/f5176e5b693a9d6adbd3606ada8a24e394ab2ce7/pulsar-broker/src/test/java/org/apache/pulsar/client/processor/DefaultProcessorWithRefCnt.java#L46
### Modifications
Moved ```totalRefCnt += ((MessagePayloadImpl) payload).getByteBuf().refCnt()```<sup>[2]</sup>   above the ```MessagePayloadProcessor.DEFAULT.process```<sup>[3]</sup> call.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/3pacccccc/pulsar/pull/25

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
