### PR TITLE
[fix][test] Fixed Nondeterministic Ordering in Generated Docs Topics

### DIFF
--- a/pulsar-docs-tools/src/main/java/org/apache/pulsar/docs/tools/CmdGenerateDocs.java
+++ b/pulsar-docs-tools/src/main/java/org/apache/pulsar/docs/tools/CmdGenerateDocs.java
@@ -108,7 +108,7 @@ public class CmdGenerateDocs implements Callable<Integer> {
                     sb.append("```shell\n$ ");
                     sb.append(this.commander.getCommandName()).append(" ");
                     sb.append(module).append(" ").append(subK).append(" options").append("\n```\n\n");
-                    List<ArgSpec> argSpecs = subV.getCommandSpec().args();
+                    List<ArgSpec> argSpecs = getSortedArgs(subV.getCommandSpec().args());
                     if (argSpecs.size() > 0) {
                         sb.append("|Flag|Description|Default|\n");
                         sb.append("|---|---|---|\n");
@@ -128,7 +128,7 @@ public class CmdGenerateDocs implements Callable<Integer> {
             sb.append(" options").append("\n```").append("\n\n");
             sb.append("|Flag|Description|Default|\n");
             sb.append("|---|---|---|\n");
-            List<ArgSpec> argSpecs = commander.getCommandSpec().args();
+            List<ArgSpec> argSpecs = getSortedArgs(commander.getCommandSpec().args());
             argSpecs.forEach(option -> {
                 if (option.hidden() || !(option instanceof OptionSpec)) {
                     return;
@@ -142,6 +142,27 @@ public class CmdGenerateDocs implements Callable<Integer> {
             });
         }
         return sb.toString();
+    }
+
+    /**
+     * Returns a sorted copy of the argument specifications list, ordered by the
+     * OptionSpec order attribute for option specs. Non-option arguments
+     * retain their relative ordering.
+     *
+     * @param args the list of argument specifications to sort
+     * @return a new sorted list
+     */
+    private List<ArgSpec> getSortedArgs(List<ArgSpec> args) {
+        List<ArgSpec> sorted = new ArrayList<>(args);
+        sorted.sort((a, b) -> {
+            if (a instanceof OptionSpec && b instanceof OptionSpec) {
+                OptionSpec optA = (OptionSpec) a;
+                OptionSpec optB = (OptionSpec) b;
+                return Integer.compare(optA.order(), optB.order());
+            }
+            return 0;
+        });
+        return sorted;
     }
 
     @Override

--- a/pulsar-docs-tools/src/test/java/org/apache/pulsar/docs/tools/CmdGenerateDocsTest.java
+++ b/pulsar-docs-tools/src/test/java/org/apache/pulsar/docs/tools/CmdGenerateDocsTest.java
@@ -29,10 +29,10 @@ public class CmdGenerateDocsTest {
 
     @Command
     public class Arguments {
-        @Option(names = {"-h", "--help"}, description = "Show this help message")
+        @Option(names = {"-h", "--help"}, description = "Show this help message", order = 0)
         private boolean help = false;
 
-        @Option(names = {"-n", "--name"}, description = "Name")
+        @Option(names = {"-n", "--name"}, description = "Name", order = 1)
         private String name;
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24968

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

The below test compares the generated documentation of `CmdGenerateDocsTest#testGenerateDocs`.  The test assumes a deterministic order of the generated documentation but the order of the listed `help` and `name` options was not guaranteed. Due to two sources of nondeterminism hidden in the test and production code, the options could be listed in a different order. Picocli's `CommandLine` class uses [Class#getDeclaredFields](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields) internally (via reflection), which has a non-deterministic specification to retrieve the `Option` annotations and orders these options accordingly. Even though picocli supports an order attribute on `Option` annotations, [CommandLine](https://github.com/remkop/picocli/blob/main/src/main/java/picocli/CommandLine.java) never sorts by this order - it just maintains whatever order the reflection API gave it. `CmdGenerateDocs#generateDocument` then iterates over the order that the `args` method returns, with the assumption that the order is deterministic. Unfortunately, the ordering can change due to different environments producing the contents in different orders despite the logical contents being the same. Harmless re-ordering could flip the tests from pass to fail despite the data being semantically the same.
- `org.apache.pulsar.docs.tools.CmdGenerateDocsTest.testGenerateDocs`

### Modifications

<!-- Describe the modifications you've done. -->

The order of each option in the Argument class is now explicitly stated so `getDeclaredFields` is no longer utilized to determine the order of the options. Additionally, `generateDocument` now sorts all `argSpecs` by their specified order with a new helper method called `getSortedArgs`. This combination of changes enforces the expected nondeterminism in the ordering of the listed options.

If order is not specified because it does not matter, the order for each option will remain in it's original order as before. This is because according to [Collection's](https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html) documentation, it's sort method is guaranteed to be stable: equal elements will not be reordered as a result of the sort (and the orders are equal because Piccocli's `CommandLine` class sets order to -1 by default).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as
- `org.apache.pulsar.client.impl.schema.SchemaInfoTest$SchemaInfoBuilderTest.testNullPropertyValue`
- `org.apache.pulsar.client.impl.schema.SchemaInfoTest.testSchemaInfoToString`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/LucasEby/pulsar/pull/8

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->