### PR TITLE
[fix] Exclude commons-lang dep from bookkeeper

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -286,7 +286,6 @@ The Apache Software License, Version 2.0
     - commons-cli-commons-cli-1.9.0.jar
     - commons-codec-commons-codec-1.18.0.jar
     - commons-io-commons-io-2.19.0.jar
-    - commons-lang-commons-lang-2.6.jar
     - commons-logging-commons-logging-1.3.5.jar
     - commons-collections-commons-collections-3.2.2.jar
     - org.apache.commons-commons-collections4-4.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1390,6 +1390,10 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 


### PR DESCRIPTION
### Motivation

Certain components of BookKeeper are still including the old `commons-lang` dependency (which is already replaced by `commons-lang3`.

We should exclude to avoid CVE: 

```
│ commons-lang:commons-lang                                   │ CVE-2025-48924 │ MEDIUM   │          │ 2.6               │                │ commons-lang/commons-lang: org.apache.commons/commons-lang3: │
│ (commons-lang-commons-lang-2.6.jar)                         │                │          │          │                   │                │ Uncontrolled Recursion vulnerability in Apache Commons Lang  │
│                                                             │                │          │          │                   │                │ https://avd.aquasec.com/nvd/cve-2025-48924                   │
├─────────────────────────────────────────────────────────────┤                │          │          │                   ├────────────────┤                                                              │
```
### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
