### PR TITLE
[improve][broker]Remove the warn log that frequently prints

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3881,8 +3881,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 || pos2.getLedgerId() < getFirstPosition().getLedgerId()
                 || pos1.getLedgerId() > getLastPosition().getLedgerId()
                 || pos2.getLedgerId() > getLastPosition().getLedgerId()) {
-            log.warn("[{}] Comparing un-exist position {} and {}", name, pos1, pos2,
-                    new IllegalArgumentException("Comparing un-exist position"));
             return pos1.compareTo(pos2);
         }
         if (pos1.getLedgerId() == pos2.getLedgerId()) {


### PR DESCRIPTION
### Motivation

When I added the log below with https://github.com/apache/pulsar/pull/24938, I assumed the method `ManagedLedgerImpl.comparePositions` will only be executed when mark deleting cursors, so a position does not exist should not happen, but it is also used when getting metrics. 

The logs that were frequently printed are noisy.

```
2025-11-25T11:30:49,286+0000 [pulsar-stats-updater-31-1] WARN org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/__transaction_buffer_snapshot-partition-0] Comparing un-exist position 57:9 and 421199:-1 java.lang.IllegalArgumentException: Comparing un-exist position at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.comparePositions(ManagedLedgerImpl.java:3737) at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.getNumberOfEntries(ManagedLedgerImpl.java:3762) at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNumberOfEntries(ManagedCursorImpl.java:1754) at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNumberOfEntriesInBacklog(ManagedCursorImpl.java:1268) at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getNumberOfEntriesInBacklog(ManagedCursorImpl.java:1279) at org.apache.pulsar.broker.service.persistent.PersistentSubscription.getNumberOfEntriesInBacklog(PersistentSubscription.java:977) at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$updateRates$109(PersistentTopic.java:2680) at java.base/java.util.concurrent.ConcurrentHashMap.forEach(Unknown Source) at org.apache.pulsar.broker.service.persistent.PersistentTopic.updateRates(PersistentTopic.java:2650) at org.apache.pulsar.broker.service.PulsarStats.lambda$updateStats$1(PulsarStats.java:141) at java.base/java.util.concurrent.ConcurrentHashMap.forEach(Unknown Source) at org.apache.pulsar.broker.service.PulsarStats.lambda$updateStats$3(PulsarStats.java:138) at java.base/java.util.concurrent.ConcurrentHashMap.forEach(Unknown Source) at org.apache.pulsar.broker.service.PulsarStats.lambda$updateStats$4(PulsarStats.java:126) at java.base/java.util.concurrent.ConcurrentHashMap.forEach(Unknown Source) at org.apache.pulsar.broker.service.PulsarStats.updateStats(PulsarStats.java:116) at org.apache.pulsar.broker.service.BrokerService.updateRates(BrokerService.java:2244) at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) at java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source) at org.apache.pulsar.common.util.SingleThreadNonConcurrentFixedRateScheduler$ScheduledFutureTask.run(SingleThreadNonConcurrentFixedRateScheduler.java:371) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) at java.base/java.lang.Thread.run(Unknown Source)
```

### Modifications

Remove the log.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x