### PR TITLE
[fix][io][kca] kafka headers silently dropped

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -288,7 +288,6 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
     public abstract AbstractKafkaSourceRecord<T> processSourceRecord(SourceRecord srcRecord);
 
-    private static final Map<String, String> PROPERTIES = Collections.emptyMap();
     private static final Optional<Long> RECORD_SEQUENCE = Optional.empty();
 
     public abstract class AbstractKafkaSourceRecord<T> implements Record {
@@ -331,9 +330,11 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
             return RECORD_SEQUENCE;
         }
 
+        Map<String, String> properties = Collections.emptyMap();
+
         @Override
         public Map<String, String> getProperties() {
-            return PROPERTIES;
+            return properties;
         }
 
         public boolean isEmpty() {

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -23,6 +23,7 @@ import com.google.common.cache.CacheBuilder;
 import io.confluent.connect.avro.AvroData;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -240,6 +241,20 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
                 .map(e -> e.getKey() + "=" + e.getValue())
                 .collect(Collectors.joining(",")));
             this.partitionIndex = Optional.ofNullable(srcRecord.kafkaPartition());
+
+            // Propagate Kafka Connect record headers as Pulsar message properties.
+            if (srcRecord.headers() != null && !srcRecord.headers().isEmpty()) {
+                Map<String, String> headerProperties = new HashMap<>();
+                for (var h : srcRecord.headers()) {
+                    Object val = h.value();
+                    if (val != null) {
+                        headerProperties.put(h.key(), val instanceof byte[]
+                                ? Base64.getEncoder().encodeToString((byte[]) val)
+                                : val.toString());
+                    }
+                }
+                this.properties = Collections.unmodifiableMap(headerProperties);
+            }
         }
 
         @Override

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -301,6 +301,35 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase {
     }
 
     @Test
+    void testHeadersPropagatedAsProperties() throws Exception {
+        Map<String, Object> config = getConfig();
+        config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");
+        config.put(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG, "default-tenant/default-ns");
+
+        kafkaConnectSource = new KafkaConnectSource();
+        kafkaConnectSource.open(config, context);
+
+        Map<String, Object> sourcePartition = new HashMap<>();
+        Map<String, Object> sourceOffset = new HashMap<>();
+        sourcePartition.put("test", "test");
+        sourceOffset.put("test", 0);
+        SourceRecord srcRecord = new SourceRecord(
+                sourcePartition, sourceOffset, topicName, null,
+                null, null, null, "value"
+        );
+        srcRecord.headers().addString("event-type", "order.created");
+        srcRecord.headers().addString("event-id", "abc-123");
+        srcRecord.headers().addLong("event-version", 42L);
+
+        KafkaSourceRecord record = kafkaConnectSource.processSourceRecord(srcRecord);
+
+        assertEquals("order.created", record.getProperties().get("event-type"));
+        assertEquals("abc-123", record.getProperties().get("event-id"));
+        assertEquals("42", record.getProperties().get("event-version"));
+        assertEquals(3, record.getProperties().size());
+    }
+
+    @Test
     void testShortTopicNames() throws Exception {
         Map<String, Object> config = getConfig();
         config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");


### PR DESCRIPTION
### Motivation

The current implementation of the Kafka Connect adaptor silently discards headers from the Kafka Connect SourceRecord instead of mapping them to Pulsar message properties. This is particularly impactful when using [Debezium's Outbox Event Router SMT](https://debezium.io/documentation//reference/3.5/transformations/outbox-event-router.html) with the [table.fields.additional.placement](https://debezium.io/documentation//reference/3.5/transformations/outbox-event-router.html#emitting-messages-with-additional-fields) option, which allows outbox table columns to be placed in the `header`, `envelope`, or `partition` of the resulting record. Columns configured with header placement are silently ignored because the adaptor never propagates Connect record headers to Pulsar message properties. Since Kafka Connect headers and Pulsar message properties are semantically equivalent (string key/value metadata outside the payload), the expected behavior is a direct mapping.

A similar issue was previously identified for `pulsar-io-kafka` and addressed in [#17829](https://github.com/apache/pulsar/pull/17829). However, `kafka-connect-adaptor` was not covered by that fix and still silently discards Kafka Connect SourceRecord headers.

### Modifications

`AbstractKafkaConnectSource` previously returned a hard-coded empty map from `getProperties()`, causing all Kafka Connect headers to be silently dropped. This change maps headers from the transformed `SourceRecord` to Pulsar message properties, preserving metadata that would otherwise be lost in transit (eg. columns placed in header position via Debezium's Outbox Event Router SMT and `table.fields.additional.placement`).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended the existing `KafkaConnectSourceTest` test suite with an additional test to confirm Kafka headers are correctly propagated to the resulting record.

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/efcasado/pulsar/pull/2