### PR TITLE
[cleanup][build] Update bin/ scripts from Maven to Gradle for dev classpath

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -99,10 +99,10 @@ if [ $? == 0 ]; then
 fi
 
 # exclude tests jar
-BUILT_JAR=`ls $BK_HOME/target/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1`
+BUILT_JAR=`ls $BK_HOME/build/libs/bookkeeper-server-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? != 0 ] && [ ! -e "$BOOKIE_JAR" ]; then
     echo "\nCouldn't find bookkeeper jar.";
-    echo "Make sure you've run 'mvn package'\n";
+    echo "Make sure you've run './gradlew assemble'\n";
     exit 1;
 elif [ -e "$BUILT_JAR" ]; then
     BOOKIE_JAR=$BUILT_JAR
@@ -134,21 +134,13 @@ These variable can also be set in conf/bkenv.sh
 EOF
 }
 
-add_maven_deps_to_classpath() {
-    MVN="mvn"
-    if [ "$MAVEN_HOME" != "" ]; then
-	MVN=${MAVEN_HOME}/bin/mvn
-    fi
-
-    # Need to generate classpath from maven pom. This is costly so generate it
-    # and cache it. Save the file into our target dir so a mvn clean will get
-    # clean it up and force us create a new one.
-    f="${BK_HOME}/distribution/server/target/classpath.txt"
+add_gradle_deps_to_classpath() {
+    f="${BK_HOME}/distribution/server/build/classpath.txt"
     if [ ! -f "${f}" ]
     then
     (
       cd "${BK_HOME}"
-      ${MVN} -pl distribution/server generate-sources &> /dev/null
+      ./gradlew :distribution:pulsar-server-distribution:exportClasspath --no-configuration-cache -q 2> /dev/null
     )
     fi
     BOOKIE_CLASSPATH=${CLASSPATH}:`cat "${f}"`
@@ -159,7 +151,7 @@ if [ -d "$BK_HOME/lib" ]; then
 	BOOKIE_CLASSPATH=$BOOKIE_CLASSPATH:$i
     done
 else
-    add_maven_deps_to_classpath
+    add_gradle_deps_to_classpath
 fi
 
 # if no args specified, show usage

--- a/bin/function-localrunner
+++ b/bin/function-localrunner
@@ -80,21 +80,13 @@ if [ -z "$PULSAR_LOG_CONF" ]; then
     PULSAR_LOG_CONF=$DEFAULT_LOG_CONF
 fi
 
-add_maven_deps_to_classpath() {
-    MVN="mvn"
-    if [ "$MAVEN_HOME" != "" ]; then
-	    MVN=${MAVEN_HOME}/bin/mvn
-    fi
-
-    # Need to generate classpath from maven pom. This is costly so generate it
-    # and cache it. Save the file into our target dir so a mvn clean will get
-    # clean it up and force us create a new one.
-    f="${PULSAR_HOME}/distribution/server/target/classpath.txt"
+add_gradle_deps_to_classpath() {
+    f="${PULSAR_HOME}/distribution/server/build/classpath.txt"
     if [ ! -f "${f}" ]
     then
     (
       cd "${PULSAR_HOME}"
-      ${MVN} -pl distribution/server generate-sources &> /dev/null
+      ./gradlew :distribution:pulsar-server-distribution:exportClasspath --no-configuration-cache -q 2> /dev/null
     )
     fi
     PULSAR_CLASSPATH=${CLASSPATH}:`cat "${f}"`
@@ -103,7 +95,7 @@ add_maven_deps_to_classpath() {
 if [ -d "$PULSAR_HOME/lib" ]; then
     PULSAR_CLASSPATH="$PULSAR_CLASSPATH:$PULSAR_HOME/lib/*"
 else
-    add_maven_deps_to_classpath
+    add_gradle_deps_to_classpath
 fi
 
 PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
@@ -174,12 +166,12 @@ PY_INSTANCE_FILE=${PULSAR_PY_INSTANCE_FILE:-"${DEFAULT_PY_INSTANCE_FILE}"}
 # find the java instance location
 if [ ! -f "${JAVA_INSTANCE_JAR}" ]; then
     # didn't find a released jar, then search the built jar
-    BUILT_JAVA_INSTANCE_JAR="${FUNCTIONS_HOME}/runtime-all/target/java-instance.jar"
+    BUILT_JAVA_INSTANCE_JAR="${FUNCTIONS_HOME}/runtime-all/build/libs/java-instance.jar"
     if [ -f "${BUILT_JAVA_INSTANCE_JAR}" ]; then
         JAVA_INSTANCE_JAR=${BUILT_JAVA_INSTANCE_JAR}
     else
         echo "\nCouldn't find pulsar java instance jar.";
-        echo "Make sure you've run 'mvn package'\n";
+        echo "Make sure you've run './gradlew assemble'\n";
         exit 1;
     fi
 fi
@@ -187,12 +179,12 @@ fi
 # find the python instance location
 if [ ! -f "${PY_INSTANCE_FILE}" ]; then
     # didn't find a released python instance, then search the built python instance
-    BUILT_PY_INSTANCE_FILE="${FUNCTIONS_HOME}/instance/target/python-instance/python_instance_main.py"
+    BUILT_PY_INSTANCE_FILE="${FUNCTIONS_HOME}/instance/build/python-instance/python_instance_main.py"
     if [ -f "${BUILT_PY_INSTANCE_FILE}" ]; then
         PY_INSTANCE_FILE=${BUILT_PY_INSTANCE_FILE}
     else
         echo "\nCouldn't find pulsar python instance.";
-        echo "Make sure you've run 'mvn package'\n";
+        echo "Make sure you've run './gradlew assemble'\n";
         exit 1;
     fi
 fi

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -159,10 +159,10 @@ if [ $? == 0 ]; then
 fi
 
 # exclude tests jar
-BUILT_JAR=`ls $PULSAR_HOME/pulsar-broker/target/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1`
+BUILT_JAR=`ls $PULSAR_HOME/pulsar-broker/build/libs/pulsar-broker-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? != 0 ] && [ ! -e "$PULSAR_JAR" ]; then
     echo "\nCouldn't find pulsar jar.";
