### PR TITLE
[fix][test] Fix flaky ReplicatorTest.testResumptionAfterBacklogRelaxed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1046,8 +1046,10 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         metrics = metricReader1.collectAllMetrics();
         assertMetricLongSumValue(metrics, OpenTelemetryReplicatorStats.BACKLOG_COUNTER, attributes, 1);
+        // The delay can be 0.0 when the replicator producer is stopped (e.g. due to backlog quota),
+        // because AbstractReplicator.getReplicationDelayMs() returns 0 when producer is null.
         assertMetricDoubleGaugeValue(metrics, OpenTelemetryReplicatorStats.DELAY_GAUGE, attributes,
-                aDouble -> assertThat(aDouble).isPositive());
+                aDouble -> assertThat(aDouble).isGreaterThanOrEqualTo(0.0));
 
         // Consumer will now drain 1 message and the replication backlog will be cleared
         consumer2.receive(1);


### PR DESCRIPTION
## Flaky test failure

```
ReplicatorTest.testResumptionAfterBacklogRelaxed[producer_exception](4):
Expecting actual:
  0.0
to be greater than:
  0.0
	at ReplicatorTest.testResumptionAfterBacklogRelaxed(ReplicatorTest.java:1049)
```

## Summary

- Fix flaky `ReplicatorTest.testResumptionAfterBacklogRelaxed` which asserts `pulsar.broker.replication.message.backlog.age` is strictly positive when there is a replication backlog.
- `AbstractReplicator.getReplicationDelayMs()` returns `0` when the replicator's producer is `null`, which happens when replication is paused due to backlog quota being exceeded. The metric is derived from this value, so it can legitimately be `0.0` even with a non-empty backlog.
- Change the assertion from `isPositive()` to `isGreaterThanOrEqualTo(0.0)`.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.