### PR TITLE
[improve][admin] Apply all configurations instead of partial ones

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -92,7 +92,7 @@ webserviceTlsProvider=
 proxyServiceUrl=
 
 #Proxy protocol to select type of routing at proxy
-proxyProtocol=
+#proxyProtocol=
 
 # Pulsar Admin Custom Commands
 #customCommandFactoriesDirectory=commandFactories

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminPropertiesProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminPropertiesProvider.java
@@ -21,10 +21,12 @@ package org.apache.pulsar.admin.cli;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.Properties;
+import lombok.Getter;
 import picocli.CommandLine.PropertiesDefaultProvider;
 
 class PulsarAdminPropertiesProvider extends PropertiesDefaultProvider {
     private static final String webServiceUrlKey = "webServiceUrl";
+    @Getter
     private final Properties properties;
 
     private PulsarAdminPropertiesProvider(Properties properties) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -37,7 +37,6 @@ import org.apache.pulsar.admin.cli.utils.CustomCommandFactoryProvider;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.admin.internal.PulsarAdminImpl;
-import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
 import org.apache.pulsar.common.util.ShutdownUtil;
 import org.apache.pulsar.internal.CommandHook;
 import org.apache.pulsar.internal.CommanderFactory;
@@ -108,47 +107,20 @@ public class PulsarAdminTool implements CommandHook {
     public PulsarAdminTool(Properties properties) throws Exception {
         // Use -v instead -V
         System.setProperty("picocli.version.name.0", "-v");
+        pulsarAdminPropertiesProvider = PulsarAdminPropertiesProvider.create(properties);
         commander = CommanderFactory.createRootCommanderWithHook(this, pulsarAdminPropertiesProvider);
-        pulsarAdminSupplier = new PulsarAdminSupplier(createAdminBuilderFromProperties(properties), rootParams);
-        initCommander(properties);
+        pulsarAdminSupplier =
+                new PulsarAdminSupplier(createAdminBuilderFromProperties(pulsarAdminPropertiesProvider.getProperties()),
+                        rootParams);
+        initCommander(pulsarAdminPropertiesProvider.getProperties());
     }
 
     private static PulsarAdminBuilder createAdminBuilderFromProperties(Properties properties) {
-        boolean useKeyStoreTls = Boolean
-                .parseBoolean(properties.getProperty("useKeyStoreTls", "false"));
-        String tlsTrustStoreType = properties.getProperty("tlsTrustStoreType", "JKS");
-        String tlsTrustStorePath = properties.getProperty("tlsTrustStorePath");
-        String tlsTrustStorePassword = properties.getProperty("tlsTrustStorePassword");
-        String tlsKeyStoreType = properties.getProperty("tlsKeyStoreType", "JKS");
-        String tlsKeyStorePath = properties.getProperty("tlsKeyStorePath");
-        String tlsKeyStorePassword = properties.getProperty("tlsKeyStorePassword");
-        String tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
-        String tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
-
-        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties
-                .getProperty("tlsAllowInsecureConnection", "false"));
-
-        boolean tlsEnableHostnameVerification = Boolean.parseBoolean(properties
-                .getProperty("tlsEnableHostnameVerification", "false"));
-        final String tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
-        final String sslFactoryPlugin = properties.getProperty("sslFactoryPlugin",
-                DefaultPulsarSslFactory.class.getName());
-        final String sslFactoryPluginParams = properties.getProperty("sslFactoryPluginParams", "");
-
-        return PulsarAdmin.builder().allowTlsInsecureConnection(tlsAllowInsecureConnection)
-                .enableTlsHostnameVerification(tlsEnableHostnameVerification)
-                .tlsTrustCertsFilePath(tlsTrustCertsFilePath)
-                .useKeyStoreTls(useKeyStoreTls)
-                .tlsTrustStoreType(tlsTrustStoreType)
-                .tlsTrustStorePath(tlsTrustStorePath)
-                .tlsTrustStorePassword(tlsTrustStorePassword)
-                .tlsKeyStoreType(tlsKeyStoreType)
-                .tlsKeyStorePath(tlsKeyStorePath)
-                .tlsKeyStorePassword(tlsKeyStorePassword)
-                .tlsKeyFilePath(tlsKeyFilePath)
-                .tlsCertificateFilePath(tlsCertificateFilePath)
-                .sslFactoryPlugin(sslFactoryPlugin)
-                .sslFactoryPluginParams(sslFactoryPluginParams);
+        Map<String, Object> conf = new HashMap<>();
+        for (String key : properties.stringPropertyNames()) {
+            conf.put(key, properties.getProperty(key));
+        }
+        return PulsarAdmin.builder().loadConf(conf);
     }
 
     private void setupCommands(Properties properties) {
@@ -268,7 +240,6 @@ public class PulsarAdminTool implements CommandHook {
 
     private void initCommander(Properties properties) throws IOException {
         customCommandFactories = CustomCommandFactoryProvider.createCustomCommandFactories(properties);
-        pulsarAdminPropertiesProvider = PulsarAdminPropertiesProvider.create(properties);
         commander.setDefaultValueProvider(pulsarAdminPropertiesProvider);
         commandMap = new HashMap<>();
         commandMap.put("clusters", CmdClusters.class);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientPropertiesProvider.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientPropertiesProvider.java
@@ -21,10 +21,12 @@ package org.apache.pulsar.client.cli;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.Properties;
+import lombok.Getter;
 import picocli.CommandLine.PropertiesDefaultProvider;
 
 class PulsarClientPropertiesProvider extends PropertiesDefaultProvider {
     private static final String brokerServiceUrlKey = "brokerServiceUrl";
+    @Getter
     private final Properties properties;
 
     private PulsarClientPropertiesProvider(Properties properties) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -22,6 +22,8 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.FileInputStream;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -96,23 +98,6 @@ public class PulsarClientTool implements CommandHook {
 
     @ArgGroup(exclusive = false)
     protected RootParams rootParams = new RootParams();
-    boolean tlsAllowInsecureConnection;
-    boolean tlsEnableHostnameVerification;
-
-    String tlsKeyFilePath;
-    String tlsCertificateFilePath;
-
-
-    // for tls with keystore type config
-    boolean useKeyStoreTls;
-    String tlsTrustStoreType;
-    String tlsTrustStorePath;
-    String tlsTrustStorePassword;
-    String tlsKeyStoreType;
-    String tlsKeyStorePath;
-    String tlsKeyStorePassword;
-    String sslFactoryPlugin;
-    String sslFactoryPluginParams;
 
     protected final CommandLine commander;
     protected CmdProduce produceCommand;
@@ -139,24 +124,6 @@ public class PulsarClientTool implements CommandHook {
         readCommand = new CmdRead();
         generateDocumentation = new CmdGenerateDocumentation();
 
-        this.tlsAllowInsecureConnection = Boolean
-                .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
-        this.tlsEnableHostnameVerification = Boolean
-                .parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
-        this.useKeyStoreTls = Boolean
-                .parseBoolean(properties.getProperty("useKeyStoreTls", "false"));
-        this.tlsTrustStoreType = properties.getProperty("tlsTrustStoreType", "JKS");
-        this.tlsTrustStorePath = properties.getProperty("tlsTrustStorePath");
-        this.tlsTrustStorePassword = properties.getProperty("tlsTrustStorePassword");
-
-        this.tlsKeyStoreType = properties.getProperty("tlsKeyStoreType", "JKS");
-        this.tlsKeyStorePath = properties.getProperty("tlsKeyStorePath");
-        this.tlsKeyStorePassword = properties.getProperty("tlsKeyStorePassword");
-        this.tlsKeyFilePath = properties.getProperty("tlsKeyFilePath");
-        this.tlsCertificateFilePath = properties.getProperty("tlsCertificateFilePath");
-        this.sslFactoryPlugin = properties.getProperty("sslFactoryPlugin");
-        this.sslFactoryPluginParams = properties.getProperty("sslFactoryPluginParams");
-
         pulsarClientPropertiesProvider = PulsarClientPropertiesProvider.create(properties);
         commander.setDefaultValueProvider(pulsarClientPropertiesProvider);
         commander.addSubcommand("produce", produceCommand);
@@ -170,7 +137,13 @@ public class PulsarClientTool implements CommandHook {
     }
 
     private int updateConfig() throws UnsupportedAuthenticationException {
-        ClientBuilder clientBuilder = PulsarClient.builder()
+        Map<String, Object> conf = new HashMap<>();
+        Properties properties = pulsarClientPropertiesProvider.getProperties();
+        for (String key : properties.stringPropertyNames()) {
+            conf.put(key, properties.getProperty(key));
+        }
+
+        ClientBuilder clientBuilder = PulsarClient.builder().loadConf(conf)
                 .memoryLimit(rootParams.memoryLimit, SizeUnit.BYTES);
         Authentication authentication = null;
         if (isNotBlank(this.rootParams.authPluginClassName)) {
@@ -180,25 +153,8 @@ public class PulsarClientTool implements CommandHook {
         if (isNotBlank(this.rootParams.listenerName)) {
             clientBuilder.listenerName(this.rootParams.listenerName);
         }
-        clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
-        clientBuilder.enableTlsHostnameVerification(this.tlsEnableHostnameVerification);
         clientBuilder.serviceUrl(rootParams.serviceURL);
-
-        clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath)
-                .tlsKeyFilePath(tlsKeyFilePath)
-                .tlsCertificateFilePath(tlsCertificateFilePath);
-
-        clientBuilder.useKeyStoreTls(useKeyStoreTls)
-                .tlsTrustStoreType(tlsTrustStoreType)
-                .tlsTrustStorePath(tlsTrustStorePath)
-                .tlsTrustStorePassword(tlsTrustStorePassword)
-                .tlsKeyStoreType(tlsKeyStoreType)
-                .tlsKeyStorePath(tlsKeyStorePath)
-                .tlsKeyStorePassword(tlsKeyStorePassword);
-
-        clientBuilder.sslFactoryPlugin(sslFactoryPlugin)
-                .sslFactoryPluginParams(sslFactoryPluginParams);
-
+        clientBuilder.tlsTrustCertsFilePath(this.rootParams.tlsTrustCertsFilePath);
         if (isNotBlank(rootParams.proxyServiceURL)) {
             if (rootParams.proxyProtocol == null) {
                 commander.getErr().println("proxy-protocol must be provided with proxy-url");


### PR DESCRIPTION
### Motivation

Both `PulsarAdminTool` and `PulsarClientTool` manually extracted a fixed subset of TLS-related properties from the config file and applied them one-by-one to the builder. This approach has two problems:

1. **Incomplete config loading** — only a hardcoded subset of properties (TLS/keystore fields) were read. Any other configuration in the file was silently ignored.
2. **Code duplication** — the same property-extraction boilerplate was duplicated across both tools.

Since `PulsarAdmin.builder()` and `PulsarClient.builder()` already support `loadConf(Map<String, Object>)` which handles all recognized config keys, the manual extraction is unnecessary.

### Modifications

- **`PulsarAdminTool`**: Replace manual property extraction with `Properties` → `Map` conversion + `PulsarAdmin.builder().loadConf(conf)`.
- **`PulsarClientTool`**: Replace manual property extraction and per-field builder calls with `Properties` → `Map` conversion + `PulsarClient.builder().loadConf(conf)`.
- Remove unused field declarations and imports in both classes.