### PR TITLE
[improve][broker]Reduce the lock range of SimpleCache to enhance performance

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -308,7 +308,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     private TransactionPendingAckStoreProvider transactionPendingAckStoreProvider;
     private final ExecutorProvider transactionExecutorProvider;
-    private final ExecutorProvider transactionSnapshotRecoverExecutorProvider;
+    private final OrderedScheduler transactionSnapshotRecoverExecutorProvider;
     private final MonotonicClock monotonicClock;
     private String brokerId;
     private final CompletableFuture<Void> readyForIncomingRequestsFuture = new CompletableFuture<>();
@@ -380,8 +380,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         if (config.isTransactionCoordinatorEnabled()) {
             this.transactionExecutorProvider = new ExecutorProvider(this.getConfiguration()
                     .getNumTransactionReplayThreadPoolSize(), "pulsar-transaction-executor");
-            this.transactionSnapshotRecoverExecutorProvider = new ExecutorProvider(this.getConfiguration()
-                    .getNumTransactionReplayThreadPoolSize(), "pulsar-transaction-snapshot-recover");
+            this.transactionSnapshotRecoverExecutorProvider = OrderedScheduler.newSchedulerBuilder()
+                    .numThreads(this.getConfiguration().getNumTransactionReplayThreadPoolSize())
+                    .name("pulsar-transaction-snapshot-recover")
+                    .build();
         } else {
             this.transactionExecutorProvider = null;
             this.transactionSnapshotRecoverExecutorProvider = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -21,8 +21,8 @@ package org.apache.pulsar.broker.service;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -41,13 +41,14 @@ public class SystemTopicTxnBufferSnapshotService<T> {
 
     protected final ConcurrentHashMap<NamespaceName, SystemTopicClient<T>> clients;
     protected final NamespaceEventsSystemTopicFactory namespaceEventsSystemTopicFactory;
+    protected final PulsarClientImpl pulsarClient;
 
     protected final Class<T> schemaType;
     protected final EventType systemTopicType;
 
     private final ConcurrentHashMap<NamespaceName, ReferenceCountedWriter<T>> refCountedWriterMap;
-    @Getter
-    private final TableView<T> tableView;
+
+    private final ConcurrentHashMap<Thread, TableView<T>> tableView = new ConcurrentHashMap<>();
 
     // The class ReferenceCountedWriter will maintain the reference count,
     // when the reference count decrement to 0, it will be removed from writerFutureMap, the writer will be closed.
@@ -103,14 +104,12 @@ public class SystemTopicTxnBufferSnapshotService<T> {
 
     public SystemTopicTxnBufferSnapshotService(PulsarService pulsar, EventType systemTopicType,
                                                Class<T> schemaType) throws PulsarServerException {
-        final var client = (PulsarClientImpl) pulsar.getClient();
-        this.namespaceEventsSystemTopicFactory = new NamespaceEventsSystemTopicFactory(client);
+        this.pulsarClient = (PulsarClientImpl) pulsar.getClient();
+        this.namespaceEventsSystemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
         this.systemTopicType = systemTopicType;
         this.schemaType = schemaType;
         this.clients = new ConcurrentHashMap<>();
         this.refCountedWriterMap = new ConcurrentHashMap<>();
-        this.tableView = new TableView<>(this::createReader,
-                client.getConfiguration().getOperationTimeoutMs(), pulsar.getExecutor());
     }
 
     public CompletableFuture<SystemTopicClient.Reader<T>> createReader(TopicName topicName) {
@@ -171,6 +170,12 @@ public class SystemTopicTxnBufferSnapshotService<T> {
             }
         }
         refCountedWriterMap.clear();
+    }
+
+    public TableView<T> getTableView(ScheduledExecutorService scheduledExecutor) {
+        return tableView.computeIfAbsent(Thread.currentThread(),
+            k -> new TableView<>(this::createReader, pulsarClient.getConfiguration().getOperationTimeoutMs(),
+                scheduledExecutor));
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -48,7 +48,7 @@ public class SystemTopicTxnBufferSnapshotService<T> {
 
     private final ConcurrentHashMap<NamespaceName, ReferenceCountedWriter<T>> refCountedWriterMap;
 
-    private final ConcurrentHashMap<Thread, TableView<T>> tableView = new ConcurrentHashMap<>();
+    private final ThreadLocal<TableView<T>> tableViewThreadLocal = new ThreadLocal<>();
 
     // The class ReferenceCountedWriter will maintain the reference count,
     // when the reference count decrement to 0, it will be removed from writerFutureMap, the writer will be closed.
@@ -173,9 +173,13 @@ public class SystemTopicTxnBufferSnapshotService<T> {
     }
 
     public TableView<T> getTableView(ScheduledExecutorService scheduledExecutor) {
-        return tableView.computeIfAbsent(Thread.currentThread(),
-            k -> new TableView<>(this::createReader, pulsarClient.getConfiguration().getOperationTimeoutMs(),
-                scheduledExecutor));
+        TableView<T> tableView = tableViewThreadLocal.get();
+        if (tableView == null) {
+            tableView = new TableView<>(this::createReader,
+                    pulsarClient.getConfiguration().getOperationTimeoutMs(), scheduledExecutor);
+            tableViewThreadLocal.set(tableView);
+        }
+        return tableView;
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -48,6 +48,11 @@ public class SystemTopicTxnBufferSnapshotService<T> {
 
     private final ConcurrentHashMap<NamespaceName, ReferenceCountedWriter<T>> refCountedWriterMap;
 
+    /** SystemTopicTxnBufferSnapshotService is created only three, see also
+     *  {@link TransactionBufferSnapshotServiceFactory}. At the same time, each object can only
+     * be fixed threads access, see also {@link PulsarService#transactionSnapshotRecoverExecutorProvider}.
+     * So the un-static ThreadLocal is safe.
+     */
     private final ThreadLocal<TableView<T>> tableViewThreadLocal = new ThreadLocal<>();
 
     // The class ReferenceCountedWriter will maintain the reference count,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -91,10 +92,13 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     public CompletableFuture<Position> recoverFromSnapshot() {
         final var future = new CompletableFuture<Position>();
         final var pulsar = topic.getBrokerService().getPulsar();
-        pulsar.getTransactionSnapshotRecoverExecutorProvider().getExecutor(this).execute(() -> {
+        final String namespace = TopicName.get(topic.getName()).getNamespace();
+        final ScheduledExecutorService scheduledExecutor = pulsar.getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(namespace);
+        scheduledExecutor.execute(() -> {
             try {
                 final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
-                        .getTableView().readLatest(topic.getName());
+                        .getTableView(scheduledExecutor).readLatest(topic.getName());
                 if (snapshot != null) {
                     handleSnapshot(snapshot);
                     final var startReadCursorPosition = PositionFactory.create(snapshot.getMaxReadPositionLedgerId(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -231,10 +232,14 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
     public CompletableFuture<Position> recoverFromSnapshot() {
         final var pulsar = topic.getBrokerService().getPulsar();
         final var future = new CompletableFuture<Position>();
-        pulsar.getTransactionSnapshotRecoverExecutorProvider().getExecutor(this).execute(() -> {
+        final String namespace = TopicName.get(topic.getName()).getNamespace();
+        final ScheduledExecutorService scheduledExecutor = pulsar.getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(namespace);
+        scheduledExecutor.execute(() -> {
             try {
                 final var indexes = pulsar.getTransactionBufferSnapshotServiceFactory()
-                        .getTxnBufferSnapshotIndexService().getTableView().readLatest(topic.getName());
+                        .getTxnBufferSnapshotIndexService().getTableView(scheduledExecutor)
+                        .readLatest(topic.getName());
                 if (indexes == null) {
                     // Try recovering from the old format snapshot
                     future.complete(recoverOldSnapshot());
@@ -342,6 +347,10 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
     // This method will be deprecated and removed in version 4.x.0
     private Position recoverOldSnapshot() throws Exception {
+        final String namespace = TopicName.get(topic.getName()).getNamespace();
+        final ScheduledExecutorService scheduledExecutor = topic.getBrokerService().getPulsar()
+                .getTransactionSnapshotRecoverExecutorProvider()
+                .chooseThread(namespace);
         final var pulsar = topic.getBrokerService().getPulsar();
         final var topicName = TopicName.get(topic.getName());
         final var topics = wait(pulsar.getPulsarResources().getTopicResources().listPersistentTopicsAsync(
@@ -351,7 +360,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
             return null;
         }
         final var snapshot = pulsar.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService()
-                .getTableView().readLatest(topic.getName());
+                .getTableView(scheduledExecutor).readLatest(topic.getName());
         if (snapshot == null) {
             return null;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -592,6 +593,10 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
 
     @Test(timeOut = 30000)
     public void testTransactionBufferRecoverThrowException() throws Exception {
+        OrderedScheduler scheduler = OrderedScheduler.newSchedulerBuilder()
+                .numThreads(1)
+                .name("pulsar-transaction-snapshot-recover")
+                .build();
         String topic = NAMESPACE1 + "/testTransactionBufferRecoverThrowPulsarClientException";
         @Cleanup
         Producer<byte[]> producer = pulsarClient
@@ -620,7 +625,8 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         doReturn(CompletableFuture.completedFuture(reader))
                 .when(systemTopicTxnBufferSnapshotService).createReader(any());
         doReturn(refCounterWriter).when(systemTopicTxnBufferSnapshotService).getReferenceWriter(any());
-        doReturn(new MockTableView(pulsarServiceList.get(0))).when(systemTopicTxnBufferSnapshotService).getTableView();
+        doReturn(new MockTableView(pulsarServiceList.get(0))).when(systemTopicTxnBufferSnapshotService)
+                .getTableView(scheduler);
         TransactionBufferSnapshotServiceFactory transactionBufferSnapshotServiceFactory =
                 mock(TransactionBufferSnapshotServiceFactory.class);
         doReturn(systemTopicTxnBufferSnapshotService)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1155,9 +1155,11 @@ public class TransactionTest extends TransactionTestBase {
 
     @Test
     public void testNotChangeMaxReadPositionCountWhenCheckIfNoSnapshot() throws Exception {
+        final String topic = NAMESPACE1 + "/changeMaxReadPositionCount" + UUID.randomUUID();
+        pulsarClient.newProducer().topic(topic).create().close();
         PersistentTopic persistentTopic = (PersistentTopic) getPulsarServiceList().get(0)
                 .getBrokerService()
-                .getTopic(NAMESPACE1 + "/changeMaxReadPositionCount" + UUID.randomUUID(), true)
+                .getTopic(topic, true)
                 .get().get();
         TransactionBuffer buffer = persistentTopic.getTransactionBuffer();
         Field processorField = TopicTransactionBuffer.class.getDeclaredField("snapshotAbortedTxnProcessor");


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/23062 improved the behaviour of initialising the Transaction Buffer: Synchronise the reader creation, read loop and the following process on its result. Maintain only one reader for each namespace. The reader is now not closed unless there is no snapshot read request in 1 minute.

However, [SimpleCache](https://github.com/apache/pulsar/pull/23062/changes#diff-874612f5aa0d34f1df3c8d48bd8d4a4b28dc826a12fd08c45e1a62e10f6b5182) is a global lock, and the lock force is too strong, causing all `pulsar-transaction-snapshot-recover` threads to get stuck in the creation of the first reader. When system resources are insufficient, the problem will be magnified infinitely

<img width="1515" height="965" alt="Screenshot 2026-03-05 at 22 31 03" src="https://github.com/user-attachments/assets/58d90c68-f68d-49b8-9cb9-d10be152a071" />

---

Q1: The creation of the reader that reads `__transaction_buffer_snapshot` and the reading of existing messages are both executed synchronously.  Is it necessary to change it to be completed asynchronously?

A1: It is not necessary, since the initialisation of all TransactionBuffers under the same namespace requires waiting for the reader to complete the processing of all messages, whether it is asynchronous or not is not important

Q2. Will these synchronisation operations cause the thread `pulsar-transaction-snapshot-recover` to get stuck and affect other functions

A2: No. The function of this thread is quite simple: 1. Initialise Transaction Buffer. 2. After the Transaction Buffer recovery is completed, handle the accumulated transaction write operations (subsequent writes will no longer use this thread).
So the stuck functions actually all need to wait for the reader's messages to be processed, and thus, no other impacts have been caused


### Modifications

No longer wait for the initialisation of the reader to complete within the lock code block

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x
