### PR TITLE
[improve][broker]Skip to mark delete if the target position of expira…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -231,7 +231,8 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
     @Override
     public void findEntryComplete(Position position, Object ctx) {
         if (position != null) {
-            if (cursor.getMarkDeletedPosition() != null && cursor.getMarkDeletedPosition().compareTo(position) >= 0) {
+            var markDeletedPosition = cursor.getMarkDeletedPosition();
+            if (markDeletedPosition != null && markDeletedPosition.compareTo(position) >= 0) {
                 return;
             }
             log.info("[{}][{}] Expiring all messages until position {}", topicName, subName, position);


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/24622 improved the message expiration, but forgot to skip expiring if the target position is less than mark deleted position

```
2025-10-22T02:22:37,301+0000 [BookKeeperClientWorker-OrderedExecutor-2-0] WARN  org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor - [persistent://t1/ns/tp-partition-8][ostFixtureSubscription2] Message expiry failed - mark delete failed
org.apache.bookkeeper.mledger.ManagedLedgerException: org.apache.bookkeeper.mledger.impl.ManagedCursorImpl$MarkDeletingMarkedPosition: Mark deleting an already mark-deleted position. Current mark-delete: 4200475:458 -- attempted mark delete: 4193092:3606
Caused by: org.apache.bookkeeper.mledger.impl.ManagedCursorImpl$MarkDeletingMarkedPosition: Mark deleting an already mark-deleted position. Current mark-delete: 4200475:458 -- attempted mark delete: 4193092:3606
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setAcknowledgedPosition(ManagedCursorImpl.java:2031) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncMarkDelete(ManagedCursorImpl.java:2163) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor.findEntryComplete(PersistentMessageExpiryMonitor.java:237) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor.expireMessages(PersistentMessageExpiryMonitor.java:157) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at org.apache.pulsar.broker.service.persistent.PersistentSubscription.expireMessages(PersistentSubscription.java:1258) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$checkMessageExpiryWithSharedPosition$85(PersistentTopic.java:2205) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(Unknown Source) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$checkMessageExpiryWithSharedPosition$88(PersistentTopic.java:2197) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic$8.findEntryComplete(PersistentTopic.java:2179) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at org.apache.pulsar.broker.service.persistent.PersistentMessageFinder.findEntryComplete(PersistentMessageFinder.java:160) ~[io.streamnative-pulsar-broker-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.OpFindNewest.readEntryComplete(OpFindNewest.java:138) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl$1.readEntriesComplete(RangeEntryCacheImpl.java:241) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl$2.readEntriesComplete(RangeEntryCacheImpl.java:362) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager$PendingRead.readEntriesComplete(PendingReadsManager.java:278) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager$PendingRead.lambda$attach$0(PendingReadsManager.java:244) ~[io.streamnative-managed-ledger-4.0.6.6.jar:4.0.6.6]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.safeRunTask(SingleThreadExecutor.java:128) ~[io.streamnative-bookkeeper-common-4.17.2.2.jar:4.17.2.2]
	at org.apache.bookkeeper.common.util.SingleThreadExecutor.run(SingleThreadExecutor.java:99) ~[io.streamnative-bookkeeper-common-4.17.2.2.jar:4.17.2.2]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.127.Final.jar:4.1.127.Final]
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
```


### Modifications

Improve the behaviour

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
