### PR TITLE
[fix][ci] Disable trivy-action

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -596,7 +596,7 @@ jobs:
           $GITHUB_WORKSPACE/build/pulsar_ci_tool.sh restore_tar_from_github_actions_artifacts pulsar-maven-repository-binaries
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
         with:
           platforms: arm64
 


### PR DESCRIPTION
## Motivation

The `aquasecurity/trivy-action` repository was compromised in a supply chain attack where an attacker force-pushed malicious payloads to 75 out of 76 version tags. Version v0.35.0 is the first safe release after the incident.

References:
- https://github.com/aquasecurity/trivy-action/issues/541
- https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0
- https://github.com/aquasecurity/trivy/discussions/10265

## Modifications

- Disable `aquasecurity/trivy-action` in the CI workflow. 
  - We need to get the action allowed by ASF in the https://github.com/apache/infrastructure-actions repository before we can enable it again. PR: https://github.com/apache/infrastructure-actions/pull/546
     - Approved actions: https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml
- Replace `docker/setup-qemu-action@v3` with `docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392` which is approved. ASF restricted all actions to the approved ones after the trivy-action incident.

## Documentation

- [x] `doc-not-needed`
