### PR TITLE
Make PulsarStandaloneBuilder a public API (#10473)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneBuilder.java
@@ -21,6 +21,10 @@ package org.apache.pulsar;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public final class PulsarStandaloneBuilder {
 
@@ -95,6 +99,31 @@ public final class PulsarStandaloneBuilder {
         pulsarStandalone.setAdvertisedAddress(advertisedAddress);
         return this;
     }
+
+    public PulsarClient buildClient () throws Exception {
+        return PulsarClient.builder() 
+            .serviceUrl(pulsarStandalone.getConfig().getBrokerServiceUrl())
+            .build();
+    }
+
+    public PulsarAdmin buildAdmin() throws Exception {
+        return PulsarAdmin.builder() 
+            .serviceHttpUrl(pulsarStandalone.getConfig().getWebServiceAddress())
+            .build();
+    }
+
+    private PulsarStandaloneBuilder() throws IOException {
+        pulsarStandalone = new PulsarStandalone();
+        pulsarStandalone.setWipeData(true);
+        pulsarStandalone.setNoFunctionsWorker(true);
+
+        Path tempZkDir = Files.createTempDirectory("zk");
+        Path tempBkDir = Files.createTempDirectory("bk");
+
+        pulsarStandalone.setZkDir(tempZkDir.toString());
+        pulsarStandalone.setBkDir(tempBkDir.toString());
+    }
+
 
     public PulsarStandalone build() {
         ServiceConfiguration config = new ServiceConfiguration();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarStandaloneBuilderTest.java
@@ -1,0 +1,30 @@
+package org.apache.pulsar;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.junit.jupiter.api.Test;
+
+public class PulsarStandaloneBuilderTest {
+
+    @Test
+    public void testStandaloneBuilder() throws Exception {
+
+        PulsarStandaloneBuilder builder = PulsarStandaloneBuilder.instance();
+        
+        PulsarStandalone standalone = builder.build();
+        standalone.start();
+
+        PulsarClient client = builder.buildClient();
+        PulsarAdmin admin = builder.buildAdmin();
+
+        assertNotNull(client);
+        assertNotNull(admin);
+
+        client.close();
+        admin.close();
+        standalone.stop();
+    }
+
+}


### PR DESCRIPTION
## Description
- Added convenience methods to build `PulsarClient` and `PulsarAdmin`.
- Enabled starting the server without creating real files on disk.
- Added unit tests to ensure usage via Java program.

**Fixes:** #10473

## Motivation
Make `PulsarStandaloneBuilder` usable as a public API for unit tests, without requiring Docker/Testcontainers.

## Modifications
- Added `buildClient()` and `buildAdmin()` methods.
- Create temporary directories for ZK and BK to avoid writing on disk.
- Added `PulsarStandaloneBuilderTest.java` unit test.

## Verifying this change
- Ran `mvn test` to ensure all unit tests pass, including `PulsarStandaloneBuilderTest`.

## Does this pull request potentially affect one of the following parts:
- [x] The public API

## Documentation
- [x] `doc-not-needed`