### PR TITLE
[fix][test] Fix flaky OneWayReplicatorUsingGlobalZKTest.cleanup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -322,9 +322,15 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
             admin1.namespaces().deleteNamespace(sourceClusterAlwaysSchemaCompatibleNamespace, true);
         });
         if (!usingGlobalZK) {
-            admin2.namespaces().deleteNamespace(replicatedNamespace, true);
-            admin2.namespaces().deleteNamespace(nonReplicatedNamespace, true);
-            admin2.namespaces().deleteNamespace(sourceClusterAlwaysSchemaCompatibleNamespace, true);
+            Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+                admin2.namespaces().deleteNamespace(replicatedNamespace, true);
+            });
+            Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+                admin2.namespaces().deleteNamespace(nonReplicatedNamespace, true);
+            });
+            Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+                admin2.namespaces().deleteNamespace(sourceClusterAlwaysSchemaCompatibleNamespace, true);
+            });
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTestBase.java
@@ -303,8 +303,12 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
         // delete namespaces.
         waitChangeEventsInit(replicatedNamespace);
         admin1.namespaces().setNamespaceReplicationClusters(replicatedNamespace, Sets.newHashSet(cluster1), true);
+        admin1.namespaces().setNamespaceReplicationClusters(
+                sourceClusterAlwaysSchemaCompatibleNamespace, Sets.newHashSet(cluster1), true);
         if (!usingGlobalZK) {
             admin2.namespaces().setNamespaceReplicationClusters(replicatedNamespace, Sets.newHashSet(cluster2), true);
+            admin2.namespaces().setNamespaceReplicationClusters(
+                    sourceClusterAlwaysSchemaCompatibleNamespace, Sets.newHashSet(cluster2), true);
         }
         // When using global ZK, reducing replication clusters triggers async topic cleanup on removed clusters.
         // Retry namespace deletion to handle topics that may be in a transitional state.
@@ -314,16 +318,27 @@ public abstract class OneWayReplicatorTestBase extends TestRetrySupport {
         Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
             admin1.namespaces().deleteNamespace(nonReplicatedNamespace, true);
         });
+        Awaitility.await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+            admin1.namespaces().deleteNamespace(sourceClusterAlwaysSchemaCompatibleNamespace, true);
+        });
         if (!usingGlobalZK) {
             admin2.namespaces().deleteNamespace(replicatedNamespace, true);
             admin2.namespaces().deleteNamespace(nonReplicatedNamespace, true);
+            admin2.namespaces().deleteNamespace(sourceClusterAlwaysSchemaCompatibleNamespace, true);
         }
     }
 
     @Override
     protected void cleanup() throws Exception {
         // cleanup pulsar resources.
-        cleanupPulsarResources();
+        // Wrap in try-catch to ensure brokers, ZK, and BK are always shut down even if
+        // namespace deletion fails (e.g., topics in transitional state during async replication cleanup).
+        try {
+            cleanupPulsarResources();
+        } catch (Exception e) {
+            log.warn("Failed to cleanup Pulsar resources during shutdown, "
+                    + "continuing with broker/ZK/BK shutdown", e);
+        }
 
         // shutdown.
         markCurrentSetupNumberCleaned();


### PR DESCRIPTION
### Motivation

The `OneWayReplicatorUsingGlobalZKTest.cleanup` method is flaky, failing ~5 times per week in CI. The failure occurs because:

1. The test enables `transactionCoordinatorEnabled`, which creates a `__transaction_buffer_snapshot` system topic
2. During cleanup, reducing replication clusters triggers async topic cleanup
3. The `__transaction_buffer_snapshot` topic enters a transitional state (compaction `CancellationException`), causing its force-delete to return HTTP 422 repeatedly
4. The 30-second Awaitility timeout in `cleanupPulsarResources()` expires and throws
5. **Critically**, the exception prevents the rest of `cleanup()` from running — brokers, ZK, and BK are never shut down, leaking resources

See [flaky test report](https://github.com/lhotari/pulsar-flakes/blob/master/2026-03-16-to-2026-03-23/org.apache.pulsar.broker.service.OneWayReplicatorUsingGlobalZKTest.cleanup.md) for CI failure details.

### Modifications

- Wrap `cleanupPulsarResources()` in try-catch in `OneWayReplicatorTestBase.cleanup()` so that broker, ZK, and BK shutdown always proceeds even if namespace deletion fails
- Add missing cleanup for `sourceClusterAlwaysSchemaCompatibleNamespace` which was created in `setup()` but never deleted in `cleanupPulsarResources()`
- Use `Awaitility.await().ignoreExceptions()` retry pattern for the `admin2` namespace deletions in the non-global ZK path, matching the pattern already used for `admin1` deletions

### Verifying this change

This change is already covered by existing tests:
- Ran `OneWayReplicatorUsingGlobalZKTest` 4 times locally — all passed (21 tests, 0 failures each)
- Ran `OneWayReplicatorTest` 1 time locally — passed (35 tests, 0 failures)

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency): no
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/new/lh-fix-onewayreplicatortestbase-close