### PR TITLE
[feat][broker] Add adaptive publish throttle controller (disabled by default)

### DIFF
--- a/ADAPTIVE_THROTTLE_PR.md
+++ b/ADAPTIVE_THROTTLE_PR.md
@@ -1,0 +1,292 @@
+# Adaptive Publish Throttling — PR Reference
+
+## Config Keys
+
+All keys live under the `CATEGORY_SERVER` section of `ServiceConfiguration`.
+A **dynamic** key can be changed at runtime via the admin API without a restart.
+
+| Key | Default | Dynamic | Purpose |
+|-----|---------|:-------:|---------|
+| `adaptivePublisherThrottlingEnabled` | `false` | No | Master switch. Requires broker restart to enable or disable. |
+| `adaptivePublisherThrottlingObserveOnly` | `false` | **Yes** | When `true`, controller computes everything but never applies throttling. Flip at runtime as an emergency rollback. |
+| `adaptivePublisherThrottlingIntervalMs` | `1000` | **Yes** | Milliseconds between controller evaluation cycles. |
+| `adaptivePublisherThrottlingMemoryHighWatermarkPct` | `0.85` | **Yes** | JVM heap fraction where memory pressure reaches 1.0 (full throttle). |
+| `adaptivePublisherThrottlingMemoryLowWatermarkPct` | `0.70` | **Yes** | JVM heap fraction below which memory pressure drops to 0 (hysteresis floor). Must be < high watermark. |
+| `adaptivePublisherThrottlingBacklogHighWatermarkPct` | `0.90` | **Yes** | Backlog/quota fraction where backlog pressure reaches 1.0. Only topics with a backlog quota are affected. |
+| `adaptivePublisherThrottlingBacklogLowWatermarkPct` | `0.75` | **Yes** | Backlog/quota fraction below which backlog pressure drops to 0 (hysteresis floor). Must be < high watermark. |
+| `adaptivePublisherThrottlingMinRateFactor` | `0.10` | **Yes** | Hard floor: effective rate never drops below `naturalRate × minRateFactor`. |
+| `adaptivePublisherThrottlingMaxRateChangeFactor` | `0.25` | **Yes** | Maximum rate change per cycle as a fraction of natural rate; prevents sudden jumps and oscillation. |
+| `adaptivePublisherThrottlingPerTopicMetricsEnabled` | `false` | **Yes** | Emit per-topic OpenTelemetry metrics. Adds 6 time-series per topic; review cardinality before enabling in large clusters. |
+
+---
+
+## Files Changed and Added
+
+### Modified (4 files)
+
+| File | What changed |
+|------|-------------|
+| `pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java` | 10 new `@FieldContext`-annotated config fields with Javadoc |
+| `conf/broker.conf` | 10 new commented-out config entries |
+| `pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java` | `AdaptivePublishRateLimiter` field; `handlePublishThrottling()` delegates to it when feature is enabled |
+| `pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java` | `AdaptivePublishThrottleController` lifecycle (`start()` on boot, `close()` on shutdown); `forEachPersistentTopic()` helper |
+
+### Added (7 files)
+
+| File | Purpose |
+|------|---------|
+| `pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiter.java` | Per-topic `PublishRateLimiter` implementation. No-op when inactive. Asymmetric EWMA natural-rate tracking. Wraps `PublishRateLimiterImpl` delegate. |
+| `pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleController.java` | Broker-level single-threaded scheduler. Computes memory + backlog pressure, applies bounded-step rate changes, enforces hysteresis, respects `observeOnly` flag. Never dies silently (try-catch-finally on every cycle). |
+| `pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryAdaptiveThrottleStats.java` | OpenTelemetry instrumentation: 3 broker-level gauges + 3 controller health metrics (always on) + 6 per-topic gauges (opt-in). |
+| `pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiterTest.java` | Unit tests for the limiter: no-op guarantee, activate/deactivate lifecycle, asymmetric EWMA correctness, `observeOnly` channel-autoread safety. |
+| `pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleControllerTest.java` | Unit tests for controller math: `linearPressure()`, `computeTargetRate()` bounded-step arithmetic, hysteresis transitions, `observeOnly` guarantee, backlog pressure. |
+| `pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptiveThrottleEndToEndTest.java` | End-to-end tests for the full control loop: no-pressure steady state, smooth rate reduction, monotonic decrease, deactivation on drain, `observeOnly` end-to-end (with IO-thread throttle-count assertion), null-limiter skip, first-cycle warmup. |
+| `pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ThrottleTypeEnumTest.java` | Ordinal stability guard for `ThrottleType` enum: asserts minimum constant count, that `AdaptivePublishRate` is present and last, and that it is declared reentrant. |
+
+---
+
+## Test Commands
+
+Run these in a normal Pulsar developer environment from the repository root.
+All commands require a full `mvn install -DskipTests` of the project first to
+populate the local Maven cache with SNAPSHOT artifacts.
+
+```bash
+# Unit tests — controller math, limiter correctness, observeOnly guarantee
+# Runs in ~15 seconds with no broker required.
+mvn test -pl pulsar-broker -am \
+  -Dtest="AdaptivePublishRateLimiterTest,AdaptivePublishThrottleControllerTest,AdaptiveThrottleEndToEndTest" \
+  -DfailIfNoTests=false \
+  --no-transfer-progress
+
+# Regression — include existing publish rate limiter tests to catch regressions
+mvn test -pl pulsar-broker -am \
+  -Dtest="AdaptivePublish*,AdaptiveThrottle*,PublishRateLimiterTest" \
+  -DfailIfNoTests=false \
+  --no-transfer-progress
+
+# Integration — broader broker service tests (slow; run before merging)
+mvn test -pl pulsar-broker -am \
+  -Dtest="PublishRateLimiterTest,RateLimiterTest,MessagePublishBufferThrottleTest" \
+  -DfailIfNoTests=false \
+  --no-transfer-progress
+```
+
+---
+
+## Metrics Reference
+
+### Always-on broker-level metrics (no cardinality cost)
+
+| Metric | Type | Alert condition |
+|--------|------|----------------|
+| `pulsar.broker.adaptive.throttle.memory.pressure` | Gauge (0–1) | > 0.5 sustained |
+| `pulsar.broker.adaptive.throttle.active.topic.count` | Gauge | > 0 unexpectedly |
+| `pulsar.broker.adaptive.throttle.activation.count` | Counter | Rapid increase |
+| `pulsar.broker.adaptive.throttle.controller.last.evaluation.timestamp` | Gauge (epoch ms) | `now − value > 3 × intervalMs` |
+| `pulsar.broker.adaptive.throttle.controller.evaluation.duration` | Gauge (ms) | > `intervalMs` consistently |
+| `pulsar.broker.adaptive.throttle.controller.evaluation.failure.count` | Counter | Any non-zero value |
+
+### Per-topic metrics (opt-in via `adaptivePublisherThrottlingPerTopicMetricsEnabled=true`)
+
+`pulsar.broker.topic.adaptive.throttle.{active, natural.publish.rate, effective.publish.rate, memory.pressure, backlog.pressure, rate.reduction.ratio}`
+
+---
+
+## Troubleshooting Guide
+
+### Producers are being throttled — what is the cause?
+
+**Step 1 — Confirm adaptive throttling is active, not static rate limits.**
+Look for log lines: `[AdaptiveThrottle] ACTIVATED topic=...`
+Static rate limit throttling logs differently (`PublishRateLimiterImpl`).
+
+**Step 2 — Identify the pressure signal.**
+
+| Signal | How to check |
+|--------|-------------|
+| **Memory pressure** | `pulsar.broker.adaptive.throttle.memory.pressure > 0`. Also check: `grep "memoryPressure=[^0]" broker.log`. The ACTIVATED log line shows both `memoryPressure=` and `backlogPressure=` fields. |
+| **Backlog pressure** | Check ACTIVATED log: `backlogPressure=` field > 0. Or enable per-topic metrics and check `pulsar.broker.topic.adaptive.throttle.backlog.pressure`. |
+| **Both** | `pressureFactor = max(memory, backlog)`. The higher signal dominates. |
+
+**Step 3 — Remediation by signal type.**
+
+*Memory pressure* (`memoryPressure > 0`):
+- Identify topics with high message sizes or high throughput (`pulsar-admin topics stats`)
+- Consider scaling out (add brokers, trigger topic offloading)
+- Short-term: raise `adaptivePublisherThrottlingMemoryHighWatermarkPct` (dynamic, no restart)
+- Emergency: set `adaptivePublisherThrottlingObserveOnly=true` to suspend all throttling instantly
+
+*Backlog pressure* (`backlogPressure > 0`):
+- Check consumer lag: `pulsar-admin topics stats --get-precise-backlog`
+- Verify subscriptions are active and consumers are running
+- Check if a consumer is stuck or restarting in a loop
+- Review the topic's backlog quota: `pulsar-admin namespaces get-backlog-quota <namespace>`
+- Short-term: raise `adaptivePublisherThrottlingBacklogHighWatermarkPct` (dynamic)
+
+**Step 4 — Verify observe-only mode is not masking a real problem.**
+
+If `adaptivePublisherThrottlingObserveOnly=true`:
+- `pulsar.broker.adaptive.throttle.active.topic.count` will be **0** even under pressure
+- Log lines say `OBSERVE-ONLY would-activate` — no actual throttling is applied
+- Check: `pulsar-admin brokers get-runtime-configuration | grep observeOnly`
+
+**Step 5 — Check controller health.**
+
+If `pulsar.broker.adaptive.throttle.controller.evaluation.failure.count > 0`:
+- Search broker logs: `grep "Evaluation cycle failed" broker.log`
+- Common causes: NPE during topic iteration, unexpected `BrokerService` state at startup
+- If the controller is stalled (`last.evaluation.timestamp` not advancing): broker restart required
+
+**Step 6 — Confirm the throttle is releasing.**
+
+When pressure drops below the low watermarks, the limiter deactivates and logs:
+`[AdaptiveThrottle] DEACTIVATED topic=... naturalMsgRate=.../s`
+If DEACTIVATED never appears after pressure clears, check that both
+`memoryPressure` AND `backlogPressure` are below their respective low watermarks
+(deactivation requires both, not just one).
+
+---
+
+## Commit Message
+
+```
+[feat][broker] Add adaptive publish throttle controller (disabled by default)
+
+Introduces an opt-in, broker-level adaptive publish throttle that
+dynamically reduces producer publish rates when JVM heap usage or
+per-topic backlog size approaches configurable watermarks.
+
+Key design points
+-----------------
+- AdaptivePublishRateLimiter: per-topic PublishRateLimiter that is a
+  complete no-op (zero overhead) when inactive. Asymmetric EWMA
+  (α_up=0.30, α_down=0.05) tracks the producer's peak natural rate.
+- AdaptivePublishThrottleController: single-threaded broker-level
+  scheduler; bounded-step rate changes (≤ 25 % of natural rate per
+  cycle) prevent oscillation; hysteresis (activate on pressure > 0,
+  deactivate only when pressure == 0) prevents rapid toggling.
+- observeOnly mode: compute + log + emit metrics without applying
+  any throttling; togglable via dynamic config as an emergency
+  circuit-breaker (no restart required).
+- Controller never dies silently: every evaluation cycle is wrapped
+  in try-catch-finally; failures are counted and logged at ERROR.
+- ThrottleType.AdaptivePublishRate: dedicated reentrant enum constant
+  appended at the end of ThrottleType to preserve existing ordinals.
+- OpenTelemetry: 3 always-on broker metrics + 3 controller health
+  metrics (last-eval timestamp, duration, failure count) + 6 optional
+  per-topic metrics (disabled by default).
+
+Disabled by default: adaptivePublisherThrottlingEnabled=false.
+A broker restart is required to enable it. All tuning parameters
+(watermarks, rate factors, observeOnly flag) are dynamic.
+
+Tests added
+-----------
+- AdaptivePublishRateLimiterTest  (13 unit tests)
+- AdaptivePublishThrottleControllerTest  (30+ unit tests)
+- AdaptiveThrottleEndToEndTest  (9 integration tests)
+- ThrottleTypeEnumTest  (4 ordinal-stability guard tests)
+```
+
+## PR Description
+
+> **Experimental feature** — disabled by default (`adaptivePublisherThrottlingEnabled=false`).
+> A broker restart is required to enable it; all tuning parameters are dynamic config.
+>
+> **Focused review request** — the areas most likely to have subtle bugs are:
+> 1. **Concurrency** — `AdaptivePublishRateLimiter`: the `volatile boolean active` fast path on IO threads (see `handlePublishThrottling`), and the single-writer contract on the controller scheduler thread.
+> 2. **Lifecycle** — `BrokerService.startAdaptivePublishThrottleController()` and the `close()` path; `ThrottleType.AdaptivePublishRate` ordinal stability and the new `states[]` slot.
+> 3. **Hysteresis** — deactivation requires **both** memory **and** backlog pressure to drop below their low watermarks simultaneously; verify this is correct for your use case.
+
+---
+
+### Summary
+
+- Adds an adaptive publish throttle controller that dynamically reduces producer publish rates when JVM heap usage or per-topic backlog size approaches configurable watermarks.
+- **Disabled by default.** Zero code path changes when `adaptivePublisherThrottlingEnabled=false`.
+- **Observe-only mode** (`adaptivePublisherThrottlingObserveOnly=true`, toggleable at runtime) computes and logs decisions but never applies throttling — safe for validating in production and usable as an emergency circuit-breaker.
+- Controller never dies silently: every cycle is wrapped in `try-catch-finally`; failures increment a dedicated OTel counter.
+- `ThrottleType.AdaptivePublishRate` is appended as the last enum constant to preserve existing ordinals 0–6. A guard test (`ThrottleTypeEnumTest`) fails immediately if the enum is accidentally mutated.
+
+---
+
+### Diff navigation
+
+#### Configuration (reviewers: verify defaults, dynamic flags, and conf entry comments)
+
+| File | What changed |
+|------|-------------|
+| `ServiceConfiguration.java` | 10 new `@FieldContext` fields — `adaptivePublisherThrottling*` |
+| `conf/broker.conf` | 10 new commented-out entries with inline docs and a recommended quick-start snippet |
+| `README.md` | New "Experimental broker features" section with quick-start `broker.conf` snippet |
+
+#### Broker wiring (reviewers: focus on concurrency, lifecycle, and enum ordinal safety)
+
+| File | What changed |
+|------|-------------|
+| `ServerCnxThrottleTracker.java` | New `ThrottleType.AdaptivePublishRate` constant (appended last, reentrant); class-level Javadoc on ordinal stability |
+| `AbstractTopic.java` | New `AdaptivePublishRateLimiter` field; `handlePublishThrottling()` delegation; uses `ThrottleType.AdaptivePublishRate` |
+| `BrokerService.java` | `startAdaptivePublishThrottleController()` lifecycle; `forEachPersistentTopic()` helper; `close()` teardown |
+| `AdaptivePublishRateLimiter.java` *(new)* | Per-topic limiter: `volatile boolean active` fast path, asymmetric EWMA, `activate()`/`deactivate()` |
+| `AdaptivePublishThrottleController.java` *(new)* | Broker-level scheduler: pressure math, bounded-step rate changes, hysteresis, `observeOnly` guard, `try-catch-finally` safety |
+| `OpenTelemetryAdaptiveThrottleStats.java` *(new)* | 6 broker-level OTel metrics (3 always-on + 3 health); 6 per-topic metrics (opt-in) |
+
+#### Tests (reviewers: check the observeOnly safety tests and the enum guard tests)
+
+| File | Key assertions |
+|------|---------------|
+| `AdaptivePublishRateLimiterTest.java` *(new)* | No-op guarantee, activate/deactivate, asymmetric EWMA, `observeOnly` never changes channel autoread |
+| `AdaptivePublishThrottleControllerTest.java` *(new)* | `linearPressure()`, bounded-step `computeTargetRate()`, hysteresis, `observeOnly` never calls `activate()` |
+| `AdaptiveThrottleEndToEndTest.java` *(new)* | Full control-loop integration: pressure → throttle → drain → deactivate; `observeOnly` IO-thread safety |
+| `ThrottleTypeEnumTest.java` *(new)* | Minimum constant count, `AdaptivePublishRate` present and last, declared reentrant |
+
+---
+
+### Design FAQ
+
+**Q: Why introduce a new `ThrottleType.AdaptivePublishRate` instead of reusing `TopicPublishRate`?**
+
+`ServerCnxThrottleTracker` uses reference-counting via `states[ThrottleType.ordinal()]`.
+If the adaptive limiter shared `TopicPublishRate` with the static rate limiter, a single
+`unmarkThrottled()` call from the adaptive side could decrement the count that the static
+limiter had incremented — leaving the connection unthrottled even though the static limit is
+still exceeded. A dedicated constant keeps the two signals fully independent and eliminates an
+entire class of ordering bugs.
+
+**Q: Why does the controller not coordinate across brokers? Each broker throttles independently.**
+
+Adaptive throttling reacts to local signals — JVM heap on this JVM, backlog on topics owned
+by this broker. Cross-broker coordination would require a consensus protocol, introduce network
+latency on the hot publish path, and create a single point of failure. Local-only decisions
+are simpler, faster, and fail-safe: if the network partition occurs, each broker still protects
+itself independently. Cluster-wide load imbalance (e.g. one hot broker) is better addressed
+by Pulsar's topic-migration and load-balancer machinery than by throttle coordination.
+
+**Q: What happens if the controller thread crashes?**
+
+The evaluation loop is wrapped in `try-catch-finally`. A caught exception:
+
+1. Increments `evaluationFailureCount` (surfaced as OTel counter
+   `pulsar.broker.adaptive.throttle.controller.evaluation.failure.count`).
+2. Logs the full stack trace at `ERROR` level so it appears in broker logs immediately.
+3. Does **not** kill the `ScheduledExecutorService` — the scheduler reschedules the next
+   cycle unconditionally (the `finally` block always completes before the next cycle fires).
+
+If the failure is persistent (e.g. NPE on every cycle), the `last.evaluation.timestamp` metric
+stops advancing while `evaluation.failure.count` climbs — a clear alert signal.
+Active throttle limiters already applied to topics remain in place until the next successful
+cycle; they do not release autonomously, so producers stay protected during transient failures.
+A full controller stall (scheduler thread itself dies — only possible via an unchecked
+`Error`) requires a broker restart; the OTel staleness alert on
+`controller.last.evaluation.timestamp` will fire within `3 × intervalMs` of the stall.
+
+---
+
+### Test plan
+
+- [ ] `mvn test -pl pulsar-broker -am -Dtest="AdaptivePublishRateLimiterTest,AdaptivePublishThrottleControllerTest,AdaptiveThrottleEndToEndTest,ThrottleTypeEnumTest" -DfailIfNoTests=false --no-transfer-progress` passes
+- [ ] `mvn test -pl pulsar-broker -am -Dtest="PublishRateLimiterTest" -DfailIfNoTests=false --no-transfer-progress` (regression: static rate limiter unaffected)
+- [ ] Broker starts with `adaptivePublisherThrottlingEnabled=false` (default): no controller thread, no `AdaptivePublishRateLimiter` allocated, no OTel instruments registered
+- [ ] `observeOnly=true`: logs show `OBSERVE-ONLY would-activate`, zero `ACTIVATED` lines, `active.topic.count` metric stays at 0
+- [ ] OTel scrape shows all 6 broker-level metrics when feature is enabled

