### PR TITLE
[fix][test] Fix flaky PersistentStickyKeyDispatcherMultipleConsumersClassicTest.testSkipRedeliverTemporally

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
@@ -499,13 +499,23 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
             return Collections.emptySet();
         }).when(cursorMock).asyncReplayEntries(anySet(), any(), any(), anyBoolean());
 
+        // Simulate real cursor behavior: track read position so entries are only returned once
+        // by normal reads (subsequent access must go through asyncReplayEntries).
+        // When no new entries are available, don't call the callback (simulating "OrWait" behavior).
+        Set<Position> normalReadReturned = new ConcurrentSkipListSet<>();
         doAnswer(invocationOnMock -> {
             int maxEntries = invocationOnMock.getArgument(0);
             AsyncCallbacks.ReadEntriesCallback callback = invocationOnMock.getArgument(2);
             List<Entry> entries = allEntries.stream()
-                    .filter(entry -> entry.getLedgerId() != -1 && !alreadySent.contains(entry.getPosition()))
+                    .filter(entry -> entry.getLedgerId() != -1
+                            && !normalReadReturned.contains(entry.getPosition()))
                     .limit(maxEntries)
                     .toList();
+            if (entries.isEmpty()) {
+                // No new entries available - simulate "wait" by not calling callback
+                return null;
+            }
+            entries.forEach(e -> normalReadReturned.add(e.getPosition()));
             Object ctx = invocationOnMock.getArgument(3);
             callback.readEntriesComplete(copyEntries(entries), ctx);
             return null;
@@ -550,6 +560,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
 
         // set permits to 2
         slowConsumerAvailablePermits.set(2);
+
+        // Trigger a new read cycle so the dispatcher can do a replay read to deliver
+        // messages to the slow consumer. In production, this would be triggered by
+        // consumerFlow when the consumer sends more permits.
+        persistentDispatcher.readMoreEntriesAsync();
 
         // now wait for slow consumer messages since there are permits
         assertTrue(slowConsumerMessagesSent.await(5, TimeUnit.SECONDS));


### PR DESCRIPTION
### Motivation

Fix flaky `testSkipRedeliverTemporally` in `PersistentStickyKeyDispatcherMultipleConsumersClassicTest`.

The test was flaky because the `asyncReadEntriesOrWait` mock returned the same entries (msg1, msg2 for the slow consumer) indefinitely, creating an infinite normal-read loop. Normal reads couldn't deliver to the slow consumer because `getRestrictedMaxEntriesForConsumer` returns 0 when `readType==Normal` and the `stickyKeyHashes` are in `redeliveryMessages`. Only replay reads can deliver these messages, but the `isDispatcherStuckOnReplays` flag prevented replay reads from being attempted.

In a real cursor, `asyncReadEntriesOrWait` advances the read position — entries can only be re-read through `asyncReplayEntries`. The mock didn't simulate this behavior.

### Modifications

1. **Realistic cursor mock** — `asyncReadEntriesOrWait` now tracks which entries it has already returned and doesn't return them again (simulating cursor read position advancement). When no new entries exist, it doesn't call the callback (simulating "OrWait" behavior), which stops the infinite normal-read loop.

2. **Explicit `readMoreEntriesAsync()` call** — After setting the slow consumer's permits, the test triggers a new dispatch cycle. This mimics what `consumerFlow` does in production when a consumer sends more permits. With the loop stopped and `isDispatcherStuckOnReplays` never set, the dispatcher correctly enters the replay read path and delivers messages to the slow consumer.

### Verifying this change

This change is already covered by existing tests:
- `PersistentStickyKeyDispatcherMultipleConsumersClassicTest.testSkipRedeliverTemporally` — the test itself, verified passing 5/5 consecutive runs
- All 7 tests in `PersistentStickyKeyDispatcherMultipleConsumersClassicTest` pass

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL after creating -->