### PR TITLE
[improve][broker]Improve ManagedLedger search position by offset

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -712,6 +712,17 @@ public interface ManagedLedger {
     CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate);
 
     /**
+     * Optimized find position by offset with predicate.
+     * Uses first entry index metadata to skip ledgers where the target offset
+     * is smaller than the ledger's first entry index, improving performance.
+     *
+     * @param offset the target offset to find
+     * @param predicate the predicate to test entries
+     * @return CompletableFuture<Position> the position where the predicate matches
+     */
+    CompletableFuture<Position> asyncFindPosition(long offset, Predicate<Entry> predicate);
+
+    /**
      * Get the ManagedLedgerInterceptor for ManagedLedger.
      * */
     ManagedLedgerInterceptor getManagedLedgerInterceptor();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -157,9 +157,12 @@ import org.slf4j.LoggerFactory;
 
 public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private static final long MegaByte = 1024 * 1024;
+    private static final String FIRST_ENTRY_INDEX_PROPS = "firstEntryIndex";
 
     protected static final int AsyncOperationTimeoutSeconds = 30;
 
+    // Store the firstEntryIndex calculated during ledger creation for use in createComplete callback
+    private volatile Long pendingLedgerFirstEntryIndex;
     protected final BookKeeper bookKeeper;
     protected final String name;
     private final Map<String, byte[]> ledgerMetadata;
@@ -459,9 +462,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                 if (State.Terminated.equals(state)) {
                                     currentLedger = lh;
                                 }
+                                LedgerInfo oldInfo = ledgers.get(id);
+                                List<MLDataFormats.KeyValue> oldProperties = oldInfo.getPropertiesList();
+                                Map<String, String> propertiesMap = new HashMap<>();
+                                oldProperties.forEach(kv -> propertiesMap.put(kv.getKey(), kv.getValue()));
                                 LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(id)
                                         .setEntries(lh.getLastAddConfirmed() + 1).setSize(lh.getLength())
                                         .setTimestamp(clock.millis()).build();
+                                info = updateLedgerProps(info, propertiesMap);
                                 ledgers.put(id, info);
                                 if (managedLedgerInterceptor != null) {
                                     managedLedgerInterceptor
@@ -631,9 +639,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     }
                 }
 
-                LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setTimestamp(0).build();
-                ledgers.put(lh.getId(), info);
-
+                if (managedLedgerInterceptor != null) {
+                    long firstEntryIndex = managedLedgerInterceptor.getIndex() + 1;
+                    Map<String, String> newPropertiesMap = new HashMap<>();
+                    newPropertiesMap.put(FIRST_ENTRY_INDEX_PROPS, Long.toString(firstEntryIndex));
+                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setTimestamp(0).build();
+                    info = updateLedgerProps(info, newPropertiesMap);
+                    ledgers.put(lh.getId(), info);
+                    log.info("[{}] InitializeBookKeeper "
+                            + "Creating ledger with first entry index: {}", name, firstEntryIndex);
+                } else {
+                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setTimestamp(0).build();
+                    ledgers.put(lh.getId(), info);
+                }
                 // Save it back to ensure all nodes exist
                 store.asyncUpdateLedgerIds(name, getManagedLedgerInfo(), ledgersStat, storeLedgersCb);
             });
@@ -1741,9 +1759,23 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             // Empty the list of pending requests and make all of them fail
             clearPendingAddEntries(status);
             lastLedgerCreationFailureTimestamp = clock.millis();
+            // Clear the stored firstEntryIndex on failure
+            pendingLedgerFirstEntryIndex = null;
         } else {
             log.info("[{}] Created new ledger {}", name, lh.getId());
             LedgerInfo newLedger = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setTimestamp(0).build();
+            // Use the stored firstEntryIndex instead of recalculating
+            if (pendingLedgerFirstEntryIndex != null) {
+                Map<String, String> newPropertiesMap = new HashMap<>();
+                newPropertiesMap.put(FIRST_ENTRY_INDEX_PROPS, Long.toString(pendingLedgerFirstEntryIndex));
+                newLedger = updateLedgerProps(newLedger, newPropertiesMap);
+                log.info("[{}] CreateComplete Creating ledger with stored first entry index: {}",
+                        name, pendingLedgerFirstEntryIndex);
+                // Clear the stored value after use
+                pendingLedgerFirstEntryIndex = null;
+            }
+            final LedgerInfo createdNewLedger = newLedger;
+
             final MetaStoreCallback<Void> cb = new MetaStoreCallback<Void>() {
                 @Override
                 public void operationComplete(Void v, Stat stat) {
@@ -1753,7 +1785,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     ledgersStat = stat;
                     synchronized (ManagedLedgerImpl.this) {
                         LedgerHandle originalCurrentLedger = currentLedger;
-                        ledgers.put(lh.getId(), newLedger);
+                        ledgers.put(lh.getId(), createdNewLedger);
                         currentLedger = lh;
                         currentLedgerTimeoutTriggered = new AtomicBoolean();
                         currentLedgerEntries = 0;
@@ -1805,7 +1837,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 }
             };
 
-            updateLedgersListAfterRollover(cb, newLedger);
+            updateLedgersListAfterRollover(cb, createdNewLedger);
         }
     }
 
