### PR TITLE
[improve][test] Use Oxia project docker container for integration tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/oxia/OxiaContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/oxia/OxiaContainer.java
@@ -32,7 +32,7 @@ public class OxiaContainer extends ChaosContainer<OxiaContainer> {
     public static final int METRICS_PORT = 8080;
     private static final int DEFAULT_SHARDS = 1;
 
-    private static final String DEFAULT_IMAGE_NAME = "streamnative/oxia:main";
+    private static final String DEFAULT_IMAGE_NAME = "oxia/oxia:main";
 
     public OxiaContainer(String clusterName) {
         this(clusterName, DEFAULT_IMAGE_NAME, DEFAULT_SHARDS);


### PR DESCRIPTION
### Motivation

Oxia project has been migrated to https://github.com/oxia-db/oxia. The docker images are published at https://hub.docker.com/r/oxia/oxia

### Modifications

- replace `streamnative/oxia:main` with `oxia/oxia:main` in integration tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->