### PR TITLE
[feat][monitor] Add custom topic metric labels to OpenTelemetry metrics attributes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -18,14 +18,21 @@
  */
 package org.apache.pulsar.broker.service;
 
+import static org.apache.pulsar.broker.service.AbstractTopic.getCustomMetricLabelsMap;
 import io.opentelemetry.api.common.Attributes;
+import java.util.Map;
 import lombok.Getter;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 
 @Getter
 public class PersistentTopicAttributes extends TopicAttributes {
 
+    private final TopicName topicName;
+    private final PulsarService pulsar;
+
+    // Pre-built attributes with specific labels (without custom metric labels)
     private final Attributes timeBasedQuotaAttributes;
     private final Attributes sizeBasedQuotaAttributes;
 
@@ -41,8 +48,10 @@ public class PersistentTopicAttributes extends TopicAttributes {
     private final Attributes transactionBufferClientAbortSucceededAttributes;
     private final Attributes transactionBufferClientAbortFailedAttributes;
 
-    public PersistentTopicAttributes(TopicName topicName) {
+    public PersistentTopicAttributes(TopicName topicName, PulsarService pulsar) {
         super(topicName);
+        this.topicName = topicName;
+        this.pulsar = pulsar;
 
         timeBasedQuotaAttributes = Attributes.builder()
                 .putAll(commonAttributes)
@@ -98,6 +107,61 @@ public class PersistentTopicAttributes extends TopicAttributes {
         compactionFailureAttributes = Attributes.builder()
                 .putAll(commonAttributes)
                 .putAll(OpenTelemetryAttributes.CompactionStatus.FAILURE.attributes)
+                .build();
+    }
+
+    /**
+     * Converts a custom metric label key to OpenTelemetry format.
+     * The conversion follows OpenTelemetry semantic conventions by converting to lowercase.
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code custom_label} → {@code custom_label}</li>
+     *   <li>{@code MY_LABEL} → {@code my_label}</li>
+     * </ul>
+     *
+     * @param originalKey the original key of the custom metric label
+     * @return the OpenTelemetry-compliant attribute key
+     * @see <a href="https://opentelemetry.io/docs/specs/semconv/general/naming/">OpenTelemetry Naming Conventions</a>
+     */
+    public static String toOpenTelemetryAttributeKey(String originalKey) {
+        return originalKey.toLowerCase();
+    }
+
+    /**
+     * Get custom attributes (metric labels) for this topic.
+     * This method dynamically fetches custom labels to ensure they are always up-to-date.
+     * Only supported for persistent topics.
+     *
+     * @return attributes containing only custom metric labels, or empty attributes if not available
+     */
+    public Attributes getCustomAttributes() {
+        if (pulsar == null || !pulsar.getConfiguration().isExposeCustomTopicMetricLabelsEnabled()) {
+            return Attributes.empty();
+        }
+        Map<String, String> customLabels = getCustomMetricLabelsMap(pulsar, topicName);
+        if (customLabels.isEmpty()) {
+            return Attributes.empty();
+        }
+        var builder = Attributes.builder();
+        customLabels.forEach((key, value) -> builder.put(toOpenTelemetryAttributeKey(key), value));
+        return builder.build();
+    }
+
+    /**
+     * Build attributes by merging custom attributes into the given base attributes.
+     *
+     * @param baseAttributes the base attributes to merge custom attributes into
+     * @param customAttributes the custom attributes to merge
+     * @return attributes with custom attributes merged
+     */
+    public Attributes buildAttributesWithCustomLabels(Attributes baseAttributes, Attributes customAttributes) {
+        if (customAttributes.isEmpty()) {
+            return baseAttributes;
+        }
+        return Attributes.builder()
+                .putAll(baseAttributes)
+                .putAll(customAttributes)
                 .build();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -32,7 +32,7 @@ public class PersistentTopicAttributes extends TopicAttributes {
     @Getter
     public static class MetricAttributes {
         private final Attributes customAttributes;
-        private final Attributes commonAttributes;
+        private final Attributes resolvedCommonAttributes;
         private final Attributes timeBasedQuotaAttributes;
         private final Attributes sizeBasedQuotaAttributes;
         private final Attributes compactionSuccessAttributes;
@@ -46,7 +46,7 @@ public class PersistentTopicAttributes extends TopicAttributes {
         private final Attributes transactionBufferClientAbortFailedAttributes;
 
         private MetricAttributes(Attributes customAttributes,
-                                 Attributes commonAttributes,
+                                 Attributes resolvedCommonAttributes,
                                  Attributes timeBasedQuotaAttributes,
                                  Attributes sizeBasedQuotaAttributes,
                                  Attributes compactionSuccessAttributes,
@@ -59,7 +59,7 @@ public class PersistentTopicAttributes extends TopicAttributes {
                                  Attributes transactionBufferClientAbortSucceededAttributes,
                                  Attributes transactionBufferClientAbortFailedAttributes) {
             this.customAttributes = customAttributes;
-            this.commonAttributes = commonAttributes;
+            this.resolvedCommonAttributes = resolvedCommonAttributes;
             this.timeBasedQuotaAttributes = timeBasedQuotaAttributes;
             this.sizeBasedQuotaAttributes = sizeBasedQuotaAttributes;
             this.compactionSuccessAttributes = compactionSuccessAttributes;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PersistentTopicAttributes.java
@@ -29,6 +29,51 @@ import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 @Getter
 public class PersistentTopicAttributes extends TopicAttributes {
 
+    @Getter
+    public static class MetricAttributes {
+        private final Attributes customAttributes;
+        private final Attributes commonAttributes;
+        private final Attributes timeBasedQuotaAttributes;
+        private final Attributes sizeBasedQuotaAttributes;
+        private final Attributes compactionSuccessAttributes;
+        private final Attributes compactionFailureAttributes;
+        private final Attributes transactionActiveAttributes;
+        private final Attributes transactionCommittedAttributes;
+        private final Attributes transactionAbortedAttributes;
+        private final Attributes transactionBufferClientCommitSucceededAttributes;
+        private final Attributes transactionBufferClientCommitFailedAttributes;
+        private final Attributes transactionBufferClientAbortSucceededAttributes;
+        private final Attributes transactionBufferClientAbortFailedAttributes;
+
+        private MetricAttributes(Attributes customAttributes,
+                                 Attributes commonAttributes,
+                                 Attributes timeBasedQuotaAttributes,
+                                 Attributes sizeBasedQuotaAttributes,
+                                 Attributes compactionSuccessAttributes,
+                                 Attributes compactionFailureAttributes,
+                                 Attributes transactionActiveAttributes,
+                                 Attributes transactionCommittedAttributes,
+                                 Attributes transactionAbortedAttributes,
+                                 Attributes transactionBufferClientCommitSucceededAttributes,
+                                 Attributes transactionBufferClientCommitFailedAttributes,
+                                 Attributes transactionBufferClientAbortSucceededAttributes,
+                                 Attributes transactionBufferClientAbortFailedAttributes) {
+            this.customAttributes = customAttributes;
+            this.commonAttributes = commonAttributes;
+            this.timeBasedQuotaAttributes = timeBasedQuotaAttributes;
+            this.sizeBasedQuotaAttributes = sizeBasedQuotaAttributes;
+            this.compactionSuccessAttributes = compactionSuccessAttributes;
+            this.compactionFailureAttributes = compactionFailureAttributes;
+            this.transactionActiveAttributes = transactionActiveAttributes;
+            this.transactionCommittedAttributes = transactionCommittedAttributes;
+            this.transactionAbortedAttributes = transactionAbortedAttributes;
+            this.transactionBufferClientCommitSucceededAttributes = transactionBufferClientCommitSucceededAttributes;
+            this.transactionBufferClientCommitFailedAttributes = transactionBufferClientCommitFailedAttributes;
+            this.transactionBufferClientAbortSucceededAttributes = transactionBufferClientAbortSucceededAttributes;
+            this.transactionBufferClientAbortFailedAttributes = transactionBufferClientAbortFailedAttributes;
+        }
+    }
+
     private final TopicName topicName;
     private final PulsarService pulsar;
 
@@ -163,5 +208,27 @@ public class PersistentTopicAttributes extends TopicAttributes {
                 .putAll(baseAttributes)
                 .putAll(customAttributes)
                 .build();
+    }
+
+    /**
+     * Resolve all topic metric attributes for the current scrape cycle.
+     * The returned snapshot keeps the dynamic custom labels explicit while avoiding repeated merges.
+     */
+    public MetricAttributes resolveMetricAttributes() {
+        var customAttributes = getCustomAttributes();
+        return new MetricAttributes(
+                customAttributes,
+                buildAttributesWithCustomLabels(commonAttributes, customAttributes),
+                buildAttributesWithCustomLabels(timeBasedQuotaAttributes, customAttributes),
+                buildAttributesWithCustomLabels(sizeBasedQuotaAttributes, customAttributes),
+                buildAttributesWithCustomLabels(compactionSuccessAttributes, customAttributes),
+                buildAttributesWithCustomLabels(compactionFailureAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionActiveAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionCommittedAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionAbortedAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionBufferClientCommitSucceededAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionBufferClientCommitFailedAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionBufferClientAbortSucceededAttributes, customAttributes),
+                buildAttributesWithCustomLabels(transactionBufferClientAbortFailedAttributes, customAttributes));
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4840,7 +4840,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return persistentTopicAttributes;
         }
         return PERSISTENT_TOPIC_ATTRIBUTES_FIELD_UPDATER.updateAndGet(this,
-                old -> old != null ? old : new PersistentTopicAttributes(TopicName.get(topic)));
+                old -> old != null ? old : new PersistentTopicAttributes(TopicName.get(topic), brokerService.pulsar()));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
@@ -415,73 +415,94 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
             var persistentTopicMetrics = persistentTopic.getPersistentTopicMetrics();
 
             var persistentTopicAttributes = persistentTopic.getTopicAttributes();
+            // For persistent topics, get custom attributes once and reuse
+            var customLabels = persistentTopicAttributes.getCustomAttributes();
+            var attributesWithCustomLabels = persistentTopicAttributes
+                .buildAttributesWithCustomLabels(attributes, customLabels);
             var managedLedger = persistentTopic.getManagedLedger();
             var managedLedgerStats = persistentTopic.getManagedLedger().getStats();
-            storageCounter.record(managedLedgerStats.getStoredMessagesSize(), attributes);
-            storageLogicalCounter.record(managedLedgerStats.getStoredMessagesLogicalSize(), attributes);
-            storageBacklogCounter.record(managedLedger.getEstimatedBacklogSize(), attributes);
-            storageOffloadedCounter.record(managedLedger.getOffloadedSize(), attributes);
-            storageInCounter.record(managedLedgerStats.getReadEntriesSucceededTotal(), attributes);
-            storageOutCounter.record(managedLedgerStats.getAddEntrySucceedTotal(), attributes);
+            storageCounter.record(managedLedgerStats.getStoredMessagesSize(), attributesWithCustomLabels);
+            storageLogicalCounter.record(managedLedgerStats.getStoredMessagesLogicalSize(), attributesWithCustomLabels);
+            storageBacklogCounter.record(managedLedger.getEstimatedBacklogSize(), attributesWithCustomLabels);
+            storageOffloadedCounter.record(managedLedger.getOffloadedSize(), attributesWithCustomLabels);
+            storageInCounter.record(managedLedgerStats.getReadEntriesSucceededTotal(), attributesWithCustomLabels);
+            storageOutCounter.record(managedLedgerStats.getAddEntrySucceedTotal(), attributesWithCustomLabels);
 
             backlogQuotaLimitSize.record(
-                    topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
-                    attributes);
+                topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
+                attributesWithCustomLabels);
             backlogQuotaLimitTime.record(
-                    topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime(),
-                    attributes);
-            backlogQuotaAge.record(topic.getBestEffortOldestUnacknowledgedMessageAgeSeconds(), attributes);
+                topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime(),
+                attributesWithCustomLabels);
+            backlogQuotaAge.record(topic.getBestEffortOldestUnacknowledgedMessageAgeSeconds(),
+                attributesWithCustomLabels);
             var backlogQuotaMetrics = persistentTopicMetrics.getBacklogQuotaMetrics();
             backlogEvictionCounter.record(backlogQuotaMetrics.getSizeBasedBacklogQuotaExceededEvictionCount(),
-                    persistentTopicAttributes.getSizeBasedQuotaAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getSizeBasedQuotaAttributes(), customLabels));
             backlogEvictionCounter.record(backlogQuotaMetrics.getTimeBasedBacklogQuotaExceededEvictionCount(),
-                    persistentTopicAttributes.getTimeBasedQuotaAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTimeBasedQuotaAttributes(), customLabels));
 
             var txnBuffer = persistentTopic.getTransactionBuffer();
             transactionCounter.record(txnBuffer.getOngoingTxnCount(),
-                    persistentTopicAttributes.getTransactionActiveAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionActiveAttributes(), customLabels));
             transactionCounter.record(txnBuffer.getCommittedTxnCount(),
-                    persistentTopicAttributes.getTransactionCommittedAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionCommittedAttributes(), customLabels));
             transactionCounter.record(txnBuffer.getAbortedTxnCount(),
-                    persistentTopicAttributes.getTransactionAbortedAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionAbortedAttributes(), customLabels));
 
             var txnBufferClientMetrics = persistentTopicMetrics.getTransactionBufferClientMetrics();
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getCommitSucceededCount().sum(),
-                    persistentTopicAttributes.getTransactionBufferClientCommitSucceededAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionBufferClientCommitSucceededAttributes(), customLabels));
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getCommitFailedCount().sum(),
-                    persistentTopicAttributes.getTransactionBufferClientCommitFailedAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionBufferClientCommitFailedAttributes(), customLabels));
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getAbortSucceededCount().sum(),
-                    persistentTopicAttributes.getTransactionBufferClientAbortSucceededAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionBufferClientAbortSucceededAttributes(), customLabels));
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getAbortFailedCount().sum(),
-                    persistentTopicAttributes.getTransactionBufferClientAbortFailedAttributes());
+                persistentTopicAttributes.buildAttributesWithCustomLabels(
+                    persistentTopicAttributes.getTransactionBufferClientAbortFailedAttributes(), customLabels));
 
             Optional.ofNullable(pulsar.getNullableCompactor())
