### PR TITLE
[fix][build] Fix maven deploy with maven-source-plugin 3.3.1

### DIFF
--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -496,6 +496,17 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- this is required when maven-shade-plugin sets createSourcesJar to true -->
+            <id>attach-sources</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${maven-enforcer-plugin.version}</version>
         <executions>


### PR DESCRIPTION
### Motivation

Apache Parent POM was updated from version 29 to 35 in PR #24742. That broke `mvn deploy` with this type of error message:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.1:jar-no-fork (attach-sources) on project pulsar-client-all: Presumably you have configured maven-source-plugin to execute twice in your build. You have to configure a classifier for at least one of them. -> [Help 1]
```

### Modifications

Set `attach-sources` phase to `none` for `maven-source-plugin` when `maven-shade-plugin` has been configured with `<createSourcesJar>true</createSourcesJar>`. This currently applies to `pulsar-client-all` module.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->