### PR TITLE
[fix][client] Fix thread leak in reloadLookUp method which is used by ServiceUrlProvider

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1206,6 +1206,13 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public void reloadLookUp() throws PulsarClientException {
+        if (lookup != null) {
+            try {
+                lookup.close();
+            } catch (Exception e) {
+                log.warn("Failed to close previous lookup service before replacing", e);
+            }
+        }
         lookup = createLookup(conf.getServiceUrl());
     }
 


### PR DESCRIPTION
### Motivation

LookupService is replaced by calling reloadLookUp. However the previous instance is not closed. This causes a thread leak.

### Modifications

Call the close method before replacing LookupService.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->