### PR TITLE
[fix][broker] Move newPosition to nextValidLedger:-1 to avoid cursor position and ledger inconsistency in ManagedCursorImpl

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -497,6 +497,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Assert persist mark deleted position to ZK was successful.
         Position slowestReadPosition = ml.getCursors().getSlowestCursorPosition();
+        assertThat(slowestReadPosition).isGreaterThanOrEqualTo(lastEntry);
         assertThat(cursor.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
         assertThat(cursor.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
 
@@ -6177,7 +6178,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         }
     }
 
-    @Test(timeOut = 20000, invocationCount = 100)
+    @Test(timeOut = 20000)
     void testMarkDeletePreviousLacManyTimesInRolloverScenario() throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(1);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -456,7 +457,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ml.delete();
     }
 
-    @Test
+    @Test(timeOut = 20000)
     void testPersistentMarkDeleteIfSwitchCursorLedgerFailed() throws Exception {
         final int entryCount = 10;
         final String cursorName = "c1";
@@ -496,9 +497,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         // Assert persist mark deleted position to ZK was successful.
         Position slowestReadPosition = ml.getCursors().getSlowestCursorPosition();
-        assertTrue(slowestReadPosition.getLedgerId() >= lastEntry.getLedgerId());
-        assertTrue(slowestReadPosition.getEntryId() >= lastEntry.getEntryId());
-        assertEquals(cursor.getPersistentMarkDeletedPosition(), lastEntry);
         assertThat(cursor.getPersistentMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
         assertThat(cursor.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastEntry);
 
@@ -1837,7 +1835,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         }
     }
 
-    @Test
+    @Test(timeOut = 20000)
     void failDuringRecoveryWithEmptyLedger() throws Exception {
         ManagedLedger ledger = factory.open("my_test_ledger");
         ManagedCursor cursor = ledger.openCursor("cursor");
@@ -1853,6 +1851,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         // Re-open
         ledger = factory.open("my_test_ledger");
         cursor = ledger.openCursor("cursor");
+        // Move markDeletePosition to nextLedger:-1 since current ledger entries are consumed.
         cursor.markDelete(p3);
 
         // Force-reopen so the recovery will be forced to read from ledger
@@ -1861,11 +1860,15 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
 
         @Cleanup("shutdown")
         ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc, conf);
-        ledger = factory2.open("my_test_ledger");
-        cursor = ledger.openCursor("cursor");
+        ManagedLedger newLedger = factory2.open("my_test_ledger");
+        cursor = newLedger.openCursor("cursor");
 
-        // Cursor was rolled back to p2 because of the ledger recovery failure
-        assertEquals(cursor.getMarkDeletedPosition(), p2);
+        // Previous empty ledger would be deleted, and create a new ledger.
+        assertThat(newLedger.getLedgersInfo().size()).isEqualTo(1);
+
+        // Cursor move to newestEmptyLedgerId:-1 since all entries are consumed.
+        assertThat(cursor.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(newLedger.getLedgersInfo().lastKey(), -1));
     }
 
     @Test(timeOut = 20000)
@@ -2115,12 +2118,15 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         c1.skipEntries(1, IndividualDeletedEntries.Exclude);
         assertEquals(c1.getNumberOfEntries(), 0);
         assertEquals(c1.getReadPosition(), PositionFactory.create(ledger.currentLedger.getId(), 0));
-        assertEquals(c1.getMarkDeletedPosition(), pos);
+        assertThat(c1.getMarkDeletedPosition()).isGreaterThan(pos);
 
         // skip entries across ledgers
         for (int i = 0; i < 6; i++) {
             pos = ledger.addEntry("dummy-entry".getBytes(Encoding));
         }
+
+        // Wait new empty ledger created completely.
+        Awaitility.await().untilAsserted(() -> assertThat(ledger.getLedgersInfo().size()).isEqualTo(4));
 
         c1.skipEntries(5, IndividualDeletedEntries.Exclude);
         assertEquals(c1.getNumberOfEntries(), 1);
