### PR TITLE
[improve][build] Upgrade LightProto to 0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,6 @@ flexible messaging model and an intuitive client API.</description>
     <maven-shade-plugin>3.6.0</maven-shade-plugin>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-    <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
     <nifi-nar-maven-plugin.version>1.5.0</nifi-nar-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
@@ -364,7 +363,7 @@ flexible messaging model and an intuitive client API.</description>
     <errorprone.version>2.45.0</errorprone.version>
     <errorprone-slf4j.version>0.1.29</errorprone-slf4j.version>
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
-    <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
+    <lightproto-maven-plugin.version>0.6.1</lightproto-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <roaringbitmap.version>1.6.9</roaringbitmap.version>
@@ -2230,31 +2229,6 @@ flexible messaging model and an intuitive client API.</description>
             </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties combine.children="append">
-                <!-- for lightproto (protostuff) -->
-                <property>
-                  <name>proto_path</name>
-                  <value>${pulsar.basedir}</value>
-                </property>
-                <property>
-                  <name>proto_search_strategy</name>
-                  <value>2</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -2379,11 +2353,6 @@ flexible messaging model and an intuitive client API.</description>
              -->
             <omitVisitors>ConstructorThrow,FindPublicAttributes,SharedVariableAtomicityDetector,UnreadFields,MultipleInstantiationsOfSingletons,InitializeNonnullFieldsInConstructor,FindNullDeref</omitVisitors>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>properties-maven-plugin</artifactId>
