### PR TITLE
[fix][client] Fix AutoProduceBytesSchema.clone() method

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchema.java
@@ -50,7 +50,7 @@ public class AutoProduceBytesSchema<T> implements Schema<byte[]> {
     }
 
     private AutoProduceBytesSchema(AutoProduceBytesSchema<T> other) {
-        this.schema = other.schema;
+        this.schema = other.schema != null ? other.schema.clone() : null;
         this.userProvidedSchema = other.userProvidedSchema;
         this.requireSchemaValidation = other.requireSchemaValidation;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoProduceBytesSchemaTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
@@ -62,6 +65,14 @@ public class AutoProduceBytesSchemaTest {
         assertFalse(castedClone3.hasUserProvidedSchema());
         assertTrue(castedClone3.schemaInitialized());
         assertEquals(castedClone3.getSchemaInfo().getType(), SchemaType.STRING);
+    }
+
+    @Test
+    public void testInnerSchemaGetsCloned() {
+        Schema<String> stringSchema = spy(Schema.STRING);
+        AutoProduceBytesSchema<String> schema = new AutoProduceBytesSchema<>(stringSchema);
+        schema.clone();
+        verify(stringSchema, times(1)).clone();
     }
 
 }


### PR DESCRIPTION
### Motivation

AutoProduceBytesSchema has a clone method and it would be expected that it returns a new instance which has similar state as the original instance. This is not the case currently.

### Modifications

- implement `AutoProduceBytesSchema.clone()` properly

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->