### PR TITLE
[improve][build] Show test failure exceptions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -156,6 +156,13 @@ subprojects {
             val excludedTestGroups = providers.gradleProperty("excludedTestGroups").getOrElse("quarantine,flaky")
             excludeGroups(*(excludedTestGroups.split(",").map { it.trim() }.toTypedArray()))
         }
+        testLogging {
+            events("FAILED")
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.SHORT
+            showStackTraces = true
+            showExceptions = true
+            showCauses = true
+        }
         maxHeapSize = "1300m"
         maxParallelForks = 4
         systemProperty("testRetryCount", System.getProperty("testRetryCount", "1"))


### PR DESCRIPTION
### Motivation

When Gradle tests fail, the console output does not include the exception details by default. This makes it harder to diagnose test failures without digging into the HTML/XML test reports, especially in CI environments where quick feedback is important.

### Modifications

Added a `testLogging` block to the `tasks.withType<Test>` configuration in the root `build.gradle.kts` that applies to all Java subprojects:
- Enabled `FAILED` test events so that failures are reported to the console
- Set `exceptionFormat` to `SHORT` for compact exception output
- Enabled `showStackTraces`, `showExceptions`, and `showCauses` to include the full failure context

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This can be verified by running any test that fails and confirming that the exception details now appear in the console output.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`