@@ -2133,7 +2139,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(c1.getReadPosition().getEntryId(), 0);
         });
-        assertEquals(c1.getMarkDeletedPosition(), pos);
+        assertThat(c1.getMarkDeletedPosition()).isGreaterThan(pos);
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")
@@ -2161,7 +2167,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         c1.skipEntries(3, IndividualDeletedEntries.Exclude);
         assertEquals(c1.getNumberOfEntries(), 0);
         assertEquals(c1.getReadPosition(), PositionFactory.create(pos5.getLedgerId() + 1, 0));
-        assertEquals(c1.getMarkDeletedPosition(), pos5);
+        assertEquals(c1.getMarkDeletedPosition(), PositionFactory.create(pos5.getLedgerId() + 1, -1));
 
         Position pos6 = ledger.addEntry("dummy-entry-1".getBytes(Encoding));
         Position pos7 = ledger.addEntry("dummy-entry-2".getBytes(Encoding));
@@ -5924,6 +5930,316 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         }
         ledger.addEntry("msg".getBytes());
         assertEquals(future1.get(2, TimeUnit.SECONDS).get(0).getData(), "msg".getBytes());
+    }
+
+    @Test(timeOut = 20000)
+    public void testAsyncMarkDeleteMoveToNextLedgerInNonRolloverScenario() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        int maxEntriesPerLedger = 10;
+        config.setMaxEntriesPerLedger(maxEntriesPerLedger);
+        ManagedLedger ledger = factory.open("async_mark_delete_move_to_next_ledger_in_non_rollover_test", config);
+        final ManagedCursor c1 = ledger.openCursor("c1");
+
+        final int addEntryNum = 101;
+        final CountDownLatch addEntryLatch = new CountDownLatch(addEntryNum);
+        AtomicReference<Position> secondLastPosition = new AtomicReference<>();
+        AtomicReference<Position> lastPosition = new AtomicReference<>();
+        for (int i = 0; i < addEntryNum; i++) {
+            String entryStr = "entry-" + i;
+            int index = i;
+            ledger.asyncAddEntry(entryStr.getBytes(Encoding), new AddEntryCallback() {
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                }
+
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    if (index == addEntryNum - 2) {
+                        secondLastPosition.set(position);
+                    }
+                    lastPosition.set(position);
+                    addEntryLatch.countDown();
+                }
+            }, null);
+        }
+        addEntryLatch.await();
+
+        assertEquals(ledger.getNumberOfEntries(), addEntryNum);
+        assertEquals(secondLastPosition.get().getEntryId(), maxEntriesPerLedger - 1);
+        assertEquals(lastPosition.get().getEntryId(), addEntryNum % maxEntriesPerLedger - 1);
+
+        final CountDownLatch c1MarkDeleteLatch = new CountDownLatch(1);
+        c1.asyncMarkDelete(secondLastPosition.get(), new MarkDeleteCallback() {
+            @Override
+            public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+            }
+
+            @Override
+            public void markDeleteComplete(Object ctx) {
+                c1MarkDeleteLatch.countDown();
+            }
+        }, null);
+        c1MarkDeleteLatch.await();
+
+        assertEquals(c1.getNumberOfEntries(), 1);
+        // Should move to lastPositionLedgerId:-1 since entries in secondLastPositionLedger are all consumed.
+        assertEquals(c1.getMarkDeletedPosition(),
+                PositionFactory.create(lastPosition.get().getLedgerId(), -1));
+
+        // Reopen
+        @Cleanup("shutdown") ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ledger = factory2.open("async_mark_delete_move_to_next_ledger_in_non_rollover_test");
+        ManagedCursor c2 = ledger.openCursor("c1");
+
+        assertEquals(c2.getNumberOfEntries(), 1);
+        assertEquals(c2.getMarkDeletedPosition(),
+                PositionFactory.create(lastPosition.get().getLedgerId(), -1));
+
+        final CountDownLatch c2MarkDeleteLatch = new CountDownLatch(1);
+        c2.asyncMarkDelete(lastPosition.get(), new MarkDeleteCallback() {
+            @Override
+            public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+            }
+
+            @Override
+            public void markDeleteComplete(Object ctx) {
+                c2MarkDeleteLatch.countDown();
+            }
+        }, null);
+        c2MarkDeleteLatch.await();
+
+        assertEquals(c2.getNumberOfEntries(), 0);
+        // Should move to nextLedgerId:-1 since entries in lastPositionLedger are all consumed.
+        // Here we can guarantee next ledger is created since the asyncOpenLedger guarantees this order.
+        assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get());
+    }
+
+    @Test(timeOut = 20000)
+    public void testAsyncMarkDeleteMayMoveToNextLedgerInRolloverScenario() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        // Make sure acked ledgers will never be trimmed in this test.
+        config.setMaxEntriesPerLedger(10);
+        config.setRetentionTime(1, TimeUnit.MINUTES);
+        config.setRetentionSizeInMB(5);
+        ManagedLedger ledger = factory.open("async_mark_delete_may_move_to_next_ledger_in_non_rollover_test", config);
+        final ManagedCursor c1 = ledger.openCursor("c1");
+        final AtomicReference<Position> lastPosition = new AtomicReference<>();
+
+        final int num = 100;
+        final CountDownLatch addEntryLatch = new CountDownLatch(num);
+        for (int i = 0; i < num; i++) {
+            ledger.asyncAddEntry("entry".getBytes(Encoding), new AddEntryCallback() {
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                }
+
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    lastPosition.set(position);
+                    c1.asyncMarkDelete(position, new MarkDeleteCallback() {
+                        @Override
+                        public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                        }
+
+                        @Override
+                        public void markDeleteComplete(Object ctx) {
+                            addEntryLatch.countDown();
+                        }
+                    }, null);
+                }
+            }, null);
+        }
+        addEntryLatch.await();
+
+        assertEquals(c1.getNumberOfEntries(), 0);
+        assertThat(c1.getMarkDeletedPosition()).isGreaterThanOrEqualTo(lastPosition.get());
+
+        // Reopen
+        @Cleanup("shutdown") ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedger newLedger = ManagedLedgerTestUtil.retry(
+                () -> factory2.open("async_mark_delete_may_move_to_next_ledger_in_non_rollover_test"));
+        ManagedCursor c2 = newLedger.openCursor("c1");
+
+        assertEquals(c2.getNumberOfEntries(), 0);
+        Awaitility.await()
+                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
+    }
+
+    @Test(timeOut = 20000)
+    public void testAsyncMarkDeleteMoveToNextLedgerOneByOne() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        int maxEntriesPerLedger = 10;
+        config.setMaxEntriesPerLedger(maxEntriesPerLedger);
+        ManagedLedger ledger = factory.open("async_mark_delete_move_to_next_ledger_one_by_one_test", config);
+        final ManagedCursor c1 = ledger.openCursor("c1");
+        final AtomicReference<Position> lastPosition = new AtomicReference<>();
+
+        final int entryNum = 101;
+        final CountDownLatch addEntryLatch = new CountDownLatch(entryNum);
+        Deque<Position> positions = new ConcurrentLinkedDeque<>();
+        for (int i = 0; i < entryNum; i++) {
+            ledger.asyncAddEntry("entry".getBytes(Encoding), new AddEntryCallback() {
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                }
+
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    lastPosition.set(position);
+                    positions.offer(position);
+                    addEntryLatch.countDown();
+                }
+            }, null);
+        }
+        addEntryLatch.await();
+
+        for (int i = 0; i < entryNum; i++) {
+            CountDownLatch markDeleteLatch = new CountDownLatch(1);
+            Position position = positions.poll();
+            c1.asyncMarkDelete(position, new MarkDeleteCallback() {
+                @Override
+                public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                }
+
+                @Override
+                public void markDeleteComplete(Object ctx) {
+                    markDeleteLatch.countDown();
+                }
+            }, null);
+            markDeleteLatch.await();
+            assertEquals(c1.getNumberOfEntries(), entryNum - i - 1);
+            if ((i + 1) % maxEntriesPerLedger == 0) {
+                assertThat(c1.getMarkDeletedPosition()).isGreaterThan(position);
+            } else {
+                assertThat(c1.getMarkDeletedPosition()).isEqualByComparingTo(position);
+            }
+        }
+
+        // Reopen
+        @Cleanup("shutdown") ManagedLedgerFactory factory2 = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedger newLedger = ManagedLedgerTestUtil.retry(
+                () -> factory2.open("async_mark_delete_move_to_next_ledger_one_by_one_test"));
+        ManagedCursor c2 = newLedger.openCursor("c1");
+        assertEquals(c2.getNumberOfEntries(), 0);
+        Awaitility.await()
+                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
+    }
+
+    @Test(timeOut = 20000)
+    public void testAsyncMarkDeleteNextLedgerMinusOneEntryIdPosition() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        int maxEntriesPerLedger = 10;
+        config.setMaxEntriesPerLedger(maxEntriesPerLedger);
+        ManagedLedger ledger = factory.open("async_mark_delete_next_ledger_minus_one_entry_id_test", config);
+        final ManagedCursor c1 = ledger.openCursor("c1");
+
+        final int entryNum = 100;
+        for (int i = 0; i < entryNum / maxEntriesPerLedger; i++) {
+            final CountDownLatch addEntryLatch = new CountDownLatch(maxEntriesPerLedger);
+            for (int j = 0; j < maxEntriesPerLedger; j++) {
+                ledger.asyncAddEntry("entry".getBytes(Encoding), new AddEntryCallback() {
+                    @Override
+                    public void addFailed(ManagedLedgerException exception, Object ctx) {
+                    }
+
+                    @Override
+                    public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                        addEntryLatch.countDown();
+                    }
+                }, null);
+            }
+            addEntryLatch.await();
+
+            // Wait for new ledger creation completed.
+            Awaitility.await().untilAsserted(() -> assertThat(ledger.getLedgersInfo().size()).isEqualTo(2));
+
+            long ledgerId = ledger.getLedgersInfo().firstEntry().getValue().getLedgerId();
+            Position firstEntryPosition = PositionFactory.create(ledgerId, 0);
+            c1.markDelete(firstEntryPosition);
+            assertThat(c1.getMarkDeletedPosition()).isEqualTo(firstEntryPosition);
+
+            Long nextLedgerId = ledger.getLedgersInfo().lastEntry().getKey();
+            Position markDeletePosition = PositionFactory.create(nextLedgerId, -1);
+            CountDownLatch markDeleteLatch = new CountDownLatch(1);
+            c1.asyncMarkDelete(markDeletePosition, new MarkDeleteCallback() {
+                @Override
+                public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                }
+
+                @Override
+                public void markDeleteComplete(Object ctx) {
+                    markDeleteLatch.countDown();
+                }
+            }, null);
+            markDeleteLatch.await();
+            assertEquals(c1.getNumberOfEntries(), 0);
+            assertThat(c1.getMarkDeletedPosition()).isEqualByComparingTo(markDeletePosition);
+        }
+    }
+
+    @Test(timeOut = 20000, invocationCount = 100)
+    void testMarkDeletePreviousLacManyTimesInRolloverScenario() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(1);
+        // Set retention in order to not trim ledger.
+        config.setRetentionTime(20, TimeUnit.SECONDS);
+        config.setRetentionSizeInMB(1);
+
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("testMarkDeletePreviousLacManyTimesInRolloverScenario", config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        Position position = ledger.addEntry("entry1".getBytes(Encoding));
+        cursor.markDelete(position);
+
+        // Wait for new ledger created.
+        Awaitility.await().untilAsserted(() -> assertThat(ledger.getLedgersInfo().size()).isEqualTo(2));
+
+        int markDeleteTimes = 10;
+        for (int i = 0; i < markDeleteTimes; i++) {
+            cursor.markDelete(position);
+        }
+
+        assertThat(cursor.getMarkDeletedPosition()).isGreaterThan(position);
+    }
+
+    @Test
+    void testMarkDeletePositionNeverExceedLacOrNextLedgerMinusOneEntryIdPos() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        int maxEntriesPerLedger = 1;
+        config.setMaxEntriesPerLedger(maxEntriesPerLedger);
+        config.setRetentionTime(0, TimeUnit.MILLISECONDS);
+        config.setRetentionSizeInMB(0);
+
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("testMarkDeletePositionNeverExceedLacOrNextLedgerMinusOneEntryIdPos",
+                        config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        Position p1 = ledger.addEntry("entry-1".getBytes(Encoding));
+        Position p2 = ledger.addEntry("entry-2".getBytes(Encoding));
+        Position p3 = ledger.addEntry("entry-3".getBytes(Encoding));
+
+        // Wait for new ledger created.
+        Awaitility.await().untilAsserted(() -> assertThat(ledger.getLedgersInfo().size()).isEqualTo(4));
+        long emptyLedgerId = ledger.getLedgersInfo().lastEntry().getValue().getLedgerId();
+
+        cursor.markDelete(p1);
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(PositionFactory.create(p2.getLedgerId(), -1));
+
+        // If requestMarkDeleteLedgerId == lacLedgerId, and current ledger is all consumed, and next ledger exists,
+        // we move markDeletePosition to nextLedgerId:-1. This is reasonable since we can also mark delete
+        // nextLedgerId:-1, which is also larger than lac.
+        Position lacPlusOnePos = PositionFactory.create(p2.getLedgerId(), 1);
+        cursor.markDelete(lacPlusOnePos);
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(PositionFactory.create(p3.getLedgerId(), -1));
+
+        // But we can not mark delete emptyLedgerId:1, since it is a valid entry position.
+        Position invalidMarkDeletePos = PositionFactory.create(emptyLedgerId, 1);
+        Throwable thrown = expectThrows(ManagedLedgerException.class, () -> {
+            cursor.markDelete(invalidMarkDeletePos);
+        });
+        assertThat(thrown.getMessage()).contains("Invalid mark deleted position");
     }
 
     class TestPulsarMockBookKeeper extends PulsarMockBookKeeper {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2103,8 +2103,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         c1.skipEntries(1, IndividualDeletedEntries.Exclude);
         assertEquals(c1.getReadPosition(), pos);
 
-        pos = ledger.addEntry("dummy-entry-1".getBytes(Encoding));
-        pos = ledger.addEntry("dummy-entry-2".getBytes(Encoding));
+        ledger.addEntry("dummy-entry-1".getBytes(Encoding));
+        ledger.addEntry("dummy-entry-2".getBytes(Encoding));
 
         // Wait new empty ledger created completely.
         Awaitility.await().untilAsserted(() -> {
@@ -2119,11 +2119,12 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         c1.skipEntries(1, IndividualDeletedEntries.Exclude);
         assertEquals(c1.getNumberOfEntries(), 0);
         assertEquals(c1.getReadPosition(), PositionFactory.create(ledger.currentLedger.getId(), 0));
-        assertThat(c1.getMarkDeletedPosition()).isGreaterThan(pos);
+        assertThat(c1.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(ledger.ledgers.lastKey(), -1));
 
         // skip entries across ledgers
         for (int i = 0; i < 6; i++) {
-            pos = ledger.addEntry("dummy-entry".getBytes(Encoding));
+            ledger.addEntry("dummy-entry".getBytes(Encoding));
         }
 
         // Wait new empty ledger created completely.
@@ -2140,7 +2141,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(c1.getReadPosition().getEntryId(), 0);
         });
-        assertThat(c1.getMarkDeletedPosition()).isGreaterThan(pos);
+        assertThat(c1.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(ledger.ledgers.lastKey(), -1));
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")
@@ -6012,7 +6014,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(c2.getNumberOfEntries(), 0);
         // Should move to nextLedgerId:-1 since entries in lastPositionLedger are all consumed.
         // Here we can guarantee next ledger is created since the asyncOpenLedger guarantees this order.
-        assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get());
+        assertThat(c2.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(ledger.getLedgersInfo().lastKey(), -1));
     }
 
     @Test(timeOut = 20000)
