### PR TITLE
[fix][test] Add Delta Tolerance in Double-Precision Assertions to Fix Rounding Flakiness

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -110,6 +110,7 @@ import org.testng.annotations.Test;
 public class TransferShedderTest {
     double setupLoadAvg = 0.36400000000000005;
     double setupLoadStd = 0.3982762860126121;
+    double delta = 1e-5;
 
     PulsarService pulsar;
     NamespaceService namespaceService;
@@ -522,8 +523,8 @@ public class TransferShedderTest {
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -543,8 +544,8 @@ public class TransferShedderTest {
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoLoadData).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -587,8 +588,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
 
         var now = System.currentTimeMillis();
         recentlyUnloadedBrokers.put("broker1:8080", now);
@@ -616,8 +617,8 @@ public class TransferShedderTest {
                 Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -635,8 +636,8 @@ public class TransferShedderTest {
                 Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -674,8 +675,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
 
         // Test unload a has isolation policies broker.
         ctx.brokerConfiguration().setLoadBalancerTransferEnabled(false);
@@ -685,8 +686,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.empty()),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
 
 
         // test setLoadBalancerSheddingBundlesWithPoliciesEnabled=false;
@@ -697,16 +698,16 @@ public class TransferShedderTest {
         res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
 
         // Test unload a has isolation policies broker.
         ctx.brokerConfiguration().setLoadBalancerTransferEnabled(false);
         res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 2);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     public BrokerLookupData getLookupData() {
@@ -788,8 +789,8 @@ public class TransferShedderTest {
 
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
 
         doAnswer(invocationOnMock -> {
             Map<String, BrokerLookupData> brokers = invocationOnMock.getArgument(0);
@@ -806,8 +807,8 @@ public class TransferShedderTest {
         expected2.add(new UnloadDecision(new Unload("broker5:8080", bundleE1, Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res2, expected2);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -837,8 +838,8 @@ public class TransferShedderTest {
 
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -900,8 +901,8 @@ public class TransferShedderTest {
 
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(HitCount).get(), 1);
-        assertEquals(counter.getLoadAvg(), 0.2000000063578288);
-        assertEquals(counter.getLoadStd(), 0.08164966587949089);
+        assertEquals(counter.getLoadAvg(), 0.2000000063578288, delta);
+        assertEquals(counter.getLoadStd(), 0.08164966587949089, delta);
     }
 
     @Test
@@ -919,8 +920,8 @@ public class TransferShedderTest {
 
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -941,8 +942,8 @@ public class TransferShedderTest {
                 Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -961,8 +962,8 @@ public class TransferShedderTest {
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         assertTrue(res.isEmpty());
         assertEquals(counter.getBreakdownCounters().get(Skip).get(NoBundles).get(), 1);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
 
@@ -980,8 +981,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker5:8080", bundleE1, Optional.of("broker1:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), 0.26400000000000007);
-        assertEquals(counter.getLoadStd(), 0.27644891028904417);
+        assertEquals(counter.getLoadAvg(), 0.26400000000000007, delta);
+        assertEquals(counter.getLoadStd(), 0.27644891028904417, delta);
     }
 
     @Test
@@ -1032,12 +1033,12 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(
                 new Unload("broker1:8080", "my-tenant/my-namespaceA/0x3FFFFFFF_0x4FFFFFFF",
                         Optional.of("broker2:8080")), Success, Overloaded));
-        assertEquals(counter.getLoadAvg(), 5.05);
-        assertEquals(counter.getLoadStd(), 4.95);
+        assertEquals(counter.getLoadAvg(), 5.05, delta);
+        assertEquals(counter.getLoadStd(), 4.95, delta);
         assertEquals(res, expected);
         var stats = (TransferShedder.LoadStats)
                 FieldUtils.readDeclaredField(transferShedder, "stats", true);
-        assertEquals(stats.std(), 0.050000004900021836);
+        assertEquals(stats.std(), 0.050000004900021836, delta);
     }
 
     @Test
@@ -1103,12 +1104,12 @@ public class TransferShedderTest {
                 new Unload("broker2:8080", "my-tenant/my-namespaceB/0x00000000_0x0FFFFFFF",
                         Optional.of("broker1:8080")),
                 Success, Overloaded));
-        assertEquals(counter.getLoadAvg(), 5.05);
-        assertEquals(counter.getLoadStd(), 4.95);
+        assertEquals(counter.getLoadAvg(), 5.05, delta);
+        assertEquals(counter.getLoadStd(), 4.95, delta);
         assertEquals(res, expected);
         var stats = (TransferShedder.LoadStats)
                 FieldUtils.readDeclaredField(transferShedder, "stats", true);
-        assertEquals(stats.std(), 0.050000004900021836);
+        assertEquals(stats.std(), 0.050000004900021836, delta);
 
     }
 
@@ -1142,19 +1143,19 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(
                 new Unload("broker1:8080",
                         res.stream().filter(x -> x.getUnload().sourceBroker().equals("broker1:8080")).findFirst().get()
-                        .getUnload().serviceUnit(), Optional.of("broker2:8080")),
+                                .getUnload().serviceUnit(), Optional.of("broker2:8080")),
                 Success, Overloaded));
         expected.add(new UnloadDecision(
                 new Unload("broker2:8080",
                         res.stream().filter(x -> x.getUnload().sourceBroker().equals("broker2:8080")).findFirst().get()
                                 .getUnload().serviceUnit(), Optional.of("broker1:8080")),
                 Success, Overloaded));
-        assertEquals(counter.getLoadAvg(), 0.74);
-        assertEquals(counter.getLoadStd(), 0.26);
+        assertEquals(counter.getLoadAvg(), 0.74, delta);
+        assertEquals(counter.getLoadStd(), 0.26, delta);
         assertEquals(res, expected);
         var stats = (TransferShedder.LoadStats)
                 FieldUtils.readDeclaredField(transferShedder, "stats", true);
-        assertEquals(stats.std(), 2.5809568279517847E-8);
+        assertEquals(stats.std(), 2.5809568279517847E-8, delta);
     }
 
     @Test
@@ -1180,8 +1181,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Underloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), 0.26400000000000007);
-        assertEquals(counter.getLoadStd(), 0.27644891028904417);
+        assertEquals(counter.getLoadAvg(), 0.26400000000000007, delta);
+        assertEquals(counter.getLoadStd(), 0.27644891028904417, delta);
     }
 
     @Test
