### PR TITLE
[fix][broker]Resolve the issue where markDeletePosition points to a non-existent location when creating a new subscription

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4225,7 +4225,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         if (ledgerId > lastConfirmedEntry.getLedgerId()) {
             checkState(ledgers.get(ledgerId).getEntries() == 0);
-            ledgerId = lastConfirmedEntry.getLedgerId();
+            return PositionFactory.create(lastConfirmedEntry.getLedgerId(), lastConfirmedEntry.getEntryId());
         }
         return PositionFactory.create(ledgerId, -1);
     }


### PR DESCRIPTION

### Motivation
when a ManagedLedger performs a ledger rollover (switching to a new ledger), the newly created ledger starts in an empty state. During this transition, lastConfirmedEntry is temporarily set to (newLedgerId, -1), which represents a position in a ledger that contains no entries — i.e., a non-existent position in BookKeeper.

Although recoveredCursor has a guard to handle the case where entryId == -1 and the ledger does not exist in the ledger map, the newly created (but empty) ledger is present in the ledgers map (since it was just registered), so ledgerExists() returns true. As a result, the markDeletePosition of the newly created subscription is incorrectly set to (newLedgerId, -1) — a position that does not correspond to any real message in BookKeeper.
This incorrect markDeletePosition can cause issues such as:
Inaccurate backlog calculation for the subscription.
Potential errors when components try to read or validate the mark-delete position against BookKeeper.
Inconsistent behavior when the empty ledger is later trimmed or deleted.

<img width="410" height="786" alt="Clipboard_Screenshot_1772633839" src="https://github.com/user-attachments/assets/85e216f1-a7d4-438a-8d85-cc2cedd7319a" />

### Modifications

<!-- Describe the modifications you've done. -->

Modified the asyncOpenCursor method in ManagedLedgerImpl to ensure that when InitialPosition.Latest is used, the position passed to cursor.initialize() is validated and does not point to a non-existent entry (i.e., entryId == -1 in an empty ledger). If the resolved lastConfirmedEntry has entryId == -1, the position is adjusted to point to the last valid entry of the previous non-empty ledger instead.
Updated recoveredCursor in ManagedCursorImpl (or the position resolution logic) to correctly handle the case where the markDeletePosition falls on an empty ledger that exists in the ledger map but contains no entries, ensuring the position is adjusted to a valid, existing entry.



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
