### PR TITLE
[fix][ml]Fix EOFException after enabled topics offloading

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -229,11 +229,6 @@ public class BlobStoreBackedReadHandleImpl implements ReadHandle, OffloadedLedge
             log.debug("Ledger {}: reading {} - {} ({} entries}",
                     getId(), firstEntry, lastEntry, (1 + lastEntry - firstEntry));
         }
-        if (lastEntry < firstEntry || lastEntry > getLastAddConfirmed()) {
-            log.warn("Failed to read entries [ {} ~ {} ] from ledger {}, because the entries do not exist. LAC is {}",
-                    firstEntry, lastEntry, getId(), getLastAddConfirmed());
-            return CompletableFuture.failedFuture(new BKException.BKIncorrectParameterException());
-        }
         CompletableFuture<LedgerEntries> promise = new CompletableFuture<>();
 
         // Ledger handles will be only marked idle when "pendingRead" is "0", it is not needed to update

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java
@@ -20,7 +20,6 @@ package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
-import io.netty.util.concurrent.FastThreadLocal;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,7 +47,6 @@ import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlock;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlockBuilder;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexEntry;
 import org.apache.bookkeeper.mledger.offload.jcloud.impl.DataBlockUtils.VersionCheck;
-import org.apache.commons.lang3.tuple.MutableTriple;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.jclouds.blobstore.BlobStore;

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexEntryImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/OffloadIndexEntryImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.offload.jcloud.impl;
 
