### PR TITLE
[fix][build] Fix IntelliJ build after Jetty 12 upgrade

### DIFF
--- a/jetty-upgrade/zookeeper-with-patched-admin/pom.xml
+++ b/jetty-upgrade/zookeeper-with-patched-admin/pom.xml
@@ -68,28 +68,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-shade-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <artifact>
-                  <file>${project.build.directory}/${project.build.finalName}.jar</file>
-                  <type>jar</type>
-                  <classifier>shaded</classifier>
-                </artifact>
-              </artifacts>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
@@ -106,10 +84,6 @@
                 <includes>
                   <include>org.apache.zookeeper:zookeeper</include>
                 </includes>
-                <excludes>
-                  <!-- This is required for execute shade multiple times without clean -->
-                  <exclude>org.apache.pulsar:zookeeper-with-patched-admin</exclude>
-                </excludes>
               </artifactSet>
               <filters>
                 <filter>
@@ -128,4 +102,43 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <!-- Profile that is activated when using IntelliJ IDEA -->
+      <id>intellij</id>
+      <activation>
+        <property>
+          <name>idea.maven.embedder.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- Add shaded jar to artifacts for IntelliJ IDEA so that IntelliJ builds
+          and running tests work -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-shade-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.build.finalName}.jar</file>
+                      <type>jar</type>
+                      <classifier>shaded</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Motivation

The Jetty 12 upgrade PR #25100 patches ZooKeeper by upgrading from Jetty 9 to Jetty 12. This patching uses a shaded jar without really shading packages, but just replacing a single package.
This solution breaks IntelliJ build since the pom.xml is missing required definitions for IntelliJ Maven integration with shaded jars. When the IntelliJ build is broken, it's not possible to run all tests in the IntelliJ UI.

### Modifications

- add definitions to pom.xml required for IntelliJ Maven integration

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->