-                    .map(Compactor::getStats)
-                    .flatMap(compactorMXBean -> compactorMXBean.getCompactionRecordForTopic(topic.getName()))
-                    .ifPresent(compactionRecord -> {
-                        compactionRemovedCounter.record(compactionRecord.getCompactionRemovedEventCount(), attributes);
-                        compactionOperationCounter.record(compactionRecord.getCompactionSucceedCount(),
-                                persistentTopicAttributes.getCompactionSuccessAttributes());
-                        compactionOperationCounter.record(compactionRecord.getCompactionFailedCount(),
-                                persistentTopicAttributes.getCompactionFailureAttributes());
-                        compactionDurationSeconds.record(MetricsUtil.convertToSeconds(
-                            compactionRecord.getCompactionDurationTimeInMills(), TimeUnit.MILLISECONDS), attributes);
-                        compactionBytesInCounter.record(compactionRecord.getCompactionReadBytes(), attributes);
-                        compactionBytesOutCounter.record(compactionRecord.getCompactionWriteBytes(), attributes);
+                .map(Compactor::getStats)
+                .flatMap(compactorMXBean -> compactorMXBean.getCompactionRecordForTopic(topic.getName()))
+                .ifPresent(compactionRecord -> {
+                    compactionRemovedCounter.record(compactionRecord.getCompactionRemovedEventCount(),
+                        attributesWithCustomLabels);
+                    compactionOperationCounter.record(compactionRecord.getCompactionSucceedCount(),
+                        persistentTopicAttributes.buildAttributesWithCustomLabels(
+                            persistentTopicAttributes.getCompactionSuccessAttributes(), customLabels));
+                    compactionOperationCounter.record(compactionRecord.getCompactionFailedCount(),
+                        persistentTopicAttributes.buildAttributesWithCustomLabels(
+                            persistentTopicAttributes.getCompactionFailureAttributes(), customLabels));
+                    compactionDurationSeconds.record(MetricsUtil.convertToSeconds(
+                            compactionRecord.getCompactionDurationTimeInMills(), TimeUnit.MILLISECONDS),
+                        attributesWithCustomLabels);
+                    compactionBytesInCounter.record(compactionRecord.getCompactionReadBytes(),
+                        attributesWithCustomLabels);
+                    compactionBytesOutCounter.record(compactionRecord.getCompactionWriteBytes(),
+                        attributesWithCustomLabels);
 
-                        persistentTopic.getCompactedTopicContext().map(CompactedTopicContext::getLedger)
-                                .ifPresent(ledger -> {
-                                    compactionEntriesCounter.record(ledger.getLastAddConfirmed() + 1, attributes);
-                                    compactionBytesCounter.record(ledger.getLength(), attributes);
-                                });
-                    });
+                    persistentTopic.getCompactedTopicContext().map(CompactedTopicContext::getLedger)
+                        .ifPresent(ledger -> {
+                            compactionEntriesCounter.record(ledger.getLastAddConfirmed() + 1,
+                                attributesWithCustomLabels);
+                            compactionBytesCounter.record(ledger.getLength(), attributesWithCustomLabels);
+                        });
+                });
 
             var delayedMessages = topic.getSubscriptions().values().stream()
