### PR TITLE
[fix][test] Fix flaky ConsumedLedgersTrimTest.testAdminTrimLedgers

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumedLedgersTrimTest.java
@@ -219,7 +219,7 @@ public class ConsumedLedgersTrimTest extends SharedPulsarBaseTest {
         }
         //consumed ledger should be cleaned
         admin.topics().trimTopic(partitionedTopic);
-        Awaitility.await().untilAsserted(() ->
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() ->
                 Assert.assertEquals(managedLedger.getLedgersInfoAsList().size(), 1));
 
     }


### PR DESCRIPTION
## Flaky test failure

```
org.awaitility.core.ConditionTimeoutException: Assertion condition expected [1] but found [2] within 10 seconds.
	at org.apache.pulsar.broker.service.ConsumedLedgersTrimTest.testAdminTrimLedgers
```

## Summary

- Fix flaky `ConsumedLedgersTrimTest.testAdminTrimLedgers` which asserts exactly 1 ledger remains after trimming consumed ledgers.
- With `maxEntriesPerLedger=2`, if partition-0 receives an even number of messages, the last ledger becomes full and a new empty active ledger is created. After trimming, 2 ledgers remain: the one containing the last confirmed entry (cannot be trimmed) and the new empty active ledger.
- Change assertion from `assertEquals(size, 1)` to `assertTrue(size <= 2)` since the remaining count depends on whether the last write caused a ledger rollover.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.