### PR TITLE
[fix][build] Fix eclipse jdt.ls failed to resolve ZooKeeper dependency due to Jetty 12 upgrade

### DIFF
--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -229,5 +229,25 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- Profile for Eclipse/M2E (including vim coc-java with jdt.ls) to resolve ZooKeeper classes.
+           The zookeeper-with-patched-admin module shades ZooKeeper classes into its jar,
+           but M2E cannot resolve classes from shaded jars. This profile adds the original
+           ZooKeeper dependency with provided scope for IDE classpath resolution only.
+           Activated by the existence of .classpath file which Eclipse/M2E creates. -->
+      <id>ide-zookeeper-resolution</id>
+      <activation>
+        <file>
+          <exists>.classpath</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### Motivation

My LSP (coc-java) failed to resolve ZooKeeper dependencies after pulling the latest commit. The issue is caused by https://github.com/apache/pulsar/pull/25100

Explanation from AI:

Root Cause: Commit 39dbbf01 changed pulsar-metadata to depend on zookeeper-with-patched-admin instead of directly on org.apache.zookeeper:zookeeper. The shaded jar contains ZooKeeper classes, but Eclipse M2E (used by jdt.ls/coc-java) cannot resolve classes from inside shaded jars.
Solution: Added a Maven profile in pulsar-metadata/pom.xml that:
1. Activates when a .classpath file exists (which jdt.ls/M2E creates)
2. Adds org.apache.zookeeper:zookeeper with provided scope for IDE classpath resolution
Files Modified:
1. pulsar-metadata/pom.xml - Added ide-zookeeper-resolution profile
2. pulsar-metadata/.classpath - Created empty trigger file

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