-                    .map(Subscription::getDispatcher)
-                    .filter(Objects::nonNull)
-                    .mapToLong(Dispatcher::getNumberOfDelayedMessages)
-                    .sum();
-            delayedSubscriptionCounter.record(delayedMessages, attributes);
+                .map(Subscription::getDispatcher)
+                .filter(Objects::nonNull)
+                .mapToLong(Dispatcher::getNumberOfDelayedMessages)
+                .sum();
+            delayedSubscriptionCounter.record(delayedMessages, attributesWithCustomLabels);
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.stats;
 
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
@@ -27,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.Dispatcher;
+import org.apache.pulsar.broker.service.PersistentTopicAttributes;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -394,7 +396,17 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
 
     private void recordMetricsForTopic(Topic topic) {
         var topicAttributes = topic.getTopicAttributes();
-        var attributes = topicAttributes.getCommonAttributes();
+        var topicMetricAttributes = topicAttributes.getCommonAttributes();
+        PersistentTopic persistentTopic = null;
+        PersistentTopicAttributes.MetricAttributes persistentMetricAttributes = null;
+        if (topic instanceof PersistentTopic pt) {
+            persistentTopic = pt;
+            persistentMetricAttributes = pt.getTopicAttributes().resolveMetricAttributes();
+            topicMetricAttributes = persistentMetricAttributes.getCommonAttributes();
+        }
+        final var attributes = topicMetricAttributes;
+        final var currentPersistentTopic = persistentTopic;
+        final var persistentAttributes = persistentMetricAttributes;
 
         if (topic instanceof AbstractTopic abstractTopic) {
             subscriptionCounter.record(abstractTopic.getSubscriptions().size(), attributes);
@@ -411,89 +423,72 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
             // Omitted: consumerMsgAckCounter
         }
 
-        if (topic instanceof PersistentTopic persistentTopic) {
-            var persistentTopicMetrics = persistentTopic.getPersistentTopicMetrics();
-
-            var persistentTopicAttributes = persistentTopic.getTopicAttributes();
-            // For persistent topics, get custom attributes once and reuse
-            var customLabels = persistentTopicAttributes.getCustomAttributes();
-            var attributesWithCustomLabels = persistentTopicAttributes
-                .buildAttributesWithCustomLabels(attributes, customLabels);
-            var managedLedger = persistentTopic.getManagedLedger();
-            var managedLedgerStats = persistentTopic.getManagedLedger().getStats();
-            storageCounter.record(managedLedgerStats.getStoredMessagesSize(), attributesWithCustomLabels);
-            storageLogicalCounter.record(managedLedgerStats.getStoredMessagesLogicalSize(), attributesWithCustomLabels);
-            storageBacklogCounter.record(managedLedger.getEstimatedBacklogSize(), attributesWithCustomLabels);
-            storageOffloadedCounter.record(managedLedger.getOffloadedSize(), attributesWithCustomLabels);
-            storageInCounter.record(managedLedgerStats.getReadEntriesSucceededTotal(), attributesWithCustomLabels);
-            storageOutCounter.record(managedLedgerStats.getAddEntrySucceedTotal(), attributesWithCustomLabels);
+        if (currentPersistentTopic != null) {
+            var persistentTopicMetrics = currentPersistentTopic.getPersistentTopicMetrics();
+            var managedLedger = currentPersistentTopic.getManagedLedger();
+            var managedLedgerStats = currentPersistentTopic.getManagedLedger().getStats();
+            storageCounter.record(managedLedgerStats.getStoredMessagesSize(), attributes);
+            storageLogicalCounter.record(managedLedgerStats.getStoredMessagesLogicalSize(), attributes);
+            storageBacklogCounter.record(managedLedger.getEstimatedBacklogSize(), attributes);
+            storageOffloadedCounter.record(managedLedger.getOffloadedSize(), attributes);
+            storageInCounter.record(managedLedgerStats.getReadEntriesSucceededTotal(), attributes);
+            storageOutCounter.record(managedLedgerStats.getAddEntrySucceedTotal(), attributes);
 
             backlogQuotaLimitSize.record(
                 topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.destination_storage).getLimitSize(),
-                attributesWithCustomLabels);
+                attributes);
             backlogQuotaLimitTime.record(
                 topic.getBacklogQuota(BacklogQuota.BacklogQuotaType.message_age).getLimitTime(),
-                attributesWithCustomLabels);
+                attributes);
             backlogQuotaAge.record(topic.getBestEffortOldestUnacknowledgedMessageAgeSeconds(),
-                attributesWithCustomLabels);
+                attributes);
             var backlogQuotaMetrics = persistentTopicMetrics.getBacklogQuotaMetrics();
             backlogEvictionCounter.record(backlogQuotaMetrics.getSizeBasedBacklogQuotaExceededEvictionCount(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getSizeBasedQuotaAttributes(), customLabels));
