### PR TITLE
[fix][offload] Close all resources in BlobStoreBackedReadHandleImplV2.closeAsync

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedReadHandleImplV2.java
@@ -132,34 +132,39 @@ public class BlobStoreBackedReadHandleImplV2 implements ReadHandle {
 
         CompletableFuture<Void> promise = closeFuture.get();
         executor.execute(() -> {
-            IOException first = null;
-            for (OffloadIndexBlockV2 indexBlock : indices) {
-                try {
-                    indexBlock.close();
-                } catch (IOException e) {
-                    if (first == null) {
-                        first = e;
-                    } else {
-                        first.addSuppressed(e);
+            try {
+                IOException first = null;
+                for (OffloadIndexBlockV2 indexBlock : indices) {
+                    try {
+                        indexBlock.close();
+                    } catch (IOException e) {
+                        if (first == null) {
+                            first = e;
+                        } else {
+                            first.addSuppressed(e);
+                        }
                     }
                 }
-            }
-            for (DataInputStream dataStream : dataStreams) {
-                try {
-                    dataStream.close();
-                } catch (IOException e) {
-                    if (first == null) {
-                        first = e;
-                    } else {
-                        first.addSuppressed(e);
+                for (DataInputStream dataStream : dataStreams) {
+                    try {
+                        dataStream.close();
+                    } catch (IOException e) {
+                        if (first == null) {
+                            first = e;
+                        } else {
+                            first.addSuppressed(e);
+                        }
                     }
                 }
-            }
-            if (first != null) {
-                promise.completeExceptionally(e);
-            } else {
                 state = State.Closed;
-                promise.complete(null);
+                if (first != null) {
+                    promise.completeExceptionally(first);
+                } else {
+                    promise.complete(null);
+                }
+            } catch (Throwable t) {
+                state = State.Closed;
+                promise.completeExceptionally(t);
             }
         });
         return promise;


### PR DESCRIPTION
### Motivation
`BlobStoreBackedReadHandleImplV2#closeAsync()` closes indices and dataStreams sequentially inside a single try/catch. If closing one resource throws, the method exits early and the remaining resources are never closed. This can leak file descriptors and leave resources open when offload read handles are closed.

### Modifications
- Update `closeAsync()` to attempt closing all `OffloadIndexBlockV2` instances and all `DataInputStreams`.
- Collect the first `IOException` and attach subsequent failures via suppressed exceptions.
- Complete the returned `CompletableFuture` exceptionally if any close operation fails; otherwise mark the handle Closed and complete normally.

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