-    echo "Make sure you've run 'mvn package'\n";
+    echo "Make sure you've run './gradlew assemble'\n";
     exit 1;
 elif [ -e "$BUILT_JAR" ]; then
     PULSAR_JAR=$BUILT_JAR
@@ -175,10 +175,10 @@ fi
 # find the java instance location
 if [ ! -f "${JAVA_INSTANCE_JAR}" ]; then
     # didn't find a released jar, then search the built jar
-    BUILT_JAVA_INSTANCE_JAR="${FUNCTIONS_HOME}/runtime-all/target/java-instance.jar"
+    BUILT_JAVA_INSTANCE_JAR="${FUNCTIONS_HOME}/runtime-all/build/libs/java-instance.jar"
     if [ -z "${BUILT_JAVA_INSTANCE_JAR}" ]; then
         echo "\nCouldn't find pulsar-functions java instance jar.";
-        echo "Make sure you've run 'mvn package'\n";
+        echo "Make sure you've run './gradlew assemble'\n";
         exit 1;
     fi
     JAVA_INSTANCE_JAR=${BUILT_JAVA_INSTANCE_JAR}
@@ -187,30 +187,23 @@ fi
 # find the python instance location
 if [ ! -f "${PY_INSTANCE_FILE}" ]; then
     # didn't find a released python instance, then search the built python instance
-    BUILT_PY_INSTANCE_FILE="${FUNCTIONS_HOME}/instance/target/python-instance/python_instance_main.py"
+    BUILT_PY_INSTANCE_FILE="${FUNCTIONS_HOME}/instance/build/python-instance/python_instance_main.py"
     if [ -z "${BUILT_PY_INSTANCE_FILE}" ]; then
         echo "\nCouldn't find pulsar-functions python instance.";
-        echo "Make sure you've run 'mvn package'\n";
+        echo "Make sure you've run './gradlew assemble'\n";
         exit 1;
     fi
     PY_INSTANCE_FILE=${BUILT_PY_INSTANCE_FILE}
 fi
 
