### PR TITLE
[fix][test] Fix flaky PulsarFunctionTlsTest.testFunctionsCreation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
@@ -261,21 +261,22 @@ public class PulsarFunctionTlsTest {
             log.info(" -------- Start test function : {}", functionName);
 
             int finalI = i;
+            // Wait for a leader to be ready and create the function.
+            // The createFunctionWithUrl call is included in the retry loop because a leadership
+            // transition can happen between the leader check and the actual API call, causing
+            // a 503 "Leader not yet ready" error.
+            final PulsarAdmin createAdmin = pulsarAdmins[i];
             Awaitility.await().atMost(1, TimeUnit.MINUTES).pollInterval(1, TimeUnit.SECONDS).untilAsserted(() -> {
                 final PulsarWorkerService workerService = ((PulsarWorkerService) fnWorkerServices[finalI]);
                 final LeaderService leaderService = workerService.getLeaderService();
                 assertNotNull(leaderService);
-                if (leaderService.isLeader()) {
-                    assertTrue(true);
-                } else {
+                if (!leaderService.isLeader()) {
                     final WorkerInfo workerInfo = workerService.getMembershipManager().getLeader();
                     assertTrue(workerInfo != null
                             && !workerInfo.getWorkerId().equals(workerService.getWorkerConfig().getWorkerId()));
                 }
+                createAdmin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
             });
-            pulsarAdmins[i].functions().createFunctionWithUrl(
-                functionConfig, jarFilePathUrl
-            );
 
             // Function creation is not strongly consistent, so this test can fail with a get that is too eager and
             // does not have retries.


### PR DESCRIPTION
## Flaky test failure

```
org.apache.pulsar.client.admin.PulsarAdminException: javax.ws.rs.ServiceUnavailableException: HTTP 503 {"reason":"Leader not yet ready. Please retry again"}
	at org.apache.pulsar.client.admin.PulsarAdminException.wrap(PulsarAdminException.java:252)
	at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:360)
	at org.apache.pulsar.client.admin.internal.FunctionsImpl.createFunctionWithUrl(FunctionsImpl.java:199)
	at org.apache.pulsar.functions.worker.PulsarFunctionTlsTest.testFunctionsCreation(PulsarFunctionTlsTest.java:276)
```

## Summary

- Fix flaky `PulsarFunctionTlsTest.testFunctionsCreation` which fails with HTTP 503 "Leader not yet ready" when a leadership transition occurs between the leader readiness check and the `createFunctionWithUrl` call.
- Moved the `createFunctionWithUrl` call inside the Awaitility retry loop so transient leadership transitions are automatically retried.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.