@@ -1949,9 +1981,16 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("[{}] Ledger has been closed id={} entries={}", name, lh.getId(), entriesInLedger);
         }
         if (entriesInLedger > 0) {
-            LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setEntries(entriesInLedger)
+            LedgerInfo oldInfo = ledgers.get(lh.getId());
+            LedgerInfo newLedgerInfo = LedgerInfo.newBuilder().setLedgerId(lh.getId()).setEntries(entriesInLedger)
                     .setSize(lh.getLength()).setTimestamp(clock.millis()).build();
-            ledgers.put(lh.getId(), info);
+            if (oldInfo != null) {
+                List<MLDataFormats.KeyValue> oldProperties = oldInfo.getPropertiesList();
+                Map<String, String> newPropertiesMap = new HashMap<>();
+                oldProperties.forEach(kv -> newPropertiesMap.put(kv.getKey(), kv.getValue()));
+                newLedgerInfo = updateLedgerProps(newLedgerInfo, newPropertiesMap);
+            }
+            ledgers.put(lh.getId(), newLedgerInfo);
         } else {
             // The last ledger was empty, so we can discard it
             ledgers.remove(lh.getId());
@@ -2022,6 +2061,148 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
+    /**
+     * Optimized version of asyncFindPosition for offset-based searches.
+     * Uses getFirstEntryIndexFromLedgerMetadataAsync to skip ledgers where the target offset
+     * is smaller than the ledger's first entry index.
+     *
+     * @param offset the target offset to find
+     * @param predicate the predicate to test entries
+     * @return CompletableFuture<Position> the position where the predicate matches
+     */
+    public CompletableFuture<Position> asyncFindPosition(long offset, Predicate<Entry> predicate) {
+        CompletableFuture<Position> future = new CompletableFuture<>();
+
+        if (ledgers.isEmpty()) {
+            future.complete(null);
+            return future;
+        }
+
+        // Find the appropriate starting ledger by checking first entry indices
+        findStartingLedgerForOffset(offset)
+            .thenCompose(startLedgerId -> {
+                if (startLedgerId == null) {
+                    // No suitable ledger found, return first position
+                    Long firstLedgerId = ledgers.firstKey();
+                    Position startPosition = firstLedgerId == null ? null : PositionFactory.create(firstLedgerId, 0);
+                    return CompletableFuture.completedFuture(startPosition);
+                }
+
+                // Use the optimized starting position
+                Position startPosition = PositionFactory.create(startLedgerId, 0);
+                return asyncFindPosition(startPosition, predicate);
+            })
+            .whenComplete((position, throwable) -> {
+                if (throwable != null) {
+                    future.completeExceptionally(throwable);
+                } else {
+                    future.complete(position);
+                }
+            });
+
+        return future;
+    }
+
+    /**
+     * Find the first ledger where we should start searching based on the target offset.
+     */
+    private CompletableFuture<Long> findStartingLedgerForOffset(long targetOffset) {
+        CompletableFuture<Long> result = new CompletableFuture<>();
+
+        if (ledgers.isEmpty()) {
+            result.complete(null);
+            return result;
+        }
+
+        // Check ledgers in order to find the first one where firstEntryIndex <= targetOffset
+        checkLedgersRecursively(ledgers.navigableKeySet().iterator(), targetOffset, result);
+
+        return result;
+    }
+
+    private void checkLedgersRecursively(java.util.Iterator<Long> ledgerIterator,
+                                         long targetOffset,
+                                         CompletableFuture<Long> result) {
+        if (!ledgerIterator.hasNext()) {
+            // No suitable ledger found, use the last ledger
+            result.complete(ledgers.isEmpty() ? null : ledgers.lastKey());
+            return;
+        }
+
+        Long ledgerId = ledgerIterator.next();
+        // Check if this ledger has firstEntryIndex property
+        asyncGetLedgerProperty(ledgerId, FIRST_ENTRY_INDEX_PROPS)
+                .whenComplete((firstEntryIndexStr, throwable) -> {
+                    if (throwable != null) {
+                        log.warn("[{}] Failed to get first entry index for ledger {}, "
+                                        + "using this ledger as starting point",
+                                name, ledgerId, throwable);
+                        result.complete(ledgerId);
+                        return;
+                    }
+
+                    // If firstEntryIndex property is missing, we cannot optimize and should use this ledger
+                    if (firstEntryIndexStr == null || firstEntryIndexStr.isEmpty()) {
+                        log.debug("[{}] First entry index missing for ledger {}, using this ledger as starting point",
+                                name, ledgerId);
+                        result.complete(ledgerId);
+                        return;
+                    }
+
+                    long firstEntryIndex;
+                    try {
+                        firstEntryIndex = Long.parseLong(firstEntryIndexStr);
+                    } catch (NumberFormatException e) {
+                        log.warn("[{}] Invalid first entry index value '{}' for ledger {}, "
+                                        + "using this ledger as starting point",
+                                name, firstEntryIndexStr, ledgerId, e);
+                        result.complete(ledgerId);
+                        return;
+                    }
+
+                    if (firstEntryIndex <= targetOffset) {
+                        // Found a suitable ledger, but need to check if the next ledger might be better
+                        if (ledgerIterator.hasNext()) {
+                            Long nextLedgerId = ledgers.higherKey(ledgerId);
+                            if (nextLedgerId != null) {
+                                asyncGetLedgerProperty(nextLedgerId, FIRST_ENTRY_INDEX_PROPS)
+                                        .whenComplete((nextFirstIndexStr, nextThrowable) -> {
+                                            if (nextThrowable != null
+                                                    || nextFirstIndexStr == null
+                                                    || nextFirstIndexStr.isEmpty()) {
+                                                // Next ledger has no firstEntryIndex or error, use current ledger
+                                                result.complete(ledgerId);
+                                                return;
+                                            }
+
+                                            try {
+                                                long nextFirstIndex = Long.parseLong(nextFirstIndexStr);
+                                                if (nextFirstIndex > targetOffset) {
+                                                    // Next ledger is not suitable, use current ledger
+                                                    result.complete(ledgerId);
+                                                } else {
+                                                    // Continue checking next ledgers
+                                                    checkLedgersRecursively(ledgerIterator, targetOffset, result);
+                                                }
+                                            } catch (NumberFormatException e) {
+                                                // Next ledger has invalid firstEntryIndex, use current ledger
+                                                result.complete(ledgerId);
+                                            }
+                                        });
+                            } else {
+                                result.complete(ledgerId);
+                            }
+                        } else {
+                            result.complete(ledgerId);
+                        }
+                    } else {
+                        // This ledger's first entry is greater than target, use previous ledger if exists
+                        Long prevLedgerId = ledgers.lowerKey(ledgerId);
+                        result.complete(prevLedgerId != null ? prevLedgerId : ledgerId);
+                    }
+                });
+    }
+
     @Override
     public CompletableFuture<Position> asyncFindPosition(Predicate<Entry> predicate) {
 
@@ -2032,6 +2213,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             future.complete(null);
             return future;
         }
+        return asyncFindPosition(startPosition, predicate);
+
+    }
+
+    private CompletableFuture<Position> asyncFindPosition(Position startPosition, Predicate<Entry> predicate) {
+        CompletableFuture<Position> future = new CompletableFuture<>();
         AsyncCallbacks.FindEntryCallback findEntryCallback = new AsyncCallbacks.FindEntryCallback() {
             @Override
             public void findEntryComplete(Position position, Object ctx) {
@@ -4561,6 +4748,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 return;
             }
         }
+        if (managedLedgerInterceptor != null) {
+            long firstEntryIndex = managedLedgerInterceptor.getIndex() + 1;
+            // Store the firstEntryIndex for use in createComplete callback
+            this.pendingLedgerFirstEntryIndex = firstEntryIndex;
+        }
         createdLedgerCustomMetadata = finalMetadata;
         try {
             bookKeeper.asyncCreateLedger(config.getEnsembleSize(), config.getWriteQuorumSize(),
@@ -5144,5 +5336,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     boolean shouldCacheAddedEntry() {
         // Avoid caching entries if no cursor has been created
         return getActiveCursors().shouldCacheAddedEntry();
+    }
+
+    private LedgerInfo updateLedgerProps(LedgerInfo ledgerInfo,
+                                         Map<String, String> propertiesMap) {
+        List<MLDataFormats.KeyValue> oldProperties = ledgerInfo.getPropertiesList();
+        Map<String, String> newPropertiesMap = new HashMap<>();
+        oldProperties.forEach(kv -> newPropertiesMap.put(kv.getKey(), kv.getValue()));
+        newPropertiesMap.putAll(propertiesMap);
+        List<MLDataFormats.KeyValue> newProperties = newPropertiesMap.entrySet().stream()
+                .map(e -> MLDataFormats.KeyValue.newBuilder()
+                        .setKey(e.getKey()).setValue(e.getValue()).build()).toList();
+        return ledgerInfo.toBuilder().clearProperties().addAllProperties(newProperties).build();
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/intercept/ManagedLedgerInterceptor.java
@@ -75,6 +75,7 @@ public interface ManagedLedgerInterceptor {
      */
     void onManagedLedgerPropertiesInitialize(Map<String, String> propertiesMap);
 
+    long getIndex();
     /**
      * A handle for reading the last ledger entry.
      */

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -71,6 +71,7 @@ public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
         }
     }
 
+    @Override
     public long getIndex() {
         long index = -1;
 

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerStorageForTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerStorageForTest.java
@@ -611,6 +611,11 @@ public class CustomizedManagedLedgerStorageForTest extends ManagedLedgerClientFa
         }
 
         @Override
+        public CompletableFuture<Position> asyncFindPosition(long offset, Predicate<Entry> predicate) {
+            return delegate.asyncFindPosition(offset, predicate);
+        }
+
+        @Override
         public ManagedLedgerInterceptor getManagedLedgerInterceptor() {
             return delegate.getManagedLedgerInterceptor();
         }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionSequenceIdGenerator.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionSequenceIdGenerator.java
@@ -90,4 +90,9 @@ public class MLTransactionSequenceIdGenerator implements ManagedLedgerIntercepto
     long getCurrentSequenceId() {
         return sequenceId.get();
     }
+
+    @Override
+    public long getIndex() {
+        return -1L;
+    }
 }

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -353,6 +353,11 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
+    public CompletableFuture<Position> asyncFindPosition(long offset, Predicate<Entry> predicate) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public ManagedLedgerInterceptor getManagedLedgerInterceptor() {
         return null;
     }


### PR DESCRIPTION
### Motivation

  The current `asyncFindPosition` method has performance issues: it performs binary search by reading all entries from the beginning based on offset to find the position. This implementation causes several problems when dealing with large amounts of data:

  1. **High Latency**: Requires traversing and reading large amounts of unrelated ledgers and entries
  2. **High Traffic**: Reads unnecessary data from BookKeeper
  3. **Resource Waste**: CPU and network resources are consumed by ineffective search operations

  This problem becomes particularly severe in Pulsar topics with large amounts of historical data, significantly impacting consumer startup speed and overall performance.

  ### Modifications

  This PR optimizes the `asyncFindPosition` method through the following approaches:

  1. **Record index information during ledger creation**:
     - Write the current `ManagedLedgerInterceptor` index into `LedgerInfo`
     - Store it as the relative position of `firstEntryIndex`

  2. **Optimize search logic**:
     - Pre-judge the size relationship between the target offset and `firstEntryIndex` in `asyncFindPosition`
     - Decide whether to search the ledger based on the comparison result
     - Skip ledgers that don't contain the target offset and proceed to the next one

  3. **Reduce unnecessary data reads**:
     - Avoid reading ledger data that obviously doesn't contain the target position
     - Significantly reduce data transfer from BookKeeper
     - Substantially decrease search latency

  ### Verifying this change

  - [x] Make sure that the change passes the CI checks.

  This change added tests and can be verified as follows:

  - *Added unit tests in `ManagedLedgerInterceptorImplTest` including:*
    - `testSetFirstEntryIndex`: Verifies proper setting of firstEntryIndex during ledger creation
    - `testFindPositionByOffsetWithMissingFirstEntryIndex`: Tests backward compatibility when firstEntryIndex is not available
    - `testFindPositionByOffset`: Tests optimized position finding with various offset scenarios

  ### Does this pull request potentially affect one of the following parts:

  *If the box was checked, please highlight the changes*

  - [ ] Dependencies (add or upgrade a dependency)
  - [x] The public API - *Added `firstEntryIndex` field to LedgerInfo metadata structure*
  - [ ] The schema - *Modified LedgerInfo protobuf schema to include firstEntryIndex*
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints - *Position lookup performance improvements may affect REST API response times*
  - [ ] The admin CLI options
  - [ ] The metrics - *Added new metrics for search optimization hit/miss rates*
  - [ ] Anything that affects deployment - *LedgerInfo schema changes require careful rollout strategy*

  ### Documentation

  <!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

  - [ ] `doc` <!-- Your PR contains doc changes. -->
  - [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
  - [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
  - [ ] `doc-complete` <!-- Docs have been already added -->

  ### Matching PR in forked repository
https://github.com/gaozhangmin/pulsar/pull/13


