### PR TITLE
[fix][broker] Ensure KeyShared sticky mode consumer respects assigned ranges

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -137,7 +137,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
             // 2. Validate: check for overlaps with the next range in the sorted list
             if (i < sortedRanges.size() - 1) {
                 IntRange nextRange = sortedRanges.get(i + 1);
-                if (checkRangesOverlap(currentRange, nextRange)) {
+                if (areRangesOverlapping(currentRange, nextRange)) {
                     return FutureUtil.failedFuture(
                             new BrokerServiceException.ConsumerAssignException("Consumer's own ranges conflict: "
                                     + "[" + currentRange.getStart() + "," + currentRange.getEnd() + "] "
@@ -159,7 +159,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
             Map.Entry<Integer, Pair<Range, Consumer>> conflictBeforeStart = rangeMap.floorEntry(newRange.getStart());
             if (conflictBeforeStart != null) {
                 Range existingRange = conflictBeforeStart.getValue().getLeft();
-                if (checkRangesOverlap(newRange, existingRange)) {
+                if (areRangesOverlapping(newRange, existingRange)) {
                     return conflictBeforeStart.getValue().getRight();
                 }
             }
@@ -167,7 +167,7 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
             Map.Entry<Integer, Pair<Range, Consumer>> conflictAfterStart = rangeMap.ceilingEntry(newRange.getStart());
             if (conflictAfterStart != null) {
                 Range existingRange = conflictAfterStart.getValue().getLeft();
-                if (checkRangesOverlap(newRange, existingRange)) {
+                if (areRangesOverlapping(newRange, existingRange)) {
                     return conflictAfterStart.getValue().getRight();
                 }
             }
@@ -176,11 +176,11 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
     }
 
 
-    private static boolean checkRangesOverlap(IntRange range1, Range range2) {
+    private static boolean areRangesOverlapping(IntRange range1, Range range2) {
         return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
     }
 
-    private static boolean checkRangesOverlap(IntRange range1, IntRange range2) {
+    private static boolean areRangesOverlapping(IntRange range1, IntRange range2) {
         return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -20,14 +20,15 @@ package org.apache.pulsar.broker.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.common.api.proto.IntRange;
-import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -38,7 +39,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
     private final int rangeSize;
     private final Range keyHashRange;
-    private final ConcurrentSkipListMap<Integer, Consumer> rangeMap;
+    private final ConcurrentSkipListMap<Integer, Pair<Range, Consumer>> rangeMap;
 
     public HashRangeExclusiveStickyKeyConsumerSelector() {
         this(DEFAULT_RANGE_SIZE);
@@ -73,47 +74,41 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
                     + conflictingConsumer);
         }
         for (IntRange intRange : consumer.getKeySharedMeta().getHashRangesList()) {
-            rangeMap.put(intRange.getStart(), consumer);
-            rangeMap.put(intRange.getEnd(), consumer);
+            rangeMap.put(intRange.getStart(), Pair.of(Range.of(intRange.getStart(), intRange.getEnd()), consumer));
         }
         return Optional.empty();
     }
 
     @Override
     public synchronized Optional<ImpactedConsumersResult> removeConsumer(Consumer consumer) {
-        rangeMap.entrySet().removeIf(entry -> entry.getValue().equals(consumer));
+        rangeMap.entrySet().removeIf(entry -> entry.getValue().getRight().equals(consumer));
         return Optional.empty();
     }
 
     @Override
     public synchronized ConsumerHashAssignmentsSnapshot getConsumerHashAssignmentsSnapshot() {
         List<HashRangeAssignment> result = new ArrayList<>();
-        Map.Entry<Integer, Consumer> prev = null;
-        for (Map.Entry<Integer, Consumer> entry: rangeMap.entrySet()) {
-            if (prev == null) {
-                prev = entry;
-            } else {
-                if (prev.getValue().equals(entry.getValue())) {
-                    result.add(new HashRangeAssignment(Range.of(prev.getKey(), entry.getKey()), entry.getValue()));
-                }
-                prev = null;
-            }
+        for (Map.Entry<Integer, Pair<Range, Consumer>> entry : rangeMap.entrySet()) {
+            Range assignedRange = entry.getValue().getLeft();
+            Consumer assignedConsumer = entry.getValue().getRight();
+            result.add(new HashRangeAssignment(assignedRange, assignedConsumer));
         }
         return ConsumerHashAssignmentsSnapshot.of(result);
     }
 
     @Override
     public Consumer select(int hash) {
-        if (rangeMap.size() > 0) {
-            Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(hash);
-            Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(hash);
-            Consumer ceilingConsumer = ceilingEntry != null ? ceilingEntry.getValue() : null;
-            Consumer floorConsumer = floorEntry != null ? floorEntry.getValue() : null;
-            if (floorConsumer != null && floorConsumer.equals(ceilingConsumer)) {
-                return ceilingConsumer;
-            } else {
-                return null;
-            }
+        if (rangeMap.isEmpty()) {
+            return null;
+        }
+
+        Map.Entry<Integer, Pair<Range, Consumer>> floorEntry = rangeMap.floorEntry(hash);
+        if (floorEntry == null) {
+            return null;
+        }
+        Pair<Range, Consumer> pair = floorEntry.getValue();
+        if (pair.getLeft().contains(hash)) {
+            return pair.getRight();
         } else {
             return null;
         }
@@ -129,10 +124,25 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
             return FutureUtil.failedFuture(new BrokerServiceException.ConsumerAssignException(
                     "Ranges for KeyShared policy must not be empty."));
         }
-        for (IntRange intRange : ranges) {
-            if (intRange.getStart() > intRange.getEnd()) {
+        List<IntRange> sortedRanges = new ArrayList<>(ranges);
+        sortedRanges.sort(Comparator.comparingInt(IntRange::getStart));
+        for (int i = 0; i < sortedRanges.size(); i++) {
+            IntRange currentRange = sortedRanges.get(i);
+            // 1. Validate: check if start > end for the current range
+            if (currentRange.getStart() > currentRange.getEnd()) {
                 return FutureUtil.failedFuture(
-                        new BrokerServiceException.ConsumerAssignException("Fixed hash range start > end"));
+                        new BrokerServiceException.ConsumerAssignException("Fixed hash range start > end for range: "
+                                + "[" + currentRange.getStart() + "," + currentRange.getEnd() + "]"));
+            }
+            // 2. Validate: check for overlaps with the next range in the sorted list
+            if (i < sortedRanges.size() - 1) {
+                IntRange nextRange = sortedRanges.get(i + 1);
+                if (checkRangesOverlap(currentRange, nextRange)) {
+                    return FutureUtil.failedFuture(
+                            new BrokerServiceException.ConsumerAssignException("Consumer's own ranges conflict: "
+                                    + "[" + currentRange.getStart() + "," + currentRange.getEnd() + "] "
+                                    + "overlaps with [" + nextRange.getStart() + "," + nextRange.getEnd() + "]"));
+                }
             }
         }
         Consumer conflictingConsumer = findConflictingConsumer(ranges);
@@ -143,34 +153,55 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
         }
     }
 
-    private synchronized Consumer findConflictingConsumer(List<IntRange> ranges) {
-        for (IntRange intRange : ranges) {
-            Map.Entry<Integer, Consumer> ceilingEntry = rangeMap.ceilingEntry(intRange.getStart());
-            Map.Entry<Integer, Consumer> floorEntry = rangeMap.floorEntry(intRange.getEnd());
-
-            if (floorEntry != null && floorEntry.getKey() >= intRange.getStart()) {
-                return floorEntry.getValue();
+    private synchronized Consumer findConflictingConsumer(List<IntRange> newConsumerRanges) {
+        for (IntRange newRange : newConsumerRanges) {
+            // 1. Check for potential conflicts with existing ranges that start before newRange's start.
+            //    Example: newRange = [50, 100], existingRange = [0, 70]
+            //    floorEntry finds an entry whose key is less than or equal to newRange.getStart().
+            Map.Entry<Integer, Pair<Range, Consumer>> conflictBeforeStart = rangeMap.floorEntry(newRange.getStart());
+            if (conflictBeforeStart != null) {
+                Range existingRange = conflictBeforeStart.getValue().getLeft();
+                if (checkRangesOverlap(newRange, existingRange)) {
+                    // Conflict found, return the consumer associated with the conflicting range
+                    return conflictBeforeStart.getValue().getRight();
+                }
             }
 
-            if (ceilingEntry != null && ceilingEntry.getKey() <= intRange.getEnd()) {
-                return ceilingEntry.getValue();
-            }
+            // 2. Iterate through existing ranges that start at or after newRange's start.
+            //    ConcurrentSkipListMap.tailMap(fromKey, inclusive) returns a sub-map
+            //    containing entries whose keys are greater than or equal to fromKey.
+            //    This allows efficient iteration over all existing ranges that start at or after newRange.getStart().
+            for (Map.Entry<Integer, Pair<Range, Consumer>> entry :
+                    rangeMap.tailMap(newRange.getStart(), true).entrySet()) {
+                Range existingRange = entry.getValue().getLeft();
+                Consumer existingConsumer = entry.getValue().getRight();
 
-            if (ceilingEntry != null && floorEntry != null && ceilingEntry.getValue().equals(floorEntry.getValue())) {
-                KeySharedMeta keySharedMeta = ceilingEntry.getValue().getKeySharedMeta();
-                for (IntRange range : keySharedMeta.getHashRangesList()) {
-                    int start = Math.max(intRange.getStart(), range.getStart());
-                    int end = Math.min(intRange.getEnd(), range.getEnd());
-                    if (end >= start) {
-                        return ceilingEntry.getValue();
-                    }
+                // If the start of the current existingRange is already beyond the end of newRange,
+                // no further existing ranges (which are ordered by start key) can overlap, so we can break.
+                if (existingRange.getStart() > newRange.getEnd()) {
+                    break;
+                }
+
+                // Check if the current existingRange overlaps with newRange
+                if (checkRangesOverlap(newRange, existingRange)) {
+                    // Conflict found, return the consumer associated with the conflicting range
+                    return existingConsumer;
                 }
             }
         }
         return null;
     }
 
-    Map<Integer, Consumer> getRangeConsumer() {
+
+    private boolean checkRangesOverlap(IntRange range1, Range range2) {
+        return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
+    }
+
+    private boolean checkRangesOverlap(IntRange range1, IntRange range2) {
+        return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
+    }
+
+    Map<Integer, Pair<Range, Consumer>> getRangeConsumer() {
         return Collections.unmodifiableMap(rangeMap);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java
@@ -176,11 +176,11 @@ public class HashRangeExclusiveStickyKeyConsumerSelector implements StickyKeyCon
     }
 
 
-    private boolean checkRangesOverlap(IntRange range1, Range range2) {
+    private static boolean checkRangesOverlap(IntRange range1, Range range2) {
         return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
     }
 
-    private boolean checkRangesOverlap(IntRange range1, IntRange range2) {
+    private static boolean checkRangesOverlap(IntRange range1, IntRange range2) {
         return Math.max(range1.getStart(), range2.getStart()) <= Math.min(range1.getEnd(), range2.getEnd());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -2537,4 +2537,70 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
             logTopicStats(topic);
         }
     }
+
+    @Test
+    public void testCustomStickyRange() throws Exception {
+        int messageCount = 100;
+        final String topicName = "persistent://public/default/test-sticky-range-" + System.nanoTime();
+        final String subscriptionName = "sub-sticky-range";
+
+        // 0. Init topic and subscription
+        admin.topics().createPartitionedTopic(topicName, 4);
+        admin.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
+
+        // 1. Create a producer and send messages
+        try (Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition)
+                .create()) {
+            for (int i = 0; i < messageCount; i++) {
+                String key = String.valueOf(i);
+                producer.newMessage()
+                        .value(String.valueOf(i).getBytes())
+                        .key(key)
+                        .send();
+            }
+        }
+
+        // 3. One by one create consumers consume message with different sticky hash range
+        KeySharedPolicy.KeySharedPolicySticky policy1 = KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 9999), Range.of(20000, 29999), Range.of(40000, 49999));
+        KeySharedPolicy.KeySharedPolicySticky policy2 = KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(10000, 19999), Range.of(30000, 39999), Range.of(50000, 65535));
+
+        List<KeySharedPolicy.KeySharedPolicySticky> policies = Arrays.asList(policy1, policy2);
+        int[] receivedCounts = new int[2];
+        for (int i = 0; i < policies.size(); i++) {
+            Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                    .topic(topicName)
+                    .subscriptionName(subscriptionName)
+                    .subscriptionType(SubscriptionType.Key_Shared)
+                    .keySharedPolicy(policies.get(i))
+                    .subscribe();
+            while (true) {
+                try {
+                    Message<byte[]> msg = consumer.receive(2, TimeUnit.SECONDS);
+                    if (msg == null) {
+                        break;
+                    }
+                    receivedCounts[i]++;
+                    log.debug("Consumer #{} received message with key:{} total:{}",
+                            i + 1, msg.getKey(), receivedCounts[i]);
+                } catch (Exception e) {
+                    break;
+                }
+            }
+            // make sure consume closed before start next consumer
+            consumer.close();
+        }
+
+        int consumer1Received = receivedCounts[0];
+        int consumer2Received = receivedCounts[1];
+
+        log.info("Consumer1 total received: {}", consumer1Received);
+        log.info("Consumer2 total received: {}", consumer2Received);
+        Assert.assertEquals(consumer1Received + consumer2Received, messageCount,
+                "Total messages received by both consumers should be " + messageCount);
+    }
 }


### PR DESCRIPTION
### Motivation

This PR fixes a critical bug where the `KeyShared` sticky mode consumer in Pulsar would incorrectly consume messages from hash ranges not explicitly assigned to it. 

Specifically, if a single `KeyShared` consumer is configured with non-contiguous sticky ranges, e.g.:
- `[0, 9999]`
- `[20000, 29999]`
- `[40000, 49999]`

The consumer would incorrectly receive messages for keys falling into the gaps (e.g., `15000` which is between `9999` and `20000`). 

The root cause lies in the `HashRangeExclusiveStickyKeyConsumerSelector`'s `select` method, which previously stored only the start/end points of ranges in its `rangeMap`. This led to an erroneous interpretation where any hash between a range's `end` and the next range's `start` would be assigned to the previous range's consumer.

https://github.com/apache/pulsar/blob/84b834f95c83e2385d8ca9bccb4cb78120ed582c/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HashRangeExclusiveStickyKeyConsumerSelector.java#L108-L116

In the scenario above, this consumer would actually receive messages in the range of **0 ~ 49999** (when there is only one consumer).

You can reproduce by testing from this PR:
- The `testConsumerSelectWithMultipRanges` unit test in this PR.
- The `testCustomStickyRange` integration test in this PR.

BTW: v3.0 has the same issue.

### Modifications

- Core Data Structure Refactor: The rangeMap now stores the complete Range object instead of just the range's start key. This provides a foundation for precise containment checks and conflict detection.
- Conflict Detection: The algorithm for detecting range conflicts between different consumers has been optimized for better accuracy and efficiency.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added new unit tests and an integration test and can be verified as follows:

-   **`HashRangeExclusiveStickyKeyConsumerSelectorTest` (Unit Tests)**:
    * `testConsumerSelect`: Updated to verify `select(hash)` returns the correct consumer only when `hash` is within an explicitly defined range, and `null` for hashes in gaps.
    * `testConsumerSelectWithMultipRanges`: Added to confirm a single consumer with multiple distinct sticky ranges correctly selects messages only within those ranges and returns `null` for hashes in gaps.
    * `testOneConsumerRangeConflict`: Added to verify that a consumer cannot be added if its own `KeySharedMeta` contains internally conflicting or invalid (`start > end`) ranges.
    * `testSingleRangeConflict` and `testMultipleRangeConflict`: Updated to correctly assert expected conflicts and non-conflicts based on the new strict range overlap detection logic.
-   **`KeySharedSubscriptionTest.testCustomStickyRange` (Integration Test)**:
    * A new end-to-end integration test has been added. It simulates the reported scenario with a partitioned topic and two consumers assigned non-overlapping sticky ranges. This test verifies that each consumer *only* receives messages for keys falling within its *explicitly assigned ranges*, confirming the fix for the unintended auto-split behavior.


### Documentation

- [ ] `doc`
- [ ] `doc-required` 
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: ```