### PR TITLE
[improve][broker] Optimize lookup result warn log

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -327,6 +327,10 @@ public class TopicLookupBase extends PulsarWebResource {
         if (!pulsar.getBrokerService().isSystemTopic(topic)) {
             return;
         }
+        if (SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName()
+                .equals(topic.getPartitionedTopicName())) {
+            return;
+        }
         boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
         if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
             log.warn("[{}] Unexpected lookup result: brokerUrl is required when TLS isn't enabled. options: {},"


### PR DESCRIPTION
### Motivation

Whenever we use transactions, we find the broker is printing the following WARN log:

```
2025-11-03T14:37:19,206+0000 [pulsar-io-9-5] WARN  org.apache.pulsar.broker.lookup.TopicLookupBase - [persistent://pulsar/system/transaction_coordinator_assign-partition-11] Unexpected lookup result: brokerUrl is required when TLS isn't enabled. options: LookupOptions(authoritative=false, readOnly=false, loadTopicsInBundle=true, requestHttps=false, advertisedListenerName=gw, properties={}), result LookupData{brokerUrl=null, brokerUrlTls=pulsar+ssl://xxxx:6651, httpUrl=http://xxxx:8080/, httpUrlTls=null}
```


PR #23642 added a validation log for the internal lookup results of system topics by the broker client. However, for transaction_coordinator_assign, the user's client also performs a lookup.

https://github.com/apache/pulsar/blob/0214b97005825b7b4896f6aa7099a1699e5151c1/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java#L334

Because the check here uses the broker client's configuration to determine if TLS is enabled, it is not applicable for validating the lookup result from a user's client.

### Modifications

- Skip print warn log for topic:transaction_coordinator_assign 

### Verifying this change
- verified on localhost.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
