### PR TITLE
[improve][io] upgrade to debezium 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.5.0</aerospike-client.version>
-    <kafka-client.version>3.8.1</kafka-client.version>
+    <kafka-client.version>3.9.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.788</aws-sdk.version>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
@@ -239,9 +239,9 @@ flexible messaging model and an intuitive client API.</description>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
-    <sqlite-jdbc.version>3.42.0.0</sqlite-jdbc.version>
-    <mysql-jdbc.version>8.0.33</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.6.0</postgresql-jdbc.version>
+    <sqlite-jdbc.version>3.47.1.0</sqlite-jdbc.version>
+    <mysql-jdbc.version>9.1.0</mysql-jdbc.version>
+    <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
     <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -239,20 +239,20 @@ flexible messaging model and an intuitive client API.</description>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
-    <sqlite-jdbc.version>3.47.1.0</sqlite-jdbc.version>
-    <mysql-jdbc.version>8.0.11</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.5.5</postgresql-jdbc.version>
+    <sqlite-jdbc.version>3.42.0.0</sqlite-jdbc.version>
+    <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
+    <postgresql-jdbc.version>42.6.1</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>1.9.7.Final</debezium.version>
-    <debezium.postgresql.version>42.5.5</debezium.postgresql.version>
-    <debezium.mysql.version>8.0.33</debezium.mysql.version>
+    <debezium.version>2.7.4.Final</debezium.version>
+    <debezium.postgresql.version>42.6.1</debezium.postgresql.version>
+    <debezium.mysql.version>8.3.0</debezium.mysql.version>
     <!-- Override version that brings CVE-2022-3143 with debezium -->
-    <wildfly-elytron.version>1.15.16.Final</wildfly-elytron.version>
+    <wildfly-elytron.version>1.20.4.Final</wildfly-elytron.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
     <hadoop3.version>3.4.0</hadoop3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@ flexible messaging model and an intuitive client API.</description>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra.version>3.11.2</cassandra.version>
     <aerospike-client.version>4.5.0</aerospike-client.version>
-    <kafka-client.version>3.9.1</kafka-client.version>
+    <kafka-client.version>3.8.1</kafka-client.version>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.788</aws-sdk.version>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
@@ -240,8 +240,8 @@ flexible messaging model and an intuitive client API.</description>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
     <sqlite-jdbc.version>3.42.0.0</sqlite-jdbc.version>
-    <mysql-jdbc.version>8.3.0</mysql-jdbc.version>
-    <postgresql-jdbc.version>42.6.1</postgresql-jdbc.version>
+    <mysql-jdbc.version>8.0.33</mysql-jdbc.version>
+    <postgresql-jdbc.version>42.6.0</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
     <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -251,8 +251,6 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.version>2.7.4.Final</debezium.version>
     <debezium.postgresql.version>42.6.1</debezium.postgresql.version>
     <debezium.mysql.version>8.3.0</debezium.mysql.version>
-    <!-- Override version that brings CVE-2022-3143 with debezium -->
-    <wildfly-elytron.version>1.20.4.Final</wildfly-elytron.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
     <hadoop3.version>3.4.0</hadoop3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -243,14 +243,14 @@ flexible messaging model and an intuitive client API.</description>
     <mysql-jdbc.version>8.0.33</mysql-jdbc.version>
     <postgresql-jdbc.version>42.6.0</postgresql-jdbc.version>
     <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
-    <mariadb-jdbc.version>2.7.5</mariadb-jdbc.version>
+    <mariadb-jdbc.version>3.5.3</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>2.7.4.Final</debezium.version>
-    <debezium.postgresql.version>42.6.1</debezium.postgresql.version>
-    <debezium.mysql.version>8.3.0</debezium.mysql.version>
+    <debezium.version>3.2.2.Final</debezium.version>
+    <debezium.postgresql.version>42.7.7</debezium.postgresql.version>
+    <debezium.mysql.version>9.1.0</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
     <hadoop3.version>3.4.0</hadoop3.version>

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/SerDeUtils.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/SerDeUtils.java
@@ -37,7 +37,7 @@ public class SerDeUtils {
            return ois.readObject();
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Failed to initialize the pulsar client to store debezium database history", e);
+                    "Failed to initialize the pulsar client to store debezium schema history", e);
         }
     }
 

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarSchemaHistoryTest.java
@@ -26,8 +26,8 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
-import io.debezium.relational.history.DatabaseHistory;
-import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
 import java.io.ByteArrayOutputStream;
@@ -46,11 +46,11 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * Test the implementation of {@link PulsarDatabaseHistory}.
+ * Test the implementation of {@link PulsarSchemaHistory}.
  */
-public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
+public class PulsarSchemaHistoryTest extends ProducerConsumerBase {
 
-    private PulsarDatabaseHistory history;
+    private PulsarSchemaHistory history;
     private Map<String, Object> position;
     private Map<String, String> source;
     private String topicName;
@@ -65,7 +65,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         source = Collect.hashMapOf("server", "my-server");
         setLogPosition(0);
         this.topicName = "persistent://my-property/my-ns/schema-changes-topic";
-        this.history = new PulsarDatabaseHistory();
+        this.history = new PulsarSchemaHistory();
     }
 
     @AfterMethod(alwaysRun = true)
