### PR TITLE
[fix][client]Producer stuck or geo-replication stuck due to wrong value of message.numMessagesInBatch

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -5445,6 +5445,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *   https://github.com/streamnative/pulsar-rs/issues/376.
      * - Before the fix, the resend mechanism relies on `message.metadata.numMessagesInBatch`, after the fix, the
      *   producer only care about whether there are pending messages.
+     * see also https://github.com/apache/pulsar/pull/25106.
      */
     @Test
     public void testResendMessagesWhichNumMessagesInBatchIsZero() throws Exception {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -56,7 +56,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
### Motivation

**Background**
- Replication uses producer to copy messages, which will use the original message metadata(including `message.numMessagesInBatch`).
- Producer uses a int variable `messagesCount` to cache how many messages is in pending sending state.
- Producer will resent all pending messages after reconnections, if `messagesCount`.

**Root cause: `Producer.resendMessages` was skipped due to the following issue**
- the client side issue causes `message.metadata.numMessagesInBatch` being `0`, such as https://github.com/streamnative/pulsar-rs/issues/376
- the internal producer will copy message metadata from the original messages, which also copied a `0` value `message.metadata.numMessagesInBatch`.
- since `message.metadata.numMessagesInBatch` can be `0` due to client-side bugs, `producer.pendingMessages.messagesCount` will also be `0`, and lead to that the producer assumed there is no messages need to be resent. see also https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java#L1808
- the internal producer of replicators went to stuck state.

---

**The issue we encountered**: there are many pending requests, but `producer.messagesCount` is `0`, which leaded to skipping to resend messages.
<img width="924" height="809" alt="Screenshot 2025-12-23 at 21 59 09" src="https://github.com/user-attachments/assets/b3b3a34c-ba8d-4c2c-92a3-917372da3f7f" />


### Modifications

`Producer.resendMessage` should only care about whether there is pending requests in `producer.pendingMessages`, It should not care about how many messages in packages.


### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x