### PR TITLE
[improve][build] Upgrade SpotBugs to a version that supports JDK25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,8 +357,8 @@ flexible messaging model and an intuitive client API.</description>
     <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-    <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
-    <spotbugs.version>4.9.3</spotbugs.version>
+    <spotbugs-maven-plugin.version>4.9.6.0</spotbugs-maven-plugin.version>
+    <spotbugs.version>4.9.6</spotbugs.version>
     <errorprone.version>2.38.0</errorprone.version>
     <errorprone-slf4j.version>0.1.28</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>


### PR DESCRIPTION
### Motivation

To build with JDK25, SpotBugs needs to be upgraded.

### Modifications

- upgrade SpotBugs to latest version 4.9.6

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->