+import java.util.Objects;
 import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexEntry;
 
 /**
@@ -64,6 +65,20 @@ public class OffloadIndexEntryImpl implements OffloadIndexEntry {
     public String toString() {
         return String.format("[eid:%d, part:%d, offset:%d, doffset:%d]",
                 entryId, partId, offset, getDataOffset());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OffloadIndexEntryImpl that)) {
+            return false;
+        }
+        return entryId == that.entryId && partId == that.partId && offset == that.offset
+                && blockHeaderSize == that.blockHeaderSize;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entryId, partId, offset, blockHeaderSize);
     }
 }
 

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.offload.jcloud.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.client.LedgerMetadataBuilder;
+import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.client.api.LedgerEntries;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.mledger.offload.jcloud.BackedInputStream;
+import org.apache.bookkeeper.mledger.offload.jcloud.OffloadIndexBlock;
+import org.apache.bookkeeper.net.BookieId;
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Comprehensive test suite for BlobStoreBackedReadHandleImpl.readAsync method.
+ * 
+ * This test covers:
+ * - Normal read operations with valid entry ranges
+ * - Error handling for invalid parameters
+ * - State management (open/closed handle)
+ * - Concurrent read operations
+ * - Exception scenarios (IOException, KeyNotFoundException)
+ * - Entry seeking and caching behavior
+ * - Pending read counter management
+ * - Last access timestamp updates
+ */
+public class BlobStoreBackedReadHandleImplTest {
+
+    private OffsetsCache offsetsCache = new OffsetsCache();
+
+    private ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+
+    @AfterClass
+    public void tearDown() throws Exception {
+        if (executor != null) {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (offsetsCache != null) {
+            offsetsCache.close();
+        }
+    }
+
+    @AfterClass
+    public void clearCache() throws Exception {
+        offsetsCache.clear();
+    }
+
+    private String getExpectedEntryContent(int entryId) {
+        return "Entry " + entryId;
+    }
+
+    private Pair<BlobStoreBackedReadHandleImpl,ByteBuf> createReadHandle(long ledgerId, int entries,
+                                                                         boolean hasDirtyData) throws Exception {
+        // Build data.
+        List<Pair<Integer, Integer>> offsets = new ArrayList<>();
+        int totalLen = 0;
+        ByteBuf data = ByteBufAllocator.DEFAULT.heapBuffer(1024);
+        data.writeInt(0);
+        data.writerIndex(128);
+        //data.readerIndex(128);
+        for (int i = 0; i < entries; i++) {
+            if (hasDirtyData && i == 1) {
+                data.writeBytes("dirty data".getBytes(UTF_8));
+            }
+            offsets.add(Pair.of(i, data.writerIndex()));
+            offsetsCache.put(ledgerId, i, data.writerIndex());
+            byte[] entryContent = getExpectedEntryContent(i).getBytes(UTF_8);
+            totalLen += entryContent.length;
+            data.writeInt(entryContent.length);
+            data.writeLong(i);
+            data.writeBytes(entryContent);
+        }
+        // Build metadata.
+        LedgerMetadata metadata = LedgerMetadataBuilder.create()
+                .withId(ledgerId)
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withAckQuorumSize(1)
+                .withDigestType(DigestType.CRC32C)
+                .withPassword("pwd".getBytes(UTF_8))
+                .withClosedState()
+                .withLastEntryId(entries)
+                .withLength(totalLen)
+                .newEnsembleEntry(0L, Arrays.asList(BookieId.parse("127.0.0.1:3181")))
+                .build();
+        BackedInputStreamImpl inputStream = new BackedInputStreamImpl(data);
+        // Since we have written data to "offsetsCache", the index will never be used.
+        OffloadIndexBlock mockIndex = mock(OffloadIndexBlock.class);
+        when(mockIndex.getLedgerMetadata()).thenReturn(metadata);
+        for (Pair<Integer, Integer> pair : offsets) {
+            when(mockIndex.getIndexEntryForEntry(pair.getLeft())).thenReturn(
+                    OffloadIndexEntryImpl.of(pair.getLeft(), 0, pair.getRight(), 0));
+        }
+        // Build obj.
+        return Pair.of(new BlobStoreBackedReadHandleImpl(ledgerId, mockIndex, inputStream, executor, offsetsCache),
+                data);
+    }
+
+    private static class BackedInputStreamImpl extends BackedInputStream {
+
+        private ByteBuf data;
+
+        private BackedInputStreamImpl(ByteBuf data){
+            this.data = data;
+        }
+
+        @Override
+        public void seek(long position) {
+            data.readerIndex((int) position);
+        }
+
+        @Override
+        public void seekForward(long position) throws IOException {
+            data.readerIndex((int) position);
+        }
+
+        @Override
+        public long getCurrentPosition() {
+            return data.readerIndex();
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (data.readableBytes() == 0) {
+                throw new EOFException("The input-stream has no bytes to read");
+            }
+            return data.readByte();
+        }
+
+        @Override
+        public int available() throws IOException {
+            return data.readableBytes();
+        }
+    }
+
+    @DataProvider
+    public Object[][] streamStartAt() {
+        return new Object[][] {
+//            // It gives a 0 value of the entry length.
+//            { 0, false },
+//            // It gives a 0 value of the entry length.
+//            { 1, false },
+//            // The first entry starts at 128.
+//            { 128, false },
+//            // It gives a 0 value of the entry length.
+//            { 0, true },
+//            // It gives a 0 value of the entry length.
+//            { 1, true },
+            // The first entry starts at 128.
+            { 128, true }
+        };
+    }
+
+    @Test(dataProvider = "streamStartAt")
+    public void testRead(int streamStartAt, boolean hasDirtyData) throws Exception {
+        int entryCount = 5;
+        Pair<BlobStoreBackedReadHandleImpl,ByteBuf> ledgerDataPair = createReadHandle(1, entryCount,
+                hasDirtyData);
+        BlobStoreBackedReadHandleImpl ledger = ledgerDataPair.getLeft();
+        ByteBuf data = ledgerDataPair.getRight();
+        data.readerIndex(streamStartAt);
+        // Teat read each entry.
+        for (int i = 0; i < 5; i++) {
+            LedgerEntries entries = ledger.read(i, i);
+            assertEquals(new String(entries.iterator().next().getEntryBytes()), getExpectedEntryContent(i));
+        }
+        // Test read all entries.
+        LedgerEntries entries1 = ledger.read(0, entryCount - 1);
+        Iterator<LedgerEntry> iterator1 = entries1.iterator();
+        for (int i = 0; i < entryCount; i++) {
+            assertEquals(new String(iterator1.next().getEntryBytes()), getExpectedEntryContent(i));
+        }
+        // Test a special case.
+        // 1. Read from 0 to "lac - 1".
+        // 2. Any reading.
+        LedgerEntries entries2 = ledger.read(0, entryCount - 2);
+        Iterator<LedgerEntry> iterator2 = entries2.iterator();
+        for (int i = 0; i < entryCount - 1; i++) {
+            assertEquals(new String(iterator2.next().getEntryBytes()), getExpectedEntryContent(i));
+        }
+        LedgerEntries entries3 = ledger.read(0, entryCount - 1);
+        Iterator<LedgerEntry> iterator3 = entries3.iterator();
+        for (int i = 0; i < entryCount; i++) {
+            assertEquals(new String(iterator3.next().getEntryBytes()), getExpectedEntryContent(i));
+        }
+        // cleanup.
+        ledger.close();
+    }
+}

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
@@ -72,8 +72,8 @@ public class BlobStoreBackedReadHandleImplTest {
         return "Entry " + entryId;
     }
 
-    private Pair<BlobStoreBackedReadHandleImpl,ByteBuf> createReadHandle(
-            long ledgerId, int entries,boolean hasDirtyData) throws Exception {
+    private Pair<BlobStoreBackedReadHandleImpl, ByteBuf> createReadHandle(
+            long ledgerId, int entries, boolean hasDirtyData) throws Exception {
         // Build data.
         List<Pair<Integer, Integer>> offsets = new ArrayList<>();
         int totalLen = 0;
@@ -177,8 +177,8 @@ public class BlobStoreBackedReadHandleImplTest {
     @Test(dataProvider = "streamStartAt")
     public void testRead(int streamStartAt, boolean hasDirtyData) throws Exception {
         int entryCount = 5;
-        Pair<BlobStoreBackedReadHandleImpl,ByteBuf> ledgerDataPair
-                = createReadHandle(1, entryCount, hasDirtyData);
+        Pair<BlobStoreBackedReadHandleImpl, ByteBuf> ledgerDataPair =
+                createReadHandle(1, entryCount, hasDirtyData);
         BlobStoreBackedReadHandleImpl ledger = ledgerDataPair.getLeft();
         ByteBuf data = ledgerDataPair.getRight();
         data.readerIndex(streamStartAt);

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
@@ -172,16 +172,16 @@ public class BlobStoreBackedReadHandleImplTest {
     @DataProvider
     public Object[][] streamStartAt() {
         return new Object[][] {
-//            // It gives a 0 value of the entry length.
-//            { 0, false },
-//            // It gives a 0 value of the entry length.
-//            { 1, false },
-//            // The first entry starts at 128.
-//            { 128, false },
-//            // It gives a 0 value of the entry length.
-//            { 0, true },
-//            // It gives a 0 value of the entry length.
-//            { 1, true },
+            // It gives a 0 value of the entry length.
+            { 0, false },
+            // It gives a 0 value of the entry length.
+            { 1, false },
+            // The first entry starts at 128.
+            { 128, false },
+            // It gives a 0 value of the entry length.
+            { 0, true },
+            // It gives a 0 value of the entry length.
+            { 1, true },
             // The first entry starts at 128.
             { 128, true }
         };

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplTest.java
@@ -46,19 +46,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-/**
- * Comprehensive test suite for BlobStoreBackedReadHandleImpl.readAsync method.
- * 
- * This test covers:
- * - Normal read operations with valid entry ranges
- * - Error handling for invalid parameters
- * - State management (open/closed handle)
- * - Concurrent read operations
- * - Exception scenarios (IOException, KeyNotFoundException)
- * - Entry seeking and caching behavior
- * - Pending read counter management
- * - Last access timestamp updates
- */
 public class BlobStoreBackedReadHandleImplTest {
 
     private OffsetsCache offsetsCache = new OffsetsCache();
@@ -85,8 +72,8 @@ public class BlobStoreBackedReadHandleImplTest {
         return "Entry " + entryId;
     }
 
-    private Pair<BlobStoreBackedReadHandleImpl,ByteBuf> createReadHandle(long ledgerId, int entries,
-                                                                         boolean hasDirtyData) throws Exception {
+    private Pair<BlobStoreBackedReadHandleImpl,ByteBuf> createReadHandle(
+            long ledgerId, int entries,boolean hasDirtyData) throws Exception {
         // Build data.
         List<Pair<Integer, Integer>> offsets = new ArrayList<>();
         int totalLen = 0;
@@ -190,8 +177,8 @@ public class BlobStoreBackedReadHandleImplTest {
     @Test(dataProvider = "streamStartAt")
     public void testRead(int streamStartAt, boolean hasDirtyData) throws Exception {
         int entryCount = 5;
-        Pair<BlobStoreBackedReadHandleImpl,ByteBuf> ledgerDataPair = createReadHandle(1, entryCount,
-                hasDirtyData);
+        Pair<BlobStoreBackedReadHandleImpl,ByteBuf> ledgerDataPair
+                = createReadHandle(1, entryCount, hasDirtyData);
         BlobStoreBackedReadHandleImpl ledger = ledgerDataPair.getLeft();
         ByteBuf data = ledgerDataPair.getRight();
         data.readerIndex(streamStartAt);


### PR DESCRIPTION
### Motivation

The steps of reproducing the issue:
- We have a ledger, which contains `5` entries, the last confirmed is `4`
- Enable offloading for a topic
- Read the first round: `[0 ~ 3]`
- Read the second round `[0 ~ 4]`, the error will occur.

```
2025-09-11T11:22:09,210+0000 [offloader-OrderedScheduler-1-0] ERROR org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl - Failed to read entries 0 - 10 from the offloader in ledger 1670362
java.io.EOFException: null
	at java.base/java.io.DataInputStream.readFully(Unknown Source) ~[?:?]
	at java.base/java.io.DataInputStream.readInt(Unknown Source) ~[?:?]
	at org.apache.bookkeeper.mledger.offload.jcloud.impl.BlobStoreBackedReadHandleImpl.lambda$readAsync$2(BlobStoreBackedReadHandleImpl.java:171) ~[?:?]
	at org.apache.bookkeeper.common.util.SingleThreadSafeScheduledExecutorService$SafeRunnable.run(SingleThreadSafeScheduledExecutorService.java:45) ~[io.streamnative-bookkeeper-common-4.17.2.2.jar:4.17.2.2]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.124.Final.jar:4.1.124.Final]
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
```

### Root cause

After the previous round of reading, the `offset` of the stream is the start position of the latest entry. If Pulsar tries to read `[0 ~ LAC]`, it will encounter the bottom logic branch: `skip the latest entry`, then the next round look will receive an `EOFException` because the stream is empty.

https://github.com/apache/pulsar/blob/v4.1.0/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java#L210

```java
if (entryId == nextExpectedId) {
    entries.add(LedgerEntryImpl.create(ledgerId, entryId, length, buf));
} else if (entryId > nextExpectedId && entryId < lastEntry) {
    seekToEntry(nextExpectedId);
} else if (entryId < nextExpectedId
    && !index.getIndexEntryForEntry(nextExpectedId).equals(index.getIndexEntryForEntry(entryId))) {
    seekToEntry(nextExpectedId);
} else if (entryId > lastEntry) {
    seekToEntry(nextExpectedId);
} else {
    long ignore = inputStream.skip(length);
}
```

### Modifications
- Fix the issue.
- Improve logs.
- Add `hashCode and equals` for `OffloadIndexEntryImpl`, since Pulsar calls `equals` here: https://github.com/apache/pulsar/blob/v4.1.0/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImpl.java#L193
- Seek first before the reading loop, to avoid another case of EOFException, which is thrown by `DataInputStream.readInt` if the value is unexpected.

```java
 public final int readInt() throws IOException {
    int ch1 = in.read();
    int ch2 = in.read();
    int ch3 = in.read();
    int ch4 = in.read();
    if ((ch1 | ch2 | ch3 | ch4) < 0)
        throw new EOFException(); // if the value is not an int, it throws an error here.
    return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
}
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
