### PR TITLE
[improve][broker] Add http produce backlog quota check

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -87,6 +87,7 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
@@ -270,34 +271,44 @@ public class TopicsBase extends PersistentTopicsBase {
     private CompletableFuture<Position> publishSingleMessageToPartition(String topic, Message message) {
         CompletableFuture<Position> publishResult = new CompletableFuture<>();
         pulsar().getBrokerService().getTopic(topic, false)
-        .thenAccept(t -> {
-            // TODO: Check message backlog and fail if backlog too large.
-            if (!t.isPresent()) {
-                // Topic not found, and remove from owning partition list.
-                publishResult.completeExceptionally(new BrokerServiceException.TopicNotFoundException("Topic not "
-                        + "owned by current broker."));
-                TopicName topicName = TopicName.get(topic);
-                pulsar().getBrokerService().getOwningTopics().get(topicName.getPartitionedTopicName())
-                        .remove(topicName.getPartitionIndex());
-            } else {
-                try {
-                    ByteBuf headersAndPayload = messageToByteBuf(message);
-                    try {
-                        Topic topicObj = t.get();
-                        topicObj.publishMessage(headersAndPayload,
-                                RestMessagePublishContext.get(publishResult, topicObj, System.nanoTime()));
-                    } finally {
-                        headersAndPayload.release();
+                .thenCompose(tOpt -> {
+                    if (tOpt.isEmpty()) {
+                        publishResult.completeExceptionally(
+                                new BrokerServiceException.TopicNotFoundException("Topic not "
+                                        + "owned by current broker."));
+                        TopicName tn = TopicName.get(topic);
+                        pulsar().getBrokerService().getOwningTopics().get(tn.getPartitionedTopicName())
+                                .remove(tn.getPartitionIndex());
+                        return CompletableFuture.completedFuture(null);
                     }
-                } catch (Exception e) {
-                        log.debug()
-                                .attr("topic", topicName)
-                                .exceptionMessage(e)
-                                .log("Fail to publish single messages to topic");
-                                        publishResult.completeExceptionally(e);
-                }
-            }
-        });
+                    Topic topicObj = tOpt.get();
+                    CompletableFuture<Void> backlogQuotaCheckFuture = CompletableFuture.allOf(
+                            topicObj.checkBacklogQuotaExceeded(message.getProducerName(),
+                                    BacklogQuota.BacklogQuotaType.destination_storage),
+                            topicObj.checkBacklogQuotaExceeded(message.getProducerName(),
+                                    BacklogQuota.BacklogQuotaType.message_age));
+                    return backlogQuotaCheckFuture.thenRun(() -> {
+                        ByteBuf headersAndPayload = messageToByteBuf(message);
+                        try {
+                            topicObj.publishMessage(headersAndPayload,
+                                    RestMessagePublishContext.get(publishResult, topicObj, System.nanoTime()));
+                        } finally {
+                            headersAndPayload.release();
+                        }
+                    });
+                })
+                .exceptionally(ex -> {
+                    Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                    log.debug()
+                            .attr("topic", topicName)
+                            .exceptionMessage(ex)
+                            .log("Fail to publish single messages to topic");
+                    publishResult.completeExceptionally(cause);
+                    if (!publishResult.isDone()) {
+                        publishResult.completeExceptionally(cause);
+                    }
+                    return null;
+                });
 
         return publishResult;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,6 +67,7 @@ import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -82,6 +84,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonSchema;
 import org.apache.pulsar.client.impl.schema.generic.GenericSchemaImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.ClusterDataImpl;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.schema.KeyValue;
@@ -938,6 +941,86 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(sellerGenericJsonRecord.getField("street"), expected.get(i).getSeller().getStreet());
             Number zipCode = (Number) sellerGenericJsonRecord.getField("zipCode");
             Assert.assertEquals(zipCode.longValue(), expected.get(i).getSeller().getZipCode());
+        }
+    }
+
+    @Test
+    public void testProduceWithBacklogQuotaSizeExceeded() throws Exception {
+        String namespaceName = testTenant + "/" + testNamespace;
+        String topicName = "persistent://" + namespaceName + "/" + testTopicName;
+        admin.topics().createNonPartitionedTopic(topicName);
+        BacklogQuota backlogQuota = BacklogQuota.builder()
+                .limitSize(0)
+                .retentionPolicy(BacklogQuota.RetentionPolicy.producer_exception)
+                .build();
+        admin.namespaces().setBacklogQuota(namespaceName, backlogQuota,
+                BacklogQuota.BacklogQuotaType.destination_storage);
+
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+        ProducerMessages producerMessages = new ProducerMessages();
+        String message = "[{\"payload\":\"rest-produce\"}]";
+        producerMessages.setMessages(createMessages(message));
+        topics.produceOnPersistentTopic(asyncResponse, testTenant, testNamespace, testTopicName,
+                false, producerMessages);
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(asyncResponse, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.OK.getStatusCode());
+        Object responseEntity = responseCaptor.getValue().getEntity();
+        Assert.assertTrue(responseEntity instanceof ProducerAcks);
+        ProducerAcks response = (ProducerAcks) responseEntity;
+        Assert.assertEquals(response.getMessagePublishResults().size(), 1);
+        for (int index = 0; index < response.getMessagePublishResults().size(); index++) {
+            Assert.assertEquals(response.getMessagePublishResults().get(index).getErrorCode(), 2);
+            Assert.assertTrue(response.getMessagePublishResults().get(index).getErrorMsg()
+                    .contains("Cannot create producer on topic with backlog quota exceeded"));
+        }
+    }
+
+    @Test
+    public void testProduceWithBacklogQuotaTimeExceeded() throws Exception {
+        pulsar.getConfiguration().setPreciseTimeBasedBacklogQuotaCheck(true);
+        String namespaceName = testTenant + "/" + testNamespace;
+        String topicName = "persistent://" + namespaceName + "/" + testTopicName;
+        admin.topics().createNonPartitionedTopic(topicName);
+        BacklogQuota backlogQuota = BacklogQuota.builder()
+                .limitTime(1)
+                .retentionPolicy(BacklogQuota.RetentionPolicy.producer_exception)
+                .build();
+        admin.namespaces().setBacklogQuota(namespaceName, backlogQuota,
+                BacklogQuota.BacklogQuotaType.message_age);
+        admin.topics().createSubscription(topicName, "time-quota-sub", MessageId.earliest);
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .create();
+        producer.send("backlog-message");
+        Topic topic = pulsar.getBrokerService().getTopic(topicName, false)
+                .get()
+                .orElseThrow(() -> new IllegalStateException("Topic not loaded: " + topicName));
+        PersistentTopic persistentTopic = (PersistentTopic) topic;
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertTrue(persistentTopic.checkTimeBacklogExceeded(true).get()));
+
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+        ProducerMessages producerMessages = new ProducerMessages();
+        String message = "["
+                + "{\"key\":\"my-key\",\"payload\":\"RestProducer:1\",\"eventTime\":1603045262772,\"sequenceId\":1},"
+                + "{\"key\":\"my-key\",\"payload\":\"RestProducer:2\",\"eventTime\":1603045262772,\"sequenceId\":2}]";
+        producerMessages.setMessages(createMessages(message));
+        topics.produceOnPersistentTopic(asyncResponse, testTenant, testNamespace, testTopicName,
+                false, producerMessages);
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(asyncResponse, timeout(5000).times(1)).resume(responseCaptor.capture());
+        Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.OK.getStatusCode());
+        Object responseEntity = responseCaptor.getValue().getEntity();
+        Assert.assertTrue(responseEntity instanceof ProducerAcks);
+        ProducerAcks response = (ProducerAcks) responseEntity;
+        Assert.assertEquals(response.getMessagePublishResults().size(), 2);
+        for (int index = 0; index < response.getMessagePublishResults().size(); index++) {
+            Assert.assertEquals(response.getMessagePublishResults().get(index).getErrorCode(), 2);
+            Assert.assertTrue(response.getMessagePublishResults().get(index).getErrorMsg()
+                    .contains("Cannot create producer on topic with backlog quota exceeded"));
         }
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

