### PR TITLE
[fix][sec] Upgrade aircompressor to 2.0.3 to resolve CVE-2025-67721

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -387,7 +387,7 @@ The Apache Software License, Version 2.0
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.15.jar
  * AirCompressor
-    - io.airlift-aircompressor-0.27.jar
+    - io.airlift-aircompressor-2.0.3.jar
  * AsyncHttpClient
     - org.asynchttpclient-async-http-client-2.12.4.jar
     - org.asynchttpclient-async-http-client-netty-utils-2.12.4.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -395,7 +395,7 @@ The Apache Software License, Version 2.0
     - cpu-affinity-4.17.3.jar
     - circe-checksum-4.17.3.jar
   * AirCompressor
-     - aircompressor-0.27.jar
+     - aircompressor-2.0.3.jar
  * AsyncHttpClient
     - async-http-client-2.12.4.jar
     - async-http-client-netty-utils-2.12.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@ flexible messaging model and an intuitive client API.</description>
     <guava.version>33.4.8-jre</guava.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>7.9.2</confluent.version>
-    <aircompressor.version>0.27</aircompressor.version>
+    <aircompressor.version>2.0.3</aircompressor.version>
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <commons-lang3.version>3.19.0</commons-lang3.version>
     <commons-io.version>2.21.0</commons-io.version>


### PR DESCRIPTION
Fixes #25139

### Motivation

io.airlift:aircompressor:0.27 contains CVE-2025-67721

### Modifications

Upgrade io.airlift:aircompressor to 2.0.3 to get the required fixes.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->