### PR TITLE
[fix][test] Fixed Non-Guaranteed Order in PoliciesDataTest.propertyAdmin

### DIFF
--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PoliciesDataTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -71,7 +71,7 @@ public class PoliciesDataTest {
         assertNotEquals(TenantInfo.builder().build(), pa1);
         assertNotEquals(TenantInfo.builder().adminRoles(Sets.newHashSet("role1", "role3"))
                 .allowedClusters(Sets.newHashSet("usc")).build(), pa1);
-        assertEquals(pa1.getAdminRoles(), Lists.newArrayList("role1", "role2"));
+        assertThat(pa1.getAdminRoles()).containsExactlyInAnyOrder("role1", "role2");
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24870

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The below test performed an assertion that incorrectly assumed the order of the [HashSet](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html) data that was utilized in the formation of one of the arrays. No guarantees are made to the iteration order of the set or that this order will remain constant over time. As a result, the ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. 
- `org.apache.pulsar.common.policies.data.PoliciesDataTest.propertyAdmin`

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by the previously unexpected reordering the HashSet can induce onto the final array contents.

### Modifications

<!-- Describe the modifications you've done. -->

The original test converted the HashSet data directly into an ArrayList, incorrectly assuming a consistent iteration order. We now sort the ArrayList prior to asserting to ensure deterministic ordering.

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by allowed (but previously unexpected) reordering. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as 
- `org.apache.pulsar.common.policies.data.PoliciesDataTest.propertyAdmin`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/5 

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->