### PR TITLE
[improve] Upgrade RoaringBitmap to 1.6.9 version

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -529,7 +529,7 @@ The Apache Software License, Version 2.0
   * RxJava
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
-    - org.roaringbitmap-RoaringBitmap-1.2.0.jar
+    - org.roaringbitmap-RoaringBitmap-1.6.9.jar
   * OpenTelemetry
     - io.opentelemetry-opentelemetry-api-1.56.0.jar
     - io.opentelemetry-opentelemetry-api-incubator-1.56.0-alpha.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -420,7 +420,7 @@ The Apache Software License, Version 2.0
     - avro-protobuf-1.12.0.jar
  * RE2j -- re2j-1.8.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar
- * RoaringBitmap -- RoaringBitmap-1.2.0.jar
+ * RoaringBitmap -- RoaringBitmap-1.6.9.jar
  * Fastutil -- fastutil-8.5.16.jar
  * JSpecify -- jspecify-1.0.0.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@ flexible messaging model and an intuitive client API.</description>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
-    <roaringbitmap.version>1.2.0</roaringbitmap.version>
+    <roaringbitmap.version>1.6.9</roaringbitmap.version>
     <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
     <oshi.version>6.4.0</oshi.version>
     <checkerframework.version>3.33.0</checkerframework.version>


### PR DESCRIPTION
### Motivation

There have been improvements and bug fixes in RoaringBitmap since 1.2.0 version. We haven't been able to upgrade since the artifact hasn't been published to maven central for a while. Recent RoaringBitmap version is now available in maven central.

### Modifications

- upgrade RoaringBitmap to 1.6.9 version

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->