### PR TITLE
[fix][sec] Upgrade vertx to address CVE-2026-1002

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -508,11 +508,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-4.0.5.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.5.22.jar
-    - io.vertx-vertx-bridge-common-4.5.22.jar
-    - io.vertx-vertx-core-4.5.22.jar
-    - io.vertx-vertx-web-4.5.22.jar
-    - io.vertx-vertx-web-common-4.5.22.jar
+    - io.vertx-vertx-auth-common-4.5.24.jar
+    - io.vertx-vertx-bridge-common-4.5.24.jar
+    - io.vertx-vertx-core-4.5.24.jar
+    - io.vertx-vertx-web-4.5.24.jar
+    - io.vertx-vertx-web-common-4.5.24.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.9.4.jar
   * Snappy Java

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.42</jersey.version>
     <athenz.version>1.10.62</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <vertx.version>4.5.22</vertx.version>
+    <vertx.version>4.5.24</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.17</slf4j.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>


### PR DESCRIPTION
### Motivation

There's a moderate vulnerability CVE-2026-1002 in io.vertx:vertx-core

### Modifications

Upgrade vertx-core to 4.5.24

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->