### PR TITLE
[fix][sec] Upgrade jetty, jclouds, sqlite-jdbc, postgresql-jdbc, clickhouse-jdbc, elasticsearch-java, debezium, okio to solve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@ flexible messaging model and an intuitive client API.</description>
     <curator.version>5.7.1</curator.version>
     <netty.version>4.1.131.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
-    <jetty.version>12.1.5</jetty.version>
+    <jetty.version>12.1.7</jetty.version>
     <!-- Jetty 9 is used in tiered-storage/file-system tests and pulsar-io/alluxio -->
     <jetty9.version>9.4.58.v20250814</jetty9.version>
     <conscrypt.version>2.5.2</conscrypt.version>
@@ -240,17 +240,17 @@ flexible messaging model and an intuitive client API.</description>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
     <avro.version>1.12.0</avro.version>
     <joda.version>2.10.10</joda.version>
-    <jclouds.version>2.6.0</jclouds.version>
+    <jclouds.version>2.7.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
-    <sqlite-jdbc.version>3.47.1.0</sqlite-jdbc.version>
-    <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
-    <clickhouse-jdbc.version>0.4.6</clickhouse-jdbc.version>
+    <sqlite-jdbc.version>3.51.2.0</sqlite-jdbc.version>
+    <postgresql-jdbc.version>42.7.10</postgresql-jdbc.version>
+    <clickhouse-jdbc.version>0.9.7</clickhouse-jdbc.version>
     <mariadb-jdbc.version>3.5.5</mariadb-jdbc.version>
     <openmldb-jdbc.version>0.4.4-hotfix1</openmldb-jdbc.version>
     <json-smart.version>2.5.2</json-smart.version>
     <opensearch.version>2.19.4</opensearch.version>
-    <elasticsearch-java.version>8.15.3</elasticsearch-java.version>
-    <debezium.version>3.2.5.Final</debezium.version>
+    <elasticsearch-java.version>8.19.12</elasticsearch-java.version>
+    <debezium.version>3.2.7.Final</debezium.version>
     <debezium.postgresql.version>${postgresql-jdbc.version}</debezium.postgresql.version>
     <debezium.mysql.version>9.4.0</debezium.mysql.version>
     <jsonwebtoken.version>0.13.0</jsonwebtoken.version>
@@ -289,7 +289,7 @@ flexible messaging model and an intuitive client API.</description>
     <jose4j.version>0.9.6</jose4j.version>
     <okhttp3.version>5.3.1</okhttp3.version>
     <!-- use okio version that matches the okhttp3 version -->
-    <okio.version>3.16.3</okio.version>
+    <okio.version>3.16.4</okio.version>
     <!-- override kotlin-stdlib used by okio in order to address CVE-2020-29582 -->
     <kotlin-stdlib.version>1.8.20</kotlin-stdlib.version>
     <nsq-client.version>1.0</nsq-client.version>


### PR DESCRIPTION
### Motivation & Modifications

https://github.com/apache/pulsar/actions/runs/22915772155/job/66558830133?pr=25170

- Upgrade to address Jetty CVEs detected by OWASP: CVE-2026-1605
- <del>Upgrade to address OWASP findings on jclouds/openstack artifacts: CVE-2017-16613, CVE-2020-12689, CVE-2020-12690, CVE-2020-12691, CVE-2021-3563</del>
- Upgrade to address sqlite-jdbc CVEs detected by OWASP: CVE-2025-6965, CVE-2025-29087 
- Upgrade to reduce PostgreSQL CVEs reported via debezium-connector-postgres: CVE-2019-10210, CVE-2019-10211, CVE-2021-23214
- Upgrade to address clickhouse-jdbc shaded dependency CVEs: CVE-2024-7254, CVE-2023-3635 
- Upgrade to address Elasticsearch client CVEs detected by OWASP: CVE-2025-37731, CVE-2024-52979 
- Upgrade to address Debezium connector CVEs detected by OWASP: CVE-2021-32036, CVE-2017-15945 
- Upgrade to address Okio CVE detected by OWASP: CVE-2023-3635 -->



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x