### PR TITLE
[improve][broker] Add lastDelayedMessageTimestamp to delayed delivery tracker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -57,6 +57,11 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
     long getBufferMemoryUsage();
 
     /**
+     * Get the delivery timestamp of the last delayed message.
+     */
+    long getLastDelayedMessageTimestamp();
+
+    /**
      * Get a set of position of messages that have already reached the delivery time.
      */
     NavigableSet<Position> getScheduledMessages(int maxMessages);
@@ -104,6 +109,11 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
 
         @Override
         public long getBufferMemoryUsage() {
+            return 0;
+        }
+
+        @Override
+        public long getLastDelayedMessageTimestamp() {
             return 0;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -256,6 +256,14 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     }
 
     @Override
+    public long getLastDelayedMessageTimestamp() {
+        if (delayedMessageMap.isEmpty()) {
+            return 0;
+        }
+        return delayedMessageMap.lastLongKey();
+    }
+
+    @Override
     public void close() {
         super.close();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -49,6 +50,10 @@ class ImmutableBucket extends Bucket {
 
     @Setter
     List<Long> firstScheduleTimestamps = new ArrayList<>();
+
+    @Getter
+    @Setter
+    private long lastScheduleTimestamp = 0;
 
     ImmutableBucket(String dispatcherName, ManagedCursor cursor, FutureUtil.Sequencer<Void> sequencer,
                     BucketSnapshotStorage storage, long startLedgerId, long endLedgerId) {
@@ -99,6 +104,12 @@ class ImmutableBucket extends Bucket {
                         List<Long> firstScheduleTimestamps = metadataList.stream().map(
                                 SnapshotSegmentMetadata::getMinScheduleTimestamp).toList();
                         this.setFirstScheduleTimestamps(firstScheduleTimestamps);
+
+                        long lastTimestamp = metadataList.stream()
+                                .mapToLong(SnapshotSegmentMetadata::getMaxScheduleTimestamp)
+                                .max()
+                                .orElse(0L);
+                        this.setLastScheduleTimestamp(lastTimestamp);
 
                         return nextSnapshotEntryIndex + 1;
                     });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/AbstractDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/AbstractDeliveryTrackerTest.java
@@ -78,6 +78,7 @@ public abstract class AbstractDeliveryTrackerTest {
 
         assertFalse(tracker.hasMessageAvailable());
         assertEquals(tracker.getNumberOfDelayedMessages(), 5);
+        assertEquals(tracker.getLastDelayedMessageTimestamp(), 50);
 
         assertEquals(tracker.getScheduledMessages(10), Collections.emptySet());
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -189,6 +189,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
 
         assertEquals(tracker.getNumberOfDelayedMessages(), 100);
+        assertEquals(tracker.getLastDelayedMessageTimestamp(), 100 * 10);
 
         clockTime.set(1 * 10);
 
@@ -206,6 +207,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         });
 
         tracker.addMessage(101, 101, 101 * 10);
+        assertEquals(tracker.getLastDelayedMessageTimestamp(), 101 * 10);
 
         tracker.close();
 
@@ -216,6 +218,9 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
         assertFalse(tracker2.containsMessage(101, 101));
         assertEquals(tracker2.getNumberOfDelayedMessages(), 70);
+        // Verify lastDelayedMessageTimestamp is correctly recovered from snapshot
+        // Messages 31-100 remain, so the max timestamp should be 100 * 10 = 1000
+        assertEquals(tracker2.getLastDelayedMessageTimestamp(), 100 * 10);
 
         clockTime.set(100 * 10);
 
@@ -453,6 +458,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
       assertEquals(tracker.getNumberOfDelayedMessages(), 1001);
       assertTrue(tracker.getImmutableBuckets().asMapOfRanges().size() > 0);
       assertEquals(tracker.getLastMutableBucket().size(), 1);
+      assertTrue(tracker.getLastDelayedMessageTimestamp() > 0);
 
       tracker.clear().get(1, TimeUnit.MINUTES);
 
@@ -460,7 +466,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
       assertEquals(tracker.getImmutableBuckets().asMapOfRanges().size(), 0);
       assertEquals(tracker.getLastMutableBucket().size(), 0);
       assertEquals(tracker.getSharedBucketPriorityQueue().size(), 0);
-
+      assertEquals(tracker.getLastDelayedMessageTimestamp(), 0);
       tracker.close();
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->



<!-- or this PR is one task of an issue -->

Main Issue: #25267

<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Without knowing when the last delayed message is scheduled to be delivered, we cannot easily:

1. **Monitor** how far in the future delayed messages extend (e.g. "last message is 7 days from now")
2. **Alert** when delayed messages are scheduled too far ahead (e.g. misconfigured producers)
3. **Debug** delayed delivery issues (e.g. why consumers are not receiving messages yet)
4. **Plan capacity** (e.g. understanding the time range of pending delayed messages)

Tracker layer only. Metric  will be added in a follow-up commit.


<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

#### Interface

- Added `getLastDelayedMessageTimestamp()` to `DelayedDeliveryTracker`
- Updated the `DISABLE` implementation to return 0

#### InMemoryDelayedDeliveryTracker

- Implemented via `Long2ObjectSortedMap.lastLongKey()` (O(1))
- Recovers on restart as the map is rebuilt from cursor

#### BucketDelayedDeliveryTracker

- Added `lastDelayedMessageTimestamp` (AtomicLong), updated in `addMessage()` with CAS (`updateLastTimestamp()`), reset in `clear()`
- Recovery: uses pre-computed `ImmutableBucket.lastScheduleTimestamp` in the same loop as message count (single pass, no extra I/O)

#### ImmutableBucket

- Added `lastScheduleTimestamp` (max schedule timestamp across all segments), set during recovery from snapshot metadata

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.
**Unit tests**

- **AbstractDeliveryTrackerTest**: `test()` cover the new behavior
- **BucketDelayedDeliveryTrackerTest**: `testRecoverSnapshot()` and `testClear()` verify recovery and reset

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: (https://github.com/Dream95/pulsar/pull/6)

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
