### PR TITLE
[fix][broker] Producer still publishes messages to Broker after Topic was unloaded

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -765,11 +765,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         return brokerService.checkTopicNsOwnership(getName())
                 .thenCompose(__ ->
                         incrementTopicEpochIfNeeded(producer, producerQueuedFuture))
-                .thenCompose(producerEpoch -> 
+                .thenCompose(producerEpoch ->
                         internalAddProducer(producer).thenApply(ignore -> {
                             USAGE_COUNT_UPDATER.incrementAndGet(this);
                             if (log.isDebugEnabled()) {
-                                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(), 
+                                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(),
                                         USAGE_COUNT_UPDATER.get(this));
                             }
                             return producerEpoch;
@@ -963,7 +963,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 log.warn("[{}] Attempting to add producer to a terminated topic", topic);
                 throw new TopicTerminatedException("Topic was already terminated");
             }
-            
+
             if (isSameAddressProducersExceeded(producer)) {
                 log.warn("[{}] Attempting to add producer to topic which reached max same address producers limit",
                         topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
-import com.google.common.collect.ImmutableMap;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -77,7 +77,7 @@ public class AbstractTopicTest extends BrokerTestBase {
             }
             Topic topic = spy(topicOpt.get());
             AbstractSubscription subscription = mock(subscriptionClass);
-            doReturn(ImmutableMap.of("subscription", subscription))
+            doReturn(Map.of("subscription", subscription))
                     .when(topic).getSubscriptions();
             return Pair.of((AbstractTopic) topic, subscription);
         };
@@ -127,7 +127,7 @@ public class AbstractTopicTest extends BrokerTestBase {
 
         // Add old producer
         topic.addProducer(oldProducer, new CompletableFuture<>()).join();
-        
+
         CountDownLatch oldCnxCheckInvokedLatch = new CountDownLatch(1);
         CountDownLatch oldCnxCheckStartLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
@@ -151,14 +151,14 @@ public class AbstractTopicTest extends BrokerTestBase {
 
         // Wait until new producer entered `AbstractTopic#tryOverwriteOldProducer`
         oldCnxCheckInvokedLatch.await();
-        
+
         topic.close(true);
         // Run pending tasks to remove old producer from topic.
         ((EmbeddedChannel) oldCnx.ctx().channel()).runPendingTasks();
-        
+
         // Unblock ServerCnx#checkConnectionLiveness to resume `AbstractTopic#tryOverwriteOldProducer`
         oldCnxCheckStartLatch.countDown();
-        
+
         // As topic is fenced, adding new producer should fail.
         try {
             producerEpoch.join();


### PR DESCRIPTION
<!-- Either this PR fixes an issue, -->

Fixes #24792

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

After unloading a bundle with many non-persistent topics from Broker, we found some producers in `ProducerAccessMode.Shared` mode were still publishing messages to the broker. Even thought the topic was not loaded by the broker any more.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Run [AbstractTopicTest#testOverwriteOldProducerAfterTopicClosed](https://github.com/apache/pulsar/blob/8c6eb0c5d1541d49451cecfa2af43cef71def416/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractTopicTest.java#L120)

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/zhouyifan279/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
