### PR TITLE
[improve][build] Build docker image only once when pushing

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -152,8 +152,7 @@
                 <id>default</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>build</goal>
-                  <goal>push</goal>
+                  <goal>${docker.goal}</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -196,6 +195,7 @@
     <profile>
       <id>docker-push</id>
       <properties>
+        <docker.goal>push</docker.goal>
         <docker.skip.push>false</docker.skip.push>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
       </properties>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -75,8 +75,7 @@
                 <id>default</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>build</goal>
-                  <goal>push</goal>
+                  <goal>${docker.goal}</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -137,6 +136,7 @@
     <profile>
       <id>docker-push</id>
       <properties>
+        <docker.goal>push</docker.goal>
         <docker.skip.push>false</docker.skip.push>
         <docker.skip.tag>true</docker.skip.tag>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ flexible messaging model and an intuitive client API.</description>
          To create multi-arch image, pass -Ddocker.platforms=linux/arm64,linux/amd64
     -->
     <docker.platforms></docker.platforms>
+    <docker.goal>build</docker.goal>
     <docker.skip.push>true</docker.skip.push>
     <docker.skip.tag>false</docker.skip.tag>
 


### PR DESCRIPTION
### Motivation

When pushing images to Docker Hub, the `docker-maven-plugin` currently builds the image twice: once during the `build` goal and again during the `push` goal. This results in redundant work and unnecessary build time.

This change makes the Docker goal configurable so that the image is built only once when pushing.

### Modifications

* Replaced the hardcoded Docker goals (`build` and `push`) in the default execution of the Docker Maven plugin with the `${docker.goal}` property in both `docker/pulsar/pom.xml` and `docker/pulsar-all/pom.xml`, allowing the active goal to be configured.
* Set the default value of the `docker.goal` property to `build` in the root `pom.xml`, preserving the existing behavior for normal builds.
* Added the `docker.goal=push` property to the `docker-push` Maven profile in both `docker/pulsar/pom.xml` and `docker/pulsar-all/pom.xml`, so activating this profile pushes the image without triggering an extra build.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->