### PR TITLE
[fix][test] Fix flaky PersistentTopicTerminateTest.testRecoverAfterTerminate

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PersistentTopicTerminateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PersistentTopicTerminateTest.java
@@ -64,8 +64,8 @@ public class PersistentTopicTerminateTest extends SharedPulsarBaseTest {
         assertEquals(msg2.getValue(), "2");
 
         // Verify: the ledgers acked will be cleaned up.
-        admin.topics().skipAllMessages(topicName, subscriptionName);
-        Awaitility.await().untilAsserted(() -> {
+        consumer.acknowledgeCumulative(msg2);
+        Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
             PersistentTopic persistentTopic =
                     (PersistentTopic) getTopic(topicName, false).join().get();
             ManagedLedgerImpl ml = (ManagedLedgerImpl) persistentTopic.getManagedLedger();


### PR DESCRIPTION
## Flaky test failure

```
org.awaitility.core.ConditionTimeoutException: Assertion condition expected [true] but found [false] within 10 seconds.
	at org.apache.pulsar.client.api.PersistentTopicTerminateTest.testRecoverAfterTerminate
```

## Summary

- Fix flaky `PersistentTopicTerminateTest.testRecoverAfterTerminate` by increasing the Awaitility timeout from 10s (default) to 30s.
- The ledger trim operation after topic termination involves metadata store operations that may not complete within 10s under load.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.