### PR TITLE
[fix][test] Fixed nondeterministic JSON ordering in multiple tests

### DIFF
--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -282,6 +282,13 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${skyscreamer.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/NamespaceOwnershipStatusTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/NamespaceOwnershipStatusTest.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.Test;
 
 public class NamespaceOwnershipStatusTest {
@@ -55,6 +57,10 @@ public class NamespaceOwnershipStatusTest {
                 assertTrue(nsStatus.is_active);
             }
         }
-        assertEquals(jsonMapper.writeValueAsString(nsMap), jsonStr);
+        JSONAssert.assertEquals(
+                jsonMapper.writeValueAsString(nsMap),
+                jsonStr,
+                JSONCompareMode.STRICT
+        );
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/impl/NamespaceIsolationPoliciesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/impl/NamespaceIsolationPoliciesTest.java
@@ -40,6 +40,8 @@ import org.apache.pulsar.common.policies.data.BrokerStatus;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationDataImpl;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.Test;
 
 public class NamespaceIsolationPoliciesTest {
@@ -67,7 +69,11 @@ public class NamespaceIsolationPoliciesTest {
         assertEquals(new String(secondaryBrokersJson), "[\"prod1-broker.*.use.example.com\"]");
 
         byte[] outJson = jsonMapperForWriter.writeValueAsBytes(policies.getPolicies());
-        assertEquals(new String(outJson), this.defaultJson);
+        JSONAssert.assertEquals(
+                new String(outJson),
+                this.defaultJson,
+                JSONCompareMode.STRICT
+        );
 
         Map<String, String> parameters = new HashMap<>();
         parameters.put("min_limit", "1");

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -123,6 +123,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${skyscreamer.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -52,6 +52,9 @@ import org.apache.pulsar.functions.api.WindowFunction;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.Test;
 
 /**
@@ -83,7 +86,7 @@ public class FunctionConfigUtilsTest {
     }
 
     @Test
-    public void testConvertBackFidelity() {
+    public void testConvertBackFidelity() throws JSONException {
         FunctionConfig functionConfig = new FunctionConfig();
         functionConfig.setTenant("test-tenant");
         functionConfig.setNamespace("test-namespace");
@@ -121,9 +124,10 @@ public class FunctionConfigUtilsTest {
         functionConfig.setResources(Resources.getDefaultResources());
         // set default cleanupSubscription config
         functionConfig.setCleanupSubscription(true);
-        assertEquals(
+        JSONAssert.assertEquals(
                 new Gson().toJson(functionConfig),
-                new Gson().toJson(convertedConfig)
+                new Gson().toJson(convertedConfig),
+                JSONCompareMode.STRICT
         );
     }
 

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -49,6 +49,9 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.SinkContext;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.Test;
 
 /**
@@ -99,7 +102,7 @@ public class SinkConfigUtilsTest {
     }
 
     @Test
-    public void testConvertBackFidelity() throws IOException  {
+    public void testConvertBackFidelity() throws IOException, JSONException  {
         SinkConfig sinkConfig = new SinkConfig();
         sinkConfig.setTenant("test-tenant");
         sinkConfig.setNamespace("test-namespace");
@@ -143,9 +146,10 @@ public class SinkConfigUtilsTest {
                 new SinkConfigUtils.ExtractedSinkDetails(null, null, null));
         assertEquals(Function.SubscriptionType.SHARED, functionDetails.getSource().getSubscriptionType());
         SinkConfig convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
-        assertEquals(
+        JSONAssert.assertEquals(
                 new Gson().toJson(convertedConfig),
-                new Gson().toJson(sinkConfig)
+                new Gson().toJson(sinkConfig),
+                JSONCompareMode.STRICT
         );
 
         sinkConfig.setRetainOrdering(true);
@@ -155,9 +159,11 @@ public class SinkConfigUtilsTest {
                 new SinkConfigUtils.ExtractedSinkDetails(null, null, null));
         assertEquals(Function.SubscriptionType.FAILOVER, functionDetails.getSource().getSubscriptionType());
         convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
-        assertEquals(
+        JSONAssert.assertEquals(
                 new Gson().toJson(convertedConfig),
-                new Gson().toJson(sinkConfig));
+                new Gson().toJson(sinkConfig),
+                JSONCompareMode.STRICT
+        );
 
         sinkConfig.setRetainOrdering(false);
         sinkConfig.setRetainKeyOrdering(true);
@@ -166,9 +172,11 @@ public class SinkConfigUtilsTest {
                 new SinkConfigUtils.ExtractedSinkDetails(null, null, null));
         assertEquals(Function.SubscriptionType.KEY_SHARED, functionDetails.getSource().getSubscriptionType());
         convertedConfig = SinkConfigUtils.convertFromDetails(functionDetails);
-        assertEquals(
+        JSONAssert.assertEquals(
                 new Gson().toJson(convertedConfig),
-                new Gson().toJson(sinkConfig));
+                new Gson().toJson(sinkConfig),
+                JSONCompareMode.STRICT
+        );
     }
 
     @Test

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SourceConfigUtilsTest.java
@@ -40,6 +40,9 @@ import org.apache.pulsar.config.validation.ConfigValidationAnnotations;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.io.core.BatchSourceTriggerer;
 import org.apache.pulsar.io.core.SourceContext;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.Test;
 
 /**
@@ -115,13 +118,14 @@ public class SourceConfigUtilsTest {
     }
 
     @Test
-    public void testBatchConfigMergeEqual() {
+    public void testBatchConfigMergeEqual() throws JSONException {
         SourceConfig sourceConfig = createSourceConfigWithBatch();
         SourceConfig newSourceConfig = createSourceConfigWithBatch();
         SourceConfig mergedConfig = SourceConfigUtils.validateUpdate(sourceConfig, newSourceConfig);
-        assertEquals(
+        JSONAssert.assertEquals(
                 new Gson().toJson(sourceConfig),
-                new Gson().toJson(mergedConfig)
+                new Gson().toJson(mergedConfig),
+                JSONCompareMode.STRICT
         );
     }
 

--- a/pulsar-io/elastic-search/pom.xml
+++ b/pulsar-io/elastic-search/pom.xml
@@ -105,6 +105,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${skyscreamer.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -162,6 +162,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${skyscreamer.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/UtilsTest.java
@@ -52,6 +52,8 @@ import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.io.kinesis.fbs.KeyValue;
 import org.apache.pulsar.io.kinesis.fbs.Message;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
@@ -510,15 +512,21 @@ public class UtilsTest {
         ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
         String json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, false);
 
-        assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
-                + "\"payload\":{},"
-                + "\"eventTime\":1648502845803}");
+        JSONAssert.assertEquals(
+                json,
+                "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
+                + "\"payload\":{},\"eventTime\":1648502845803}",
+                JSONCompareMode.STRICT
+        );
 
         json = Utils.serializeRecordToJsonExpandingValue(objectMapper, genericObjectRecord, true);
 
-        assertEquals(json, "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
-                + "\"payload\":{},"
-                + "\"eventTime\":1648502845803}");
+        JSONAssert.assertEquals(
+                json,
+                "{\"topicName\":\"data-ks1.table1\",\"key\":\"message-key\","
+                + "\"payload\":{},\"eventTime\":1648502845803}",
+                JSONCompareMode.STRICT
+        );
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24820

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Each of the tests below were written with the assumption that the json key-value pairs would have a deterministic order (by comparing json results vs hard coded strings). The order of key-value pairs is not guaranteed in [JSON files](https://www.json.org/json-en.html) or [JSON objects](https://docs.oracle.com/javaee/7/api/javax/json/JsonObject.html), though. As a result, the ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. Since each of the tests below compare the raw strings/trees "as-is", harmless re-ordering could flip the test from pass to fail despite the data being semantically the same.
- `org.apache.pulsar.common.policies.data.NamespaceOwnershipStatusTest#testSerialization`
- `org.apache.pulsar.common.policies.impl.NamespaceIsolationPoliciesTest#testJsonSerialization`
- `org.apache.pulsar.functions.utils.FunctionConfigUtilsTest#testConvertBackFidelity`
- `org.apache.pulsar.functions.utils.SinkConfigUtilsTest#testConvertBackFidelity`
- `org.apache.pulsar.functions.utils.SourceConfigUtilsTest#testBatchConfigMergeEqual `
- `org.apache.pulsar.io.elasticsearch.ElasticSearchExtractTest#testGenericRecord`
- `org.apache.pulsar.io.kinesis.UtilsTest#testKeyValueSerializeNoValue`.

### Modifications

<!-- Describe the modifications you've done. -->

We no longer compare raw strings "as-is" with ```Assert.assertEquals```. Instead, we compare the json structures with ```JsonAssert.assertEquals(expectedJson, actualJson, JSONCompareMode)``` which parses both inputs into JSON trees. It treats these JSON trees as unordered collections of key-value pairs when determining if they are equal so differences in property order no longer matter. This ensures the tests pass consistently, even when the serializer outputs fields in a different order.

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by allowed (but previously unexpected) reordering. 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.common.policies.data.NamespaceOwnershipStatusTest#testSerialization`, `org.apache.pulsar.common.policies.impl.NamespaceIsolationPoliciesTest#testJsonSerialization`, `org.apache.pulsar.functions.utils.FunctionConfigUtilsTest#testConvertBackFidelity`, `org.apache.pulsar.functions.utils.SinkConfigUtilsTest#testConvertBackFidelity`, `org.apache.pulsar.functions.utils.SourceConfigUtilsTest#testBatchConfigMergeEqual `, `org.apache.pulsar.io.elasticsearch.ElasticSearchExtractTest#testGenericRecord`, and `org.apache.pulsar.io.kinesis.UtilsTest#testKeyValueSerializeNoValue`.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/3

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
