### PR TITLE
[improve][pip] PIP-440: WaitForExclusive priority queueing

### DIFF
--- a/pip/pip-440.md
+++ b/pip/pip-440.md
@@ -1,0 +1,214 @@
+# PIP-440: `WaitForExclusive` priority queueing
+
+# Background knowledge
+
+Topics can choose to enter a single-writer mode (defined in [PIP-68](https://github.com/apache/pulsar/blob/master/pip/pip-68.md)) which acts as a simple leader-election mechanism.
+Any producer connecting with a `WaitForExclusive` mode will be put into a queue if it is not able to be promoted to the exclusive producer immediately. This queue is first-in-first-out.
+
+The wait-for-exclusive queue is not persistent, and there does not need to be cluster-level agreement on the ordering of it's contents; the queue ordering is only significant to the
+broker that owns the topic. When the topic is migrated from one broker to another, all producers are disconnected, and perform a reconnect on the new broker. 
+In other words, there's no replication shenanigans to consider with the queue itself.
+
+# Motivation
+
+As the `WaitForExclusive` queue is first-in first-out, we have no control over which producer will be promoted to the exclusive producer when the primary drops out.
+
+Let's consider a scenario where Pulsar is being used to check the uptime of various services; There are *N* endpoints each with their own topic in Pulsar.
+An uptime checker begins in a state where each of these *N* endpoints are being checked by *M* hosts, each of which holds exclusivity over approximately *N*/*M* percent of the endpoint topics.
+
+If any of these *M* nodes fail, then all of that node's work will fall onto the first remaining node to create a `WaitForExclusive` producer, leaving that new node with *2N*/*M-1* percent of the workload,
+or about twice that of the other nodes. This failure has the **potential** to cause a cascading outage if a large, rapid redistribution of work to one machine could cause that machine to fail too.
+
+Now let's assume, for reliability's sake, we have a whole failover cluster provisioned as a "last resort". We want this failover cluster to be ready to step in immediately, so we create
+`WaitForExclusive` producers in preparation for future downtime in the primary cluster. However, if one of the primary nodes fail, then the work could possibly be prematurely shifted to the backup cluster,
+depending on which cluster came up first. In other words, first-in-first-out limits the way we can plan and handle producer failures.
+
+# Goals
+
+## In Scope
+
+The scope of this PIP is to address the queueing mechanism used by `WaitForExclusive` and revise it to support a wider variety of failover modes.
+The queue ordering for `WaitForExclusive` has never been explicitly documented, so exposing more functionality to producers to pick their place in line would give developers more flexibility in balancing failovers across nodes.
+
+## Out of Scope
+
+**Voluntary retirement of producers:** Once a producer has become the exclusive publisher for a topic, it should not be retired by the broker itself so long as it does not fail in some capacity.
+If a producer wishes to perform a mutiny and eject the currently exclusive producer, they can use `ExclusiveWithFencing` and joust there. Regardless, the decision to change producers should only happen if:
+
+1. A producer specifically requests it
+2. As a last resort (current exclusive producer has failed)
+
+**Failure of broker modes:** This change is only intended to handle producer disconnects, whether intentional or unintentional. Producers being disconnected *by* the broker is decidedly out of scope.
+
+# High Level Design
+
+The `CommandProducer` message will be extended with a new optional integer field, `queue_priority`, which is considered `0` on the server if not present.
+The `waitingExclusiveProducers` field on `AbstractTopic` will be changed to a `PriorityBlockingQueue` with a custom ordering comparator as described below in the "spec" section.
+Additionally, `AbstractTopic.handleProducerRemoved` will be modified to try *all* queued providers instead of silently failing if the first promotion attempt fails.
+
+## Spec
+
+A producer MAY choose to provide an integer "priority" value to the broker during creation.
+If the producer's access mode is not `WaitForExclusive`, then the priority value SHALL have no effect and SHALL be ignored by the broker.
+If no priority is provided, then the broker SHALL consider the producer as having a priority of 0 (zero).
+
+When deciding the ordering of producers within the producer queue, the broker SHALL rely on the following ordering:
+* Producer-provided priority (highest first, lowest last)
+* Producer creation time (earliest first, latest last)
+
+If two or more producers are identical in this ordering, then the broker SHALL decide ordering between identical entries at random.
+
+The producer SHOULD publish it's own priority and information about the producer itself upon gaining exclusivity over the topic.
+The producer SHOULD publish any information needed to resume control over the topic on another node, should the current producer fail.
+The producer SHOULD NOT use the topic as a general messaging channel. 
+Instead, the producer SHOULD use transactions to publish messages on alternate channels, while re-publishing the existing metadata message on it's exclusive topic to ensure it still owns exclusivity.
+
+A producer SHOULD implement a delay approximately correlating to it's chosen priority value when re-connecting to a broker after being disconnected, to give
+producers with significantly lower priorities time to be the first to reconnect for exclusivity.
+
+A producer SHOULD tolerate alternative ordering of producers when the broker does not support producer priorities.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+#### Producers
+
+Producers will be modified to have a new integer `priority` field. All producers will have this field, but it will be ignored unless the producer enters a WaitForExclusive queue.
+
+#### Producer Queue
+
+The waiting producer queue looks like:
+
+```java
+private final Queue<Pair<Producer, CompletableFuture<Optional<Long>>>> waitingExclusiveProducers =
+        new ConcurrentLinkedQueue<>();
+```
+I would like to replace this implementation with a `PriorityBlockingQueue` using a custom comparator that sorts based on producer-provided priority and then the creation time (sourced from `PublisherStatsImpl` maybe?).
+This change would be all that's needed to implement most of the PIP.
+
+#### Producer Registration
+
+The code for registering a waiting exclusive producer looks like this:
+
+```java
+if (hasExclusiveProducer || !producers.isEmpty()) {
+    CompletableFuture<Optional<Long>> future = new CompletableFuture<>();
+    log.info("[{}] Queuing producer {} since there's already a producer", topic, producer);
+    waitingExclusiveProducers.add(Pair.of(producer, future));
+    producerQueuedFuture.complete(null);
+    return future;
+}
+return handleTopicEpochForExclusiveProducer(producer);
+```
+I don't think I want to make any changes here.
+
+#### Producer Failover
+
+Currently, the code for handling a dropped producer looks like this:
+
+```java
+protected void handleProducerRemoved(Producer producer) {
+    // decrement usage only if this was a valid producer close
+    USAGE_COUNT_UPDATER.decrementAndGet(this);
+    // this conditional check is an optimization so we only need to acquire the write lock
+    // and execute following routine when:
+    // 1. If there was an exclusive producer before.
+    // 2. If this was the last producer closed and there are waiting exclusive producers
+    if (hasExclusiveProducer || (producers.isEmpty() && !waitingExclusiveProducers.isEmpty())) {
+        lock.writeLock().lock();
+        try {
+            hasExclusiveProducer = false;
+            exclusiveProducerName = null;
+            Pair<Producer, CompletableFuture<Optional<Long>>> nextWaitingProducer =
+                    waitingExclusiveProducers.poll();
+            if (nextWaitingProducer != null) {
+                Producer nextProducer = nextWaitingProducer.getKey();
+                CompletableFuture<Optional<Long>> producerFuture = nextWaitingProducer.getValue();
+                hasExclusiveProducer = true;
+                exclusiveProducerName = nextProducer.getProducerName();
+
+                CompletableFuture<Long> future;
+                if (nextProducer.getTopicEpoch().isPresent()) {
+                    future = setTopicEpoch(nextProducer.getTopicEpoch().get());
+                } else {
+                    future = incrementTopicEpoch(topicEpoch);
+                }
+
+                future.thenAccept(epoch -> {
+                    topicEpoch = Optional.of(epoch);
+                    producerFuture.complete(topicEpoch);
+                }).exceptionally(ex -> {
+                    hasExclusiveProducer = false;
+                    exclusiveProducerName = null;
+                    producerFuture.completeExceptionally(ex);
+                    return null;
+                });
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+    if (log.isDebugEnabled()) {
+        log.debug("[{}] [{}] Removed producer -- count: {}", topic, producer.getProducerName(),
+                USAGE_COUNT_UPDATER.get(this));
+    }
+    lastActive = System.nanoTime();
+}
+```
+
+I would like to rewrite this to take the form `while (!waitingExclusiveProducers.isEmpty()) {}` rather than just popping the first waiting producer
+and then silently failing if the promotion fails. In other words, there should be no scenario where this method *doesn't* promote a producer
+while it has a producer waiting in the queue; this is a potentially catastrophic silent failure state.
+
+## Public-facing Changes
+
+### Public API
+
+A new optional integer field, `priority`, will be added to the producer-builder component of each client.
+This field is writable during creation but read-only after the producer has been created. Attempting to write to the priority after
+the producer has been formed should throw an exception.
+
+Besides that, behavior will mostly remain the same: Producers will be chosen in the same first-in-first-out ordering unless
+a producer specifically chooses a higher priority than the default.
+
+### Binary protocol
+
+A new optional integer field, `queue_priority`, will be added to `CommandProducer`. This field will default to zero. 
+Sending a `queue_priority` to a broker that does not support it, or not receiving a `queue_priority` from a producer that does not support it, should NOT be an error.
+
+# Monitoring
+
+Users should implement their own monitoring to observe how their Pulsar producers react during failure scenarios.
+Producers taking control of a topic should always broadcast information about themselves on the topic, to ensure that
+any monitoring tooling can observe when failovers occur and also observe the load placed on each server.
+
+Ultimately, it's the user's responsibility to ensure that priorities are properly selected, and monitor failures
+as they happen.
+
+# Backward & Forward Compatibility
+
+## Upgrade
+
+As this is a new optional field of a protocol message, both broker and client will need to support priorities for priorities to be used.
+If a broker is upgraded, then any clients that are upgraded will be able to select a priority, while non-updated clients will still function as normal.
+
+## Downgrade / Rollback
+
+There should not be any specific steps that are required to rollback a cluster from priorities to the original FIFO behavior.
+
+## Geo Replication
+
+I have not considered geo-replication; I don't know what to look for or how these changes could impact geo-replication.
+
+# Alternatives
+
+Initially, simply *randomizing* the queue order was considered as it's the simplest way to achieve a "load-balancing" scenario, but producer priorities ultimately prevailed
+because priorities preserve original semantics while not in use, and enable more verbose control over producer promotion.
+
+# General Notes
+
+# Links
+
+* Mailing List discussion thread:
+* Mailing List voting thread:


### PR DESCRIPTION
### Motivation

This PIP documents changes to the `WaitForExclusive` producer mode which allows producers to choose the order in which they are promoted to the exclusive producer during failure conditions. This allows producers to balance the load from one client disconnect across many other clients, rather than the current opaque first-in-first out.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [x] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
