### PR TITLE
[improve][ci] Replace PULSARBOT_TOKEN with GITHUB_TOKEN configured with permissions

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -22,6 +22,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   pulsarbot:
     runs-on: ubuntu-24.04
@@ -31,5 +35,5 @@ jobs:
       - name: Execute pulsarbot command
         id: pulsarbot
         env:
-          GITHUB_TOKEN: ${{ secrets.PULSARBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: apache/pulsar-test-infra/pulsarbot@master


### PR DESCRIPTION
### Motivation

The use of `PULSARBOT_TOKEN` secret is unnecessary and should be replaced with `GITHUB_TOKEN` that is configured with sufficient permissions in the workflow file.

### Modifications

- add sufficient permissions to `GITHUB_TOKEN`
- pass `GITHUB_TOKEN` to pulsarbot action

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->