### PR TITLE
[improve][test] Set k8s test retry count to 0

### DIFF
--- a/build/run_integration_group.sh
+++ b/build/run_integration_group.sh
@@ -208,7 +208,7 @@ test_group_sql() {
 }
 
 test_group_pulsar_k8s() {
-  mvn_run_integration_test "$@" -DintegrationTestSuiteFile=pulsar-k8s.xml -DintegrationTests
+  mvn_run_integration_test "$@" -DintegrationTestSuiteFile=pulsar-k8s.xml -DintegrationTests -DtestRetryCount=0
 }
 
 test_group_pulsar_io() {


### PR DESCRIPTION
Related to #25218

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The PULSAR_K8S integration test group consists of one test only (PulsarFunctionsK8STest). Currently, the `testRetryCount` is set to 1. This leads to misleading logs in CI if the test fails. An example can be seen here: https://github.com/apache/pulsar/actions/runs/21718811469/job/62651627693?pr=25207#step:12:5662

```
Error:  Tests run: 2, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 126.1 s <<< FAILURE! -- in TestSuite
Error:  org.apache.pulsar.tests.integration.functions.k8s.PulsarFunctionsK8STest.testCreateFunctionInK8sWithSecrets -- Time elapsed: 0.068 s <<< FAILURE!
org.apache.pulsar.client.admin.PulsarAdminException: Function test-function already exists
 ```
 
If the first test run fails after the Pulsar function was created, there is no cleanup before the second test run, and the second run always fails because the function it tries to create already exists. 
The logs in CI only show the error from the second test run. To get the original error from the first test run, one needs to download the corresponding artifacts.

For the test retry to make sense, one would need to properly clean up existing resources after the first run. This is not easily possible. Even if the function is deleted, the package metadata will remain, and the second test run will fail due to:

```
org.apache.pulsar.client.admin.PulsarAdminException$ServerSideErrorException: Package 'function://public/default/test-function@0' metadata already exists
```

That's why I propose to disable the retry for this test. Then, if the first attempt fails, the CI logs show the actual failure reason.

### Modifications

Changed `testRetryCount` to 0 for PULSAR_K8S integration test group.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/21