### PR TITLE
[improve][pip] PIP-449: Improve metadata sync to have exclusions in syncing specific config matching regex pattern across onprem and cloud clusters

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -36,6 +36,7 @@ metadataSyncEventTopic=
 configurationMetadataSyncEventTopic=
 
 # Exclusions for metadata sync between separate clusters on different cloud platforms
+# multiple configurations are separated by comma eg. /admin/clusters/.*,/admin/test/.*
 metadataSyncEventExclusions=
 
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -35,6 +35,9 @@ metadataSyncEventTopic=
 # Event topic to sync configuration-metadata between separate pulsar clusters on different cloud platforms.
 configurationMetadataSyncEventTopic=
 
+# Exclusions for metadata sync between separate clusters on different cloud platforms
+metadataSyncEventExclusions=
+
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl
 configurationMetadataStoreUrl=
 

--- a/pip/pip-449.md
+++ b/pip/pip-449.md
@@ -12,8 +12,9 @@ The metadata sync feature syncs all the configuration metadata cluster/tenant/na
 
 
 # Motivation
-The pulsar metadata sync feature syncs all the configuration metadata cluster/tenant/namespace/topic policies and has no way to exclude specific config (eg. cluster configuration) from synchronization across clusters. This is crucial for pulsar multi-environment cluster set up where a cluster can have different configuration in on-prem and cloud and synchronizing this configuration can break geo replication across clusters in different environments on-prem and cloud. Also in pulsar set up where there is separate cluster for a high value tenant in on-prem vs a common cluster for all other tenants, this exclusion in metadata sync becomes crucial in synchronizing tenant policies across onprem and cloud clusters. 
+The pulsar metadata sync feature syncs all the configuration metadata cluster/tenant/namespace/topic policies and has no way to exclude specific config (eg. cluster configuration) from synchronization across clusters. This is crucial for pulsar multi-environment cluster set up where a cluster can have different configuration in on-prem and cloud and synchronizing this configuration can break geo replication across clusters in different environments on-prem and cloud. Also in pulsar set up where there is separate cluster for a high value tenant in on-prem vs a common cluster for all other tenants, this exclusion in metadata sync becomes crucial in synchronizing tenant/namespace/topic policies across onprem and cloud clusters. 
 
