### PR TITLE
[improve][misc] Improve entry index location RocksDB config

### DIFF
--- a/conf/entry_location_rocksdb.conf
+++ b/conf/entry_location_rocksdb.conf
@@ -65,6 +65,6 @@
  # set by jni: tableOptions.setChecksumType
  checksum=kxxHash
  # set by jni: tableOptions.setFilterPolicy, bloomfilter:[bits_per_key]:[use_block_based_builder]
- filter_policy=rocksdb.BloomFilter:10:false
+ filter_policy=rocksdb.BloomFilter:10:true
  # set by jni: tableOptions.setCacheIndexAndFilterBlocks
  cache_index_and_filter_blocks=true


### PR DESCRIPTION
### Motivation

- use more efficient `filter_policy` that is available for `format_version=5` (available since Pulsar 2.6 with RocksDB 6.6+)
  - check ["Full Filters (new format)"](https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter#full-filters-new-format) for details

### Modifications

* `filter_policy`: `rocksdb.BloomFilter:10:false` → `rocksdb.BloomFilter:10:true`

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->