### PR TITLE
[fix][test] Fix the flaky test ProduceWithMessageIdTest. sendWithCallBack

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProduceWithMessageIdTest.java
@@ -143,8 +143,8 @@ public class ProduceWithMessageIdTest extends ProducerConsumerBase {
             public void sendComplete(Throwable e, OpSendMsgStats opSendMsgStats) {
                 log.info("sendComplete", e);
                 if (e == null){
-                    cdl.countDown();
                     sendMsgStats.set(opSendMsgStats);
+                    cdl.countDown();
                 }
             }
 


### PR DESCRIPTION

### Motivation
```
Error:  Failures: 
  Error:  org.apache.pulsar.client.impl.ProduceWithMessageIdTest.sendWithCallBack
  [INFO]   Run 1: PASS
  Error:    Run 2: ProduceWithMessageIdTest.sendWithCallBack:185 NullPointer Cannot invoke "org.apache.pulsar.client.impl.OpSendMsgStats.getUncompressedSize()" because "opSendMsgStats" is null
```

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

