### PR TITLE
[improve][broker] Optimize AsyncTokenBucket overflow solution further to reduce fallback to BigInteger

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -205,6 +205,8 @@ public class AsyncTokenBucketTest {
                 {1_000_000_000L},
                 {1_500_000_000L},
                 {2_000_000_000L},
+                {100_000_000_000L},
+                {Long.MAX_VALUE / 1_000_000_000L * 1_000_000_000L},
                 {Long.MAX_VALUE / 100L},
                 {Long.MAX_VALUE / 10L},
                 {Long.MAX_VALUE / 9L},


### PR DESCRIPTION
### Motivation

#25262 added a solution to prevent overflow in token & duration calculations. The solution falls back to the usage of BigInteger for very large values. This PR introduces yet another optimization that reduces the need to fallback to BigInteger.
This would be relevant when using multi gigabyte byte rate limits.

### Modifications

- Add an internal RateParameters class which precalculates reduced values where the operands are reduced by dividing by the highest common power of ten.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->