### PR TITLE
[fix][sec][branch-3.0] Upgrade avro to 1.11.5 to address CVE-2025-33042

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -450,8 +450,8 @@ The Apache Software License, Version 2.0
   * zt-zip
     - org.zeroturnaround-zt-zip-1.17.jar
   * Apache Avro
-    - org.apache.avro-avro-1.11.4.jar
-    - org.apache.avro-avro-protobuf-1.11.4.jar
+    - org.apache.avro-avro-1.11.5.jar
+    - org.apache.avro-avro-protobuf-1.11.5.jar
   * Apache Curator
     - org.apache.curator-curator-client-5.7.1.jar
     - org.apache.curator-curator-framework-5.7.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -411,8 +411,8 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - error_prone_annotations-2.5.1.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro
-    - avro-1.11.4.jar
-    - avro-protobuf-1.11.4.jar
+    - avro-1.11.5.jar
+    - avro-protobuf-1.11.5.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar
 
 BSD 3-clause "New" or "Revised" License

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ flexible messaging model and an intuitive client API.</description>
     <rabbitmq-client.version>5.18.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.788</aws-sdk.version>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
-    <avro.version>1.11.4</avro.version>
+    <avro.version>1.11.5</avro.version>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1743,6 +1743,8 @@ flexible messaging model and an intuitive client API.</description>
             <testRetryCount>${testRetryCount}</testRetryCount>
             <testFailFast>${testFailFast}</testFailFast>
             <testFailFastFile>${testFailFastFile}</testFailFastFile>
+            <!-- See https://github.com/apache/avro/pull/3376 -->
+            <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal,java.math.BigInteger,java.net.URI,java.net.URL,java.io.File,java.lang.Integer</org.apache.avro.SERIALIZABLE_CLASSES>
           </systemPropertyVariables>
           <properties>
             <property>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -366,8 +366,8 @@ The Apache Software License, Version 2.0
   * OpenCSV
     - opencsv-2.3.jar
   * Avro
-    - avro-1.11.4.jar
-    - avro-protobuf-1.11.4.jar
+    - avro-1.11.5.jar
+    - avro-protobuf-1.11.5.jar
   * Caffeine
     - caffeine-2.9.1.jar
   * Javax


### PR DESCRIPTION
### Motivation

- Avro release 1.11.5 contains backported security fixes that were [included in 1.12.1](https://avro.apache.org/blog/2025/10/16/avro-1.12.1/)
  - https://github.com/apache/avro/commits/release-1.11.5/lang/java

### Modifications

- Upgrade Avro from 1.11.4 to 1.11.5 in branch-3.0

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->