### PR TITLE
[fix] Fix typos in class Message and Producer   

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -838,7 +838,7 @@ public class Producer {
                     .allowTopicOperationAsync(topicName, TopicOperation.PRODUCE, appId, cnx.getAuthenticationData())
                     .handle((ok, ex) -> {
                         if (ex != null) {
-                            log.warn("[{}] Get unexpected error while autorizing [{}]  {}", appId, topic.getName(),
+                            log.warn("[{}] Get unexpected error while authorizing [{}]  {}", appId, topic.getName(),
                                     ex.getMessage(), ex);
                         }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -185,7 +185,7 @@ public interface Message<T> {
      * {@link EncryptionContext} contains encryption and compression information in it using which application can
      * decrypt consumed message with encrypted-payload.
      *
-     * @return the optiona encryption context
+     * @return the optional encryption context
      */
     Optional<EncryptionContext> getEncryptionCtx();
 


### PR DESCRIPTION
### Motivation
Fix typos in `Message` and `Producer` classes to improve code readability and documentation clarity.

### Modifications
Fixed a typo in the Message class ( `optiona ` -> `optional ` )
Fixed a typo in the Producer class ( `autorizing ` -> `authorizing ` )

Documentation
- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->