### PR TITLE
[improve][offload] Bump hadoop to 3.4.3 and hbase to 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,10 +255,10 @@ flexible messaging model and an intuitive client API.</description>
     <debezium.mysql.version>9.4.0</debezium.mysql.version>
     <jsonwebtoken.version>0.13.0</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
-    <hadoop3.version>3.4.2</hadoop3.version>
+    <hadoop3.version>3.4.3</hadoop3.version>
     <dnsjava3.version>3.6.2</dnsjava3.version>
     <hdfs-offload-version3>${hadoop3.version}</hdfs-offload-version3>
-    <hbase.version>2.6.3-hadoop3</hbase.version>
+    <hbase.version>2.6.4-hadoop3</hbase.version>
     <guava.version>33.4.8-jre</guava.version>
     <prometheus-jmx.version>0.16.1</prometheus-jmx.version>
     <confluent.version>8.1.1</confluent.version>


### PR DESCRIPTION
### Motivation

hadoop dependencies are used in the filesystem offloader. There are some vulnerabilities.
There's a fairly recent release 3.4.3 which might fix some issues.
"switch lz4-java to at.yawk.lz4 version due to CVE" in [3.4.3 release notes](https://hadoop.apache.org/docs/r3.4.3/hadoop-project-dist/hadoop-common/release/3.4.3/RELEASENOTES.3.4.3.html).
"Bump org.bouncycastle:bcpkix-jdk18on from 1.78 to 1.81" in hbase 2.6.4

### Modifications

- upgrade hadoop to 3.4.3
- upgrade hbase to 2.6.4-hadoop3

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->