### PR TITLE
[fix][test] Fix flaky ClusterMigrationTest.testClusterMigrationWithReplicationBacklog

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -521,7 +521,7 @@ public class ClusterMigrationTest {
         pulsar3 = broker3.getPulsarService();
 
         // verify that the replication backlog drains once service in cluster "r3" is restarted.
-        retryStrategically((test) -> !topic1.isReplicationBacklogExist(), 10, 1000);
+        retryStrategically((test) -> !topic1.isReplicationBacklogExist(), 30, 1000);
         assertFalse(topic1.isReplicationBacklogExist());
 
         // verify that the producer1 is now connected to migrated cluster "r2" since backlog is cleared.


### PR DESCRIPTION
## Flaky test failure

```
java.lang.AssertionError: expected [false] but found [true]
	at org.testng.Assert.fail(Assert.java:110)
	at org.testng.Assert.failNotEquals(Assert.java:1577)
	at org.testng.Assert.assertFalse(Assert.java:78)
	at org.testng.Assert.assertFalse(Assert.java:88)
	at org.apache.pulsar.broker.service.ClusterMigrationTest.testClusterMigrationWithReplicationBacklog(ClusterMigrationTest.java:525)
```

## Summary

- Fix flaky `ClusterMigrationTest.testClusterMigrationWithReplicationBacklog` by increasing the retry timeout for the replication backlog drain check from 10s to 30s.
- After restarting broker3, the replication backlog may take longer to drain due to reconnection and replication catchup time.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.