### PR TITLE
[fix][test] Fix flaky EndToEndMetadataTest.testPublishConsume

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
@@ -120,7 +120,6 @@ public class EmbeddedPulsarCluster implements AutoCloseable {
         conf.setManagedLedgerNumSchedulerThreads(1);
         conf.setWebSocketNumIoThreads(1);
         conf.setNumTransactionReplayThreadPoolSize(1);
-        conf.setNumHttpServerThreads(4);
 
         if (numBookies < 2) {
             conf.setManagedLedgerDefaultEnsembleSize(1);


### PR DESCRIPTION
### Motivation
When executing this test case in a 16C32G Linux environment, the following error will be encountered. The problem is that Jetty requires more than 4 threads. Therefore, we cannot configure it to 4 here; instead, we must use the default value `Math.max(8, 2 * Runtime.getRuntime().availableProcessors())`

<img width="2284" height="720" alt="Clipboard_Screenshot_1763638875" src="https://github.com/user-attachments/assets/195f7634-c176-4f90-b090-ccfa8f0a9f17" />


### Modifications 
Use the default values ​​configured for `numHttpServerThreads`.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->