### PR TITLE
[fix][broker] replace thenComposeAsync with thenCompose method in AuthorizationService

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -219,7 +219,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
@@ -244,7 +244,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {
@@ -326,7 +326,7 @@ public class AuthorizationService {
         if (!this.conf.isAuthorizationEnabled()) {
             return CompletableFuture.completedFuture(true);
         }
-        return provider.isSuperUser(role, authenticationData, conf).thenComposeAsync(isSuperUser -> {
+        return provider.isSuperUser(role, authenticationData, conf).thenCompose(isSuperUser -> {
             if (isSuperUser) {
                 return CompletableFuture.completedFuture(true);
             } else {


### PR DESCRIPTION
### Motivation

I think we should not use any `CompletableFuture.xxxAsync()` method in Pulsar broker, unless we specify a thread pool using Netty `DefaultThreadlFactory`. I encountered `DataSketchesSummaryLogger` memory leak due to FastThreadLocal data not released after thread terminated when using mop.
https://github.com/streamnative/mop/blob/06b9763c1842915c3fd0133874088de96d821293/mqtt-broker/src/main/java/io/streamnative/pulsar/handlers/mqtt/broker/processor/MQTTBrokerProtocolMethodProcessor.java#L395-L402

`CompletableFuture.xxxAsync()` use new Thread or ForkJoinPool by default(base on CPU cores), Pulsar has many metrics loggers using FastThreadLocal, which need FastThreadLocalThread to release the memory.

### Modifications

Before: use `thenComposeAsync` method
After: use `thenCompose` method

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, see AuthorizationTest.

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
### Matching PR in forked repository

PR in forked repository: https://github.com/oneby-wang/pulsar/pull/2

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
