### PR TITLE
[cleanup][client] Remove unnecessary pause/resume logic from MultiTopicsConsumerImpl and cleanup putIfAbsent logic

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1131,18 +1132,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 List<CompletableFuture<Consumer<T>>> subscribeList = new ArrayList<>();
                 for (int partitionIndex : partitions) {
                     String partitionName = TopicName.get(topicName).getPartition(partitionIndex).toString();
-                    CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
-                    ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
-                            partitionIndex, subFuture, createIfDoesNotExist, schema);
-                    Consumer originalValue = consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
-                    if (originalValue != null) {
-                        newConsumer.closeAsync().exceptionally(ex -> {
-                            log.error("[{}] [{}] Failed to close the orphan consumer",
-                                    partitionName, subscription, ex);
-                            return null;
-                        });
-                    }
-                    subscribeList.add(subFuture);
+                    subscribeList.add(addNewConsumerIfNotExists(partitionName,
+                            () -> createInternalConsumer(configurationData, partitionName, partitionIndex,
+                                    new CompletableFuture<>(), createIfDoesNotExist, schema)));
                 }
                 return FutureUtil.waitForAll(subscribeList);
             });
@@ -1429,16 +1421,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     .stream()
                     .map(partitionName -> {
                         int partitionIndex = TopicName.getPartitionIndex(partitionName);
-                        CompletableFuture<Consumer<T>> subFuture = new CompletableFuture<>();
-                        ConsumerConfigurationData<T> configurationData = getInternalConsumerConfig();
-                        ConsumerImpl<T> newConsumer = createInternalConsumer(configurationData, partitionName,
-                                partitionIndex, subFuture, true, schema);
-                        consumers.putIfAbsent(newConsumer.getTopic(), newConsumer);
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] create consumer {} for partitionName: {}",
-                                    topicName, newConsumer.getTopic(), partitionName);
-                        }
-                        return subFuture;
+                        return addNewConsumerIfNotExists(partitionName,
+                                () -> createInternalConsumer(getInternalConsumerConfig(), partitionName,
+                                        partitionIndex, new CompletableFuture<>(), true, schema));
                     })
                     .collect(Collectors.toList());
                 // call interceptor
@@ -1460,6 +1445,33 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             log.warn("Failed to get partitions for topic to determine if new partitions are added", throwable);
             return null;
         });
+    }
+
+    private CompletableFuture<Consumer<T>> addNewConsumerIfNotExists(String internalTopicName,
+                                                                     Supplier<ConsumerImpl<T>> newConsumerSupplier) {
+        ConsumerImpl<T> consumer = consumers.compute(internalTopicName, (__, existingConsumer) -> {
+            if (existingConsumer != null) {
+                if (existingConsumer.subscribeFuture().isCompletedExceptionally()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Closing and replacing existing consumer that wasn't completed successfully "
+                                + "for {}", topic, subscription, internalTopicName);
+                    }
+                    existingConsumer.closeAsync();
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Reusing existing consumer for {}", topic, subscription, internalTopicName);
+                    }
+                    return existingConsumer;
+                }
+            }
+            // create the new consumer
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Creating consumer for {}", topic, subscription, internalTopicName);
+            }
+            return newConsumerSupplier.get();
+        });
+        // return the subscribe future
+        return consumer.subscribeFuture();
     }
 
     private TimerTask partitionsAutoUpdateTimerTask = new TimerTask() {


### PR DESCRIPTION
### Motivation

Cleanup code in MultiTopicsConsumerImpl.
- The pause/resume logic is unnecessary that was added in #14566. The only necessary change would be to set `configurationData.setStartPaused(paused)`
- The putIfAbsent logic is not optimal since the new consumer is first created and then closed if there's a duplicate
- The logic for putIfAbsent handling was missing in another location

### Modifications

- cleanup pause/resume logic for internal consumers
- cleanup and replace the putIfAbsent logic

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->