@@ -6062,8 +6065,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedCursor c2 = newLedger.openCursor("c1");
 
         assertEquals(c2.getNumberOfEntries(), 0);
-        Awaitility.await()
-                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
+        assertThat(c2.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(newLedger.getLedgersInfo().lastKey(), -1));
     }
 
     @Test(timeOut = 20000)
@@ -6122,8 +6125,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
                 () -> factory2.open("async_mark_delete_move_to_next_ledger_one_by_one_test"));
         ManagedCursor c2 = newLedger.openCursor("c1");
         assertEquals(c2.getNumberOfEntries(), 0);
-        Awaitility.await()
-                .untilAsserted(() -> assertThat(c2.getMarkDeletedPosition()).isGreaterThan(lastPosition.get()));
+        assertThat(c2.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(newLedger.getLedgersInfo().lastKey(), -1));
     }
 
     @Test(timeOut = 20000)
@@ -6201,7 +6204,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
             cursor.markDelete(position);
         }
 
-        assertThat(cursor.getMarkDeletedPosition()).isGreaterThan(position);
+        assertThat(cursor.getMarkDeletedPosition()).isEqualByComparingTo(
+                PositionFactory.create(ledger.getLedgersInfo().lastKey(), -1));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -1370,11 +1370,10 @@ public class BacklogQuotaManagerTest {
         rolloverStats();
 
         Awaitility.await().untilAsserted(() -> {
-            // Cause the last ledger is empty, it is not possible to skip first ledger,
-            // so the number of ledgers will keep unchanged, and backlog is clear
+            // Mark deleting moves cursor position to nextLedgerId:-1, and backlog is clear.
             PersistentTopicInternalStats latestInternalStats = admin.topics().getInternalStats(topic);
-            assertEquals(latestInternalStats.ledgers.size(), 2);
-            assertEquals(latestInternalStats.ledgers.get(1).entries, 0);
+            assertEquals(latestInternalStats.ledgers.size(), 1);
+            assertEquals(latestInternalStats.ledgers.get(0).entries, 0);
             TopicStats latestStats = getTopicStats(topic);
             assertEquals(latestStats.getSubscriptions().get(subName).getMsgBacklog(), 0);
         });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -425,7 +425,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertEquals(lastLedgerInfo.getEntries(), 0);
         assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
 
-        // this will make sure that all entries should be deleted
+        // This will make sure that all entries should be deleted, and move markDeletePosition to nextLedgerId:-1.
         Thread.sleep(TimeUnit.SECONDS.toMillis(ttlSeconds));
 
         bkc.deleteLedger(ledgers.get(0).getLedgerId());
@@ -438,9 +438,9 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertTrue(monitor.expireMessages(ttlSeconds));
         Awaitility.await().untilAsserted(() -> {
             Position markDeletePosition = c1.getMarkDeletedPosition();
-            // The markDeletePosition points to the last entry of the previous ledger in lastLedgerInfo.
-            assertEquals(markDeletePosition.getLedgerId(), lastLedgerInfo.getLedgerId() - 1);
-            assertEquals(markDeletePosition.getEntryId(), entriesPerLedger - 1);
+            // The markDeletePosition already moved to nextLedgerId:-1
+            assertEquals(markDeletePosition.getLedgerId(), lastLedgerInfo.getLedgerId());
+            assertEquals(markDeletePosition.getEntryId(), -1);
         });
 
         c1.close();
@@ -481,7 +481,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertEquals(lastLedgerInfo.getEntries(), 0);
         assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
 
-        // this will make sure that all entries should be deleted
+        // This will make sure that all entries should be deleted, and move markDeletePosition to nextLedgerId:-1.
         Thread.sleep(TimeUnit.SECONDS.toMillis(ttlSeconds));
 
         bkc.deleteLedger(ledgers.get(0).getLedgerId());
@@ -494,9 +494,9 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertTrue(monitor.expireMessagesAsync(ttlSeconds).get());
         Awaitility.await().untilAsserted(() -> {
             Position markDeletePosition = c1.getMarkDeletedPosition();
-            // The markDeletePosition points to the last entry of the previous ledger in lastLedgerInfo.
-            assertEquals(markDeletePosition.getLedgerId(), lastLedgerInfo.getLedgerId() - 1);
-            assertEquals(markDeletePosition.getEntryId(), entriesPerLedger - 1);
+            // The markDeletePosition already moved to nextLedgerId:-1
+            assertEquals(markDeletePosition.getLedgerId(), lastLedgerInfo.getLedgerId());
+            assertEquals(markDeletePosition.getEntryId(), -1);
         });
 
         c1.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import java.util.concurrent.CompletableFuture;
@@ -92,7 +93,7 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
         admin.topics().skipAllMessages(tp, "s1");
         Awaitility.await().untilAsserted(() -> {
             assertEquals(cursor.getNumberOfEntriesInBacklog(true), 0);
-            assertEquals(cursor.getMarkDeletedPosition(), ml.getLastConfirmedEntry());
+            assertThat(cursor.getMarkDeletedPosition()).isGreaterThanOrEqualTo(ml.getLastConfirmedEntry());
         });
         CompletableFuture completableFuture = new CompletableFuture();
         ml.trimConsumedLedgersInBackground(completableFuture);
@@ -100,7 +101,7 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(ml.getLedgersInfo().size(), 1);
             assertEquals(cursor.getNumberOfEntriesInBacklog(true), 0);
-            assertEquals(cursor.getMarkDeletedPosition(), ml.getLastConfirmedEntry());
+            assertThat(cursor.getMarkDeletedPosition()).isGreaterThanOrEqualTo(ml.getLastConfirmedEntry());
         });
 
         // Verify: "persistentTopic.estimatedTimeBasedBacklogQuotaCheck" will not get a NullPointerException.


