### PR TITLE
[fix][client] Make auto partitions update work for old brokers without PIP-344

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1291,7 +1291,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public CompletableFuture<List<String>> getPartitionsForTopic(String topic, boolean metadataAutoCreationEnabled) {
-        return getPartitionedTopicMetadata(topic, metadataAutoCreationEnabled, false).thenApply(metadata -> {
+        return getPartitionedTopicMetadata(topic, metadataAutoCreationEnabled, true).thenApply(metadata -> {
             if (metadata.partitions > 0) {
                 TopicName topicName = TopicName.get(topic);
                 List<String> partitions = new ArrayList<>(metadata.partitions);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest25.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/backwardscompatibility/ClientTest25.java
@@ -19,8 +19,19 @@
 package org.apache.pulsar.tests.integration.backwardscompatibility;
 
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageIdAdv;
+import org.apache.pulsar.client.api.MessageRouter;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.tests.integration.topologies.ClientTestBase;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ClientTest25 extends PulsarStandaloneTestSuite25 {
@@ -34,4 +45,47 @@ public class ClientTest25 extends PulsarStandaloneTestSuite25 {
         clientTestBase.resetCursorCompatibility(serviceUrl.get(), httpServiceUrl.get(), topicName);
     }
 
+    @Test(timeOut = 20000)
+    public void testAutoPartitionsUpdate() throws Exception {
+        @Cleanup final var pulsarClient = PulsarClient.builder()
+                .serviceUrl(getContainer().getPlainTextServiceUrl())
+                .build();
+        final var topic = "test-auto-part-update";
+        final var topic2 = "dummy-topic";
+        @Cleanup final var admin = PulsarAdmin.builder().serviceHttpUrl(getContainer().getHttpServiceUrl()).build();
+        // Use 2 as the initial partition number because old version broker cannot update partitions on a topic that
+        // has only 1 partition.
+        admin.topics().createPartitionedTopic(topic, 2);
+        admin.topics().createPartitionedTopic(topic2, 2);
+        @Cleanup final var producer = pulsarClient.newProducer().autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .messageRoutingMode(MessageRoutingMode.CustomPartition)
+                .messageRouter(new MessageRouter() {
+                    @Override
+                    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
+                        return metadata.numPartitions() - 1;
+                    }
+                })
+                .topic(topic)
+                .create();
+        @Cleanup final var consumer = pulsarClient.newConsumer().autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .topic(topic).subscriptionName("sub")
+                .subscribe();
+        @Cleanup final var multiTopicsConsumer = pulsarClient.newConsumer().autoUpdatePartitions(true)
+                .autoUpdatePartitionsInterval(1, TimeUnit.SECONDS)
+                .topics(List.of(topic, topic2)).subscriptionName("sub-2").subscribe();
+
+        admin.topics().updatePartitionedTopic(topic, 3);
+        Thread.sleep(1500);
+        final var msgId = (MessageIdAdv) producer.send("msg".getBytes());
+        Assert.assertEquals(msgId.getPartitionIndex(), 2);
+
+        final var msg = consumer.receive(3, TimeUnit.SECONDS);
+        Assert.assertNotNull(msg);
+        Assert.assertEquals(((MessageIdAdv) msg.getMessageId()).getPartitionIndex(), 2);
+        final var msg2 = multiTopicsConsumer.receive(3, TimeUnit.SECONDS);
+        Assert.assertNotNull(msg2);
+        Assert.assertEquals(msg2.getMessageId(), msg.getMessageId());
+    }
 }


### PR DESCRIPTION
### Motivation

See https://lists.apache.org/thread/tpd2kgl4v3x8bkw0skv0nj38rzrk56t7

### Modifications

Set the 3rd argument of `getPartitionedTopicMetadata` to `true` in `PulsarClientImpl#getPartitionsForTopic`, which is used to query the number of partitions.

Add `testAutoPartitionsUpdate` to cover the case. Specially, it tests a consumer that subscribes two partitioned topics to cover the path here: https://github.com/apache/pulsar/blob/008e4ebbaf5808c0f859dddabd8382991f32d3aa/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L182

P.S. This test is only added to `ClientTest25`, which runs tests against `apachepulsar/pulsar:2.5.0` image. The current backward compatibility test strategy is ambiguous that only 2.2.0, 2.3.0, 2.4.0, 2.5.0 are tested. It's hard to cover all old versions, but only choose these 4 versions does not make sense. This topic should be out of the scope of this PR. Anyway, the test on 2.5.0 can already prevent regression on the fix.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: