### PR TITLE
[fix][client] Add description method to ClientBuilder

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -98,7 +98,6 @@ import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
-import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.ConsumerBase;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -4868,7 +4867,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         assertEquals(stats.getPublishers().size(), 1);
         assertEquals(stats.getPublishers().get(0).getClientVersion(), defaultClientVersion);
 
-        PulsarClient client = ((ClientBuilderImpl) PulsarClient.builder())
+        PulsarClient client = PulsarClient.builder()
                 .description("my-java-client")
                 .serviceUrl(lookupUrl.toString())
                 .build();

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -717,4 +717,21 @@ public interface ClientBuilder extends Serializable, Cloneable {
      * - The `loadManagerClassName` config in broker is a class that implements the `ExtensibleLoadManager` interface
      */
     ClientBuilder lookupProperties(Map<String, String> properties);
+
+    /**
+     * Set the description.
+     *
+     * <p> By default, when the client connects to the broker, a version string like "Pulsar-Java-v<x.y.z>" will be
+     * carried and saved by the broker. The client version string could be queried from the topic stats.
+     *
+     * <p> This method provides a way to add more description to a specific PulsarClient instance. If it's configured,
+     * the description will be appended to the original client version string, with '-' as the separator.
+     *
+     * <p>For example, if the client version is 3.0.0, and the description is "forked", the final client version string
+     * will be "Pulsar-Java-v3.0.0-forked".
+     *
+     * @param description the description of the current PulsarClient instance
+     * @throws IllegalArgumentException if the length of description exceeds 64
+     */
+    ClientBuilder description(String description);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -477,21 +477,7 @@ public class ClientBuilderImpl implements ClientBuilder {
         return this;
     }
 
-    /**
-     * Set the description.
-     *
-     * <p> By default, when the client connects to the broker, a version string like "Pulsar-Java-v<x.y.z>" will be
-     * carried and saved by the broker. The client version string could be queried from the topic stats.
-     *
-     * <p> This method provides a way to add more description to a specific PulsarClient instance. If it's configured,
-     * the description will be appended to the original client version string, with '-' as the separator.
-     *
-     * <p>For example, if the client version is 3.0.0, and the description is "forked", the final client version string
-     * will be "Pulsar-Java-v3.0.0-forked".
-     *
-     * @param description the description of the current PulsarClient instance
-     * @throws IllegalArgumentException if the length of description exceeds 64
-     */
+    @Override
     public ClientBuilder description(String description) {
         if (description != null && description.length() > 64) {
             throw new IllegalArgumentException("description should be at most 64 characters");


### PR DESCRIPTION
### Modifications

https://github.com/apache/pulsar/pull/20009 introduced the `description(String)` method, but it was not added to the `ClientBuilder`. As a result, it is currently impossible to set the description using `PulsarClient.builder().description()`.

### Modifications

- Add the `description(String)` method to `ClientBuilder` to support setting a client description through the builder API.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->