### PR TITLE
[fix][test] Stabilize SequenceIdWithErrorTest by fencing after first publish to avoid empty-ledger deletion and send timeout

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.opentelemetry.api.OpenTelemetry;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
@@ -56,6 +57,13 @@ public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
         Consumer<String> consumer = client.newConsumer(Schema.STRING).topic(topicName).subscriptionName("sub")
                 .subscribe();
 
+        // Create a producer
+        Producer<String> producer = client.newProducer(Schema.STRING).topic(topicName).create();
+        // Move the fence timing to after the first message is successfully written
+        // The current ledger is not empty, the Broker recovery will not take the abnormal path of
+        // "deleting empty ledger + unable to find old ledger"
+        producer.send("Hello-0");
+
         // Fence the topic by opening the ManagedLedger for the topic outside the Pulsar broker. This will cause the
         // broker to fail subsequent send operation and it will trigger a recover
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
@@ -67,15 +75,12 @@ public class SequenceIdWithErrorTest extends BkEnsemblesTestBase {
         ml.close();
         clientFactory.close();
 
-        // Create a producer
-        Producer<String> producer = client.newProducer(Schema.STRING).topic(topicName).create();
-
-        for (int i = 0; i < num; i++) {
+        for (int i = 1; i < num; i++) {
             producer.send("Hello-" + i);
         }
 
         for (int i = 0; i < num; i++) {
-            Message<String> msg = consumer.receive();
+            Message<String> msg = consumer.receive(10, TimeUnit.SECONDS);
             assertEquals(msg.getValue(), "Hello-" + i);
             assertEquals(msg.getSequenceId(), i);
             consumer.acknowledge(msg);


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24849

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Detailed log as follows: https://gist.github.com/Denovo1998/0707fff19079a6694e4f7edbceddc10a

- Previously the test fenced the topic (by opening/closing the ManagedLedger externally) before the producer sent any message. If the current ledger is empty (LAC = -1), the broker’s recovery path deletes that empty ledger. Meanwhile, the managed ledger’s metadata update loop still tries to read/write that deleted ledger, leading to BKNoSuchLedgerExistsOnMetadataServerException and putting the ManagedLedger into a Fenced state.
- Recovery then fails to complete within the producer’s send timeout, so the first send blocks and times out, making the test flaky or consistently failing.
- By moving the fence after the first message is successfully written, the current ledger is non-empty, recovery proceeds by rolling to a new ledger instead of deleting the empty one, and the test can reliably verify the sequenceId behavior across a transient send error.

### Modifications

- Reordered the test flow in SequenceIdWithErrorTest:
  - Create the producer and send the first message ("Hello-0") before fencing, ensuring the current ledger is not empty.
  - Then fence the topic by externally opening/closing the ManagedLedger (via ManagedLedgerClientFactory), which triggers broker recovery as intended.
  - Continue sending the remaining messages and verify their values and sequenceId.
- Added a timeout to consumer.receive(..., 10, TimeUnit.SECONDS) to avoid unbounded waits in abnormal conditions.
- Ensured resources are properly closed (ManagedLedger clientFactory.close() and eventLoopGroup.shutdownGracefully().get()), and the Pulsar client is closed at the end of the test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Denovo1998/pulsar/pull/12

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