--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ Learn more about Pulsar at https://pulsar.apache.org
 - Transparent handling of partitioned topics
 - Transparent batching of messages
 
+## Experimental broker features
+
+### Adaptive publish throttling (disabled by default)
+
+The broker includes an opt-in adaptive publish-rate controller that dynamically
+reduces producer publish rates when JVM heap usage or per-topic backlog size
+approaches configurable watermarks.  It is additive to existing static rate
+limits and backlog quota enforcement and is safe to enable alongside them.
+
+**Quick start** — add the following to `conf/broker.conf` (broker restart required
+to enable; all tuning knobs can be changed dynamically at runtime):
+
+```properties
+# Enable the feature (requires restart)
+adaptivePublisherThrottlingEnabled=true
+
+# Recommended starting values — validate with observeOnly=true first
+adaptivePublisherThrottlingObserveOnly=true          # dry-run: log but do not throttle
+adaptivePublisherThrottlingMemoryHighWatermarkPct=0.85
+adaptivePublisherThrottlingMemoryLowWatermarkPct=0.70
+adaptivePublisherThrottlingBacklogHighWatermarkPct=0.90
+adaptivePublisherThrottlingBacklogLowWatermarkPct=0.75
+adaptivePublisherThrottlingMinRateFactor=0.10         # floor: never below 10 % of natural rate
+adaptivePublisherThrottlingMaxRateChangeFactor=0.25   # max 25 % change per 1 s cycle
+```
+
+Once the observe-only logs look correct, flip `adaptivePublisherThrottlingObserveOnly=false`
+via the dynamic config admin API without restarting the broker.  See
+[`ADAPTIVE_THROTTLE_PR.md`](ADAPTIVE_THROTTLE_PR.md) for the full config reference,
+metrics guide, and troubleshooting steps.
+
 ## Repositories
 
 This repository is the main repository of Apache Pulsar. Pulsar PMC also maintains other repositories for

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -2159,3 +2159,40 @@ brokerInterceptors=
 
 # Enable or disable the broker interceptor, which is only used for testing for now
 disableBrokerInterceptors=true
