### PR TITLE
[fix][test] Fix flaky SingleThreadNonConcurrentFixedRateSchedulerTest.testPeriodicTaskCancellation

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/SingleThreadNonConcurrentFixedRateSchedulerTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/SingleThreadNonConcurrentFixedRateSchedulerTest.java
@@ -477,9 +477,9 @@ public class SingleThreadNonConcurrentFixedRateSchedulerTest {
         assertTrue(cancelled);
         assertTrue(future.isCancelled());
 
-        // Wait and verify no more executions
+        // Wait and verify no more executions (allowing one execution that was in progress during cancellation)
         Thread.sleep(200);
-        assertEquals(executionCount.get(), countBeforeCancel);
+        assertTrue(executionCount.get() - countBeforeCancel <= 1);
     }
 
     @Test


### PR DESCRIPTION
Fixes #24814

### Motivation

The test is flaky. It works like this:

1. Schedule a task incrementing a counter to run every 50ms.
2. Wait 200ms so that the task is executed a few times.
3. Get task execution count and verify it is greater than 0.
4. Cancel the task.
5. Wait 200ms.
6. Verify execution count is still the same as before cancelling the task (take count from step 3).

What can happen is that between getting the execution count in step 3 and cancelling the task in step 4, another execution is started. Then the assertion in step 6 fails because one additional execution took place.

### Modifications

Change the assertion in step 6 to allow one additional execution. This still verifies that the scheduled task is cancelled because we wait 200ms in step 5, and more than one additional execution would be expected if the task is not cancelled properly.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/16
