### PR TITLE
[fix][test] Fix ResourceQuotaCalculatorImplTest#testNeedToReportLocalUsage

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImplTest.java
@@ -113,6 +113,9 @@ public class ResourceQuotaCalculatorImplTest extends MockedPulsarServiceBaseTest
 
     @Test
     public void testNeedToReportLocalUsage() {
+        // This field is 0 when the schedulers of `ResourceGroupService` are not started, then `needToReportLocalUsage`
+        // will always return true. Set it to a non-zero value to test the percentage change logic.
+        ResourceGroupService.maxIntervalForSuppressingReportsMSecs = 60 * 1000L; // 1 minute
         // If the percentage change (increase or decrease) in usage is more than 5% for
         // either bytes or messages, send a report.
         Assert.assertFalse(rqCalc.needToReportLocalUsage(1040, 1000, 104, 100, System.currentTimeMillis()));


### PR DESCRIPTION
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
