### PR TITLE
[fix][ml] Fix NoSuchElementException in EntryCountEstimator caused by a race condition

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimator.java
@@ -192,13 +192,17 @@ class EntryCountEstimator {
         // to the first available ledger or the last active ledger, respectively.
         if (lastLedgerId != null && readPosition.getLedgerId() > lastLedgerId.longValue()) {
             return PositionFactory.create(lastLedgerId, Math.max(lastLedgerTotalEntries - 1, 0));
-        } else if (lastLedgerId == null && readPosition.getLedgerId() > ledgersInfo.lastKey()) {
+        }
+        long lastKey = ledgersInfo.lastKey();
+        if (lastLedgerId == null && readPosition.getLedgerId() > lastKey) {
             Map.Entry<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> lastEntry = ledgersInfo.lastEntry();
-            if (lastEntry != null) {
+            if (lastEntry != null && lastEntry.getKey() == lastKey) {
                 return PositionFactory.create(lastEntry.getKey(), Math.max(lastEntry.getValue().getEntries() - 1, 0));
             }
-        } else if (readPosition.getLedgerId() < ledgersInfo.firstKey()) {
-            return PositionFactory.create(ledgersInfo.firstKey(), 0);
+        }
+        long firstKey = ledgersInfo.firstKey();
+        if (readPosition.getLedgerId() < firstKey) {
+            return PositionFactory.create(firstKey, 0);
         }
         return readPosition;
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimatorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCountEstimatorTest.java
@@ -310,6 +310,7 @@ public class EntryCountEstimatorTest {
         ledgersInfo = mock(NavigableMap.class);
         when(ledgersInfo.isEmpty()).thenReturn(false);
         when(ledgersInfo.firstKey()).thenThrow(NoSuchElementException.class);
+        when(ledgersInfo.lastKey()).thenReturn(1L);
         int result = estimateEntryCountByBytesSize(5_000_000);
         // expect that result is 1 because the estimation couldn't be done
         assertEquals(result, 1);


### PR DESCRIPTION
Fixes #25174

### Motivation

An NoSuchElementException could occur in EntryCountEstimator, causing dispatching to stop.
This condition could happen as a result of a race condition caused by ledger trimming. The ledgersInfo map appear to be be empty.

### Modifications

- check if ledgersInfo map is empty
- catch NoSuchElementException when firstKey or lastKey is accessed to avoid race conditions after checking if the map was empty
- add tests

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->