### PR TITLE
[fix][broker] Fix regex matching of namespace name which might contain a regex char

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/TopicResources.java
@@ -124,8 +124,8 @@ public class TopicResources {
     }
 
     Pattern namespaceNameToTopicNamePattern(NamespaceName namespaceName) {
-        return Pattern.compile(
-                MANAGED_LEDGER_PATH + "/(" + namespaceName + ")/(" + TopicDomain.persistent + ")/(" + "[^/]+)");
+        return Pattern.compile(MANAGED_LEDGER_PATH + "/(" + Pattern.quote(namespaceName.toString()) + ")/("
+                        + TopicDomain.persistent + ")/(" + "[^/]+)");
     }
 
     public void registerPersistentTopicListener(

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
@@ -123,4 +123,15 @@ public class TopicResourcesTest {
         verify(listener).accept("persistent://tenant/namespace/topic:test", NotificationType.Created);
     }
 
+    @Test
+    public void testNamespaceContainsDotsShouldntMatchAny() {
+        BiConsumer<String, NotificationType> listener = mock(BiConsumer.class);
+        topicResources.registerPersistentTopicListener(NamespaceName.get("tenant/name.pace"), listener);
+        topicResources.handleNotification(new Notification(NotificationType.Created,
+                "/managed-ledgers/tenant/namespace/persistent/topic"));
+        verifyNoInteractions(listener);
+        topicResources.handleNotification(new Notification(NotificationType.Created,
+                "/managed-ledgers/tenant/name.pace/persistent/topic"));
+        verify(listener).accept("persistent://tenant/name.pace/topic", NotificationType.Created);
+    }
 }


### PR DESCRIPTION
### Motivation

Topic list watcher subscribes to metadata store change events and matches the metadata path using a regex. The namespace name part might contain a special character such as `.` and without escaping, it could match other namespaces that it shouldn't match.

### Modifications

Use `Pattern.quote` to escape the namespace name part in the pattern.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->