### PR TITLE
[fix][sec] Upgrade Trivy GitHub Action to 0.35.0

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -998,7 +998,7 @@ jobs:
 
       - name: Run Trivy container scan
         id: trivy_scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:


### PR DESCRIPTION
## Motivation

The `aquasecurity/trivy-action` repository was compromised in a supply chain attack where an attacker force-pushed malicious payloads to 75 out of 76 version tags. Version 0.35.0 is the first safe release after the incident.

References:
- https://github.com/aquasecurity/trivy-action/issues/541
- https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
- https://github.com/aquasecurity/trivy/discussions/10265

## Modifications

Upgrade `aquasecurity/trivy-action` from `0.26.0` to `0.35.0` in CI workflow.

## Documentation

- [x] `doc-not-needed`

## Matching PR in forked repository

_No response_

### Label checklist

- [x] `ready-to-test`
- [x] `area/test`