### PR TITLE
[PIP-459] Admin API to Pause and Resume Subscription Dispatching

### DIFF
--- a/pip/pip-459.md
+++ b/pip/pip-459.md
@@ -42,7 +42,7 @@ Operators dealing with downstream incidents, consumer deployments, or backlog in
 
 # High Level Design
 
-A `dispatchingPaused` boolean field is added to the `ManagedCursorInfo` protobuf message. When an operator calls the pause endpoint, this field is set and persisted in cursor metadata. The dispatcher's read loop checks this field before initiating new reads — if paused, it returns immediately. Connected consumers remain attached but receive no new messages. On resume, the field is cleared and the dispatcher restarts its read loop. No messages are skipped or lost — the cursor position is unchanged throughout.
+A `paused` boolean field is added to the `ManagedCursorInfo` protobuf message. When an operator calls the pause endpoint, this field is set and persisted in cursor metadata. The dispatcher's read loop checks this field before initiating new reads — if paused, it returns immediately. Connected consumers remain attached but receive no new messages. On resume, the field is cleared and the dispatcher restarts its read loop. No messages are skipped or lost — the cursor position is unchanged throughout.
 
 The paused state is stored as a dedicated cursor field rather than a cursor property to prevent users from accidentally setting or clearing it via the subscription properties admin API.
 
@@ -56,7 +56,7 @@ Add three methods to the `Subscription` interface:
 
 - `CompletableFuture<Void> pauseDispatching()` — Sets the paused flag and persists it.
 - `CompletableFuture<Void> resumeDispatching()` — Clears the paused flag and triggers the dispatcher to resume reading.
-- `boolean isDispatchingPaused()` — Returns the current paused state.
+- `boolean isPaused()` — Returns the current paused state.
 
 ### ManagedCursor Changes
 
@@ -65,14 +65,14 @@ A new field is added to the `ManagedCursorInfo` protobuf message:
 ```protobuf
 message ManagedCursorInfo {
     // ... existing fields ...
-    optional bool dispatchingPaused = 9;
+    optional bool paused = 9;
 }
 ```
 
 The `ManagedCursor` interface gains two methods:
 
-- `boolean isDispatchingPaused()` — Returns the current paused state.
-- `CompletableFuture<Void> setDispatchingPaused(boolean paused)` — Persists the paused state to cursor metadata.
+- `boolean isPaused()` — Returns the current paused state.
+- `CompletableFuture<Void> setPaused(boolean paused)` — Persists the paused state to cursor metadata.
 
 `ManagedCursorImpl` persists this field in `persistPositionMetaStore()` and restores it in `recover()` and `recoverFromLedger()`. The protobuf `optional bool` defaults to `false`, so existing cursors are unaffected.
 
@@ -82,7 +82,7 @@ On subscription load, the paused state is read from the cursor. On resume, `disp
 
 ### Dispatcher Changes
 
-In `PersistentDispatcherMultipleConsumers.readMoreEntries()` and `PersistentDispatcherSingleActiveConsumer.readMoreEntries()`, a check for `subscription.isDispatchingPaused()` is added at the top of the method, before any cursor read is initiated.
+In `PersistentDispatcherMultipleConsumers.readMoreEntries()` and `PersistentDispatcherSingleActiveConsumer.readMoreEntries()`, a check for `subscription.isPaused()` is added at the top of the method, before any cursor read is initiated.
 
 ### In-flight Messages
 
@@ -124,7 +124,7 @@ Messages already dispatched to consumers before the pause call will still be pro
   {
     "subscriptions": {
       "my-sub": {
-        "dispatchingPaused": true
+        "paused": true
       }
     }
   }
@@ -156,11 +156,11 @@ pulsar-admin topics resume-subscription \
 
 | Name | Description | Labels | Unit |
 |---|---|---|---|
-| `pulsar_subscription_dispatching_paused` | Whether dispatching is paused for this subscription | `tenant`, `namespace`, `topic`, `subscription` | boolean (0/1) |
+| `pulsar_subscription_paused` | Whether dispatching is paused for this subscription | `tenant`, `namespace`, `topic`, `subscription` | boolean (0/1) |
 
 # Monitoring
 
-Operators can set up alerts on `pulsar_subscription_dispatching_paused == 1` to detect subscriptions that have been paused longer than expected (e.g., someone paused during an incident and forgot to resume). The `dispatchingPaused` field in subscription stats can also be checked via the admin API for dashboards.
+Operators can set up alerts on `pulsar_subscription_paused == 1` to detect subscriptions that have been paused longer than expected (e.g., someone paused during an incident and forgot to resume). The `paused` field in subscription stats can also be checked via the admin API for dashboards.
 
 # Security Considerations
 
@@ -179,7 +179,7 @@ No special upgrade steps required. The feature is additive — new API endpoints
 If rolling back to a version without this feature:
 
 1. Resume all paused subscriptions before downgrading.
-2. If a subscription is left paused, the `dispatchingPaused` field will remain in cursor metadata but will be ignored by older brokers (standard protobuf forward compatibility) — dispatching will resume normally.
+2. If a subscription is left paused, the `paused` field will remain in cursor metadata but will be ignored by older brokers (standard protobuf forward compatibility) — dispatching will resume normally.
 
 ## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
 


### PR DESCRIPTION
## Motivation

Pulsar has broker-side controls for rate limiting, delayed delivery, and unacked message blocking — but no simple admin command to say "stop delivering to this subscription right now."

This PIP proposes adding `pause` and `resume` admin API endpoints for subscription dispatching, allowing operators to immediately halt message delivery without disconnecting consumers, losing cursor position, or coordinating across client instances.

## Changes

- Adds `pip/pip-459.md`

## Key Design Points

- Two new REST endpoints: `PUT .../subscription/{subName}/dispatching/pause` and `.../resume`
- Paused state persisted as cursor property (`__paused`), survives broker restarts
- Connected consumers remain attached but receive no new messages
- No protocol changes, no new configuration

See [pip-459.md](pip/pip-459.md) for the full proposal.