### PR TITLE
[fix][test] Fix flaky ModularLoadManagerImplTest.testRemoveNonExistBundleData

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -1126,10 +1126,12 @@ public class ModularLoadManagerImplTest {
 
         // check bundle data should be deleted from metadata store.
 
-        CompletableFuture<List<String>> childrenAfterSplit = bundlesCache.getChildren(bundleDataPath);
-        List<String> bundlesAfterSplit = childrenAfterSplit.join();
+        Awaitility.await().untilAsserted(() -> {
+            CompletableFuture<List<String>> childrenAfterSplit = bundlesCache.getChildren(bundleDataPath);
+            List<String> bundlesAfterSplit = childrenAfterSplit.join();
 
-        assertFalse(bundlesAfterSplit.contains(bundleWillBeSplit.getBundleRange()));
+            assertFalse(bundlesAfterSplit.contains(bundleWillBeSplit.getBundleRange()));
+        });
     }
 
     @Test


### PR DESCRIPTION
### Motivation

The test ModularLoadManagerImplTest.testRemoveNonExistBundleData is flaky.

### Modifications

Use Awaitility to check the assertion.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->