### PR TITLE
[fix][broker] Missing assignment of the corresponding InFlightTask in PersistentReplicator.readEntriesFailed

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -508,6 +508,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
             return;
         }
 
+        InFlightTask inFlightTask = (InFlightTask) ctx;
+        inFlightTask.setEntries(Collections.emptyList());
+
         // Reduce read batch size to avoid flooding bookies with retries
         readBatchSize = topic.getBrokerService().pulsar().getConfiguration().getDispatcherMinReadBatchSize();
 
@@ -988,5 +991,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
     @VisibleForTesting
     String getReplicatorId() {
         return  replicatorId;
+    }
+
+    @VisibleForTesting
+    public void incrementWaitForCursorRewindingRefCnf() {
+        waitForCursorRewindingRefCnf++;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -992,9 +992,4 @@ public abstract class PersistentReplicator extends AbstractReplicator
     String getReplicatorId() {
         return  replicatorId;
     }
-
-    @VisibleForTesting
-    public void incrementWaitForCursorRewindingRefCnf() {
-        waitForCursorRewindingRefCnf++;
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -642,12 +642,8 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @Test(timeOut = 30000)
     public void testReplicatorClearBacklog() throws Exception {
 
-        // This test is to verify that reset cursor fails on global topic
-        SortedSet<String> testDests = new TreeSet<>();
-
         final TopicName dest = TopicName
                 .get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns/clearBacklogTopic"));
-        testDests.add(dest.toString());
 
         @Cleanup
         MessageProducer producer1 = new MessageProducer(url1, dest);
@@ -655,12 +651,31 @@ public class ReplicatorTest extends ReplicatorTestBase {
         @Cleanup
         MessageConsumer consumer1 = new MessageConsumer(url3, dest);
 
-        // Produce from cluster1 and consume from the rest
+        // Produce from cluster1 to trigger topic and replicator creation
         producer1.produce(2);
+
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
-        PersistentReplicator replicator = (PersistentReplicator) spy(
-                topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.incrementWaitForCursorRewindingRefCnf();
+        PersistentReplicator replicator = (PersistentReplicator) topic.getReplicators()
+                .get(topic.getReplicators().keySet().stream().toList().get(0));
+
+        // Wait until the first batch of messages is fully replicated (backlog = 0),
+        // so that disconnect() won't be rejected due to non-zero backlog
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(replicator.getNumberOfEntriesInBacklog(), 0);
+        });
+
+        // Disconnect replicator to stop geo-replication, so new messages will form backlog
+        pauseReplicator(replicator);
+
+        // Produce more messages while replication is paused ¡ª these will accumulate as backlog
+        producer1.produce(2);
+
+        // wait for backlog to accumulate
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(replicator.getNumberOfEntriesInBacklog(), 2);
+        });
+
+        // Clear the backlog
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage
@@ -672,12 +687,8 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @Test(timeOut = 30000)
     public void testReplicatorExpireMsgAsync() throws Exception {
 
-        // This test is to verify that reset cursor fails on global topic
-        SortedSet<String> testDests = new TreeSet<>();
-
         final TopicName dest = TopicName
                 .get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns/clearBacklogTopic"));
-        testDests.add(dest.toString());
 
         @Cleanup
         MessageProducer producer1 = new MessageProducer(url1, dest);
@@ -685,12 +696,31 @@ public class ReplicatorTest extends ReplicatorTestBase {
         @Cleanup
         MessageConsumer consumer1 = new MessageConsumer(url3, dest);
 
-        // Produce from cluster1 and consume from the rest
+        // Produce from cluster1 to trigger topic and replicator creation
         producer1.produce(2);
+
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
-        PersistentReplicator replicator = (PersistentReplicator) spy(
-                topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.incrementWaitForCursorRewindingRefCnf();
+        PersistentReplicator replicator = (PersistentReplicator) topic.getReplicators()
+                .get(topic.getReplicators().keySet().stream().toList().get(0));
+
+        // Wait until the first batch of messages is fully replicated (backlog = 0),
+        // so that disconnect() won't be rejected due to non-zero backlog
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(replicator.getNumberOfEntriesInBacklog(), 0);
+        });
+
+        // Disconnect replicator to stop geo-replication, so new messages will form backlog
+        pauseReplicator(replicator);
+
+        // Produce more messages while replication is paused ¡ª these will accumulate as backlog
+        producer1.produce(2);
+
+        // wait for backlog to accumulate
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(replicator.getNumberOfEntriesInBacklog(), 2);
+        });
+
+        // Clear the backlog
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -667,7 +667,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // Disconnect replicator to stop geo-replication, so new messages will form backlog
         pauseReplicator(replicator);
 
-        // Produce more messages while replication is paused ¡ª these will accumulate as backlog
+        // Produce more messages while replication is paused ï¿½ï¿½ these will accumulate as backlog
         producer1.produce(2);
 
         // wait for backlog to accumulate
@@ -689,7 +689,6 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         final TopicName dest = TopicName
                 .get(BrokerTestUtil.newUniqueName("persistent://pulsar/ns/clearBacklogTopic"));
-
         @Cleanup
         MessageProducer producer1 = new MessageProducer(url1, dest);
 
@@ -712,7 +711,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // Disconnect replicator to stop geo-replication, so new messages will form backlog
         pauseReplicator(replicator);
 
-        // Produce more messages while replication is paused ¡ª these will accumulate as backlog
+        // Produce more messages while replication is paused ï¿½ï¿½ these will accumulate as backlog
         producer1.produce(2);
 
         // wait for backlog to accumulate

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -665,7 +665,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // Disconnect replicator to stop geo-replication, so new messages will form backlog
         pauseReplicator(replicator);
 