@@ -78,9 +78,9 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
     private void testHistoryTopicContent(boolean skipUnparseableDDL, boolean testWithClientBuilder,
                                          boolean testWithReaderConfig) throws Exception {
         Configuration.Builder configBuidler = Configuration.create()
-                .with(PulsarDatabaseHistory.TOPIC, topicName)
-                .with(DatabaseHistory.NAME, "my-db-history")
-                .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
+                .with(PulsarSchemaHistory.TOPIC, topicName)
+                .with(SchemaHistory.NAME, "my-db-history")
+                .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
 
         if (testWithClientBuilder) {
             ClientBuilder builder = PulsarClient.builder().serviceUrl(brokerUrl.toString());
@@ -89,18 +89,18 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
                 oos.writeObject(builder);
                 oos.flush();
                 byte[] data = bao.toByteArray();
-                configBuidler.with(PulsarDatabaseHistory.CLIENT_BUILDER, Base64.getEncoder().encodeToString(data));
+                configBuidler.with(PulsarSchemaHistory.CLIENT_BUILDER, Base64.getEncoder().encodeToString(data));
             }
         } else {
-            configBuidler.with(PulsarDatabaseHistory.SERVICE_URL, brokerUrl.toString());
+            configBuidler.with(PulsarSchemaHistory.SERVICE_URL, brokerUrl.toString());
         }
 
         if (testWithReaderConfig) {
-            configBuidler.with(PulsarDatabaseHistory.READER_CONFIG, "{\"subscriptionName\":\"my-subscription\"}");
+            configBuidler.with(PulsarSchemaHistory.READER_CONFIG, "{\"subscriptionName\":\"my-subscription\"}");
         }
 
         // Start up the history ...
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // Should be able to call start more than once ...
@@ -159,8 +159,8 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
 
         // Stop the history (which should stop the producer) ...
         history.stop();
-        history = new PulsarDatabaseHistory();
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history = new PulsarSchemaHistory();
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         // no need to start
 
         // Recover from the very beginning to just past the first change ...
@@ -244,13 +244,13 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
 
         // Set history to use dummy topic
         Configuration config = Configuration.create()
-            .with(PulsarDatabaseHistory.SERVICE_URL, brokerUrl.toString())
-            .with(PulsarDatabaseHistory.TOPIC, "persistent://my-property/my-ns/dummytopic")
-            .with(DatabaseHistory.NAME, "my-db-history")
-            .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
+            .with(PulsarSchemaHistory.SERVICE_URL, brokerUrl.toString())
+            .with(PulsarSchemaHistory.TOPIC, "persistent://my-property/my-ns/dummytopic")
+            .with(SchemaHistory.NAME, "my-db-history")
+            .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
             .build();
 