<!-- Fixes #xyz -->

<!-- or this PR is one task of an issue -->

<!-- Main Issue: #xyz -->

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- PIP: #xyz --> 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The binary protocol already performs check backlog quota in `ServerCnx` when creating producers, but the HTTP REST API path was missing this validation.

~~~Java
      .thenAccept(t -> {
            // TODO: Check message backlog and fail if backlog too large.
            if (!t.isPresent()) {
                // Topic not found, and remove from owning partition list.
                publishResult.completeExceptionally(new BrokerServiceException.TopicNotFoundException("Topic not "
                        + "owned by current broker."));
                TopicName topicName = TopicName.get(topic);
                pulsar().getBrokerService().getOwningTopics().get(topicName.getPartitionedTopicName())
                        .remove(topicName.getPartitionIndex());
~~~
### Modifications

- Added backlog quota checks in `publishSingleMessageToPartition` method for both `destination_storage` and `message_age` quota types

The implementation follows the same pattern used in `ServerCnx.handleProducer` where backlog quota checks are performed before allowing message production.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:
- Existing backlog quota tests should cover this functionality
- HTTP produce endpoint tests should verify the behavior

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

**Changes to REST endpoints:**
- The HTTP produce endpoint (`/persistent/{tenant}/{namespace}/{topic}/partitions/{partition}`) now properly enforces backlog quota limits before publishing messages. When backlog quota is exceeded, the request will fail with an appropriate error, consistent with the binary protocol behavior.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/Dream95/pulsar/pull/4

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
