### PR TITLE
[feat][monitor] Add publish latency histogram as OTel metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -67,7 +67,6 @@ import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.exceptions.SchemaException;
-import org.apache.pulsar.broker.stats.prometheus.metrics.Summary;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -899,7 +898,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     public void recordAddLatency(long latency, TimeUnit unit) {
         addEntryLatencyStatsUsec.addValue(unit.toMicros(latency));
 
-        PUBLISH_LATENCY.observe(latency, unit);
+        brokerService.getPulsarStats().recordPublishLatency(latency, unit);
     }
 
     @Override
@@ -908,15 +907,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         return RATE_LIMITED_UPDATER.incrementAndGet(this);
     }
 
-    private static final Summary PUBLISH_LATENCY = Summary.build("pulsar_broker_publish_latency", "-")
-            .quantile(0.0)
-            .quantile(0.50)
-            .quantile(0.95)
-            .quantile(0.99)
-            .quantile(0.999)
-            .quantile(0.9999)
-            .quantile(1.0)
-            .register();
 
     @Override
     public void incrementPublishCount(Producer producer, int numOfMessages, long msgSizeInBytes) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import lombok.Getter;
@@ -279,5 +280,9 @@ public class PulsarStats implements Closeable {
 
     public void recordConnectionCreateFail() {
         brokerOperabilityMetrics.recordConnectionCreateFail();
+    }
+
+    public void recordPublishLatency(long latency, TimeUnit unit) {
+        brokerOperabilityMetrics.recordPublishLatency(latency, unit);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BrokerOpenTelemetryTestUtil.java
@@ -121,4 +121,19 @@ public class BrokerOpenTelemetryTestUtil {
                                             valueConsumer.accept(point.getValue());
                                         }))));
     }
+
+    public static void assertMetricHistogramValue(Collection<MetricData> metrics, String metricName,
+                                                  Attributes attributes, Consumer<Long> countConsumer,
+                                                  Consumer<Double> sumConsumer) {
+        final Map<AttributeKey<?>, Object> attributesMap = attributes.asMap();
+        assertThat(metrics).anySatisfy(metric -> assertThat(metric)
+                        .hasName(metricName)
+                        .hasHistogramSatisfying(histogram -> histogram.satisfies(
+                                histoData -> assertThat(histoData.getPoints()).anySatisfy(
+                                        point -> {
+                                            assertThat(point.getAttributes().asMap()).isEqualTo(attributesMap);
+                                            countConsumer.accept(point.getCount());
+                                            sumConsumer.accept(point.getSum());
+                                        }))));
+    }
 }


### PR DESCRIPTION
PIP: #21080

### Motivation

Please see the [PIP-264 doc](https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md).

ref.
* https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md#switching-summary-to-histograms-in-namespacebroker-level-only
* https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md#which-summaries--histograms-are-effected

### Modifications

* Added publish latency histogram as OTel metrics
* Added `PulsarDeprecatedMetric` annotation to the `pulsar_broker_publish_latency` Prometheus metrics

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added a simple E2E test to verify the expected metrics is exposed

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
  - Introducing the new OTel metrics `pulsar.broker.topic.publish.latency`
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/equanz/pulsar/pull/13