+                persistentAttributes.getSizeBasedQuotaAttributes());
             backlogEvictionCounter.record(backlogQuotaMetrics.getTimeBasedBacklogQuotaExceededEvictionCount(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTimeBasedQuotaAttributes(), customLabels));
+                persistentAttributes.getTimeBasedQuotaAttributes());
 
-            var txnBuffer = persistentTopic.getTransactionBuffer();
+            var txnBuffer = currentPersistentTopic.getTransactionBuffer();
             transactionCounter.record(txnBuffer.getOngoingTxnCount(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionActiveAttributes(), customLabels));
+                persistentAttributes.getTransactionActiveAttributes());
             transactionCounter.record(txnBuffer.getCommittedTxnCount(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionCommittedAttributes(), customLabels));
+                persistentAttributes.getTransactionCommittedAttributes());
             transactionCounter.record(txnBuffer.getAbortedTxnCount(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionAbortedAttributes(), customLabels));
+                persistentAttributes.getTransactionAbortedAttributes());
 
             var txnBufferClientMetrics = persistentTopicMetrics.getTransactionBufferClientMetrics();
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getCommitSucceededCount().sum(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionBufferClientCommitSucceededAttributes(), customLabels));
+                persistentAttributes.getTransactionBufferClientCommitSucceededAttributes());
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getCommitFailedCount().sum(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionBufferClientCommitFailedAttributes(), customLabels));
+                persistentAttributes.getTransactionBufferClientCommitFailedAttributes());
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getAbortSucceededCount().sum(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionBufferClientAbortSucceededAttributes(), customLabels));
+                persistentAttributes.getTransactionBufferClientAbortSucceededAttributes());
             transactionBufferClientOperationCounter.record(txnBufferClientMetrics.getAbortFailedCount().sum(),
-                persistentTopicAttributes.buildAttributesWithCustomLabels(
-                    persistentTopicAttributes.getTransactionBufferClientAbortFailedAttributes(), customLabels));
+                persistentAttributes.getTransactionBufferClientAbortFailedAttributes());
 
             Optional.ofNullable(pulsar.getNullableCompactor())
                 .map(Compactor::getStats)
                 .flatMap(compactorMXBean -> compactorMXBean.getCompactionRecordForTopic(topic.getName()))
                 .ifPresent(compactionRecord -> {
                     compactionRemovedCounter.record(compactionRecord.getCompactionRemovedEventCount(),
-                        attributesWithCustomLabels);
+                        attributes);
                     compactionOperationCounter.record(compactionRecord.getCompactionSucceedCount(),
-                        persistentTopicAttributes.buildAttributesWithCustomLabels(
-                            persistentTopicAttributes.getCompactionSuccessAttributes(), customLabels));
+                        persistentAttributes.getCompactionSuccessAttributes());
                     compactionOperationCounter.record(compactionRecord.getCompactionFailedCount(),
-                        persistentTopicAttributes.buildAttributesWithCustomLabels(
-                            persistentTopicAttributes.getCompactionFailureAttributes(), customLabels));
+                        persistentAttributes.getCompactionFailureAttributes());
                     compactionDurationSeconds.record(MetricsUtil.convertToSeconds(
                             compactionRecord.getCompactionDurationTimeInMills(), TimeUnit.MILLISECONDS),
-                        attributesWithCustomLabels);
+                        attributes);
                     compactionBytesInCounter.record(compactionRecord.getCompactionReadBytes(),
-                        attributesWithCustomLabels);
+                        attributes);
                     compactionBytesOutCounter.record(compactionRecord.getCompactionWriteBytes(),
-                        attributesWithCustomLabels);
+                        attributes);
 
