### PR TITLE
[improve][misc] Upgrade jjwt library version to 0.13.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -488,9 +488,9 @@ The Apache Software License, Version 2.0
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens
-    - io.jsonwebtoken-jjwt-api-0.11.1.jar
-    - io.jsonwebtoken-jjwt-impl-0.11.1.jar
-    - io.jsonwebtoken-jjwt-jackson-0.11.1.jar
+    - io.jsonwebtoken-jjwt-api-0.13.0.jar
+    - io.jsonwebtoken-jjwt-impl-0.13.0.jar
+    - io.jsonwebtoken-jjwt-jackson-0.13.0.jar
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-4.0.5.jar
   * Vertx

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.version>3.2.5.Final</debezium.version>
     <debezium.postgresql.version>${postgresql-jdbc.version}</debezium.postgresql.version>
     <debezium.mysql.version>9.4.0</debezium.mysql.version>
-    <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
+    <jsonwebtoken.version>0.13.0</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
     <hadoop3.version>3.4.2</hadoop3.version>
     <dnsjava3.version>3.6.2</dnsjava3.version>
@@ -1208,18 +1208,10 @@ flexible messaging model and an intuitive client API.</description>
 
       <dependency>
         <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-api</artifactId>
+        <artifactId>jjwt-bom</artifactId>
         <version>${jsonwebtoken.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-impl</artifactId>
-        <version>${jsonwebtoken.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-jackson</artifactId>
-        <version>${jsonwebtoken.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/pulsar-broker-auth-oidc/pom.xml
+++ b/pulsar-broker-auth-oidc/pom.xml
@@ -34,10 +34,6 @@
   <description>Open ID Connect authentication plugin for broker</description>
   <name>Pulsar Broker Auth OIDC</name>
 
-  <properties>
-    <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
-  </properties>
-
   <dependencies>
 
     <dependency>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pulsar.broker.authorization;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwt;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.RequiredTypeException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -64,12 +67,16 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
     // The token's claim that corresponds to the "role" string
     static final String CONF_TOKEN_AUTH_CLAIM = "tokenAuthClaim";
 
+    static final String DEFAULT_ROLE_CLAIM = "roles";
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     private final JwtParser parser;
     private String roleClaim;
 
     public MultiRolesTokenAuthorizationProvider() {
-        this.roleClaim = Claims.SUBJECT;
-        this.parser = Jwts.parserBuilder().build();
+        this.roleClaim = DEFAULT_ROLE_CLAIM;
+        this.parser = Jwts.parser().unsecured().build();
     }
 
     @Override
@@ -179,30 +186,26 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
             log.warn("Unable to extract additional roles from JWT token");
             return Collections.emptySet();
         }
-        String unsignedToken = splitToken[0] + "." + splitToken[1] + ".";
-
-        Jwt<?, Claims> jwt = parser.parseClaimsJwt(unsignedToken);
-        try {
-            final String jwtRole = jwt.getBody().get(roleClaim, String.class);
-            if (jwtRole == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Do not have corresponding claim in jwt token. claim={}", roleClaim);
-                }
-                return Collections.emptySet();
-            }
-            return new HashSet<>(Collections.singletonList(jwtRole));
-        } catch (RequiredTypeException requiredTypeException) {
-            try {
-                List list = jwt.getBody().get(roleClaim, List.class);
-                if (list != null) {
-                    return new HashSet<String>(list);
-                }
-            } catch (RequiredTypeException requiredTypeException1) {
-                return Collections.emptySet();
-            }
+        String unsignedToken = replaceAlgWithNoneInHeader(splitToken[0]) + "." + splitToken[1] + ".";
+        Object jwtRole = parser.parseUnsecuredClaims(unsignedToken).getBody().get(roleClaim);
+        if (jwtRole instanceof String) {
+            return new HashSet<String>(Collections.singletonList((String) jwtRole));
+        } else if (jwtRole instanceof Collection) {
+            return new HashSet<>((Collection<String>) jwtRole);
+        } else {
+            return Collections.emptySet();
         }
+    }
 
-        return Collections.emptySet();
+    // replace alg with none in header so that it can be parsed in unsecured mode
+    private static String replaceAlgWithNoneInHeader(String header) {
+        try {
+            JsonNode jsonNode = mapper.readTree(Base64.getDecoder().decode(header));
+            ((ObjectNode) jsonNode).put("alg", "none");
+            return Base64.getEncoder().withoutPadding().encodeToString(mapper.writeValueAsBytes(jsonNode));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public CompletableFuture<Boolean> authorize(String role, AuthenticationDataSource authenticationData,

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -92,10 +92,10 @@ public class AuthenticationProviderTokenTest {
                 .compact();
 
         @SuppressWarnings("unchecked")
-        Jwt<?, Claims> jwt = Jwts.parserBuilder()
+        Jws<Claims> jwt = Jwts.parser()
                 .setSigningKey(AuthTokenUtils.decodeSecretKey(secretKey.getEncoded()))
                 .build()
-                .parse(token);
+                .parseSignedClaims(token);
 
         assertNotNull(jwt);
         assertNotNull(jwt.getBody());
@@ -115,10 +115,10 @@ public class AuthenticationProviderTokenTest {
                 Optional.empty());
 
         @SuppressWarnings("unchecked")
-        Jwt<?, Claims> jwt = Jwts.parserBuilder().setSigningKey(
-                AuthTokenUtils.decodePublicKey(Decoders.BASE64.decode(publicKey), SignatureAlgorithm.RS256))
+        Jws<Claims> jwt = Jwts.parser().setSigningKey(
+                        AuthTokenUtils.decodePublicKey(Decoders.BASE64.decode(publicKey), SignatureAlgorithm.RS256))
                 .build()
-                .parse(token);
+                .parseSignedClaims(token);
 
         assertNotNull(jwt);
         assertNotNull(jwt.getBody());

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -43,7 +43,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
         String userA = "user-a";
         String userB = "user-b";
-        String token = Jwts.builder().claim("sub", new String[]{userA, userB}).signWith(secretKey).compact();
+        String token = Jwts.builder().claim("roles", new String[]{userA, userB}).signWith(secretKey).compact();
 
         MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
         ServiceConfiguration conf = new ServiceConfiguration();
@@ -84,7 +84,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
     @Test
     public void testMultiRolesAuthzWithEmptyRoles() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
-        String token = Jwts.builder().claim("sub", new String[]{}).signWith(secretKey).compact();
+        String token = Jwts.builder().claim("roles", new String[]{}).signWith(secretKey).compact();
 
         MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
         ServiceConfiguration conf = new ServiceConfiguration();
@@ -113,7 +113,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
     public void testMultiRolesAuthzWithSingleRole() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
         String testRole = "test-role";
-        String token = Jwts.builder().claim("sub", testRole).signWith(secretKey).compact();
+        String token = Jwts.builder().claim("roles", testRole).signWith(secretKey).compact();
 
         MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
         ServiceConfiguration conf = new ServiceConfiguration();
@@ -147,7 +147,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
     public void testMultiRolesAuthzWithoutClaim() throws Exception {
         final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
         final String testRole = "test-role";
-        // broker will use "sub" as the claim by default.
+        // broker will use "roles" as the claim by default.
         final String token = Jwts.builder()
                 .claim("whatever", testRole).signWith(secretKey).compact();
         ServiceConfiguration conf = new ServiceConfiguration();
@@ -268,7 +268,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
     public void testMultiRolesAuthzWithSuperUser() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
         String testAdminRole = "admin";
-        String token = Jwts.builder().claim("sub", testAdminRole).signWith(secretKey).compact();
+        String token = Jwts.builder().claim("roles", testAdminRole).signWith(secretKey).compact();
 
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setSuperUserRoles(Set.of(testAdminRole));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtils.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.utils.auth.tokens;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -291,7 +291,7 @@ public class TokensCliUtils {
             }
 
             // Validate the token
-            Jwt<?, Claims> jwt = Jwts.parserBuilder()
+            Jws<Claims> jwt = Jwts.parser()
                     .setSigningKey(validationKey)
                     .build()
                     .parseClaimsJws(token);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
@@ -21,8 +21,8 @@ package org.apache.pulsar.utils.auth.tokens;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwsHeader;
-import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import java.io.ByteArrayOutputStream;
@@ -73,12 +73,12 @@ public class TokensCliUtilsTest {
             };
 
             new TokensCliUtils().execute(command);
-            String token = baoStream.toString();
+            String token = baoStream.toString().trim();
 
-            Jwt<?, ?> jwt = Jwts.parserBuilder()
+            Jws<Claims> jwt = Jwts.parser()
                     .setSigningKey(Decoders.BASE64.decode(secretKey))
                     .build()
-                    .parseClaimsJws(token);
+                    .parseSignedClaims(token);
 
             JwsHeader header = (JwsHeader) jwt.getHeader();
             String keyId = header.getKeyId();
@@ -108,13 +108,13 @@ public class TokensCliUtilsTest {
             };
 
             new TokensCliUtils().execute(command);
-            String token = baoStream.toString();
+            String token = baoStream.toString().trim();
 
             Instant start = (new Date().toInstant().plus(expireAsSec - 5, ChronoUnit.SECONDS));
             Instant stop = (new Date().toInstant().plus(expireAsSec + 5, ChronoUnit.SECONDS));
 
             //Act
-            Claims jwt = Jwts.parserBuilder()
+            Claims jwt = Jwts.parser()
                     .setSigningKey(Decoders.BASE64.decode("u+FxaxYWpsTfxeEmMh8fQeS3g2jfXw4+sGIv+PTY+BY="))
                     .build()
                     .parseClaimsJws(token)


### PR DESCRIPTION
### Motivation

The jjwt library version is very old and outdated. It's better to make changes in Pulsar so that the recent version of the library could be used.

### Modifications

- upgrade jjwt (jsonwebtoken) library from 0.11.1 to 0.13.0 version
- make changes to adapt to breaking changes in jjwt library
- since the library has breaking changes, it's better to not cherry-pick this change to maintenance branches
- another breaking change is that MultiRolesTokenAuthorizationProvider cannot use "sub" for multiple roles since the newer jjwt library validates that the token conforms to the JWT spec. The spec doesn't allow a list for "sub". The default property has been changed from "sub" to "roles".

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->