### PR TITLE
[improve][ci] Upgrade official GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -42,7 +42,7 @@ jobs:
       docs_only: ${{ steps.check_changes.outputs.docs_only }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect changed files
         id: changes
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
         id: go

--- a/.github/workflows/ci-gradle-cache-update.yaml
+++ b/.github/workflows/ci-gradle-cache-update.yaml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -66,7 +66,7 @@ jobs:
               - 'gradle.properties'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         if: ${{ github.event_name == 'schedule' || steps.changes.outputs.build_files == 'true' }}
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -53,13 +53,13 @@ jobs:
 
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: 17
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,4 +26,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v6

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Cancel scheduled jobs in forks by default
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'schedule' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.actions.cancelWorkflowRun({owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId});
@@ -116,7 +116,7 @@ jobs:
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect changed files
         if: ${{ github.event_name == 'pull_request' }}
@@ -179,7 +179,7 @@ jobs:
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -197,7 +197,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -241,7 +241,7 @@ jobs:
         run: $GITHUB_WORKSPACE/pulsar-build/pulsar_ci_tool.sh report_netty_leaks
 
       - name: Upload test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
         with:
           name: Unit-BROKER_FLAKY-test-reports
@@ -251,7 +251,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload possible heap dump, core dump or crash files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: Unit-BROKER_FLAKY-dumps

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - name: Cancel scheduled jobs in forks by default
         if: ${{ github.repository != 'apache/pulsar' && github.event_name == 'schedule' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.actions.cancelWorkflowRun({owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId});
@@ -109,7 +109,7 @@ jobs:
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect changed files
         if: ${{ github.event_name == 'pull_request' }}
@@ -156,7 +156,7 @@ jobs:
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -170,7 +170,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -202,7 +202,7 @@ jobs:
             | tar cf /tmp/gradle-build-outputs.tar --files-from=-
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gradle-build-outputs
           path: /tmp/gradle-build-outputs.tar
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -287,7 +287,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ matrix.jdk || env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ matrix.jdk || env.CI_JDK_MAJOR_VERSION }}
@@ -300,7 +300,7 @@ jobs:
           add-job-summary: always
 
       - name: Restore build outputs from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gradle-build-outputs
 
@@ -344,7 +344,7 @@ jobs:
         run: $GITHUB_WORKSPACE/pulsar-build/pulsar_ci_tool.sh report_netty_leaks
 
       - name: Upload test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() || env.TRACE_TEST_RESOURCE_CLEANUP != 'off' }}
         with:
           name: Unit-${{ matrix.group }}-test-reports
@@ -354,7 +354,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload possible heap dump, core dump or crash files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: Unit-${{ matrix.group }}-dumps
@@ -387,13 +387,13 @@ jobs:
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -419,7 +419,7 @@ jobs:
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -432,7 +432,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -445,7 +445,7 @@ jobs:
           add-job-summary: always
 
       - name: Restore build outputs from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gradle-build-outputs
 
@@ -460,7 +460,7 @@ jobs:
           docker save apachepulsar/java-test-image:latest | gzip > /tmp/java-test-image.tar.gz
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: java-test-image
           path: /tmp/java-test-image.tar.gz
@@ -536,7 +536,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -549,7 +549,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -562,7 +562,7 @@ jobs:
           add-job-summary: always
 
       - name: Restore build outputs from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gradle-build-outputs
 
@@ -570,7 +570,7 @@ jobs:
         run: tar xf gradle-build-outputs.tar
 
       - name: Download docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: java-test-image
           path: /tmp
@@ -584,7 +584,7 @@ jobs:
           ${{ matrix.setup }}
 
       - name: Set up runtime JDK ${{ matrix.runtime_jdk }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         if: ${{ matrix.runtime_jdk }}
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
@@ -610,7 +610,7 @@ jobs:
           annotate_only: 'true'
 
       - name: Upload test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() }}
         with:
           name: Integration-${{ matrix.upload_name || matrix.group }}-test-reports
@@ -620,7 +620,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload possible heap dump, core dump or crash files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: Integration-${{ matrix.upload_name || matrix.group }}-dumps
@@ -632,7 +632,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload container logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() }}
         continue-on-error: true
         with:
@@ -658,7 +658,7 @@ jobs:
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -671,7 +671,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -684,7 +684,7 @@ jobs:
           add-job-summary: always
 
       - name: Restore build outputs from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gradle-build-outputs
 
@@ -724,7 +724,7 @@ jobs:
           docker save apachepulsar/pulsar-test-latest-version:latest | gzip > /tmp/pulsar-test-latest-version.tar.gz
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pulsar-test-latest-version-image
           path: /tmp/pulsar-test-latest-version.tar.gz
@@ -776,7 +776,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -789,7 +789,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
@@ -802,7 +802,7 @@ jobs:
           add-job-summary: always
 
       - name: Restore build outputs from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gradle-build-outputs
 
@@ -810,7 +810,7 @@ jobs:
         run: tar xf gradle-build-outputs.tar
 
       - name: Download docker image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pulsar-test-latest-version-image
           path: /tmp
@@ -838,7 +838,7 @@ jobs:
           annotate_only: 'true'
 
       - name: Upload test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() }}
         with:
           name: System-${{ matrix.group }}-test-reports
@@ -848,7 +848,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload possible heap dump, core dump or crash files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: System-${{ matrix.group }}-dumps
@@ -860,7 +860,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload container logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !success() }}
         continue-on-error: true
         with:
@@ -891,7 +891,7 @@ jobs:
       CODEQL_LANGUAGE: java-kotlin
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
@@ -905,7 +905,7 @@ jobs:
           limit-access-to-actor: true
 
       - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}


### PR DESCRIPTION
### Motivation

All official GitHub Actions (`actions/*`) used in CI workflows were on older major versions. Upgrading to the latest major versions ensures:
- **Node.js 24 runtime support** — all updated actions now run on Node.js 24 (requires runner ≥ v2.327.1, which GitHub-hosted runners already satisfy)
- Access to latest bug fixes, security patches, and features

### Modifications

Upgraded all `actions/*` GitHub Actions in `.github/workflows/` to their latest major version tags:

| Action | Before | After | Key Changes |
|--------|--------|-------|-------------|
| `actions/checkout` | v4 | **v6** | Node 24 runtime; credentials persisted to separate file |
| `actions/setup-java` | v4 | **v5** | Node 24 runtime |
| `actions/upload-artifact` | v4 | **v7** | Node 24; ESM module; new `archive` param for direct uploads |
| `actions/download-artifact` | v4 | **v8** | Node 24; ESM; hash digest mismatch now errors by default |
| `actions/github-script` | v6, v7 | **v8** | Node 24 runtime |
| `actions/labeler` | v5 | **v6** | Node 24 runtime |
| `actions/setup-go` | v5 | **v6** | Node 24 runtime; improved toolchain handling |

**Files changed:** `ci-go-functions.yaml`, `ci-gradle-cache-update.yaml`, `codeql.yaml`, `labeler.yml`, `pulsar-ci-flaky.yaml`, `pulsar-ci.yaml`

**Note on `actions/download-artifact` v8:** Hash digest mismatches now error by default (previously warned). If this causes issues, the `digest-mismatch: warn` parameter can restore the old behavior.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing CI workflow runs — all workflows will exercise the upgraded actions.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`