-                    persistentTopic.getCompactedTopicContext().map(CompactedTopicContext::getLedger)
+                    currentPersistentTopic.getCompactedTopicContext().map(CompactedTopicContext::getLedger)
                         .ifPresent(ledger -> {
                             compactionEntriesCounter.record(ledger.getLastAddConfirmed() + 1,
-                                attributesWithCustomLabels);
-                            compactionBytesCounter.record(ledger.getLength(), attributesWithCustomLabels);
+                                attributes);
+                            compactionBytesCounter.record(ledger.getLength(), attributes);
                         });
                 });
 
@@ -502,7 +497,7 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
                 .filter(Objects::nonNull)
                 .mapToLong(Dispatcher::getNumberOfDelayedMessages)
                 .sum();
-            delayedSubscriptionCounter.record(delayedMessages, attributesWithCustomLabels);
+            delayedSubscriptionCounter.record(delayedMessages, attributes);
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.stats;
 
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/OpenTelemetryTopicStats.java
@@ -395,20 +395,16 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
     }
 
     private void recordMetricsForTopic(Topic topic) {
-        var topicAttributes = topic.getTopicAttributes();
-        var topicMetricAttributes = topicAttributes.getCommonAttributes();
         PersistentTopic persistentTopic = null;
         PersistentTopicAttributes.MetricAttributes persistentMetricAttributes = null;
-        if (topic instanceof PersistentTopic pt) {
-            persistentTopic = pt;
-            persistentMetricAttributes = pt.getTopicAttributes().resolveMetricAttributes();
-            topicMetricAttributes = persistentMetricAttributes.getCommonAttributes();
-        }
-        final var attributes = topicMetricAttributes;
-        final var currentPersistentTopic = persistentTopic;
-        final var persistentAttributes = persistentMetricAttributes;
 
         if (topic instanceof AbstractTopic abstractTopic) {
+            var attributes = topic.getTopicAttributes().getCommonAttributes();
+            if (topic instanceof PersistentTopic pt) {
+                persistentTopic = pt;
+                persistentMetricAttributes = pt.getTopicAttributes().resolveMetricAttributes();
+                attributes = persistentMetricAttributes.getResolvedCommonAttributes();
+            }
             subscriptionCounter.record(abstractTopic.getSubscriptions().size(), attributes);
             producerCounter.record(abstractTopic.getProducers().size(), attributes);
             consumerCounter.record(abstractTopic.getNumberOfConsumers(), attributes);
@@ -423,10 +419,13 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
             // Omitted: consumerMsgAckCounter
         }
 
-        if (currentPersistentTopic != null) {
-            var persistentTopicMetrics = currentPersistentTopic.getPersistentTopicMetrics();
-            var managedLedger = currentPersistentTopic.getManagedLedger();
-            var managedLedgerStats = currentPersistentTopic.getManagedLedger().getStats();
+        if (persistentTopic != null) {
+            final var attributes = persistentMetricAttributes.getResolvedCommonAttributes();
+            final var persistentAttributes = persistentMetricAttributes;
+            final var currentPersistentTopic = persistentTopic;
+            var persistentTopicMetrics = persistentTopic.getPersistentTopicMetrics();
+            var managedLedger = persistentTopic.getManagedLedger();
+            var managedLedgerStats = persistentTopic.getManagedLedger().getStats();
             storageCounter.record(managedLedgerStats.getStoredMessagesSize(), attributes);
             storageLogicalCounter.record(managedLedgerStats.getStoredMessagesLogicalSize(), attributes);
             storageBacklogCounter.record(managedLedger.getEstimatedBacklogSize(), attributes);
@@ -448,7 +447,7 @@ public class OpenTelemetryTopicStats implements AutoCloseable {
             backlogEvictionCounter.record(backlogQuotaMetrics.getTimeBasedBacklogQuotaExceededEvictionCount(),
                 persistentAttributes.getTimeBasedQuotaAttributes());
 
-            var txnBuffer = currentPersistentTopic.getTransactionBuffer();
+            var txnBuffer = persistentTopic.getTransactionBuffer();
             transactionCounter.record(txnBuffer.getOngoingTxnCount(),
                 persistentAttributes.getTransactionActiveAttributes());
             transactionCounter.record(txnBuffer.getCommittedTxnCount(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.stats;
+
+import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import io.opentelemetry.api.common.Attributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.Cleanup;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.testcontext.PulsarTestContext;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
+
+    private static final Set<String> ALLOWED_CUSTOM_METRIC_LABEL_KEYS = Set.of("__SLA_TIER", "APP_OWNER");
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void customizeMainPulsarTestContextBuilder(PulsarTestContext.Builder builder) {
+        super.customizeMainPulsarTestContextBuilder(builder);
+        builder.enableOpenTelemetry(true);
+    }
+
+    @Override
+    protected ServiceConfiguration getDefaultConf() {
+        ServiceConfiguration conf = super.getDefaultConf();
+        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setSystemTopicEnabled(true);
+        conf.setExposeCustomTopicMetricLabelsEnabled(true);
+        conf.setAllowedTopicPropertiesForMetrics(ALLOWED_CUSTOM_METRIC_LABEL_KEYS);
+        conf.setBrokerShutdownTimeoutMs(5000L);
+        return conf;
+    }
+
+    @Test(timeOut = 30_000)
+    public void testCustomLabelsInOpenTelemetryMetrics() throws Exception {
+        var topic1 = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testCustomLabels1");
+        var topic2 = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testCustomLabels2");
+
+        admin.topics().createNonPartitionedTopic(topic1);
+        admin.topics().createPartitionedTopic(topic2, 2);
+
+        @Cleanup
+        Producer<byte[]> p1 = pulsarClient.newProducer().topic(topic1).create();
+        @Cleanup
+        Producer<byte[]> p2 = pulsarClient.newProducer().topic(topic2).create();
+
+        @Cleanup
+        Consumer<byte[]> c1 = pulsarClient.newConsumer()
+            .topic(topic1)
+            .subscriptionName("test")
+            .subscribe();
+        @Cleanup
+        Consumer<byte[]> c2 = pulsarClient.newConsumer()
+            .topic(topic2)
+            .subscriptionName("test")
+            .subscribe();
+
+        // Produce and consume messages
+        for (int i = 0; i < 5; i++) {
+            p1.send(("message-" + i).getBytes());
+            p2.send(("message-" + i).getBytes());
+        }
+        for (int i = 0; i < 5; i++) {
+            c1.acknowledge(c1.receive());
+            c2.acknowledge(c2.receive());
+        }
+
+        // Set custom metric labels for topic1
+        Map<String, String> labels1 = new HashMap<>();
+        labels1.put("SLA_TIER", "gold");
+        labels1.put("APP_OWNER", "team-a");
+        admin.topics().updateProperties(topic1, labels1);
+
+        // Set custom metric labels for topic2
+        Map<String, String> labels2 = new HashMap<>();
+        labels2.put("SLA_TIER", "platinum");
+        labels2.put("APP_OWNER", "team-b");
+        admin.topics().updateProperties(topic2, labels2);
+
+        // Wait for labels to be set
+        Awaitility.await().untilAsserted(() -> {
+            var retrievedLabels1 = admin.topics().getProperties(topic1);
+            assertThat(retrievedLabels1.get("sla_tier")).isEqualTo("gold");
+            assertThat(retrievedLabels1.get("app_owner")).isEqualTo("team-a");
+
+            var retrievedLabels2 = admin.topics().getProperties(topic2);
+            assertThat(retrievedLabels2.get("sla_tier")).isEqualTo("platinum");
+            assertThat(retrievedLabels2.get("app_owner")).isEqualTo("team-b");
+        });
+
+        // Collect metrics and verify custom labels are present
+        var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
+
+        // Build expected attributes for topic1 with custom labels
+        var attributesTopic1 = Attributes.builder()
+            .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
+            .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
+            .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+            .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic1)
+            .put("sla_tier", "gold")
+            .put("app_owner", "team-a")
+            .build();
+
+        // Build expected attributes for topic2 with custom labels
+        var attributesTopic2 = Attributes.builder()
+            .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
+            .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
+            .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+            .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic2)
+            .put("sla_tier", "platinum")
+            .put("app_owner", "team-b")
+            .build();
+
+        // Verify metrics contain custom labels for topic1
+        assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.MESSAGE_IN_COUNTER, attributesTopic1, 5);
+        assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.PRODUCER_COUNTER, attributesTopic1, 1);
+
+        // Verify metrics contain custom labels for topic2 (partitioned topic)
+        // For partitioned topics, metrics are reported per partition
+        boolean foundTopic2Metrics = metrics.stream()
+            .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.MESSAGE_IN_COUNTER))
+            .flatMap(metric -> metric.getLongSumData().getPoints().stream())
+            .anyMatch(point -> {
+                var attrs = point.getAttributes();
+                return attrs.get(OpenTelemetryAttributes.PULSAR_TOPIC).equals(topic2)
+                    && "platinum".equals(attrs.get(io.opentelemetry.api.common.AttributeKey
+                    .stringKey("sla_tier")))
+                    && "team-b".equals(attrs.get(io.opentelemetry.api.common.AttributeKey
+                    .stringKey("app_owner")));
+            });
+        assertThat(foundTopic2Metrics).isTrue();
+    }
+
+    @Test(timeOut = 30_000)
+    public void testCustomLabelsDisabled() throws Exception {
+        // Create a new test with custom labels disabled
+        var topic = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/testCustomLabelsDisabled");
+        admin.topics().createNonPartitionedTopic(topic);
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+        producer.send("test".getBytes());
+
+        // Set custom metric labels
+        Map<String, String> labels = new HashMap<>();
+        labels.put("SLA_TIER", "gold");
+        admin.topics().updateProperties(topic, labels);
+
+        // Wait for labels to be set
+        Awaitility.await().untilAsserted(() -> {
+            var retrievedLabels = admin.topics().getProperties(topic);
+            assertThat(retrievedLabels.get("sla_tier")).isEqualTo("gold");
+        });
+
+        // Temporarily disable custom labels
+        pulsar.getConfiguration().setExposeCustomTopicMetricLabelsEnabled(false);
+
+        try {
+            // Collect metrics
+            var metrics = pulsarTestContext.getOpenTelemetryMetricReader().collectAllMetrics();
+
+            // Build expected attributes without custom labels
+            var attributesWithoutCustomLabels = Attributes.builder()
+                .put(OpenTelemetryAttributes.PULSAR_DOMAIN, "persistent")
+                .put(OpenTelemetryAttributes.PULSAR_TENANT, "prop")
+                .put(OpenTelemetryAttributes.PULSAR_NAMESPACE, "prop/ns-abc")
+                .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic)
+                .build();
+
+            // Verify metrics do NOT contain custom labels
+            assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.MESSAGE_IN_COUNTER, attributesWithoutCustomLabels,
+                1);
+
+            // Verify no metrics contain the custom label
+            boolean foundCustomLabel = metrics.stream()
+                .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.MESSAGE_IN_COUNTER))
+                .flatMap(metric -> metric.getLongSumData().getPoints().stream())
+                .anyMatch(point -> point.getAttributes()
+                    .get(io.opentelemetry.api.common.AttributeKey.stringKey("sla_tier")) != null);
+            assertThat(foundCustomLabel).isFalse();
+        } finally {
+            // Re-enable custom labels for other tests
+            pulsar.getConfiguration().setExposeCustomTopicMetricLabelsEnabled(true);
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
@@ -66,7 +66,7 @@ public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
         conf.setTopicLevelPoliciesEnabled(true);
         conf.setSystemTopicEnabled(true);
         conf.setExposeCustomTopicMetricLabelsEnabled(true);
-        conf.setAllowedTopicPropertiesForMetrics(ALLOWED_CUSTOM_METRIC_LABEL_KEYS);
+        conf.setAllowedTopicPropertyKeysForMetrics(ALLOWED_CUSTOM_METRIC_LABEL_KEYS);
         conf.setBrokerShutdownTimeoutMs(5000L);
         return conf;
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryCustomLabelsTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
 
-    private static final Set<String> ALLOWED_CUSTOM_METRIC_LABEL_KEYS = Set.of("__SLA_TIER", "APP_OWNER");
+    private static final Set<String> ALLOWED_CUSTOM_METRIC_LABEL_KEYS = Set.of("SLA_TIER", "APP_OWNER");
 
     @BeforeMethod(alwaysRun = true)
     @Override
@@ -120,12 +120,12 @@ public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
         // Wait for labels to be set
         Awaitility.await().untilAsserted(() -> {
             var retrievedLabels1 = admin.topics().getProperties(topic1);
-            assertThat(retrievedLabels1.get("sla_tier")).isEqualTo("gold");
-            assertThat(retrievedLabels1.get("app_owner")).isEqualTo("team-a");
+            assertThat(retrievedLabels1.get("SLA_TIER")).isEqualTo("gold");
+            assertThat(retrievedLabels1.get("APP_OWNER")).isEqualTo("team-a");
 
             var retrievedLabels2 = admin.topics().getProperties(topic2);
-            assertThat(retrievedLabels2.get("sla_tier")).isEqualTo("platinum");
-            assertThat(retrievedLabels2.get("app_owner")).isEqualTo("team-b");
+            assertThat(retrievedLabels2.get("SLA_TIER")).isEqualTo("platinum");
+            assertThat(retrievedLabels2.get("APP_OWNER")).isEqualTo("team-b");
         });
 
         // Collect metrics and verify custom labels are present
@@ -151,14 +151,19 @@ public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
             .put("app_owner", "team-b")
             .build();
 
-        // Verify metrics contain custom labels for topic1
+        // Verify shared topic metrics contain custom labels for topic1
         assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.MESSAGE_IN_COUNTER, attributesTopic1, 5);
         assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.PRODUCER_COUNTER, attributesTopic1, 1);
