### PR TITLE
[fix] Handle TLS close_notify to avoid SslClosedEngineException: SSLEngine closed already

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -29,7 +29,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.Errors.NativeIoException;
-import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.concurrent.Promise;
 import io.opentelemetry.api.common.Attributes;
 import java.net.InetSocketAddress;
@@ -1440,18 +1439,6 @@ public class ClientCnx extends PulsarHandler {
        if (ctx != null) {
            ctx.close();
        }
-    }
-
-    @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (evt instanceof SslHandshakeCompletionEvent) {
-            SslHandshakeCompletionEvent sslHandshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
-            if (sslHandshakeCompletionEvent.cause() != null) {
-                log.warn("{} Got ssl handshake exception {}", ctx.channel(),
-                        sslHandshakeCompletionEvent);
-            }
-        }
-        ctx.fireUserEventTriggered(evt);
     }
 
     protected void closeWithException(Throwable e) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarDecoder.java
@@ -24,6 +24,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundInvoker;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import org.apache.pulsar.common.api.proto.BaseCommand;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandAckResponse;
@@ -748,5 +750,27 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
 
     private void writeAndFlush(ChannelOutboundInvoker ctx, ByteBuf cmd) {
         NettyChannelUtil.writeAndFlushWithVoidPromise(ctx, cmd);
+    }
+
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof SslHandshakeCompletionEvent) {
+            // log handshake failures
+            SslHandshakeCompletionEvent sslHandshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
+            if (!sslHandshakeCompletionEvent.isSuccess()) {
+                log.warn("[{}] TLS handshake failed. {}", ctx.channel(), sslHandshakeCompletionEvent);
+            }
+        } else if (evt instanceof SslCloseCompletionEvent) {
+            // handle TLS close_notify event and immediately close the channel
+            // this is not handled by Netty by default
+            // See https://datatracker.ietf.org/doc/html/rfc8446#section-6.1 for more details
+            SslCloseCompletionEvent sslCloseCompletionEvent = (SslCloseCompletionEvent) evt;
+            if (sslCloseCompletionEvent.isSuccess() && ctx.channel().isActive()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Received a TLS close_notify, closing the channel.", ctx.channel());
+                }
+                ctx.close();
+            }
+        }
+        ctx.fireUserEventTriggered(evt);
     }
 }


### PR DESCRIPTION
### Motivation

Received this log entry which caused unnecessary retries and latency on a Pulsar client:
```
failed to get Partitioned metadata : SSLEngine closed already org.apache.pulsar.shade.io.netty.handler.ssl.SslClosedEngineException: SSLEngine closed already
```

The main impact of this is additional latency on client for topic lookup requests, partitioned metadata lookup requests, creating consumers and producers since the connection in closing state will be in the connection pool for some time. The assumption of this additional latency is 100ms-1 second.

There's a similar "SSLEngine closed already" issue that was resolved in reactor-netty with this PR https://github.com/reactor/reactor-netty/pull/2518

More details:
* https://datatracker.ietf.org/doc/html/rfc8446#section-6.1
* [SSL / TLS: Is a server always required to respond to a close notify?](https://security.stackexchange.com/questions/82028/ssl-tls-is-a-server-always-required-to-respond-to-a-close-notify)
  * Since TLS 1.3, it's not even part of the spec to have a response. In TLS 1.2, it's optional.

### Modifications

- Close the channel immediately when TLS close_notify event is received

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->