### PR TITLE
[fix][sec] Exclude org.lz4:lz4-java and standardize on at.yawk.lz4-java to remediate CVE-2025-12183 and CVE-2025-66566

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -382,7 +382,7 @@ The Apache Software License, Version 2.0
     - org.apache.bookkeeper-bookkeeper-slogger-api-4.17.3.jar
     - org.apache.bookkeeper-bookkeeper-slogger-slf4j-4.17.3.jar
     - org.apache.bookkeeper-native-io-4.17.3.jar
-    - at.yawk.lz4-lz4-java-1.10.2.jar
+    - at.yawk.lz4-lz4-java-1.10.3.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.15.jar

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,7 @@ flexible messaging model and an intuitive client API.</description>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-configuration2.version>2.12.0</commons-configuration2.version>
     <mina-core.version>2.1.10</mina-core.version>
+    <lz4java.version>1.10.3</lz4java.version>
   </properties>
 
   <dependencyManagement>
@@ -1758,6 +1759,12 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>zookeeper</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>at.yawk.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4java.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -261,7 +261,7 @@
     <dependency>
       <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -261,7 +261,6 @@
     <dependency>
       <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
-      <version>1.10.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -261,7 +261,7 @@
     <dependency>
       <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
-      <version>1.10.3</version>
+      <version>1.10.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pulsar-io/debezium/core/pom.xml
+++ b/pulsar-io/debezium/core/pom.xml
@@ -85,6 +85,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pulsar-io/kafka-connect-adaptor/pom.xml
+++ b/pulsar-io/kafka-connect-adaptor/pom.xml
@@ -89,6 +89,10 @@
           <artifactId>jose4j</artifactId>
           <groupId>org.bitbucket.b_c</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pulsar-io/kafka/pom.xml
+++ b/pulsar-io/kafka/pom.xml
@@ -84,6 +84,10 @@
           <artifactId>jose4j</artifactId>
           <groupId>org.bitbucket.b_c</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pulsar-io/kinesis-kpl-shaded/pom.xml
+++ b/pulsar-io/kinesis-kpl-shaded/pom.xml
@@ -58,6 +58,12 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -44,6 +44,12 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka-client.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
Apache Pulsar currently pulls in org.lz4:lz4-java (1.8.0) transitively via Kafka-related dependencies. This version is affected by CVE-2025-12183 and CVE-2025-66566.

The goal of this change is to remediate these CVEs without upgrading Kafka or altering runtime behavior, by standardizing on the actively maintained at.yawk.lz4:lz4-java implementation already used elsewhere in the Pulsar build.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
This PR makes the following changes:

- Excludes org.lz4:lz4-java from all Kafka-related dependency paths that bring it transitively (Kafka clients, connect runtime, adapters, and IO modules).
- Standardizes on at.yawk.lz4:lz4-java, upgrading it to version 1.10.3.
- Updates the binary license list (LICENSE.bin.txt) to reflect the upgraded LZ4 artifact version.

No functional logic changes are introduced.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->https://github.com/Nordix/pulsar/pull/16

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
