### PR TITLE
[fix] Fix flaky OneWayReplicatorTest.testTopicPoliciesReplicationRule

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -1693,8 +1693,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         producer1.close();
         assertTrue(pulsar2.getPulsarResources().getTopicResources().persistentTopicExists(topicNameObj).join());
         admin1.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
-        admin1.topics().createSubscription(subscriptionName, topicName, MessageId.earliest);
-        admin2.topics().createSubscription(subscriptionName, topicName, MessageId.earliest);
+        admin2.topics().createSubscription(topicName, subscriptionName, MessageId.earliest);
 
         // Case 1: Global topic level policies -> Add: replicate.
         PublishRate publishRateAddGlobal = new PublishRate(100, 10000);


### PR DESCRIPTION
The createSubscription calls on lines 1696-1697 had swapped arguments (subscriptionName, topicName instead of topicName, subscriptionName), causing a timeout trying to create a subscription on a non-existent topic named "s1". Fixed arg order and removed the duplicate call.

```
 Error:  Tests run: 25, Failures: 1, Errors: 0, Skipped: 8, Time elapsed: 202.4 s <<< FAILURE! -- in org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest
  Error:  org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest.testTopicPoliciesReplicationRule -- Time elapsed: 60.97 s <<< FAILURE!
org.apache.pulsar.client.admin.PulsarAdminException$TimeoutException: java.util.concurrent.TimeoutException
	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:355)
	at org.apache.pulsar.client.admin.internal.TopicsImpl.createSubscription(TopicsImpl.java:1073)
	at org.apache.pulsar.client.admin.Topics.createSubscription(Topics.java:1865)
	at org.apache.pulsar.client.admin.Topics.createSubscription(Topics.java:1823)
	at org.apache.pulsar.broker.service.OneWayReplicatorTest.testTopicPoliciesReplicationRule(OneWayReplicatorTest.java:1696)
	at org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest.testTopicPoliciesReplicationRule(OneWayReplicatorUsingGlobalZKTest.java:544)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:139)
	at org.testng.internal.invokers.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:47)
	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:76)
	at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:11)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:350)
	... 15 more
```
### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
