### PR TITLE
[fix][test] Fix thread leaks in ManagedLedgerTest and PulsarMockBookKeeper

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4445,6 +4445,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     public void testNonDurableCursorCreateForInactiveLedger() throws Exception {
         String mlName = "testLedgerInfoMetaCorrectIfAddEntryTimeOut";
         BookKeeper spyBookKeeper = spy(bkc);
+        @Cleanup("shutdown")
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, spyBookKeeper);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         initManagedLedgerConfig(config);
@@ -4498,6 +4499,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     @Test
     public void testNoOrphanScheduledTasksAfterCloseML() throws Exception {
         String mlName = UUID.randomUUID().toString();
+        @Cleanup("shutdown")
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         initManagedLedgerConfig(config);

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -306,7 +306,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
             ledger.entries.clear();
             ledger.totalLengthCounter.set(0);
         }
-        scheduler.shutdown();
+        scheduler.shutdownNow();
         ledgers.clear();
     }
 


### PR DESCRIPTION
## Summary

- **ManagedLedgerTest**: Two test methods (`testNonDurableCursorCreateForInactiveLedger` and `testNoOrphanScheduledTasksAfterCloseML`) created local `ManagedLedgerFactoryImpl` instances that were never shut down, leaking ~10 threads (OrderedScheduler + cache eviction executor). Fixed by adding `@Cleanup("shutdown")`, consistent with other test methods in the same class.
- **PulsarMockBookKeeper**: `shutdown()` used `scheduler.shutdown()` (graceful) which doesn't force thread termination. Changed to `shutdownNow()` so the mock BK scheduler thread terminates immediately during test cleanup.

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

## Matching PR in forked repository

_none_

### Documentation Checklist
- [x] This PR does not require documentation changes

---

> [!NOTE]
> Ready to test

_Labels: `area/test`_