### PR TITLE
[fix][test] Fix flaky ManagedCursorTest.testSkipEntries

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2133,7 +2133,9 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(c1.getReadPosition().getEntryId(), 0);
         });
-        assertEquals(c1.getMarkDeletedPosition(), pos);
+        // The mark-delete position can be advanced beyond `pos` by TrimConsumedLedgers
+        // which runs asynchronously and may move it to the next ledger's -1 position.
+        assertTrue(c1.getMarkDeletedPosition().compareTo(pos) >= 0);
     }
 
     @Test(timeOut = 20000, dataProvider = "useOpenRangeSet")


### PR DESCRIPTION
## Flaky test failure

```
java.lang.AssertionError: expected [7:1] but found [8:-1]
	at org.testng.Assert.fail(Assert.java:110)
	at org.testng.Assert.failNotEquals(Assert.java:1577)
	at org.testng.Assert.assertEqualsImpl(Assert.java:149)
	at org.testng.Assert.assertEquals(Assert.java:131)
	at org.testng.Assert.assertEquals(Assert.java:643)
	at org.apache.bookkeeper.mledger.impl.ManagedCursorTest.testSkipEntries(ManagedCursorTest.java:2136)
```

## Summary

- Fix race condition in `ManagedCursorTest.testSkipEntries` where the assertion on mark-delete position fails because `TrimConsumedLedgers` asynchronously advances it beyond the expected value.
- Changed strict `assertEquals` to `>=` comparison since the mark-delete position can legitimately be advanced by the trim operation.

## Documentation

- [ ] `doc-required`
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

- [ ] `doc`
(Your PR contains doc changes)

- [ ] `doc-complete`
(Your PR changeserta existing doc and the changes are complete)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.