### PR TITLE
[feat][monitor] Add ML write latency histogram and entry size histogram as OTel metrics

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerAttributes.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerAttributes.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.ManagedLedgerOper
 public class ManagedLedgerAttributes {
 
     private final Attributes attributes;
+    private final Attributes attributesOnlyNamespace;
     private final Attributes attributesOperationSucceed;
     private final Attributes attributesOperationFailure;
 
@@ -35,6 +36,9 @@ public class ManagedLedgerAttributes {
         var mlName = ml.getName();
         attributes = Attributes.of(
                 OpenTelemetryAttributes.ML_NAME, mlName,
+                OpenTelemetryAttributes.PULSAR_NAMESPACE, getNamespace(mlName)
+        );
+        attributesOnlyNamespace = Attributes.of(
                 OpenTelemetryAttributes.PULSAR_NAMESPACE, getNamespace(mlName)
         );
         attributesOperationSucceed = Attributes.builder()

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -138,6 +138,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final MetadataStore metadataStore;
 
     private final OpenTelemetryManagedLedgerCacheStats openTelemetryCacheStats;
+    @Getter
     private final OpenTelemetryManagedLedgerStats openTelemetryManagedLedgerStats;
     private final OpenTelemetryManagedCursorStats openTelemetryManagedCursorStats;
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerMBeanImpl.java
@@ -87,6 +87,8 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
     public void addAddEntrySample(long size) {
         addEntryOps.recordEvent(size);
         entryStats.addValue(size);
+        managedLedger.getFactory().getOpenTelemetryManagedLedgerStats()
+                .recordEntrySize(size, managedLedger);
         addEntryWithReplicasOps.recordEvent(size * managedLedger.getConfig().getWriteQuorumSize());
     }
 
@@ -108,14 +110,20 @@ public class ManagedLedgerMBeanImpl implements ManagedLedgerMXBean {
 
     public void addAddEntryLatencySample(long latency, TimeUnit unit) {
         addEntryLatencyStatsUsec.addValue(unit.toMicros(latency));
+        managedLedger.getFactory().getOpenTelemetryManagedLedgerStats()
+                .recordAddEntryLatency(latency, unit, managedLedger);
     }
 
     public void addLedgerAddEntryLatencySample(long latency, TimeUnit unit) {
         ledgerAddEntryLatencyStatsUsec.addValue(unit.toMicros(latency));
+        managedLedger.getFactory().getOpenTelemetryManagedLedgerStats()
+                .recordLedgerAddEntryLatency(latency, unit, managedLedger);
     }
 
     public void addLedgerSwitchLatencySample(long latency, TimeUnit unit) {
         ledgerSwitchLatencyStatsUsec.addValue(unit.toMicros(latency));
+        managedLedger.getFactory().getOpenTelemetryManagedLedgerStats()
+                .recordLedgerSwitchLatency(latency, unit, managedLedger);
     }
 
     public void addReadEntriesSample(int count, long totalSize) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedLedgerStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpenTelemetryManagedLedgerStats.java
@@ -20,11 +20,17 @@ package org.apache.bookkeeper.mledger.impl;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.pulsar.opentelemetry.Constants;
 
 public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
+
+    // ml-level metrics
 
     // Replaces pulsar_ml_AddEntryMessagesRate
     public static final String ADD_ENTRY_COUNTER = "pulsar.broker.managed_ledger.message.outgoing.count";
@@ -61,6 +67,34 @@ public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
     private final ObservableLongMeasurement markDeleteCounter;
 
     private final BatchCallback batchCallback;
+
+    // namespace-level metrics
+
+    // Histograms support only synchronous mode, so record measurements directly.
+    // Synchronous histograms currently do not support delete operations.
+    // Therefore, use only namespace-level attributes to avoid leaking high-cardinality attributes (e.g. topic name).
+    // See: https://github.com/apache/pulsar/blob/master/pip/pip-264.md
+
+    // Replaces ['pulsar_ml_AddEntryLatencyBuckets', 'pulsar_ml_AddEntryLatencyBuckets_OVERFLOW',
+    //           'pulsar_storage_write_latency_*']
+    public static final String ADD_ENTRY_LATENCY_HISTOGRAM = "pulsar.broker.managed_ledger.message.outgoing.latency";
+    private final DoubleHistogram addEntryLatencyHistogram;
+
+    // Replaces ['pulsar_ml_LedgerAddEntryLatencyBuckets', 'pulsar_ml_LedgerAddEntryLatencyBuckets_OVERFLOW',
+    //           'pulsar_storage_ledger_write_latency_*']
+    public static final String LEDGER_ADD_ENTRY_LATENCY_HISTOGRAM =
+            "pulsar.broker.managed_ledger.message.outgoing.ledger.latency";
+    private final DoubleHistogram ledgerAddEntryLatencyHistogram;
+
+    // Replaces ['pulsar_ml_LedgerSwitchLatencyBuckets', 'pulsar_ml_LedgerSwitchLatencyBuckets_OVERFLOW']
+    public static final String LEDGER_SWITCH_LATENCY_HISTOGRAM =
+            "pulsar.broker.managed_ledger.ledger.switch.latency";
+    private final DoubleHistogram ledgerSwitchLatencyHistogram;
+
+    // Replaces ['pulsar_ml_EntrySizeBuckets', 'pulsar_ml_EntrySizeBuckets_OVERFLOW',
+    //           'pulsar_entry_size_*']
+    public static final String ENTRY_SIZE_HISTOGRAM = "pulsar.broker.managed_ledger.entry.size";
+    private final LongHistogram entrySizeHistogram;
 
     public OpenTelemetryManagedLedgerStats(OpenTelemetry openTelemetry, ManagedLedgerFactoryImpl factory) {
         var meter = openTelemetry.getMeter(Constants.BROKER_INSTRUMENTATION_SCOPE_NAME);
@@ -124,6 +158,39 @@ public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
                 bytesInCounter,
                 readEntryCacheMissCounter,
                 markDeleteCounter);
+
+        addEntryLatencyHistogram = meter
+                .histogramBuilder(ADD_ENTRY_LATENCY_HISTOGRAM)
+                .setDescription("End-to-end write latency, including time spent in the executor queue.")
+                .setUnit("s")
+                .setExplicitBucketBoundariesAdvice(Arrays.asList(0.001, 0.005, 0.01, 0.02, 0.05, 0.1,
+                        0.2, 0.5, 1.0, 5.0, 30.0))
+                .build();
+
+        ledgerAddEntryLatencyHistogram = meter
+                .histogramBuilder(LEDGER_ADD_ENTRY_LATENCY_HISTOGRAM)
+                .setDescription("End-to end write latency.")
+                .setUnit("s")
+                .setExplicitBucketBoundariesAdvice(Arrays.asList(0.001, 0.005, 0.01, 0.02, 0.05, 0.1,
+                        0.2, 0.5, 1.0, 5.0, 30.0))
+                .build();
+
+        ledgerSwitchLatencyHistogram = meter
+                .histogramBuilder(LEDGER_SWITCH_LATENCY_HISTOGRAM)
+                .setDescription("Time taken to switch to a new ledger.")
+                .setUnit("s")
+                .setExplicitBucketBoundariesAdvice(Arrays.asList(0.001, 0.005, 0.01, 0.02, 0.05, 0.1,
+                        0.2, 0.5, 1.0, 5.0, 30.0))
+                .build();
+
+        entrySizeHistogram = meter
+                .histogramBuilder(ENTRY_SIZE_HISTOGRAM)
+                .ofLongs()
+                .setDescription("Size of entries written to the ledger.")
+                .setUnit("By")
+                .setExplicitBucketBoundariesAdvice(Arrays.asList(128L, 512L, 1024L, 2048L, 4096L, 16_384L,
+                        102_400L, 1_048_576L))
+                .build();
     }
 
     @Override
@@ -150,5 +217,25 @@ public class OpenTelemetryManagedLedgerStats implements AutoCloseable {
         backlogCounter.record(stats.getNumberOfMessagesInBacklog(), attributes);
         markDeleteCounter.record(stats.getMarkDeleteTotal(), attributes);
         readEntryCacheMissCounter.record(stats.getReadEntriesOpsCacheMissesTotal(), attributes);
+    }
+
+    void recordAddEntryLatency(long latency, TimeUnit unit, ManagedLedger ml) {
+        final var attributes = ml.getManagedLedgerAttributes().getAttributesOnlyNamespace();
+        this.addEntryLatencyHistogram.record(unit.toMillis(latency) / 1000.0, attributes);
+    }
+
+    void recordLedgerAddEntryLatency(long latency, TimeUnit unit, ManagedLedger ml) {
+        final var attributes = ml.getManagedLedgerAttributes().getAttributesOnlyNamespace();
+        this.ledgerAddEntryLatencyHistogram.record(unit.toMillis(latency) / 1000.0, attributes);
+    }
+
+    void recordLedgerSwitchLatency(long latency, TimeUnit unit, ManagedLedger ml) {
+        final var attributes = ml.getManagedLedgerAttributes().getAttributesOnlyNamespace();
+        this.ledgerSwitchLatencyHistogram.record(unit.toMillis(latency) / 1000.0, attributes);
+    }
+
+    void recordEntrySize(long entrySize, ManagedLedger ml) {
+        final var attributes = ml.getManagedLedgerAttributes().getAttributesOnlyNamespace();
+        this.entrySizeHistogram.record(entrySize, attributes);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricHistogramValue;
 import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
 import static org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,6 +136,9 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
                 OpenTelemetryAttributes.ML_NAME, mlName,
                 OpenTelemetryAttributes.PULSAR_NAMESPACE, topicNameObj.getNamespace()
         );
+        final var attribOnlyNamespace = Attributes.of(
+                OpenTelemetryAttributes.PULSAR_NAMESPACE, topicNameObj.getNamespace()
+        );
         var metricReader = pulsarTestContext.getOpenTelemetryMetricReader();
 
         Awaitility.await().untilAsserted(() -> {
@@ -189,6 +193,16 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
                     value -> assertThat(value).isGreaterThanOrEqualTo(0));
             assertMetricLongSumValue(otelMetrics, OpenTelemetryManagedLedgerStats.READ_ENTRY_CACHE_MISS_COUNTER,
                     attribCommon, value -> assertThat(value).isGreaterThanOrEqualTo(0));
+
+            assertMetricHistogramValue(otelMetrics, OpenTelemetryManagedLedgerStats.ADD_ENTRY_LATENCY_HISTOGRAM,
+                    attribOnlyNamespace, count -> assertThat(count).isEqualTo(15L),
+                    sum -> assertThat(sum).isGreaterThan(0.0));
+            assertMetricHistogramValue(otelMetrics, OpenTelemetryManagedLedgerStats.LEDGER_ADD_ENTRY_LATENCY_HISTOGRAM,
+                    attribOnlyNamespace, count -> assertThat(count).isEqualTo(15L),
+                    sum -> assertThat(sum).isGreaterThan(0.0));
+            assertMetricHistogramValue(otelMetrics, OpenTelemetryManagedLedgerStats.ENTRY_SIZE_HISTOGRAM,
+                    attribOnlyNamespace, count -> assertThat(count).isEqualTo(15L),
+                    sum -> assertThat(sum).isGreaterThan(0.0));
         });
     }
 


### PR DESCRIPTION
PIP: #21080

### Motivation

Please see the [PIP-264 doc](https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md).

ref.
* https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md#moving-topic-level-histograms-to-namespace-and-broker-level-only
  * Note:
  > Histograms are problematic in that sense, since they yet to have an asynchronous version - alas they are only synchronous. Hence, if we use them for topic instruments, used attributes can never be cleared from memory for them thus we’ll have an “attributes” (topic) leak, as over time it will only grow.
  * Therefore, even if a namespace is deleted, the namespace-level histogram metrics persist
* https://github.com/apache/pulsar/blob/v4.1.1/pip/pip-264.md#which-summaries--histograms-are-effected

### Modifications

* Added ML write latency histogram and entry size histogram as OTel metrics

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added a simple E2E test to verify the expected metrics is exposed

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
  - Introducing the new OTel metrics
    - `pulsar.broker.managed_ledger.message.outgoing.latency`
    - `pulsar.broker.managed_ledger.message.outgoing.ledger.latency`
    - `pulsar.broker.managed_ledger.ledger.switch.latency`
    - `pulsar.broker.managed_ledger.entry.size`
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/equanz/pulsar/pull/14