### PR TITLE
[revert] "[improve][build] Build docker image only once when pushing"

### DIFF
--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -152,7 +152,8 @@
                 <id>default</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>${docker.goal}</goal>
+                  <goal>build</goal>
+                  <goal>push</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -195,7 +196,6 @@
     <profile>
       <id>docker-push</id>
       <properties>
-        <docker.goal>push</docker.goal>
         <docker.skip.push>false</docker.skip.push>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
       </properties>

--- a/docker/pulsar/pom.xml
+++ b/docker/pulsar/pom.xml
@@ -75,7 +75,8 @@
                 <id>default</id>
                 <phase>package</phase>
                 <goals>
-                  <goal>${docker.goal}</goal>
+                  <goal>build</goal>
+                  <goal>push</goal>
                 </goals>
                 <configuration>
                   <images>
@@ -136,7 +137,6 @@
     <profile>
       <id>docker-push</id>
       <properties>
-        <docker.goal>push</docker.goal>
         <docker.skip.push>false</docker.skip.push>
         <docker.skip.tag>true</docker.skip.tag>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,6 @@ flexible messaging model and an intuitive client API.</description>
          To create multi-arch image, pass -Ddocker.platforms=linux/arm64,linux/amd64
     -->
     <docker.platforms></docker.platforms>
-    <docker.goal>build</docker.goal>
     <docker.skip.push>true</docker.skip.push>
     <docker.skip.tag>false</docker.skip.tag>
 


### PR DESCRIPTION
Reverts apache/pulsar#25194

Reason: The `push` goal depends on the `build` goal, so #25194 should be reverted.

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
