### PR TITLE
[fix][broker] Fix issue with schemaValidationEnforced in geo-replication

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import org.apache.pulsar.zookeeper.ZookeeperServerTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker-replication")
+public class OneWayReplicatorSchemaValidationEnforcedTest extends OneWayReplicatorTestBase {
+
+    @Override
+    @BeforeClass(alwaysRun = true, timeOut = 300000)
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true, timeOut = 300000)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Data
+    private static class MyClass {
+        int field1;
+        String field2;
+        Long field3;
+    }
+
+    @Override
+    protected void setConfigDefaults(ServiceConfiguration config, String clusterName,
+                                     LocalBookkeeperEnsemble bookkeeperEnsemble, ZookeeperServerTest brokerConfigZk) {
+        super.setConfigDefaults(config, clusterName, bookkeeperEnsemble, brokerConfigZk);
+        config.setSchemaValidationEnforced(true);
+        // disable topic auto creation so that it's possible to reproduce the scenario consistently
+        config.setAllowAutoTopicCreation(false);
+    }
+
+    @Test(timeOut = 30000)
+    public void testReplicationWithAvroSchemaWithSchemaValidationEnforced() throws Exception {
+        Schema<MyClass> myClassSchema = Schema.AVRO(MyClass.class);
+        final String topicName =
+                BrokerTestUtil.newUniqueName("persistent://" + sourceClusterAlwaysSchemaCompatibleNamespace + "/tp_");
+        // create the topic and schema in the local cluster (r1)
+        admin1.topics().createNonPartitionedTopic(topicName);
+        admin1.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
+        // create the topic and schema in the remote cluster (r2)
+        admin2.topics().createNonPartitionedTopic(topicName);
+        admin2.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
+
+        // consume from the remote cluster (r2)
+        Consumer<MyClass> consumer2 = client2.newConsumer(myClassSchema)
+                .topic(topicName).subscriptionName("sub").subscribe();
+
+        // produce to local cluster (r1)
+        Producer<MyClass> producer1 = client1.newProducer(myClassSchema).topic(topicName).create();
+        MyClass sentBody = new MyClass();
+        sentBody.setField1(1);
+        sentBody.setField2("test");
+        sentBody.setField3(123456789L);
+        producer1.send(sentBody);
+
+        // verify that the message was received from the remote cluster (r2)
+        Message<MyClass> received = consumer2.receive(10, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.getValue()).isNotNull().satisfies(receivedBody -> {
+            assertThat(receivedBody.getField1()).isEqualTo(1);
+            assertThat(receivedBody.getField2()).isEqualTo("test");
+            assertThat(receivedBody.getField3()).isEqualTo(123456789L);
+        });
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -424,7 +424,7 @@ public class PulsarClientImpl implements PulsarClient {
 
         if (schema instanceof AutoProduceBytesSchema) {
             AutoProduceBytesSchema autoProduceBytesSchema = (AutoProduceBytesSchema) schema;
-            if (autoProduceBytesSchema.schemaInitialized()) {
+            if (autoProduceBytesSchema.hasUserProvidedSchema()) {
                 return createProducerAsync(topic, conf, schema, interceptors);
             }
             return lookup.getSchema(TopicName.get(conf.getTopicName()))

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -35,12 +35,14 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
     @Setter
     private boolean requireSchemaValidation = true;
     private Schema<T> schema;
+    private boolean userProvidedSchema;
 
     public AutoProduceBytesSchema() {
     }
 
     public AutoProduceBytesSchema(Schema<T> schema) {
         this.schema = schema;
+        this.userProvidedSchema = true;
         SchemaInfo schemaInfo = schema.getSchemaInfo();
         this.requireSchemaValidation = schemaInfo != null
                                        && schemaInfo.getType() != SchemaType.BYTES
@@ -60,6 +62,10 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
 
     public boolean schemaInitialized() {
         return schema != null;
+    }
+
+    public boolean hasUserProvidedSchema() {
+        return userProvidedSchema;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Geo-replication will fail with `schemaValidationEnforced` enabled in certain cases currently. 
The replication will be in a loop loggin "IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled" warnings and errors.

Example logs from the test that reproduces the issue:
```
2025-11-24T17:45:05,002 - WARN  - [pulsar-io-64-7:ClientCnx] - [id: 0xca37c05a, L:/127.0.0.1:61297 - R:localhost/127.0.0.1:61194] Received error from server: org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled
2025-11-24T17:45:05,002 - ERROR - [pulsar-io-64-7:ProducerImpl] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8] [pulsar.repl.r1-->r2] Failed to create producer: {"errorMsg":"org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled","reqId":1217737249645833457, "remote":"localhost/127.0.0.1:61194", "local":"/127.0.0.1:61297"}
2025-11-24T17:45:05,002 - WARN  - [pulsar-io-64-7:AbstractReplicator] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8 | r1-->r2] Failed to create remote producer (org.apache.pulsar.client.api.PulsarClientException$IncompatibleSchemaException: {"errorMsg":"org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled","reqId":1217737249645833457, "remote":"localhost/127.0.0.1:61194", "local":"/127.0.0.1:61297"}), retrying in 0.382 s
2025-11-24T17:45:05,012 - INFO  - [pulsar-io-64-5:AbstractReplicator] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8 | r1-->r2] Starting replicator
2025-11-24T17:45:05,013 - INFO  - [pulsar-io-64-10:ConnectionPool] - [[id: 0x153925b5, L:/127.0.0.1:61298 - R:localhost/127.0.0.1:61194]] Connected to server
2025-11-24T17:45:05,013 - INFO  - [pulsar-io-105-14:ServerCnx] - [/127.0.0.1:61298] connected with clientVersion=Pulsar-Java-v4.2.0-SNAPSHOT, clientProtocolVersion=21, proxyVersion=null
2025-11-24T17:45:05,014 - INFO  - [pulsar-io-64-24:ProducerImpl] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8] [pulsar.repl.r1-->r2] Creating producer on cnx [id: 0xae6e9a97, L:/127.0.0.1:61237 - R:localhost/127.0.0.1:61194]
2025-11-24T17:45:05,015 - WARN  - [pulsar-io-64-18:ClientCnx] - [id: 0xae6e9a97, L:/127.0.0.1:61237 - R:localhost/127.0.0.1:61194] Received error from server: org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled
2025-11-24T17:45:05,015 - ERROR - [pulsar-io-64-18:ProducerImpl] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8] [pulsar.repl.r1-->r2] Failed to create producer: {"errorMsg":"org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled","reqId":1217737249645833460, "remote":"localhost/127.0.0.1:61194", "local":"/127.0.0.1:61237"}
2025-11-24T17:45:05,015 - WARN  - [pulsar-io-64-18:AbstractReplicator] - [persistent://public/always-compatible/tp_-206e9fd0-3dab-49eb-99f6-ebfa1a8452d8 | r1-->r2] Failed to create remote producer (org.apache.pulsar.client.api.PulsarClientException$IncompatibleSchemaException: {"errorMsg":"org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled caused by org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException: Producers cannot connect or send message without a schema to topics with a schemawhen SchemaValidationEnforced is enabled","reqId":1217737249645833460, "remote":"localhost/127.0.0.1:61194", "local":"/127.0.0.1:61237"}), retrying in 0.782 s
```

The root cause of the problem is in this implementation code in the Pulsar client that geo-replication uses:
https://github.com/apache/pulsar/blob/c8d6208bb364c3c65215cf235feeaec20c0adb9d/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java#L426-L443

After the first lookup for the schema, the schema will be cached. When the schema is missing from the remote cluster's topic, it will always be initialized to `Schema.BYTES`. If topic is configured to have a schema, this will get ignored by the replicator since it will continue to use `Schema.BYTES` for replication.

### Modifications

- modify the logic to only use the cached schema when it was provided by the user code with `org.apache.pulsar.client.api.Schema#AUTO_PRODUCE_BYTES(org.apache.pulsar.client.api.Schema<?>)` method.
- continue to cache the returned schema since it's needed for producing messages. However, when reinitializing the producer, it will get fetched each time from the broker so that schema updates will be detected. This is needed for fixing the replication issue.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->