### PR TITLE
[fix][broker] Use compatible Avro name validator in JsonSchemaCompatibilityCheck

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/JsonSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/JsonSchemaCompatibilityCheck.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
+import org.apache.pulsar.broker.service.schema.validator.StructSchemaDataValidator;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -91,7 +92,7 @@ public class JsonSchemaCompatibilityCheck extends AvroSchemaBasedCompatibilityCh
     private boolean isAvroSchema(SchemaData schemaData) {
         try {
 
-            Schema.Parser fromParser = new Schema.Parser();
+            Schema.Parser fromParser = new Schema.Parser(StructSchemaDataValidator.COMPATIBLE_NAME_VALIDATOR);
             fromParser.setValidateDefaults(false);
             Schema fromSchema = fromParser.parse(new String(schemaData.getData(), UTF_8));
             return true;


### PR DESCRIPTION
### Motivation

Follow-up to #25193 as noted by @codelipenghui in [this review comment](https://github.com/apache/pulsar/pull/25193#pullrequestreview-2690299893).

`JsonSchemaCompatibilityCheck.isAvroSchema()` still uses `new Schema.Parser()` with the default `UTF_VALIDATOR`, which rejects `$` in record names. This means JSON schema compatibility checks would incorrectly fail for Protobuf-derived Avro schemas containing `$` in nested type names.

### Modifications

- Apply `StructSchemaDataValidator.COMPATIBLE_NAME_VALIDATOR` to the `Schema.Parser` in `JsonSchemaCompatibilityCheck.isAvroSchema()`, consistent with the fix already applied to:
  - `AvroSchemaBasedCompatibilityCheck`
  - `SchemaRegistryServiceImpl`
  - `StructSchemaDataValidator`
- Add a unit test verifying that Avro schemas with `$` in record names are correctly recognized as valid Avro schemas in the JSON schema compatibility check path.

### Verifying this change

- Added `testIsAvroSchemaWithDollarSignInRecordName` test in `JsonSchemaCompatibilityCheckTest`.

### Documentation

- [x] `doc-not-needed`
