### PR TITLE
[fix][test] Fix flaky ExtensibleLoadManagerImplTest.testLoadBalancerServiceUnitTableViewSyncer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -1318,12 +1318,19 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 ? "SystemTopicToMetadataStoreSyncer" : "MetadataStoreToSystemTopicSyncer";
         pulsar.getAdminClient().brokers()
                 .updateDynamicConfiguration("loadBalancerServiceUnitTableViewSyncer", syncerTyp);
+        // Wait for the dynamic config to propagate to both brokers before triggering
+        // leader transitions. Without this, the leader callback may see the old config
+        // and skip activating the syncer.
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(pulsar1.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(pulsar2.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
         makeSecondaryAsLeader();
         makePrimaryAsLeader();
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertTrue(primaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertFalse(secondaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
         ServiceConfiguration defaultConf = getDefaultConf();
@@ -1503,11 +1510,16 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
 
         pulsar.getAdminClient().brokers()
                 .deleteDynamicConfiguration("loadBalancerServiceUnitTableViewSyncer");
+        // Wait for config deletion to propagate before leader transition
+        Awaitility.await().untilAsserted(() ->
+                assertFalse(pulsar1.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
+        Awaitility.await().untilAsserted(() ->
+                assertFalse(pulsar2.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
         makeSecondaryAsLeader();
-        Awaitility.waitAtMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertFalse(primaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
-        Awaitility.waitAtMost(5, TimeUnit.SECONDS)
+        Awaitility.await()
                 .untilAsserted(() -> assertFalse(secondaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
     }


### PR DESCRIPTION
## Flaky test failure

```
org.awaitility.core.ConditionTimeoutException: Assertion condition expected [true] but found [false] within 10 seconds.
	at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImplTest.testLoadBalancerServiceUnitTableViewSyncer(ExtensibleLoadManagerImplTest.java:1324)
```

## Summary

- Fix flaky `ExtensibleLoadManagerImplTest.testLoadBalancerServiceUnitTableViewSyncer` by making it deterministic instead of time-dependent.
- The test updates the `loadBalancerServiceUnitTableViewSyncer` dynamic config and immediately triggers leader transitions. If the config hasn't propagated to the broker's `ServiceConfiguration` by the time the leader callback fires, `isLoadBalancerServiceUnitTableViewSyncerEnabled()` returns false and the syncer is never activated — causing the 10s Awaitility timeout to expire.
- Fix by explicitly waiting for the dynamic config to propagate to both brokers (by polling `isLoadBalancerServiceUnitTableViewSyncerEnabled()`) before triggering leader transitions. This ensures the leader callback sees the updated config and activates the syncer deterministically.
- Apply the same pattern to the cleanup section where the config is deleted.

## Documentation

- [x] `doc-not-needed`
(Your PR doesn't need any doc update)

## Matching PR in forked repository

_No response_

### Tip

Add the labels `ready-to-test` and `area/test` to trigger the CI.