### PR TITLE
[fix][broker] Fix partitioned topic auto deletion http request timeout

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -829,44 +829,61 @@ public class PersistentTopicsBase extends AdminResource {
 
     private CompletableFuture<Void> internalRemovePartitionsTopicNoAutoCreationDisableAsync(int numPartitions,
                                                                                             boolean force) {
-        return FutureUtil.waitForAll(IntStream.range(0, numPartitions)
-                .mapToObj(i -> {
-                    TopicName topicNamePartition = topicName.getPartition(i);
-                    try {
-                        CompletableFuture<Void> future = new CompletableFuture<>();
-                        pulsar().getAdminClient().topics()
-                                .deleteAsync(topicNamePartition.toString(), force)
-                                .whenComplete((r, ex) -> {
-                                    if (ex != null) {
-                                        Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                                        if (realCause instanceof NotFoundException){
-                                            // if the sub-topic is not found, the client might not have called
-                                            // create producer or it might have been deleted earlier,
-                                            // so we ignore the 404 error.
-                                            // For all other exception,
-                                            // we fail the delete partition method even if a single
-                                            // partition is failed to be deleted
-                                            if (log.isDebugEnabled()) {
-                                                log.debug("[{}] Partition not found: {}", clientAppId(),
-                                                        topicNamePartition);
-                                            }
-                                            future.complete(null);
-                                        } else {
-                                            log.error("[{}] Failed to delete partition {}", clientAppId(),
-                                                    topicNamePartition, realCause);
-                                            future.completeExceptionally(realCause);
-                                        }
-                                    } else {
-                                        future.complete(null);
-                                    }
-                                });
-                        return future;
-                    } catch (PulsarServerException ex) {
-                        log.error("[{}] Failed to get admin client while delete partition {}",
-                                clientAppId(), topicNamePartition, ex);
-                        return FutureUtil.failedFuture(ex);
-                    }
-                }).collect(Collectors.toList()));
+        return FutureUtil.waitForAll(IntStream.range(0, numPartitions).mapToObj(i -> {
+            TopicName topicNamePartition = topicName.getPartition(i);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            pulsar().getPulsarResources().getTopicResources().persistentTopicExists(topicNamePartition)
+                    .thenCompose(exists -> {
+                        if (exists) {
+                            try {
+                                return pulsar().getAdminClient().topics()
+                                        .deleteAsync(topicNamePartition.toString(), force);
+                            } catch (PulsarServerException ex) {
+                                log.error("[{}] Failed to get admin client while delete partition {}", clientAppId(),
+                                        topicNamePartition, ex);
+                                return FutureUtil.failedFuture(ex);
+                            }
+                        } else {
+                            // If the sub-topic is not found, so we ignore this partition. This use case is mainly for
+                            // partitioned-topic auto deletion.
+                            // Call chain:  1.gc process(invoked on broker0)
+                            //              2.delete partitioned-topic admin api(invoked on broker0)
+                            //              3.delete topic-partition-0 admin api(invoked on broker0).
+                            // If brokerClient's maxConnection is 1, then broker0 wait itself to release the
+                            // connection, the result is timeout. So we check topic-partition-0 existence first to
+                            // avoid connection pool deadlock.
+                            // See issue: https://github.com/apache/pulsar/issues/24879
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] Persistent topic partition not found: {}", clientAppId(),
+                                        topicNamePartition);
+                            }
+                            return CompletableFuture.completedFuture(null);
+                        }
+                    }).whenComplete((r, ex) -> {
+                        if (ex != null) {
+                            Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                            if (realCause instanceof NotFoundException) {
+                                // Here, we check the exception again to avoid some race conditions
+                                // If the sub-topic is not found, the client might not have called create producer or
+                                // it might have been deleted earlier, so we ignore the 404 error.
+                                // For all other exception, we fail the delete partition method even if a single
+                                // partition is failed to be deleted
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] Delete topic partition not found: {}", clientAppId(),
+                                            topicNamePartition);
+                                }
+                                future.complete(null);
+                            } else {
+                                log.error("[{}] Failed to delete partition {}", clientAppId(), topicNamePartition,
+                                 realCause);
+                                future.completeExceptionally(realCause);
+                            }
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+            return future;
+        }).collect(Collectors.toList()));
     }
 
     private CompletableFuture<Void> internalRemovePartitionsAuthenticationPoliciesAsync() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -835,8 +835,8 @@ public class PersistentTopicsBase extends AdminResource {
             // This method is reused by non-persistent topic, which doesn't have /managed-ledgers/** path
             // Non-persistent partitioned topic gc process won't call delete partition topic admin api,
             // so it is safe to directly call admin api when topic is non-persistent partitioned.
-            CompletableFuture<Boolean> needAdminClientCall = topicName.isPersistent() ?
-                    pulsar().getPulsarResources().getTopicResources().persistentTopicExists(topicNamePartition) :
+            CompletableFuture<Boolean> needAdminClientCall = topicName.isPersistent()
+                    ? pulsar().getPulsarResources().getTopicResources().persistentTopicExists(topicNamePartition) :
                     CompletableFuture.completedFuture(true);
             needAdminClientCall.thenCompose(deleteThroughAdminClient -> {
                 if (deleteThroughAdminClient) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -832,56 +832,57 @@ public class PersistentTopicsBase extends AdminResource {
         return FutureUtil.waitForAll(IntStream.range(0, numPartitions).mapToObj(i -> {
             TopicName topicNamePartition = topicName.getPartition(i);
             CompletableFuture<Void> future = new CompletableFuture<>();
-            pulsar().getPulsarResources().getTopicResources().persistentTopicExists(topicNamePartition)
-                    .thenCompose(exists -> {
-                        if (exists) {
-                            try {
-                                return pulsar().getAdminClient().topics()
-                                        .deleteAsync(topicNamePartition.toString(), force);
-                            } catch (PulsarServerException ex) {
-                                log.error("[{}] Failed to get admin client while delete partition {}", clientAppId(),
-                                        topicNamePartition, ex);
-                                return FutureUtil.failedFuture(ex);
-                            }
-                        } else {
-                            // If the sub-topic is not found, so we ignore this partition. This use case is mainly for
-                            // partitioned-topic auto deletion.
-                            // Call chain:  1.gc process(invoked on broker0)
-                            //              2.delete partitioned-topic admin api(invoked on broker0)
-                            //              3.delete topic-partition-0 admin api(invoked on broker0).
-                            // If brokerClient's maxConnection is 1, then broker0 wait itself to release the
-                            // connection, the result is timeout. So we check topic-partition-0 existence first to
-                            // avoid connection pool deadlock.
-                            // See issue: https://github.com/apache/pulsar/issues/24879
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Persistent topic partition not found: {}", clientAppId(),
-                                        topicNamePartition);
-                            }
-                            return CompletableFuture.completedFuture(null);
+            // This method is reused by non-persistent topic, which doesn't have /managed-ledgers/** path
+            // Non-persistent partitioned topic gc process won't call delete partition topic admin api,
+            // so it is safe to directly call admin api when topic is non-persistent partitioned.
+            CompletableFuture<Boolean> needAdminClientCall = topicName.isPersistent() ?
+                    pulsar().getPulsarResources().getTopicResources().persistentTopicExists(topicNamePartition) :
+                    CompletableFuture.completedFuture(true);
+            needAdminClientCall.thenCompose(deleteThroughAdminClient -> {
+                if (deleteThroughAdminClient) {
+                    try {
+                        return pulsar().getAdminClient().topics().deleteAsync(topicNamePartition.toString(), force);
+                    } catch (PulsarServerException ex) {
+                        log.error("[{}] Failed to get admin client while delete partition {}", clientAppId(),
+                                topicNamePartition, ex);
+                        return FutureUtil.failedFuture(ex);
+                    }
+                } else {
+                    // If the sub-topic is not found, so we ignore this partition. This use case is mainly for
+                    // partitioned-topic auto deletion.
+                    // Call chain:  1.gc process(invoked on broker0)
+                    //              2.delete partitioned-topic admin api(invoked on broker0)
+                    //              3.delete topic-partition-0 admin api(invoked on broker0)
+                    // If brokerClient's maxConnection is 1, then broker0 wait itself to release the
+                    // connection, the result is timeout. So we check topic-partition-0 existence first to
+                    // avoid connection pool deadlock.
+                    // See issue: https://github.com/apache/pulsar/issues/24879
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Persistent topic partition not found: {}", clientAppId(), topicNamePartition);
+                    }
+                    return CompletableFuture.completedFuture(null);
+                }
+            }).whenComplete((r, ex) -> {
+                if (ex != null) {
+                    Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+                    if (realCause instanceof NotFoundException) {
+                        // Here, we check the exception again to avoid some race conditions
+                        // If the sub-topic is not found, the client might not have called create producer or
+                        // it might have been deleted earlier, so we ignore the 404 error.
+                        // For all other exception, we fail the delete partition method even if a single
+                        // partition is failed to be deleted
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Delete topic partition not found: {}", clientAppId(), topicNamePartition);
                         }
-                    }).whenComplete((r, ex) -> {
-                        if (ex != null) {
-                            Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                            if (realCause instanceof NotFoundException) {
-                                // Here, we check the exception again to avoid some race conditions
-                                // If the sub-topic is not found, the client might not have called create producer or
-                                // it might have been deleted earlier, so we ignore the 404 error.
-                                // For all other exception, we fail the delete partition method even if a single
-                                // partition is failed to be deleted
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Delete topic partition not found: {}", clientAppId(),
-                                            topicNamePartition);
-                                }
-                                future.complete(null);
-                            } else {
-                                log.error("[{}] Failed to delete partition {}", clientAppId(), topicNamePartition,
-                                 realCause);
-                                future.completeExceptionally(realCause);
-                            }
-                        } else {
-                            future.complete(null);
-                        }
-                    });
+                        future.complete(null);
+                    } else {
+                        log.error("[{}] Failed to delete partition {}", clientAppId(), topicNamePartition, realCause);
+                        future.completeExceptionally(realCause);
+                    }
+                } else {
+                    future.complete(null);
+                }
+            });
             return future;
         }).collect(Collectors.toList()));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -58,6 +59,11 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
     @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @Override
