### PR TITLE
[fix][broker] Fix memory leak when metrics are updated in a thread other than FastThreadLocalThread

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
@@ -165,8 +165,7 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
         return s != null ? s.getQuantile(quantile) : Double.NaN;
     }
 
-    @VisibleForTesting
-    static class LocalData {
+    private static class LocalData {
         private final DoublesSketch successSketch = new DoublesSketchBuilder().build();
         private final DoublesSketch failSketch = new DoublesSketchBuilder().build();
         private final StampedLock lock = new StampedLock();
@@ -184,7 +183,7 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
             }
         }
 
-        boolean shouldRemove() {
+        private boolean shouldRemove() {
             if (ownerThreadReference == null) {
                 // the owner is a FastThreadLocalThread which handles the removal using FastThreadLocal#onRemoval
                 return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesOpStatsLogger.java
@@ -60,15 +60,7 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
         failCountAdder.increment();
         failSumAdder.add((long) valueMillis);
-
-        var localData = current.localData.get();
-
-        long stamp = localData.lock.readLock();
-        try {
-            localData.failSketch.update(valueMillis);
-        } finally {
-            localData.lock.unlockRead(stamp);
-        }
+        current.getLocalData().updateFail(valueMillis);
     }
 
     @Override
@@ -77,45 +69,21 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
         successCountAdder.increment();
         successSumAdder.add((long) valueMillis);
-
-        var localData = current.localData.get();
-
-        long stamp = localData.lock.readLock();
-        try {
-            localData.successSketch.update(valueMillis);
-        } finally {
-            localData.lock.unlockRead(stamp);
-        }
+        current.getLocalData().updateSuccess(valueMillis);
     }
 
     @Override
     public void registerSuccessfulValue(long value) {
         successCountAdder.increment();
         successSumAdder.add(value);
-
-        var localData = current.localData.get();
-
-        long stamp = localData.lock.readLock();
-        try {
-            localData.successSketch.update(value);
-        } finally {
-            localData.lock.unlockRead(stamp);
-        }
+        current.getLocalData().updateSuccess(value);
     }
 
     @Override
     public void registerFailedValue(long value) {
         failCountAdder.increment();
         failSumAdder.add(value);
-
-        var localData = current.localData.get();
-
-        long stamp = localData.lock.readLock();
-        try {
-            localData.failSketch.update(value);
-        } finally {
-            localData.lock.unlockRead(stamp);
-        }
+        current.getLocalData().updateFail(value);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
@@ -50,14 +50,7 @@ public class DataSketchesSummaryLogger {
         countAdder.increment();
         sumAdder.add((long) valueMillis);
 
-        var localData = current.localData.get();
-
-        long stamp = localData.lock.readLock();
-        try {
-            localData.successSketch.update(valueMillis);
-        } finally {
-            localData.lock.unlockRead(stamp);
-        }
+        current.getLocalData().updateSuccess(valueMillis);
     }
 
     public void rotateLatencyCollection() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/DataSketchesSummaryLogger.java
@@ -19,15 +19,10 @@
 package org.apache.pulsar.broker.stats.prometheus.metrics;
 
 import com.yahoo.sketches.quantiles.DoublesSketch;
-import com.yahoo.sketches.quantiles.DoublesSketchBuilder;
 import com.yahoo.sketches.quantiles.DoublesUnion;
 import com.yahoo.sketches.quantiles.DoublesUnionBuilder;
-import io.netty.util.concurrent.FastThreadLocal;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.concurrent.locks.StampedLock;
 
 public class DataSketchesSummaryLogger {
 
@@ -55,7 +50,7 @@ public class DataSketchesSummaryLogger {
         countAdder.increment();
         sumAdder.add((long) valueMillis);
 
-        LocalData localData = current.localData.get();
+        var localData = current.localData.get();
 
         long stamp = localData.lock.readLock();
         try {
@@ -72,15 +67,7 @@ public class DataSketchesSummaryLogger {
         replacement = local;
 
         final DoublesUnion aggregateValues = new DoublesUnionBuilder().build();
-        local.map.forEach((localData, b) -> {
-            long stamp = localData.lock.writeLock();
-            try {
-                aggregateValues.update(localData.successSketch);
-                localData.successSketch.reset();
-            } finally {
-                localData.lock.unlockWrite(stamp);
-            }
-        });
+        local.record(aggregateValues, null);
 
         values = aggregateValues.getResultAndReset();
     }
@@ -96,28 +83,5 @@ public class DataSketchesSummaryLogger {
     public double getQuantileValue(double quantile) {
         DoublesSketch s = values;
         return s != null ? s.getQuantile(quantile) : Double.NaN;
-    }
-
-    private static class LocalData {
-        private final DoublesSketch successSketch = new DoublesSketchBuilder().build();
-        private final StampedLock lock = new StampedLock();
-    }
-
-    private static class ThreadLocalAccessor {
-        private final Map<LocalData, Boolean> map = new ConcurrentHashMap<>();
-        private final FastThreadLocal<LocalData> localData = new FastThreadLocal<LocalData>() {
-
-            @Override
-            protected LocalData initialValue() throws Exception {
-                LocalData localData = new LocalData();
-                map.put(localData, Boolean.TRUE);
-                return localData;
-            }
-
-            @Override
-            protected void onRemoval(LocalData value) throws Exception {
-                map.remove(value);
-            }
-        };
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessor.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.yahoo.sketches.quantiles.DoublesSketch;
+import com.yahoo.sketches.quantiles.DoublesSketchBuilder;
+import com.yahoo.sketches.quantiles.DoublesUnion;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.StampedLock;
+import org.jspecify.annotations.Nullable;
+
+class ThreadLocalAccessor {
+
+    private final ConcurrentHashMap<LocalData, Boolean> map = new ConcurrentHashMap<>();
+    final FastThreadLocal<LocalData> localData = new FastThreadLocal<>() {
+
+        @Override
+        protected LocalData initialValue() {
+            LocalData localData = new LocalData(Thread.currentThread());
+            map.put(localData, Boolean.TRUE);
+            return localData;
+        }
+
+        @Override
+        protected void onRemoval(LocalData value) {
+            map.remove(value);
+        }
+    };
+
+    void record(DoublesUnion aggregateSuccess, @Nullable DoublesUnion aggregateFail) {
+        map.keySet().forEach(key -> {
+            key.record(aggregateSuccess, aggregateFail);
+            if (key.shouldRemove()) {
+                map.remove(key);
+            }
+        });
+    }
+
+    @VisibleForTesting
+    int getLocalDataCount() {
+        return map.keySet().size();
+    }
+
+    static class LocalData {
+
+        final DoublesSketch successSketch = new DoublesSketchBuilder().build();
+        final DoublesSketch failSketch = new DoublesSketchBuilder().build();
+        final StampedLock lock = new StampedLock();
+        // Keep a weak reference to the owner thread so that we can remove the LocalData when the thread
+        // is not alive anymore or has been garbage collected.
+        // This reference isn't needed when the owner thread is a FastThreadLocalThread and will be null in that case.
+        // The removal is handled by FastThreadLocal#onRemoval when the owner thread is a FastThreadLocalThread.
+        final WeakReference<Thread> ownerThreadReference;
+
+        LocalData(Thread ownerThread) {
+            if (ownerThread instanceof FastThreadLocalThread) {
+                ownerThreadReference = null;
+            } else {
+                ownerThreadReference = new WeakReference<>(ownerThread);
+            }
+        }
+
+        private boolean shouldRemove() {
+            if (ownerThreadReference == null) {
+                // the owner is a FastThreadLocalThread which handles the removal using FastThreadLocal#onRemoval
+                return false;
+            } else {
+                Thread ownerThread = ownerThreadReference.get();
+                if (ownerThread == null) {
+                    // the thread has already been garbage collected, LocalData should be removed
+                    return true;
+                } else {
+                    // the thread isn't alive anymore, LocalData should be removed
+                    return !ownerThread.isAlive();
+                }
+            }
+        }
+
+        void record(DoublesUnion aggregateSuccess, @Nullable DoublesUnion aggregateFail) {
+            long stamp = lock.writeLock();
+            try {
+                aggregateSuccess.update(successSketch);
+                successSketch.reset();
+                if (aggregateFail != null) {
+                    aggregateFail.update(failSketch);
+                    failSketch.reset();
+                }
+            } finally {
+                lock.unlockWrite(stamp);
+            }
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
@@ -50,7 +50,7 @@ public class ThreadLocalAccessorTest {
         Phaser phaser = new Phaser(2);
         Thread thread = getThread(fastThreadLocalThread, () -> {
             // Create a new LocalData instance for the current thread.
-            threadLocalAccessor.localData.get();
+            threadLocalAccessor.getLocalData();
             // sync point #1, wait and advance at the same time
             phaser.arriveAndAwaitAdvance();
             // sync point #2, wait and advance at the same time
@@ -77,7 +77,7 @@ public class ThreadLocalAccessorTest {
     @Test(dataProvider = "provider")
     public void testThreadGc(boolean fastThreadLocalThread, @Nullable DoublesUnion aggregateFail) throws Exception {
         final var accessor = new ThreadLocalAccessor();
-        getThread(fastThreadLocalThread, accessor.localData::get).join();
+        getThread(fastThreadLocalThread, accessor::getLocalData).join();
         System.gc();
         // FastThreadLocalThread removes the LocalData from the map when the thread finishes
         assertEquals(accessor.getLocalDataCount(), fastThreadLocalThread ? 0 : 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats.prometheus.metrics;
+
+import static org.testng.Assert.assertEquals;
+import com.yahoo.sketches.quantiles.DoublesUnion;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import java.util.concurrent.Phaser;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ThreadLocalAccessorTest {
+
+    @DataProvider(name = "fastThreadLocalThread")
+    public Object[][] booleanProvider() {
+        return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    }
+
+    @Test(dataProvider = "fastThreadLocalThread")
+    public void testShouldRemoveLocalDataWhenOwnerThreadIsNotAlive(boolean fastThreadLocalThread) throws Exception {
+        // given a ThreadLocalAccessor instance
+        final var threadLocalAccessor = new DataSketchesOpStatsLogger.ThreadLocalAccessor();
+        DoublesUnion aggregateSuccess = DoublesUnion.builder().build();
+        DoublesUnion aggregateFail = DoublesUnion.builder().build();
+        // using phaser to synchronize threads
+        Phaser phaser = new Phaser(2);
+        Thread thread = getThread(fastThreadLocalThread, threadLocalAccessor, phaser);
+        // sync point #1, wait and advance at the same time
+        phaser.arriveAndAwaitAdvance();
+        // and record is called
+        threadLocalAccessor.record(aggregateSuccess, aggregateFail);
+        // then LocalData should exist
+        assertEquals(threadLocalAccessor.map.keySet().size(), 1);
+
+        // when thread is not alive anymore
+        // sync point #2, wait and advance at the same time
+        phaser.arriveAndAwaitAdvance();
+        // wait for thread to finish
+        thread.join();
+        // and record is called
+        threadLocalAccessor.record(aggregateSuccess, aggregateFail);
+        // then LocalData should be removed
+        assertEquals(threadLocalAccessor.map.keySet().size(), 0);
+    }
+
+    @Test(dataProvider = "fastThreadLocalThread")
+    public void testThreadGc(boolean fastThreadLocalThread) throws Exception {
+        final var accessor = createAccessor(fastThreadLocalThread);
+        System.gc();
+        // FastThreadLocalThread removes the LocalData from the map when the thread finishes
+        assertEquals(accessor.map.keySet().size(), fastThreadLocalThread ? 0 : 1);
+        accessor.record(DoublesUnion.builder().build(), DoublesUnion.builder().build());
+        assertEquals(accessor.map.keySet().size(), 0);
+    }
+
+    private static Thread getThread(boolean fastThreadLocalThread,
+                                    DataSketchesOpStatsLogger.ThreadLocalAccessor threadLocalAccessor,
+                                    Phaser phaser) {
+        Runnable runnable = () -> {
+            // Create a new LocalData instance for the current thread.
+            threadLocalAccessor.localData.get();
+            // sync point #1, wait and advance at the same time
+            phaser.arriveAndAwaitAdvance();
+            // sync point #2, wait and advance at the same time
+            phaser.arriveAndAwaitAdvance();
+        };
+        Thread thread = fastThreadLocalThread ? new FastThreadLocalThread(runnable) : new Thread(runnable);
+
+        // when LocalData is created
+        thread.start();
+        return thread;
+    }
+
+    private static DataSketchesOpStatsLogger.ThreadLocalAccessor createAccessor(boolean fastThreadLocalThread)
+            throws Exception {
+        final var accessor = new DataSketchesOpStatsLogger.ThreadLocalAccessor();
+        final var thread = fastThreadLocalThread ? new FastThreadLocalThread(accessor.localData::get) :
+                new Thread(accessor.localData::get);
+        thread.start();
+        thread.join();
+        return accessor;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
@@ -22,31 +22,46 @@ import static org.testng.Assert.assertEquals;
 import com.yahoo.sketches.quantiles.DoublesUnion;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.util.concurrent.Phaser;
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ThreadLocalAccessorTest {
 
-    @DataProvider(name = "fastThreadLocalThread")
-    public Object[][] booleanProvider() {
-        return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    @DataProvider
+    public static Object[][] provider() {
+        return new Object[][] {
+                // 1st element: whether the thread is a astThreadLocalThread
+                // 2nd element: the 2nd argument passed to the `record` object
+                { true, DoublesUnion.builder().build() },
+                { true, null },
+                { false, DoublesUnion.builder().build() },
+                { false, null },
+        };
     }
 
-    @Test(dataProvider = "fastThreadLocalThread")
-    public void testShouldRemoveLocalDataWhenOwnerThreadIsNotAlive(boolean fastThreadLocalThread) throws Exception {
+    @Test(dataProvider = "provider")
+    public void testShouldRemoveLocalDataWhenOwnerThreadIsNotAlive(
+            boolean fastThreadLocalThread, @Nullable DoublesUnion aggregateFail) throws Exception {
         // given a ThreadLocalAccessor instance
-        final var threadLocalAccessor = new DataSketchesOpStatsLogger.ThreadLocalAccessor();
+        final var threadLocalAccessor = new ThreadLocalAccessor();
         DoublesUnion aggregateSuccess = DoublesUnion.builder().build();
-        DoublesUnion aggregateFail = DoublesUnion.builder().build();
         // using phaser to synchronize threads
         Phaser phaser = new Phaser(2);
-        Thread thread = getThread(fastThreadLocalThread, threadLocalAccessor, phaser);
+        Thread thread = getThread(fastThreadLocalThread, () -> {
+            // Create a new LocalData instance for the current thread.
+            threadLocalAccessor.localData.get();
+            // sync point #1, wait and advance at the same time
+            phaser.arriveAndAwaitAdvance();
+            // sync point #2, wait and advance at the same time
+            phaser.arriveAndAwaitAdvance();
+        });
         // sync point #1, wait and advance at the same time
         phaser.arriveAndAwaitAdvance();
         // and record is called
         threadLocalAccessor.record(aggregateSuccess, aggregateFail);
         // then LocalData should exist
-        assertEquals(threadLocalAccessor.map.keySet().size(), 1);
+        assertEquals(threadLocalAccessor.getLocalDataCount(), 1);
 
         // when thread is not alive anymore
         // sync point #2, wait and advance at the same time
@@ -56,44 +71,23 @@ public class ThreadLocalAccessorTest {
         // and record is called
         threadLocalAccessor.record(aggregateSuccess, aggregateFail);
         // then LocalData should be removed
-        assertEquals(threadLocalAccessor.map.keySet().size(), 0);
+        assertEquals(threadLocalAccessor.getLocalDataCount(), 0);
     }
 
-    @Test(dataProvider = "fastThreadLocalThread")
-    public void testThreadGc(boolean fastThreadLocalThread) throws Exception {
-        final var accessor = createAccessor(fastThreadLocalThread);
+    @Test(dataProvider = "provider")
+    public void testThreadGc(boolean fastThreadLocalThread, @Nullable DoublesUnion aggregateFail) throws Exception {
+        final var accessor = new ThreadLocalAccessor();
+        getThread(fastThreadLocalThread, accessor.localData::get).join();
         System.gc();
         // FastThreadLocalThread removes the LocalData from the map when the thread finishes
-        assertEquals(accessor.map.keySet().size(), fastThreadLocalThread ? 0 : 1);
-        accessor.record(DoublesUnion.builder().build(), DoublesUnion.builder().build());
-        assertEquals(accessor.map.keySet().size(), 0);
+        assertEquals(accessor.getLocalDataCount(), fastThreadLocalThread ? 0 : 1);
+        accessor.record(DoublesUnion.builder().build(), aggregateFail);
+        assertEquals(accessor.getLocalDataCount(), 0);
     }
 
-    private static Thread getThread(boolean fastThreadLocalThread,
-                                    DataSketchesOpStatsLogger.ThreadLocalAccessor threadLocalAccessor,
-                                    Phaser phaser) {
-        Runnable runnable = () -> {
-            // Create a new LocalData instance for the current thread.
-            threadLocalAccessor.localData.get();
-            // sync point #1, wait and advance at the same time
-            phaser.arriveAndAwaitAdvance();
-            // sync point #2, wait and advance at the same time
-            phaser.arriveAndAwaitAdvance();
-        };
-        Thread thread = fastThreadLocalThread ? new FastThreadLocalThread(runnable) : new Thread(runnable);
-
-        // when LocalData is created
-        thread.start();
+    private static Thread getThread(boolean fastThreadLocalThread, Runnable runnable) {
+        final var thread = fastThreadLocalThread ? new FastThreadLocalThread(runnable) : new Thread(runnable);
+        thread.start(); // when LocalData is created
         return thread;
-    }
-
-    private static DataSketchesOpStatsLogger.ThreadLocalAccessor createAccessor(boolean fastThreadLocalThread)
-            throws Exception {
-        final var accessor = new DataSketchesOpStatsLogger.ThreadLocalAccessor();
-        final var thread = fastThreadLocalThread ? new FastThreadLocalThread(accessor.localData::get) :
-                new Thread(accessor.localData::get);
-        thread.start();
-        thread.join();
-        return accessor;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/prometheus/metrics/ThreadLocalAccessorTest.java
@@ -31,8 +31,8 @@ public class ThreadLocalAccessorTest {
     @DataProvider
     public static Object[][] provider() {
         return new Object[][] {
-                // 1st element: whether the thread is a astThreadLocalThread
-                // 2nd element: the 2nd argument passed to the `record` object
+                // 1st element: whether the thread is a FastThreadLocalThread
+                // 2nd element: the 2nd argument passed to the `ThreadLocalAccessor#record` method
                 { true, DoublesUnion.builder().build() },
                 { true, null },
                 { false, DoublesUnion.builder().build() },


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar/pull/24714#issuecomment-3266369903

Currently this issue rarely happens because most metrics updates happen in Netty I/O threads when handling requests. However, `DataSketchesOpStatsLogger` and `DataSketchesSummaryLogger` are public and can be used by downstream plugins (e.g. protocol handlers).

### Modifications

- Refactor the code by adding a `record` method to `LocalData` and `ThreadLocalAccessor` responsible for updating the metrics.
- Then, add `ThreadLocalAccessorTest` to verify when the metrics are updated in a normal thread (not `FastThreadLocalRunnable`), the `LocalData` objects won't be removed from the map in `ThreadLocalAccessor`
- Fix this issue by introducing a weak reference that holds the current thread when creating a `LocalData` in a non-Netty thread and remove it from the map if it's garbage collected or not alive when iterating the whole map called by `rotateLatencyCollection`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
