### PR TITLE
[improve][test] Disable flaky PatternConsumerBackPressureTest until the problem is fixed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerBackPressureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerBackPressureTest.java
@@ -64,7 +64,7 @@ public class PatternConsumerBackPressureTest extends MockedPulsarServiceBaseTest
         conf.setPulsarChannelWriteBufferLowWaterMark(32 * 1024);
     }
 
-    @Test(timeOut = 60 * 1000)
+    @Test(timeOut = 60 * 1000, enabled = false)
     public void testInfiniteGetThousandsTopics() throws PulsarAdminException, InterruptedException {
         final int topicCount = 8192;
         final int requests = 2048;


### PR DESCRIPTION
### Motivation

PatternConsumerBackPressureTest is really flaky. Reported issue is #24827

### Modifications

Disable PatternConsumerBackPressureTest until the problem is fixed

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->