### PR TITLE
[fix][test] Fixed ResponseBody Check in Test Helper

### DIFF
--- a/pulsar-io/http/src/test/java/org/apache/pulsar/io/http/HttpSinkTest.java
+++ b/pulsar-io/http/src/test/java/org/apache/pulsar/io/http/HttpSinkTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.io.http;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -429,7 +430,7 @@ public class HttpSinkTest {
         httpSink.write(record);
 
         verify(postRequestedFor(urlEqualTo("/"))
-            .withRequestBody(equalTo(responseBody))
+            .withRequestBody(equalToJson(responseBody))
             .withHeader("Content-Type", equalTo("application/json"))
             .withHeader("header-name", equalTo("header-value"))
             .withHeader("PulsarTopic", equalTo("test-topic"))


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24869

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Each of the below tests utilized a helper test method (called test) which incorrectly assumed that the json key-value pairs in responseBody would have a deterministic order. The order of key-value pairs is not guaranteed in [JSON](https://www.json.org/json-en.html), however. As a result, the ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. Each of the tests below used this helper to compare the responseBody "as-is" with an incorrect equals method so harmless re-ordering could flip the tests from pass to fail despite the data being semantically the same.
- `org.apache.pulsar.io.http.HttpSinkTest#testGenericRecord`
- `org.apache.pulsar.io.http.HttpSinkTest#testKeyValueGenericRecord`
- `org.apache.pulsar.io.http.HttpSinkTest#testKeyValuePrimitives`

This fix is similar to this other pull request which was previously merged (with the small difference that I used the test library these tests were already utilizing instead): https://github.com/apache/pulsar/pull/24821 

### Modifications

<!-- Describe the modifications you've done. -->

We no longer compare raw strings "as-is" with ```WireMock.equalTo```. Instead, we compare the json structures with ```WireMock.equalToJson``` to perform a semantic comparison of the input JSON against the expected JSON as described in their [documentation](https://docs.wiremock.io/request-matching/json). This ensures the tests pass consistently, even when the serializer outputs fields in a different order.

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by allowed (but previously unexpected) reordering. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as 
- `org.apache.pulsar.io.http.HttpSinkTest#testGenericRecord`
- `org.apache.pulsar.io.http.HttpSinkTest#testKeyValueGenericRecord`
- `org.apache.pulsar.io.http.HttpSinkTest#testKeyValuePrimitives`
- `org.apache.pulsar.io.http.HttpSinkTest#testKeyValueGenericRecord`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/6 

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->

