### PR TITLE
[fix][fn] complete flushAsync before closeAsync in ProducerCache and wait for completion in closing the cache

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ProducerCache.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ProducerCache.java
@@ -22,12 +22,16 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
@@ -62,11 +66,14 @@ public class ProducerCache implements Closeable {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     @VisibleForTesting
     final CopyOnWriteArrayList<CompletableFuture<Void>> closeFutures = new CopyOnWriteArrayList<>();
+    private final ExecutorService cacheExecutor;
 
     public ProducerCache() {
+        cacheExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("ProducerCache"));
         Caffeine<ProducerCacheKey, Producer<?>> builder = Caffeine.newBuilder()
                 .recordStats()
                 .scheduler(Scheduler.systemScheduler())
+                .executor(cacheExecutor)
                 .<ProducerCacheKey, Producer<?>>removalListener((key, producer, cause) -> {
                     log.info("Closing producer for topic {}, cause {}", key.topic(), cause);
                     CompletableFuture closeFuture =
@@ -132,10 +139,21 @@ public class ProducerCache implements Closeable {
     public void close() {
         if (closed.compareAndSet(false, true)) {
             cache.invalidateAll();
-            try {
-                FutureUtil.waitForAll(closeFutures).get();
-            } catch (InterruptedException | ExecutionException e) {
-                log.warn("Failed to close producers", e);
+            // schedule the waiting job on the cache executor
+            cacheExecutor.execute(() -> {
+                try {
+                    FutureUtil.waitForAll(closeFutures).get();
+                } catch (InterruptedException | ExecutionException e) {
+                    log.warn("Failed to close producers", e);
+                }
+            });
+            // Wait for the cache executor to terminate.
+            // The eviction jobs and waiting for the close futures to complete will run on the single-threaded
+            // cache executor, so we need to wait for them to finish to ensure that the cache is closed properly.
+            boolean terminated = MoreExecutors.shutdownAndAwaitTermination(cacheExecutor,
+                    Duration.ofSeconds(FLUSH_OR_CLOSE_TIMEOUT_SECONDS));
+            if (!terminated) {
+                log.warn("Failed to shutdown cache executor gracefully.");
             }
         }
     }


### PR DESCRIPTION
Fixes [issue discussed on Slack](https://apache-pulsar.slack.com/archives/C5ZSVEN4E/p1768277318266049)

### Motivation

While trying to implement a very similar component, I was poking around the `ProducerCache` and noticed that `closeAsync` was invoked without waiting for `flushAsync` to complete. I believe this could lead to correctness issues.

### Modifications

I've simplified the code to directly call `flushAsync`, rather than start a future that calls it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change attempted to add tests, but they currently fail because the existing test harness makes false assumptions / the code it's testing doesn't actually work (specifically, `ProducerCache.close` doesn't actually wait for cache removal listener futures).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/dontgitit/pulsar/pull/1

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
