### PR TITLE
[fix] Fix flaky testEstimatedTimeBasedBacklogQuotaCheckWhenNoBacklog

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
@@ -92,7 +92,9 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
         admin.topics().skipAllMessages(tp, "s1");
         Awaitility.await().untilAsserted(() -> {
             assertEquals(cursor.getNumberOfEntriesInBacklog(true), 0);
-            assertEquals(cursor.getMarkDeletedPosition(), ml.getLastConfirmedEntry());
+            // Use >= comparison: after skipAll, a ledger rollover may create a new empty ledger,
+            // moving the cursor's mark-delete position past the LAC (e.g., 10:-1 vs 9:1).
+            assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) >= 0);
         });
         CompletableFuture completableFuture = new CompletableFuture();
         ml.trimConsumedLedgersInBackground(completableFuture);
@@ -100,7 +102,7 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(ml.getLedgersInfo().size(), 1);
             assertEquals(cursor.getNumberOfEntriesInBacklog(true), 0);
-            assertEquals(cursor.getMarkDeletedPosition(), ml.getLastConfirmedEntry());
+            assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) >= 0);
         });
 
         // Verify: "persistentTopic.estimatedTimeBasedBacklogQuotaCheck" will not get a NullPointerException.


### PR DESCRIPTION

### Motivation

After skipAllMessages, a ledger rollover may create a new empty ledger, moving the cursor's mark-delete position past the LAC (e.g., 10:-1 vs 9:1). These positions are logically equivalent (no backlog) but fail strict assertEquals.

Replace exact position equality with >= comparison since the cursor position can legitimately advance beyond the LAC to the start of a new ledger.
### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
