### PR TITLE
[fix][test] Fixed Nondeterministic Ordering in SchemaInfoTest

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaInfoTest.java
@@ -25,6 +25,9 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -289,8 +292,8 @@ public class SchemaInfoTest {
     }
 
     @Test(dataProvider = "schemas")
-    public void testSchemaInfoToString(SchemaInfo si, String jsonifiedStr) {
-        assertEquals(si.toString(), jsonifiedStr);
+    public void testSchemaInfoToString(SchemaInfo si, String jsonifiedStr) throws JSONException {
+        JSONAssert.assertEquals(si.toString(), jsonifiedStr, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public static class SchemaInfoBuilderTest {
@@ -327,7 +330,7 @@ public class SchemaInfoTest {
         }
 
         @Test
-        public void testNullPropertyValue() {
+        public void testNullPropertyValue() throws JSONException {
             final Map<String, String> map = new HashMap<>();
             map.put("key", null);
 
@@ -339,7 +342,7 @@ public class SchemaInfoTest {
                     .build();
 
             // null key will be skipped by Gson when serializing JSON to String
-            assertEquals(si.toString(), INT32_SCHEMA_INFO);
+            JSONAssert.assertEquals(si.toString(), INT32_SCHEMA_INFO, JSONCompareMode.NON_EXTENSIBLE);
         }
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24967

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

This fix is the same as this fix which was previously accepted and merged: https://github.com/apache/pulsar/pull/24821

Each of the below tests incorrectly assumes that the json key-value pairs being asserted would have a deterministic order. The order of key-value pairs is not guaranteed in [JSON](https://www.json.org/json-en.html), however. As a result, the ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. Harmless re-ordering could flip the tests from pass to fail despite the data being semantically the same:
- org.apache.pulsar.client.impl.schema.SchemaInfoTest$SchemaInfoBuilderTest.testNullPropertyValue
- org.apache.pulsar.client.impl.schema.SchemaInfoTest.testSchemaInfoToString

### Modifications

<!-- Describe the modifications you've done. -->

We no longer compare raw strings "as-is" with ```Assert.assertEquals```. Instead, we compare the json structures with ```JsonAssert.assertEquals(expectedJson, actualJson, JSONCompareMode)``` which parses both inputs into JSON trees. It treats these JSON trees as unordered collections of key-value pairs when determining if they are equal so differences in property order no longer matter. This ensures the tests pass consistently, even when the serializer outputs fields in a different order. 

In essence, these changes keep the spirit of the original tests while eliminating failures caused solely by allowed (but previously unexpected) reordering. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as
- `org.apache.pulsar.client.impl.schema.SchemaInfoTest$SchemaInfoBuilderTest.testNullPropertyValue`
- `org.apache.pulsar.client.impl.schema.SchemaInfoTest.testSchemaInfoToString`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/9

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
