### PR TITLE
[fix][test] Fix flaky TopicTerminationTest.testCreatingProducerTasksCleanupWhenOnTerminatedTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicTerminationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicTerminationTest.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderListener;
@@ -98,9 +99,17 @@ public class TopicTerminationTest extends SharedPulsarBaseTest {
         }
     }
 
+    @Test(groups = "broker")
     public void testCreatingProducerTasksCleanupWhenOnTerminatedTopic() throws Exception {
         String topicName = newTopicName();
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+        // Use a dedicated PulsarClient so that the timer is not shared with other tests.
+        // The original test asserted timer.pendingTimeouts() == 0, which is unreliable
+        // when using the shared pulsarClient because other tests' producers/consumers
+        // may leave pending timeouts in the shared HashedWheelTimer.
+        @Cleanup
+        PulsarClient client = newPulsarClient();
+
+        Producer<byte[]> producer = client.newProducer().topic(topicName)
                 .enableBatching(false)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
                 .create();
@@ -114,12 +123,12 @@ public class TopicTerminationTest extends SharedPulsarBaseTest {
         producer.close();
 
         try {
-            pulsarClient.newProducer().topic(topicName).create();
+            client.newProducer().topic(topicName).create();
             fail("Should have thrown exception");
         } catch (PulsarClientException.TopicTerminatedException e) {
             // Expected
         }
-        HashedWheelTimer timer = (HashedWheelTimer) ((PulsarClientImpl) pulsarClient).timer();
+        HashedWheelTimer timer = (HashedWheelTimer) ((PulsarClientImpl) client).timer();
         Awaitility.await().untilAsserted(() -> Assert.assertEquals(timer.pendingTimeouts(), 0));
     }
 


### PR DESCRIPTION
## Flaky test failure

```
TopicTerminationTest.testCreatingProducerTasksCleanupWhenOnTerminatedTopic:123 » ConditionTimeout
Assertion condition expected [0] but found [6] within 10 seconds.
```

## Summary

- Fix flaky `TopicTerminationTest.testCreatingProducerTasksCleanupWhenOnTerminatedTopic` which asserts `timer.pendingTimeouts() == 0` but the `HashedWheelTimer` is shared across all tests in the suite via `SharedPulsarCluster`.
- Other producers/consumers from previous tests may have pending timeouts unrelated to this test, causing the assertion to find 6 pending timeouts instead of 0.
- Fix by using a dedicated `PulsarClient` for this test so the timer is fully isolated and `pendingTimeouts() == 0` is reliable.
- Also add the missing `@Test` annotation — the method was only running when targeted by surefire `-Dtest=` pattern matching.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.