-        // Produce more messages while replication is paused �� these will accumulate as backlog
+        // Produce more messages while replication is paused, these will accumulate as backlog
         producer1.produce(2);
 
         // wait for backlog to accumulate
@@ -709,7 +709,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // Disconnect replicator to stop geo-replication, so new messages will form backlog
         pauseReplicator(replicator);
 
-        // Produce more messages while replication is paused �� these will accumulate as backlog
+        // Produce more messages while replication is paused, these will accumulate as backlog
         producer1.produce(2);
 
         // wait for backlog to accumulate

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -660,7 +660,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
         PersistentReplicator replicator = (PersistentReplicator) spy(
                 topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
+        replicator.incrementWaitForCursorRewindingRefCnf();
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage
@@ -690,7 +690,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
         PersistentReplicator replicator = (PersistentReplicator) spy(
                 topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
+        replicator.incrementWaitForCursorRewindingRefCnf();
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage
@@ -1653,7 +1653,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     @Test
     public void testReplicatorWithFailedAck() throws Exception {
 
-        log.info("--- Starting ReplicatorTest::testReplication ---");
+        log.info("--- Starting ReplicatorTest::testReplicatorWithFailedAck ---");
 
         String namespace = BrokerTestUtil.newUniqueName("pulsar/ns");
         admin1.namespaces().createNamespace(namespace, Sets.newHashSet("r1"));
@@ -1686,14 +1686,28 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }).when(spyCursor).asyncDelete(Mockito.any(Position.class), Mockito.any(AsyncCallbacks.DeleteCallback.class),
                 Mockito.any());
 
+        // Mock the readEntriesFailed scenario:
+        // Use AtomicBoolean to control whether to trigger read failure
+        // Initialized to true to ensure the first readMoreEntries after replicator startup is intercepted.
+        AtomicBoolean isMakeReadFail = new AtomicBoolean(true);
+        doAnswer(invocation -> {
+            if (isMakeReadFail.get()) {
+                AsyncCallbacks.ReadEntriesCallback callback = invocation.getArgument(2);
+                Object ctx = invocation.getArgument(3);
+                log.info("asyncReadEntriesOrWait will be failed");
+                callback.readEntriesFailed(new ManagedLedgerException("Mocked read failure"), ctx);
+                return null;
+            } else {
+                log.info("asyncReadEntriesOrWait will proceed normally");
+                return invocation.callRealMethod();
+            }
+        }).when(spyCursor).asyncReadEntriesOrWait(Mockito.anyInt(), Mockito.anyLong(),
+                Mockito.any(AsyncCallbacks.ReadEntriesCallback.class), Mockito.any(), Mockito.any(Position.class));
+
         log.info("--- Starting producer --- " + url1);
         admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"), false);
-        // Produce from cluster1 and consume from the rest
-        producer1.produce(2);
 
-        MessageIdImpl lastMessageId = (MessageIdImpl) topic.getLastMessageId().get();
-        Position lastPosition = PositionFactory.create(lastMessageId.getLedgerId(), lastMessageId.getEntryId());
-
+        // Wait for replicator to start
         Awaitility.await().pollInterval(1, TimeUnit.SECONDS).timeout(30, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
@@ -1703,9 +1717,33 @@ public class ReplicatorTest extends ReplicatorTestBase {
                             replicator.getState());
                 });
 
-        // Make sure all the data has replicated to the remote cluster before close the cursor.
-        Awaitility.await().untilAsserted(() -> assertEquals(cursor.getMarkDeletedPosition(), lastPosition));
+        // --- Test readEntriesFailed scenario ---
+        // isMakeReadFail is already true, replicator's readMoreEntries keeps failing
+        // Record current mark delete position
+        Position posBeforeReadFail = cursor.getMarkDeletedPosition();
 
+        // Produce messages; since reads keep failing, messages cannot be replicated
+        producer1.produce(2);
+
+        MessageIdImpl lastMessageId = (MessageIdImpl) topic.getLastMessageId().get();
+        Position lastPosition = PositionFactory.create(lastMessageId.getLedgerId(), lastMessageId.getEntryId());
+
+        // During 2 seconds of continuous read failure, mark delete position should not advance
+        Awaitility.await()
+                .during(2, TimeUnit.SECONDS)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertEquals(cursor.getMarkDeletedPosition(), posBeforeReadFail));
+
+        // Disable the read failure flag; replicator will read normally on retry, thus resuming replication
+        isMakeReadFail.set(false);
+
+        // Wait for replicator to recover from read failure and complete replication
+        // (mark delete catches up to the latest position)
+        Awaitility.await().timeout(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(cursor.getMarkDeletedPosition(), lastPosition);
+        });
+
+        // --- Test DeleteCallback scenario ---
         isMakeAckFail.set(true);
 
         producer1.produce(10);


### PR DESCRIPTION

### Motivation

The situation that replication does not work as expected.

Fixed an implementation bug:

When PersistentReplicator replicates an entry, it constructs an InFlightTask object to track the replication process. However, in the readEntriesFailed() function, the failure result is not filled into the corresponding InFlightTask object. This caused the readMoreEntries() function to continuously report the "Not scheduling read due to pending read or no permits." error after encountering a failure in the readEntriesFailed() function, blocking replica replication and causing geo replication stuck.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

https://github.com/gosonzhang/pulsar/pull/1
