### PR TITLE
[fix][cli] Fix some pulsar-admin topicPolicies commands exiting before async operations complete

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1959,7 +1959,7 @@ public class CmdTopicPolicies extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
-            getTopicPolicies(isGlobal).setDispatcherPauseOnAckStatePersistent(persistentTopic);
+            sync(() -> getTopicPolicies(isGlobal).setDispatcherPauseOnAckStatePersistent(persistentTopic));
         }
     }
 
@@ -1978,7 +1978,8 @@ public class CmdTopicPolicies extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
-            print(getTopicPolicies(isGlobal).getDispatcherPauseOnAckStatePersistent(persistentTopic, applied));
+            print(sync(() ->
+                    (getTopicPolicies(isGlobal).getDispatcherPauseOnAckStatePersistent(persistentTopic, applied))));
         }
     }
 
@@ -1994,7 +1995,7 @@ public class CmdTopicPolicies extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(topicName);
-            getTopicPolicies(isGlobal).removeDispatcherPauseOnAckStatePersistent(persistentTopic);
+            sync(() -> getTopicPolicies(isGlobal).removeDispatcherPauseOnAckStatePersistent(persistentTopic));
         }
     }
 


### PR DESCRIPTION
### Background
`PulsarAdminTool` is the management of execution of pulsar admin client commans, it calls `command.run` and then calls`systm.exit`.

### Motivation

The command `pulsar-admin topicPolicies set-replication-clusters` is an asynchronize method, so it can not be executed since `system.exit` runs before the asynchronize method. See also https://github.com/apache/pulsar/blob/v4.1.2/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java#L227-L233

When you call `pulsar-admin topicPolicies set-replication-clusters`, it does nothing.

### Modifications

Wrap these async topicPolicies operations with sync() to prevent premature exit
* setReplicationClusters
* setDispatcherPauseOnAckStatePersistent
* getDispatcherPauseOnAckStatePersistent
* removeDispatcherPauseOnAckStatePersistent


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
