### PR TITLE
[fix][test] Made ProtobufNativeSchemaTest.testSchema order-independent

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaTest.java
@@ -20,14 +20,25 @@ package org.apache.pulsar.client.impl.schema;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -46,6 +57,28 @@ public class ProtobufNativeSchemaTest {
             + "gBQjUKJW9yZy5hcGFjaGUucHVsc2FyLmNsaWVudC5zY2hlbWEucHJvdG9CDEV4dGVybmFsVGVzdGIGcHJvdG8z\",\"rootMessageT"
             + "ypeName\":\"proto.TestMessage\",\"rootFileDescriptorName\":\"Test.proto\"}";
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Decode a base64-encoded Protobuf FileDescriptorSet into a canonical JSON tree.
+     * @param b64 a base64 string
+     * @return a normalized JSON tree that can be compared with JSONAssert, ensuring deterministic
+     * equality checks regardless of field ordering.
+     * @throws IllegalArgumentException if b64 isn't valid Base64
+     * @throws InvalidProtocolBufferException if the decoded bytes are not a valid FileDescriptorSet
+     * @throws JSONException if the JSON string is invalid
+     */
+    private static JSONObject fdsToJson(String b64)
+            throws IllegalArgumentException, InvalidProtocolBufferException, JSONException {
+        DescriptorProtos.FileDescriptorSet fds =
+            DescriptorProtos.FileDescriptorSet.parseFrom(Base64.getDecoder().decode(b64));
+        String json = JsonFormat.printer()
+            .includingDefaultValueFields()
+            .omittingInsignificantWhitespace()
+            .print(fds);
+        return new JSONObject(json);
+    }
+
     @Test
     public void testEncodeAndDecode() {
         final String stringFieldValue = "StringFieldValue";
@@ -61,15 +94,49 @@ public class ProtobufNativeSchemaTest {
     }
 
     @Test
-    public void testSchema() {
+    public void testSchema() throws Exception {
         ProtobufNativeSchema<org.apache.pulsar.client.schema.proto.Test.TestMessage> protobufSchema =
                 ProtobufNativeSchema.of(org.apache.pulsar.client.schema.proto.Test.TestMessage.class);
 
         assertEquals(protobufSchema.getSchemaInfo().getType(), SchemaType.PROTOBUF_NATIVE);
 
         assertNotNull(ProtobufNativeSchemaUtils.deserialize(protobufSchema.getSchemaInfo().getSchema()));
-        assertEquals(new String(protobufSchema.getSchemaInfo().getSchema(),
-                StandardCharsets.UTF_8), EXPECTED_SCHEMA_JSON);
+
+        // Parse the actual/expected JSON into trees
+        String actualJson   = new String(protobufSchema.getSchemaInfo().getSchema(), StandardCharsets.UTF_8);
+        JsonNode actualRoot   = MAPPER.readTree(actualJson);
+        JsonNode expectedRoot = MAPPER.readTree(EXPECTED_SCHEMA_JSON);
+
+        // Extract and validate the FileDescriptorSet field for semantic comparison
+        // (When decoded, Protobuf descriptors can serialize fields in varying orders
+        // causing hard coded string comparisons to fail)
+        String fdSetField = "fileDescriptorSet";
+        JsonNode actualB64Node = actualRoot.path(fdSetField);
+        JsonNode expectedB64Node = expectedRoot.path(fdSetField);
+        Assert.assertFalse(actualB64Node.isMissingNode());
+        Assert.assertFalse(expectedB64Node.isMissingNode());
+        Assert.assertTrue(actualB64Node.isValueNode());
+        Assert.assertTrue(expectedB64Node.isValueNode());
+
+        // Decode FileDescriptorSets to JSON and compare semantically (order-insensitive)
+        JSONObject actualFdsObj   = fdsToJson(actualB64Node.asText());
+        JSONObject expectedFdsObj = fdsToJson(expectedB64Node.asText());
+        JSONAssert.assertEquals(
+                "FileDescriptorSet mismatch: decoded Protobuf descriptors have mismatched schema contents",
+                expectedFdsObj,
+                actualFdsObj,
+                JSONCompareMode.NON_EXTENSIBLE
+        );
+
+        // Remove the already verified field and compare remaining schema attributes, order does not matter
+        ((ObjectNode) actualRoot).remove(fdSetField);
+        ((ObjectNode) expectedRoot).remove(fdSetField);
+        JSONAssert.assertEquals(
+                "Schema metadata mismatch: remaining JSON fields differ after verifying FileDescriptorSet",
+                MAPPER.writeValueAsString(expectedRoot),
+                MAPPER.writeValueAsString(actualRoot),
+                JSONCompareMode.NON_EXTENSIBLE
+        );
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24804 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

In ProtobufNativeSchemaTest.testSchema, the json's contents and the FileDescriptorSet field's contents do not have a deterministic order but the hardcoded string assertion assumes a deterministic order. The json serializer did not guarantee attribute order and inside FileDescriptorSet the contents can also be in different orders due to different generation paths or environments producing the contents in different orders despite the logical content being the same. Since the original test compared the raw strings/trees "as-is", harmless re-ordering could flip the test from pass to fail without any real schema change.

### Modifications

<!-- Describe the modifications you've done. -->

We no longer compare raw strings/trees "as-is". Instead the fileDescriptorSet field is base64-decoded into a FileDescriptorSet, then converted into a JSONObject. We compare the expected and actual descriptors with JsonAssert in NON_EXTENSIBLE mode, which ignores field ordering but forbids missing or extra fields. 

Next, we remove FileDescriptorSet from the outer JSON and compare the remainder in the NON_EXTENSIBLE mode again. We implemented this two stage approach because JSON assertion does not re-order the inner contents of the FileDescriptorSet (compares directly as strings instead) even if though it's decoded contents can be re-ordered. 

By decoding and normalizing fileDescriptorSet first, we ensure the test remains robust to nondeterministic ordering inside the descriptor set, while still validating the schema structure strictly. This change keeps the spirit of the original test while eliminating failures caused solely by allowed reordering. 

NOTE: Some additional assertTrue and assertFalse assertions were also added to ensure the test remains robust in the event that the hardcoded string is ever modified for some reason. This will prevent someone from modifying the string and then forgetting to modify the test afterwards, thus causing the fileDescriptorSet assertion to incorrectly pass from comparing empty strings.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.client.impl.schema.ProtobufSchemaTest#testSchema`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
