### PR TITLE
[fix][sec] Upgrade jose4j to 0.9.6 to address CVE-2024-29371

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -264,7 +264,7 @@ The Apache Software License, Version 2.0
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.59.2.jar
- * Bitbucket -- org.bitbucket.b_c-jose4j-0.9.4.jar
+ * Bitbucket -- org.bitbucket.b_c-jose4j-0.9.6.jar
  * Gson
     - com.google.code.gson-gson-2.13.2.jar
     - io.gsonfire-gson-fire-1.9.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@ flexible messaging model and an intuitive client API.</description>
     <jakarta.validation.version>2.0.2</jakarta.validation.version>
     <jna.version>5.12.1</jna.version>
     <kubernetesclient.version>23.0.0</kubernetesclient.version>
-    <jose4j.version>0.9.4</jose4j.version>
+    <jose4j.version>0.9.6</jose4j.version>
     <okhttp3.version>5.3.1</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
     <okio.version>3.16.3</okio.version>


### PR DESCRIPTION
### Motivation

jose4j 0.9.4 contains CVE-2024-29371 vulnerability

### Modifications

upgrade jose4j from 0.9.4 to 0.9.6 (latest)

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->