### PR TITLE
[improve][broker] Change the log level from error to info when throwing NotAllowedException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1090,7 +1090,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 } else if (ex.getCause() instanceof BrokerServiceException.ConnectionClosedException) {
                     log.warn("[{}][{}] Connection was closed while the opening the cursor", topic, subscriptionName);
                 } else if (ex.getCause() instanceof BrokerServiceException.NotAllowedException) {
-                    log.warn("[{}][{}] Not allowed to create subscription: {}", topic, subscriptionName,
+                    log.info("[{}][{}] Not allowed to create subscription: {}", topic, subscriptionName,
                             ex.getCause().getMessage());
                 } else {
                     log.error("[{}] Failed to create subscription: {}", topic, subscriptionName, ex);


### PR DESCRIPTION
### Motivation

When create the consumer/reader with the same sub name, the broker will print the error log as below, to avoid printing the noise log, change the log from ERROR to INFO
```
2026-01-07T15:39:16,075+0000 [ForkJoinPool.commonPool-worker-2] INFO  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://public/default/test-staging-partition-0][test-consumer-1014-9873] Creating non-durable subscription at msg id 1014:37462:0:2 - {}
2026-01-07T15:39:16,075+0000 [ForkJoinPool.commonPool-worker-2] ERROR org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://public/default/test-staging-partition-0] Failed to create subscription: test-consumer-1014-9873
java.util.concurrent.CompletionException: org.apache.pulsar.broker.service.BrokerServiceException$NotAllowedException: Durable subscription with the same name already exists.
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(Unknown Source) ~[?:?]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$internalSubscribe$25(PersistentTopic.java:1022) ~[io.streamnative-pulsar-broker-4.1.0.7.jar:4.1.0.7]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(Unknown Source) ~[?:?]
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
