### PR TITLE
[fix][ci] Add missing permissions to ci-pulsarbot.yaml

### DIFF
--- a/.github/workflows/ci-pulsarbot.yaml
+++ b/.github/workflows/ci-pulsarbot.yaml
@@ -25,6 +25,9 @@ on:
 permissions:
   actions: write
   contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
 
 jobs:
   pulsarbot:


### PR DESCRIPTION
### Motivation

- follow up on #24916
- If the permission isn't specified, there will be no permission
  - https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- it seems that this request fails without pull-request read permission: https://github.com/apache/pulsar-test-infra/blob/a0ef898276e191789153842618f854a39f972c61/pulsarbot/entrypoint.sh#L52

### Modifications

- Add more permissions so that pulsarbot could work

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->