### PR TITLE
[fix][build] Remove Confluent and Restlet maven repositories from top level pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3141,12 +3141,5 @@ flexible messaging model and an intuitive client API.</description>
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>confluent</id>
-      <url>https://packages.confluent.io/maven/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
   </repositories>
 </project>

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -249,4 +249,14 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <url>https://packages.confluent.io/maven/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -159,4 +159,14 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <url>https://packages.confluent.io/maven/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
### Motivation

Currently Confluent and Restlet repositories get scanned for dependencies in the build.
This is a problem from both security & privacy perspective and build performance & reliability perspective.
This also makes progress in achieving the goal of #23476 although doesn't completely resolve it.

### Modifications

- Remove Restlet repository completely since it's not needed at all. It was added in #13248, but it's no longer needed.
- Move Confluent repository definitions to the modules that require Confluent Schema Registry Apache 2.0 licensed dependencies. These are `pulsar-io/kafka-connect-adaptor` and `pulsar-io/kafka`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->