+
+        // Verify persistent-topic metrics contain custom labels for topic1
+        assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.STORAGE_COUNTER, attributesTopic1,
+            actual -> assertThat(actual).isPositive());
+        assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.STORAGE_OUT_COUNTER, attributesTopic1, 5);
 
         // Verify metrics contain custom labels for topic2 (partitioned topic)
         // For partitioned topics, metrics are reported per partition
         boolean foundTopic2Metrics = metrics.stream()
-            .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.MESSAGE_IN_COUNTER))
+            .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.STORAGE_COUNTER))
             .flatMap(metric -> metric.getLongSumData().getPoints().stream())
             .anyMatch(point -> {
                 var attrs = point.getAttributes();
@@ -189,7 +194,7 @@ public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
         // Wait for labels to be set
         Awaitility.await().untilAsserted(() -> {
             var retrievedLabels = admin.topics().getProperties(topic);
-            assertThat(retrievedLabels.get("sla_tier")).isEqualTo("gold");
+            assertThat(retrievedLabels.get("SLA_TIER")).isEqualTo("gold");
         });
 
         // Temporarily disable custom labels
@@ -207,13 +212,17 @@ public class OpenTelemetryCustomLabelsTest extends BrokerTestBase {
                 .put(OpenTelemetryAttributes.PULSAR_TOPIC, topic)
                 .build();
 
-            // Verify metrics do NOT contain custom labels
+            // Verify shared topic metrics do NOT contain custom labels
             assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.MESSAGE_IN_COUNTER, attributesWithoutCustomLabels,
                 1);
 
+            // Verify persistent-topic metrics do NOT contain custom labels
+            assertMetricLongSumValue(metrics, OpenTelemetryTopicStats.STORAGE_COUNTER, attributesWithoutCustomLabels,
+                actual -> assertThat(actual).isPositive());
+
             // Verify no metrics contain the custom label
             boolean foundCustomLabel = metrics.stream()
-                .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.MESSAGE_IN_COUNTER))
+                .filter(metric -> metric.getName().equals(OpenTelemetryTopicStats.STORAGE_COUNTER))
                 .flatMap(metric -> metric.getLongSumData().getPoints().stream())
                 .anyMatch(point -> point.getAttributes()
                     .get(io.opentelemetry.api.common.AttributeKey.stringKey("sla_tier")) != null);


### PR DESCRIPTION
Main Issue: N/A

PIP: https://github.com/apache/pulsar/blob/master/pip/pip-447.md

### Motivation

This PR is part 2 of PIP-447.

Part 1 for Prometheus labels has already been merged in https://github.com/apache/pulsar/pull/24991. This follow-up extends the same custom topic metric label support to OpenTelemetry topic metrics so both metrics pipelines expose the same topic property based labels.

### Modifications

- add custom topic metric labels to OpenTelemetry topic metrics for persistent topics
- extend `PersistentTopicAttributes` to build OpenTelemetry attributes with custom labels
- update `OpenTelemetryTopicStats` to attach custom labels across topic metrics
- add broker tests for custom labels in OpenTelemetry metrics
- fix the renamed config setter in the test after rebasing on latest `master`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Ran `mvn clean install -DskipTests`
- Added `OpenTelemetryCustomLabelsTest` to verify custom labels are exposed in OpenTelemetry metrics and omitted when the feature is disabled

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: https://github.com/coderzc/pulsar/pull/51
