### PR TITLE
[fix][test] Fix flaky LookupPropertiesTest.testConcurrentLookupProperties

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/LookupPropertiesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/LookupPropertiesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -112,7 +113,7 @@ public class LookupPropertiesTest extends MultiBrokerBaseTest {
             client.getConfiguration().setLookupProperties(Collections.emptyMap());
         }
         FutureUtil.waitForAll(futures).get();
-        Assert.assertEquals(clientIdList, BrokerIdAwareLoadManager.CLIENT_ID_LIST);
+        assertThat(BrokerIdAwareLoadManager.CLIENT_ID_LIST).containsExactlyInAnyOrderElementsOf(clientIdList);
     }
 
     public static class BrokerIdAwareLoadManager extends ExtensibleLoadManagerImpl {


### PR DESCRIPTION
Fixes #24837

### Motivation

The test is flaky. It verifies that lookup requests use the lookup properties configured at the time when the request is triggered (and not at the time it is executed).
Therefore, it triggers 10 broker lookups in sequence and changes the lookup properties before each. The property "broker.id" is set to "key-0", "key-1",..., "key-9" respectively. To verify that the correct properties are used, the test uses the `BrokerIdAwareLoadManager`, which extends `ExtensibleLoadManagerImpl`. It stores a `CLIENT_ID_LIST`. When `assign()` is called, the "broker.id" property is added to the `CLIENT_ID_LIST`. 
The test waits until all lookup requests finish, and then asserts that `CLIENT_ID_LIST` is equal to "key-0", "key-1",..., "key-9". The assertion fails if the list contains the values in a different order.

When running the tests, I noticed that the order is either "key-0", "key-1",..., "key-9" (ascending) or the reverse order. The reason seems to be related to CompletableFuture "callbacks" like `thenCompose()` and their execution order. For example, for each of the 10 lookup requests, `NamespaceService.getBrokerServiceUrlAsync()` is called (in sequence), which contains the following code:

https://github.com/apache/pulsar/blob/461ffd84d641b855fcc0d09d586ff4b580c21974/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L225-L226

When `thenCompose()` is called, it can either be that the `getBundleAsync(topic)` CompletableFuture is completed or not. If it is completed, `thenCompose()` can be executed immediately for each of the 10 lookup requests. The test passes. If it is not completed, `thenCompose()` is called 10 times but not executed immediately. It seems like the "callbacks" are stacked. Once the CompletableFuture completes, the 10 "callbacks" are executed in LIFO order, i.e., the one for "key-9" is executed first. Therefore, the order in `CLIENT_ID_LIST` will be reversed, and the test fails.

### Modifications

Make the assertion less strict and ignore the value order.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/17