### PR TITLE
[fix][ml] Negative backlog & acked positions does not exist & message lost when concurrently occupying topic owner

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1878,7 +1878,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    void ledgerFailedWriteBecauseClosedByOthers(final LedgerHandle currentLedger) {
+    void ledgerAddFailedDueToConcurrentlyModified(final LedgerHandle currentLedger) {
         bookKeeper.asyncOpenLedger(currentLedger.getId(), digestType, config.getPassword(), (rc, lh, ctx) -> {
             if (rc == Code.OK) {
                 log.warn("[{}] Successfully opened ledger {} to check the last add confirmed position when the ledger"
@@ -1909,7 +1909,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     // //////////////////////////////////////////////////////////////////////
     // Private helpers
 
-    synchronized void ledgerClosed(final LedgerHandle lh, @Nullable Long forcedLastAddConfirmed) {
+    synchronized void ledgerClosed(final LedgerHandle lh, @Nullable Long lastAddConfirmed) {
         final State state = STATE_UPDATER.get(this);
         LedgerHandle currentLedger = this.currentLedger;
         if (currentLedger == lh && (state == State.ClosingLedger || state == State.LedgerOpened)) {
@@ -1924,7 +1924,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         }
 
-        long entriesInLedger = forcedLastAddConfirmed != null ? forcedLastAddConfirmed.longValue() + 1
+        long entriesInLedger = lastAddConfirmed != null ? lastAddConfirmed.longValue() + 1
                 : lh.getLastAddConfirmed() + 1;
         if (log.isDebugEnabled()) {
             log.debug("[{}] Ledger has been closed id={} entries={}", name, lh.getId(), entriesInLedger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1879,8 +1879,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     void addEntryFailedDueToConcurrentlyModified(final LedgerHandle currentLedger, int rc) {
-        log.error("[{}] Fencing the topic because the current ledger was concurrent modified but a other"
-                + " bookie client, which is not expcted. Current ledger: {}, lastAddConfirmed: {}, error coder: {}.",
+        log.error("[{}] Fencing the topic to ensure durability and consistency(the current ledger was concurrent"
+                + " modified by a other bookie client, which is not expcted)."
+                + " Current ledger: {}, lastAddConfirmed: {} (the value stored may be larger), error coder: {}.",
                 name, currentLedger.getId(), currentLedger.getLastAddConfirmed(), rc);
         // Stop switching ledger and write topic metadata, to avoid messages lost. The doc of
         // LedgerHandle also mentioned this: https://github.com/apache/bookkeeper/blob/release-4.17.2/

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1888,13 +1888,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     + " repeated.", name, lh.getId(), currentLedger.getLastAddConfirmed(), lh.getLastAddConfirmed());
                 ledgerClosed(currentLedger, lh.getLastAddConfirmed());
             } else {
-                log.error("[{}] Failed opened ledger {} to check the last add confirmed position when the ledger"
-                        + " was concurrent modified(it is an unexpected behaviour, which happens when the load-balancer"
-                        + " does not work as expected). The add confirmed position in memory is {}, and the error"
-                        + " code {}. When you get this log, the entries count in the ledger of the topic metadata may"
-                        + " be less than expected.",
+                log.error("[{}] Going to fence the topic because failed opened ledger {} to check the last add"
+                        + " confirmed position when the ledger was concurrent modified(it is an unexpected behaviour,"
+                        + " which happens when the load-balancer does not work as expected). The add confirmed position"
+                        + " in memory is {}, and the error code {}. Fecing the topic to avoid messages lost.",
                         name, lh.getId(), currentLedger.getLastAddConfirmed(), rc);
-                // Stop switching ledger and write topic matadata, to avoid messages lost.
+                // Stop switching ledger and write topic metadata, to avoid messages lost. The doc of
+                // LedgerHandle also mentioned this: https://github.com/apache/bookkeeper/blob/release-4.17.2/
+                // bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L2047-L2048
                 handleBadVersion(new BadVersionException("Failed opened ledger {} to check the last add confirmed"
                         + " position when the ledger was concurrent modified, error code: " + rc));
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1880,14 +1880,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     void addEntryFailedDueToConcurrentlyModified(final LedgerHandle currentLedger, int rc) {
         log.error("[{}] Fencing the topic to ensure durability and consistency(the current ledger was concurrent"
-                + " modified by a other bookie client, which is not expcted)."
+                + " modified by a other bookie client, which is not expected)."
                 + " Current ledger: {}, lastAddConfirmed: {} (the value stored may be larger), error coder: {}.",
                 name, currentLedger.getId(), currentLedger.getLastAddConfirmed(), rc);
         // Stop switching ledger and write topic metadata, to avoid messages lost. The doc of
         // LedgerHandle also mentioned this: https://github.com/apache/bookkeeper/blob/release-4.17.2/
         // bookkeeper-server/src/main/java/org/apache/bookkeeper/client/LedgerHandle.java#L2047-L2048.
-        handleBadVersion(new BadVersionException("Failed opened ledger {} to check the last add confirmed"
-                + " position when the ledger was concurrent modified."));
+        handleBadVersion(new BadVersionException("the current ledger " + currentLedger.getId() + " was concurrent"
+            + " modified by a other bookie client. The error code is: " + rc));
     }
 
     // //////////////////////////////////////////////////////////////////////

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -231,7 +231,7 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
         }
 
         if (rc != BKException.Code.OK || timeoutTriggered.get()) {
-            handleAddFailure(lh);
+            handleAddFailure(lh, rc);
         } else {
             // Trigger addComplete callback in a thread hashed on the managed ledger name
             ml.getExecutor().execute(this);
@@ -351,7 +351,7 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
      *
      * @param lh
      */
-    void handleAddFailure(final LedgerHandle lh) {
+    void handleAddFailure(final LedgerHandle lh, Integer rc) {
         // If we get a write error, we will try to create a new ledger and re-submit the pending writes. If the
         // ledger creation fails (persistent bk failure, another instance owning the ML, ...), then the writes will
         // be marked as failed.
@@ -361,7 +361,15 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
         finalMl.getExecutor().execute(() -> {
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock
             // from a BK callback.
-            finalMl.ledgerClosed(lh);
+            // If we received a "MetadataVersionException" or a "LedgerFencedException", we should tell the ML that
+            // the ledger has been closed by others, and the entries count in the ledger may is not correct. The ML
+            // will handle it.
+            if (rc != null && (rc.intValue() == BKException.Code.MetadataVersionException
+                    || rc.intValue() == BKException.Code.LedgerFencedException)) {
+                finalMl.ledgerFailedWriteBecauseClosedByOthers(lh);
+            } else {
+                finalMl.ledgerClosed(lh);
+            }
         });
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -364,9 +364,10 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
             // If we received a "MetadataVersionException" or a "LedgerFencedException", we should tell the ML that
             // the ledger has been closed by others, and the entries count in the ledger may is not correct. The ML
             // will handle it.
+            finalMl.ledgerClosed(lh);
             if (rc != null && (rc.intValue() == BKException.Code.MetadataVersionException
                     || rc.intValue() == BKException.Code.LedgerFencedException)) {
-                finalMl.ledgerAddFailedDueToConcurrentlyModified(lh);
+                finalMl.addEntryFailedDueToConcurrentlyModified(lh, rc);
             } else {
                 finalMl.ledgerClosed(lh);
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -364,7 +364,6 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
             // If we received a "MetadataVersionException" or a "LedgerFencedException", we should tell the ML that
             // the ledger has been closed by others, and the entries count in the ledger may is not correct. The ML
             // will handle it.
-            finalMl.ledgerClosed(lh);
             if (rc != null && (rc.intValue() == BKException.Code.MetadataVersionException
                     || rc.intValue() == BKException.Code.LedgerFencedException)) {
                 finalMl.addEntryFailedDueToConcurrentlyModified(lh, rc);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -366,7 +366,7 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
             // will handle it.
             if (rc != null && (rc.intValue() == BKException.Code.MetadataVersionException
                     || rc.intValue() == BKException.Code.LedgerFencedException)) {
-                finalMl.ledgerFailedWriteBecauseClosedByOthers(lh);
+                finalMl.ledgerAddFailedDueToConcurrentlyModified(lh);
             } else {
                 finalMl.ledgerClosed(lh);
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -162,7 +162,8 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
         ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
         BookieClientImpl bookieClient =
                 (BookieClientImpl) mlFactory.getBookKeeper().get().getClientCtx().getBookieClient();
-        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).join().get();
         ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
         LedgerHandle ledgerHandle = ml.getCurrentLedger();
         BookieId bookieId1 = ledgerHandle.getLedgerMetadata().getEnsembleAt(bkIndexOfEnsemble).get(0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BkEnsemblesTestBase.java
@@ -19,17 +19,36 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.collect.Sets;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.Closeable;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.bookkeeper.proto.BookieClientImpl;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks;
+import org.apache.bookkeeper.proto.PerChannelBookieClient;
+import org.apache.bookkeeper.proto.PerChannelBookieClientPool;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.awaitility.reflect.WhiteboxImpl;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -129,6 +148,60 @@ public abstract class BkEnsemblesTestBase extends TestRetrySupport {
             bkEnsemble.stop();
             bkEnsemble = null;
         }
+    }
+
+    /***
+     * Inject a delay for the following requests to the specified bookie in the ensemble of the current ledger of
+     * the topic.
+     * @param bkIndexOfEnsemble the bk index of the ensemble.
+     * @return a cancellation of the injection.
+     */
+    protected Closeable injectBKServerDelayForCurrentLedger(String topic, long delayTime, TimeUnit unit,
+                                                            int bkIndexOfEnsemble) throws Exception {
+        // Make an injection to let the next publishing delay.
+        ManagedLedgerFactoryImpl mlFactory = (ManagedLedgerFactoryImpl) pulsar.getDefaultManagedLedgerFactory();
+        BookieClientImpl bookieClient =
+                (BookieClientImpl) mlFactory.getBookKeeper().get().getClientCtx().getBookieClient();
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        LedgerHandle ledgerHandle = ml.getCurrentLedger();
+        BookieId bookieId1 = ledgerHandle.getLedgerMetadata().getEnsembleAt(bkIndexOfEnsemble).get(0);
+        PerChannelBookieClientPool perChannelBookieClientPool = bookieClient.lookupClient(bookieId1);
+        CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
+        perChannelBookieClientPool.obtain(new BookkeeperInternalCallbacks.GenericCallback<PerChannelBookieClient>() {
+            @Override
+            public void operationComplete(int rc, PerChannelBookieClient result) {
+                channelFuture.complete(WhiteboxImpl.getInternalState(result, "channel"));
+            }
+        }, ledgerHandle.getId());
+        Channel channel = channelFuture.get();
+
+        ScheduledExecutorService bkServerIoMock =
+                Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("bk-server-io-mock"));
+        channel.eventLoop().execute(() -> {
+            // To avoid client IO thread being stuck, we use a separate event loop to mock the server delay. And the
+            // response handling is still in the client IO thread.
+            channel.pipeline().addAfter("bookieProtoDecoder", "delayInjection", new ChannelInboundHandlerAdapter(){
+                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    bkServerIoMock.schedule(() -> {
+                        // Call the real client io thread to handle the requests after a delayed time.
+                        ctx.executor().execute(() -> {
+                            ctx.fireChannelRead(msg);
+                        });
+                    }, delayTime, unit);
+                }
+            });
+        });
+        return () -> {
+            CompletableFuture<Void> removing = new CompletableFuture<>();
+            channel.eventLoop().execute(() -> {
+                channel.pipeline().remove("delayInjection");
+                removing.complete(null);
+            });
+            removing.whenComplete((__, ex) -> {
+                bkServerIoMock.shutdown();
+            });
+        };
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
@@ -536,8 +536,8 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
 
     @Test(timeOut = 60_000)
     public void testConcurrentlyModifyCurrentLedger() throws Exception {
-        EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(config.getNumIOThreads(), config.isEnableBusyWait(),
-                new DefaultThreadFactory("pulsar-io-test-1"));
+        EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(config.getNumIOThreads(),
+                config.isEnableBusyWait(), new DefaultThreadFactory("pulsar-io-test-1"));
         BookKeeper bkClient2 = pulsar.getBkClientFactory().create(pulsar.getConfiguration(),
                 pulsar.getLocalMetadataStore(),
                 eventLoopGroup,
@@ -550,7 +550,8 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         admin.namespaces().createNamespace(namespace);
         admin.topics().createNonPartitionedTopic(topic);
         admin.topics().createSubscription(topic, subscription, MessageId.earliest);
-        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
+        PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopic(topic, false).join().get();
         ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
 
         @Cleanup


### PR DESCRIPTION
### Motivation

Our pulsar cluster encountered an issue where the response of the command `pulsar-admin topics stats --get-precise-backlog --get-subscription-backlog-size  <topic>` has a negative backlog.

And topic internal stats show that a consumer acknowledged messages that do not exist in `topic.ledgers`
- ledgerInfo:  `{"ledgerId":1140377,"entries":5,"size":45573,"offloaded":false,"metadata":null,"underReplicated":false}`
- But the acknowledged more entries: `(1140377:-1..1140377:6]`

---

The issue happened this way:

- Configurations
  - `managedLedgerDefaultEnsembleSize=2`
  - `managedLedgerDefaultWriteQuorum=2`
  - `managedLedgerDefaultAckQuorum=2`
- Topic state
  - `ledgers`: `[3: {entries: 1}]`
- Scenarios
  -  `bookie-2` is slow
  - ZK connections are unstable, which may cause a race condition on owning topics

| time | `broker-1` | `broker-2` | `bookie-1` | `bookie-2` |
| --- | --- | --- | --- | --- |
| 1 | owned the topic |
| 2 | start publish message `3:1`(has not completed yet) |
| 3 | | | receives the write request `3:1` | receives the write request `3:1` |
| 4 | | | write disk finished | write disk finished |
| 5 | | | responds to `broker-1` | 
| 2 | start publish message `3:2`(has not sent to Bookies yet) |
| 6 | metadata store connection unstable |
| 7 | | onwed the topic |
| 8 | assumes itself is still the owner of the topic |
| 9 | | start to close the ledger `3` |
| 10 | | | receives the close request of the ledger `3` | receives the close request of the ledger `3` |
| 11 | | | fence & close the ledger `3` |
| 12 | | | receives the write request `3:2` | receives the write request `3:2` |
| 13 | | | responds `fenced error` since the ledger has been closed |
| 14 | received a `fenced error`|
| 15 | switch ledger to `4` and write topic metadata with `[3: {entries: 1}]` since `bookie-2` has not responded to the request of writing `3:1` |
| 16 | | | | responds to `broker-1` for the writing `3:1` |
| 17 | | | | fence & close the ledger `3` |
| 18 | | closed ledger `3`, and it has `2` entries |
| 19 | received the response of writing `3:1` |

Highlight: The issue also leads to messages being lost.

You can reproduce the issue with the new test `testConcurrentlyCloseCurrentLedger`


### Modifications

Re-check the ledger entries from the metadata store if received a `fenced error` when writing Bookies

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x