### PR TITLE
[fix][broker] Guard AsyncTokenBucket against long overflow

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucket.java
@@ -265,6 +265,7 @@ public abstract class AsyncTokenBucket {
      */
     public long calculateThrottlingDuration(long requiredTokens) {
         long currentTokens = consumeTokensAndMaybeUpdateTokensBalance(0);
+
         if (currentTokens >= requiredTokens) {
             return 0L;
         }
@@ -289,9 +290,24 @@ public abstract class AsyncTokenBucket {
         if (multiplicand == 0 || multiplier == 0) {
             return 0;
         }
-        if (multiplicand <= Long.MAX_VALUE / multiplier) {
-            return (multiplicand * multiplier) / divisor;
+        // Fast path
+        // Check if multiplication fits in a 64-bit value
+        // Math.multiplyHigh is intrinsified by the JVM (single mulq/mul instruction),
+        // avoiding the cost of a division-based overflow check.
+        // It returns the upper 64 bits of the full 128-bit multiplication result.
+        // When the result is 0, the product fits in 64 bits.
+        if (Math.multiplyHigh(multiplicand, multiplier) == 0) {
+            long product = multiplicand * multiplier;
+            if (product >= 0) {
+                // product fits in signed 64-bit
+                return product / divisor;
+            }
+            // product is in [2^63, 2^64): fits unsigned but not signed
+            long result = Long.divideUnsigned(product, divisor);
+            // cap at Long.MAX_VALUE if result itself overflows signed long
+            return result >= 0 ? result : Long.MAX_VALUE;
         }
+        // Fallback to BigInteger division
         BigInteger result = BigInteger.valueOf(multiplicand)
                 .multiply(BigInteger.valueOf(multiplier))
                 .divide(BigInteger.valueOf(divisor));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -196,9 +197,23 @@ public class AsyncTokenBucketTest {
                 .isEqualTo(initialTokens);
     }
 
-    @Test
-    void shouldRefillTokensWithoutOverflowForLargeRateAnd10sPeriod() {
-        long rate = 980_000_000L;
+    @DataProvider(name = "largeRates")
+    public Object[][] largeRates() {
+        return new Object[][]{
+                {500_000_000L},
+                {980_000_000L},
+                {1_000_000_000L},
+                {1_500_000_000L},
+                {2_000_000_000L},
+                {Long.MAX_VALUE / 100L},
+                {Long.MAX_VALUE / 10L},
+                {Long.MAX_VALUE / 9L},
+                {Long.MAX_VALUE}
+        };
+    }
+
+    @Test(dataProvider = "largeRates")
+    void shouldRefillTokensWithoutOverflowForLargeRateAnd10sPeriod(long rate) {
         long ratePeriodNanos = TimeUnit.SECONDS.toNanos(10);
         asyncTokenBucket =
                 AsyncTokenBucket.builder()


### PR DESCRIPTION
### Motivation

The async dispatch rate limiter (`AsyncTokenBucket`) performs multiply-then-divide arithmetic using `long`. With large rates and longer rate periods (for example, `980,000,000` tokens per `10s`), the multiplication can overflow and produce incorrect negative/intermediate values. In dispatch throttling this can keep available tokens at invalid values and effectively stall consumption.

### Modifications

- Added overflow-safe floor multiply/divide helper in `AsyncTokenBucket`:
  - Fast path for non-overflowing `long` multiplication.
  - Fallback to `BigInteger` for overflow cases.
  - Clamp large results to `Long.MAX_VALUE`.
- Replaced overflow-prone arithmetic in token refill path:
  - `calculateNewTokensSinceLastUpdate` now uses safe multiply/divide.
  - Remainder-nanos back-calculation now uses safe multiply/divide as well.
- Hardened throttling duration calculation:
  - `calculateThrottlingDuration(long requiredTokens)` now handles subtraction overflow and uses safe multiply/divide.
- Added regression tests in `AsyncTokenBucketTest`:
  - `shouldRefillTokensWithoutOverflowForLargeRateAnd10sPeriod`
  - `shouldCalculateThrottlingDurationWithoutOverflowForLargeNeedTokens`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Ran unit/regression tests:
  - `./mvnw -pl pulsar-broker -Dtest=AsyncTokenBucketTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Ran dispatch-throttling integration tests:
  - `./mvnw -pl pulsar-broker -Dtest=SubscriptionMessageDispatchThrottlingTest -Dsurefire.failIfNoSpecifiedTests=false -DargLine='-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading' test`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/codelipenghui/incubator-pulsar/pull/26
