### PR TITLE
[fix][test] Fix flaky OneWayReplicatorUsingGlobalZKTest cleanup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -306,8 +306,14 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
         if (!usingGlobalZK) {
             admin2.namespaces().setNamespaceReplicationClusters(replicatedNamespace, Sets.newHashSet(cluster2), true);
         }
-        admin1.namespaces().deleteNamespace(replicatedNamespace, true);
-        admin1.namespaces().deleteNamespace(nonReplicatedNamespace, true);
+        // When using global ZK, reducing replication clusters triggers async topic cleanup on removed clusters.
+        // Retry namespace deletion to handle topics that may be in a transitional state.
+        Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+            admin1.namespaces().deleteNamespace(replicatedNamespace, true);
+        });
+        Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+            admin1.namespaces().deleteNamespace(nonReplicatedNamespace, true);
+        });
         if (!usingGlobalZK) {
             admin2.namespaces().deleteNamespace(replicatedNamespace, true);
             admin2.namespaces().deleteNamespace(nonReplicatedNamespace, true);


### PR DESCRIPTION
## Summary
- Fix flaky `OneWayReplicatorUsingGlobalZKTest.cleanup` that fails with HTTP 422
- When using global ZK, reducing replication clusters triggers async topic cleanup on removed clusters. The namespace force-delete can fail if topics are still in a transitional state.
- Wrap `deleteNamespace` calls with `Awaitility` retry to handle this race condition.

## Test plan
- [x] Existing tests pass — the change only affects test cleanup resilience
- [ ] Verify `OneWayReplicatorUsingGlobalZKTest` no longer fails during cleanup

---

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`