### PR TITLE
[fix][broker] Fix MultiRolesTokenAuthorizationProvider error when subscription prefix doesn't match.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProvider.java
@@ -220,7 +220,11 @@ public class MultiRolesTokenAuthorizationProvider extends PulsarAuthorizationPro
                         return CompletableFuture.completedFuture(false);
                     }
                     List<CompletableFuture<Boolean>> futures = new ArrayList<>(roles.size());
-                    roles.forEach(r -> futures.add(authorizeFunc.apply(r)));
+                    if (roles.size() == 1) {
+                        roles.forEach(r -> futures.add(authorizeFunc.apply(r)));
+                    } else {
+                        roles.forEach(r -> futures.add(authorizeFunc.apply(r).exceptionally(ex -> false)));
+                    }
                     return FutureUtil.waitForAny(futures, ret -> (boolean) ret).thenApply(v -> v.isPresent());
                 });
     }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -21,14 +21,17 @@ package org.apache.pulsar.broker.authorization;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSubscription;
@@ -303,5 +306,109 @@ public class MultiRolesTokenAuthorizationProviderTest {
                 (String role) -> CompletableFuture.completedFuture(false)).get());
         assertTrue(provider.authorize("admin1", null, authorizeFunc).get());
         assertFalse(provider.authorize("admin2", null, authorizeFunc).get());
+    }
+
+    /**
+     * Test subscription prefix mismatch exception handling.
+     * <p>
+     * Scenario 1: One role authorization succeeds, another role throws subscription prefix mismatch exception
+     * -> Returns true (exception is swallowed)
+     * Scenario 2: All roles throw subscription prefix mismatch exception -> Returns false
+     */
+    @Test
+    public void testMultiRolesAuthzWithSubscriptionPrefixMismatchException() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        String userA = "user-a";
+        String userB = "user-b";
+        String token = Jwts.builder()
+                .claim(MultiRolesTokenAuthorizationProvider.DEFAULT_ROLE_CLAIM, new String[]{userA, userB})
+                .signWith(secretKey).compact();
+
+        MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
+        ServiceConfiguration conf = new ServiceConfiguration();
+        provider.initialize(conf, mock(PulsarResources.class));
+
+        AuthenticationDataSource ads = new AuthenticationDataSource() {
+            @Override
+            public boolean hasDataFromHttp() {
+                return true;
+            }
+
+            @Override
+            public String getHttpHeader(String name) {
+                if (name.equals("Authorization")) {
+                    return "Bearer " + token;
+                } else {
+                    throw new IllegalArgumentException("Wrong HTTP header");
+                }
+            }
+        };
+
+        // userA throws subscription prefix mismatch exception, userB returns true -> result should be true
+        assertTrue(provider.authorize("test", ads, role -> {
+            if (role.equals(userA)) {
+                CompletableFuture<Boolean> future = new CompletableFuture<>();
+                future.completeExceptionally(new PulsarServerException(
+                        "The subscription name needs to be prefixed by the authentication role"));
+                return future;
+            }
+            return CompletableFuture.completedFuture(true);
+        }).get());
+
+        // All roles throw subscription prefix mismatch exception -> result should be false
+        assertFalse(provider.authorize("test", ads, role -> {
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            future.completeExceptionally(new PulsarServerException(
+                    "The subscription name needs to be prefixed by the authentication role"));
+            return future;
+        }).get());
+    }
+
+    /**
+     * Test single role with subscription prefix mismatch exception.
+     * <p>
+     * Single role throws subscription prefix mismatch exception -> Should throw the original exception
+     * (Single role keeps original behavior, does not swallow exception)
+     */
+    @Test
+    public void testSingleRoleAuthzWithSubscriptionPrefixMismatchException() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        String userA = "user-a";
+        String token = Jwts.builder()
+                .claim(MultiRolesTokenAuthorizationProvider.DEFAULT_ROLE_CLAIM, userA)
+                .signWith(secretKey).compact();
+
+        MultiRolesTokenAuthorizationProvider provider = new MultiRolesTokenAuthorizationProvider();
+        ServiceConfiguration conf = new ServiceConfiguration();
+        provider.initialize(conf, mock(PulsarResources.class));
+
+        AuthenticationDataSource ads = new AuthenticationDataSource() {
+            @Override
+            public boolean hasDataFromHttp() {
+                return true;
+            }
+
+            @Override
+            public String getHttpHeader(String name) {
+                if (name.equals("Authorization")) {
+                    return "Bearer " + token;
+                } else {
+                    throw new IllegalArgumentException("Wrong HTTP header");
+                }
+            }
+        };
+
+        // Single role throws subscription prefix mismatch exception -> should propagate exception
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> {
+            provider.authorize("test", ads, role -> {
+                CompletableFuture<Boolean> future = new CompletableFuture<>();
+                future.completeExceptionally(new PulsarServerException(
+                        "The subscription name needs to be prefixed by the authentication role"));
+                return future;
+            }).get();
+        });
+        assertTrue(ex.getCause() instanceof PulsarServerException);
+        assertTrue(ex.getCause().getMessage().contains(
+                "The subscription name needs to be prefixed by the authentication role"));
     }
 }


### PR DESCRIPTION
### Motivation

When using `MultiRolesTokenAuthorizationProvider` with multiple roles in a JWT token, if one of the roles fails the subscription prefix check in `PulsarAuthorizationProvider#canConsumeAsync`, it throws a `PulsarServerException` with the message "The subscription name needs to be prefixed by the authentication role".

This exception propagates up and causes the entire authorization to fail, even if another role in the token has valid permissions. This is problematic in multi-role scenarios where:
- A JWT token contains multiple roles (e.g., `["user-a", "user-b"]`)
- Only one role needs to have permission for the operation to succeed
- The `FutureUtil.waitForAny` mechanism should return success as soon as any role is authorized

### Modifications
Modified `MultiRolesTokenAuthorizationProvider#authorize` method to handle exceptions differently based on the number of roles:
1. **Single role**: Keep the original behavior - exceptions are propagated as-is. This ensures backward compatibility and proper error reporting when there's only one role.
2. **Multiple roles**: Swallow all exceptions and convert them to `false` (authorization failed). This allows `FutureUtil.waitForAny` to work correctly - if any role succeeds, the overall authorization succeeds; only if all roles fail (return `false` or throw exceptions), the authorization fails.
```java
if (roles.size() == 1) {
    roles.forEach(r -> futures.add(authorizeFunc.apply(r)));
} else {
    roles.forEach(r -> futures.add(authorizeFunc.apply(r).exceptionally(ex -> false)));
}
```


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added new test cases in `MultiRolesTokenAuthorizationProviderTest`:
- `testMultiRolesAuthzWithSubscriptionPrefixMismatchException`: Tests multi-role scenarios where:
  - One role succeeds, another throws exception -> returns `true`
  - All roles throw exceptions -> returns `false`
- `testSingleRoleAuthzWithSubscriptionPrefixMismatchException`: Tests single-role scenario where:
  - Single role throws exception -> propagates the original exception


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dragonls/pulsar/pull/12

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
