### PR TITLE
[improve][build] Upgrade Testcontainers to 1.21.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,9 @@ flexible messaging model and an intuitive client API.</description>
     <failsafe.version>3.3.2</failsafe.version>
 
     <!-- test dependencies -->
-    <testcontainers.version>1.20.4</testcontainers.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <!-- Set docker-java.version to the version of docker-java used in org.testcontainers:testcontainers pom -->
-    <docker-java.version>3.4.0</docker-java.version>
+    <docker-java.version>3.4.2</docker-java.version>
     <hamcrest.version>2.2</hamcrest.version>
     <restassured.version>5.4.0</restassured.version>
     <kerby.version>1.1.1</kerby.version>


### PR DESCRIPTION
### Motivation

Testcontainers version is slightly outdated. Moving to latest 1.x.x release.

### Modifications

- Upgrade Testcontainers to 1.21.3
- Upgrade docker-java to 3.4.2 (Must be compatible with Testcontainers, [version from Testcontainers pom](https://central.sonatype.com/artifact/org.testcontainers/testcontainers/1.21.3))

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->