### PR TITLE
[fix][sec] Upgrade to Netty 4.1.132.Final to address CVEs

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -55,7 +55,7 @@
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <puppycrawl.checkstyle.version>10.14.2</puppycrawl.checkstyle.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-    <netty.version>4.1.131.Final</netty.version>
+    <netty.version>4.1.132.Final</netty.version>
     <guice.version>4.2.3</guice.version>
     <guava.version>33.4.8-jre</guava.version>
     <ant.version>1.10.12</ant.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,26 +293,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.19.0.jar
     - org.apache.commons-commons-text-1.14.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.131.Final.jar
-    - io.netty-netty-codec-4.1.131.Final.jar
-    - io.netty-netty-codec-dns-4.1.131.Final.jar
-    - io.netty-netty-codec-http-4.1.131.Final.jar
-    - io.netty-netty-codec-http2-4.1.131.Final.jar
-    - io.netty-netty-codec-socks-4.1.131.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.131.Final.jar
-    - io.netty-netty-common-4.1.131.Final.jar
-    - io.netty-netty-handler-4.1.131.Final.jar
-    - io.netty-netty-handler-proxy-4.1.131.Final.jar
-    - io.netty-netty-resolver-4.1.131.Final.jar
-    - io.netty-netty-resolver-dns-4.1.131.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.131.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.131.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.131.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.131.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.131.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.131.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.131.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.131.Final.jar
+    - io.netty-netty-buffer-4.1.132.Final.jar
+    - io.netty-netty-codec-4.1.132.Final.jar
+    - io.netty-netty-codec-dns-4.1.132.Final.jar
+    - io.netty-netty-codec-http-4.1.132.Final.jar
+    - io.netty-netty-codec-http2-4.1.132.Final.jar
+    - io.netty-netty-codec-socks-4.1.132.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.132.Final.jar
+    - io.netty-netty-common-4.1.132.Final.jar
+    - io.netty-netty-handler-4.1.132.Final.jar
+    - io.netty-netty-handler-proxy-4.1.132.Final.jar
+    - io.netty-netty-resolver-4.1.132.Final.jar
+    - io.netty-netty-resolver-dns-4.1.132.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.132.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.132.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.132.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.132.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.132.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.132.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.75.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -344,22 +344,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.14.0.jar
     - commons-compress-1.28.0.jar
  * Netty
-    - netty-buffer-4.1.131.Final.jar
-    - netty-codec-4.1.131.Final.jar
-    - netty-codec-dns-4.1.131.Final.jar
-    - netty-codec-http-4.1.131.Final.jar
-    - netty-codec-socks-4.1.131.Final.jar
-    - netty-codec-haproxy-4.1.131.Final.jar
-    - netty-common-4.1.131.Final.jar
-    - netty-handler-4.1.131.Final.jar
-    - netty-handler-proxy-4.1.131.Final.jar
-    - netty-resolver-4.1.131.Final.jar
-    - netty-resolver-dns-4.1.131.Final.jar
-    - netty-transport-4.1.131.Final.jar
-    - netty-transport-classes-epoll-4.1.131.Final.jar
-    - netty-transport-native-epoll-4.1.131.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.131.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.131.Final.jar
+    - netty-buffer-4.1.132.Final.jar
+    - netty-codec-4.1.132.Final.jar
+    - netty-codec-dns-4.1.132.Final.jar
+    - netty-codec-http-4.1.132.Final.jar
+    - netty-codec-socks-4.1.132.Final.jar
+    - netty-codec-haproxy-4.1.132.Final.jar
+    - netty-common-4.1.132.Final.jar
+    - netty-handler-4.1.132.Final.jar
+    - netty-handler-proxy-4.1.132.Final.jar
+    - netty-resolver-4.1.132.Final.jar
+    - netty-resolver-dns-4.1.132.Final.jar
+    - netty-transport-4.1.132.Final.jar
+    - netty-transport-classes-epoll-4.1.132.Final.jar
+    - netty-transport-native-epoll-4.1.132.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.132.Final.jar
     - netty-tcnative-boringssl-static-2.0.75.Final.jar
     - netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar
@@ -370,9 +370,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.131.Final.jar
-    - netty-resolver-dns-native-macos-4.1.131.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.131.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.132.Final.jar
+    - netty-resolver-dns-native-macos-4.1.132.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.8</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.131.Final</netty.version>
+    <netty.version>4.1.132.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>12.1.5</jetty.version>
     <!-- Jetty 9 is used in tiered-storage/file-system tests and pulsar-io/alluxio -->


### PR DESCRIPTION
### Motivation

Netty 4.1.132.Final addresses these CVEs:
- CVE-2026-33871 rated high. This is an HTTP/2 CONTINUATION frame flood Denial of Service vulnerability.
- CVE-2026-33870 rated high. This is an HTTP/1.1 Request Smuggling vulnerability in chunked encoding parsing.
Release notes: https://netty.io/news/2026/03/24/4-1-132-Final.html

### Modifications

- upgrade to Netty 4.1.132.Final

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->