### PR TITLE
[improve][misc] Upgrade to Alpine 3.23

### DIFF
--- a/docker/kinesis-producer-alpine/Dockerfile
+++ b/docker/kinesis-producer-alpine/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG ALPINE_VERSION=3.22
+ARG ALPINE_VERSION=3.23
 
 # Builds an Alpine image with kinesis_producer compiled for Alpine Linux / musl
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -73,9 +73,9 @@ RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.secu
 FROM alpine:$ALPINE_VERSION AS snappy-java
 
 ARG SNAPPY_VERSION
-RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash tar
-ENV JAVA_HOME=/usr
-RUN curl -Ls https://github.com/xerial/snappy-java/archive/refs/tags/v$SNAPPY_VERSION.tar.gz | tar zxf - && cd snappy-java-$SNAPPY_VERSION && make clean-native native
+RUN apk add git alpine-sdk util-linux cmake autoconf automake libtool openjdk17 maven curl bash tar findutils
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+RUN curl -Ls https://github.com/xerial/snappy-java/archive/refs/tags/v$SNAPPY_VERSION.tar.gz | tar zxf - && cd snappy-java-$SNAPPY_VERSION && CMAKE_POLICY_VERSION_MINIMUM=3.5 make clean-native native
 
 
 ## Create final stage from Alpine image

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG ALPINE_VERSION=3.22
+ARG ALPINE_VERSION=3.23
 ARG IMAGE_JDK_MAJOR_VERSION=21
 
 # First create a stage with just the Pulsar tarball and scripts

--- a/src/update_python_protobuf_stubs_with_docker.sh
+++ b/src/update_python_protobuf_stubs_with_docker.sh
@@ -20,6 +20,6 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-# Create an inline docker container with alpine:3.22 base image and mount the current directory to it as the
+# Create an inline docker container with alpine:3.23 base image and mount the current directory to it as the
 # working directory and run the script inside the container.
-docker run --rm -v "$SCRIPT_DIR/..:/pulsar_src" -w /pulsar_src alpine:3.22 sh -c 'apk add --no-cache bash python3 && /pulsar_src/src/update_python_protobuf_stubs.sh'
+docker run --rm -v "$SCRIPT_DIR/..:/pulsar_src" -w /pulsar_src alpine:3.23 sh -c 'apk add --no-cache bash python3 && /pulsar_src/src/update_python_protobuf_stubs.sh'

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/PulsarContainer.java
@@ -57,7 +57,7 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
     public static final int BROKER_HTTP_PORT = 8080;
     public static final int BROKER_HTTPS_PORT = 8081;
 
-    public static final String ALPINE_IMAGE_NAME = "alpine:3.22";
+    public static final String ALPINE_IMAGE_NAME = "alpine:3.23";
     public static final String DEFAULT_IMAGE_NAME = System.getenv().getOrDefault("PULSAR_TEST_IMAGE_NAME",
             "apachepulsar/pulsar-test-latest-version:latest");
     public static final String UPGRADE_TEST_IMAGE_NAME = System.getenv().getOrDefault("PULSAR_UPGRADE_TEST_IMAGE_NAME",


### PR DESCRIPTION
### Motivation

[Alpine 3.23 has been released in December 2025](https://www.alpinelinux.org/posts/Alpine-3.23.0-released.html).
The latest version is 3.23.2 at the moment.

### Modifications

- Upgrade Alpine from 3.22 to 3.23

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->