### PR TITLE
[fix][build] Remove invalid profile in settings.xml that caused gpg signing to fail

### DIFF
--- a/src/settings.xml
+++ b/src/settings.xml
@@ -26,7 +26,7 @@
       <username>${env.APACHE_USER}</username>
       <password>${env.APACHE_PASSWORD}</password>
     </server>
-    
+
     <!-- To stage a release of some part of Maven -->
     <server>
       <id>apache.releases.https</id>
@@ -34,17 +34,4 @@
       <password>${env.APACHE_PASSWORD}</password>
     </server>
   </servers>
-
-  <profiles>
-    <profile>
-      <id>apache</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
-        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-      </properties>
-    </profile>
-  </profiles>
 </settings>


### PR DESCRIPTION
### Motivation

The gpg signing was failing due to invalid key and gpg wasn't asking for the passphrase.
Modifying the settings.xml file addressed the issue.

### Modifications

- remove invalid profile in settings.xml that is used for releases

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->