+    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
+        pulsarAdminBuilder.maxConnectionsPerHost(1);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -32,7 +32,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -53,17 +52,13 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
     @BeforeMethod
     protected void setup() throws Exception {
-        //No-op
+        // configure pulsarAdmin connectionsPerBroker to 1, to reproduce issue 24879
+        conf.getProperties().put("brokerClient_connectionsPerBroker", 1);
     }
 
     @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
         super.internalCleanup();
-    }
-
-    @Override
-    protected void customizeNewPulsarAdminBuilder(PulsarAdminBuilder pulsarAdminBuilder) {
-        pulsarAdminBuilder.maxConnectionsPerHost(1);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24879

### Motivation

Partitioned-topic auto deletion call chain:  
1. gc process(invoked on broker0)
2. delete partitioned-topic admin api(invoked on broker0)
3. delete topic-partition-0 admin api(invoked on broker0)

If brokerClient's `connectionsPerBroker` is 1, then broker0 wait itself to release the connection, the result is timeout. So we check topic-partition-0 existence first to avoid connection pool deadlock.

See also: https://github.com/apache/pulsar/issues/24879#issuecomment-3475290097

### Modifications

When calling delete partitioned-topic admin api, first check topic partitions existence to avoid calling admin api by broker itself again, which would help partitioned-topic auto deletion in gc process.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

`InactiveTopicDeleteTest#testWhenSubPartitionNotDelete()` test method.

https://github.com/apache/pulsar/blob/1ca17972459095278e2b5f7ed7fd55c8921d8826/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java#L113-L136

But the default `connectionsPerBroker` is 16, which can not reproduce the problem.

https://github.com/apache/pulsar/blob/1ca17972459095278e2b5f7ed7fd55c8921d8826/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java#L48-L51

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/oneby-wang/pulsar/pull/8
