### PR TITLE
[fix][broker] Rename TopicBacklogQuotaExceededException to TopicBlock…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -224,11 +224,11 @@ public class BrokerServiceException extends Exception {
         }
     }
 
-    public static class TopicBacklogQuotaExceededException extends BrokerServiceException {
+    public static class TopicBlockedQuotaExceededException extends BrokerServiceException {
         @Getter
         private final BacklogQuota.RetentionPolicy retentionPolicy;
 
-        public TopicBacklogQuotaExceededException(BacklogQuota.RetentionPolicy retentionPolicy) {
+        public TopicBlockedQuotaExceededException(BacklogQuota.RetentionPolicy retentionPolicy) {
             super("Cannot create producer on topic with backlog quota exceeded");
             this.retentionPolicy = retentionPolicy;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1794,9 +1794,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return backlogQuotaCheckFuture;
             }).exceptionally(exception -> {
                 Throwable cause = exception.getCause();
-                if (cause instanceof BrokerServiceException.TopicBacklogQuotaExceededException) {
-                    BrokerServiceException.TopicBacklogQuotaExceededException tbqe =
-                            (BrokerServiceException.TopicBacklogQuotaExceededException) cause;
+                if (cause instanceof BrokerServiceException.TopicBlockedQuotaExceededException) {
+                    BrokerServiceException.TopicBlockedQuotaExceededException tbqe =
+                            (BrokerServiceException.TopicBlockedQuotaExceededException) cause;
                     IllegalStateException illegalStateException = new IllegalStateException(tbqe);
                     BacklogQuota.RetentionPolicy retentionPolicy = tbqe.getRetentionPolicy();
                     if (producerFuture.completeExceptionally(illegalStateException)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -113,7 +113,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionConflictUnloadException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionNotFoundException;
-import org.apache.pulsar.broker.service.BrokerServiceException.TopicBacklogQuotaExceededException;
+import org.apache.pulsar.broker.service.BrokerServiceException.TopicBlockedQuotaExceededException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicClosedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicFencedException;
@@ -3754,14 +3754,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (backlogQuotaType == BacklogQuotaType.destination_storage && isSizeBacklogExceeded()) {
                     log.debug("[{}] Size backlog quota exceeded. Cannot create producer [{}]", this.getName(),
                             producerName);
-                    return FutureUtil.failedFuture(new TopicBacklogQuotaExceededException(retentionPolicy));
+                    return FutureUtil.failedFuture(new TopicBlockedQuotaExceededException(retentionPolicy));
                 }
                 if (backlogQuotaType == BacklogQuotaType.message_age) {
                     return checkTimeBacklogExceeded(true).thenCompose(isExceeded -> {
                         if (isExceeded) {
                             log.debug("[{}] Time backlog quota exceeded. Cannot create producer [{}]", this.getName(),
                                     producerName);
-                            return FutureUtil.failedFuture(new TopicBacklogQuotaExceededException(retentionPolicy));
+                            return FutureUtil.failedFuture(new TopicBlockedQuotaExceededException(retentionPolicy));
                         } else {
                             return CompletableFuture.completedFuture(null);
                         }


### PR DESCRIPTION
[fix][broker] Rename TopicBacklogQuotaExceededException to TopicBlockedQuotaExceededException

Fixes #25168

### Motivation

Based on the code, there is a naming inconsistency between server-side and client-side exceptions:
- When the server throws `ProducerBacklogQuotaExceededError`, the exception class is `TopicBacklogQuotaExceededException`
- But the client receives `ProducerBlockedQuotaExceededException` or `ProducerBlockedQuotaExceededError`

This makes it difficult for developers to locate key information from the server-side code when debugging quota-related issues.

### Modifications

Renamed `TopicBacklogQuotaExceededException` to [TopicBlockedQuotaExceededException](cci:2://file:///Users/chaochen/IdeaProjects/study/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java:226:4-234:5) in the following files:
- [BrokerServiceException.java](cci:7://file:///Users/chaochen/IdeaProjects/study/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java:0:0-0:0): Class definition and constructor
- [ServerCnx.java](cci:7://file:///Users/chaochen/IdeaProjects/study/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java:0:0-0:0): Exception type check and casting
- [PersistentTopic.java](cci:7://file:///Users/chaochen/IdeaProjects/study/pulsar/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java:0:0-0:0): Import statement and exception throwing

### Verifying this change

This change is already covered by existing tests, such as:
- `BacklogQuotaManagerTest` - Tests backlog quota enforcement
- `PersistentTopicTest` - Tests topic behavior with quota exceeded

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/DoChaoing/pulsar/pull/1