### PR TITLE
[fix][test] Fixed nondeterministic ordering in MongoSourceTest.testWriteBadMessage

### DIFF
--- a/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
+++ b/pulsar-io/mongo/src/test/java/org/apache/pulsar/io/mongodb/MongoSourceTest.java
@@ -128,9 +128,13 @@ public class MongoSourceTest {
 
         Record<byte[]> record = source.read();
 
-        assertEquals(new String(record.getValue()),
-                "{\"fullDocument\":{\"hello\":\"pulsar\"},"
+        String value = new String(record.getValue());
+        String expected = "{\"fullDocument\":{\"hello\":\"pulsar\"},"
                 + "\"ns\":{\"databaseName\":\"hello\",\"collectionName\":\"pulsar\",\"fullName\":\"hello.pulsar\"},"
-                + "\"operation\":\"INSERT\"}");
+                + "\"operation\":\"INSERT\"}";
+        assertEquals(
+                Document.parse(value),
+                Document.parse(expected)
+        );
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24834

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The test was written with the incorrect assumption that the compared strings have a deterministic order. Since the original data was stored with [HashMaps](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), which makes no guarantees to the order of it's map, the resulting strings that were compared could potentially have reordered contents. The ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. Since the raw strings/trees were compared "as-is", harmless re-ordering could flip the test from pass to fail despite the data being semantically the same.

### Modifications

<!-- Describe the modifications you've done. -->

We no longer compare the raw strings "as-is", we instead convert the strings into BsonDocuments which are [ordered](https://bsonspec.org/spec.html) to fix the nondeterminism. This ensures the tests pass consistently, even in cases where the original contents were in a different order due to the usage of HashMaps.

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by allowed (but previously unexpected) reordering. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `org.apache.pulsar.io.mongodb.MongoSourceTest#testWriteBadMessage`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/4

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->