### PR TITLE
[fix][broker] fix delayedMessagesCount error in InMemoryDelayedDeliveryTracker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -130,7 +130,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                 .computeIfAbsent(timestamp, k -> new Long2ObjectRBTreeMap<>())
                 .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap());
         if (!roaring64Bitmap.contains(entryId)) {
-            roaring64Bitmap.add(entryId);
+            roaring64Bitmap.addLong(entryId);
             delayedMessagesCount.incrementAndGet();
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -126,10 +126,13 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
         }
 
         long timestamp = trimLowerBit(deliverAt, timestampPrecisionBitCnt);
-        delayedMessageMap.computeIfAbsent(timestamp, k -> new Long2ObjectRBTreeMap<>())
-                .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap())
-                .add(entryId);
-        delayedMessagesCount.incrementAndGet();
+        Roaring64Bitmap roaring64Bitmap = delayedMessageMap
+                .computeIfAbsent(timestamp, k -> new Long2ObjectRBTreeMap<>())
+                .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap());
+        if (!roaring64Bitmap.contains(entryId)) {
+            roaring64Bitmap.add(entryId);
+            delayedMessagesCount.incrementAndGet();
+        }
 
         updateTimer();
 
@@ -200,7 +203,12 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                     delayedMessagesCount.addAndGet(-n);
                     n = 0;
                 }
-                if (n <= 0) {
+                if (n == 0) {
+                    break;
+                } else if (n < 0) {
+                    // should not go into this situation
+                    log.error("[{}] Delayed message tracker getScheduledMessages should not < 0, number is: {}",
+                            dispatcher.getName(), n);
                     break;
                 }
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -279,7 +279,8 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
         assertFalse(tracker.hasMessageAvailable());
 
         // case1: addMessage() with duplicate entryId,
-        // getScheduledMessages() enter "cardinality <= n" and make tracker empty
+        // getScheduledMessages() enter multiple timestamp and "cardinality <= n",
+        // finally make tracker empty
         assertTrue(tracker.addMessage(1, 1, 10));
         assertTrue(tracker.addMessage(1, 2, 20));
         assertTrue(tracker.addMessage(1, 2, 20));
@@ -298,7 +299,8 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
 
 
         // case2: addMessage() with duplicate entryId,
-        // getScheduledMessages() enter "cardinality > n" and make tracker empty
+        // getScheduledMessages() enter one timestamp and "cardinality <= n",
+        // finally make tracker empty
         clockTime.set(0);
         assertTrue(tracker.addMessage(1, 1, 10));
         assertTrue(tracker.addMessage(1, 2, 10));
@@ -318,7 +320,8 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
 
 
         // case3: addMessage() with duplicate entryId,
-        // getScheduledMessages() make tracker remain half cardinality
+        // getScheduledMessages() enter one timestamp and "cardinality > n",
+        // finally make tracker remain half cardinality
         clockTime.set(0);
         assertTrue(tracker.addMessage(1, 1, 10));
         assertTrue(tracker.addMessage(1, 2, 10));


### PR DESCRIPTION
### Motivation

Occur a NPE issue in delay message. And then find the reason is in delayedMessagesCount. When InMemoryDelayedDeliveryTracker#addMessage(), it don't judge whether the entryId is exist in roaringbitmap, that result in the delayedMessagesCount of the map size is not correct. 

<img width="1261" height="136" alt="企业微信截图_bb4f30f2-8829-413d-a7e8-e8746dc07adc" src="https://github.com/user-attachments/assets/4a6c1960-728b-4d9b-86c0-c072a2b61a25" />


### Modifications

1. add test to test the duplicate entry case 
2. check whether roaring64Bitmap contains entryId
3. log error for the case of "n < 0" in getScheduledMessages(), since this case should not occur

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

