### PR TITLE
[cleanup] PIP-462: Remove Etcd metadata store backend

### DIFF
--- a/pip/pip-462.md
+++ b/pip/pip-462.md
@@ -109,6 +109,8 @@ No changes.
 
 ## General Notes
 
+The `MetadataStore` plugin system (PIP-45) remains fully intact. If there is community interest in continuing Etcd support, it can be maintained as an external plugin outside the core Pulsar repository, without any changes to the Pulsar codebase.
+
 ### Related PIPs
 
 - PIP-45: Pluggable metadata interface (introduced the MetadataStore abstraction and Etcd backend)


### PR DESCRIPTION
## Motivation

Etcd metadata store backend is not used in production Pulsar deployments, yet maintaining it imposes significant costs:

- **Dependency burden**: jetcd-core pulls in gRPC, Netty, Vert.x and requires a dedicated shading module
- **Distribution size**: Increases Pulsar tarball and Docker image size for all users
- **Library maintenance**: jetcd is not actively maintained
- **Maintenance overhead**: Must be kept in sync with every MetadataStore interface change

Both ZooKeeper and Oxia are fully supported, battle-tested backends. The community's future efforts are focused on Oxia. Maintaining a third, unused backend dilutes this focus.

## Changes

This PR adds the PIP-462 proposal document describing the removal of:
- `EtcdMetadataStore` and `EtcdSessionWatcher` implementation classes
- `jetcd-core-shaded` shading module
- `jetcd-core` and `jetcd-test` dependencies
- `EtcdMetadataStoreTest`

### Documentation
- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`