### PR TITLE
[fix][test] fix testBatchMetadataStoreMetrics.

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -195,7 +195,6 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         String metricsStr = output.toString();
         Multimap<String, Metric> metricsMap = parseMetrics(metricsStr);
 
-        Collection<Metric> executorQueueSize = metricsMap.get("pulsar_batch_metadata_store_executor_queue_size");
         Collection<Metric> opsWaiting = metricsMap.get("pulsar_batch_metadata_store_queue_wait_time_ms" + "_sum");
         Collection<Metric> batchExecuteTime =
                 metricsMap.get("pulsar_batch_metadata_store_batch_execute_time_ms" + "_sum");
@@ -203,7 +202,6 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
 
         String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsStr + "\n";
 
-        Assert.assertTrue(executorQueueSize.size() > 1, metricsDebugMessage);
         Assert.assertTrue(opsWaiting.size() > 1, metricsDebugMessage);
         Assert.assertTrue(batchExecuteTime.size() > 0, metricsDebugMessage);
         Assert.assertTrue(opsPerBatch.size() > 0, metricsDebugMessage);
@@ -213,17 +211,6 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
         expectedMetadataStoreName.add(MetadataStoreConfig.CONFIGURATION_METADATA_STORE);
 
         AtomicInteger matchCount = new AtomicInteger(0);
-        for (Metric m : executorQueueSize) {
-            Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
-            String metadataStoreName = m.tags.get("name");
-            if (isExpectedLabel(metadataStoreName, expectedMetadataStoreName, matchCount)) {
-                continue;
-            }
-            Assert.assertTrue(m.value >= 0, metricsDebugMessage);
-        }
-        Assert.assertEquals(matchCount.get(), expectedMetadataStoreName.size());
-
-        matchCount = new AtomicInteger(0);
         for (Metric m : opsWaiting) {
             Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             String metadataStoreName = m.tags.get("name");


### PR DESCRIPTION

### Motivation

In PR https://github.com/apache/pulsar/pull/25187, the `pulsar_batch_metadata_store_executor_queue_size` metric was removed from `BatchMetadataStoreStats`. Therefore, related tests should also be updated to remove references to this metric.

### Modifications

Removed the validation of the `pulsar_batch_metadata_store_executor_queue_size` metric in the testBatchMetadataStoreMetrics test.



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
