### PR TITLE
[fix][sec] Added exclusions for vulnerable transitive dependencies (Avro, Tomcat-embed-core, Mina-core, Derby) to remediate CVEs

### DIFF
--- a/pulsar-io/flume/pom.xml
+++ b/pulsar-io/flume/pom.xml
@@ -61,6 +61,18 @@
                     <artifactId>avro</artifactId>
                     <groupId>org.apache.avro</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.mina</groupId>
+                    <artifactId>mina-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pulsar-io/hbase/pom.xml
+++ b/pulsar-io/hbase/pom.xml
@@ -77,6 +77,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
This PR addresses multiple CVEs detected in transitive dependencies used in the Pulsar IO modules **flume** and **hbase**.
The affected libraries are **Apache Tomcat Embed Core**, **Apache MINA**, **Apache Derby**, and **Apache Avro**, which were introducing vulnerabilities through indirect dependencies.

**Vulnerabilities remediated include:**

 **Apache Tomcat Embed Core**

- CVE-2020-1938 – AJP File Read/Inclusion Vulnerability
- CVE-2019-12418 – Local Privilege Escalation
- CVE-2019-17563 – Session Fixation in FORM Authentication
- CVE-2021-25122 – Request Mix-up with h2c
- CVE-2021-25329 – Incomplete fix for CVE-2020-9484 (RCE via Session Persistence)
- CVE-2022-42252 – Request Smuggling
- CVE-2023-46589 – HTTP Request Smuggling via Malformed Trailer Headers
- CVE-2024-34750 – Improper Handling of Exceptional Conditions
- CVE-2024-50379 – RCE due to TOCTOU Issue in JSP Compilation
- CVE-2025-24813 – Potential RCE / Information Disclosure via Partial PUT Handling
- CVE-2025-31650 – DoS via Malformed HTTP/2 PRIORITY_UPDATE Frame
- CVE-2025-31651 – Rewrite Valve Rule Bypass
- CVE-2025-46701 – Security Constraint Bypass for CGI Scripts
- CVE-2025-48988 – DoS in Multipart Upload Handling
- CVE-2025-49125 – Security Constraint Bypass for Pre/Post Resources
- CVE-2024-24549 – HTTP/2 Header Handling DoS
- CVE-2023-41080 – Open Redirect Vulnerability in FORM Authentication
- CVE-2023-42795 – Information Leak via Recycled Object Handling
- CVE-2021-24122 – Information Disclosure on NTFS File Systems
- CVE-2024-21733 – Request Body Leakage in Default Error Page
- CVE-2023-44487 – HTTP/2 DDoS Attack (Rapid Reset)
- CVE-2023-45648 – HTTP Trailer Header Parsing Request Smuggling
- CVE-2020-1935 – Mishandling of Transfer-Encoding header → HTTP request smuggling

 **Apache MINA**

- CVE-2024-52046 – Unbounded Deserialization Remote Code Execution

 **Apache Derby**

- CVE-2022-46337 – LDAP Authentication Bypass

 **Apache Avro**

- CVE-2024-47561 – Schema Parsing May Trigger Remote Code Execution (RCE)
- CVE-2023-39410 – Memory Consumption Issue when Deserializing Untrusted Data

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
Added exclusions for vulnerable transitive dependencies in:

- pulsar-io/flume/pom.xml → Excluded tomcat-embed-core, mina-core, and derby
- pulsar-io/hbase/pom.xml → Excluded avro

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
