### PR TITLE
[fix][build] Activate jdk21 and jdk24 profiles on Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2986,7 +2986,7 @@ flexible messaging model and an intuitive client API.</description>
     <profile>
       <id>jdk21</id>
       <activation>
-        <jdk>21</jdk>
+        <jdk>[21,)</jdk>
       </activation>
       <properties>
         <!-- nifi-nar-maven-plugin >= 2.0.0 require Java 21+ -->
@@ -3026,7 +3026,7 @@ flexible messaging model and an intuitive client API.</description>
     <profile>
       <id>jdk24</id>
       <activation>
-        <jdk>24</jdk>
+        <jdk>[24,)</jdk>
       </activation>
       <properties>
         <!-- JDK 24+ specific arguments -->


### PR DESCRIPTION
### Motivation

There's currently profiles for `jdk21` and `jdk24` which get activated when the Java version is exactly Java 21 or Java 24. These profiles are intended to be used when the build JVM is the same version or greater. This is necessary for better support for Java 25 builds. 

### Modifications

- use version rule "equal or greater" for jdk21 and jdk24 profiles

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->