### PR DESCRIPTION
### Motivation

Since `nextValidLedger:-1` is a valid `markDeletePosition`, we should move `newPosition` to `nextValidLedger:-1` to avoid cursor position and ledger inconsistency in `ManagedCursorImpl` whenever possible.

PR https://github.com/apache/pulsar/pull/25087 also made this change.

### Modifications

1. Modify `ManagedCursorImpl.asyncMarkDelete()` method, move `newPosition` to `nextValidLedger:-1` if we reach the following conditions:
  a. if `lastConfirmedEntry >= newPosition`, and next ledger exists, and current ledger entries are all consumed.
  b. if `lastConfirmedEntry < newPosition`, next ledger exists, and `newPosition == nextValidLedger:-1`.

I think the previous code might have a little problem. 
  a. If `newPosition == nextValidLedger:n`, n is an non-negative number, we might set new `newPosition` to `nextValidLedger:n` which is greater than `lastConfirmedEntry`, which is the biggest problem.
  b. We can not mark delete `lac` many times if we already moved markDeletePosition to `nextValidLedger:-1`.
  c. We can not mark delete `nextValidLedger:-1` directly if markDeletePosition is less than `lac`.

https://github.com/apache/pulsar/blob/ab65faa12ab7279a726411152af44d81b6a6704b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2184-L2195

And snapshot positions into a local variable to avoid race condition.

2. Add `testAsyncMarkDeleteMoveToNextLedgerInNonRolloverScenario`, `testAsyncMarkDeleteMayMoveToNextLedgerInRolloverScenario`, `testAsyncMarkDeleteMoveToNextLedgerOneByOne`, `testAsyncMarkDeleteNextLedgerMinusOneEntryIdPosition` tests in `ManagedCursorTest` to verify the code change.

3. Fix tests  due to this PR's code change.

4. Fix some flaky tests introduced by PR https://github.com/apache/pulsar/pull/25087.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/oneby-wang/pulsar/pull/19