### PR TITLE
[fix][broker]Topic deleting failed after removed local cluster from namespace policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1273,34 +1273,29 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 .getTransactionPendingAckStoreSuffix(topic,
                         Codec.encode(subscriptionName)));
         if (brokerService.pulsar().getConfiguration().isTransactionCoordinatorEnabled()) {
-            CompletableFuture<ManagedLedgerConfig> managedLedgerConfig = getBrokerService().getManagedLedgerConfig(tn);
-            managedLedgerConfig.thenAccept(config -> {
-                ManagedLedgerFactory managedLedgerFactory =
-                        getBrokerService().getManagedLedgerFactoryForTopic(tn, config.getStorageClassName());
+            ManagedLedgerConfig managedLedgerConfig = ledger.getConfig();
+                ManagedLedgerFactory managedLedgerFactory = getBrokerService()
+                        .getManagedLedgerFactoryForTopic(tn, managedLedgerConfig.getStorageClassName());
                 managedLedgerFactory.asyncDelete(tn.getPersistenceNamingEncoding(),
-                        managedLedgerConfig,
-                        new AsyncCallbacks.DeleteLedgerCallback() {
-                            @Override
-                            public void deleteLedgerComplete(Object ctx) {
+                    CompletableFuture.completedFuture(managedLedgerConfig),
+                    new AsyncCallbacks.DeleteLedgerCallback() {
+                        @Override
+                        public void deleteLedgerComplete(Object ctx) {
+                            asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
+                        }
+
+                        @Override
+                        public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
+                            if (exception instanceof MetadataNotFoundException) {
                                 asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
+                                return;
                             }
 
-                            @Override
-                            public void deleteLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                                if (exception instanceof MetadataNotFoundException) {
-                                    asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
-                                    return;
-                                }
-
-                                unsubscribeFuture.completeExceptionally(exception);
-                                log.error("[{}][{}] Error deleting subscription pending ack store",
-                                        topic, subscriptionName, exception);
-                            }
-                        }, null);
-            }).exceptionally(ex -> {
-                unsubscribeFuture.completeExceptionally(ex);
-                return null;
-            });
+                            unsubscribeFuture.completeExceptionally(exception);
+                            log.error("[{}][{}] Error deleting subscription pending ack store",
+                                    topic, subscriptionName, exception);
+                        }
+                    }, null);
         } else {
             asyncDeleteCursorWithClearDelayedMessage(subscriptionName, unsubscribeFuture);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -495,6 +495,7 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         admin1.namespaces().createNamespace(ns1);
         admin1.namespaces().setNamespaceReplicationClusters(ns1, new HashSet<>(Arrays.asList(cluster1, cluster2)));
         admin1.topics().createNonPartitionedTopic(topic);
+        admin1.topics().createSubscription(topic, "s1", MessageId.earliest);
 
         // Wait for loading topic up.
         Producer<String> p = client1.newProducer(Schema.STRING).topic(topic).create();


### PR DESCRIPTION
### Motivation

**Background**

Broker will delete topics automaticailly if the local cluster is removed from namespace-level policies.

The PR https://github.com/apache/pulsar/pull/23313 made topic deletion relies on reading namespace level policies, which leads to the issue that topic deletion fails if the local cluster has been removed from namespace-level policies.

**before #23313, the steps that deletes topics**
- disconnect clients
- unsubscribe all subscriptions
- delete topic

**after #23313, the steps that deletes topics**
- disconnect clients
- unsubscribe all subscriptions
  - **(Highlight)** query namespace policies and topic level policies, which will fail since the local cluster has been removed already. See also https://github.com/apache/pulsar/pull/23313/files#diff-5edf14cc6f25857d0cfdd26b2d3b3141230ecfb0dfa95aebf7583fd76ede4c4bR1237-R1238
- delete topic

```
2025-12-24T02:04:30,422+0000 [pulsar-io-9-3] ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://bedrock/bedrock-pulsar-app-1/topic-1-partition-2] Error deleting topic java.util.concurrent.CompletionException: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Topic creation encountered an exception by initialize topic policies service. topic_name=persistent://public/default/topic-1 error_message={"errorMsg":"Namespace missing local cluster name in clusters list: local_cluster=c1 ns=public/default clusters=[c2]","reqId":931862268202628430, "remote":"xxx/xxx:6650", "local":"/xxx:57840"}
 at org.apache.pulsar.common.util.FutureUtil.wrapToCompletionException(FutureUtil.java:361)
 at org.apache.pulsar.broker.service.BrokerService.lambda$getManagedLedgerConfig$97(BrokerService.java:2125) 
 at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(Unknown Source) ~[?:?] at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source) ~[?:?]
 at org.apache.pulsar.client.impl.PulsarClientImpl.lambda$createSingleTopicReaderAsync$18(PulsarClientImpl.java:783)  at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source) ~[?:?]
 at org.apache.pulsar.client.impl.PulsarClientImpl.lambda$getPartitionedTopicMetadata$32(PulsarClientImpl.java:1239) 
 at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source) ~[?:?]
 at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$getPartitionedTopicMetadata$10(BinaryProtoLookupService.java:322)
 at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source) ~[?:?] at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
 at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(Unknown Source) ~[?:?]
 at org.apache.pulsar.client.impl.ClientCnx.handlePartitionResponse(ClientCnx.java:697) 
 at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:144)
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[io.netty-netty-codec-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[io.netty-netty-codec-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final] at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152) ~[io.netty-netty-handler-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868) ~[io.netty-netty-transport-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799) ~[io.netty-netty-transport-classes-epoll-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501) ~[io.netty-netty-transport-classes-epoll-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399) ~[io.netty-netty-transport-classes-epoll-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998) ~[io.netty-netty-common-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[io.netty-netty-common-4.1.127.Final.jar:4.1.127.Final]
 at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.127.Final.jar:4.1.127.Final]
 at java.base/java.lang.Thread.run(Unknown Source) [?:?] Caused by: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Topic creation encountered an exception by initialize topic policies service. topic_name=persistent://bedrock/bedrock-pulsar-app-1/topic-1-partition-2-ford.bdrck.bokibdrckdemo.CommonRestController%24PulsarConsumer__transaction_pending_ack error_message={"errorMsg":"Namespace missing local cluster name in clusters list: local_cluster=bdrck-pulsar-live-us-east4 ns=bedrock/bedrock-pulsar-app-1 clusters=[bdrck-pulsar-live-us-central1]","reqId":931862268202628430, "remote":"bdrck-pulsar-live-us-east4-broker-1.bdrck-pulsar-live-us-east4-broker-headless.o-livi9.svc.cluster.local/10.127.48.196:6650", "local":"/10.127.48.196:57840"} ... 45 more
```

### Modifications

Modify the step "unsubscribe all subscriptions", instead of build new managed ledger configuration, use the compeletely built config(`managedLedger.config`), which avoids to access policies.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