@@ -1204,8 +1205,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Underloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), 0.262);
-        assertEquals(counter.getLoadStd(), 0.2780935094532054);
+        assertEquals(counter.getLoadAvg(), 0.262, delta);
+        assertEquals(counter.getLoadStd(), 0.2780935094532054, delta);
     }
 
     @Test
@@ -1222,8 +1223,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -1238,8 +1239,8 @@ public class TransferShedderTest {
             var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
             assertTrue(res.isEmpty());
             assertEquals(counter.getBreakdownCounters().get(Skip).get(HitCount).get(), i + 1);
-            assertEquals(counter.getLoadAvg(), setupLoadAvg);
-            assertEquals(counter.getLoadStd(), setupLoadStd);
+            assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+            assertEquals(counter.getLoadStd(), setupLoadStd, delta);
         }
         var res = transferShedder.findBundlesForUnloading(ctx, Map.of(), Map.of());
         var expected = new HashSet<UnloadDecision>();
@@ -1248,8 +1249,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -1268,8 +1269,8 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), setupLoadAvg);
-        assertEquals(counter.getLoadStd(), setupLoadStd);
+        assertEquals(counter.getLoadAvg(), setupLoadAvg, delta);
+        assertEquals(counter.getLoadStd(), setupLoadStd, delta);
     }
 
     @Test
@@ -1289,14 +1290,14 @@ public class TransferShedderTest {
         expected.add(new UnloadDecision(new Unload("broker4:8080", bundleD1, Optional.of("broker2:8080")),
                 Success, Overloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), 2.4240000000000004);
-        assertEquals(counter.getLoadStd(), 3.8633332758124816);
+        assertEquals(counter.getLoadAvg(), 2.4240000000000004, delta);
+        assertEquals(counter.getLoadStd(), 3.8633332758124816, delta);
 
 
         var stats = (TransferShedder.LoadStats)
                 FieldUtils.readDeclaredField(transferShedder, "stats", true);
-        assertEquals(stats.avg(), 2.4240000000000004);
-        assertEquals(stats.std(), 2.781643776903451);
+        assertEquals(stats.avg(), 2.4240000000000004, delta);
+        assertEquals(stats.std(), 2.781643776903451, delta);
     }
 
     @Test