+
+### --- Adaptive Publish Throttling ---
+# Dynamically reduces publish rates under memory or backlog pressure.
+# Disabled by default. A broker restart is required to enable/disable.
+# Use adaptivePublisherThrottlingObserveOnly=true to evaluate impact safely first.
+
+# Master switch — enable adaptive publish throttle controller.
+#adaptivePublisherThrottlingEnabled=false
+
+# Dry-run mode: compute and log throttle decisions but apply no actual throttling.
+# Can be toggled at runtime via dynamic config as an emergency circuit-breaker.
+#adaptivePublisherThrottlingObserveOnly=false
+
+# Controller evaluation interval in milliseconds.
+#adaptivePublisherThrottlingIntervalMs=1000
+
+# JVM heap usage fraction above which memory pressure starts (linear ramp to highWm).
+#adaptivePublisherThrottlingMemoryHighWatermarkPct=0.85
+
+# JVM heap usage fraction below which memory pressure is zero (hysteresis low watermark).
+#adaptivePublisherThrottlingMemoryLowWatermarkPct=0.70
+
+# Backlog/quota fraction above which backlog pressure starts (linear ramp to highWm).
+# Only topics with a configured backlog quota are affected.
+#adaptivePublisherThrottlingBacklogHighWatermarkPct=0.90
+
+# Backlog/quota fraction below which backlog pressure is zero (hysteresis low watermark).
+#adaptivePublisherThrottlingBacklogLowWatermarkPct=0.75
+
+# Minimum effective rate as a fraction of natural rate (floor). Must be in (0.0, 1.0).
+#adaptivePublisherThrottlingMinRateFactor=0.10
+
+# Maximum rate change per cycle as a fraction of natural rate (prevents sudden bursts).
+#adaptivePublisherThrottlingMaxRateChangeFactor=0.25
+
+# Enable per-topic OpenTelemetry metrics (6 time series per topic — evaluate cardinality first).
+#adaptivePublisherThrottlingPerTopicMetricsEnabled=false

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiter.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.qos.MonotonicClock;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.PublishRate;
+
+/**
+ * A per-topic publish rate limiter whose effective rate is controlled dynamically by
+ * {@link AdaptivePublishThrottleController}.
+ *
+ * <p>The limiter wraps a {@link PublishRateLimiterImpl} delegate. When inactive
+ * ({@code active == false}), {@link #handlePublishThrottling} is a complete no-op with
+ * no lock acquisition and no token-bucket access.  Only the controller (running on its
+ * own single-threaded scheduler) calls {@link #activate} and {@link #deactivate}; the
+ * IO threads only ever call {@link #handlePublishThrottling}.
+ *
+ * <h3>Thread-safety model</h3>
+ * <ul>
+ *   <li>{@code active} — {@code volatile boolean}: written by the controller thread,
+ *       read by IO threads; guaranteed visibility without locking.</li>
+ *   <li>{@code naturalMsgRateEstimate}, {@code naturalByteRateEstimate},
+ *       {@code currentEffectiveMsgRate}, {@code currentEffectiveByteRate},
+ *       {@code lastSampleMsgCount}, {@code lastSampleByteCount},
+ *       {@code lastSampleTimeNs} — all {@code volatile}; single writer
+ *       (controller thread), multiple readers.  No atomic compare-and-set needed
+ *       because the controller runs on a single-threaded scheduler.</li>
+ *   <li>{@code delegate.update()} — calls into {@link PublishRateLimiterImpl} which
+ *       stores token buckets in {@code volatile} fields; safe across threads.</li>
+ * </ul>
+ */
+@Slf4j
+public class AdaptivePublishRateLimiter implements PublishRateLimiter {
+
+    /** Inner delegate that owns the actual token buckets. */
+    private final PublishRateLimiterImpl delegate;
+
+    /**
+     * True when throttling is currently active.  IO threads read this on every
+     * publish; the controller writes it.  {@code volatile} guarantees visibility.
+     */
+    private volatile boolean active = false;
+
+    /**
+     * Estimated "natural" (unthrottled) publish rate — updated only while
+     * {@code active == false} so it never reflects a post-throttle reduced rate.
+     */
+    private volatile double naturalMsgRateEstimate = 0.0;
+    private volatile double naturalByteRateEstimate = 0.0;
+
+    /**
+     * The effective rate currently applied to the token bucket (msg/s).
+     * Tracks the smoothed value across controller cycles (bounded step).
+     * Zero when not throttling.
+     */
+    private volatile long currentEffectiveMsgRate = 0L;
+    private volatile long currentEffectiveByteRate = 0L;
+
+    /** Cumulative counters captured at the previous sample cycle. */
+    private volatile long lastSampleMsgCount = -1L;
+    private volatile long lastSampleByteCount = -1L;
+    private volatile long lastSampleTimeNs = 0L;
+
+    /**
+     * Nanosecond timestamp of the last ACTIVATED→DEACTIVATED transition log, used
+     * to suppress repeated log spam for oscillating topics.
+     */
+    private volatile long lastTransitionLogNs = 0L;
+
+    /** Monotonically increasing count of activate() calls (for metrics). */
+    private final LongAdder throttleActivationCount = new LongAdder();
+
+    /** Minimum log re-emission interval for transition events: 60 seconds. */
+    private static final long MIN_TRANSITION_LOG_INTERVAL_NS = 60_000_000_000L;
+
+    public AdaptivePublishRateLimiter(MonotonicClock clock,
+                                      Consumer<Producer> throttleAction,
+                                      Consumer<Producer> unthrottleAction) {
+        this.delegate = new PublishRateLimiterImpl(clock, throttleAction, unthrottleAction);
+    }
+
+    // -------------------------------------------------------------------------
+    // PublishRateLimiter interface — called from IO threads
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void handlePublishThrottling(Producer producer, int numOfMessages, long msgSizeInBytes) {
+        // Fast path: no volatile read beyond the boolean check when inactive.
+        if (active) {
+            delegate.handlePublishThrottling(producer, numOfMessages, msgSizeInBytes);
+        }
+    }
+
+    /**
+     * Not used: this limiter's rate is controlled exclusively by
+     * {@link AdaptivePublishThrottleController}, not by policy updates.
+     */
+    @Override
+    public void update(Policies policies, String clusterName) {
+        // intentional no-op
+    }
+
+    /**
+     * Not used: see {@link #update(Policies, String)}.
+     */
+    @Override
+    public void update(PublishRate maxPublishRate) {
+        // intentional no-op
+    }
+
+    // -------------------------------------------------------------------------
+    // Controller API — called only from the single-threaded controller scheduler
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sample the instantaneous publish rate from cumulative counters and update
+     * the natural rate estimate via asymmetric EWMA.  Must be called only when
+     * {@code active == false} so the estimate reflects the unthrottled rate.
+     *
+     * @param currentMsgCount  current value of AbstractTopic.getMsgInCounter()
+     * @param currentByteCount current value of AbstractTopic.getBytesInCounter()
+     * @param nowNs            current time in nanoseconds (from System.nanoTime())
+     */
+    public void sampleRate(long currentMsgCount, long currentByteCount, long nowNs) {
+        if (lastSampleTimeNs > 0 && nowNs > lastSampleTimeNs) {
+            double elapsedSec = (nowNs - lastSampleTimeNs) / 1e9;
+            if (elapsedSec > 0.0) {
+                double instantMsgRate = Math.max(0.0, (currentMsgCount - lastSampleMsgCount) / elapsedSec);
+                double instantByteRate = Math.max(0.0, (currentByteCount - lastSampleByteCount) / elapsedSec);
+                updateNaturalRateEstimate(instantMsgRate, instantByteRate);
+            }
+        }
+        lastSampleMsgCount = currentMsgCount;
+        lastSampleByteCount = currentByteCount;
+        lastSampleTimeNs = nowNs;
+    }
+
+    /**
+     * Activate throttling at the given rates.  The delegate's token buckets are
+     * replaced atomically (volatile writes inside PublishRateLimiterImpl).
+     * If already active, this updates the current effective rate.
+     *
+     * @param msgRatePerSec  target message rate (> 0)
+     * @param byteRatePerSec target byte rate (> 0, or 0 to leave byte bucket absent)
+     */
+    public void activate(long msgRatePerSec, long byteRatePerSec) {
+        boolean wasActive = active;
+        active = true;
+        currentEffectiveMsgRate = msgRatePerSec;
+        currentEffectiveByteRate = byteRatePerSec;
+        delegate.update(new PublishRate((int) Math.min(msgRatePerSec, Integer.MAX_VALUE), byteRatePerSec));
+        if (!wasActive) {
+            throttleActivationCount.increment();
+        }
+    }
+
+    /**
+     * Deactivate throttling.  The token buckets are cleared immediately, allowing
+     * all subsequent publish requests to pass through.
+     */
+    public void deactivate() {
+        active = false;
+        currentEffectiveMsgRate = 0L;
+        currentEffectiveByteRate = 0L;
+        delegate.update((PublishRate) null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors used by the controller and metrics
+    // -------------------------------------------------------------------------
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public double getNaturalMsgRateEstimate() {
+        return naturalMsgRateEstimate;
+    }
+
+    public double getNaturalByteRateEstimate() {
+        return naturalByteRateEstimate;
+    }
+
+    public long getCurrentEffectiveMsgRate() {
+        return currentEffectiveMsgRate;
+    }
+
+    public long getCurrentEffectiveByteRate() {
+        return currentEffectiveByteRate;
+    }
+
+    public long getThrottleActivationCount() {
+        return throttleActivationCount.sum();
+    }
+
+    /**
+     * Returns true if this topic's transition log should be emitted (rate-limits
+     * repeated transition logs for oscillating topics to at most once per minute).
+     */
+    public boolean shouldLogTransition(long nowNs) {
+        if (nowNs - lastTransitionLogNs >= MIN_TRANSITION_LOG_INTERVAL_NS) {
+            lastTransitionLogNs = nowNs;
+            return true;
+        }
+        return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Asymmetric EWMA: tracks increases faster (alpha=0.30) than decreases
+     * (alpha=0.05).  This captures the producer's peak desire rate rather than
+     * decaying quickly when they momentarily slow down.
+     */
+    private void updateNaturalRateEstimate(double instantMsgRate, double instantByteRate) {
+        if (instantMsgRate > naturalMsgRateEstimate) {
+            naturalMsgRateEstimate = naturalMsgRateEstimate * 0.70 + instantMsgRate * 0.30;
+        } else {
+            naturalMsgRateEstimate = naturalMsgRateEstimate * 0.95 + instantMsgRate * 0.05;
+        }
+        if (instantByteRate > naturalByteRateEstimate) {
+            naturalByteRateEstimate = naturalByteRateEstimate * 0.70 + instantByteRate * 0.30;
+        } else {
+            naturalByteRateEstimate = naturalByteRateEstimate * 0.95 + instantByteRate * 0.05;
+        }
+    }
+
+    @VisibleForTesting
+    public PublishRateLimiterImpl getDelegate() {
+        return delegate;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleController.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.apache.pulsar.common.util.SingleThreadNonConcurrentFixedRateScheduler;
+
+/**
+ * Broker-level controller that periodically evaluates system pressure signals
+ * (JVM heap usage and per-topic backlog pressure) and drives per-topic
+ * {@link AdaptivePublishRateLimiter} instances.
+ *
+ * <h3>Pressure computation</h3>
+ * <pre>
+ *   memoryPressure = clamp((heapUsed/maxHeap - lowWm) / (highWm - lowWm), 0, 1)
+ *
+ *   backlogPressure per topic:
+ *     if (quota ≤ 0)  → 0                    (no quota configured)
+ *     fraction = backlogBytes / quotaBytes
+ *     if (fraction ≤ backlogLowWm)  → 0
+ *     if (fraction ≥ backlogHighWm) → 1
+ *     else → (fraction - backlogLowWm) / (backlogHighWm - backlogLowWm)
+ *
+ *   pressureFactor = max(memoryPressure, backlogPressure)
+ * </pre>
+ *
+ * <h3>Rate computation (bounded step)</h3>
+ * <pre>
+ *   targetFactor = 1.0 - pressureFactor * (1.0 - minRateFactor)
+ *   targetMsgRate = max(1, naturalMsgRate * targetFactor)
+ *   delta = naturalMsgRate * maxRateChangeFactor
+ *   effectiveMsgRate = clamp(currentRate ± delta, towards target)
+ * </pre>
+ *
+ * <h3>Hysteresis</h3>
+ * Throttle activates when {@code pressureFactor > 0}.  It is fully released only
+ * when {@code pressureFactor == 0}, which requires both memory and backlog pressure
+ * to drop below their respective low watermarks.
+ *
+ * <h3>Observe-only mode</h3>
+ * When {@code adaptivePublisherThrottlingObserveOnly=true} (dynamic config) the
+ * controller computes everything — pressure factors, target rates, decisions — and
+ * emits metrics and OBSERVE-ONLY log lines, but never calls
+ * {@link AdaptivePublishRateLimiter#activate} or
+ * {@link AdaptivePublishRateLimiter#deactivate}.  This is the safe validation mode
+ * before going live, and also serves as an emergency circuit-breaker (flip the
+ * dynamic config at runtime to suspend all throttling without a restart).
+ */
+@Slf4j
+public class AdaptivePublishThrottleController implements Closeable {
+
+    private final BrokerService brokerService;
+    private final SingleThreadNonConcurrentFixedRateScheduler scheduler;
+
+    /**
+     * Current broker-wide memory pressure factor (0.0–1.0).
+     * Written by the controller thread; read by metrics/tests.
+     */
+    @Getter
+    private volatile double currentMemoryPressureFactor = 0.0;
+
+    /**
+     * Number of topics on this broker currently being adaptively throttled.
+     */
+    private final AtomicInteger activeThrottledTopicsCount = new AtomicInteger(0);
+
+    /**
+     * Total number of throttle activations since the controller started.
+     */
+    private final AtomicLong totalActivationCount = new AtomicLong(0L);
+
+    /**
+     * Unix epoch milliseconds when the last evaluation cycle completed (success or failure).
+     * Zero if no cycle has run yet.  Operators can alert when this stops advancing.
+     */
+    private volatile long lastEvaluationCompletedEpochMs = 0L;
+
+    /**
+     * Wall-clock duration in milliseconds of the most recent evaluation cycle.
+     * A sustained increase signals the broker has too many topics for the configured interval.
+     */
+    private volatile long lastEvaluationDurationMs = 0L;
+
+    /**
+     * Number of evaluation cycles that threw an uncaught exception.
+     * Any increment means the controller is degraded; check broker logs for
+     * "[AdaptiveThrottleController] Evaluation cycle failed".
+     */
+    private final AtomicLong evaluationFailureCount = new AtomicLong(0L);
+
+    public AdaptivePublishThrottleController(BrokerService brokerService) {
+        this.brokerService = brokerService;
+        this.scheduler =
+                new SingleThreadNonConcurrentFixedRateScheduler("pulsar-adaptive-throttle-controller");
+    }
+
+    /** Start periodic evaluation. */
+    public void start() {
+        ServiceConfiguration config = brokerService.getPulsar().getConfiguration();
+        long intervalMs = config.getAdaptivePublisherThrottlingIntervalMs();
+        log.info("[AdaptiveThrottleController] Starting with intervalMs={} observeOnly={}",
+                intervalMs, config.isAdaptivePublisherThrottlingObserveOnly());
+        scheduler.scheduleAtFixedRateNonConcurrently(
+                this::runControllerCycle, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() {
+        log.info("[AdaptiveThrottleController] Shutting down");
+        scheduler.shutdownNow();
+    }
+
+    // -------------------------------------------------------------------------
+    // Main control loop
+    // -------------------------------------------------------------------------
+
+    @VisibleForTesting
+    void runControllerCycle() {
+        long cycleStartNs = System.nanoTime();
+        try {
+            ServiceConfiguration config = brokerService.getPulsar().getConfiguration();
+            boolean observeOnly = config.isAdaptivePublisherThrottlingObserveOnly();
+
+            double memoryPressure = computeMemoryPressure(config);
+            currentMemoryPressureFactor = memoryPressure;
+
+            int[] counters = {0, 0, 0}; // [evaluated, throttled, newlyActivated]
+
+            brokerService.forEachPersistentTopic(topic -> {
+                try {
+                    evaluateTopic(topic, config, memoryPressure, observeOnly, counters);
+                } catch (Exception e) {
+                    log.warn("[AdaptiveThrottleController] Error evaluating topic {}: {}",
+                            topic.getName(), e.getMessage(), e);
+                }
+            });
+
+            activeThrottledTopicsCount.set(counters[1]);
+
+            if (log.isDebugEnabled()) {
+                long cycleMs = (System.nanoTime() - cycleStartNs) / 1_000_000;
+                log.debug("[AdaptiveThrottleController] cycle complete: "
+                                + "topicsEvaluated={} topicsThrottled={} newlyActivated={} "
+                                + "memoryPressure={} cycleMs={} observeOnly={}",
+                        counters[0], counters[1], counters[2],
+                        String.format("%.3f", memoryPressure), cycleMs, observeOnly);
+            }
+        } catch (Exception e) {
+            long failures = evaluationFailureCount.incrementAndGet();
+            log.error("[AdaptiveThrottleController] Evaluation cycle failed "
+                            + "(totalFailures={}, lastError={}). "
+                            + "Controller remains scheduled; check for broker misconfiguration.",
+                    failures, e.getMessage(), e);
+        } finally {
+            lastEvaluationDurationMs = (System.nanoTime() - cycleStartNs) / 1_000_000;
+            lastEvaluationCompletedEpochMs = System.currentTimeMillis();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-topic evaluation
+    // -------------------------------------------------------------------------
+
+    private void evaluateTopic(PersistentTopic topic, ServiceConfiguration config,
+                               double memoryPressure, boolean observeOnly, int[] counters) {
+        AdaptivePublishRateLimiter limiter = topic.getAdaptivePublishRateLimiter();
+        if (limiter == null) {
+            return;
+        }
+
+        counters[0]++;
+        long nowNs = System.nanoTime();
+
+        double backlogPressure = computeBacklogPressure(topic, config);
+        double pressureFactor = Math.max(memoryPressure, backlogPressure);
+
+        if (pressureFactor <= 0.0) {
+            // No pressure: sample natural rate and deactivate if needed.
+            boolean wasActive = limiter.isActive();
+            limiter.sampleRate(topic.getMsgInCounter(), topic.getBytesInCounter(), nowNs);
+            if (wasActive) {
+                maybeLogDeactivated(topic, limiter, nowNs, observeOnly);
+                if (!observeOnly) {
+                    limiter.deactivate();
+                }
+            }
+        } else {
+            counters[1]++;
+
+            double naturalMsgRate = limiter.getNaturalMsgRateEstimate();
+            double naturalByteRate = limiter.getNaturalByteRateEstimate();
+
+            if (naturalMsgRate <= 0.0 && naturalByteRate <= 0.0) {
+                // No baseline yet — sample now (first cycle after topic load).
+                limiter.sampleRate(topic.getMsgInCounter(), topic.getBytesInCounter(), nowNs);
+                if (log.isDebugEnabled()) {
+                    log.debug("[AdaptiveThrottle] Skipping activation: no natural rate baseline yet for {}",
+                            topic.getName());
+                }
+                return;
+            }
+
+            long targetMsgRate = computeTargetRate(naturalMsgRate, pressureFactor,
+                    limiter.getCurrentEffectiveMsgRate(), config);
+            long targetByteRate = computeTargetRate(naturalByteRate, pressureFactor,
+                    limiter.getCurrentEffectiveByteRate(), config);
+
+            boolean wasActive = limiter.isActive();
+
+            // Check if rate was clamped to minimum floor
+            double minFactor = config.getAdaptivePublisherThrottlingMinRateFactor();
+            boolean clampedByMin = naturalMsgRate > 0
+                    && targetMsgRate <= (long) Math.ceil(naturalMsgRate * minFactor * 1.05);
+
+            if (observeOnly) {
+                logObserveOnly(topic, limiter, naturalMsgRate, naturalByteRate,
+                        targetMsgRate, targetByteRate, memoryPressure, backlogPressure,
+                        pressureFactor, config);
+            } else {
+                limiter.activate(targetMsgRate, targetByteRate);
+                if (!wasActive) {
+                    counters[2]++;
+                    totalActivationCount.incrementAndGet();
+                    logActivated(topic, limiter, naturalMsgRate, naturalByteRate,
+                            targetMsgRate, targetByteRate, memoryPressure, backlogPressure,
+                            pressureFactor, config, nowNs);
+                } else if (clampedByMin && log.isWarnEnabled()) {
+                    log.warn("[AdaptiveThrottle] Rate clamped at minimum floor: "
+                                    + "topic={} computedFactor={} minRateFactor={} "
+                                    + "effectiveMsgRate={} naturalMsgRate={} "
+                                    + "backlogPressure={} memoryPressure={}",
+                            topic.getName(),
+                            String.format("%.3f", 1.0 - pressureFactor * (1.0 - minFactor)),
+                            minFactor, targetMsgRate, (long) naturalMsgRate,
+                            String.format("%.3f", backlogPressure),
+                            String.format("%.3f", memoryPressure));
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Pressure computation
+    // -------------------------------------------------------------------------
+
+    @VisibleForTesting
+    double computeMemoryPressure(ServiceConfiguration config) {
+        Runtime runtime = Runtime.getRuntime();
+        long maxMemory = runtime.maxMemory();
+        if (maxMemory == Long.MAX_VALUE) {
+            // Unbounded heap — cannot compute pressure.
+            return 0.0;
+        }
+        long usedMemory = maxMemory - runtime.freeMemory();
+        double usageFraction = (double) usedMemory / maxMemory;
+
+        double highWm = config.getAdaptivePublisherThrottlingMemoryHighWatermarkPct();
+        double lowWm = config.getAdaptivePublisherThrottlingMemoryLowWatermarkPct();
+        return linearPressure(usageFraction, lowWm, highWm);
+    }
+
+    @VisibleForTesting
+    double computeBacklogPressure(PersistentTopic topic, ServiceConfiguration config) {
+        long quotaLimit =
+                topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
+        if (quotaLimit <= 0) {
+            return 0.0;
+        }
+        long backlogSize = topic.getBacklogSize();
+        double fraction = (double) backlogSize / quotaLimit;
+
+        double highWm = config.getAdaptivePublisherThrottlingBacklogHighWatermarkPct();
+        double lowWm = config.getAdaptivePublisherThrottlingBacklogLowWatermarkPct();
+        return linearPressure(fraction, lowWm, highWm);
+    }
+
+    /**
+     * Linear pressure ramp: 0 below {@code lowWm}, 1 above {@code highWm},
+     * linear interpolation in between.
+     */
+    @VisibleForTesting
+    static double linearPressure(double value, double lowWm, double highWm) {
+        if (value <= lowWm) {
+            return 0.0;
+        }
+        if (value >= highWm) {
+            return 1.0;
+        }
+        double range = highWm - lowWm;
+        return range <= 0.0 ? 1.0 : (value - lowWm) / range;
+    }
+
+    // -------------------------------------------------------------------------
+    // Rate computation (bounded step)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Compute the new effective rate for one dimension (msg or bytes) using
+     * bounded-step logic to prevent sudden rate changes.
+     *
+     * @param naturalRate    observed natural rate (unthrottled)
+     * @param pressureFactor combined pressure factor in [0, 1]
+     * @param currentRate    the effective rate from the previous cycle (0 = inactive)
+     * @param config         broker configuration
+     * @return new effective rate (≥ 1)
+     */
+    @VisibleForTesting
+    long computeTargetRate(double naturalRate, double pressureFactor,
+                           long currentRate, ServiceConfiguration config) {
+        if (naturalRate <= 0.0) {
+            return 1L;
+        }
+        double minFactor = config.getAdaptivePublisherThrottlingMinRateFactor();
+        double maxChangeFactor = config.getAdaptivePublisherThrottlingMaxRateChangeFactor();
+
+        // Where we want to be
+        double targetFactor = 1.0 - pressureFactor * (1.0 - minFactor);
+        long idealTarget = Math.max(1L, (long) (naturalRate * targetFactor));
+
+        // Maximum allowed change this cycle
+        long maxDelta = Math.max(1L, (long) (naturalRate * maxChangeFactor));
+
+        // Start from the previous effective rate (or natural rate if just activating)
+        long base = (currentRate > 0) ? currentRate : (long) naturalRate;
+
+        long newRate;
+        if (idealTarget < base) {
+            // Ramping down
+            newRate = Math.max(idealTarget, base - maxDelta);
+        } else {
+            // Ramping up (or steady)
+            newRate = Math.min(idealTarget, base + maxDelta);
+        }
+
+        // Hard floor
+        long minAbsolute = Math.max(1L, (long) (naturalRate * minFactor));
+        return Math.max(newRate, minAbsolute);
+    }
+
+    // -------------------------------------------------------------------------
+    // Logging helpers
+    // -------------------------------------------------------------------------
+
+    private void logActivated(PersistentTopic topic, AdaptivePublishRateLimiter limiter,
+                               double naturalMsgRate, double naturalByteRate,
+                               long targetMsgRate, long targetByteRate,
+                               double memoryPressure, double backlogPressure,
+                               double pressureFactor, ServiceConfiguration config,
+                               long nowNs) {
+        if (!limiter.shouldLogTransition(nowNs)) {
+            return;
+        }
+        long backlogBytes = topic.getBacklogSize();
+        long quotaBytes = topic.getBacklogQuota(
+                BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize();
+        log.info("[AdaptiveThrottle] ACTIVATED topic={} "
+                        + "naturalMsgRate={}/s naturalByteRate={}/s "
+                        + "effectiveMsgRate={}/s effectiveByteRate={}/s "
+                        + "rateFactor={} pressureFactor={} "
+                        + "memoryPressure={} backlogPressure={} "
+                        + "backlogBytes={} backlogQuotaBytes={} backlogPct={} "
+                        + "minRateFactor={} maxRateChangeFactor={} observeOnly=false",
+                topic.getName(),
+                String.format("%.1f", naturalMsgRate),
+                String.format("%.0f", naturalByteRate),
+                targetMsgRate, targetByteRate,
+                String.format("%.3f", 1.0 - pressureFactor
+                        * (1.0 - config.getAdaptivePublisherThrottlingMinRateFactor())),
+                String.format("%.3f", pressureFactor),
+                String.format("%.3f", memoryPressure),
+                String.format("%.3f", backlogPressure),
+                backlogBytes, quotaBytes,
+                quotaBytes > 0 ? String.format("%.1f%%", 100.0 * backlogBytes / quotaBytes) : "N/A",
+                config.getAdaptivePublisherThrottlingMinRateFactor(),
+                config.getAdaptivePublisherThrottlingMaxRateChangeFactor());
+    }
+
+    private void maybeLogDeactivated(PersistentTopic topic, AdaptivePublishRateLimiter limiter,
+                                     long nowNs, boolean observeOnly) {
+        if (!limiter.shouldLogTransition(nowNs)) {
+            return;
+        }
+        log.info("[AdaptiveThrottle] {} topic={} "
+                        + "naturalMsgRate={}/s minEffectiveMsgRate={}/s "
+                        + "activationCount={}",
+                observeOnly ? "OBSERVE-ONLY would-deactivate:" : "DEACTIVATED",
+                topic.getName(),
+                String.format("%.1f", limiter.getNaturalMsgRateEstimate()),
+                limiter.getCurrentEffectiveMsgRate(),
+                limiter.getThrottleActivationCount());
+    }
+
+    private void logObserveOnly(PersistentTopic topic, AdaptivePublishRateLimiter limiter,
+                                double naturalMsgRate, double naturalByteRate,
+                                long targetMsgRate, long targetByteRate,
+                                double memoryPressure, double backlogPressure,
+                                double pressureFactor, ServiceConfiguration config) {
+        log.info("[AdaptiveThrottle] OBSERVE-ONLY would-activate: topic={} "
+                        + "wouldSetMsgRate={}/s wouldSetByteRate={}/s "
+                        + "naturalMsgRate={}/s pressureFactor={} "
+                        + "memoryPressure={} backlogPressure={} "
+                        + "[no actual throttling applied]",
+                topic.getName(),
+                targetMsgRate, targetByteRate,
+                String.format("%.1f", naturalMsgRate),
+                String.format("%.3f", pressureFactor),
+                String.format("%.3f", memoryPressure),
+                String.format("%.3f", backlogPressure));
+    }
+
+    // -------------------------------------------------------------------------
+    // Metrics accessors (used by OpenTelemetryAdaptiveThrottleStats)
+    // -------------------------------------------------------------------------
+
+    public int getActiveThrottledTopicsCount() {
+        return activeThrottledTopicsCount.get();
+    }
+
+    public long getTotalActivationCount() {
+        return totalActivationCount.get();
+    }
+
+    /**
+     * Unix epoch milliseconds when the last evaluation cycle completed.
+     * Returns 0 if no cycle has run yet.  Alert when
+     * {@code now - lastEvaluationCompletedEpochMs > 3 * intervalMs}.
+     */
+    public long getLastEvaluationCompletedEpochMs() {
+        return lastEvaluationCompletedEpochMs;
+    }
+
+    /**
+     * Duration in milliseconds of the most recent evaluation cycle.
+     * Alert when this exceeds {@code adaptivePublisherThrottlingIntervalMs} consistently.
+     */
+    public long getLastEvaluationDurationMs() {
+        return lastEvaluationDurationMs;
+    }
+
+    /**
+     * Total number of evaluation cycles that threw an uncaught exception since start.
+     * Any non-zero value means the controller is degraded; check broker logs.
+     */
+    public long getEvaluationFailureCount() {
+        return evaluationFailureCount.get();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryAdaptiveThrottleStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryAdaptiveThrottleStats.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.BatchCallback;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import java.util.Optional;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.AdaptivePublishRateLimiter;
+import org.apache.pulsar.broker.service.AdaptivePublishThrottleController;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+
+/**
+ * OpenTelemetry metrics for the adaptive publish throttle feature.
+ *
+ * <p>Broker-level metrics (3 instruments, no topic label — zero cardinality concern):
+ * <ul>
+ *   <li>{@value MEMORY_PRESSURE_GAUGE} — current JVM heap pressure factor (0.0–1.0)</li>
+ *   <li>{@value ACTIVE_TOPICS_GAUGE} — topics currently being adaptively throttled</li>
+ *   <li>{@value TOTAL_ACTIVATIONS_COUNTER} — cumulative activation count since start</li>
+ * </ul>
+ *
+ * <p>Per-topic metrics (6 instruments, topic label — only registered when
+ * {@code adaptivePublisherThrottlingPerTopicMetricsEnabled=true}):
+ * <ul>
+ *   <li>{@value TOPIC_THROTTLE_ACTIVE}</li>
+ *   <li>{@value TOPIC_NATURAL_MSG_RATE}</li>
+ *   <li>{@value TOPIC_EFFECTIVE_MSG_RATE}</li>
+ *   <li>{@value TOPIC_MEMORY_PRESSURE}</li>
+ *   <li>{@value TOPIC_BACKLOG_PRESSURE}</li>
+ *   <li>{@value TOPIC_RATE_REDUCTION_RATIO}</li>
+ * </ul>
+ */
+public class OpenTelemetryAdaptiveThrottleStats implements AutoCloseable {
+
+    // Broker-level metric names
+    public static final String MEMORY_PRESSURE_GAUGE =
+            "pulsar.broker.adaptive.throttle.memory.pressure";
+    public static final String ACTIVE_TOPICS_GAUGE =
+            "pulsar.broker.adaptive.throttle.active.topic.count";
+    public static final String TOTAL_ACTIVATIONS_COUNTER =
+            "pulsar.broker.adaptive.throttle.activation.count";
+
+    // Controller health metric names
+    /** Unix epoch ms of the last completed evaluation cycle; alert when it stops advancing. */
+    public static final String CONTROLLER_LAST_EVAL_EPOCH_GAUGE =
+            "pulsar.broker.adaptive.throttle.controller.last.evaluation.timestamp";
+    /** Wall-clock duration of the last evaluation cycle in ms; alert when it exceeds the interval. */
+    public static final String CONTROLLER_EVAL_DURATION_GAUGE =
+            "pulsar.broker.adaptive.throttle.controller.evaluation.duration";
+    /** Cumulative count of evaluation cycles that threw an uncaught exception. */
+    public static final String CONTROLLER_EVAL_FAILURE_COUNTER =
+            "pulsar.broker.adaptive.throttle.controller.evaluation.failure.count";
+
+    // Per-topic metric names
+    public static final String TOPIC_THROTTLE_ACTIVE =
+            "pulsar.broker.topic.adaptive.throttle.active";
+    public static final String TOPIC_NATURAL_MSG_RATE =
+            "pulsar.broker.topic.adaptive.throttle.natural.publish.rate";
+    public static final String TOPIC_EFFECTIVE_MSG_RATE =
+            "pulsar.broker.topic.adaptive.throttle.effective.publish.rate";
+    public static final String TOPIC_MEMORY_PRESSURE =
+            "pulsar.broker.topic.adaptive.throttle.memory.pressure";
+    public static final String TOPIC_BACKLOG_PRESSURE =
+            "pulsar.broker.topic.adaptive.throttle.backlog.pressure";
+    public static final String TOPIC_RATE_REDUCTION_RATIO =
+            "pulsar.broker.topic.adaptive.throttle.rate.reduction.ratio";
+
+    private final PulsarService pulsar;
+    private final AdaptivePublishThrottleController controller;
+    private final BatchCallback brokerCallback;
+    private final BatchCallback perTopicCallback;
+
+    private final ObservableDoubleMeasurement memoryPressureGauge;
+    private final ObservableLongMeasurement activeTopicsGauge;
+    private final ObservableLongMeasurement totalActivationsCounter;
+    private final ObservableLongMeasurement controllerLastEvalEpochGauge;
+    private final ObservableLongMeasurement controllerEvalDurationGauge;
+    private final ObservableLongMeasurement controllerEvalFailureCounter;
+
+    // Per-topic instruments (may be null when perTopicMetrics disabled)
+    private final ObservableLongMeasurement topicThrottleActive;
+    private final ObservableDoubleMeasurement topicNaturalMsgRate;
+    private final ObservableDoubleMeasurement topicEffectiveMsgRate;
+    private final ObservableDoubleMeasurement topicMemoryPressure;
+    private final ObservableDoubleMeasurement topicBacklogPressure;
+    private final ObservableDoubleMeasurement topicRateReductionRatio;
+
+    public OpenTelemetryAdaptiveThrottleStats(PulsarService pulsar,
+                                              AdaptivePublishThrottleController controller,
+                                              boolean perTopicMetricsEnabled) {
+        this.pulsar = pulsar;
+        this.controller = controller;
+        Meter meter = pulsar.getOpenTelemetry().getMeter();
+
+        // --- broker-level instruments ---
+        memoryPressureGauge = meter
+                .gaugeBuilder(MEMORY_PRESSURE_GAUGE)
+                .setDescription("Current JVM heap pressure factor driving adaptive publish throttling "
+                        + "(0.0 = no pressure, 1.0 = maximum pressure).")
+                .setUnit("{ratio}")
+                .buildObserver();
+
+        activeTopicsGauge = meter
+                .upDownCounterBuilder(ACTIVE_TOPICS_GAUGE)
+                .setDescription("Number of topics on this broker currently being adaptively throttled.")
+                .setUnit("{topic}")
+                .buildObserver();
+
+        totalActivationsCounter = meter
+                .counterBuilder(TOTAL_ACTIVATIONS_COUNTER)
+                .setDescription("Total number of adaptive throttle activations since broker start.")
+                .setUnit("{event}")
+                .buildObserver();
+
+        controllerLastEvalEpochGauge = meter
+                .upDownCounterBuilder(CONTROLLER_LAST_EVAL_EPOCH_GAUGE)
+                .setDescription("Unix epoch milliseconds when the last adaptive throttle controller "
+                        + "evaluation cycle completed. Zero if no cycle has run yet. "
+                        + "Alert when this stops advancing (stalled controller).")
+                .setUnit("ms")
+                .buildObserver();
+
+        controllerEvalDurationGauge = meter
+                .upDownCounterBuilder(CONTROLLER_EVAL_DURATION_GAUGE)
+                .setDescription("Wall-clock duration in milliseconds of the most recent adaptive "
+                        + "throttle controller evaluation cycle. Alert when this consistently "
+                        + "exceeds adaptivePublisherThrottlingIntervalMs.")
+                .setUnit("ms")
+                .buildObserver();
+
+        controllerEvalFailureCounter = meter
+                .counterBuilder(CONTROLLER_EVAL_FAILURE_COUNTER)
+                .setDescription("Cumulative number of adaptive throttle controller evaluation cycles "
+                        + "that threw an uncaught exception. Any non-zero value means the controller "
+                        + "is degraded; check broker logs for '[AdaptiveThrottleController] "
+                        + "Evaluation cycle failed'.")
+                .setUnit("{error}")
+                .buildObserver();
+
+        brokerCallback = meter.batchCallback(
+                this::recordBrokerMetrics,
+                memoryPressureGauge, activeTopicsGauge, totalActivationsCounter,
+                controllerLastEvalEpochGauge, controllerEvalDurationGauge,
+                controllerEvalFailureCounter);
+
+        // --- per-topic instruments ---
+        if (perTopicMetricsEnabled) {
+            topicThrottleActive = meter
+                    .upDownCounterBuilder(TOPIC_THROTTLE_ACTIVE)
+                    .setDescription("1 if this topic is currently adaptively throttled, 0 otherwise.")
+                    .setUnit("{bool}")
+                    .buildObserver();
+            topicNaturalMsgRate = meter
+                    .gaugeBuilder(TOPIC_NATURAL_MSG_RATE)
+                    .setDescription("Estimated natural (unthrottled) publish rate for this topic.")
+                    .setUnit("{message}/s")
+                    .buildObserver();
+            topicEffectiveMsgRate = meter
+                    .gaugeBuilder(TOPIC_EFFECTIVE_MSG_RATE)
+                    .setDescription("Current effective (throttled) publish rate for this topic.")
+                    .setUnit("{message}/s")
+                    .buildObserver();
+            topicMemoryPressure = meter
+                    .gaugeBuilder(TOPIC_MEMORY_PRESSURE)
+                    .setDescription("Memory pressure factor applied to this topic in the last cycle.")
+                    .setUnit("{ratio}")
+                    .buildObserver();
+            topicBacklogPressure = meter
+                    .gaugeBuilder(TOPIC_BACKLOG_PRESSURE)
+                    .setDescription("Backlog pressure factor applied to this topic in the last cycle.")
+                    .setUnit("{ratio}")
+                    .buildObserver();
+            topicRateReductionRatio = meter
+                    .gaugeBuilder(TOPIC_RATE_REDUCTION_RATIO)
+                    .setDescription("Ratio of effective rate to natural rate (1.0 = no throttle, "
+                            + "0.1 = throttled to minimum).")
+                    .setUnit("{ratio}")
+                    .buildObserver();
+
+            perTopicCallback = meter.batchCallback(
+                    this::recordPerTopicMetrics,
+                    topicThrottleActive, topicNaturalMsgRate, topicEffectiveMsgRate,
+                    topicMemoryPressure, topicBacklogPressure, topicRateReductionRatio);
+        } else {
+            topicThrottleActive = null;
+            topicNaturalMsgRate = null;
+            topicEffectiveMsgRate = null;
+            topicMemoryPressure = null;
+            topicBacklogPressure = null;
+            topicRateReductionRatio = null;
+            perTopicCallback = null;
+        }
+    }
+
+    private void recordBrokerMetrics() {
+        Attributes attrs = Attributes.empty();
+        memoryPressureGauge.record(controller.getCurrentMemoryPressureFactor(), attrs);
+        activeTopicsGauge.record(controller.getActiveThrottledTopicsCount(), attrs);
+        totalActivationsCounter.record(controller.getTotalActivationCount(), attrs);
+        controllerLastEvalEpochGauge.record(controller.getLastEvaluationCompletedEpochMs(), attrs);
+        controllerEvalDurationGauge.record(controller.getLastEvaluationDurationMs(), attrs);
+        controllerEvalFailureCounter.record(controller.getEvaluationFailureCount(), attrs);
+    }
+
+    private void recordPerTopicMetrics() {
+        pulsar.getBrokerService().getTopics().values().stream()
+                .map(f -> f.getNow(Optional.empty()))
+                .forEach(opt -> opt.filter(t -> t instanceof PersistentTopic)
+                        .ifPresent(t -> {
+                            PersistentTopic topic = (PersistentTopic) t;
+                            AdaptivePublishRateLimiter limiter = topic.getAdaptivePublishRateLimiter();
+                            if (limiter == null) {
+                                return;
+                            }
+                            Attributes attrs = topic.getTopicAttributes().getCommonAttributes();
+                            boolean active = limiter.isActive();
+                            double natural = limiter.getNaturalMsgRateEstimate();
+                            double effective = active ? limiter.getCurrentEffectiveMsgRate() : natural;
+                            double ratio = natural > 0 ? effective / natural : 1.0;
+
+                            topicThrottleActive.record(active ? 1L : 0L, attrs);
+                            topicNaturalMsgRate.record(natural, attrs);
+                            topicEffectiveMsgRate.record(effective, attrs);
+                            // Memory and backlog pressure are broker-level / cycle-level values;
+                            // the best approximation here is from the controller's last cycle.
+                            topicMemoryPressure.record(controller.getCurrentMemoryPressureFactor(), attrs);
+                            // Backlog pressure is not stored per-topic in the limiter;
+                            // we emit the combined rate reduction as the primary signal.
+                            topicBacklogPressure.record(active ? 1.0 - ratio : 0.0, attrs);
+                            topicRateReductionRatio.record(ratio, attrs);
+                        }));
+    }
+
+    @Override
+    public void close() {
+        brokerCallback.close();
+        if (perTopicCallback != null) {
+            perTopicCallback.close();
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishRateLimiterTest.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pulsar.broker.qos.MonotonicClock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link AdaptivePublishRateLimiter}.
+ *
+ * <p>Tests are divided into:
+ * <ul>
+ *   <li>No-op guarantee: {@code handlePublishThrottling()} must be a complete no-op when inactive.</li>
+ *   <li>Activation/deactivation cycle: correct state transitions and counter increments.</li>
+ *   <li>Rate sampling and asymmetric EWMA correctness.</li>
+ *   <li>observeOnly safety: channel autoread is NEVER changed when observeOnly is in effect.</li>
+ * </ul>
+ */
+@Test(groups = "broker")
+public class AdaptivePublishRateLimiterTest {
+
+    private static final long ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1);
+
+    private AtomicLong manualClockSource;
+    private MonotonicClock clock;
+
+    private Producer producer;
+    private ServerCnx serverCnx;
+    private ServerCnxThrottleTracker throttleTracker;
+    private DefaultEventLoop eventLoop;
+
+    /** The limiter under test. */
+    private AdaptivePublishRateLimiter limiter;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        manualClockSource = new AtomicLong(TimeUnit.SECONDS.toNanos(100));
+        clock = manualClockSource::get;
+
+        eventLoop = new DefaultEventLoop(new DefaultThreadFactory("test-io"));
+
+        producer = mock(Producer.class);
+        serverCnx = mock(ServerCnx.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        doAnswer(a -> eventLoop).when(ctx).executor();
+        doAnswer(a -> ctx).when(serverCnx).ctx();
+        doAnswer(a -> serverCnx).when(producer).getCnx();
+        throttleTracker = new ServerCnxThrottleTracker(serverCnx);
+        doAnswer(a -> throttleTracker).when(serverCnx).getThrottleTracker();
+        when(producer.getCnx()).thenReturn(serverCnx);
+
+        BrokerService brokerService = mock(BrokerService.class);
+        when(serverCnx.getBrokerService()).thenReturn(brokerService);
+        EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
+        when(brokerService.executor()).thenReturn(eventLoopGroup);
+        when(eventLoopGroup.next()).thenReturn(eventLoop);
+
+        limiter = new AdaptivePublishRateLimiter(
+                clock,
+                p -> p.getCnx().getThrottleTracker()
+                        .markThrottled(ServerCnxThrottleTracker.ThrottleType.AdaptivePublishRate),
+                p -> p.getCnx().getThrottleTracker()
+                        .unmarkThrottled(ServerCnxThrottleTracker.ThrottleType.AdaptivePublishRate));
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        eventLoop.shutdownGracefully().sync();
+    }
+
+    // -------------------------------------------------------------------------
+    // No-op guarantee when inactive
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the limiter is inactive (never activated), repeated calls to
+     * {@code handlePublishThrottling()} must NOT change the connection's
+     * {@code autoRead} state in any way — {@code throttledCount()} must
+     * remain exactly 0.
+     */
+    @Test
+    public void testInactiveIsCompleteNoop() throws Exception {
+        assertFalse(limiter.isActive(), "limiter must start inactive");
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                // Even a large publish batch must not throttle when inactive.
+                for (int i = 0; i < 1000; i++) {
+                    limiter.handlePublishThrottling(producer, 100, 1_000_000);
+                }
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "throttledCount must be 0 when limiter is inactive");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Verifies that the limiter's {@code update()} methods (called by the policy
+     * framework) are intentional no-ops and do NOT activate throttling.
+     */
+    @Test
+    public void testUpdateMethodsAreNoOps() throws Exception {
+        assertFalse(limiter.isActive());
+
+        limiter.update(new org.apache.pulsar.common.policies.data.Policies(), "cluster");
+        limiter.update(new org.apache.pulsar.common.policies.data.PublishRate(100, 1000L));
+
+        assertFalse(limiter.isActive(),
+                "update() must never activate the adaptive limiter");
+    }
+
+    // -------------------------------------------------------------------------
+    // activate() / deactivate() lifecycle
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testActivateEnablesThrottling() throws Exception {
+        // Activate at very low rate (1 msg/s) so first publish triggers throttle.
+        limiter.activate(1L, 1L);
+        assertTrue(limiter.isActive());
+        assertEquals(limiter.getCurrentEffectiveMsgRate(), 1L);
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                // Advance clock so token bucket is exhausted immediately.
+                manualClockSource.addAndGet(ONE_SECOND_NS);
+                // Publish far more than 1 msg/s.
+                limiter.handlePublishThrottling(producer, 100, 100_000);
+                // The delegate token bucket should have been exhausted and markThrottled called.
+                assertTrue(throttleTracker.throttledCount() > 0,
+                        "throttledCount must be > 0 after activating with rate=1 and publishing 100 msgs");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testDeactivateRestoresNoop() throws Exception {
+        limiter.activate(1L, 1L);
+        assertTrue(limiter.isActive());
+
+        limiter.deactivate();
+        assertFalse(limiter.isActive());
+        assertEquals(limiter.getCurrentEffectiveMsgRate(), 0L);
+        assertEquals(limiter.getCurrentEffectiveByteRate(), 0L);
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                manualClockSource.addAndGet(ONE_SECOND_NS);
+                for (int i = 0; i < 500; i++) {
+                    limiter.handlePublishThrottling(producer, 100, 100_000);
+                }
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "throttledCount must be 0 after deactivate()");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testActivationCountIncrementOnFirstActivate() {
+        assertEquals(limiter.getThrottleActivationCount(), 0L);
+        limiter.activate(100L, 10000L);
+        assertEquals(limiter.getThrottleActivationCount(), 1L,
+                "activation count must be 1 after first activate()");
+    }
+
+    @Test
+    public void testActivationCountNotDoubledByRepeatedActivate() {
+        limiter.activate(100L, 10000L);
+        limiter.activate(80L, 8000L);
+        limiter.activate(60L, 6000L);
+        assertEquals(limiter.getThrottleActivationCount(), 1L,
+                "activation count must be 1 regardless of repeated activate() without deactivate()");
+    }
+
+    @Test
+    public void testActivationCountIncrementsPerActivateDeactivateCycle() {
+        limiter.activate(100L, 10000L);
+        limiter.deactivate();
+        limiter.activate(100L, 10000L);
+        limiter.deactivate();
+        limiter.activate(100L, 10000L);
+        assertEquals(limiter.getThrottleActivationCount(), 3L,
+                "activation count must increment once per activate/deactivate cycle");
+    }
+
+    // -------------------------------------------------------------------------
+    // Rate sampling and asymmetric EWMA
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSampleRateSkipsFirstCycle() {
+        // When lastSampleTimeNs == 0, the first call sets the baseline only.
+        long t0 = manualClockSource.get();
+        limiter.sampleRate(1000L, 100_000L, t0);
+        // Natural rate estimate must still be 0.0 — no elapsed time computed yet.
+        assertEquals(limiter.getNaturalMsgRateEstimate(), 0.0, 1e-9,
+                "First sampleRate() call must not compute EWMA (no elapsed interval)");
+    }
+
+    @Test
+    public void testSampleRateDeltaComputation() {
+        // Seed baseline at t=0.
+        long t0 = TimeUnit.SECONDS.toNanos(0);
+        limiter.sampleRate(0L, 0L, t0);
+
+        // At t=1s, 100 messages have been published.
+        long t1 = TimeUnit.SECONDS.toNanos(1);
+        limiter.sampleRate(100L, 50_000L, t1);
+
+        // Instant rate = 100 msg/s. EWMA from 0: 0*0.70 + 100*0.30 = 30 msg/s (up path, α=0.30).
+        assertEquals(limiter.getNaturalMsgRateEstimate(), 30.0, 1e-6,
+                "EWMA from 0 with instant=100 and alpha_up=0.30 should be 30.0");
+    }
+
+    @Test
+    public void testAsymmetricEwmaRisesQuicklyOnIncrease() {
+        long t0 = TimeUnit.SECONDS.toNanos(0);
+        // Seed with 100 msg/s estimate by doing multiple samples.
+        // First set the estimate to ~100 by seeding.
+        limiter.sampleRate(0L, 0L, t0);
+        // t=1s: 100 msgs → instant=100
+        limiter.sampleRate(100L, 0L, TimeUnit.SECONDS.toNanos(1));
+        // t=2s: 200 msgs → instant=100 (same rate; will not change much)
+        limiter.sampleRate(200L, 0L, TimeUnit.SECONDS.toNanos(2));
+        // t=3s: 300 msgs → instant=100
+        limiter.sampleRate(300L, 0L, TimeUnit.SECONDS.toNanos(3));
+
+        double baseline = limiter.getNaturalMsgRateEstimate();
+
+        // Now spike to 200 msg/s — should rise quickly (α=0.30).
+        limiter.sampleRate(500L, 0L, TimeUnit.SECONDS.toNanos(4)); // 200 msg in 1s
+        double afterSpike = limiter.getNaturalMsgRateEstimate();
+
+        assertTrue(afterSpike > baseline,
+                "Estimate must rise when instant rate exceeds current estimate");
+        // With α=0.30: afterSpike = baseline*0.70 + 200*0.30
+        double expected = baseline * 0.70 + 200.0 * 0.30;
+        assertEquals(afterSpike, expected, 1e-6, "Up-path EWMA must use alpha=0.30");
+    }
+
+    @Test
+    public void testAsymmetricEwmaFallsSlowlyOnDecrease() {
+        // Establish a high estimate first.
+        limiter.sampleRate(0L, 0L, TimeUnit.SECONDS.toNanos(0));
+        for (int i = 1; i <= 10; i++) {
+            // 1000 msg/s for 10 seconds
+            limiter.sampleRate((long) i * 1000L, 0L, TimeUnit.SECONDS.toNanos(i));
+        }
+        double highEstimate = limiter.getNaturalMsgRateEstimate();
+        assertTrue(highEstimate > 500.0, "Estimate should be well above 500 after 10 cycles at 1000/s");
+
+        // Now drop to 0 msg/s for one cycle.
+        limiter.sampleRate(10_000L, 0L, TimeUnit.SECONDS.toNanos(11)); // same count = 0/s
+        double afterDrop = limiter.getNaturalMsgRateEstimate();
+
+        // With α_down=0.05: afterDrop = highEstimate*0.95 + 0*0.05 = highEstimate*0.95
+        double expected = highEstimate * 0.95;
+        assertEquals(afterDrop, expected, 1e-6, "Down-path EWMA must use alpha=0.05");
+        // Should NOT have fallen by more than 5%.
+        assertTrue(afterDrop > highEstimate * 0.90,
+                "Estimate must NOT fall more than 5% in one cycle (slow decay)");
+    }
+
+    // -------------------------------------------------------------------------
+    // observeOnly safety: channel autoread must NEVER change
+    // -------------------------------------------------------------------------
+
+    /**
+     * CRITICAL SAFETY TEST: When the AdaptivePublishRateLimiter is used with
+     * observe-only semantics — meaning the controller has NOT called
+     * {@code activate()} — the limiter MUST be a complete no-op.
+     *
+     * <p>This test simulates the observe-only guarantee from the limiter's
+     * perspective: since the controller never calls {@code activate()} when
+     * {@code observeOnly=true}, {@code isActive()} stays {@code false}, and
+     * {@code handlePublishThrottling()} must never change channel autoread state.
+     *
+     * <p>If this test fails, it means some code path is changing
+     * {@code ServerCnxThrottleTracker} state without going through the
+     * active flag, which would be a critical bug.
+     */
+    @Test
+    public void testObserveOnlyLimiterNeverChangesChannelAutoread() throws Exception {
+        // The limiter starts inactive — simulating observeOnly (controller never called activate()).
+        assertFalse(limiter.isActive(),
+                "Limiter must start inactive (simulating observeOnly=true)");
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                manualClockSource.addAndGet(ONE_SECOND_NS);
+                // Simulate many large publish operations as if backlog/memory is under extreme pressure.
+                for (int cycle = 0; cycle < 100; cycle++) {
+                    manualClockSource.addAndGet(ONE_SECOND_NS);
+                    limiter.handlePublishThrottling(producer, 10_000, 100_000_000);
+                }
+
+                // The critical assertion: zero throttle count.
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "observeOnly guarantee violated: throttledCount must be 0 "
+                                + "when limiter has never been activated");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Extension of the above: even after {@code deactivate()} is called (which is
+     * what the controller does in observe-only mode when it would normally deactivate),
+     * repeated calls must leave the throttle count at 0.
+     */
+    @Test
+    public void testDeactivateOnNeverActiveLimiterIsHarmless() throws Exception {
+        assertFalse(limiter.isActive());
+        limiter.deactivate(); // Should be a no-op — limiter was never active.
+        assertFalse(limiter.isActive());
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                manualClockSource.addAndGet(ONE_SECOND_NS);
+                limiter.handlePublishThrottling(producer, 50_000, 500_000_000);
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "throttledCount must be 0 after deactivate() on a never-activated limiter");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptivePublishThrottleControllerTest.java
@@ -1,0 +1,638 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link AdaptivePublishThrottleController}.
+ *
+ * <p>Tests are divided into:
+ * <ul>
+ *   <li>Pressure math: {@code linearPressure()}, {@code computeMemoryPressure()},
+ *       {@code computeBacklogPressure()}.</li>
+ *   <li>Rate computation: {@code computeTargetRate()} including bounded-step and
+ *       hard floor.</li>
+ *   <li>Hysteresis: activate above high-watermark, deactivate only below
+ *       low-watermark.</li>
+ *   <li>observeOnly guarantee: controller cycle MUST NOT call
+ *       {@link AdaptivePublishRateLimiter#activate} or
+ *       {@link AdaptivePublishRateLimiter#deactivate} when
+ *       {@code observeOnly=true}; channel autoread state must be unchanged.</li>
+ * </ul>
+ */
+@Test(groups = "broker")
+public class AdaptivePublishThrottleControllerTest {
+
+    private ServiceConfiguration config;
+    private BrokerService brokerService;
+    private PulsarService pulsarService;
+    private AdaptivePublishThrottleController controller;
+
+    // For building a realistic limiter in integration-style tests
+    private AtomicLong manualClockSource;
+    private Producer producer;
+    private ServerCnx serverCnx;
+    private ServerCnxThrottleTracker throttleTracker;
+    private DefaultEventLoop eventLoop;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        config = new ServiceConfiguration();
+        // Use effectively unreachable memory watermarks so that real JVM heap pressure
+        // never interferes with backlog-only tests (avoids test flakiness on loaded machines).
+        // Tests that specifically exercise memory pressure use linearPressure() directly.
+        config.setAdaptivePublisherThrottlingMemoryHighWatermarkPct(0.999);
+        config.setAdaptivePublisherThrottlingMemoryLowWatermarkPct(0.99);
+        config.setAdaptivePublisherThrottlingBacklogHighWatermarkPct(0.90);
+        config.setAdaptivePublisherThrottlingBacklogLowWatermarkPct(0.75);
+        config.setAdaptivePublisherThrottlingMinRateFactor(0.10);
+        config.setAdaptivePublisherThrottlingMaxRateChangeFactor(0.25);
+        config.setAdaptivePublisherThrottlingIntervalMs(1000);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+
+        pulsarService = mock(PulsarService.class);
+        brokerService = mock(BrokerService.class);
+        when(pulsarService.getConfiguration()).thenReturn(config);
+        when(brokerService.getPulsar()).thenReturn(pulsarService);
+
+        controller = new AdaptivePublishThrottleController(brokerService);
+
+        // For integration-style tests that need a real throttle tracker.
+        manualClockSource = new AtomicLong(TimeUnit.SECONDS.toNanos(100));
+        eventLoop = new DefaultEventLoop(new DefaultThreadFactory("test-io"));
+        producer = mock(Producer.class);
+        serverCnx = mock(ServerCnx.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        doAnswer(a -> eventLoop).when(ctx).executor();
+        doAnswer(a -> ctx).when(serverCnx).ctx();
+        doAnswer(a -> serverCnx).when(producer).getCnx();
+        throttleTracker = new ServerCnxThrottleTracker(serverCnx);
+        doAnswer(a -> throttleTracker).when(serverCnx).getThrottleTracker();
+        when(producer.getCnx()).thenReturn(serverCnx);
+        BrokerService bs = mock(BrokerService.class);
+        when(serverCnx.getBrokerService()).thenReturn(bs);
+        EventLoopGroup elg = mock(EventLoopGroup.class);
+        when(bs.executor()).thenReturn(elg);
+        when(elg.next()).thenReturn(eventLoop);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        controller.close();
+        eventLoop.shutdownGracefully().sync();
+    }
+
+    // =========================================================================
+    // linearPressure() — boundary and interpolation tests
+    // =========================================================================
+
+    @Test
+    public void testLinearPressureBelowLowWatermark() {
+        // Any value below lowWm must return exactly 0.0.
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.0, 0.70, 0.85), 0.0, 1e-9);
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.50, 0.70, 0.85), 0.0, 1e-9);
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.69, 0.70, 0.85), 0.0, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureAtLowWatermarkBoundary() {
+        // Exactly at lowWm should return 0.0 (inclusive lower bound).
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.70, 0.70, 0.85), 0.0, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureAboveHighWatermark() {
+        // Any value above highWm must return exactly 1.0.
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.86, 0.70, 0.85), 1.0, 1e-9);
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.90, 0.70, 0.85), 1.0, 1e-9);
+        assertEquals(AdaptivePublishThrottleController.linearPressure(1.00, 0.70, 0.85), 1.0, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureAtHighWatermarkBoundary() {
+        // Exactly at highWm should return 1.0 (inclusive upper bound).
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.85, 0.70, 0.85), 1.0, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureMidpointInterpolation() {
+        // Midpoint between 0.70 and 0.85 is 0.775 → pressure = 0.5.
+        double mid = (0.70 + 0.85) / 2.0; // 0.775
+        assertEquals(AdaptivePublishThrottleController.linearPressure(mid, 0.70, 0.85), 0.5, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureQuarterInterpolation() {
+        // Quarter of the way between 0.70 and 0.85:
+        // value = 0.70 + 0.25*(0.85-0.70) = 0.70 + 0.0375 = 0.7375 → pressure = 0.25
+        double quarter = 0.70 + 0.25 * (0.85 - 0.70);
+        assertEquals(AdaptivePublishThrottleController.linearPressure(quarter, 0.70, 0.85), 0.25, 1e-9);
+    }
+
+    @Test
+    public void testLinearPressureZeroRangeReturnsOne() {
+        // Degenerate case: highWm == lowWm must return 1.0 (not divide-by-zero).
+        assertEquals(AdaptivePublishThrottleController.linearPressure(0.80, 0.80, 0.80), 1.0, 1e-9);
+    }
+
+    // =========================================================================
+    // computeTargetRate() — bounded step and hard floor
+    // =========================================================================
+
+    @Test
+    public void testComputeTargetRateNoPressure() {
+        // At pressure=0.0, target should equal naturalRate (no reduction).
+        // But bounded step from currentRate=0 means we start from naturalRate.
+        long result = controller.computeTargetRate(1000.0, 0.0, 0L, config);
+        // targetFactor = 1.0 - 0*(1-0.10) = 1.0 → idealTarget = 1000
+        // base = naturalRate = 1000 (currentRate == 0 → use natural)
+        // delta = max(1, 1000 * 0.25) = 250
+        // rampUp: min(1000, 1000+250) = 1000
+        assertEquals(result, 1000L, "At zero pressure, target rate must equal natural rate");
+    }
+
+    @Test
+    public void testComputeTargetRateFullPressure() {
+        // At pressure=1.0, ideal = naturalRate * minFactor = 1000 * 0.10 = 100.
+        // Base = natural = 1000 (currentRate=0), delta = 250.
+        // Ramp down: max(100, 1000-250) = max(100, 750) = 750 (bounded step, first cycle).
+        long result = controller.computeTargetRate(1000.0, 1.0, 0L, config);
+        assertEquals(result, 750L,
+                "First cycle at full pressure: bounded step must limit decrease to maxChangeFactor=25%");
+    }
+
+    @Test
+    public void testComputeTargetRateReachesFloorAfterFourCycles() {
+        // At full pressure, after enough cycles the rate should reach the floor.
+        // Each cycle: decrease by maxDelta = 25% of natural = 250.
+        // natural=1000, floor=100
+        // Cycle 1: base=1000, ideal=100, delta=250 → newRate=max(100,750)=750
+        // Cycle 2: base=750,  ideal=100, delta=250 → newRate=max(100,500)=500
+        // Cycle 3: base=500,  ideal=100, delta=250 → newRate=max(100,250)=250
+        // Cycle 4: base=250,  ideal=100, delta=250 → newRate=max(100,0)=100
+        long r1 = controller.computeTargetRate(1000.0, 1.0, 0L, config);
+        long r2 = controller.computeTargetRate(1000.0, 1.0, r1, config);
+        long r3 = controller.computeTargetRate(1000.0, 1.0, r2, config);
+        long r4 = controller.computeTargetRate(1000.0, 1.0, r3, config);
+
+        assertEquals(r1, 750L, "Cycle 1 bounded step");
+        assertEquals(r2, 500L, "Cycle 2 bounded step");
+        assertEquals(r3, 250L, "Cycle 3 bounded step");
+        assertEquals(r4, 100L, "Cycle 4: should reach floor (minRateFactor=0.10 of 1000)");
+    }
+
+    @Test
+    public void testComputeTargetRateBoundedStepUp() {
+        // Recovery: pressure drops, rate should ramp up at most by maxChangeFactor per cycle.
+        // Previous cycle had rate 100 (floor). Natural=1000, pressure now 0.
+        // idealTarget = 1000, base=100, delta=250 → ramp up: min(1000, 100+250) = 350.
+        long result = controller.computeTargetRate(1000.0, 0.0, 100L, config);
+        assertEquals(result, 350L,
+                "Recovery: bounded step up must not exceed maxChangeFactor per cycle");
+    }
+
+    @Test
+    public void testComputeTargetRateBoundedStepUpEventuallyReachesNatural() {
+        // Verify full recovery after 4 cycles from floor.
+        long r1 = controller.computeTargetRate(1000.0, 0.0, 100L, config);  // 350
+        long r2 = controller.computeTargetRate(1000.0, 0.0, r1, config);    // 600
+        long r3 = controller.computeTargetRate(1000.0, 0.0, r2, config);    // 850
+        long r4 = controller.computeTargetRate(1000.0, 0.0, r3, config);    // 1000
+
+        assertEquals(r1, 350L);
+        assertEquals(r2, 600L);
+        assertEquals(r3, 850L);
+        assertEquals(r4, 1000L, "Rate must recover to natural after 4 ramp-up cycles");
+    }
+
+    @Test
+    public void testComputeTargetRateHardFloorNeverViolated() {
+        // Even at full pressure with a very small natural rate, floor must hold.
+        // natural=10, minFactor=0.10 → floor = max(1, 1) = 1.
+        long result = controller.computeTargetRate(10.0, 1.0, 10L, config);
+        assertTrue(result >= 1L, "Rate must never drop below 1 message/s");
+    }
+
+    @Test
+    public void testComputeTargetRateZeroNaturalRateReturnsOne() {
+        long result = controller.computeTargetRate(0.0, 1.0, 0L, config);
+        assertEquals(result, 1L, "naturalRate=0 must return 1 (hard minimum)");
+
+        result = controller.computeTargetRate(-5.0, 0.5, 0L, config);
+        assertEquals(result, 1L, "negative naturalRate must return 1");
+    }
+
+    @Test
+    public void testComputeTargetRateMinFloorAbsoluteValue() {
+        // natural=100, minFactor=0.10 → minAbsolute=10
+        // pressureFactor=1.0, currentRate=10 (already at floor)
+        // ideal=10, base=10, delta=25 → ramp down: max(10, 10-25)=10 → then floor max(10,10)=10
+        long result = controller.computeTargetRate(100.0, 1.0, 10L, config);
+        assertEquals(result, 10L, "Rate at the floor must stay at floor (not go lower)");
+    }
+
+    // =========================================================================
+    // Hysteresis tests via runControllerCycle()
+    // =========================================================================
+
+    private AdaptivePublishRateLimiter buildLimiterWithNaturalRate(double naturalMsgRate) {
+        AdaptivePublishRateLimiter l = new AdaptivePublishRateLimiter(
+                manualClockSource::get,
+                p -> p.getCnx().getThrottleTracker()
+                        .markThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate),
+                p -> p.getCnx().getThrottleTracker()
+                        .unmarkThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate));
+        // Seed natural rate: sampleRate at t=0, then t=1s with naturalMsgRate msgs.
+        long t0 = TimeUnit.SECONDS.toNanos(0);
+        long t1 = TimeUnit.SECONDS.toNanos(1);
+        l.sampleRate(0L, 0L, t0);
+        l.sampleRate((long) naturalMsgRate, (long) (naturalMsgRate * 1024), t1);
+        return l;
+    }
+
+    private PersistentTopic buildMockTopic(AdaptivePublishRateLimiter limiter,
+                                           long backlogBytes, long quotaBytes) {
+        PersistentTopic topic = mock(PersistentTopic.class);
+        when(topic.getAdaptivePublishRateLimiter()).thenReturn(limiter);
+        when(topic.getBacklogSize()).thenReturn(backlogBytes);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(quotaBytes);
+        when(topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        when(topic.getMsgInCounter()).thenReturn(10_000L);
+        when(topic.getBytesInCounter()).thenReturn(10_000_000L);
+        when(topic.getName()).thenReturn("persistent://tenant/ns/test-topic");
+        return topic;
+    }
+
+    /**
+     * Wires {@code brokerService.forEachPersistentTopic()} to call the consumer
+     * with exactly one topic.
+     */
+    @SuppressWarnings("unchecked")
+    private void wireSingleTopic(PersistentTopic topic) {
+        doAnswer(invocation -> {
+            Consumer<PersistentTopic> consumer = invocation.getArgument(0);
+            consumer.accept(topic);
+            return null;
+        }).when(brokerService).forEachPersistentTopic(any());
+    }
+
+    @Test
+    public void testThrottleActivatesWhenBacklogAboveHighWatermark() {
+        // backlogHighWm=0.90, quota=1000, backlog=950 (95%) → pressure=1.0 → activate
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        assertFalse(limiter.isActive(), "should start inactive");
+
+        PersistentTopic topic = buildMockTopic(limiter, 950L, 1000L);
+        wireSingleTopic(topic);
+
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+        controller.runControllerCycle();
+
+        assertTrue(limiter.isActive(),
+                "Limiter must be activated when backlog exceeds high watermark");
+    }
+
+    @Test
+    public void testThrottleDoesNotActivateBelowLowWatermark() {
+        // backlogLowWm=0.75, backlog=700/1000 (70%) → pressure=0 → no activation
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        assertFalse(limiter.isActive());
+
+        PersistentTopic topic = buildMockTopic(limiter, 700L, 1000L);
+        wireSingleTopic(topic);
+
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+        controller.runControllerCycle();
+
+        assertFalse(limiter.isActive(),
+                "Limiter must NOT activate when backlog is below low watermark");
+    }
+
+    @Test
+    public void testHysteresisRemainsActiveUntilBelowLowWatermark() {
+        // First cycle: backlog at 95% → activate.
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 950L, 1000L);
+        wireSingleTopic(topic);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(), "Must activate at 95%");
+
+        // Second cycle: backlog drops to 80% (above lowWm=75%) → still active
+        when(topic.getBacklogSize()).thenReturn(800L);
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(),
+                "Must stay active at 80% (above low watermark 75%)");
+
+        // Third cycle: backlog drops to 70% (below lowWm=75%) → deactivate
+        when(topic.getBacklogSize()).thenReturn(700L);
+        controller.runControllerCycle();
+        assertFalse(limiter.isActive(),
+                "Must deactivate only when backlog drops below low watermark (75%)");
+    }
+
+    @Test
+    public void testHysteresisInZoneBetweenLowAndHighWatermarks() {
+        // Zone: 75% < backlog < 90%
+        // pressure > 0 → activate if inactive, stay active if already active.
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 820L, 1000L); // 82%
+        wireSingleTopic(topic);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(),
+                "Should activate when backlog is in the ramp zone (82% > lowWm=75%)");
+    }
+
+    // =========================================================================
+    // observeOnly guarantee — CRITICAL SAFETY TEST
+    // =========================================================================
+
+    /**
+     * CRITICAL TEST: When {@code observeOnly=true}, the controller cycle MUST NOT
+     * call {@link AdaptivePublishRateLimiter#activate} or
+     * {@link AdaptivePublishRateLimiter#deactivate}, even under extreme pressure.
+     *
+     * <p>This test asserts:
+     * <ol>
+     *   <li>{@code limiter.isActive()} remains {@code false} after the cycle.</li>
+     *   <li>{@code throttleTracker.throttledCount()} remains {@code 0} — meaning no
+     *       {@code markThrottled()} call was made on any connection.</li>
+     * </ol>
+     *
+     * <p>If this test fails, it means the observe-only circuit-breaker is broken and
+     * the controller would throttle producers in production without operator intent.
+     */
+    @Test
+    public void testObserveOnlyNeverActivatesLimiter() throws Exception {
+        // Max pressure: backlog at 100% of quota.
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 1000L, 1000L); // 100% backlog
+        wireSingleTopic(topic);
+
+        // Enable observe-only mode — the key config that MUST prevent any throttling.
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+
+        controller.runControllerCycle();
+
+        assertFalse(limiter.isActive(),
+                "OBSERVE-ONLY VIOLATED: limiter.isActive() must be false when observeOnly=true");
+        assertEquals(limiter.getThrottleActivationCount(), 0L,
+                "OBSERVE-ONLY VIOLATED: throttleActivationCount must be 0 when observeOnly=true");
+    }
+
+    /**
+     * Extension of the above: even after 10 consecutive cycles under maximum pressure,
+     * the channel autoread state must never change when observeOnly=true.
+     *
+     * <p>This is the "never changes channel autoread" guarantee specifically requested
+     * in the implementation spec.
+     */
+    @Test
+    public void testObserveOnlyNeverChangesChannelAutoreadAfterManyCycles() throws Exception {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 1000L, 1000L); // 100% backlog
+        wireSingleTopic(topic);
+
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+
+        // Run many cycles under extreme pressure.
+        for (int i = 0; i < 10; i++) {
+            controller.runControllerCycle();
+        }
+
+        // Assert: limiter never activated.
+        assertFalse(limiter.isActive(),
+                "OBSERVE-ONLY VIOLATED after 10 cycles: limiter must never activate");
+        assertEquals(limiter.getThrottleActivationCount(), 0L,
+                "OBSERVE-ONLY VIOLATED: zero activations expected");
+
+        // Assert: no producer connection was throttled (no channel autoread change).
+        // Even if handlePublishThrottling were called on IO thread — which it won't be
+        // since active=false — throttledCount would still be 0.
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                // Simulate IO thread calling handlePublishThrottling during observe-only.
+                manualClockSource.addAndGet(TimeUnit.SECONDS.toNanos(1));
+                for (int i = 0; i < 1000; i++) {
+                    limiter.handlePublishThrottling(producer, 500, 500_000);
+                }
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "OBSERVE-ONLY VIOLATED: throttledCount must be 0 — "
+                                + "channel autoread must NEVER change when observeOnly=true");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Verify that switching FROM observeOnly=true TO observeOnly=false at runtime
+     * (dynamic config flip) correctly enables throttling on the very next cycle.
+     */
+    @Test
+    public void testObserveOnlyToLiveModeTransition() {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 1000L, 1000L); // 100%
+        wireSingleTopic(topic);
+
+        // Phase 1: observeOnly — no throttling.
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+        controller.runControllerCycle();
+        assertFalse(limiter.isActive(), "Must not be active in observeOnly mode");
+
+        // Phase 2: flip to live — throttling must now be applied.
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(),
+                "Must activate on first live-mode cycle after observeOnly→live transition");
+        assertTrue(limiter.getThrottleActivationCount() >= 1L,
+                "Activation count must be >= 1 after live cycle");
+    }
+
+    /**
+     * Verify that switching FROM live TO observeOnly=true mid-flight stops further
+     * rate adjustments. The current active state is NOT changed retroactively, but
+     * no new activate/deactivate calls are made.
+     *
+     * <p>Note: this tests the "emergency circuit-breaker" use case — operator
+     * flips observeOnly=true at runtime to immediately stop new throttle decisions.
+     * Existing active throttles are unaffected until pressure drops below lowWm
+     * in a live cycle (but since we're now in observeOnly, they will never be
+     * deactivated by the controller either until flipped back).
+     */
+    @Test
+    public void testObserveOnlyMidFlightFreezesThrottleDecisions() {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 1000L, 1000L); // 100%
+        wireSingleTopic(topic);
+
+        // Live mode: activate throttle.
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(), "Must be active in live mode");
+        long activationCountBefore = limiter.getThrottleActivationCount();
+
+        // Flip to observeOnly: controller must NOT call deactivate even when backlog drops.
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+        when(topic.getBacklogSize()).thenReturn(100L); // well below lowWm
+        controller.runControllerCycle();
+
+        // The limiter state is "frozen" — in observe-only the controller doesn't deactivate.
+        // (The limiter remains active from the previous live cycle, but no new changes made.)
+        // Activation count should not have increased.
+        assertEquals(limiter.getThrottleActivationCount(), activationCountBefore,
+                "No new activations should occur in observeOnly mode");
+    }
+
+    // =========================================================================
+    // Broker-level counters
+    // =========================================================================
+
+    @Test
+    public void testActiveThrottledTopicsCountIsUpdatedPerCycle() {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 950L, 1000L);
+        wireSingleTopic(topic);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+
+        assertEquals(controller.getActiveThrottledTopicsCount(), 0,
+                "Initial active throttled count must be 0");
+
+        controller.runControllerCycle();
+
+        assertEquals(controller.getActiveThrottledTopicsCount(), 1,
+                "Active throttled count must be 1 after cycle with one throttled topic");
+    }
+
+    @Test
+    public void testTotalActivationCountIncrementsInLiveMode() {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 950L, 1000L);
+        wireSingleTopic(topic);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+
+        assertEquals(controller.getTotalActivationCount(), 0L);
+
+        controller.runControllerCycle();
+        assertEquals(controller.getTotalActivationCount(), 1L,
+                "Total activation count must increment on first topic activation");
+
+        // Repeated cycles (still active) should NOT increment again.
+        controller.runControllerCycle();
+        assertEquals(controller.getTotalActivationCount(), 1L,
+                "Total activation count must NOT increment if topic already active");
+    }
+
+    @Test
+    public void testTotalActivationCountDoesNotIncrementInObserveOnly() {
+        AdaptivePublishRateLimiter limiter = buildLimiterWithNaturalRate(1000.0);
+        PersistentTopic topic = buildMockTopic(limiter, 950L, 1000L);
+        wireSingleTopic(topic);
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+
+        controller.runControllerCycle();
+        assertEquals(controller.getTotalActivationCount(), 0L,
+                "Total activation count must be 0 in observeOnly mode");
+    }
+
+    // =========================================================================
+    // computeBacklogPressure() — quota handling
+    // =========================================================================
+
+    @Test
+    public void testComputeBacklogPressureNoQuota() {
+        PersistentTopic topic = mock(PersistentTopic.class);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(-1L); // no quota
+        when(topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        when(topic.getBacklogSize()).thenReturn(999_999L);
+
+        double pressure = controller.computeBacklogPressure(topic, config);
+        assertEquals(pressure, 0.0, 1e-9,
+                "Backlog pressure must be 0 when no quota is configured");
+    }
+
+    @Test
+    public void testComputeBacklogPressureAboveHighWatermark() {
+        PersistentTopic topic = mock(PersistentTopic.class);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(1000L);
+        when(topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        when(topic.getBacklogSize()).thenReturn(950L); // 95% > 90% highWm
+
+        double pressure = controller.computeBacklogPressure(topic, config);
+        assertEquals(pressure, 1.0, 1e-9,
+                "Backlog pressure must be 1.0 when backlog exceeds high watermark");
+    }
+
+    @Test
+    public void testComputeBacklogPressureBelowLowWatermark() {
+        PersistentTopic topic = mock(PersistentTopic.class);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(1000L);
+        when(topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        when(topic.getBacklogSize()).thenReturn(700L); // 70% < 75% lowWm
+
+        double pressure = controller.computeBacklogPressure(topic, config);
+        assertEquals(pressure, 0.0, 1e-9,
+                "Backlog pressure must be 0.0 when backlog is below low watermark");
+    }
+
+    @Test
+    public void testComputeBacklogPressureMidpoint() {
+        PersistentTopic topic = mock(PersistentTopic.class);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(1000L);
+        when(topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        // Midpoint of [75%, 90%] = 82.5% = 825 bytes
+        when(topic.getBacklogSize()).thenReturn(825L);
+
+        double pressure = controller.computeBacklogPressure(topic, config);
+        assertEquals(pressure, 0.5, 1e-6,
+                "Backlog pressure must be 0.5 at midpoint of low/high watermarks");
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptiveThrottleEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AdaptiveThrottleEndToEndTest.java
@@ -1,0 +1,537 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end integration tests for the adaptive publish throttling control loop.
+ *
+ * <p>These tests simulate the full lifecycle:
+ * <ul>
+ *   <li>Natural rate estimation warmup</li>
+ *   <li>Backlog growth → smooth throttle activation and rate reduction (bounded step)</li>
+ *   <li>Sustained pressure → rate stays at minimum floor</li>
+ *   <li>Backlog drain → smooth rate recovery (bounded step up)</li>
+ *   <li>Full recovery to natural rate</li>
+ *   <li>observeOnly → live mode transition without disruption</li>
+ * </ul>
+ *
+ * <p>All tests use mocked BrokerService / PersistentTopic so that no real Pulsar
+ * broker or ZooKeeper is needed, yet the complete path through
+ * {@link AdaptivePublishThrottleController} → {@link AdaptivePublishRateLimiter} →
+ * {@link PublishRateLimiterImpl} → {@link ServerCnxThrottleTracker} is exercised.
+ */
+@Test(groups = "broker")
+public class AdaptiveThrottleEndToEndTest {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /** Natural publish rate used in tests (msg/s). */
+    private static final double NATURAL_RATE = 1000.0;
+
+    /** Quota limit used in tests (bytes). */
+    private static final long QUOTA_LIMIT = 10_000L;
+
+    // -------------------------------------------------------------------------
+    // Shared test state
+    // -------------------------------------------------------------------------
+
+    private ServiceConfiguration config;
+    private BrokerService brokerService;
+    private AdaptivePublishThrottleController controller;
+
+    private AtomicLong manualClockSource;
+    private Producer producer;
+    private ServerCnx serverCnx;
+    private ServerCnxThrottleTracker throttleTracker;
+    private DefaultEventLoop eventLoop;
+
+    /** The limiter under test — seeded with a natural rate before each scenario. */
+    private AdaptivePublishRateLimiter limiter;
+
+    /** The mock topic wired to the limiter. */
+    private PersistentTopic topic;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        config = new ServiceConfiguration();
+        // Use unreachable memory watermarks to avoid test interference from real JVM heap.
+        config.setAdaptivePublisherThrottlingMemoryHighWatermarkPct(0.999);
+        config.setAdaptivePublisherThrottlingMemoryLowWatermarkPct(0.99);
+        config.setAdaptivePublisherThrottlingBacklogHighWatermarkPct(0.90);
+        config.setAdaptivePublisherThrottlingBacklogLowWatermarkPct(0.75);
+        config.setAdaptivePublisherThrottlingMinRateFactor(0.10);
+        config.setAdaptivePublisherThrottlingMaxRateChangeFactor(0.25);
+        config.setAdaptivePublisherThrottlingIntervalMs(1000);
+        config.setAdaptivePublisherThrottlingObserveOnly(false);
+
+        PulsarService pulsarService = mock(PulsarService.class);
+        brokerService = mock(BrokerService.class);
+        when(pulsarService.getConfiguration()).thenReturn(config);
+        when(brokerService.getPulsar()).thenReturn(pulsarService);
+
+        controller = new AdaptivePublishThrottleController(brokerService);
+
+        manualClockSource = new AtomicLong(TimeUnit.SECONDS.toNanos(0));
+        eventLoop = new DefaultEventLoop(new DefaultThreadFactory("test-e2e-io"));
+        producer = mock(Producer.class);
+        serverCnx = mock(ServerCnx.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        doAnswer(a -> eventLoop).when(ctx).executor();
+        doAnswer(a -> ctx).when(serverCnx).ctx();
+        doAnswer(a -> serverCnx).when(producer).getCnx();
+        throttleTracker = new ServerCnxThrottleTracker(serverCnx);
+        doAnswer(a -> throttleTracker).when(serverCnx).getThrottleTracker();
+        when(producer.getCnx()).thenReturn(serverCnx);
+        BrokerService bs = mock(BrokerService.class);
+        when(serverCnx.getBrokerService()).thenReturn(bs);
+        EventLoopGroup elg = mock(EventLoopGroup.class);
+        when(bs.executor()).thenReturn(elg);
+        when(elg.next()).thenReturn(eventLoop);
+
+        // Build the limiter with a pre-seeded natural rate.
+        limiter = buildLimiterWithNaturalRate(NATURAL_RATE);
+
+        // Build the mock topic wired to the limiter.
+        topic = buildMockTopic(limiter, 0L, QUOTA_LIMIT);
+
+        // Wire the topic into the controller.
+        wireSingleTopic(topic);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        controller.close();
+        eventLoop.shutdownGracefully().sync();
+    }
+
+    // =========================================================================
+    // Scenario 1: No backlog pressure → limiter stays inactive
+    // =========================================================================
+
+    /**
+     * When backlog is at 0, the limiter must remain inactive across multiple cycles.
+     * This verifies the disabled/no-pressure path does not accidentally activate.
+     */
+    @Test
+    public void testNoPressureKeepsLimiterInactive() {
+        // Backlog = 0/10000 = 0% → below lowWm=75%.
+        when(topic.getBacklogSize()).thenReturn(0L);
+
+        for (int cycle = 1; cycle <= 5; cycle++) {
+            controller.runControllerCycle();
+            assertFalse(limiter.isActive(),
+                    "Limiter must remain inactive at cycle " + cycle + " with zero backlog");
+        }
+
+        assertEquals(limiter.getThrottleActivationCount(), 0L,
+                "Zero activation count expected with zero backlog");
+    }
+
+    // =========================================================================
+    // Scenario 2: Smooth rate reduction on backlog growth
+    // =========================================================================
+
+    /**
+     * Simulates backlog growing suddenly to 95% of quota (above highWm=90%).
+     * The rate must decrease smoothly — by at most maxRateChangeFactor=25% per cycle —
+     * until it reaches the floor (minRateFactor=10% of natural).
+     *
+     * <p>Expected rate sequence from natural=300 (EWMA estimate), pressure=1.0:
+     * <ul>
+     *   <li>Cycle 1: base=300, idealTarget=30, maxDelta=75 → max(30, 300-75) = 225</li>
+     *   <li>Cycle 2: base=225, max(30, 225-75) = 150</li>
+     *   <li>Cycle 3: base=150, max(30, 150-75) = 75</li>
+     *   <li>Cycle 4: base=75,  max(30, 75-75) = max(30,0) = 30</li>
+     *   <li>Cycle 5+: stays at 30 (floor)</li>
+     * </ul>
+     *
+     * <p>Note: naturalMsgRateEstimate after buildLimiterWithNaturalRate(1000.0) is 300
+     * because the EWMA starts at 0 and only one up-step occurs:
+     * 0 * 0.70 + 1000 * 0.30 = 300.
+     */
+    @Test
+    public void testSmoothRateReductionOnBacklogGrowth() {
+        // Spike backlog to 95% → full pressure.
+        when(topic.getBacklogSize()).thenReturn(9500L); // 95% of 10000
+
+        double naturalRate = limiter.getNaturalMsgRateEstimate(); // 300.0
+        long floor = Math.max(1L, (long) (naturalRate * 0.10)); // 30
+        long maxDelta = (long) (naturalRate * 0.25);            // 75
+
+        List<Long> rateHistory = new ArrayList<>();
+        long previousRate = 0L; // starts inactive (base = naturalRate for first cycle)
+
+        for (int cycle = 1; cycle <= 6; cycle++) {
+            controller.runControllerCycle();
+            assertTrue(limiter.isActive(), "Limiter must be active with 95% backlog at cycle " + cycle);
+
+            long effectiveRate = limiter.getCurrentEffectiveMsgRate();
+            rateHistory.add(effectiveRate);
+
+            // Each step must decrease by at most maxDelta from the previous effective rate.
+            long base = (previousRate > 0) ? previousRate : (long) naturalRate;
+            long minAllowed = Math.max(floor, base - maxDelta);
+            assertTrue(effectiveRate >= floor,
+                    "Rate must not drop below floor=" + floor + " at cycle " + cycle
+                            + " (got " + effectiveRate + ")");
+            assertTrue(effectiveRate >= minAllowed,
+                    "Rate must not decrease faster than maxRateChangeFactor per cycle at cycle " + cycle
+                            + ": base=" + base + " maxDelta=" + maxDelta
+                            + " effectiveRate=" + effectiveRate);
+
+            previousRate = effectiveRate;
+        }
+
+        // By cycle 4 or 5, rate should have reached the floor.
+        assertTrue(rateHistory.get(rateHistory.size() - 1) <= floor * 2,
+                "Rate should be near floor after 6 cycles of max pressure. "
+                        + "rateHistory=" + rateHistory);
+    }
+
+    /**
+     * Verifies each cycle's rate decrease is monotonically decreasing under
+     * sustained full pressure.
+     */
+    @Test
+    public void testRateMonotonicallyDecreasesUnderSustainedPressure() {
+        when(topic.getBacklogSize()).thenReturn(9500L); // 95%
+
+        long prevRate = Long.MAX_VALUE;
+        for (int cycle = 1; cycle <= 6; cycle++) {
+            controller.runControllerCycle();
+            long rate = limiter.getCurrentEffectiveMsgRate();
+            assertTrue(rate <= prevRate,
+                    "Rate must not increase under sustained pressure at cycle " + cycle
+                            + ": prevRate=" + prevRate + " currentRate=" + rate);
+            prevRate = rate;
+        }
+    }
+
+    // =========================================================================
+    // Scenario 3: Rate recovery when backlog drains
+    // =========================================================================
+
+    /**
+     * After reaching the minimum floor, simulates backlog drain below the low
+     * watermark. Verifies:
+     * <ol>
+     *   <li>Limiter deactivates as soon as pressure drops to 0.</li>
+     *   <li>Active throttled topics count returns to 0.</li>
+     * </ol>
+     */
+    @Test
+    public void testLimiterDeactivatesWhenBacklogDrains() {
+        // Phase 1: throttle to floor (4 cycles at 95% backlog).
+        when(topic.getBacklogSize()).thenReturn(9500L);
+        for (int i = 0; i < 4; i++) {
+            controller.runControllerCycle();
+        }
+        assertTrue(limiter.isActive(), "Should be active after 4 cycles at 95% backlog");
+        assertEquals(controller.getActiveThrottledTopicsCount(), 1,
+                "One topic should be counted as throttled");
+
+        // Phase 2: drain backlog below lowWm=75% (set to 70%).
+        when(topic.getBacklogSize()).thenReturn(7000L); // 70% < lowWm=75%
+        controller.runControllerCycle();
+
+        assertFalse(limiter.isActive(),
+                "Limiter must deactivate when backlog drains below low watermark");
+        assertEquals(controller.getActiveThrottledTopicsCount(), 0,
+                "Active throttled count must be 0 after deactivation");
+    }
+
+    // =========================================================================
+    // Scenario 4: Partial pressure in the ramp zone
+    // =========================================================================
+
+    /**
+     * When backlog is in the ramp zone (75%–90%), pressure is partial.
+     * Rate should be reduced proportionally but still above the floor.
+     */
+    @Test
+    public void testPartialPressureReducesRateProportion() {
+        // 82.5% is exactly the midpoint: pressure = 0.5.
+        // backlog = 8250L / 10000L = 82.5%
+        when(topic.getBacklogSize()).thenReturn(8250L);
+
+        controller.runControllerCycle();
+        assertTrue(limiter.isActive(), "Should activate at 82.5% backlog (> lowWm=75%)");
+
+        double naturalRate = limiter.getNaturalMsgRateEstimate(); // 300.0
+        long effectiveRate = limiter.getCurrentEffectiveMsgRate();
+        long floor = Math.max(1L, (long) (naturalRate * 0.10)); // 30
+
+        // With pressure=0.5, idealTarget = naturalRate * (1 - 0.5 * 0.9) = naturalRate * 0.55 = 165
+        // base = naturalRate = 300 (first activation), delta = 75
+        // ramp down: max(165, 300-75) = max(165, 225) = 225
+        assertTrue(effectiveRate > floor,
+                "At partial pressure (0.5), rate must be above floor=" + floor
+                        + " (got " + effectiveRate + ")");
+        assertTrue(effectiveRate < (long) naturalRate,
+                "At partial pressure, rate must be below natural rate (got " + effectiveRate + ")");
+    }
+
+    // =========================================================================
+    // Scenario 5: observeOnly mode does NOT throttle producers
+    // =========================================================================
+
+    /**
+     * Full end-to-end observeOnly test: runs 10 cycles under extreme backlog pressure
+     * with observeOnly=true and then verifies that the producer's connection was
+     * never throttled (channel autoread never changed).
+     *
+     * <p>This is the test explicitly required by the implementation spec:
+     * "include at least one test that fails if any call path would change channel
+     * auto read state while observeOnly is enabled."
+     */
+    @Test
+    public void testObserveOnlyEndToEndNeverThrottlesProducerConnection() throws Exception {
+        // Enable observeOnly mode.
+        config.setAdaptivePublisherThrottlingObserveOnly(true);
+
+        // Maximum pressure: backlog at 100%.
+        when(topic.getBacklogSize()).thenReturn(QUOTA_LIMIT);
+
+        // Run many cycles under maximum pressure.
+        for (int cycle = 0; cycle < 10; cycle++) {
+            controller.runControllerCycle();
+        }
+
+        // Assert: limiter NEVER activated.
+        assertFalse(limiter.isActive(),
+                "observeOnly END-TO-END VIOLATED: limiter must never be active");
+        assertEquals(limiter.getThrottleActivationCount(), 0L,
+                "observeOnly END-TO-END VIOLATED: activation count must be 0");
+        assertEquals(controller.getTotalActivationCount(), 0L,
+                "observeOnly END-TO-END VIOLATED: controller activation count must be 0");
+
+        // Assert: actual IO-thread publish path never throttled the connection.
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        eventLoop.execute(() -> {
+            try {
+                // Simulate bursts of publish operations as if producers are at full speed.
+                manualClockSource.addAndGet(TimeUnit.SECONDS.toNanos(1));
+                for (int burst = 0; burst < 20; burst++) {
+                    manualClockSource.addAndGet(TimeUnit.SECONDS.toNanos(1));
+                    limiter.handlePublishThrottling(producer, 5_000, 50_000_000);
+                }
+                assertEquals(throttleTracker.throttledCount(), 0,
+                        "observeOnly END-TO-END VIOLATED: throttledCount must be 0 — "
+                                + "channel autoread must NEVER change when observeOnly=true");
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    // =========================================================================
+    // Scenario 6: Existing static rate limits are unaffected
+    // =========================================================================
+
+    /**
+     * Verifies that when adaptive throttling is disabled (limiter == null in topic),
+     * the controller cycle skips the topic gracefully without side-effects.
+     */
+    @Test
+    public void testControllerSkipsTopicsWithNoLimiter() {
+        // Wire a topic that returns null limiter.
+        PersistentTopic noLimiterTopic = mock(PersistentTopic.class);
+        when(noLimiterTopic.getAdaptivePublishRateLimiter()).thenReturn(null);
+        when(noLimiterTopic.getName()).thenReturn("persistent://tenant/ns/no-limiter");
+        wireSingleTopic(noLimiterTopic);
+
+        // Should not throw.
+        controller.runControllerCycle();
+
+        assertEquals(controller.getActiveThrottledTopicsCount(), 0,
+                "No topics should be counted as throttled when limiter is null");
+        assertEquals(controller.getTotalActivationCount(), 0L);
+    }
+
+    // =========================================================================
+    // Scenario 7: Natural rate estimate warmup (first cycle skipped)
+    // =========================================================================
+
+    /**
+     * If the limiter has no natural rate estimate (first load or fresh topic),
+     * the controller must NOT activate on the first cycle — it sets the baseline
+     * and waits for the next cycle.
+     */
+    @Test
+    public void testFirstCycleWithZeroNaturalRateDoesNotActivate() {
+        // Build a limiter with NO pre-seeded natural rate.
+        AdaptivePublishRateLimiter freshLimiter = new AdaptivePublishRateLimiter(
+                manualClockSource::get,
+                p -> p.getCnx().getThrottleTracker()
+                        .markThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate),
+                p -> p.getCnx().getThrottleTracker()
+                        .unmarkThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate));
+
+        assertEquals(freshLimiter.getNaturalMsgRateEstimate(), 0.0, 1e-9,
+                "Natural rate must be 0 for a fresh limiter");
+
+        PersistentTopic freshTopic = buildMockTopic(freshLimiter, 9500L, QUOTA_LIMIT);
+        wireSingleTopic(freshTopic);
+
+        // Cycle 1: should set baseline but NOT activate (natural rate still 0 after first sample).
+        controller.runControllerCycle();
+        assertFalse(freshLimiter.isActive(),
+                "First cycle must NOT activate (no natural rate baseline yet)");
+        assertEquals(freshLimiter.getThrottleActivationCount(), 0L);
+    }
+
+    // =========================================================================
+    // Scenario 8: Full lifecycle (warmup → pressure → throttle → recovery)
+    // =========================================================================
+
+    /**
+     * Complete lifecycle test covering:
+     * <ol>
+     *   <li>Rate warmup (no pressure, limiter inactive).</li>
+     *   <li>Backlog spikes to 95% → throttle activates, rate decreases smoothly.</li>
+     *   <li>Backlog drains to 70% → throttle deactivates.</li>
+     *   <li>System returns to baseline with limiter inactive.</li>
+     * </ol>
+     */
+    @Test
+    public void testFullLifecycle() {
+        // Phase 1: warmup (no pressure, 3 cycles).
+        when(topic.getBacklogSize()).thenReturn(0L);
+        for (int i = 0; i < 3; i++) {
+            controller.runControllerCycle();
+            assertFalse(limiter.isActive(), "Phase 1: must be inactive during warmup");
+        }
+
+        long activationCountBefore = limiter.getThrottleActivationCount();
+        assertEquals(activationCountBefore, 0L, "No activations during warmup");
+
+        // Phase 2: backlog spikes to 95% (full pressure).
+        when(topic.getBacklogSize()).thenReturn(9500L);
+        long prevRate = 0L;
+        for (int cycle = 1; cycle <= 4; cycle++) {
+            controller.runControllerCycle();
+            assertTrue(limiter.isActive(), "Phase 2: must be active at cycle " + cycle);
+
+            long rate = limiter.getCurrentEffectiveMsgRate();
+            // Rate should be decreasing or at the floor.
+            if (prevRate > 0) {
+                assertTrue(rate <= prevRate,
+                        "Phase 2: rate should decrease or hold at cycle " + cycle);
+            }
+            prevRate = rate;
+        }
+
+        assertTrue(limiter.getThrottleActivationCount() >= 1L,
+                "Phase 2: at least one activation should have occurred");
+        assertEquals(controller.getActiveThrottledTopicsCount(), 1,
+                "Phase 2: one topic should be counted as throttled");
+
+        // Phase 3: backlog drains below lowWm.
+        when(topic.getBacklogSize()).thenReturn(7000L); // 70% < lowWm=75%
+        controller.runControllerCycle();
+        assertFalse(limiter.isActive(), "Phase 3: must deactivate after drain");
+        assertEquals(controller.getActiveThrottledTopicsCount(), 0,
+                "Phase 3: throttled count must be 0 after deactivation");
+
+        // Phase 4: no backlog remains.
+        when(topic.getBacklogSize()).thenReturn(0L);
+        for (int i = 0; i < 3; i++) {
+            controller.runControllerCycle();
+            assertFalse(limiter.isActive(),
+                    "Phase 4: must remain inactive with zero backlog");
+        }
+    }
+
+    // =========================================================================
+    // Helper methods
+    // =========================================================================
+
+    /**
+     * Builds a limiter whose natural rate estimate is pre-seeded via one EWMA step
+     * so the controller can immediately make throttle decisions without waiting for
+     * the warmup cycle.
+     *
+     * <p>After seeding with instant rate = {@code naturalMsgRate}:
+     * {@code naturalMsgRateEstimate = 0 * 0.70 + naturalMsgRate * 0.30}
+     */
+    private AdaptivePublishRateLimiter buildLimiterWithNaturalRate(double naturalMsgRate) {
+        AdaptivePublishRateLimiter l = new AdaptivePublishRateLimiter(
+                manualClockSource::get,
+                p -> p.getCnx().getThrottleTracker()
+                        .markThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate),
+                p -> p.getCnx().getThrottleTracker()
+                        .unmarkThrottled(ServerCnxThrottleTracker.ThrottleType.TopicPublishRate));
+        // Seed: two calls, 1 second apart, with naturalMsgRate messages published.
+        l.sampleRate(0L, 0L, TimeUnit.SECONDS.toNanos(0));
+        l.sampleRate((long) naturalMsgRate, (long) (naturalMsgRate * 1024), TimeUnit.SECONDS.toNanos(1));
+        return l;
+    }
+
+    private PersistentTopic buildMockTopic(AdaptivePublishRateLimiter l,
+                                           long backlogBytes, long quotaBytes) {
+        PersistentTopic t = mock(PersistentTopic.class);
+        when(t.getAdaptivePublishRateLimiter()).thenReturn(l);
+        when(t.getBacklogSize()).thenReturn(backlogBytes);
+        BacklogQuota bq = mock(BacklogQuota.class);
+        when(bq.getLimitSize()).thenReturn(quotaBytes);
+        when(t.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage)).thenReturn(bq);
+        when(t.getMsgInCounter()).thenReturn(10_000L);
+        when(t.getBytesInCounter()).thenReturn(10_000_000L);
+        when(t.getName()).thenReturn("persistent://tenant/ns/e2e-test-topic");
+        return t;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void wireSingleTopic(PersistentTopic t) {
+        doAnswer(invocation -> {
+            Consumer<PersistentTopic> consumer = invocation.getArgument(0);
+            consumer.accept(t);
+            return null;
+        }).when(brokerService).forEachPersistentTopic(any());
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ThrottleTypeEnumTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ThrottleTypeEnumTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.Arrays;
+import org.apache.pulsar.broker.service.ServerCnxThrottleTracker.ThrottleType;
+import org.testng.annotations.Test;
+
+/**
+ * Guard tests for {@link ThrottleType} ordinal stability.
+ *
+ * <p>{@link ServerCnxThrottleTracker} indexes its {@code states[]} array by
+ * {@link ThrottleType#ordinal()}.  Accidentally removing, renaming, or reordering
+ * an enum constant shifts every subsequent ordinal and silently corrupts the
+ * per-connection throttle-state tracking.
+ *
+ * <p>These tests exist to turn that silent corruption into a loud compile- or
+ * test-time failure.  If you intentionally add a new constant, bump
+ * {@link #EXPECTED_MIN_COUNT} and append the constant at the END of the enum.
+ */
+@Test(groups = "broker")
+public class ThrottleTypeEnumTest {
+
+    /**
+     * The number of {@link ThrottleType} constants that existed when adaptive
+     * throttling was integrated.  Increase this if you add a new constant;
+     * never decrease it.
+     */
+    private static final int EXPECTED_MIN_COUNT = 8;
+
+    /**
+     * Fails if any constant is deleted or renamed so the count drops below
+     * {@link #EXPECTED_MIN_COUNT}.  This catches "I thought it was unused"
+     * removals that would break the {@code states[]} index mapping.
+     */
+    @Test
+    public void testMinimumConstantCount() {
+        int actual = ThrottleType.values().length;
+        assertTrue(actual >= EXPECTED_MIN_COUNT,
+                "ThrottleType has " + actual + " constants but expected >= " + EXPECTED_MIN_COUNT
+                        + ". A constant was deleted or renamed — update states[] in "
+                        + "ServerCnxThrottleTracker and adjust EXPECTED_MIN_COUNT here.");
+    }
+
+    /**
+     * Fails if {@link ThrottleType#AdaptivePublishRate} is absent, confirming that
+     * the adaptive throttling wire-up in
+     * {@link AbstractTopic} has a valid target.
+     */
+    @Test
+    public void testAdaptivePublishRateIsPresent() {
+        boolean found = Arrays.stream(ThrottleType.values())
+                .anyMatch(t -> t == ThrottleType.AdaptivePublishRate);
+        assertTrue(found,
+                "ThrottleType.AdaptivePublishRate is missing. "
+                        + "Adaptive throttling in AbstractTopic will fail to compile or "
+                        + "produce a NullPointerException at runtime.");
+    }
+
+    /**
+     * Fails if {@link ThrottleType#AdaptivePublishRate} is not the last constant.
+     * New constants must always be appended; reordering shifts ordinals and breaks
+     * the index-based state array.
+     */
+    @Test
+    public void testAdaptivePublishRateIsLast() {
+        ThrottleType[] values = ThrottleType.values();
+        assertEquals(values[values.length - 1], ThrottleType.AdaptivePublishRate,
+                "ThrottleType.AdaptivePublishRate must remain the last enum constant. "
+                        + "Reordering shifts ordinals and corrupts the states[] index mapping "
+                        + "in ServerCnxThrottleTracker.");
+    }
+
+    /**
+     * Confirms that {@link ThrottleType#AdaptivePublishRate} is declared reentrant,
+     * which is required because multiple producers on the same topic share the per-topic
+     * {@link AdaptivePublishRateLimiter}.
+     */
+    @Test
+    public void testAdaptivePublishRateIsReentrant() {
+        assertTrue(ThrottleType.AdaptivePublishRate.isReentrant(),
+                "ThrottleType.AdaptivePublishRate must be reentrant (isReentrant=true). "
+                        + "Multiple producers share a single per-topic AdaptivePublishRateLimiter "
+                        + "and each independently calls markThrottled(); a non-reentrant type "
+                        + "would drop all but the first activation.");
+    }
+}


### PR DESCRIPTION
> **Experimental feature** — disabled by default (`adaptivePublisherThrottlingEnabled=false`).
> A broker restart is required to enable it; all tuning parameters are dynamic config.
>
> **Focused review request** — the areas most likely to have subtle bugs are:
> 1. **Concurrency** — `AdaptivePublishRateLimiter`: the `volatile boolean active` fast path on IO threads (see `handlePublishThrottling`), and the single-writer contract on the controller scheduler thread.
> 2. **Lifecycle** — `BrokerService.startAdaptivePublishThrottleController()` and the `close()` path; `ThrottleType.AdaptivePublishRate` ordinal stability and the new `states[]` slot.
> 3. **Hysteresis** — deactivation requires **both** memory **and** backlog pressure to drop below their low watermarks simultaneously; verify this is correct for your use case.

---

## Summary

- Adds an adaptive publish throttle controller that dynamically reduces producer publish rates when JVM heap usage or per-topic backlog size approaches configurable watermarks.
- **Disabled by default.** Zero code path changes when `adaptivePublisherThrottlingEnabled=false`.
- **Observe-only mode** (`adaptivePublisherThrottlingObserveOnly=true`, toggleable at runtime) computes and logs decisions but never applies throttling — safe for validating in production and usable as an emergency circuit-breaker.
- Controller never dies silently: every cycle is wrapped in `try-catch-finally`; failures increment a dedicated OTel counter.
- `ThrottleType.AdaptivePublishRate` is appended as the last enum constant to preserve existing ordinals 0–6. A guard test (`ThrottleTypeEnumTest`) fails immediately if the enum is accidentally mutated.

---

## Diff navigation

### Configuration (reviewers: verify defaults, dynamic flags, and conf entry comments)

| File | What changed |
|------|-------------|
| `ServiceConfiguration.java` | 10 new `@FieldContext` fields — `adaptivePublisherThrottling*` |
| `conf/broker.conf` | 10 new commented-out entries with inline docs and a recommended quick-start snippet |
| `README.md` | New "Experimental broker features" section with quick-start `broker.conf` snippet |

### Broker wiring (reviewers: focus on concurrency, lifecycle, and enum ordinal safety)

| File | What changed |
|------|-------------|
| `ServerCnxThrottleTracker.java` | New `ThrottleType.AdaptivePublishRate` constant (appended last, reentrant); class-level Javadoc on ordinal stability |
| `AbstractTopic.java` | New `AdaptivePublishRateLimiter` field; `handlePublishThrottling()` delegation; uses `ThrottleType.AdaptivePublishRate` |
| `BrokerService.java` | `startAdaptivePublishThrottleController()` lifecycle; `forEachPersistentTopic()` helper; `close()` teardown |
| `AdaptivePublishRateLimiter.java` *(new)* | Per-topic limiter: `volatile boolean active` fast path, asymmetric EWMA, `activate()`/`deactivate()` |
| `AdaptivePublishThrottleController.java` *(new)* | Broker-level scheduler: pressure math, bounded-step rate changes, hysteresis, `observeOnly` guard, `try-catch-finally` safety |
| `OpenTelemetryAdaptiveThrottleStats.java` *(new)* | 6 broker-level OTel metrics (3 always-on + 3 health); 6 per-topic metrics (opt-in) |

### Tests (reviewers: check the observeOnly safety tests and the enum guard tests)

| File | Key assertions |
|------|---------------|
| `AdaptivePublishRateLimiterTest.java` *(new)* | No-op guarantee, activate/deactivate, asymmetric EWMA, `observeOnly` never changes channel autoread |
| `AdaptivePublishThrottleControllerTest.java` *(new)* | `linearPressure()`, bounded-step `computeTargetRate()`, hysteresis, `observeOnly` never calls `activate()` |
| `AdaptiveThrottleEndToEndTest.java` *(new)* | Full control-loop integration: pressure → throttle → drain → deactivate; `observeOnly` IO-thread safety |
| `ThrottleTypeEnumTest.java` *(new)* | Minimum constant count, `AdaptivePublishRate` present and last, declared reentrant |

---

## Design FAQ

**Q: Why introduce a new `ThrottleType.AdaptivePublishRate` instead of reusing `TopicPublishRate`?**

`ServerCnxThrottleTracker` uses reference-counting via `states[ThrottleType.ordinal()]`.
If the adaptive limiter shared `TopicPublishRate` with the static rate limiter, a single
`unmarkThrottled()` call from the adaptive side could decrement the count that the static
limiter had incremented — leaving the connection unthrottled even though the static limit is
still exceeded. A dedicated constant keeps the two signals fully independent and eliminates an
entire class of ordering bugs.

**Q: Why does the controller not coordinate across brokers? Each broker throttles independently.**

Adaptive throttling reacts to local signals — JVM heap on this JVM, backlog on topics owned
by this broker. Cross-broker coordination would require a consensus protocol, introduce network
latency on the hot publish path, and create a single point of failure. Local-only decisions
are simpler, faster, and fail-safe: if a network partition occurs, each broker still protects
itself independently. Cluster-wide load imbalance (e.g. one hot broker) is better addressed
by Pulsar's topic-migration and load-balancer machinery than by throttle coordination.

**Q: What happens if the controller thread crashes?**

The evaluation loop is wrapped in `try-catch-finally`. A caught exception:
1. Increments `evaluationFailureCount` (surfaced as OTel counter `pulsar.broker.adaptive.throttle.controller.evaluation.failure.count`).
2. Logs the full stack trace at `ERROR` level so it appears in broker logs immediately.
3. Does **not** kill the `ScheduledExecutorService` — the scheduler reschedules the next cycle unconditionally.

If the failure is persistent, `last.evaluation.timestamp` stops advancing while `evaluation.failure.count` climbs — a clear alert signal. A full controller stall (only possible via an unchecked `Error`) requires a broker restart; the OTel staleness alert will fire within `3 × intervalMs`.

---

## Test plan

- [ ] `mvn test -pl pulsar-broker -am -Dtest="AdaptivePublishRateLimiterTest,AdaptivePublishThrottleControllerTest,AdaptiveThrottleEndToEndTest,ThrottleTypeEnumTest" -DfailIfNoTests=false --no-transfer-progress` passes
- [ ] `mvn test -pl pulsar-broker -am -Dtest="PublishRateLimiterTest" -DfailIfNoTests=false --no-transfer-progress` (regression: static rate limiter unaffected)
- [ ] Broker starts with `adaptivePublisherThrottlingEnabled=false` (default): no controller thread, no `AdaptivePublishRateLimiter` allocated, no OTel instruments registered
- [ ] `observeOnly=true`: logs show `OBSERVE-ONLY would-activate`, zero `ACTIVATED` lines, `active.topic.count` metric stays at 0
- [ ] OTel scrape shows all 6 broker-level metrics when feature is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)