### PR TITLE
[fix][fn] Fix graceful Pulsar Function shutdown so that consumers and producers are closed

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -380,6 +380,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (stats != null) {
                 stats.incrSysExceptions(deathException);
             }
+            // clear possible thread interrupted state so that closing can be handled gracefully
+            Thread.interrupted();
         } finally {
             log.info("Closing instance");
             close();


### PR DESCRIPTION
Fixes #25154

### Motivation

While investigating a flaky test, I noticed that a Pulsar Function instance didn't shutdown gracefully due to interrupted thread status. The change in #25140 brought this to surface since closing producers gracefully requires that the calling thread isn't interrupted.

### Modifications

Clear the interrupted state of the current thread in the Function instance before proceeding to call the close method.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->