### PR TITLE
[improve][misc] Protect branch-4.1

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -89,6 +89,7 @@ github:
     branch-3.2: {}
     branch-3.3: {}
     branch-4.0: {}
+    branch-4.1: {}
 
 notifications:
   commits:      commits@pulsar.apache.org


### PR DESCRIPTION
### Motivation

Pulsar 4.1.0 has been released and we shouldn't allow force pushes to branch-4.1 .

### Modifications

- Add configuration to `.asf.yaml` to protect `branch-4.1`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->