### PR TITLE
[improve][offload] Upgrade Hadoop from 3.4.3 to 3.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,7 +167,7 @@ lz4java = "1.10.3"
 spring = "6.2.12"
 kubernetesclient = "23.0.0"
 aws-sdk = "1.12.788"
-hadoop3 = "3.4.3"
+hadoop3 = "3.5.0"
 jclouds = "2.6.0"
 # Shading
 shadow = "9.4.1"


### PR DESCRIPTION
Fixes #25401

### Motivation

Upgrade Hadoop from 3.4.3 to 3.5.0 to pick up latest enhancements and bug fixes. This is the first Hadoop release with full support for Java 17.

### Modifications

Modify root libs.versions.toml to change Hadoop version from 3.4.3 to 3.5.0.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as existing tiered storage tests.

### Does this pull request potentially affect one of the following parts:

- [X] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [X] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/cnauroth/pulsar/pull/1
