### PR TITLE
[fix][test] Fix flaky ShadowTopicTest.testConsumeShadowMessageWithoutCache

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ShadowTopicTest.java
@@ -237,20 +237,28 @@ public class ShadowTopicTest extends SharedPulsarBaseTest {
             producer.send(content + i);
         }
 
+        // Unload the source topic to trigger a ledger rollover. The ShadowManagedLedgerImpl
+        // reads entries from the source's BookKeeper ledgers via metadata watch. Without the
+        // shadow replicator enabled, it can only discover entries in closed ledgers (the
+        // metadata for open ledgers shows entries=0). Unloading forces the current ledger
+        // to close so the shadow topic can see all entries.
+        admin.topics().unload(sourceTopic);
+
         admin.topics().createShadowTopic(shadowTopic, sourceTopic);
-        // disable shadow replicator
-        // admin.topics().setShadowTopics(sourceTopic, Lists.newArrayList(shadowTopic));
         @Cleanup Consumer<String> consumer =
                 pulsarClient.newConsumer(Schema.STRING).topic(shadowTopic).subscriptionName("sub")
                         .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                         .subscribe();
 
-        Message<String> msg = consumer.receive();
+        Message<String> msg = consumer.receive(10, TimeUnit.SECONDS);
+        Assert.assertNotNull(msg, "Should have received a message from shadow topic");
         Assert.assertEquals(msg.getMessageId(), id);
         Assert.assertEquals(msg.getValue(), content);
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(consumer.receive().getValue(), content + i);
+            msg = consumer.receive(10, TimeUnit.SECONDS);
+            Assert.assertNotNull(msg, "Should have received message " + i + " from shadow topic");
+            Assert.assertEquals(msg.getValue(), content + i);
         }
     }
 }


### PR DESCRIPTION
## Flaky test failure

```
ShadowTopicTest.testConsumeShadowMessageWithoutCache:253 » ThreadTimeout
Method org.apache.pulsar.broker.service.persistent.ShadowTopicTest.testConsumeShadowMessageWithoutCache()
didn't finish within the time-out 300000
```

## Summary

- Fix `ShadowTopicTest.testConsumeShadowMessageWithoutCache` which hangs indefinitely (5min timeout).
- The test creates a shadow topic without enabling the shadow replicator, expecting the `ShadowManagedLedgerImpl` to read entries directly from the source's BookKeeper ledgers via metadata watch.
- The shadow ML discovers entries via `processSourceManagedLedgerInfo`, but open ledgers have `entries=0` in the metadata and are skipped (`if (ledgerInfo.getEntries() > 0)`). Without a ledger rollover, the shadow topic never sees any entries and `consumer.receive()` blocks forever.
- Fix: unload the source topic before creating the shadow topic. Unloading triggers a ledger rollover, closing the current ledger so its entries become visible in the metadata.
- Also add timeouts to `consumer.receive()` calls to fail fast with a clear error instead of hanging for 5 minutes.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.