@@ -1328,8 +1329,8 @@ public class TransferShedderTest {
                         new Unload("broker99:8080", "my-tenant/my-namespace99/0x00000000_0x0FFFFFFF",
                                 Optional.of("broker83:8080")), Success, Underloaded))
         );
-        assertEquals(counter.getLoadAvg(), 0.019900000000000008, 0.00001);
-        assertEquals(counter.getLoadStd(), 0.09850375627355534, 0.00001);
+        assertEquals(counter.getLoadAvg(), 0.019900000000000008, delta);
+        assertEquals(counter.getLoadStd(), 0.09850375627355534, delta);
     }
 
     @Test
@@ -1343,8 +1344,8 @@ public class TransferShedderTest {
                 new Unload("broker98:8080", "my-tenant/my-namespace98/0x00000000_0x0FFFFFFF",
                         Optional.of("broker99:8080")), Success, Underloaded));
         assertEquals(res, expected);
-        assertEquals(counter.getLoadAvg(), 0.9704000000000005, 0.00001);
-        assertEquals(counter.getLoadStd(), 0.09652895938523735, 0.00001);
+        assertEquals(counter.getLoadAvg(), 0.9704000000000005, delta);
+        assertEquals(counter.getLoadStd(), 0.09652895938523735, delta);
     }
 
     @Test
@@ -1406,8 +1407,8 @@ public class TransferShedderTest {
         }
         stats.update(loadStore, availableBrokers, Map.of(), conf);
 
-        assertEquals(stats.avg(), 0.9417647058823528);
-        assertEquals(stats.std(), 0.23294117647058868);
+        assertEquals(stats.avg(), 0.9417647058823528, delta);
+        assertEquals(stats.std(), 0.23294117647058868, delta);
     }
 
     @Test
@@ -1424,7 +1425,7 @@ public class TransferShedderTest {
             loadStore.pushAsync("broker" + i + ":8080", getCpuLoad(ctx,  loads[i], "broker" + i + ":8080"));
         }
         stats.update(loadStore, availableBrokers, Map.of(), conf);
-        assertEquals(stats.avg(), 3.9449999999999994);
-        assertEquals(stats.std(), 0.028722813232795824);
+        assertEquals(stats.avg(), 3.9449999999999994, delta);
+        assertEquals(stats.std(), 0.028722813232795824, delta);
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24970

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The PR on my fork was already approved: https://github.com/LucasEby/pulsar/pull/11

Several tests in this suite compare double values directly using equality assertions. These assertions occasionally fail due to minor inaccuracies introduced by floating-point rounding and double-precision [limitations](https://www.baeldung.com/java-double-precision-issue) in Java’s IEEE 754 representation. Such discrepancies are expected when performing arithmetic operations on floating-point numbers and can lead to flaky test behavior. 

### Modifications

<!-- Describe the modifications you've done. -->

A small tolerance (delta) of `1e-5` was added to each double comparison. This delta is at least two orders of magnitude smaller than the smallest compared values, ensuring that it does not affect the logical correctness of the tests. The same delta is already used consistently in another method within the same test class. The tests remain the same, we are just being more careful about double precision issues when comparing values to avoid preventable flaky failures. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testNoOwnerLoadData`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testEmptyTopBundlesLoadData`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testRecentlyUnloadedBrokers`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testRecentlyUnloadedBundles`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testSheddingExcludedNamespaces`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testBundlesWithIsolationPolicies`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testBundlesWithAntiAffinityGroup`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testTargetStd`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testSingleTopBundlesLoadData`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testBundleThroughputLargerThanOffloadThreshold`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testZeroBundleThroughput`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testTargetStdAfterTransfer`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testMinBrokerWithLowTraffic`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testMinBrokerWithLowerLoadThanAvg`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testMaxNumberOfTransfersPerShedderCycle`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testLoadBalancerSheddingConditionHitCountThreshold`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testRemainingTopBundles`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testLoadMoreThan100`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testHighVarianceLoadStats`
- `org.apache.pulsar.broker.loadbalance.extensions.scheduler.TransferShedderTest#testLowVarianceLoadStats`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/11

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
