### PR TITLE
[fix][broker] Prevent NPE in ownedBundlesCountPerNamespace on first bundle load

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -393,14 +393,14 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         if (NamespaceService.isHeartbeatNamespace(namespace)) {
             return CompletableFuture.completedFuture(null);
         }
-        synchronized (this) {
-            if (readerCaches.get(namespace) != null) {
-                ownedBundlesCountPerNamespace.get(namespace).incrementAndGet();
-                return CompletableFuture.completedFuture(null);
-            } else {
-                return prepareInitPoliciesCacheAsync(namespace);
-            }
+        AtomicInteger bundlesCount =
+                ownedBundlesCountPerNamespace.computeIfAbsent(namespace, k -> new AtomicInteger(0));
+        int previousCount = bundlesCount.getAndIncrement();
+        if (previousCount == 0) {
+            // initialize policies cache asynchronously on the first bundle load
+            return prepareInitPoliciesCacheAsync(namespace);
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Motivation

Fix NPE:
```
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.atomic.AtomicInteger.incrementAndGet()" because the return value of "java.util.Map.get(Object)" is null

  at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService.addOwnedNamespaceBundleAsync(SystemTopicBasedTopicPoliciesService.java:405) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.service.SystemTopicBasedTopicPoliciesService$2.onLoad(SystemTopicBasedTopicPoliciesService.java:509) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.namespace.NamespaceService.notifyNamespaceBundleOwnershipListener(NamespaceService.java:1322) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.namespace.NamespaceService.onNamespaceBundleOwned(NamespaceService.java:1285) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.namespace.OwnershipCache.lambda$tryAcquiringOwnership$3(OwnershipCache.java:218) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:684) ~[?:?]

  at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[?:?]

  at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2168) ~[?:?]

  at org.apache.pulsar.broker.namespace.OwnershipCache.tryAcquiringOwnership(OwnershipCache.java:216) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.namespace.NamespaceService.searchForCandidateBroker(NamespaceService.java:631) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at org.apache.pulsar.broker.namespace.NamespaceService.lambda$findBrokerServiceUrl$10(NamespaceService.java:466) ~[pulsar-broker.jar:3.0.14-SNAPSHOT]

  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]

  at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]

  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]

  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]

  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]

  at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.124.Final.jar:4.1.124.Final]

  at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

### Modifications

- Replaced direct `ownedBundlesCountPerNamespace.get(...).incrementAndGet()` with
  `computeIfAbsent(namespace, k -> new AtomicInteger(0))` to ensure the counter is always initialized before incrementing.  

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->