### PR TITLE
[fix][test] Fix flaky ConnectionTimeoutTest by correcting latch count

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
@@ -29,10 +29,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@Slf4j
 public class ConnectionTimeoutTest {
 
     @Test
@@ -41,12 +43,15 @@ public class ConnectionTimeoutTest {
         // create a dummy server and fill the backlog of the server so that it won't respond
         // so that the client timeout can be tested with this server
         try (ServerSocket serverSocket = new ServerSocket(0, backlogSize, InetAddress.getByName("localhost"))) {
-            CountDownLatch latch = new CountDownLatch(backlogSize + 1);
+
+            // We to just leave 1 task pending, otherwise we don't have a chance to attemp to connect the Pulsar client
+            CountDownLatch latch = new CountDownLatch(backlogSize);
             List<Thread> threads = new ArrayList<>();
             for (int i = 0; i < backlogSize + 1; i++) {
                 Thread connectThread = new Thread(() -> {
                     try (Socket socket = new Socket()) {
                         socket.connect(serverSocket.getLocalSocketAddress());
+                        log.info("Connected to {}", socket.getRemoteSocketAddress());
                         latch.countDown();
                         Thread.sleep(10000L);
                     } catch (IOException e) {


### PR DESCRIPTION
## Summary
- Fix `ConnectionTimeoutTest.testLowTimeout` which was flaky due to incorrect `CountDownLatch` count
- The latch was initialized with `backlogSize + 1` but only `backlogSize` connections could succeed (the extra connection hangs because the server backlog is full), so the latch never reached zero
- Changed the latch count to `backlogSize` so the test proceeds once all possible connections are established
- Added debug logging to help diagnose future issues

## Test plan
- [x] Run `ConnectionTimeoutTest.testLowTimeout` — should complete in seconds instead of timing out after 5 minutes

### Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

---
*This change is the fix for https://github.com/apache/pulsar/issues/15068 regression*