-          <version>${properties-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>io.fabric8</groupId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -659,7 +659,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.github.splunk.lightproto</groupId>
+        <groupId>io.streamnative.lightproto</groupId>
         <artifactId>lightproto-maven-plugin</artifactId>
         <version>${lightproto-maven-plugin.version}</version>
         <configuration>
@@ -668,6 +668,9 @@
             <source>${project.basedir}/src/main/proto/ResourceUsage.proto</source>
             <source>${project.basedir}/src/main/proto/DelayedMessageIndexBucketSegment.proto</source>
           </sources>
+          <extraProtoPaths>
+            <extraProtoPath>${pulsar.basedir}</extraProtoPath>
+          </extraProtoPaths>
           <targetSourcesSubDir>generated-sources/lightproto/java</targetSourcesSubDir>
           <targetTestSourcesSubDir>generated-sources/lightproto/java</targetTestSourcesSubDir>
         </configuration>

--- a/pulsar-broker/src/main/proto/TransactionPendingAck.proto
+++ b/pulsar-broker/src/main/proto/TransactionPendingAck.proto
@@ -19,7 +19,7 @@
 syntax = "proto2";
 
 import "pulsar-common/src/main/proto/PulsarApi.proto";
-package pulsar.proto;
+package pulsar.proto.pendingack;
 option java_package = "org.apache.pulsar.broker.transaction.pendingack.proto";
 option optimize_for = LITE_RUNTIME;
 

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -324,7 +324,7 @@
       </plugin>
 
       <plugin>
-        <groupId>com.github.splunk.lightproto</groupId>
+        <groupId>io.streamnative.lightproto</groupId>
         <artifactId>lightproto-maven-plugin</artifactId>
         <version>${lightproto-maven-plugin.version}</version>
         <executions>

--- a/pulsar-transaction/coordinator/pom.xml
+++ b/pulsar-transaction/coordinator/pom.xml
@@ -88,9 +88,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.github.splunk.lightproto</groupId>
+                <groupId>io.streamnative.lightproto</groupId>
                 <artifactId>lightproto-maven-plugin</artifactId>
                 <version>${lightproto-maven-plugin.version}</version>
+                <configuration>
+                    <extraProtoPaths>
+                        <extraProtoPath>${pulsar.basedir}</extraProtoPath>
+                    </extraProtoPaths>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pulsar-transaction/coordinator/src/main/resources/findbugsExclude.xml
+++ b/pulsar-transaction/coordinator/src/main/resources/findbugsExclude.xml
@@ -21,7 +21,7 @@
 <FindBugsFilter>
   <Match>
     <Class name="~org.apache.pulsar.transaction.coordinator.proto.*"/>
-    <Bug pattern="UUF_UNUSED_FIELD"/>
+    <Bug pattern="UUF_UNUSED_FIELD,DE_MIGHT_IGNORE,REC_CATCH_EXCEPTION"/>
   </Match>
   <!-- Ignore violations that were present when the rule was enabled -->
   <Match>


### PR DESCRIPTION
## Motivation

Upgrade the LightProto serialization library from 0.4 to 0.6.1. LightProto is used in Pulsar for high-performance, zero-copy serialization of internal protocol buffers (PulsarApi, transaction metadata, delayed message indexes, resource usage).

## LightProto 0.6.x highlights

Full release notes: https://github.com/streamnative/lightproto/releases/tag/v0.6.0

### Serialization performance overhaul

Unsafe-based serialization, pre-ensureWritable in `writeTo()` to eliminate per-field capacity checks, ASCII fast-path for string serialization, native arrays replacing `ArrayList` for repeated fields, precomputed tag sizes, unrolled VarInt64 decoding, and cached serialized size after `parseFrom`.

### Performance: v0.4 → v0.6

| Benchmark | v0.4 | v0.6 | Speedup |
|-----------|------|------|---------|
| PulsarAPI SerializeBaseCommand | 12.4 | 26.8 | **+116%** |
| PulsarAPI SerializeMessageMetadata | 6.1 | 10.9 | **+79%** |
| PulsarAPI DeserializeBaseCommand | 39.1 | 40.3 | +3% |
| PulsarAPI DeserializeMessageMetadata | 14.0 | 14.1 | ~same |
| ProtoBenchmark Serialize | 8.3 | 22.6 | **+172%** |
| ProtoBenchmark FillAndSerialize | 5.9 | 12.8 | **+117%** |
| ProtoBenchmark Deserialize | 16.7 | 19.2 | +15% |

### LightProto v0.6 vs Google Protobuf (PulsarAPI)

| Benchmark | Protobuf | LightProto | Speedup |
|-----------|----------|------------|---------|
| Serialize MessageMetadata | 2.84 | 10.85 | **3.8x** |
| Serialize BaseCommand | 15.82 | 26.81 | **1.7x** |
| Deserialize MessageMetadata | 4.18 | 14.14 | **3.4x** |
| Deserialize BaseCommand | 12.77 | 40.30 | **3.2x** |

### Proto3 support

Full proto3 syntax support including implicit field presence, packed-by-default repeated fields, and the `optional` keyword. This opens up the opportunity to standardize more of Pulsar's serialization on LightProto. Currently, Pulsar uses a mix of Google Protobuf (with its higher allocation overhead) and LightProto. With proto3 support, additional proto definitions — such as those used in the client-broker protocol or managed ledger metadata — could be migrated to LightProto, reducing GC pressure and improving throughput in the hot path.

### New field types & features

- **`map<K, V>` fields** — complete support for protobuf map fields
- **`oneof` fields** — proto2 oneof support with efficient memory layout
- **gRPC service stubs** — generate `*Grpc.java` with zero-copy Netty marshaller
- **Parser rewrite** — replaced protostuff-parser with `protoc` descriptor sets
- **Javadoc generation** from proto source comments

## Changes in this PR

- Update plugin groupId from `com.github.splunk.lightproto` to `io.streamnative.lightproto`
- Bump version from 0.4 to 0.6.1
- Remove the `properties-maven-plugin` configuration that was only needed for the old LightProto's protostuff-based parser
- Add `extraProtoPaths` configuration for the transaction coordinator module to resolve cross-module proto imports natively
- Update SpotBugs exclusions for generated code

### Documentation
- [x] `doc-not-needed`

### Matching PR in
- https://github.com/streamnative/lightproto