### PR TITLE
[fix][broker]Leaving orphan schemas and topic-level policies after partitioned topic is deleted by GC

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTopicGcUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicationTopicGcUsingGlobalZKTest.java
@@ -43,11 +43,6 @@ public class ReplicationTopicGcUsingGlobalZKTest extends ReplicationTopicGcTest 
 
     @Test(dataProvider = "topicTypes")
     public void testTopicGC(TopicType topicType) throws Exception {
-        if (topicType.equals(TopicType.PARTITIONED)) {
-            // Pulsar does not support the feature "brokerDeleteInactivePartitionedTopicMetadataEnabled" when enabling
-            // Geo-Replication with Global ZK.
-            return;
-        }
         super.testTopicGC(topicType);
     }
 


### PR DESCRIPTION
### Motivation

**How to reproduce the issue**
- Start two clusters with a global configuration metadata store
- Enable `brokerDeleteInactiveTopicsEnabled` and `brokerDeleteInactivePartitionedTopicMetadataEnabled`
- After topic partitions and topics are deleted from the GC mechanism, the following events occur
  - `cluster 1`:  deletes all partitions
  - `cluster 2`: deletes all partitions
  - `cluster 1`: deletes partitioned topic metadata(the schema and topic-level policies will also be deleted with the operation)
  - `cluster 2`: since the partitioned topic metadata was deleted by `cluster 1`(both clusters share the same metadata), it deletes nothing, then the issue occurs: topics were deleted, but schemas and topic-level policies are still there

### Modifications

- fix the issue

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
