### PR TITLE
[improve][broker]Improve NamespaceService log that is printed when cluster was removed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2716,8 +2716,8 @@ public class BrokerService implements Closeable {
                                     pulsar().getAdminClient().namespaces().unloadNamespaceBundle(namespace.toString(),
                                             bundle.getBundleRange());
                                 } catch (Exception e) {
-                                    log.error("Failed to unload namespace-bundle {}-{} that not owned by {}, {}",
-                                            namespace.toString(), bundle.toString(), localCluster, e.getMessage());
+                                    log.error("Failed to unload namespace-bundle {} that not owned by {}, {}",
+                                            bundle.toString(), localCluster, e.getMessage());
                                 }
                             });
                         }


### PR DESCRIPTION
### Motivation

`namespaceBundle.toString()` already contains the `namespace.toString()`, the format `{ns}-{ns-bundle}` will print a namespace like `{tenant}/{ns}-{tenant}/{ns}/{bundle}`, which makes concerning that leads to users assume it is a `v1` namespace.

### Modifications

Improve the log.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x