### PR TITLE
[fix][client] Fix retry logic for BinaryProtoLookupService.getTopicsUnderNamespace method

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/utils/ClientChannelHelper.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.service.utils;
 import com.google.common.collect.Queues;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import java.util.Queue;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck;
@@ -52,6 +51,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.CommandSuccess;
 import org.apache.pulsar.common.api.proto.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
+import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.protocol.PulsarDecoder;
 
 public class ClientChannelHelper {
@@ -61,7 +61,7 @@ public class ClientChannelHelper {
 
     public ClientChannelHelper() {
         int maxMessageSize = 5 * 1024 * 1024;
-        channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(maxMessageSize, 0, 4, 0, 4), decoder);
+        channel = new EmbeddedChannel(FrameDecoderUtil.createFrameDecoder(), decoder);
     }
 
     public Object getCommand(Object obj) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -33,8 +33,8 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.commons.lang3.tuple.Pair;
@@ -61,7 +61,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-api")
 public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPulsarServiceBaseTest {
     private final boolean withInternalListener;
-    private ExecutorService executorService;
+    private ScheduledExecutorService executorService;
     private InetSocketAddress brokerAddress;
     private InetSocketAddress brokerSslAddress;
     private EventLoopGroup eventExecutors;
@@ -79,7 +79,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     @BeforeMethod(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
-        this.executorService = Executors.newFixedThreadPool(1);
+        this.executorService = Executors.newSingleThreadScheduledExecutor();
         this.eventExecutors = new NioEventLoopGroup();
         this.isTcpLookup = true;
         String host = InetAddress.getLocalHost().getHostAddress();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -61,7 +61,7 @@ public class BinaryProtoLookupService implements LookupService {
     private final PulsarClientImpl client;
     private final ServiceNameResolver serviceNameResolver;
     private final boolean useTls;
-    private final ExecutorService scheduleExecutor;
+    private final ScheduledExecutorService scheduleExecutor;
     private final String listenerName;
     private final int maxLookupRedirects;
     private final ExecutorService lookupPinnedExecutor;
@@ -83,27 +83,29 @@ public class BinaryProtoLookupService implements LookupService {
 
     /**
      * @deprecated use {@link
-     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ExecutorService, ExecutorService)} instead.
+     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ScheduledExecutorService, ExecutorService)}
+     * instead.
      */
     @Deprecated
     public BinaryProtoLookupService(PulsarClientImpl client,
                                     String serviceUrl,
                                     boolean useTls,
-                                    ExecutorService scheduleExecutor)
+                                    ScheduledExecutorService scheduleExecutor)
             throws PulsarClientException {
         this(client, serviceUrl, null, useTls, scheduleExecutor);
     }
 
     /**
      * @deprecated use {@link
-     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ExecutorService, ExecutorService)} instead.
+     * #BinaryProtoLookupService(PulsarClientImpl, String, String, boolean, ScheduledExecutorService, ExecutorService)}
+     * instead.
      */
     @Deprecated
     public BinaryProtoLookupService(PulsarClientImpl client,
                                     String serviceUrl,
                                     String listenerName,
                                     boolean useTls,
-                                    ExecutorService scheduleExecutor)
+                                    ScheduledExecutorService scheduleExecutor)
             throws PulsarClientException {
         this(client, serviceUrl, listenerName, useTls, scheduleExecutor, null);
     }
@@ -112,7 +114,7 @@ public class BinaryProtoLookupService implements LookupService {
                                     String serviceUrl,
                                     String listenerName,
                                     boolean useTls,
-                                    ExecutorService scheduleExecutor,
+                                    ScheduledExecutorService scheduleExecutor,
                                     ExecutorService lookupPinnedExecutor)
             throws PulsarClientException {
         this.client = client;
@@ -469,7 +471,7 @@ public class BinaryProtoLookupService implements LookupService {
                 return null;
             }
 
-            ((ScheduledExecutorService) scheduleExecutor).schedule(() -> {
+            scheduleExecutor.schedule(() -> {
                 log.warn("[namespace: {}] Could not get connection while getTopicsUnderNamespace -- Will try again in"
                                 + " {} ms", namespace, nextDelay);
                 remainingTime.addAndGet(-nextDelay);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -270,14 +270,8 @@ public class PulsarClientImpl implements PulsarClient {
             } else {
                 this.timer = timer;
             }
-            if (conf.getServiceUrl().startsWith("http")) {
-                lookup = new HttpLookupService(instrumentProvider, conf, this.eventLoopGroup, this.timer,
-                        getNameResolver());
-            } else {
-                lookup = new BinaryProtoLookupService(this, conf.getServiceUrl(), conf.getListenerName(),
-                        conf.isUseTls(), this.scheduledExecutorProvider.getExecutor(),
-                        this.lookupExecutorProvider.getExecutor());
-            }
+
+            lookup = createLookup(conf.getServiceUrl());
 
             if (conf.getServiceUrlProvider() != null) {
                 conf.getServiceUrlProvider().initialize(this);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1223,7 +1223,8 @@ public class PulsarClientImpl implements PulsarClient {
             return new HttpLookupService(instrumentProvider, conf, eventLoopGroup, timer, getNameResolver());
         } else {
             return new BinaryProtoLookupService(this, url, conf.getListenerName(), conf.isUseTls(),
-                    externalExecutorProvider.getExecutor());
+                    (ScheduledExecutorService) this.scheduledExecutorProvider.getExecutor(),
+                    this.lookupExecutorProvider.getExecutor());
         }
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BinaryProtoLookupServiceTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Field;
@@ -65,6 +66,7 @@ public class BinaryProtoLookupServiceTest {
     private BinaryProtoLookupService lookup;
     private TopicName topicName;
     private ExecutorService internalExecutor;
+    private ScheduledExecutorService scheduledExecutorService;
 
     @AfterMethod
     public void cleanup() throws Exception {
@@ -113,8 +115,11 @@ public class BinaryProtoLookupServiceTest {
                 Executors.newSingleThreadExecutor(new DefaultThreadFactory("pulsar-client-test-internal-executor"));
         doReturn(internalExecutor).when(client).getInternalExecutorService();
 
-        lookup = spy(new BinaryProtoLookupService(client, "pulsar://localhost:6650", null, false,
-                mock(ExecutorService.class), internalExecutor));
+        scheduledExecutorService = mock(ScheduledExecutorService.class);
+
+        ExecutorService lookupExecutor = MoreExecutors.newDirectExecutorService();
+        lookup = spy(new BinaryProtoLookupService(client, "pulsar://localhost:6650", null,
+                false, scheduledExecutorService, lookupExecutor));
 
         topicName = TopicName.get("persistent://tenant1/ns1/t1");
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/FrameDecoderUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/FrameDecoderUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.common.protocol;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import lombok.experimental.UtilityClass;
@@ -60,8 +61,14 @@ public class FrameDecoderUtil {
         pipeline.remove(FRAME_DECODER_HANDLER);
     }
 
-    private static LengthFieldBasedFrameDecoder createFrameDecoder(int maxMessageSize) {
+    @VisibleForTesting
+    public static LengthFieldBasedFrameDecoder createFrameDecoder(int maxMessageSize) {
         return new LengthFieldBasedFrameDecoder(
                 maxMessageSize + Commands.MESSAGE_SIZE_FRAME_PADDING, 0, 4, 0, 4);
+    }
+
+    @VisibleForTesting
+    public static LengthFieldBasedFrameDecoder createFrameDecoder() {
+        return createFrameDecoder(Commands.DEFAULT_MAX_MESSAGE_SIZE);
     }
 }


### PR DESCRIPTION
### Motivation

BinaryProtoLookupService.getTopicsUnderNamespace method contains retry logic, but it only applies to exceptions that occur when acquiring the connection fails.
A getTopicsUnderNamespace might fail later if the connection gets closed before the response has been successfully received. That's why it's better that the retry logic would also cover the actual operation to be effective.

### Modifications

- Fix the retry logic and add tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->