### PR TITLE
[fix][cli] Fix output of --print-metadata in cli consume

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/AbstractCmdConsume.java
@@ -134,11 +134,11 @@ public abstract class AbstractCmdConsume extends AbstractCmd {
                     encContext.getKeys().forEach((keyName, keyInfo) -> {
                         String metadata = Arrays.toString(keyInfo.getMetadata().entrySet().toArray());
                         sb.append("name:").append(keyName).append(", ").append("key-value:")
-                                .append(Base64.getEncoder().encode(keyInfo.getKeyValue())).append(", ")
+                                .append(Base64.getEncoder().encodeToString(keyInfo.getKeyValue())).append(", ")
                                 .append("metadata:").append(metadata).append(", ");
 
                     });
-                    sb.append(", ").append("param:").append(Base64.getEncoder().encode(encContext.getParam()))
+                    sb.append(", ").append("param:").append(Base64.getEncoder().encodeToString(encContext.getParam()))
                             .append(", ").append("algorithm:").append(encContext.getAlgorithm()).append(", ")
                             .append("compression-type:").append(encContext.getCompressionType()).append(", ")
                             .append("uncompressed-size").append(encContext.getUncompressedMessageSize()).append(", ")


### PR DESCRIPTION
### Motivation

Appending a bytes array to a StringBuilder doesn't make sense. Code was added in #23347.
This issue found with errorprone.

### Modifications

- fix issue by calling `encodeToString` on Base64 encoder

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->