-add_maven_deps_to_classpath() {
-    MVN="mvn"
-    if [ "$MAVEN_HOME" != "" ]; then
-	    MVN=${MAVEN_HOME}/bin/mvn
-    fi
-
-    # Need to generate classpath from maven pom. This is costly so generate it
-    # and cache it. Save the file into our target dir so a mvn clean will get
-    # clean it up and force us create a new one.
-    f="${PULSAR_HOME}/distribution/server/target/classpath.txt"
+add_gradle_deps_to_classpath() {
+    # Generate classpath from Gradle. Cache it for subsequent runs.
+    f="${PULSAR_HOME}/distribution/server/build/classpath.txt"
     if [ ! -f "${f}" ]
     then
     (
       cd "${PULSAR_HOME}"
-      ${MVN} -pl distribution/server generate-sources &> /dev/null
+      ./gradlew :distribution:pulsar-server-distribution:exportClasspath --no-configuration-cache -q 2> /dev/null
     )
     fi
     PULSAR_CLASSPATH=${CLASSPATH}:`cat "${f}"`
@@ -219,7 +212,7 @@ add_maven_deps_to_classpath() {
 if [ -d "$PULSAR_HOME/lib" ]; then
 	  PULSAR_CLASSPATH=$PULSAR_CLASSPATH:$PULSAR_HOME/lib/*
 else
-    add_maven_deps_to_classpath
+    add_gradle_deps_to_classpath
 fi
 
 if [ -z "$PULSAR_WORKER_CONF" ]; then

--- a/bin/pulsar-admin-common.sh
+++ b/bin/pulsar-admin-common.sh
@@ -59,30 +59,22 @@ if [ $? == 0 ]; then
 fi
 
 # exclude tests jar
-BUILT_JAR=`ls $PULSAR_HOME/pulsar-client-tools/target/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1`
+BUILT_JAR=`ls $PULSAR_HOME/pulsar-client-tools/build/libs/pulsar-client-tools-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? != 0 ] && [ ! -e "$PULSAR_JAR" ]; then
     echo "\nCouldn't find pulsar jar.";
-    echo "Make sure you've run 'mvn package'\n";
+    echo "Make sure you've run './gradlew assemble'\n";
     exit 1;
 elif [ -e "$BUILT_JAR" ]; then
     PULSAR_JAR=$BUILT_JAR
 fi
 
-add_maven_deps_to_classpath() {
-    MVN="mvn"
-    if [ "$MAVEN_HOME" != "" ]; then
-      MVN=${MAVEN_HOME}/bin/mvn
-    fi
-
-    # Need to generate classpath from maven pom. This is costly so generate it
-    # and cache it. Save the file into our target dir so a mvn clean will get
-    # clean it up and force us create a new one.
-    f="${PULSAR_HOME}/distribution/shell/target/classpath.txt"
+add_gradle_deps_to_classpath() {
+    f="${PULSAR_HOME}/distribution/shell/build/classpath.txt"
     if [ ! -f "${f}" ]
     then
     (
       cd "${PULSAR_HOME}"
-      ${MVN} -pl distribution/shell generate-sources &> /dev/null
+      ./gradlew :distribution:pulsar-shell-distribution:exportClasspath --no-configuration-cache -q 2> /dev/null
     )
     fi
     PULSAR_CLASSPATH=${CLASSPATH}:`cat "${f}"`
@@ -91,7 +83,7 @@ add_maven_deps_to_classpath() {
 if [ -d "$PULSAR_HOME/lib" ]; then
     PULSAR_CLASSPATH="$PULSAR_CLASSPATH:$PULSAR_HOME/lib/*"
 else
-    add_maven_deps_to_classpath
+    add_gradle_deps_to_classpath
 fi
 
 if [ -z "$PULSAR_CLIENT_CONF" ]; then

--- a/bin/pulsar-perf
+++ b/bin/pulsar-perf
@@ -56,30 +56,22 @@ if [ $? == 0 ]; then
 fi
 
 # exclude tests jar
-BUILT_JAR=`ls $PULSAR_HOME/pulsar-testclient/target/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1`
+BUILT_JAR=`ls $PULSAR_HOME/pulsar-testclient/build/libs/pulsar-testclient-*.jar 2> /dev/null | grep -v tests | tail -1`
 if [ $? != 0 ] && [ ! -e "$PULSAR_JAR" ]; then
     echo "\nCouldn't find pulsar jar.";
-    echo "Make sure you've run 'mvn package'\n";
+    echo "Make sure you've run './gradlew assemble'\n";
     exit 1;
 elif [ -e "$BUILT_JAR" ]; then
     PULSAR_JAR=$BUILT_JAR
 fi
 
-add_maven_deps_to_classpath() {
-    MVN="mvn"
-    if [ "$MAVEN_HOME" != "" ]; then
-	MVN=${MAVEN_HOME}/bin/mvn
-    fi
-
-    # Need to generate classpath from maven pom. This is costly so generate it
-    # and cache it. Save the file into our target dir so a mvn clean will get
-    # clean it up and force us create a new one.
-    f="${PULSAR_HOME}/distribution/server/target/classpath.txt"
+add_gradle_deps_to_classpath() {
+    f="${PULSAR_HOME}/distribution/server/build/classpath.txt"
     if [ ! -f "${f}" ]
     then
     (
       cd "${PULSAR_HOME}"
-      ${MVN} -pl distribution/server generate-sources &> /dev/null
+      ./gradlew :distribution:pulsar-server-distribution:exportClasspath --no-configuration-cache -q 2> /dev/null
     )
     fi
     PULSAR_CLASSPATH=${CLASSPATH}:`cat "${f}"`
@@ -88,7 +80,7 @@ add_maven_deps_to_classpath() {
 if [ -d "$PULSAR_HOME/lib" ]; then
 	PULSAR_CLASSPATH="$PULSAR_CLASSPATH:$PULSAR_HOME/lib/*"
 else
-    add_maven_deps_to_classpath
+    add_gradle_deps_to_classpath
 fi
 
 if [ -z "$PULSAR_PERFTEST_CONF" ]; then

--- a/distribution/server/build.gradle.kts
+++ b/distribution/server/build.gradle.kts
@@ -318,3 +318,16 @@ val serverDistTar by tasks.registering(Tar::class) {
 tasks.named("assemble") {
     dependsOn(serverDistTar)
 }
+
+// Export the runtime classpath to a file for bin/ scripts to use
+// when running Pulsar from a development build (without lib/ directory)
+val exportClasspath by tasks.registering {
+    val outputFile = layout.buildDirectory.file("classpath.txt")
+    outputs.file(outputFile)
+    doLast {
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(distLib.asPath)
+        }
+    }
+}

--- a/distribution/shell/build.gradle.kts
+++ b/distribution/shell/build.gradle.kts
@@ -207,3 +207,16 @@ val shellDistZip by tasks.registering(Zip::class) {
 tasks.named("assemble") {
     dependsOn(shellDistTar, shellDistZip)
 }
+
+// Export the runtime classpath to a file for bin/ scripts to use
+// when running Pulsar CLI tools from a development build
+val exportClasspath by tasks.registering {
+    val outputFile = layout.buildDirectory.file("classpath.txt")
+    outputs.file(outputFile)
+    doLast {
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(distLib.asPath)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Replace `add_maven_deps_to_classpath()` with `add_gradle_deps_to_classpath()` in all bin/ scripts. The new function runs a Gradle `exportClasspath` task that writes the resolved classpath to a file, pointing directly to jars in the Gradle cache without copying.

Updated scripts:
- `bin/pulsar`
- `bin/pulsar-admin-common.sh`
- `bin/pulsar-perf`
- `bin/bookkeeper`
- `bin/function-localrunner`

Also adds `exportClasspath` tasks to server and shell distribution modules, and updates `target/` paths to `build/libs/` for built jar lookups.

This enables running `./gradlew assemble && bin/pulsar standalone` from a development build without needing the `lib/` directory.

Follow-up to #25398 (PIP-463: Migrate build system from Maven to Gradle)

## Test plan
- `./gradlew assemble && bin/pulsar standalone` starts successfully


------ 

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->