### PR TITLE
[improve][pip] PIP-464: Deprecate legacy Jackson JsonSchema format for SchemaType.JSON

### DIFF
--- a/pip/pip-464.md
+++ b/pip/pip-464.md
@@ -1,4 +1,4 @@
-# PIP-464: Strict Avro Schema Validation for SchemaType.JSON
+# PIP-464: Deprecate legacy Jackson JsonSchema format for SchemaType.JSON
 
 ## Background knowledge
 


### PR DESCRIPTION
## Motivation

In Pulsar 2.1, `SchemaType.JSON` was standardized to use Apache Avro schema format for `SchemaInfo.schema`. However, the broker-side fallback logic (`StructSchemaDataValidator` and `JsonSchemaCompatibilityCheck`) is too lenient — it accepts **any valid JSON** as a schema definition, not just the legacy Jackson format from the 2.0 era.

This has caused real issues for non-Java clients (e.g., Rust) where users accidentally register JSON Schema Draft 2020-12 definitions. The broker accepts them, but Java consumers fail with `SchemaParseException: Type not supported: object` because `AvroBaseStructSchema` requires Avro format with no fallback.

## Changes

This PIP proposes:

- Add `schemaJsonAllowLegacyJacksonFormat` broker config (default `false`) to control whether the old Jackson JSON Schema format is accepted
- When disabled (default), both `StructSchemaDataValidator` and `JsonSchemaCompatibilityCheck` strictly require valid Avro schema format, consistent with consumer-side requirements
- When enabled, the current backward-compatible behavior is preserved
- Deprecate (not remove) the `ProducerImpl` client-side code that sends old format to pre-v13 brokers

## Impact

- The legacy format has been superseded since Pulsar 2.1 (2018)
- Java producers are unaffected (`JSONSchema.of()` has generated Avro format since 2.1)
- Non-Java clients get a clear error at registration time instead of a confusing consumer-side failure
- Users with genuine legacy schemas can opt in via the configuration flag

## Documentation

- [x] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)