### PR TITLE
[fix][broker] Use `poll` instead `remove` to avoid `NoSuchElementException`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -218,7 +218,10 @@ public class RawReaderImpl implements RawReader {
         private void failPendingRawReceives() {
             List<CompletableFuture<RawMessage>> toError = new ArrayList<>();
             while (!pendingRawReceives.isEmpty()) {
-                toError.add(pendingRawReceives.remove());
+                final CompletableFuture<RawMessage> ret = pendingRawReceives.poll();
+                if (ret != null) {
+                    toError.add(ret);
+                }
             }
             toError.forEach((f) -> f.cancel(false));
         }


### PR DESCRIPTION
### Motivation

Use `poll` instead of `remove` to avoid `NoSuchElementException`

```
2025-10-30T02:08:39,706+0000 [broker-client-shared-internal-executor-5-1] ERROR org.apache.pulsar.client.util.ExecutorProvider - Thread broker-client-shared-internal-executor-5-1 got uncaught Exception
java.util.NoSuchElementException: null
	at java.base/java.util.AbstractQueue.remove(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.failPendingRawReceives(RawReaderImpl.java:221) 
	at org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.lambda$failPendingReceive$0(RawReaderImpl.java:209) ~
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) 
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
2025-10-30T02:08:39,705+0000 [broker-client-shared-internal-executor-5-2] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://public/default/test] Compaction failure.
java.util.concurrent.CompletionException: java.util.concurrent.CancellationException
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.cancel(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.lambda$failPendingRawReceives$1(RawReaderImpl.java:223) 
	at java.base/java.util.ArrayList.forEach(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.failPendingRawReceives(RawReaderImpl.java:223) 
	at org.apache.pulsar.client.impl.RawReaderImpl$RawConsumerImpl.reset(RawReaderImpl.java:234) 
```
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->


