### PR TITLE
[fix][client] Fix thread-safety and refactor MessageCryptoBc key management

### DIFF
--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -324,6 +324,7 @@ The Apache Software License, Version 2.0
      - jackson-datatype-jdk8-2.18.6.jar
      - jackson-datatype-jsr310-2.18.6.jar
      - jackson-module-parameter-names-2.18.6.jar
+ * Caffeine -- caffeine-3.2.3.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson
     - gson-2.13.2.jar

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
@@ -46,8 +46,12 @@ public enum DefaultRoleAnonymizerType {
 
       @Override
       public String anonymize(String role) {
-         byte[] hash = DIGEST.get().digest(role.getBytes());
-         return PREFIX + Base64.getEncoder().encodeToString(hash);
+         try {
+            byte[] hash = DIGEST.get().digest(role.getBytes());
+            return PREFIX + Base64.getEncoder().encodeToString(hash);
+         } catch (Exception e) {
+            throw new RuntimeException("SHA-256 algorithm not found", e);
+         }
       }
    },
    MD5 {
@@ -62,8 +66,12 @@ public enum DefaultRoleAnonymizerType {
 
       @Override
       public String anonymize(String role) {
-         byte[] hash = DIGEST.get().digest(role.getBytes());
-         return PREFIX + Base64.getEncoder().encodeToString(hash);
+         try {
+            byte[] hash = DIGEST.get().digest(role.getBytes());
+            return PREFIX + Base64.getEncoder().encodeToString(hash);
+         } catch (Exception e) {
+            throw new RuntimeException("MD5 algorithm not found", e);
+         }
       }
    };
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
@@ -52,10 +52,10 @@ public enum DefaultRoleAnonymizerType {
    },
    MD5 {
       private static final String PREFIX = "MD5:";
-      // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
       private static final FastThreadLocal<MessageDigest> DIGEST = new FastThreadLocal<MessageDigest>() {
          @Override
          protected MessageDigest initialValue() throws Exception {
+            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
             return MessageDigest.getInstance("MD5");
          }
       };

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/anonymizer/DefaultRoleAnonymizerType.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.common.configuration.anonymizer;
 
+import io.netty.util.concurrent.FastThreadLocal;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 public enum DefaultRoleAnonymizerType {
@@ -37,40 +37,32 @@ public enum DefaultRoleAnonymizerType {
    },
    SHA256 {
       private static final String PREFIX = "SHA-256:";
-      private final MessageDigest digest;
-
-      {
-         // Initializing the MessageDigest once for SHA-256
-         try {
-            digest = MessageDigest.getInstance("SHA-256");
-         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 algorithm not found", e);
+      private static final FastThreadLocal<MessageDigest> DIGEST = new FastThreadLocal<MessageDigest>() {
+         @Override
+         protected MessageDigest initialValue() throws Exception {
+            return MessageDigest.getInstance("SHA-256");
          }
-      }
+      };
 
       @Override
       public String anonymize(String role) {
-         byte[] hash = digest.digest(role.getBytes());
+         byte[] hash = DIGEST.get().digest(role.getBytes());
          return PREFIX + Base64.getEncoder().encodeToString(hash);
       }
    },
    MD5 {
       private static final String PREFIX = "MD5:";
-      private final MessageDigest digest;
-
-      {
-         // Initializing the MessageDigest once for MD5
-         try {
-            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case&
-            digest = MessageDigest.getInstance("MD5");
-         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD5 algorithm not found", e);
+      // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
+      private static final FastThreadLocal<MessageDigest> DIGEST = new FastThreadLocal<MessageDigest>() {
+         @Override
+         protected MessageDigest initialValue() throws Exception {
+            return MessageDigest.getInstance("MD5");
          }
-      }
+      };
 
       @Override
       public String anonymize(String role) {
-         byte[] hash = digest.digest(role.getBytes());
+         byte[] hash = DIGEST.get().digest(role.getBytes());
          return PREFIX + Base64.getEncoder().encodeToString(hash);
       }
    };

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/WssClientSideEncryptUtils.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/WssClientSideEncryptUtils.java
@@ -131,7 +131,7 @@ public class WssClientSideEncryptUtils {
         try {
             PublicKey pubKey = MessageCryptoBc.loadPublicKey(publicKeyData);
             Cipher dataKeyCipher = loadAndInitCipher(pubKey);
-            return dataKeyCipher.doFinal(msgCrypto.getDataKey().getEncoded());
+            return dataKeyCipher.doFinal(msgCrypto.getEncryptionKey().getEncoded());
         } catch (Exception e) {
             log.error("Failed to encrypt data key. {}", e.getMessage());
             throw new PulsarClientException.CryptoException(e.getMessage());

--- a/pulsar-client-messagecrypto-bc/pom.xml
+++ b/pulsar-client-messagecrypto-bc/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>bouncy-castle-bc</artifactId>
       <version>${project.parent.version}</version>

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -34,6 +34,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
@@ -69,8 +70,7 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.ECNamedCurveTable;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPrivateKeySpec;
@@ -83,7 +83,6 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 
 @Slf4j
 public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMetadata> {
-
     public static final String ECDSA = "ECDSA";
     public static final String RSA = "RSA";
     public static final String ECIES = "ECIES";
@@ -95,27 +94,25 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     private static final String AESGCM_PROVIDER_NAME;
 
     private static final int tagLen = 16 * 8;
-    private String logCtx;
+    private final String logCtx;
 
     // Data key which is used to encrypt message
     @Getter
     private volatile SecretKey encryptionKey;
-    private final Cache<SecretKeyCacheKey, SecretKey> decryptionKeyCache;
+    private final Cache<SecretKeyCacheKey, SecretKeySpec> decryptionKeyCache;
     private volatile SecretKey lastUsedDecryptionKey;
 
     // Map of key name and encrypted gcm key, metadata pair which is sent with encrypted message
-    private ConcurrentHashMap<String, EncryptionKeyInfo> encryptedDataKeyMap;
-
+    private final ConcurrentHashMap<String, EncryptionKeyInfo> encryptedDataKeyMap;
 
     private static final SecureRandom secureRandom;
     static {
-        SecureRandom rand = null;
+        SecureRandom rand;
         try {
             rand = SecureRandom.getInstance("NativePRNGNonBlocking");
         } catch (NoSuchAlgorithmException nsa) {
             rand = new SecureRandom();
         }
-
         secureRandom = rand;
 
         // Initial seed
@@ -180,41 +177,52 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     }
 
-    public MessageCryptoBc(String logCtx, boolean keyGenNeeded) throws CryptoException {
+    private static SecretKey generateEncryptionKey() throws CryptoException {
+        return getKeyGenerator().generateKey();
+    }
+
+    public MessageCryptoBc(String logCtx, boolean keyGenNeeded) {
         this.logCtx = logCtx;
         encryptedDataKeyMap = new ConcurrentHashMap<String, EncryptionKeyInfo>();
         decryptionKeyCache = Caffeine.newBuilder()
                 .expireAfterAccess(4, TimeUnit.HOURS)
+                .weigher((SecretKeyCacheKey key, SecretKeySpec value) -> key.encryptedKeyBytes.length
+                        + value.getEncoded().length)
+                .maximumWeight(50 * 1024 * 1024) // 50MB as upperbound
                 .build();
         if (keyGenNeeded) {
             // Generate data key to encrypt messages
-            encryptionKey = getKeyGenerator().generateKey();
+            try {
+                encryptionKey = generateEncryptionKey();
+            } catch (CryptoException e) {
+                // retain same contract as before
+                if (e.getCause() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getCause();
+                } else {
+                    throw new RuntimeException(e.getCause());
+                }
+            }
         }
     }
 
     public static PublicKey loadPublicKey(byte[] keyBytes) throws Exception {
-
         Reader keyReader = new StringReader(new String(keyBytes));
-        PublicKey publicKey = null;
+        PublicKey publicKey;
         try (PEMParser pemReader = new PEMParser(keyReader)) {
             Object pemObj = pemReader.readObject();
             JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
-            SubjectPublicKeyInfo keyInfo = null;
+            SubjectPublicKeyInfo keyInfo;
             X9ECParameters ecParam = null;
 
             if (pemObj instanceof ASN1ObjectIdentifier) {
-
                 // make sure this is EC Parameter we're handling. In which case
                 // we'll store it and read the next object which should be our
                 // EC Public Key
-
                 ASN1ObjectIdentifier ecOID = (ASN1ObjectIdentifier) pemObj;
                 ecParam = ECNamedCurveTable.getByOID(ecOID);
                 if (ecParam == null) {
-                    throw new PEMException("Unable to find EC Parameter for the given curve oid: "
-                            + ((ASN1ObjectIdentifier) pemObj).getId());
+                    throw new PEMException("Unable to find EC Parameter for the given curve oid: " + ecOID.getId());
                 }
-
                 pemObj = pemReader.readObject();
             } else if (pemObj instanceof X9ECParameters) {
                 ecParam = (X9ECParameters) pemObj;
@@ -232,7 +240,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 ECParameterSpec ecSpec = new ECParameterSpec(ecParam.getCurve(), ecParam.getG(), ecParam.getN(),
                         ecParam.getH(), ecParam.getSeed());
                 KeyFactory keyFactory = KeyFactory.getInstance(ECDSA, BouncyCastleProvider.PROVIDER_NAME);
-                ECPublicKeySpec keySpec = new ECPublicKeySpec(((BCECPublicKey) publicKey).getQ(), ecSpec);
+                ECPublicKeySpec keySpec = new ECPublicKeySpec(((ECPublicKey) publicKey).getQ(), ecSpec);
                 publicKey = keyFactory.generatePublic(keySpec);
             }
         } catch (IOException | NoSuchAlgorithmException | NoSuchProviderException | InvalidKeySpecException e) {
@@ -241,8 +249,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         return publicKey;
     }
 
-    private PrivateKey loadPrivateKey(byte[] keyBytes) throws Exception {
-
+    private static PrivateKey loadPrivateKey(byte[] keyBytes) throws Exception {
         Reader keyReader = new StringReader(new String(keyBytes));
         PrivateKey privateKey = null;
         try (PEMParser pemReader = new PEMParser(keyReader)) {
@@ -251,31 +258,24 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             Object pemObj = pemReader.readObject();
 
             if (pemObj instanceof ASN1ObjectIdentifier) {
-
                 // make sure this is EC Parameter we're handling. In which case
                 // we'll store it and read the next object which should be our
                 // EC Private Key
-
                 ASN1ObjectIdentifier ecOID = (ASN1ObjectIdentifier) pemObj;
                 ecParam = ECNamedCurveTable.getByOID(ecOID);
                 if (ecParam == null) {
                     throw new PEMException("Unable to find EC Parameter for the given curve oid: " + ecOID.getId());
                 }
-
                 pemObj = pemReader.readObject();
-
             } else if (pemObj instanceof X9ECParameters) {
-
                 ecParam = (X9ECParameters) pemObj;
                 pemObj = pemReader.readObject();
             }
 
             if (pemObj instanceof PEMKeyPair) {
-
                 PrivateKeyInfo pKeyInfo = ((PEMKeyPair) pemObj).getPrivateKeyInfo();
                 JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
                 privateKey = pemConverter.getPrivateKey(pKeyInfo);
-
             } else if (pemObj instanceof PrivateKeyInfo) {
                 JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
                 privateKey = pemConverter.getPrivateKey((PrivateKeyInfo) pemObj);
@@ -283,12 +283,11 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
             // if our private key is EC type and we have parameters specified
             // then we need to set it accordingly
-
             if (ecParam != null && ECDSA.equals(privateKey.getAlgorithm())) {
                 ECParameterSpec ecSpec = new ECParameterSpec(ecParam.getCurve(), ecParam.getG(), ecParam.getN(),
                         ecParam.getH(), ecParam.getSeed());
                 KeyFactory keyFactory = KeyFactory.getInstance(ECDSA, BouncyCastleProvider.PROVIDER_NAME);
-                ECPrivateKeySpec keySpec = new ECPrivateKeySpec(((BCECPrivateKey) privateKey).getS(), ecSpec);
+                ECPrivateKeySpec keySpec = new ECPrivateKeySpec(((ECPrivateKey) privateKey).getS(), ecSpec);
                 privateKey = keyFactory.generatePrivate(keySpec);
             }
 
@@ -309,11 +308,9 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      *
      */
     @Override
-    public synchronized void addPublicKeyCipher(Set<String> keyNames, CryptoKeyReader keyReader)
-            throws CryptoException {
-
-        // Generate data key
-        encryptionKey = getKeyGenerator().generateKey();
+    public void addPublicKeyCipher(Set<String> keyNames, CryptoKeyReader keyReader) throws CryptoException {
+        // Rotate the encryption key each time this method is called
+        encryptionKey = generateEncryptionKey();
 
         for (String key : keyNames) {
             addPublicKeyCipher(key, keyReader);
@@ -321,7 +318,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     }
 
     private void addPublicKeyCipher(String keyName, CryptoKeyReader keyReader) throws CryptoException {
-
         if (keyName == null || keyReader == null) {
             throw new PulsarClientException.CryptoException("Keyname or KeyReader is null");
         }
@@ -339,9 +335,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             throw new PulsarClientException.CryptoException(msg);
         }
 
-        Cipher dataKeyCipher = null;
+        Cipher dataKeyCipher;
         byte[] encryptedKey;
-
         try {
             AlgorithmParameterSpec params = null;
             // Encrypt data key using public key
@@ -361,7 +356,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 dataKeyCipher.init(Cipher.ENCRYPT_MODE, pubKey);
             }
             encryptedKey = dataKeyCipher.doFinal(encryptionKey.getEncoded());
-
         } catch (IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException
                  | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
             log.error("{} Failed to encrypt data key {}. {}", logCtx, keyName, e.getMessage());
@@ -387,7 +381,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      */
     @Override
     public boolean removeKeyCipher(String keyName) {
-
         if (keyName == null) {
             return false;
         }
@@ -410,7 +403,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     public void encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
                         Supplier<MessageMetadata> messageMetadataBuilderSupplier,
                         ByteBuffer payload, ByteBuffer outBuffer) throws PulsarClientException {
-
         MessageMetadata msgMetadata = messageMetadataBuilderSupplier.get();
 
         if (encKeys.isEmpty()) {
@@ -447,7 +439,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 // We should never reach here.
                 log.error("{} Failed to find encrypted Data key for key {}.", logCtx, keyName);
             }
-
         }
 
         // Create gcm param
@@ -479,9 +470,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     }
 
-    private SecretKey tryDecryptDataKey(String keyName, byte[] encryptedDataKey, List<KeyValue> encKeyMeta,
+    private SecretKeySpec tryDecryptDataKey(String keyName, byte[] encryptedDataKey, List<KeyValue> encKeyMeta,
             CryptoKeyReader keyReader) {
-
         Map<String, String> keyMeta = new HashMap<String, String>();
         encKeyMeta.forEach(kv -> {
             keyMeta.put(kv.getKey(), kv.getValue());
@@ -533,7 +523,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
     private boolean decryptData(SecretKey dataKeySecret, MessageMetadata msgMetadata,
                                 ByteBuffer payload, ByteBuffer targetBuffer) {
-
         // unpack iv and encrypted data
         byte[] iv = msgMetadata.getEncryptionParam();
 
@@ -576,7 +565,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     @Override
     public boolean decrypt(Supplier<MessageMetadata> messageMetadataSupplier,
                         ByteBuffer payload, ByteBuffer outBuffer, CryptoKeyReader keyReader) {
-
         MessageMetadata msgMetadata = messageMetadataSupplier.get();
 
         // Pass 1: Try last used decryption key
@@ -604,7 +592,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         // Pass 3: Decrypt data keys via CryptoKeyReader (slow path)
         for (EncryptionKeys encKey : encKeys) {
-            SecretKey decryptedKey = tryDecryptDataKey(
+            SecretKeySpec decryptedKey = tryDecryptDataKey(
                     encKey.getKey(), encKey.getValue(), encKey.getMetadatasList(), keyReader);
             if (decryptedKey != null) {
                 SecretKeyCacheKey cacheKey = new SecretKeyCacheKey(encKey.getValue());

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -144,10 +144,10 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     };
 
-    // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
     private static final FastThreadLocal<MessageDigest> THREAD_LOCAL_MD5 = new FastThreadLocal<MessageDigest>() {
         @Override
         protected MessageDigest initialValue() throws Exception {
+            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
             return MessageDigest.getInstance("MD5");
         }
     };

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pulsar.client.impl.crypto;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.io.Reader;
@@ -29,7 +28,6 @@ import java.nio.ByteBuffer;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
@@ -38,6 +36,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,8 +99,9 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
     // Data key which is used to encrypt message
     @Getter
-    private SecretKey dataKey;
-    private LoadingCache<ByteBuffer, SecretKey> dataKeyCache;
+    private volatile SecretKey encryptionKey;
+    private final Cache<SecretKeyCacheKey, SecretKey> decryptionKeyCache;
+    private volatile SecretKey lastUsedDecryptionKey;
 
     // Map of key name and encrypted gcm key, metadata pair which is sent with encrypted message
     private ConcurrentHashMap<String, EncryptionKeyInfo> encryptedDataKeyMap;
@@ -144,14 +144,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     };
 
-    private static final FastThreadLocal<MessageDigest> THREAD_LOCAL_MD5 = new FastThreadLocal<MessageDigest>() {
-        @Override
-        protected MessageDigest initialValue() throws Exception {
-            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
-            return MessageDigest.getInstance("MD5");
-        }
-    };
-
     private static final FastThreadLocal<KeyGenerator> THREAD_LOCAL_KEY_GENERATOR =
             new FastThreadLocal<KeyGenerator>() {
         @Override
@@ -171,28 +163,15 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     };
 
     public MessageCryptoBc(String logCtx, boolean keyGenNeeded) {
-
         this.logCtx = logCtx;
         encryptedDataKeyMap = new ConcurrentHashMap<String, EncryptionKeyInfo>();
-        dataKeyCache = CacheBuilder.newBuilder().expireAfterAccess(4, TimeUnit.HOURS)
-                .build(new CacheLoader<ByteBuffer, SecretKey>() {
-
-                    @Override
-                    public SecretKey load(ByteBuffer key) {
-                        return null;
-                    }
-
-                });
-
-        // If keygen is not needed(e.g: consumer), data key will be decrypted from the message
-        if (!keyGenNeeded) {
-            dataKey = null;
-            return;
+        decryptionKeyCache = Caffeine.newBuilder()
+                .expireAfterAccess(4, TimeUnit.HOURS)
+                .build();
+        if (keyGenNeeded) {
+            // Generate data key to encrypt messages
+            encryptionKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
         }
-
-        // Generate data key to encrypt messages
-        dataKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
-
     }
 
     public static PublicKey loadPublicKey(byte[] keyBytes) throws Exception {
@@ -316,7 +295,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             throws CryptoException {
 
         // Generate data key
-        dataKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
+        encryptionKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
 
         for (String key : keyNames) {
             addPublicKeyCipher(key, keyReader);
@@ -363,7 +342,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             } else {
                 dataKeyCipher.init(Cipher.ENCRYPT_MODE, pubKey);
             }
-            encryptedKey = dataKeyCipher.doFinal(dataKey.getEncoded());
+            encryptedKey = dataKeyCipher.doFinal(encryptionKey.getEncoded());
 
         } catch (IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException | NoSuchProviderException
                  | NoSuchPaddingException | InvalidKeyException | InvalidAlgorithmParameterException e) {
@@ -411,8 +390,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      */
     @Override
     public void encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
-                                        Supplier<MessageMetadata> messageMetadataBuilderSupplier,
-                                     ByteBuffer payload, ByteBuffer outBuffer) throws PulsarClientException {
+                        Supplier<MessageMetadata> messageMetadataBuilderSupplier,
+                        ByteBuffer payload, ByteBuffer outBuffer) throws PulsarClientException {
 
         MessageMetadata msgMetadata = messageMetadataBuilderSupplier.get();
 
@@ -465,7 +444,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         try {
             // Encrypt the data
             Cipher cipher = THREAD_LOCAL_CIPHER.get();
-            cipher.init(Cipher.ENCRYPT_MODE, dataKey, gcmParam);
+            cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, gcmParam);
 
             int maxLength = cipher.getOutputSize(payload.remaining());
             if (outBuffer.remaining() < maxLength) {
@@ -482,7 +461,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     }
 
-    private boolean decryptDataKey(String keyName, byte[] encryptedDataKey, List<KeyValue> encKeyMeta,
+    private SecretKey tryDecryptDataKey(String keyName, byte[] encryptedDataKey, List<KeyValue> encKeyMeta,
             CryptoKeyReader keyReader) {
 
         Map<String, String> keyMeta = new HashMap<String, String>();
@@ -499,20 +478,17 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             privateKey = loadPrivateKey(keyInfo.getKey());
             if (privateKey == null) {
                 log.error("{} Failed to load private key {}.", logCtx, keyName);
-                return false;
+                return null;
             }
         } catch (Exception e) {
             log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
-            return false;
+            return null;
         }
 
         // Decrypt data key to decrypt messages
-        Cipher dataKeyCipher = null;
-        byte[] dataKeyValue = null;
-        byte[] keyDigest = null;
-
         try {
             AlgorithmParameterSpec params = null;
+            Cipher dataKeyCipher;
             // Decrypt data key using private key
             if (RSA.equals(privateKey.getAlgorithm())) {
                 dataKeyCipher = Cipher.getInstance(RSA_TRANS, BouncyCastleProvider.PROVIDER_NAME);
@@ -521,24 +497,20 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 params = createIESParameterSpec();
             } else {
                 log.error("Unsupported key type {} for key {}.", privateKey.getAlgorithm(), keyName);
-                return false;
+                return null;
             }
             if (params != null) {
                 dataKeyCipher.init(Cipher.DECRYPT_MODE, privateKey, params);
             } else {
                 dataKeyCipher.init(Cipher.DECRYPT_MODE, privateKey);
             }
-            dataKeyValue = dataKeyCipher.doFinal(encryptedDataKey);
-
-            keyDigest = THREAD_LOCAL_MD5.get().digest(encryptedDataKey);
+            byte[] dataKeyValue = dataKeyCipher.doFinal(encryptedDataKey);
+            return new SecretKeySpec(dataKeyValue, "AES");
 
         } catch (Exception e) {
             log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
-            return false;
+            return null;
         }
-        dataKey = new SecretKeySpec(dataKeyValue, "AES");
-        dataKeyCache.put(ByteBuffer.wrap(keyDigest), dataKey);
-        return true;
     }
 
     private boolean decryptData(SecretKey dataKeySecret, MessageMetadata msgMetadata,
@@ -572,34 +544,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         return inputLen + Math.max(inputLen, 512);
     }
 
-    private boolean getKeyAndDecryptData(MessageMetadata msgMetadata, ByteBuffer payload, ByteBuffer targetBuffer) {
-        List<EncryptionKeys> encKeys = msgMetadata.getEncryptionKeysList();
-
-        // Go through all keys to retrieve data key from cache
-        for (int i = 0; i < encKeys.size(); i++) {
-
-            byte[] msgDataKey = encKeys.get(i).getValue();
-            byte[] keyDigest = THREAD_LOCAL_MD5.get().digest(msgDataKey);
-            SecretKey storedSecretKey = dataKeyCache.getIfPresent(ByteBuffer.wrap(keyDigest));
-            if (storedSecretKey != null) {
-
-                // Taking a small performance hit here if the hash collides. When it
-                // returns a different key, decryption fails. At this point, we would
-                // call decryptDataKey to refresh the cache and come here again to decrypt.
-                if (decryptData(storedSecretKey, msgMetadata, payload, targetBuffer)) {
-                    // If decryption succeeded, we can already return
-                    return true;
-                }
-            } else {
-                // First time, entry won't be present in cache
-                log.debug("{} Failed to decrypt data or data key is not in cache. Will attempt to refresh", logCtx);
-            }
-
-        }
-
-        return false;
-    }
-
     /*
      * Decrypt the payload using the data key. Keys used to encrypt data key can be retrieved from msgMetadata
      *
@@ -616,29 +560,70 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                         ByteBuffer payload, ByteBuffer outBuffer, CryptoKeyReader keyReader) {
 
         MessageMetadata msgMetadata = messageMetadataSupplier.get();
-        // If dataKey is present, attempt to decrypt using the existing key
-        if (dataKey != null) {
-            if (getKeyAndDecryptData(msgMetadata, payload, outBuffer)) {
+
+        // Pass 1: Try last used decryption key
+        SecretKey localLastUsedDecryptionKey = lastUsedDecryptionKey;
+        if (localLastUsedDecryptionKey != null) {
+            if (decryptData(localLastUsedDecryptionKey, msgMetadata, payload, outBuffer)) {
                 return true;
+            } else {
+                lastUsedDecryptionKey = null;
             }
         }
 
-        // dataKey is null or decryption failed. Attempt to regenerate data key
         List<EncryptionKeys> encKeys = msgMetadata.getEncryptionKeysList();
-        EncryptionKeys encKeyInfo = encKeys.stream().filter(kbv -> {
-
-            byte[] encDataKey = kbv.getValue();
-            List<KeyValue> encKeyMeta = kbv.getMetadatasList();
-            return decryptDataKey(kbv.getKey(), encDataKey, encKeyMeta, keyReader);
-
-        }).findFirst().orElse(null);
-
-        if (encKeyInfo == null || dataKey == null) {
-            // Unable to decrypt data key
-            return false;
+        // Pass 2: Try cached keys (fast path — no CryptoKeyReader calls)
+        for (EncryptionKeys encKey : encKeys) {
+            SecretKeyCacheKey cacheKey = new SecretKeyCacheKey(encKey.getValue());
+            SecretKey cachedKey = decryptionKeyCache.getIfPresent(cacheKey);
+            if (cachedKey != null) {
+                if (decryptData(cachedKey, msgMetadata, payload, outBuffer)) {
+                    lastUsedDecryptionKey = cachedKey;
+                    return true;
+                }
+            }
         }
 
-        return getKeyAndDecryptData(msgMetadata, payload, outBuffer);
+        // Pass 3: Decrypt data keys via CryptoKeyReader (slow path)
+        for (EncryptionKeys encKey : encKeys) {
+            SecretKey decryptedKey = tryDecryptDataKey(
+                    encKey.getKey(), encKey.getValue(), encKey.getMetadatasList(), keyReader);
+            if (decryptedKey != null) {
+                SecretKeyCacheKey cacheKey = new SecretKeyCacheKey(encKey.getValue());
+                decryptionKeyCache.put(cacheKey, decryptedKey);
+                if (decryptData(decryptedKey, msgMetadata, payload, outBuffer)) {
+                    return true;
+                }
+            }
+        }
 
+        return false;
+    }
+
+    // key to be used in the cache
+    private static final class SecretKeyCacheKey {
+        private final byte[] encryptedKeyBytes;
+        private final int hashCode;
+
+        SecretKeyCacheKey(byte[] encryptedKeyBytes) {
+            this.encryptedKeyBytes = encryptedKeyBytes.clone();
+            this.hashCode = Arrays.hashCode(this.encryptedKeyBytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SecretKeyCacheKey)) {
+                return false;
+            }
+            return Arrays.equals(encryptedKeyBytes, ((SecretKeyCacheKey) o).encryptedKeyBytes);
+        }
     }
 }

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -96,7 +96,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     private static final String AESGCM_PROVIDER_NAME;
 
     private static final int tagLen = 16 * 8;
-    private byte[] iv = new byte[IV_LEN];
     private String logCtx;
 
     // Data key which is used to encrypt message
@@ -193,8 +192,6 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         // Generate data key to encrypt messages
         dataKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
-
-        iv = new byte[IV_LEN];
 
     }
 
@@ -413,7 +410,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
      * @return encryptedData if success
      */
     @Override
-    public synchronized void encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
+    public void encrypt(Set<String> encKeys, CryptoKeyReader keyReader,
                                         Supplier<MessageMetadata> messageMetadataBuilderSupplier,
                                      ByteBuffer payload, ByteBuffer outBuffer) throws PulsarClientException {
 
@@ -458,6 +455,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         // Create gcm param
         // TODO: Replace random with counter and periodic refreshing based on timer/counter value
+        byte[] iv = new byte[IV_LEN];
         secureRandom.nextBytes(iv);
         GCMParameterSpec gcmParam = new GCMParameterSpec(tagLen, iv);
 
@@ -547,7 +545,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                                 ByteBuffer payload, ByteBuffer targetBuffer) {
 
         // unpack iv and encrypted data
-        iv =  msgMetadata.getEncryptionParam();
+        byte[] iv = msgMetadata.getEncryptionParam();
 
         GCMParameterSpec gcmParams = new GCMParameterSpec(tagLen, iv);
         try {

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -162,7 +162,25 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     };
 
-    public MessageCryptoBc(String logCtx, boolean keyGenNeeded) {
+    private static Cipher getAesGcmCipher() throws CryptoException {
+        try {
+            return THREAD_LOCAL_CIPHER.get();
+        } catch (Exception e) {
+            log.error("Failed to get AES-GCM cipher instance. {}", e.getMessage());
+            throw new PulsarClientException.CryptoException(e.getMessage());
+        }
+    }
+
+    private static KeyGenerator getKeyGenerator() throws CryptoException {
+        try {
+            return THREAD_LOCAL_KEY_GENERATOR.get();
+        } catch (Exception e) {
+            log.error("Failed to get AES key generator instance. {}", e.getMessage());
+            throw new PulsarClientException.CryptoException(e.getMessage());
+        }
+    }
+
+    public MessageCryptoBc(String logCtx, boolean keyGenNeeded) throws CryptoException {
         this.logCtx = logCtx;
         encryptedDataKeyMap = new ConcurrentHashMap<String, EncryptionKeyInfo>();
         decryptionKeyCache = Caffeine.newBuilder()
@@ -170,7 +188,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 .build();
         if (keyGenNeeded) {
             // Generate data key to encrypt messages
-            encryptionKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
+            encryptionKey = getKeyGenerator().generateKey();
         }
     }
 
@@ -295,7 +313,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             throws CryptoException {
 
         // Generate data key
-        encryptionKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
+        encryptionKey = getKeyGenerator().generateKey();
 
         for (String key : keyNames) {
             addPublicKeyCipher(key, keyReader);
@@ -443,7 +461,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         try {
             // Encrypt the data
-            Cipher cipher = THREAD_LOCAL_CIPHER.get();
+            Cipher cipher = getAesGcmCipher();
             cipher.init(Cipher.ENCRYPT_MODE, encryptionKey, gcmParam);
 
             int maxLength = cipher.getOutputSize(payload.remaining());
@@ -521,7 +539,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         GCMParameterSpec gcmParams = new GCMParameterSpec(tagLen, iv);
         try {
-            Cipher cipher = THREAD_LOCAL_CIPHER.get();
+            Cipher cipher = getAesGcmCipher();
             cipher.init(Cipher.DECRYPT_MODE, dataKeySecret, gcmParams);
 
             int maxLength = cipher.getOutputSize(payload.remaining());

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.crypto;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -94,11 +95,8 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     public static final String AESGCM = "AES/GCM/NoPadding";
     private static final String AESGCM_PROVIDER_NAME;
 
-    private static KeyGenerator keyGenerator;
     private static final int tagLen = 16 * 8;
     private byte[] iv = new byte[IV_LEN];
-    private Cipher cipher;
-    MessageDigest digest;
     private String logCtx;
 
     // Data key which is used to encrypt message
@@ -139,6 +137,40 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         }
     }
 
+    // Thread-local instances for non-thread-safe JCA classes
+    private static final FastThreadLocal<Cipher> THREAD_LOCAL_CIPHER = new FastThreadLocal<Cipher>() {
+        @Override
+        protected Cipher initialValue() throws Exception {
+            return Cipher.getInstance(AESGCM, AESGCM_PROVIDER_NAME);
+        }
+    };
+
+    // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
+    private static final FastThreadLocal<MessageDigest> THREAD_LOCAL_MD5 = new FastThreadLocal<MessageDigest>() {
+        @Override
+        protected MessageDigest initialValue() throws Exception {
+            return MessageDigest.getInstance("MD5");
+        }
+    };
+
+    private static final FastThreadLocal<KeyGenerator> THREAD_LOCAL_KEY_GENERATOR =
+            new FastThreadLocal<KeyGenerator>() {
+        @Override
+        protected KeyGenerator initialValue() throws Exception {
+            KeyGenerator kg = KeyGenerator.getInstance("AES");
+            int aesKeyLength = Cipher.getMaxAllowedKeyLength("AES");
+            if (aesKeyLength <= 128) {
+                log.warn("AES Cryptographic strength is limited to {} bits. "
+                        + "Consider installing JCE Unlimited Strength Jurisdiction Policy Files.",
+                        aesKeyLength);
+                kg.init(aesKeyLength, secureRandom);
+            } else {
+                kg.init(256, secureRandom);
+            }
+            return kg;
+        }
+    };
+
     public MessageCryptoBc(String logCtx, boolean keyGenNeeded) {
 
         this.logCtx = logCtx;
@@ -153,37 +185,14 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
                 });
 
-        try {
-
-            cipher = Cipher.getInstance(AESGCM, AESGCM_PROVIDER_NAME);
-            // If keygen is not needed(e.g: consumer), data key will be decrypted from the message
-            if (!keyGenNeeded) {
-                // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
-                digest = MessageDigest.getInstance("MD5");
-
-                dataKey = null;
-                return;
-            }
-            keyGenerator = KeyGenerator.getInstance("AES");
-            int aesKeyLength = Cipher.getMaxAllowedKeyLength("AES");
-            if (aesKeyLength <= 128) {
-                log.warn("{} AES Cryptographic strength is limited to {} bits. "
-                        + "Consider installing JCE Unlimited Strength Jurisdiction Policy Files.",
-                        logCtx, aesKeyLength);
-                keyGenerator.init(aesKeyLength, secureRandom);
-            } else {
-                keyGenerator.init(256, secureRandom);
-            }
-
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException e) {
-
-            cipher = null;
-            log.error("{} MessageCrypto initialization Failed {}", logCtx, e.getMessage());
-
+        // If keygen is not needed(e.g: consumer), data key will be decrypted from the message
+        if (!keyGenNeeded) {
+            dataKey = null;
+            return;
         }
 
         // Generate data key to encrypt messages
-        dataKey = keyGenerator.generateKey();
+        dataKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
 
         iv = new byte[IV_LEN];
 
@@ -310,7 +319,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             throws CryptoException {
 
         // Generate data key
-        dataKey = keyGenerator.generateKey();
+        dataKey = THREAD_LOCAL_KEY_GENERATOR.get().generateKey();
 
         for (String key : keyNames) {
             addPublicKeyCipher(key, keyReader);
@@ -457,6 +466,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         try {
             // Encrypt the data
+            Cipher cipher = THREAD_LOCAL_CIPHER.get();
             cipher.init(Cipher.ENCRYPT_MODE, dataKey, gcmParam);
 
             int maxLength = cipher.getOutputSize(payload.remaining());
@@ -522,7 +532,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             }
             dataKeyValue = dataKeyCipher.doFinal(encryptedDataKey);
 
-            keyDigest = digest.digest(encryptedDataKey);
+            keyDigest = THREAD_LOCAL_MD5.get().digest(encryptedDataKey);
 
         } catch (Exception e) {
             log.error("{} Failed to decrypt data key {} to decrypt messages {}", logCtx, keyName, e.getMessage());
@@ -541,6 +551,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         GCMParameterSpec gcmParams = new GCMParameterSpec(tagLen, iv);
         try {
+            Cipher cipher = THREAD_LOCAL_CIPHER.get();
             cipher.init(Cipher.DECRYPT_MODE, dataKeySecret, gcmParams);
 
             int maxLength = cipher.getOutputSize(payload.remaining());
@@ -570,7 +581,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
         for (int i = 0; i < encKeys.size(); i++) {
 
             byte[] msgDataKey = encKeys.get(i).getValue();
-            byte[] keyDigest = digest.digest(msgDataKey);
+            byte[] keyDigest = THREAD_LOCAL_MD5.get().digest(msgDataKey);
             SecretKey storedSecretKey = dataKeyCache.getIfPresent(ByteBuffer.wrap(keyDigest));
             if (storedSecretKey != null) {
 

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -592,6 +592,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 SecretKeyCacheKey cacheKey = new SecretKeyCacheKey(encKey.getValue());
                 decryptionKeyCache.put(cacheKey, decryptedKey);
                 if (decryptData(decryptedKey, msgMetadata, payload, outBuffer)) {
+                    lastUsedDecryptionKey = decryptedKey;
                     return true;
                 }
             }

--- a/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
+++ b/pulsar-client-messagecrypto-bc/src/main/java/org/apache/pulsar/client/impl/crypto/MessageCryptoBc.java
@@ -100,7 +100,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     @Getter
     private volatile SecretKey encryptionKey;
     private final Cache<SecretKeyCacheKey, SecretKeySpec> decryptionKeyCache;
-    private volatile SecretKey lastUsedDecryptionKey;
+    private final Cache<String, SecretKey> lastDecryptionKeyCache;
 
     // Map of key name and encrypted gcm key, metadata pair which is sent with encrypted message
     private final ConcurrentHashMap<String, EncryptionKeyInfo> encryptedDataKeyMap;
@@ -188,7 +188,12 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 .expireAfterAccess(4, TimeUnit.HOURS)
                 .weigher((SecretKeyCacheKey key, SecretKeySpec value) -> key.encryptedKeyBytes.length
                         + value.getEncoded().length)
-                .maximumWeight(50 * 1024 * 1024) // 50MB as upperbound
+                .maximumWeight(10 * 1024 * 1024) // 10MB upperbound
+                .build();
+        lastDecryptionKeyCache = Caffeine.newBuilder()
+                .expireAfterAccess(4, TimeUnit.HOURS)
+                .maximumWeight(10 * 1024 * 1024) // 10MB upperbound
+                .weigher((String key, SecretKey value) -> key.length() + value.getEncoded().length)
                 .build();
         if (keyGenNeeded) {
             // Generate data key to encrypt messages
@@ -528,9 +533,12 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
 
         GCMParameterSpec gcmParams = new GCMParameterSpec(tagLen, iv);
         try {
+            // mark the buffers to allow resetting them in case of decryption failure
+            payload.mark();
+            targetBuffer.mark();
+
             Cipher cipher = getAesGcmCipher();
             cipher.init(Cipher.DECRYPT_MODE, dataKeySecret, gcmParams);
-
             int maxLength = cipher.getOutputSize(payload.remaining());
             if (targetBuffer.remaining() < maxLength) {
                 throw new IllegalArgumentException("Target buffer size is too small");
@@ -539,8 +547,11 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             targetBuffer.flip();
             targetBuffer.limit(decryptedSize);
             return true;
-
         } catch (Exception e) {
+            // reset the buffers so that decryption can be retried with the same buffers
+            payload.reset();
+            targetBuffer.reset();
+
             log.error("{} Failed to decrypt message {}", logCtx, e.getMessage());
             return false;
         }
@@ -566,14 +577,15 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
     public boolean decrypt(Supplier<MessageMetadata> messageMetadataSupplier,
                         ByteBuffer payload, ByteBuffer outBuffer, CryptoKeyReader keyReader) {
         MessageMetadata msgMetadata = messageMetadataSupplier.get();
+        String producerName = msgMetadata.hasProducerName() ? msgMetadata.getProducerName() : "__not_set__";
 
-        // Pass 1: Try last used decryption key
-        SecretKey localLastUsedDecryptionKey = lastUsedDecryptionKey;
-        if (localLastUsedDecryptionKey != null) {
-            if (decryptData(localLastUsedDecryptionKey, msgMetadata, payload, outBuffer)) {
+        // Pass 1: Try last used decryption key for this producer
+        SecretKey lastKey = lastDecryptionKeyCache.getIfPresent(producerName);
+        if (lastKey != null) {
+            if (decryptData(lastKey, msgMetadata, payload, outBuffer)) {
                 return true;
             } else {
-                lastUsedDecryptionKey = null;
+                lastDecryptionKeyCache.invalidate(producerName);
             }
         }
 
@@ -584,7 +596,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
             SecretKey cachedKey = decryptionKeyCache.getIfPresent(cacheKey);
             if (cachedKey != null) {
                 if (decryptData(cachedKey, msgMetadata, payload, outBuffer)) {
-                    lastUsedDecryptionKey = cachedKey;
+                    lastDecryptionKeyCache.put(producerName, cachedKey);
                     return true;
                 }
             }
@@ -598,7 +610,7 @@ public class MessageCryptoBc implements MessageCrypto<MessageMetadata, MessageMe
                 SecretKeyCacheKey cacheKey = new SecretKeyCacheKey(encKey.getValue());
                 decryptionKeyCache.put(cacheKey, decryptedKey);
                 if (decryptData(decryptedKey, msgMetadata, payload, outBuffer)) {
-                    lastUsedDecryptionKey = decryptedKey;
+                    lastDecryptionKeyCache.put(producerName, decryptedKey);
                     return true;
                 }
             }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -52,7 +52,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
@@ -83,10 +82,7 @@ public class SecurityUtility {
     public static final String BC_NON_FIPS_PROVIDER_CLASS = "org.bouncycastle.jce.provider.BouncyCastleProvider";
     public static final String CONSCRYPT_PROVIDER_CLASS = "org.conscrypt.OpenSSLProvider";
     public static final Provider CONSCRYPT_PROVIDER = loadConscryptProvider();
-    private static final List<KeyFactory> KEY_FACTORIES = Arrays.asList(
-            createKeyFactory("RSA"),
-            createKeyFactory("EC")
-    );
+    private static final List<String> KEY_FACTORY_ALGORITHMS = List.of("RSA", "EC");
 
     // Security.getProvider("BC") / Security.getProvider("BCFIPS").
     // also used to get Factories. e.g. CertificateFactory.getInstance("X.509", "BCFIPS")
@@ -521,12 +517,12 @@ public class SecurityUtility {
                 sb.append(currentLine);
             }
             final KeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(sb.toString()));
-            final List<String> failedAlgorithm = new ArrayList<>(KEY_FACTORIES.size());
-            for (KeyFactory kf : KEY_FACTORIES) {
+            final List<String> failedAlgorithm = new ArrayList<>(KEY_FACTORY_ALGORITHMS.size());
+            for (String algorithm : KEY_FACTORY_ALGORITHMS) {
                 try {
-                    return kf.generatePrivate(keySpec);
-                } catch (InvalidKeySpecException ex) {
-                    failedAlgorithm.add(kf.getAlgorithm());
+                    return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException ex) {
+                    failedAlgorithm.add(algorithm);
                 }
             }
             throw new KeyManagementException("The private key algorithm is not supported. attempted: "
@@ -596,11 +592,4 @@ public class SecurityUtility {
         return provider;
     }
 
-    private static KeyFactory createKeyFactory(String algorithm) {
-        try {
-            return KeyFactory.getInstance(algorithm);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(String.format("Illegal key factory algorithm " + algorithm), e);
-        }
-    }
 }


### PR DESCRIPTION
### Motivation

Java Cryptography Architecture (JCA) classes like `Cipher`, `MessageDigest`, `KeyGenerator`, `CertificateFactory`, etc. are **not thread-safe** per [Oracle's Java PKI Programmer's Guide](https://docs.oracle.com/en/java/javase/21/security/java-pki-programmers-guide.html). Sharing instances across threads without synchronization can cause corrupted output, `BadPaddingException`, or silently wrong cryptographic results.

This was confirmed by Netty's [PR #16350](https://github.com/netty/netty/pull/16350) for `CertificateFactory`, and is well-documented for `MessageDigest` ([pmd/pmd#1862](https://github.com/pmd/pmd/issues/1862)), `Cipher` ([ekino/hibernate-crypto-types#14](https://github.com/ekino/hibernate-crypto-types/issues/14)), and `KeyGenerator`.

A review of the Pulsar codebase identified the following thread-safety issues:

**MessageCryptoBc (HIGH):**
- `Cipher cipher` instance field — `encrypt()` is `synchronized` but `decrypt()`/`decryptData()` are not, so the shared Cipher can be used concurrently from different threads
- `MessageDigest digest` instance field — used in `decryptDataKey()` and `getKeyAndDecryptData()` without any synchronization
- `static KeyGenerator keyGenerator` — shared across ALL instances, written from constructors on different threads with only per-instance synchronization
- `byte[] iv` instance field — written and read in both `encrypt()` and `decryptData()` without synchronization, causing a race between IV generation and use

**DefaultRoleAnonymizerType (MEDIUM-HIGH):**
- `MessageDigest digest` fields in `SHA256` and `MD5` enum singletons — `anonymize()` called concurrently without synchronization; `MessageDigest.digest()` resets internal state, so concurrent use produces corrupted hashes

**SecurityUtility (LOW):**
- `static List<KeyFactory> KEY_FACTORIES` — cached instances shared across threads. While likely safe in practice for standard JDK implementations, the API contract doesn't guarantee thread-safety.

### Modifications

**Thread-safety fixes:**
- **MessageCryptoBc:** Replaced shared `Cipher`, `MessageDigest`, and `KeyGenerator` fields with `FastThreadLocal`-cached instances behind utility methods (`getAesGcmCipher()`, `getKeyGenerator()`) that provide proper error handling matching the original behavior.
- **MessageCryptoBc:** Made `iv` byte array a local variable in both `encrypt()` and `decryptData()`, fixing a race condition and allowing removal of `synchronized` from `encrypt()`.
- **DefaultRoleAnonymizerType:** Replaced `MessageDigest` instance fields in enum singletons with `FastThreadLocal`-cached instances, with error handling matching the original `RuntimeException` behavior.
- **SecurityUtility:** Removed cached static `KeyFactory` instances; new instances created per call in `loadPrivateKeyFromPemStream()` (not a hot path).

**MessageCryptoBc key management refactoring:**
- Replaced Guava `LoadingCache` (whose loader returned null) with Caffeine `Cache` for decryption key caching.
- Replaced MD5-of-encrypted-key-bytes cache key hack with a proper `SecretKeyCacheKey` inner class using `Arrays.hashCode`/`equals` — all MD5 usage eliminated.
- Separated encryption/decryption key management: renamed `dataKey` to `encryptionKey` (producer-side only), `dataKeyCache` to `decryptionKeyCache` (consumer-side only).
- Refactored `decryptDataKey()` to `tryDecryptDataKey()` returning `SecretKey` with no side-effects; removed `getKeyAndDecryptData()`.
- Replaced single volatile `lastUsedDecryptionKey` with a producer-name-keyed Caffeine cache (`lastDecryptionKeyCache`), providing stable fast-path decryption per producer.
- Added `mark()`/`reset()` on ByteBuffers in `decryptData()` so retry with a different key gets the original buffer positions.
- Both caches use 10MB weight limits as a guardrail against high memory usage on client JVMs.
- Updated `WssClientSideEncryptUtils` test to use renamed `getEncryptionKey()`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:
- `MessageCryptoBc` unit tests in `pulsar-client-messagecrypto-bc`
- `DefaultRoleAnonymizerType` tests in `pulsar-broker-common`
- `SecurityUtility` tests in `pulsar-common`
- End-to-end encryption integration tests like `SimpleProducerConsumerTest#testCryptoWithChunking`

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->