### PR TITLE
[fix][test] Fix flaky NonPersistentTopicTest.testProducerRateLimit

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -371,9 +371,8 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             stopBroker();
             startBroker();
             // produce message concurrently
-            final int totalProduceMessages = 10;
             @Cleanup("shutdownNow")
-            ExecutorService executor = Executors.newFixedThreadPool(totalProduceMessages);
+            ExecutorService executor = Executors.newFixedThreadPool(10);
             AtomicBoolean failed = new AtomicBoolean(false);
             @Cleanup
             Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("subscriber-1")
@@ -382,12 +381,11 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             @Cleanup
             Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).producerName(producerName).create();
             byte[] msgData = "testData".getBytes();
+            final int totalProduceMessages = 500;
             CountDownLatch latch = new CountDownLatch(totalProduceMessages);
-            final CyclicBarrier barrier = new CyclicBarrier(totalProduceMessages);
             for (int i = 0; i < totalProduceMessages; i++) {
                 executor.submit(() -> {
                     try {
-                        barrier.await();
                         producer.send(msgData);
                     } catch (Exception e) {
                         log.error("Failed to send message", e);


### PR DESCRIPTION
Fixes #24909 

### Motivation

The test uses 5 threads and produces 10 messages. It happens frequently that the test fails because the rate limit is not triggered. 

### Modifications

To increase the probability of triggering the rate limit, the number of threads is increased from 5 to 10, and the number of messages produced is increased from 10 to 500. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/18