### PR TITLE
[improve] Upgrade Log4j2 to 2.25.2 and slf4j to 2.0.17

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -48,8 +48,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
     <surefire.version>3.1.0</surefire.version>
-    <log4j2.version>2.23.1</log4j2.version>
-    <slf4j.version>2.0.13</slf4j.version>
+    <log4j2.version>2.25.2</log4j2.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <testng.version>7.7.1</testng.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -349,10 +349,10 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.23.1.jar
-    - org.apache.logging.log4j-log4j-core-2.23.1.jar
-    - org.apache.logging.log4j-log4j-slf4j2-impl-2.23.1.jar
-    - org.apache.logging.log4j-log4j-web-2.23.1.jar
+    - org.apache.logging.log4j-log4j-api-2.25.2.jar
+    - org.apache.logging.log4j-log4j-core-2.25.2.jar
+    - org.apache.logging.log4j-log4j-slf4j2-impl-2.25.2.jar
+    - org.apache.logging.log4j-log4j-web-2.25.2.jar
  * Java Native Access JNA
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
@@ -562,8 +562,8 @@ BSD 2-Clause License
 MIT License
  * Java SemVer -- com.github.zafarkhaja-java-semver-0.9.0.jar -- ../licenses/LICENSE-SemVer.txt
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
-    - org.slf4j-slf4j-api-2.0.13.jar
-    - org.slf4j-jcl-over-slf4j-2.0.13.jar
+    - org.slf4j-slf4j-api-2.0.17.jar
+    - org.slf4j-jcl-over-slf4j-2.0.17.jar
  * The Checker Framework
     - org.checkerframework-checker-qual-3.33.0.jar
  * oshi

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -384,10 +384,10 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
  * Log4J
-    - log4j-api-2.23.1.jar
-    - log4j-core-2.23.1.jar
-    - log4j-slf4j2-impl-2.23.1.jar
-    - log4j-web-2.23.1.jar
+    - log4j-api-2.25.2.jar
+    - log4j-core-2.25.2.jar
+    - log4j-slf4j2-impl-2.25.2.jar
+    - log4j-web-2.25.2.jar
  * OpenTelemetry
     - opentelemetry-api-1.45.0.jar
     - opentelemetry-api-incubator-1.45.0-alpha.jar
@@ -428,7 +428,7 @@ BSD 3-clause "New" or "Revised" License
 
 MIT License
  * SLF4J -- ../licenses/LICENSE-SLF4J.txt
-    - slf4j-api-2.0.13.jar
+    - slf4j-api-2.0.17.jar
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Annotations API

--- a/pom.xml
+++ b/pom.xml
@@ -198,9 +198,9 @@ flexible messaging model and an intuitive client API.</description>
     <prometheus.version>0.16.0</prometheus.version>
     <vertx.version>4.5.22</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
-    <slf4j.version>2.0.13</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <log4j2.version>2.23.1</log4j2.version>
+    <log4j2.version>2.25.2</log4j2.version>
     <!-- bouncycastle dependencies aren't necessarily aligned -->
     <bouncycastle.bcprov-jdk18on.version>1.78.1</bouncycastle.bcprov-jdk18on.version>
     <bouncycastle.bcpkix-jdk18on.version>1.81</bouncycastle.bcpkix-jdk18on.version>


### PR DESCRIPTION
### Motivation

Keep Log4J and SLF4J version up-to-date to get latest bug fixes and possible performance improvements. It's necessary to keep dependencies up-to-date.

### Modifications

- upgrade Log4j2 version from 2.23.1 to 2.25.2
- upgrade SLF4J version from 2.0.13 to 2.0.17

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->