### PR TITLE
[improve][broker] Add tests for using absolute FQDN for advertisedAddress and remove extra dot from brokerId

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -960,9 +960,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             // the broker id is used in the load manager to identify the broker
             // it should not be used for making connections to the broker
-            this.brokerId =
-                    String.format("%s:%s", advertisedAddress, config.getWebServicePort()
-                            .or(config::getWebServicePortTls).orElseThrow());
+            this.brokerId = createBrokerId();
 
             if (this.compactionServiceFactory == null) {
                 this.compactionServiceFactory = loadCompactionServiceFactory();
@@ -1090,6 +1088,16 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         } finally {
             mutex.unlock();
         }
+    }
+
+    private String createBrokerId() {
+        // Remove any trailing dot from the absolute FQDN in the broker id to prevent it from impacting
+        // broker entries in the metadata store when making the advertised address absolute
+        String brokerIdHostPart = advertisedAddress.replaceFirst("\\.$", "");
+        // Although broker id contains a hostname and port, it is not meant to be used for connecting to the broker,
+        // It is simply a unique identifier for the broker.
+        return String.format("%s:%s", brokerIdHostPart, config.getWebServicePort()
+                .or(config::getWebServicePortTls).orElseThrow());
     }
 
     public void runWhenReadyForIncomingRequests(Runnable runnable) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceBrokerIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceBrokerIdTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import java.net.InetAddress;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class PulsarServiceBrokerIdTest extends MockedPulsarServiceBaseTest {
+    private String hostAddress;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        hostAddress = InetAddress.getLocalHost().getCanonicalHostName();
+        // make it an absolute FQDN by adding a trailing dot
+        conf.setAdvertisedAddress(hostAddress + ".");
+    }
+
+    @Test
+    public void testBrokerIdDoesntContainTrailingDot() throws Exception {
+        Assert.assertEquals(pulsar.getBrokerId(), hostAddress + ":" + conf.getWebServicePort().get());
+    }
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/ClientTlsAbsoluteAdvertisedAddressTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/tls/ClientTlsAbsoluteAdvertisedAddressTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.tls;
+
+/**
+ * Test that the client can connect to a broker using TLS with an absolute advertised address.
+ */
+public class ClientTlsAbsoluteAdvertisedAddressTest extends ClientTlsTest {
+    @Override
+    protected void beforeStartCluster() throws Exception {
+        super.beforeStartCluster();
+        getPulsarCluster().getBrokers().forEach(brokerContainer -> {
+            // make the advertised address absolute by adding a dot at the end
+            brokerContainer.withEnv("advertisedAddress", brokerContainer.getHostName() + ".");
+        });
+    }
+}


### PR DESCRIPTION
### Motivation

When brokers are exposed directly to clients, there might be a need to make the `advertisedAddress` absolute so that clients with unoptimal ndots configuration won't do unnecessary DNS lookups on the client side when an `advertisedAddress` with less dots than ndots is returned to the client from topic lookup.

### Modifications

- remove extra dot from brokerId so that the brokerId format doesn't change when advertisedAddress is made absolute
- add tests for brokerId
- add integration tests to ensure that client can connect when TLS is enabled. This ensures that TLS hostname validation doesn't fail with the extra trailing dot.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->