+![diagram](https://github-production-user-asset-6210df.s3.amazonaws.com/95091480/523150696-462180ad-2dbf-4e80-929f-26134c087691.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20251205%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20251205T202822Z&X-Amz-Expires=300&X-Amz-Signature=3b3ec1d227d1ca5f1283a18488aa21d3c227ad782507ba87e6f821a5e8f5d7ff&X-Amz-SignedHeaders=host)
 # Goals
 
 ## In Scope
@@ -34,7 +35,6 @@ Configure regex pattern in `metadataSyncEventExclusions` as part of the broker c
 - Add a config `metadataSyncEventExclusions` in the broker config to capture exclusion patterns for the cluster.
 - Add a method `private boolean isMetadataEventExcluded(MetadataEvent metadataEvent)` to PulsarMetadataEventSynchronizer.java to match the regex pattern. Return true if the pattern matches the path in the MetadataEvent, false otherwise.
 - Update the message listener for the consumer on metadata sync topic to acknowledge the event without processing it if the event is excluded. 
-
 
 ### Configuration
 - Add a broker config `metadataSyncEventExclusions`

--- a/pip/pip-449.md
+++ b/pip/pip-449.md
@@ -47,4 +47,6 @@ metadataSyncEventExclusions=
 # General Notes
 
 # Links
+- Mailing List Discussion Thread - https://lists.apache.org/thread/kbkgy0q6fgt2hfyrqync2gvxsordzv0d
+- Mailing List Voting Thread -  
 

--- a/pip/pip-449.md
+++ b/pip/pip-449.md
@@ -1,0 +1,50 @@
+# PIP-449: Improve metadata sync to have exclusions in syncing config across clusters in different environments (on-prem and cloud) 
+
+Implementation: https://github.com/apache/pulsar/pull/25035
+
+# Background knowledge
+
+Apache Pulsar is a cloud-native, distributed messaging framework which natively provides geo-replication. Many organizations deploy pulsar instances on-prem and on multiple different cloud providers and at the same time they would like to enable replication between multiple clusters deployed in different cloud providers. Pulsar already provides various proxy options (Pulsar proxy/ enterprise proxy solutions on SNI) to fulfill security requirements when brokers are deployed on different security zones connected with each other.
+
+However, sometimes it's not possible to share metadata-store (global zookeeper) between pulsar clusters deployed on separate cloud provider platforms, and synchronizing configuration metadata (policies) can be a critical path to share tenant/namespace/topic policies between clusters and administrate pulsar policies uniformly across all clusters. Pulsar has metadata sync feature that syncs configurations across clusters in different environments.
+
+The metadata sync feature syncs all the configuration metadata cluster/tenant/namespace/topic policies and has no way to exclude specific config sync. This is needed as a cluster can have different config in on-prem vs cloud and synchronizing such config breaks the geo-replication. This PIP is to enhance metadata sync to exclude cluster config from syncing across clusters in on-prem and cloud.      
+
+
+# Motivation
+The pulsar metadata sync feature syncs all the configuration metadata cluster/tenant/namespace/topic policies and has no way to exclude specific config (eg. cluster configuration) from synchronization across clusters. This is crucial for pulsar multi-environment cluster set up where a cluster can have different configuration in on-prem and cloud and synchronizing this configuration can break geo replication across clusters in different environments on-prem and cloud. Also in pulsar set up where there is separate cluster for a high value tenant in on-prem vs a common cluster for all other tenants, this exclusion in metadata sync becomes crucial in synchronizing tenant policies across onprem and cloud clusters. 
+
+# Goals
+
+## In Scope
+
+Pulsar metadata sync should exclude synchronization of configuration metadata cluster/tenant/namespace/topic policies across clusters based on the exclusion regex pattern set in the broker config. This helps the cluster admin to set up desired cluster configuration to achieve geo replication across multi-environment cluster in on-prem and cloud while still achieving synchronization of tenant/namespace/topic policies across clusters.
+
+## Out of Scope
+None as part of the metadata sync feature.
+
+# High Level Design
+
+Configure regex pattern in `metadataSyncEventExclusions` as part of the broker config on cluster to exclude metadata sync events from synchronizing on the cluster. The destination cluster will receive the event from the source cluster on the metadata sync topic but would not update/delete config from the metadata store if the metadata sync event matches the regex pattern configured as exclusion. A destination cluster would receive all the metadata sync events but ignore them if they match the regex pattern configured as exclusion in the broker config. Multiple comma separated regex patterns can be provided and sync event would be excluded if it matches any of the pattern. IF no exclusions are provided, configuration metadata will sync as before without any exclusions. 
+
+# Detailed Design
+
+## Design & Implementation Details
+
+- Add a config `metadataSyncEventExclusions` in the broker config to capture exclusion patterns for the cluster.
+- Add a method `private boolean isMetadataEventExcluded(MetadataEvent metadataEvent)` to PulsarMetadataEventSynchronizer.java to match the regex pattern. Return true if the pattern matches the path in the MetadataEvent, false otherwise.
+- Update the message listener for the consumer on metadata sync topic to acknowledge the event without processing it if the event is excluded. 
+
+
+### Configuration
+- Add a broker config `metadataSyncEventExclusions`
+```
+# Exclusions for metadata sync between separate clusters on different cloud platforms
+# multiple configurations are separated by comma eg. /admin/clusters/.*,/admin/test/.*
+metadataSyncEventExclusions=
+```
+
+# General Notes
+
+# Links
+

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -589,6 +589,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String configurationMetadataSyncEventTopic = null;
 
     @FieldContext(
+            category = CATEGORY_SERVER,
+            doc = "Metadata events to be excluded from synchronization between Pulsar "
+                    + "clusters deployed on different cloud platforms."
+    )
+    private String metadataSyncEventExclusions = null;
+
+    @FieldContext(
             dynamic = true,
             doc = "Factory class-name to create topic with custom workflow"
         )

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/LocalMemoryMetadataStoreTest.java
@@ -342,11 +342,11 @@ public class LocalMemoryMetadataStoreTest {
                 "Event for /critical/data path should be notified");
 
         // Test 3: Other path - should be excluded
-        String excludedPath = "excludedPath";
+        String excludedPath = "/data/temp";
         store1.put(excludedPath, value, Optional.empty()).join();
         Thread.sleep(100);
         assertNull(sync.notifiedEvents.get(excludedPath),
-                "Event for excludedPath should be excluded");
+                "Event for /data/temp should be excluded");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The pulsar metadata sync does not have a way to exclude specific config from syncing across clusters. For example, a cluster need to have a separate config in on-prem and cloud for it to function correctly for geo-replication. Syncing the cluster config creates issues in geo-replication. Enhance pulsar metadata synchronizer to exclude cluster config from syncing across clusters.
Apply the exclusion in a way that a specific destination cluster can ignore a config sync based on the pattern set at the destination cluster level. Pulsar metadata synchronizer will publish the metadata change event to the destination cluster, which may or may not exclude the event depending on the exclusion pattern set in the destination broker config.
Multiple exclusions patterns can be configured and sync would be excluded if any of the patterns match. 

### Modifications

- Add config `metadataSyncEventExclusions` to exclude sync. Provide regex pattern eg /admin/clusters/.*, /admin/(?!.*test).* to exclude the config sync event.
- Enhance PulsarMetadataEventSynchronizer to exclude syncing events configured with `metadataSyncEventExclusions`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - Added tests to verify different regex patterns to apply exclusions to the metadata sync.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
