### PR TITLE
[fix][sec] Upgrade log4j to 2.25.3 to address CVE-2025-68161

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
     <surefire.version>3.1.0</surefire.version>
-    <log4j2.version>2.25.2</log4j2.version>
+    <log4j2.version>2.25.3</log4j2.version>
     <slf4j.version>2.0.17</slf4j.version>
     <testng.version>7.7.1</testng.version>
     <commons-lang3.version>3.19.0</commons-lang3.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -348,11 +348,11 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.25.2.jar
-    - org.apache.logging.log4j-log4j-core-2.25.2.jar
-    - org.apache.logging.log4j-log4j-slf4j2-impl-2.25.2.jar
-    - org.apache.logging.log4j-log4j-web-2.25.2.jar
-    - org.apache.logging.log4j-log4j-layout-template-json-2.25.2.jar
+    - org.apache.logging.log4j-log4j-api-2.25.3.jar
+    - org.apache.logging.log4j-log4j-core-2.25.3.jar
+    - org.apache.logging.log4j-log4j-slf4j2-impl-2.25.3.jar
+    - org.apache.logging.log4j-log4j-web-2.25.3.jar
+    - org.apache.logging.log4j-log4j-layout-template-json-2.25.3.jar
  * Java Native Access JNA
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -383,10 +383,10 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
  * Log4J
-    - log4j-api-2.25.2.jar
-    - log4j-core-2.25.2.jar
-    - log4j-slf4j2-impl-2.25.2.jar
-    - log4j-web-2.25.2.jar
+    - log4j-api-2.25.3.jar
+    - log4j-core-2.25.3.jar
+    - log4j-slf4j2-impl-2.25.3.jar
+    - log4j-web-2.25.3.jar
  * OpenTelemetry
     - opentelemetry-api-1.56.0.jar
     - opentelemetry-api-incubator-1.56.0-alpha.jar

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.17</slf4j.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>
-    <log4j2.version>2.25.2</log4j2.version>
+    <log4j2.version>2.25.3</log4j2.version>
     <!-- bouncycastle dependencies aren't necessarily aligned -->
     <bouncycastle.bcprov-jdk18on.version>1.78.1</bouncycastle.bcprov-jdk18on.version>
     <bouncycastle.bcpkix-jdk18on.version>1.81</bouncycastle.bcpkix-jdk18on.version>


### PR DESCRIPTION
### Motivation

log4j < 2.25.3 contains CVE-2025-68161. It's a vulnerability in the SocketAppender. It doesn't impact Pulsar users with the default configuration since SocketAppender isn't used in the default configuration. However, it's necessary to upgrade library versions to ones that don't contain known vulnerabilities.

### Modifications

- Upgrade log4j2 from 2.25.2 to 2.25.3

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->