### PR TITLE
[improve][offload]use dedicated bookkeeper-ml-offload-scheduler to avoid block core service

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1249,6 +1249,9 @@ managedLedgerDigestType=CRC32C
 # Number of threads to be used for managed ledger scheduled tasks
 managedLedgerNumSchedulerThreads=
 
+# Number of threads to be use for managed ledger scheduled offload operations.
+managedLedgerNumOffloadSchedulerThreads=
+
 # Amount of memory to use for caching data payload in managed ledger. This memory
 # is allocated from JVM direct memory and it's shared across all the topics
 # running  in the same broker. By default, uses 1/5th of available direct memory

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactoryConfig.java
@@ -148,6 +148,11 @@ public class ManagedLedgerFactoryConfig {
     private String managedCursorInfoCompressionType = MLDataFormats.CompressionType.NONE.name();
 
     /**
+     * Number of threads to use for ML offload operations.
+     */
+    private int numManagedLedgerOffloadSchedulerThreads = Runtime.getRuntime().availableProcessors();
+
+    /**
      * ManagedCursorInfo compression threshold. If the origin metadata size below configuration.
      * compression will not apply.
      */

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2313,6 +2313,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int managedLedgerNumSchedulerThreads = Runtime.getRuntime().availableProcessors();
 
+    private int managedLedgerNumOffloadSchedulerThreads = Runtime.getRuntime().availableProcessors();
+
     @FieldContext(
         category = CATEGORY_STORAGE_ML,
         doc = "Max number of entries to append to a ledger before triggering a rollover.\n\n"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -113,6 +113,8 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
                 conf.getManagedLedgerInfoCompressionThresholdInBytes());
         managedLedgerFactoryConfig.setStatsPeriodSeconds(conf.getManagedLedgerStatsPeriodSeconds());
         managedLedgerFactoryConfig.setManagedCursorInfoCompressionType(conf.getManagedCursorInfoCompressionType());
+        managedLedgerFactoryConfig.setNumManagedLedgerOffloadSchedulerThreads(
+                conf.getManagedLedgerNumOffloadSchedulerThreads());
         managedLedgerFactoryConfig.setManagedCursorInfoCompressionThresholdInBytes(
                 conf.getManagedCursorInfoCompressionThresholdInBytes());
 


### PR DESCRIPTION
### Motivation
We use HDFS as the offload remote storage in our online scenarios. During an HDFS namenode switchover, the normal service of the broker was disrupted due to the failure and retry of a large number of offload operations. The logs are as follows:
<img width="3066" height="444" alt="image" src="https://github.com/user-attachments/assets/a1344a45-39af-4666-9db6-11a847d24b37" />


Offload operations in Pulsar's managed ledger share the same scheduler thread pool with core services. When offload operations block or take too long, they can impact critical managed ledger operations like data read/write and metadata management, causing system performance degradation.

This change introduces a dedicated offload scheduler to isolate offload operations from core services, preventing potential blocking issues.

### Modifications

1. **Added configuration support**:
   - New `managedLedgerNumOffloadSchedulerThreads` parameter in `ServiceConfiguration` and `broker.conf`
   - Default thread count set to available CPU cores

2. **Created dedicated offload scheduler**:
   - Added `offloadScheduler` field in `ManagedLedgerFactoryImpl` using `OrderedScheduler`
   - Proper shutdown handling in factory cleanup

3. **Isolated offload operations**:
   - Migrated all offload-related async operations from `scheduledExecutor` to dedicated `offloadScheduler`
   - Affected operations: `maybeOffloadInBackground()`, `maybeOffload()`, `cleanupOffloaded()`, and `tryTransformLedgerInfo()`

This ensures offload operations don't interfere with core managed ledger functionality, improving overall system stability and performance.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:  https://github.com/ethqunzhong/pulsar/pull/11
