### PR TITLE
[improve] Upgrade Caffeine to 3.2.3

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -260,7 +260,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.17.2.jar
      - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.17.2.jar
      - com.fasterxml.jackson.module-jackson-module-parameter-names-2.17.2.jar
- * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.1.jar
+ * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.3.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.59.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
     <hdrHistogram.version>2.1.9</hdrHistogram.version>
     <javax.servlet-api>3.1.0</javax.servlet-api>
-    <caffeine.version>3.2.1</caffeine.version>
+    <caffeine.version>3.2.3</caffeine.version>
     <java-semver.version>0.9.0</java-semver.version>
     <jline.version>2.14.6</jline.version>
     <jline3.version>3.21.0</jline3.version>


### PR DESCRIPTION
### Motivation

Caffeine 3.2.3 contains some useful fixes and improvements.
* https://github.com/ben-manes/caffeine/releases

### Modifications

- Upgrade Caffeine from 3.2.1 to 3.2.3

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->