### PR TITLE
[improve][io] Upgrade Debezium version to 3.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@ flexible messaging model and an intuitive client API.</description>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.16.0</opensearch.version>
     <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>3.2.2.Final</debezium.version>
+    <debezium.version>3.2.4.Final</debezium.version>
     <debezium.postgresql.version>${postgresql-jdbc.version}</debezium.postgresql.version>
     <debezium.mysql.version>9.4.0</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>


### PR DESCRIPTION
### Motivation

Debezium 3.2.4.Final comes with recommended improvements for Oracle usage:
https://debezium.io/blog/2025/10/07/debezium-3-2-4-final-released/

### Modifications

- upgrade Debezium from 3.2.2.Final to 3.2.4.Final

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->