### PR TITLE
[fix][client] PIP-84: Skip processing a message in the message listener if the consumer epoch is no longer valid

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -1186,6 +1186,17 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             // after enabled message listener.
             receivedConsumer.increaseAvailablePermits((MessageImpl<?>) (msg instanceof TopicMessageImpl
                                 ? ((TopicMessageImpl<T>) msg).getMessage() : msg));
+
+            MessageImpl<T> innerMessage = (MessageImpl<T>) (msg instanceof TopicMessageImpl
+                    ? ((TopicMessageImpl<T>) msg).getMessage() : msg);
+            if (!receivedConsumer.isValidConsumerEpoch(innerMessage)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{}] Skipping processing message since the consumer epoch is not valid. {}", topic,
+                            subscription, msg.getMessageId());
+                }
+                return;
+            }
+
             MessageId id;
             if (this instanceof ConsumerImpl) {
                 id = MessageIdAdvUtils.discardBatch(msg.getMessageId());


### PR DESCRIPTION
### Motivation

[PIP-84: Pulsar client: Redeliver command add epoch](https://github.com/apache/pulsar/blob/master/pip/pip-84.md) was implemented for Pulsar 2.10 with PR #10478, however it missed handling of the usage of message listeners.
When message listeners are used, the messages will get buffered in the listener's executor. This case wasn't covered.

### Modifications

Before processing a message in the message listener, add a similar check that is done for messages before processing while using the receive API. 

Tests TBD

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->