### PR TITLE
[fix][broker] AvgShedder comparison error

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/AvgShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/AvgShedder.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -224,7 +225,7 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
         }
 
         // sort brokers by scores.
-        return brokerScoreMap.entrySet().stream().sorted((o1, o2) -> (int) (o1.getValue() - o2.getValue()))
+        return brokerScoreMap.entrySet().stream().sorted(Comparator.comparingDouble(Map.Entry::getValue))
                 .map(Map.Entry::getKey).toList();
     }
 


### PR DESCRIPTION
### Motivation
AvgShedder encounter Exception when sort broker  by scores.

```
2025-11-05T17:11:24,894+0800 [pulsar-load-manager-1-1] WARN  org.apache.pulsar.broker.loadbalance.LoadSheddingTask.run(LoadSheddingTask.java:59) - Error during the load shedding
java.lang.IllegalArgumentException: Comparison method violates its general contract!        
        at java.base/java.util.TimSort.mergeHi(TimSort.java:903) ~[?:?]
        at java.base/java.util.TimSort.mergeAt(TimSort.java:520) ~[?:?]
        at java.base/java.util.TimSort.mergeForceCollapse(TimSort.java:461) ~[?:?]
        at java.base/java.util.TimSort.sort(TimSort.java:254) ~[?:?]
        at java.base/java.util.Arrays.sort(Arrays.java:1307) ~[?:?]
        at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627) ~[?:?]
        at org.apache.pulsar.broker.loadbalance.impl.AvgShedder.calculateScoresAndSort(AvgShedder.java:228) ~[org.apache.pulsar-pulsar-broker-3.3.6.13-kwai.jar:3.3.6.13-kwai]
        at org.apache.pulsar.broker.loadbalance.impl.AvgShedder.findBundlesForUnloading(AvgShedder.java:79) ~[org.apache.pulsar-pulsar-broker-3.3.6.13-kwai.jar:3.3.6.13-kwai]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.doLoadShedding(ModularLoadManagerImpl.java:652) ~[org.apache.pulsar-pulsar-broker-3.3.6.13-kwai.jar:3.3.6.13-kwai]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.doLoadShedding(ModularLoadManagerWrapper.java:52) ~[org.apache.pulsar-pulsar-broker-3.3.6.13-kwai.jar:3.3.6.13-kwai]
        at org.apache.pulsar.broker.loadbalance.LoadSheddingTask.run(LoadSheddingTask.java:57) ~[org.apache.pulsar-pulsar-broker-3.3.6.13-kwai.jar:3.3.6.13-kwai]
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.119.Final.jar:4.1.119.Final]
        at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
```

```
    private List<String> calculateScoresAndSort(LoadData loadData, ServiceConfiguration conf) {
        brokerScoreMap.clear();

        // calculate scores of brokers.
        for (Map.Entry<String, BrokerData> entry : loadData.getBrokerData().entrySet()) {
            LocalBrokerData localBrokerData = entry.getValue().getLocalData();
            String broker = entry.getKey();
            Double score = calculateScores(localBrokerData, conf);
            brokerScoreMap.put(broker, score);
            if (log.isDebugEnabled()) {
                log.info("broker:{}, scores:{}, throughput:{}, messageRate:{}", broker, score,
                        localBrokerData.getMsgThroughputIn() + localBrokerData.getMsgThroughputOut(),
                        localBrokerData.getMsgRateIn() + localBrokerData.getMsgRateOut());
            }
        }

        // sort brokers by scores.
        return brokerScoreMap.entrySet().stream().sorted((o1, o2) -> (int) (o1.getValue() - o2.getValue()))
                .map(Map.Entry::getKey).toList();
    }
```
There is why:

Double value `o1.getValue() - o2.getValue()` cast to int wil loss precision and break violation of transitivity.
For example:

brokerScoreMap.put("X", 0.999);
brokerScoreMap.put("Y", 1.0);
brokerScoreMap.put("Z", 1.999);

(int)(0.999 - 1.0) = (int)(-0.001) = 0 → X == Y
(int)(1.0 - 1.999) = (int)(-0.999) = 0 → Y == Z
(int)(0.999 - 1.999) = (int)(-1.0) = -1 → X < Z


### Modifications

Fix double cost to int. Use `Comparator.comparingDouble`


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
