### PR TITLE
[fix][ws] Fix issue where metadataStoreAllowReadOnlyOperations setting is ignored by WebSocket server

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -75,6 +75,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     @FieldContext(doc = "Metadata store cache expiry time in seconds.")
     private int metadataStoreCacheExpirySeconds = 300;
 
+    @FieldContext(doc = "Is metadata store read-only operations.")
+    private boolean metadataStoreAllowReadOnlyOperations;
+
     @FieldContext(
             deprecated = true,
             doc = "ZooKeeper session timeout in milliseconds. "

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketServiceTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import java.io.InputStream;
+import java.util.Properties;
+import lombok.Cleanup;
+import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
+import org.testng.annotations.Test;
+
+public class WebSocketServiceTest {
+
+    @Test
+    public void testMetadataStoreAllowReadOnlyOperations() throws Exception {
+        @Cleanup
+        InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("websocket.conf");
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        properties.setProperty("authenticationEnabled", "false");
+        properties.setProperty("authorizationEnabled", "false");
+        properties.setProperty("metadataStoreAllowReadOnlyOperations", "true");
+        WebSocketProxyConfiguration config = PulsarConfigurationLoader.create(properties,
+                WebSocketProxyConfiguration.class);
+        @Cleanup
+        WebSocketService service = spy(new WebSocketService(config));
+        service.start();
+        verify(service).createConfigMetadataStore(eq("memory:127.0.0.1:2181"), eq(30000), eq(true));
+    }
+
+}


### PR DESCRIPTION
### Motivation

Brokers and proxies can continue to provide services even if more than half of the ZooKeeper servers acting as configuration metadata store go down and switch to read-only mode by writing `metadataStoreAllowReadOnlyOperations=true` in their configuration files.

- https://github.com/apache/pulsar/pull/19156
- https://github.com/apache/pulsar/pull/19246

On the other hand, WebSocket servers could not continue to provide services even though `metadataStoreAllowReadOnlyOperations=true` was written in the configuration file.

This is because the `metadataStoreAllowReadOnlyOperations` field exists in the [ServiceConfiguration](https://github.com/apache/pulsar/blob/d992dc530bea4f4737da93f1527133b1c9389a45/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java#L505-L509) and [ProxyConfiguration](https://github.com/apache/pulsar/blob/d992dc530bea4f4737da93f1527133b1c9389a45/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java#L138-L142) classes, but not in the [WebSocketProxyConfiguration](https://github.com/apache/pulsar/blob/d992dc530bea4f4737da93f1527133b1c9389a45/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java) class.

### Modifications

Added the `metadataStoreAllowReadOnlyOperations` field to the `WebSocketProxyConfiguration` class.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