-        history.configure(config, null, DatabaseHistoryListener.NOOP, true);
+        history.configure(config, null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // dummytopic should not exist yet

--- a/pulsar-io/debezium/mongodb/src/main/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSource.java
+++ b/pulsar-io/debezium/mongodb/src/main/java/org/apache/pulsar/io/debezium/mongodb/DebeziumMongoDbSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium.mongodb;
 
 import java.util.Map;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.io.core.SourceContext;
 import org.apache.pulsar.io.debezium.DebeziumSource;
@@ -27,7 +28,13 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium mongodb source.
  */
 public class DebeziumMongoDbSource extends DebeziumSource {
+    private static final String DEFAULT_CONNECTOR = "io.debezium.connector.mongodb.MongoDbConnector";
     private static final String DEFAULT_TASK = "io.debezium.connector.mongodb.MongoDbConnectorTask";
+
+    @Override
+    public void setDbConnectorClass(Map<String, Object> config) throws Exception {
+        throwExceptionIfConfigNotMatch(config, ConnectorConfig.CONNECTOR_CLASS_CONFIG, DEFAULT_CONNECTOR);
+    }
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
+++ b/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
@@ -28,10 +28,10 @@ parallelism: 1
 configs:
   ## config for pg, docker image: debezium/example-mongodb:0.8
   mongodb.hosts: "rs0/mongodb:27017"
-  mongodb.name: "dbserver1"
   mongodb.user: "debezium"
   mongodb.password: "dbz"
   mongodb.task.id: "1"
   database.whitelist: "inventory"
+  topic.previx: "dbserver1"
 
-  database.history.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
+++ b/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
@@ -35,3 +35,4 @@ configs:
   topic.previx: "dbserver1"
 
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  connector.class: "io.debezium.connector.mongodb.MongoDbConnector"

--- a/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
+++ b/pulsar-io/debezium/mongodb/src/main/resources/debezium-mongodb-source-config.yaml
@@ -32,7 +32,7 @@ configs:
   mongodb.password: "dbz"
   mongodb.task.id: "1"
   database.whitelist: "inventory"
-  topic.previx: "dbserver1"
+  topic.prefix: "dbserver1"
 
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
   connector.class: "io.debezium.connector.mongodb.MongoDbConnector"

--- a/pulsar-io/debezium/mssql/src/main/java/org/apache/pulsar/io/debezium/mssql/DebeziumMsSqlSource.java
+++ b/pulsar-io/debezium/mssql/src/main/java/org/apache/pulsar/io/debezium/mssql/DebeziumMsSqlSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium.mssql;
 
 import java.util.Map;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.io.debezium.DebeziumSource;
 
@@ -27,7 +28,13 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium mssql source.
  */
 public class DebeziumMsSqlSource extends DebeziumSource {
+    private static final String DEFAULT_CONNECTOR = "io.debezium.connector.sqlserver.SqlServerConnector";
     private static final String DEFAULT_TASK = "io.debezium.connector.sqlserver.SqlServerConnectorTask";
+
+    @Override
+    public void setDbConnectorClass(Map<String, Object> config) throws Exception {
+        throwExceptionIfConfigNotMatch(config, ConnectorConfig.CONNECTOR_CLASS_CONFIG, DEFAULT_CONNECTOR);
+    }
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
+++ b/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
@@ -31,6 +31,6 @@ configs:
   database.user: "sa"
   database.password: "MyP@ssword1"
   database.dbname: "MyDB"
-  database.server.name: "mssql"
+  topic.prefix: "mssql"
 
-  database.history.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
+++ b/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
@@ -34,3 +34,4 @@ configs:
   topic.prefix: "mssql"
 
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  connector.class: "io.debezium.connector.sqlserver.SqlServerConnector"

--- a/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
+++ b/pulsar-io/debezium/mssql/src/main/resources/debezium-mssql-source-config.yaml
@@ -30,7 +30,7 @@ configs:
   database.port: "1521"
   database.user: "sa"
   database.password: "MyP@ssword1"
-  database.dbname: "MyDB"
+  database.names: "MyDB"
   topic.prefix: "mssql"
 
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/debezium/mysql/src/main/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSource.java
+++ b/pulsar-io/debezium/mysql/src/main/java/org/apache/pulsar/io/debezium/mysql/DebeziumMysqlSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium.mysql;
 
 import java.util.Map;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.io.debezium.DebeziumSource;
 
@@ -26,7 +27,13 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium mysql source.
  */
 public class DebeziumMysqlSource extends DebeziumSource {
+    private static final String DEFAULT_CONNECTOR = "io.debezium.connector.mysql.MySqlConnector";
     private static final String DEFAULT_TASK = "io.debezium.connector.mysql.MySqlConnectorTask";
+
+    @Override
+    public void setDbConnectorClass(Map<String, Object> config) throws Exception {
+        throwExceptionIfConfigNotMatch(config, ConnectorConfig.CONNECTOR_CLASS_CONFIG, DEFAULT_CONNECTOR);
+    }
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
+++ b/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
@@ -35,9 +35,9 @@ configs:
   database.whitelist: "inventory"
   topic.prefix: "dbserver1"
 
-
   schema.history.internal.pulsar.topic: "mysql-history-topic"
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
   offset.storage.topic: "mysql-offset-topic"
+  connector.class: "io.debezium.connector.mysql.MySqlConnector"
 
 

--- a/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
+++ b/pulsar-io/debezium/mysql/src/main/resources/debezium-mysql-source-config.yaml
@@ -32,11 +32,12 @@ configs:
   database.user: "debezium"
   database.password: "dbz"
   database.server.id: "184054"
-  database.server.name: "dbserver1"
   database.whitelist: "inventory"
+  topic.prefix: "dbserver1"
 
-  database.history.pulsar.topic: "mysql-history-topic"
-  database.history.pulsar.service.url: "pulsar://127.0.0.1:6650"
+
+  schema.history.internal.pulsar.topic: "mysql-history-topic"
+  schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
   offset.storage.topic: "mysql-offset-topic"
 
 

--- a/pulsar-io/debezium/oracle/src/main/java/org/apache/pulsar/io/debezium/oracle/DebeziumOracleSource.java
+++ b/pulsar-io/debezium/oracle/src/main/java/org/apache/pulsar/io/debezium/oracle/DebeziumOracleSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium.oracle;
 
 import java.util.Map;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.io.debezium.DebeziumSource;
 
@@ -27,7 +28,13 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium oracle source.
  */
 public class DebeziumOracleSource extends DebeziumSource {
+    private static final String DEFAULT_CONNECTOR = "io.debezium.connector.oracle.OracleConnector";
     private static final String DEFAULT_TASK = "io.debezium.connector.oracle.OracleConnectorTask";
+
+    @Override
+    public void setDbConnectorClass(Map<String, Object> config) throws Exception {
+        throwExceptionIfConfigNotMatch(config, ConnectorConfig.CONNECTOR_CLASS_CONFIG, DEFAULT_CONNECTOR);
+    }
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/oracle/src/main/resources/debezium-oracle-source-config.yaml
+++ b/pulsar-io/debezium/oracle/src/main/resources/debezium-oracle-source-config.yaml
@@ -36,3 +36,4 @@ configs:
   topic.prefix: "XE"
 
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  connector.class: "io.debezium.connector.oracle.OracleConnector"

--- a/pulsar-io/debezium/oracle/src/main/resources/debezium-oracle-source-config.yaml
+++ b/pulsar-io/debezium/oracle/src/main/resources/debezium-oracle-source-config.yaml
@@ -33,6 +33,6 @@ configs:
   database.user: "sysdba"
   database.password: "oracle"
   database.dbname: "XE"
-  database.server.name: "XE"
+  topic.prefix: "XE"
 
-  database.history.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/debezium/pom.xml
+++ b/pulsar-io/debezium/pom.xml
@@ -31,46 +31,6 @@
   <artifactId>pulsar-io-debezium</artifactId>
   <name>Pulsar IO :: Debezium</name>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-digest</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-external</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-gs2</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-oauth2</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-plain</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-sasl-scram</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.wildfly.security</groupId>
-        <artifactId>wildfly-elytron-password-impl</artifactId>
-        <version>${wildfly-elytron.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <modules>
     <module>core</module>
     <module>mysql</module>

--- a/pulsar-io/debezium/postgres/src/main/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSource.java
+++ b/pulsar-io/debezium/postgres/src/main/java/org/apache/pulsar/io/debezium/postgres/DebeziumPostgresSource.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.io.debezium.postgres;
 
 import java.util.Map;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.pulsar.io.debezium.DebeziumSource;
 
@@ -27,7 +28,13 @@ import org.apache.pulsar.io.debezium.DebeziumSource;
  * A pulsar source that runs debezium postgres source.
  */
 public class DebeziumPostgresSource extends DebeziumSource {
+    private static final String DEFAULT_CONNECTOR = "io.debezium.connector.postgresql.PostgresConnector";
     private static final String DEFAULT_TASK = "io.debezium.connector.postgresql.PostgresConnectorTask";
+
+    @Override
+    public void setDbConnectorClass(Map<String, Object> config) throws Exception {
+        throwExceptionIfConfigNotMatch(config, ConnectorConfig.CONNECTOR_CLASS_CONFIG, DEFAULT_CONNECTOR);
+    }
 
     @Override
     public void setDbConnectorTask(Map<String, Object> config) throws Exception {

--- a/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
+++ b/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
@@ -35,5 +35,5 @@ configs:
   schema.allow.list: "inventory"
   topic.prefix: "dbserver1"
 
-
   schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"
+  connector.class: "io.debezium.connector.postgresql.PostgresConnector"

--- a/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
+++ b/pulsar-io/debezium/postgres/src/main/resources/debezium-postgres-source-config.yaml
@@ -32,7 +32,8 @@ configs:
   database.user: "postgres"
   database.password: "postgres"
   database.dbname: "postgres"
-  database.server.name: "dbserver1"
-  schema.whitelist: "inventory"
+  schema.allow.list: "inventory"
+  topic.prefix: "dbserver1"
 
-  database.history.pulsar.service.url: "pulsar://127.0.0.1:6650"
+
+  schema.history.internal.pulsar.service.url: "pulsar://127.0.0.1:6650"

--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -33,7 +33,7 @@
   <name>Pulsar IO :: MongoDB</name>
 
   <properties>
-    <mongo-reactivestreams.version>4.11.5</mongo-reactivestreams.version>
+    <mongo-reactivestreams.version>4.11.0</mongo-reactivestreams.version>
   </properties>
 
   <dependencies>

--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -33,7 +33,7 @@
   <name>Pulsar IO :: MongoDB</name>
 
   <properties>
-    <mongo-reactivestreams.version>4.1.2</mongo-reactivestreams.version>
+    <mongo-reactivestreams.version>4.11.5</mongo-reactivestreams.version>
   </properties>
 
   <dependencies>

--- a/pulsar-io/mongo/pom.xml
+++ b/pulsar-io/mongo/pom.xml
@@ -33,7 +33,7 @@
   <name>Pulsar IO :: MongoDB</name>
 
   <properties>
-    <mongo-reactivestreams.version>4.11.0</mongo-reactivestreams.version>
+    <mongo-reactivestreams.version>5.2.0</mongo-reactivestreams.version>
   </properties>
 
   <dependencies>

--- a/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
+++ b/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
@@ -110,17 +110,21 @@ public class MongoSourceTest {
 
         source.open(map, mockSourceContext);
 
-        subscriber.onNext(new ChangeStreamDocument<>(
-                OperationType.INSERT,
+        subscriber.onNext(new ChangeStreamDocument<Document>(
+                OperationType.INSERT.getValue(),
                 BsonDocument.parse("{token: true}"),
                 BsonDocument.parse("{db: \"hello\", coll: \"pulsar\"}"),
                 BsonDocument.parse("{db: \"hello2\", coll: \"pulsar2\"}"),
                 new Document("hello", "pulsar"),
+                new Document("hello", "pulsar"), // documentKey
                 BsonDocument.parse("{_id: 1}"),
                 new BsonTimestamp(1234, 2),
-                null,
+                null, // UpdateDescription
                 new BsonInt64(1),
-                BsonDocument.parse("{id: 1, uid: 1}")));
+                BsonDocument.parse("{id: 1, uid: 1}"),
+                null, // BsonDateTime
+                null, // SplitEvent
+                BsonDocument.parse("{extra: 1}")));
 
         Record<byte[]> record = source.read();
 

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -367,9 +367,9 @@
     <!-- debezium-related misdetections -->
     <suppress>
         <notes><![CDATA[
-       file name: debezium-connector-mysql-1.9.7.Final.jar
+       file name: debezium-connector-mysql-2.6.0.Final.jar
        ]]></notes>
-        <sha1>74c623b4a9b231e2f0e8f6053b38abd3bc487ce2</sha1>
+        <sha1><!-- Update with actual SHA1 for 2.6.0.Final when available --></sha1>
         <cve>CVE-2017-15945</cve>
     </suppress>
     <suppress>
@@ -381,9 +381,9 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: debezium-connector-postgres-1.9.7.Final.jar
+       file name: debezium-connector-postgres-2.6.0.Final.jar
        ]]></notes>
-        <sha1>300ff0bbf795643e914b7c8a6d6ba812a8354d62</sha1>
+        <sha1><!-- Update with actual SHA1 for 2.6.0.Final when available --></sha1>
         <cve>CVE-2015-0241</cve>
         <cve>CVE-2015-0242</cve>
         <cve>CVE-2015-0243</cve>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -364,49 +364,6 @@
         <cpe>cpe:/a:apache:solr</cpe>
     </suppress>
 
-    <!-- debezium-related misdetections -->
-    <suppress>
-        <notes><![CDATA[
-       file name: debezium-connector-mysql-2.6.0.Final.jar
-       ]]></notes>
-        <sha1><!-- Update with actual SHA1 for 2.6.0.Final when available --></sha1>
-        <cve>CVE-2017-15945</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: mysql-binlog-connector-java-0.27.2.jar
-       ]]></notes>
-        <sha1>23294cd730e29c00b8ddfbde517dfc955aba090f</sha1>
-        <cve>CVE-2017-15945</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-       file name: debezium-connector-postgres-2.6.0.Final.jar
-       ]]></notes>
-        <sha1><!-- Update with actual SHA1 for 2.6.0.Final when available --></sha1>
-        <cve>CVE-2015-0241</cve>
-        <cve>CVE-2015-0242</cve>
-        <cve>CVE-2015-0243</cve>
-        <cve>CVE-2015-0244</cve>
-        <cve>CVE-2015-3166</cve>
-        <cve>CVE-2015-3167</cve>
-        <cve>CVE-2016-0766</cve>
-        <cve>CVE-2016-0768</cve>
-        <cve>CVE-2016-0773</cve>
-        <cve>CVE-2016-5423</cve>
-        <cve>CVE-2016-5424</cve>
-        <cve>CVE-2016-7048</cve>
-        <cve>CVE-2017-14798</cve>
-        <cve>CVE-2017-7484</cve>
-        <cve>CVE-2018-1115</cve>
-        <cve>CVE-2019-10127</cve>
-        <cve>CVE-2019-10128</cve>
-        <cve>CVE-2019-10210</cve>
-        <cve>CVE-2019-10211</cve>
-        <cve>CVE-2020-25694</cve>
-        <cve>CVE-2020-25695</cve>
-        <cve>CVE-2021-23214</cve>
-    </suppress>
     <suppress>
         <notes><![CDATA[
        file name: protostream-types-4.4.1.Final.jar

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <integrationTestSuiteFile>pulsar.xml</integrationTestSuiteFile>
-    <mongo-reactivestreams.version>4.11.5</mongo-reactivestreams.version>
+    <mongo-reactivestreams.version>5.2.0</mongo-reactivestreams.version>
     <inttest.asyncprofiler.opts>event=cpu,lock=1ms,alloc=2m,jfrsync=profile</inttest.asyncprofiler.opts>
     <inttest.asyncprofiler.outputformat>jfr</inttest.asyncprofiler.outputformat>
     <inttest.asyncprofiler.dir></inttest.asyncprofiler.dir>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <integrationTestSuiteFile>pulsar.xml</integrationTestSuiteFile>
-    <mongo-reactivestreams.version>4.1.2</mongo-reactivestreams.version>
+    <mongo-reactivestreams.version>4.11.5</mongo-reactivestreams.version>
     <inttest.asyncprofiler.opts>event=cpu,lock=1ms,alloc=2m,jfrsync=profile</inttest.asyncprofiler.opts>
     <inttest.asyncprofiler.outputformat>jfr</inttest.asyncprofiler.outputformat>
     <inttest.asyncprofiler.dir></inttest.asyncprofiler.dir>

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
@@ -25,7 +25,7 @@ public class DebeziumMongoDbContainer extends ChaosContainer<DebeziumMongoDbCont
     public static final String NAME = "debezium-mongodb-example";
 
     public static final Integer[] PORTS = { 27017 };
-    private static final String IMAGE_NAME = "debezium/example-mongodb:2.7.3.Final";
+    private static final String IMAGE_NAME = "debezium/example-mongodb:2.5.4.Final";
 
     public DebeziumMongoDbContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
@@ -25,7 +25,7 @@ public class DebeziumMongoDbContainer extends ChaosContainer<DebeziumMongoDbCont
     public static final String NAME = "debezium-mongodb-example";
 
     public static final Integer[] PORTS = { 27017 };
-    private static final String IMAGE_NAME = "debezium/example-mongodb:0.10";
+    private static final String IMAGE_NAME = "debezium/example-mongodb:2.7.3.Final";
 
     public DebeziumMongoDbContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
@@ -25,7 +25,7 @@ public class DebeziumMongoDbContainer extends ChaosContainer<DebeziumMongoDbCont
     public static final String NAME = "debezium-mongodb-example";
 
     public static final Integer[] PORTS = { 27017 };
-    private static final String IMAGE_NAME = "debezium/example-mongodb:2.5.4.Final";
+    private static final String IMAGE_NAME = "debezium/example-mongodb:3.2.2.Final";
 
     public DebeziumMongoDbContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMongoDbContainer.java
@@ -25,7 +25,7 @@ public class DebeziumMongoDbContainer extends ChaosContainer<DebeziumMongoDbCont
     public static final String NAME = "debezium-mongodb-example";
 
     public static final Integer[] PORTS = { 27017 };
-    private static final String IMAGE_NAME = "debezium/example-mongodb:3.2.2.Final";
+    private static final String IMAGE_NAME = "debezium/example-mongodb:3.0.0.Final";
 
     public DebeziumMongoDbContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
@@ -26,7 +26,7 @@ public class DebeziumMySQLContainer extends ChaosContainer<DebeziumMySQLContaine
     public static final String NAME = "debezium-mysql-example";
     static final Integer[] PORTS = { 3306 };
 
-    private static final String IMAGE_NAME = "debezium/example-mysql:2.7.3.Final";
+    private static final String IMAGE_NAME = "debezium/example-mysql:2.5.4.Final";
 
     public DebeziumMySQLContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
@@ -26,7 +26,7 @@ public class DebeziumMySQLContainer extends ChaosContainer<DebeziumMySQLContaine
     public static final String NAME = "debezium-mysql-example";
     static final Integer[] PORTS = { 3306 };
 
-    private static final String IMAGE_NAME = "debezium/example-mysql:0.8";
+    private static final String IMAGE_NAME = "debezium/example-mysql:2.7.3.Final";
 
     public DebeziumMySQLContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
@@ -26,7 +26,7 @@ public class DebeziumMySQLContainer extends ChaosContainer<DebeziumMySQLContaine
     public static final String NAME = "debezium-mysql-example";
     static final Integer[] PORTS = { 3306 };
 
-    private static final String IMAGE_NAME = "debezium/example-mysql:2.5.4.Final";
+    private static final String IMAGE_NAME = "debezium/example-mysql:3.2.2.Final";
 
     public DebeziumMySQLContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumMySQLContainer.java
@@ -26,7 +26,7 @@ public class DebeziumMySQLContainer extends ChaosContainer<DebeziumMySQLContaine
     public static final String NAME = "debezium-mysql-example";
     static final Integer[] PORTS = { 3306 };
 
-    private static final String IMAGE_NAME = "debezium/example-mysql:3.2.2.Final";
+    private static final String IMAGE_NAME = "debezium/example-mysql:3.0.0.Final";
 
     public DebeziumMySQLContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
@@ -26,7 +26,7 @@ public class DebeziumPostgreSqlContainer extends ChaosContainer<DebeziumPostgreS
     public static final String NAME = "debezium-postgresql-example";
     static final Integer[] PORTS = { 5432 };
 
-    private static final String IMAGE_NAME = "debezium/example-postgres:2.7.3.Final";
+    private static final String IMAGE_NAME = "debezium/example-postgres:2.5.4.Final";
 
     public DebeziumPostgreSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
@@ -26,7 +26,7 @@ public class DebeziumPostgreSqlContainer extends ChaosContainer<DebeziumPostgreS
     public static final String NAME = "debezium-postgresql-example";
     static final Integer[] PORTS = { 5432 };
 
-    private static final String IMAGE_NAME = "debezium/example-postgres:0.10";
+    private static final String IMAGE_NAME = "debezium/example-postgres:2.7.3.Final";
 
     public DebeziumPostgreSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
@@ -26,7 +26,7 @@ public class DebeziumPostgreSqlContainer extends ChaosContainer<DebeziumPostgreS
     public static final String NAME = "debezium-postgresql-example";
     static final Integer[] PORTS = { 5432 };
 
-    private static final String IMAGE_NAME = "debezium/example-postgres:3.2.2.Final";
+    private static final String IMAGE_NAME = "debezium/example-postgres:3.0.0.Final";
 
     public DebeziumPostgreSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/DebeziumPostgreSqlContainer.java
@@ -26,7 +26,7 @@ public class DebeziumPostgreSqlContainer extends ChaosContainer<DebeziumPostgreS
     public static final String NAME = "debezium-postgresql-example";
     static final Integer[] PORTS = { 5432 };
 
-    private static final String IMAGE_NAME = "debezium/example-postgres:2.5.4.Final";
+    private static final String IMAGE_NAME = "debezium/example-postgres:3.2.2.Final";
 
     public DebeziumPostgreSqlContainer(String clusterName) {
         super(clusterName, IMAGE_NAME);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
@@ -272,6 +272,21 @@ public class PulsarIOSourceRunner extends PulsarIOTestRunner {
             result.getStdout()
         );
         result.assertNoStderr();
+
+        final String[] packageCommands = {
+            PulsarCluster.ADMIN_SCRIPT,
+            "packages",
+            "delete",
+            "source://" + tenant + "/" + namespace + "/" + sourceName + "@0"
+        };
+
+        try {
+            ContainerExecResult packageResult = pulsarCluster.getAnyWorker().execCmd(packageCommands);
+            log.info("Package metadata deletion result: {}", packageResult.getStdout());
+        } catch (Exception e) {
+            log.warn("Failed to delete package metadata for source://{}/{}/{}@0: {}", 
+                     tenant, namespace, sourceName, e.getMessage());
+        }
     }
 
     protected void getSourceInfoNotFound(String tenant, String namespace, String sourceName) throws Exception {

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/PulsarIOSourceRunner.java
@@ -284,7 +284,7 @@ public class PulsarIOSourceRunner extends PulsarIOTestRunner {
             ContainerExecResult packageResult = pulsarCluster.getAnyWorker().execCmd(packageCommands);
             log.info("Package metadata deletion result: {}", packageResult.getStdout());
         } catch (Exception e) {
-            log.warn("Failed to delete package metadata for source://{}/{}/{}@0: {}", 
+            log.warn("Failed to delete package metadata for source://{}/{}/{}@0: {}",
                      tenant, namespace, sourceName, e.getMessage());
         }
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/SourceTester.java
@@ -58,6 +58,8 @@ public abstract class SourceTester<ServiceContainerT extends GenericContainer> i
         add("source");
         add("op");
         add("ts_ms");
+        add("ts_us");
+        add("ts_ns");
         add("transaction");
     }};
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -42,7 +42,7 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         this.pulsarCluster = cluster;
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
-        sourceConfig.put("mongodb.hosts", "rs0/" + DebeziumMongoDbContainer.NAME + ":27017");
+        sourceConfig.put("mongodb.connection.string", "mongodb://debezium:dbz@" + DebeziumMongoDbContainer.NAME + ":27017/admin?replicaSet=rs0");
         sourceConfig.put("mongodb.user", "debezium");
         sourceConfig.put("mongodb.password", "dbz");
         sourceConfig.put("mongodb.task.id","1");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -51,6 +51,7 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mongodb");
         sourceConfig.put("capture.mode", "oplog");
+        sourceConfig.put("connector.class", "io.debezium.connector.mongodb.MongoDbConnector");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -50,7 +50,7 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         sourceConfig.put("database.include.list", "inventory");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mongodb");
-        sourceConfig.put("capture.mode", "oplog");
+        sourceConfig.put("capture.mode", "change_streams_update_full");
         sourceConfig.put("connector.class", "io.debezium.connector.mongodb.MongoDbConnector");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -70,38 +70,38 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
     @Override
     public void prepareInsertEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.insert({ "
-                        + "_id : NumberLong(\"110\"),"
-                        + "name : \"test-debezium\","
-                        + "description: \"24 inch spare tire\","
-                        + "weight : 22.2,"
-                        + "quantity : NumberInt(\"5\")})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.insert({ " +
+                        "_id : NumberLong(\"110\")," +
+                        "name : \"test-debezium\"," +
+                        "description: \"24 inch spare tire\"," +
+                        "weight : 22.2," +
+                        "quantity : NumberInt(\"5\")})'");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongo -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
-                        + "--eval 'db.products.update({"
-                        + "_id : 110},"
-                        + "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
+                        "--eval 'db.products.update({" +
+                        "_id : 110}," +
+                        "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -43,12 +43,12 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
         sourceConfig.put("mongodb.hosts", "rs0/" + DebeziumMongoDbContainer.NAME + ":27017");
-        sourceConfig.put("mongodb.name", "dbserver1");
         sourceConfig.put("mongodb.user", "debezium");
         sourceConfig.put("mongodb.password", "dbz");
-        sourceConfig.put("mongodb.task.id", "1");
+        sourceConfig.put("mongodb.task.id","1");
+        sourceConfig.put("topic.prefix", "dbserver1");
         sourceConfig.put("database.include.list", "inventory");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mongodb");
         sourceConfig.put("capture.mode", "oplog");
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMongoDbSourceTester.java
@@ -42,10 +42,11 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
         this.pulsarCluster = cluster;
         pulsarServiceUrl = "pulsar://pulsar-proxy:" + PulsarContainer.BROKER_PORT;
 
-        sourceConfig.put("mongodb.connection.string", "mongodb://debezium:dbz@" + DebeziumMongoDbContainer.NAME + ":27017/admin?replicaSet=rs0");
+        sourceConfig.put("mongodb.connection.string",
+                "mongodb://debezium:dbz@" + DebeziumMongoDbContainer.NAME + ":27017/admin?replicaSet=rs0");
         sourceConfig.put("mongodb.user", "debezium");
         sourceConfig.put("mongodb.password", "dbz");
-        sourceConfig.put("mongodb.task.id","1");
+        sourceConfig.put("mongodb.task.id", "1");
         sourceConfig.put("topic.prefix", "dbserver1");
         sourceConfig.put("database.include.list", "inventory");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
@@ -70,38 +71,38 @@ public class DebeziumMongoDbSourceTester extends SourceTester<DebeziumMongoDbCon
     @Override
     public void prepareInsertEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.insert({ " +
-                        "_id : NumberLong(\"110\")," +
-                        "name : \"test-debezium\"," +
-                        "description: \"24 inch spare tire\"," +
-                        "weight : 22.2," +
-                        "quantity : NumberInt(\"5\")})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.insert({ "
+                        + "_id : NumberLong(\"110\"),"
+                        + "name : \"test-debezium\","
+                        + "description: \"24 inch spare tire\","
+                        + "weight : 22.2,"
+                        + "quantity : NumberInt(\"5\")})'");
     }
 
     @Override
     public void prepareDeleteEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.deleteOne({name : \"test-debezium-update\"})'");
     }
 
     @Override
     public void prepareUpdateEvent() throws Exception {
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.find()'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.find()'");
         this.debeziumMongoDbContainer.execCmd("/bin/bash", "-c",
-                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory " +
-                        "--eval 'db.products.update({" +
-                        "_id : 110}," +
-                        "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
+                "mongosh -u debezium -p dbz --authenticationDatabase admin localhost:27017/inventory "
+                        + "--eval 'db.products.update({"
+                        + "_id : 110},"
+                        + "{$set:{name:\"test-debezium-update\", description: \"this is update description\"}})'");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -149,12 +149,12 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
 
     @Override
     public String keyContains() {
-        return "mssql.TestDB.dbo.customers.Key";
+        return "TestDB";
     }
 
     @Override
     public String valueContains() {
-        return "mssql.TestDB.dbo.customers.Value";
+        return "TestDB";
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -149,12 +149,12 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
 
     @Override
     public String keyContains() {
-        return "mssql.dbo.customers.Key";
+        return "mssql.TestDB.dbo.customers.Key";
     }
 
     @Override
     public String valueContains() {
-        return "mssql.dbo.customers.Value";
+        return "mssql.TestDB.dbo.customers.Value";
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -60,7 +60,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
         sourceConfig.put("database.names", "TestDB");
         sourceConfig.put("database.encrypt", "false");
-        sourceConfig.put("snapshot.mode", "schema_only");
+        //sourceConfig.put("snapshot.mode", "schema_only");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.prefix", "mssql");
         sourceConfig.put("topic.namespace", "debezium/mssql");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -59,7 +59,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.user", "sa");
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
         sourceConfig.put("database.server.name", "mssql");
-        sourceConfig.put("database.dbname", "TestDB");
+        sourceConfig.put("database.names", "TestDB");
         sourceConfig.put("snapshot.mode", "schema_only");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mssql");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -64,6 +64,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.prefix", "mssql");
         sourceConfig.put("topic.namespace", "debezium/mssql");
+        sourceConfig.put("task.id", "1");
         sourceConfig.put("connector.class", "io.debezium.connector.sqlserver.SqlServerConnector");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -59,6 +59,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.user", "sa");
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
         sourceConfig.put("database.names", "TestDB");
+        sourceConfig.put("database.encrypt", "false");
         sourceConfig.put("snapshot.mode", "schema_only");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.prefix", "mssql");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -60,7 +60,8 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
         sourceConfig.put("database.names", "TestDB");
         sourceConfig.put("database.encrypt", "false");
-        //sourceConfig.put("snapshot.mode", "schema_only");
+        sourceConfig.put("snapshot.mode", "schema_only");
+        sourceConfig.put("schema.history.internal.pulsar.topic", "debezium-schema-history-mssql");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.prefix", "mssql");
         sourceConfig.put("topic.namespace", "debezium/mssql");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -58,10 +58,10 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.port", "1433");
         sourceConfig.put("database.user", "sa");
         sourceConfig.put("database.password", DebeziumMsSqlContainer.SA_PASSWORD);
-        sourceConfig.put("database.server.name", "mssql");
         sourceConfig.put("database.names", "TestDB");
         sourceConfig.put("snapshot.mode", "schema_only");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("topic.prefix", "mssql");
         sourceConfig.put("topic.namespace", "debezium/mssql");
         sourceConfig.put("connector.class", "io.debezium.connector.sqlserver.SqlServerConnector");
     }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -63,6 +63,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("snapshot.mode", "schema_only");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mssql");
+        sourceConfig.put("connector.class", "io.debezium.connector.sqlserver.SqlServerConnector");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMsSqlSourceTester.java
@@ -61,7 +61,7 @@ public class DebeziumMsSqlSourceTester extends SourceTester<DebeziumMsSqlContain
         sourceConfig.put("database.server.name", "mssql");
         sourceConfig.put("database.dbname", "TestDB");
         sourceConfig.put("snapshot.mode", "schema_only");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/mssql");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -58,8 +58,8 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
         sourceConfig.put("database.user", "debezium");
         sourceConfig.put("database.password", "dbz");
         sourceConfig.put("database.server.id", "184054");
-        sourceConfig.put("database.server.name", "dbserver1");
-        sourceConfig.put("database.whitelist", "inventory");
+        sourceConfig.put("topic.prefix", "dbserver1");
+        sourceConfig.put("database.include.list", "inventory");
         if (!testWithClientBuilder) {
             sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -61,7 +61,7 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
         sourceConfig.put("database.server.name", "dbserver1");
         sourceConfig.put("database.whitelist", "inventory");
         if (!testWithClientBuilder) {
-            sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+            sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         }
         sourceConfig.put("key.converter", converterClassName);
         sourceConfig.put("value.converter", converterClassName);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumMySqlSourceTester.java
@@ -67,6 +67,7 @@ public class DebeziumMySqlSourceTester extends SourceTester<DebeziumMySQLContain
         sourceConfig.put("value.converter", converterClassName);
         sourceConfig.put("topic.namespace", "debezium/mysql-"
                + (converterClassName.endsWith("AvroConverter") ? "avro" : "json"));
+        sourceConfig.put("connector.class", "io.debezium.connector.mysql.MySqlConnector");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
@@ -63,7 +63,7 @@ public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbC
         sourceConfig.put("snapshot.mode", "schema_only");
 
         sourceConfig.put("schema.include.list", "inv");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/oracle");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
@@ -58,7 +58,7 @@ public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbC
         sourceConfig.put("database.port", "1521");
         sourceConfig.put("database.user", "dbzuser");
         sourceConfig.put("database.password", "dbz");
-        sourceConfig.put("database.server.name", "XE");
+        sourceConfig.put("topic.prefix", "XE");
         sourceConfig.put("database.dbname", "XE");
         sourceConfig.put("snapshot.mode", "schema_only");
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumOracleDbSourceTester.java
@@ -65,6 +65,8 @@ public class DebeziumOracleDbSourceTester extends SourceTester<DebeziumOracleDbC
         sourceConfig.put("schema.include.list", "inv");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/oracle");
+
+        sourceConfig.put("connector.class", "io.debezium.connector.oracle.OracleConnector");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -73,9 +73,9 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("database.server.id", "184055");
         sourceConfig.put("database.server.name", "dbserver1");
         sourceConfig.put("database.dbname", "postgres");
-        sourceConfig.put("schema.whitelist", "inventory");
+        sourceConfig.put("schema.allow.list", "inventory");
         sourceConfig.put("table.blacklist", "inventory.spatial_ref_sys,inventory.geom");
-        sourceConfig.put("database.history.pulsar.service.url", pulsarServiceUrl);
+        sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/postgresql");
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -70,7 +70,6 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("database.port", "5432");
         sourceConfig.put("database.user", "postgres");
         sourceConfig.put("database.password", "postgres");
-        sourceConfig.put("database.server.id", "184055");
         sourceConfig.put("topic.prefix", "dbserver1");
         sourceConfig.put("database.dbname", "postgres");
         sourceConfig.put("schema.include.list", "inventory");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -77,6 +77,7 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("table.blacklist", "inventory.spatial_ref_sys,inventory.geom");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/postgresql");
+        sourceConfig.put("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/DebeziumPostgreSqlSourceTester.java
@@ -71,10 +71,10 @@ public class DebeziumPostgreSqlSourceTester extends SourceTester<DebeziumPostgre
         sourceConfig.put("database.user", "postgres");
         sourceConfig.put("database.password", "postgres");
         sourceConfig.put("database.server.id", "184055");
-        sourceConfig.put("database.server.name", "dbserver1");
+        sourceConfig.put("topic.prefix", "dbserver1");
         sourceConfig.put("database.dbname", "postgres");
-        sourceConfig.put("schema.allow.list", "inventory");
-        sourceConfig.put("table.blacklist", "inventory.spatial_ref_sys,inventory.geom");
+        sourceConfig.put("schema.include.list", "inventory");
+        sourceConfig.put("table.exclude.list", "inventory.spatial_ref_sys,inventory.geom");
         sourceConfig.put("schema.history.internal.pulsar.service.url", pulsarServiceUrl);
         sourceConfig.put("topic.namespace", "debezium/postgresql");
         sourceConfig.put("connector.class", "io.debezium.connector.postgresql.PostgresConnector");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
@@ -214,7 +214,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         final String tenant = TopicName.PUBLIC_TENANT;
         final String namespace = TopicName.DEFAULT_NAMESPACE;
         final String outputTopicName = "debe-output-topic-name-" + testId.getAndIncrement();
-        final String consumeTopicName = "debezium/mssql/mssql";
+        final String consumeTopicName = "debezium/mssql/mssql.TestDB.dbo.customers";
         final String sourceName = "test-source-debezium-mssql-" + functionRuntimeType + "-" + randomName(8);
 
         final int numMessages = 1;

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
@@ -91,7 +91,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
                 + "-" + functionRuntimeType + "-" + randomName(8);
 
         // This is the binlog count that contained in mysql container.
-        final int numMessages = 47;
+        final int numMessages = 52;
 
         @Cleanup
         PulsarClient client = PulsarClient.builder()

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/io/sources/debezium/PulsarDebeziumSourcesTest.java
@@ -214,7 +214,7 @@ public class PulsarDebeziumSourcesTest extends PulsarIOTestBase {
         final String tenant = TopicName.PUBLIC_TENANT;
         final String namespace = TopicName.DEFAULT_NAMESPACE;
         final String outputTopicName = "debe-output-topic-name-" + testId.getAndIncrement();
-        final String consumeTopicName = "debezium/mssql/mssql.dbo.customers";
+        final String consumeTopicName = "debezium/mssql/mssql";
         final String sourceName = "test-source-debezium-mssql-" + functionRuntimeType + "-" + randomName(8);
 
         final int numMessages = 1;

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -30,5 +30,5 @@ docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest
 docker pull cassandra:3
 docker pull confluentinc/cp-kafka:4.0.0
-docker pull debezium/example-mysql:2.7.3.Final
+docker pull debezium/example-mysql:2.5.4.Final
 docker pull mysql:5.7.22

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -30,5 +30,5 @@ docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest
 docker pull cassandra:3
 docker pull confluentinc/cp-kafka:4.0.0
-docker pull debezium/example-mysql:0.8
+docker pull debezium/example-mysql:2.7.3.Final
 docker pull mysql:5.7.22

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -30,5 +30,5 @@ docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest
 docker pull cassandra:3
 docker pull confluentinc/cp-kafka:4.0.0
-docker pull debezium/example-mysql:3.2.2.Final
+docker pull debezium/example-mysql:3.0.0.Final
 docker pull mysql:9.1.0

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -30,5 +30,5 @@ docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest
 docker pull cassandra:3
 docker pull confluentinc/cp-kafka:4.0.0
-docker pull debezium/example-mysql:2.5.4.Final
-docker pull mysql:5.7.22
+docker pull debezium/example-mysql:3.2.2.Final
+docker pull mysql:9.1.0


### PR DESCRIPTION
Fixes #24333

### Motivation

The version of Debezium supported by the project is very old. Debezium 1.9.7 was released in October 25th 2022 and it is lagging two major versions behind the latest stable version, ie. [Debezium 3.2.2, which was released in September 4th 2025](https://debezium.io/blog/2025/09/04/debezium-3-2-2-final-released/).

The main motivation behind this change is to bridge this gap and offer the Pulsar community a more recent version of Debezium that can run natively on Pulsar without resorting to external dependencies such as [debezium-server](https://github.com/debezium/debezium-server).

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
