### PR TITLE
[improve][build] Fix compile warnings in production code

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/FailFastNotifier.java
@@ -93,6 +93,8 @@ public class FailFastNotifier
     }
 
     static class FailFastSkipException extends SkipException {
+        private static final long serialVersionUID = 1L;
+
         FailFastSkipException(String skipMessage) {
             super(skipMessage);
             reduceStackTrace();

--- a/jetty-upgrade/zookeeper-prometheus-metrics/src/main/java/org/apache/pulsar/metrics/prometheus/zookeeper/PrometheusMetricsProvider.java
+++ b/jetty-upgrade/zookeeper-prometheus-metrics/src/main/java/org/apache/pulsar/metrics/prometheus/zookeeper/PrometheusMetricsProvider.java
@@ -558,6 +558,7 @@ public class PrometheusMetricsProvider implements MetricsProvider {
     }
 
     class MetricsServletImpl extends MetricsServlet {
+        private static final long serialVersionUID = 1L;
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/jetty-upgrade/zookeeper-with-patched-admin/src/main/java/org/apache/zookeeper/server/admin/Commands.java
+++ b/jetty-upgrade/zookeeper-with-patched-admin/src/main/java/org/apache/zookeeper/server/admin/Commands.java
@@ -668,7 +668,7 @@ public class Commands {
                 return response;
             }
 
-            if (!zkServer.isSerializeLastProcessedZxidEnabled()) {
+            if (!ZooKeeperServer.isSerializeLastProcessedZxidEnabled()) {
                 response.setStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 LOG.warn("Restore command requires serializeLastProcessedZxidEnable flag is set to true");
                 return response;
@@ -790,7 +790,7 @@ public class Commands {
                 return response;
             }
 
-            if (!zkServer.isSerializeLastProcessedZxidEnabled()) {
+            if (!ZooKeeperServer.isSerializeLastProcessedZxidEnabled()) {
                 response.setStatusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 LOG.warn("Snapshot command requires serializeLastProcessedZxidEnable flag is set to true");
                 return response;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2234,6 +2234,8 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     private final class MarkDeletingMarkedPosition extends IllegalArgumentException {
+        private static final long serialVersionUID = 1L;
+
         public MarkDeletingMarkedPosition(String s) {
             super(s);
         }
@@ -3125,7 +3127,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         log.warn("[{}] [{}] Since the ledger [{}] is lost and the autoSkipNonRecoverableData is true, this ledger will"
                 + " be auto acknowledge in subscription", ledger.getName(), name, ledgerId);
         asyncDelete(() -> LongStream.range(0, ledgerInfo.getEntries())
-                        .mapToObj(i -> (Position) PositionFactory.create(ledgerId, i)).iterator(),
+                        .mapToObj(i -> PositionFactory.create(ledgerId, i)).iterator(),
                 new AsyncCallbacks.DeleteCallback() {
                     @Override
                     public void deleteComplete(Object ctx) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -3507,7 +3507,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 case Code.NoSuchLedgerExistsException:
                 case Code.NoSuchLedgerExistsOnMetadataServerException:
                     log.warn("[{}] Ledger {} not found when deleting it", name, ls.getLedgerId());
-                    // Continue anyway
+                    // falls through
 
                 case BKException.Code.OK:
                     if (ledgersToDelete.decrementAndGet() == 0) {
@@ -3766,6 +3766,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     };
 
     static class OffloadConflict extends ManagedLedgerException {
+        private static final long serialVersionUID = 1L;
+
         OffloadConflict(String msg) {
             super(msg);
         }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/packages/management/core/common/PackageMetadata.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/packages/management/core/common/PackageMetadata.java
@@ -37,6 +37,8 @@ import lombok.Setter;
 @Setter
 @Getter
 public class PackageMetadata implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     String description;
     String contact;
     long createTime;

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/packages/management/core/exceptions/PackagesManagementException.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/packages/management/core/exceptions/PackagesManagementException.java
@@ -22,6 +22,8 @@ package org.apache.pulsar.packages.management.core.exceptions;
  * Packages management related exceptions.
  */
 public class PackagesManagementException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     /**
      * Constructs an {@code PackagesManagementException} with the specified cause.
      *
@@ -56,6 +58,8 @@ public class PackagesManagementException extends Exception {
 
 
     public static class NotFoundException extends PackagesManagementException {
+        private static final long serialVersionUID = 1L;
+
         /**
          * Constructs an {@code NotFoundException} with the specified cause.
          *
@@ -90,6 +94,8 @@ public class PackagesManagementException extends Exception {
     }
 
     public static class MetadataFormatException extends PackagesManagementException {
+        private static final long serialVersionUID = 1L;
+
         /**
          * Constructs an {@code MetadataFormatException} with the specified detail message.
          *

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/NamespaceBundleStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/NamespaceBundleStats.java
@@ -27,6 +27,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class NamespaceBundleStats implements Comparable<NamespaceBundleStats>, Serializable {
+    private static final long serialVersionUID = 1L;
 
     public double msgRateIn;
     public double msgThroughputIn;

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DummyCryptoKeyReaderImpl.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/DummyCryptoKeyReaderImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * An empty implement. Doesn't provide any public key or private key, and just returns `null`.
  */
 public class DummyCryptoKeyReaderImpl implements CryptoKeyReader {
+    private static final long serialVersionUID = 1L;
 
     public static final DummyCryptoKeyReaderImpl INSTANCE = new DummyCryptoKeyReaderImpl();
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/KeySharedPolicy.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public abstract class KeySharedPolicy implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     protected KeySharedMode keySharedMode;
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SchemaSerializationException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/SchemaSerializationException.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public class SchemaSerializationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs an {@code SchemaSerializationException} with the specified detail message.

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionBufferClientException.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class TransactionBufferClientException extends IOException {
+    private static final long serialVersionUID = 1L;
 
     public TransactionBufferClientException(Throwable t) {
         super(t);
@@ -42,6 +43,7 @@ public class TransactionBufferClientException extends IOException {
      * Thrown when operation timeout.
      */
     public static class RequestTimeoutException extends TransactionBufferClientException {
+        private static final long serialVersionUID = 1L;
 
         public RequestTimeoutException() {
             super("Transaction buffer request timeout.");
@@ -56,6 +58,7 @@ public class TransactionBufferClientException extends IOException {
      * Thrown when transaction buffer op over max pending numbers.
      */
     public static class ReachMaxPendingOpsException extends TransactionBufferClientException {
+        private static final long serialVersionUID = 1L;
 
         public ReachMaxPendingOpsException() {
             super("Transaction buffer op reach max pending numbers.");

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/transaction/TransactionCoordinatorClientException.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class TransactionCoordinatorClientException extends IOException {
+    private static final long serialVersionUID = 1L;
 
     public TransactionCoordinatorClientException(Throwable t) {
         super(t);
@@ -43,6 +44,7 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when transaction coordinator with unexpected state.
      */
     public static class CoordinatorClientStateException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
 
         public CoordinatorClientStateException() {
             super("Unexpected state for transaction metadata client.");
@@ -57,6 +59,8 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when transaction coordinator not found in broker side.
      */
     public static class CoordinatorNotFoundException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
+
         public CoordinatorNotFoundException(String message) {
             super(message);
         }
@@ -66,6 +70,8 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when transaction switch to a invalid status.
      */
     public static class InvalidTxnStatusException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
+
         public InvalidTxnStatusException(String message) {
             super(message);
         }
@@ -80,6 +86,8 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when transaction not found in transaction coordinator.
      */
     public static class TransactionNotFoundException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
+
         public TransactionNotFoundException(String message) {
             super(message);
         }
@@ -89,6 +97,7 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when transaction meta store handler not exists.
      */
     public static class MetaStoreHandlerNotExistsException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
 
         public MetaStoreHandlerNotExistsException(long tcId) {
             super("Transaction meta store handler for transaction meta store {} not exists.");
@@ -103,6 +112,8 @@ public class TransactionCoordinatorClientException extends IOException {
      * Thrown when send request to transaction meta store but the transaction meta store handler not ready.
      */
     public static class MetaStoreHandlerNotReadyException extends TransactionCoordinatorClientException {
+        private static final long serialVersionUID = 1L;
+
         public MetaStoreHandlerNotReadyException(long tcId) {
             super("Transaction meta store handler for transaction meta store {} not ready now.");
         }

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -229,7 +229,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
                         privateKey, keyId);
                 ztsClient = new ZTSClient(ztsUrl, ztsProxyUrl, tenantDomain, tenantService, siaProvider);
             }
-            ztsClient.setPrefetchAutoEnable(this.autoPrefetchEnabled);
+            ZTSClient.setPrefetchAutoEnable(this.autoPrefetchEnabled);
         }
         return ztsClient;
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CliCommand.java
@@ -142,6 +142,8 @@ public abstract class CliCommand implements Callable<Integer> {
     abstract void run() throws Exception;
 
     protected class ParameterException extends CommandLine.ParameterException {
+        private static final long serialVersionUID = 1L;
+
         public ParameterException(String msg) {
             super(commandSpec.commandLine(), msg);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -109,6 +109,8 @@ public abstract class CmdBase {
     }
 
     protected class ParameterException extends CommandLine.ParameterException {
+        private static final long serialVersionUID = 1L;
+
         public ParameterException(String msg) {
             super(commander, msg);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/shell/PulsarShell.java
@@ -312,6 +312,7 @@ public class PulsarShell {
     }
 
     private static class InterruptShellException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     private static class CommandsInfo {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -561,7 +561,7 @@ public class MessageImpl<T> implements TraceableMessage, Message<T> {
         byte[] schemaVersion = getSchemaVersion();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             org.apache.pulsar.common.schema.KeyValue keyValue =
-                    (org.apache.pulsar.common.schema.KeyValue) kvSchema.decode(getKeyBytes(), getData(), schemaVersion);
+                    kvSchema.decode(getKeyBytes(), getData(), schemaVersion);
             if (schema instanceof AutoConsumeSchema) {
                 return (T) AutoConsumeSchema.wrapPrimitiveObject(keyValue,
                         ((AutoConsumeSchema) schema).getSchemaInfo(schemaVersion).getType(), schemaVersion);
@@ -591,7 +591,7 @@ public class MessageImpl<T> implements TraceableMessage, Message<T> {
         KeyValueSchemaImpl kvSchema = getKeyValueSchema();
         if (kvSchema.getKeyValueEncodingType() == KeyValueEncodingType.SEPARATED) {
             org.apache.pulsar.common.schema.KeyValue keyValue =
-                    (org.apache.pulsar.common.schema.KeyValue) kvSchema.decode(getKeyBytes(), getData(), null);
+                    kvSchema.decode(getKeyBytes(), getData(), null);
             if (schema instanceof AutoConsumeSchema) {
                 return (T) AutoConsumeSchema.wrapPrimitiveObject(keyValue,
                         ((AutoConsumeSchema) schema).getSchemaInfo(getSchemaVersion()).getType(), null);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -326,7 +326,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         }
 
         AtomicReference<Throwable> closeFail = new AtomicReference<Throwable>();
-        AtomicInteger completed = new AtomicInteger((int) producers.size());
+        AtomicInteger completed = new AtomicInteger(producers.size());
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
         for (Producer<T> producer : producers.values()) {
             if (producer != null) {
@@ -436,7 +436,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                                     // error happened, remove
                                     log.warn("[{}] fail create producers for extended partitions. old: {}, new: {}",
                                             topic, oldPartitionNumber, currentPartitionNumber);
-                                    IntStream.range(oldPartitionNumber, (int) producers.size())
+                                    IntStream.range(oldPartitionNumber, producers.size())
                                             .forEach(i -> producers.remove(i).closeAsync());
                                     future.completeExceptionally(ex);
                                     return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.api.TraceableMessageId;
 
 public class TopicMessageIdImpl implements MessageIdAdv, TopicMessageId, TraceableMessageId {
+    private static final long serialVersionUID = 1L;
 
     private final String ownerTopic;
     private final MessageIdAdv msgId;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/TopicConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/TopicConsumerConfigurationData.java
@@ -62,6 +62,8 @@ public class TopicConsumerConfigurationData implements Serializable {
 
         @RequiredArgsConstructor
         class TopicsPattern implements TopicNameMatcher {
+            private static final long serialVersionUID = 1L;
+
             @NonNull
             private final Pattern topicsPattern;
 
@@ -73,6 +75,8 @@ public class TopicConsumerConfigurationData implements Serializable {
 
         @RequiredArgsConstructor
         class TopicName implements TopicNameMatcher {
+            private static final long serialVersionUID = 1L;
+
             @NonNull
             private final String topicName;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecZstd.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecZstd.java
@@ -56,7 +56,7 @@ public class CompressionCodecZstd implements CompressionCodec {
     @Override
     public ByteBuf encode(ByteBuf source) {
         int uncompressedLength = source.readableBytes();
-        int maxLength = (int) ZSTD_COMPRESSOR.maxCompressedLength(uncompressedLength);
+        int maxLength = ZSTD_COMPRESSOR.maxCompressedLength(uncompressedLength);
 
         ByteBuf target = PulsarByteBufAllocator.DEFAULT.buffer(maxLength, maxLength);
         int compressedLength;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/InterceptException.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/intercept/InterceptException.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  */
 @Getter
 public class InterceptException extends Exception {
+    private static final long serialVersionUID = 1L;
 
     private final int errorCode;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
@@ -33,15 +33,12 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -147,13 +144,7 @@ public class NarClassLoader extends URLClassLoader {
                                                 String narExtractionDirectory)
         throws IOException {
         File unpacked = NarUnpacker.unpackNar(narPath, getNarExtractionDirectory(narExtractionDirectory));
-        return AccessController.doPrivileged(new PrivilegedAction<NarClassLoader>() {
-            @SneakyThrows
-            @Override
-            public NarClassLoader run() {
-                return new NarClassLoader(unpacked, additionalJars, parent);
-            }
-        });
+        return new NarClassLoader(unpacked, additionalJars, parent);
     }
 
     public static List<File> getClasspathFromArchive(File narPath, String narExtractionDirectory) throws IOException {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfig.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/EnsemblePlacementPolicyConfig.java
@@ -91,6 +91,8 @@ public class EnsemblePlacementPolicyConfig {
     }
 
     public static class ParseEnsemblePlacementPolicyConfigException extends Exception {
+        private static final long serialVersionUID = 1L;
+
         ParseEnsemblePlacementPolicyConfigException(String message, Throwable throwable) {
             super(message, throwable);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/semaphore/AsyncSemaphore.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/semaphore/AsyncSemaphore.java
@@ -79,6 +79,8 @@ public interface AsyncSemaphore {
      * Abstract base class for all exceptions thrown by acquire or update.
      */
     abstract class PermitAcquireException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
         public PermitAcquireException(String message) {
             super(message);
         }
@@ -88,6 +90,8 @@ public interface AsyncSemaphore {
      * Exception thrown when permit acquisition times out.
      */
     class PermitAcquireTimeoutException extends PermitAcquireException {
+        private static final long serialVersionUID = 1L;
+
         public PermitAcquireTimeoutException(String message) {
             super(message);
         }
@@ -97,6 +101,8 @@ public interface AsyncSemaphore {
      * Exception thrown when permit acquisition queue is full.
      */
     class PermitAcquireQueueFullException extends PermitAcquireException {
+        private static final long serialVersionUID = 1L;
+
         public PermitAcquireQueueFullException(String message) {
             super(message);
         }
@@ -106,6 +112,8 @@ public interface AsyncSemaphore {
      * Exception thrown when permit acquisition is attempted on a closed semaphore.
      */
     class PermitAcquireAlreadyClosedException extends PermitAcquireException {
+        private static final long serialVersionUID = 1L;
+
         public PermitAcquireAlreadyClosedException(String message) {
             super(message);
         }
@@ -115,6 +123,8 @@ public interface AsyncSemaphore {
      * Exception thrown when permit acquisition is cancelled.
      */
     class PermitAcquireCancelledException extends PermitAcquireException {
+        private static final long serialVersionUID = 1L;
+
         public PermitAcquireCancelledException(String message) {
             super(message);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ClassLoaderUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ClassLoaderUtils.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -42,8 +40,7 @@ public class ClassLoaderUtils {
      */
     public static ClassLoader loadJar(File jar) throws MalformedURLException {
         java.net.URL url = jar.toURI().toURL();
-        return AccessController.doPrivileged(
-            (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(new URL[]{url}));
+        return new URLClassLoader(new URL[]{url});
     }
 
     public static ClassLoader extractClassLoader(File packageFile) throws Exception {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparator.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparator.java
@@ -27,6 +27,8 @@ import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage.Resource
 /**
  */
 public class NamespaceBundleStatsComparator implements Comparator<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+
     Map<String, NamespaceBundleStats> map;
     ResourceType resType;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ProtectedObjectMapper.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ProtectedObjectMapper.java
@@ -67,6 +67,7 @@ import java.util.TimeZone;
  * those classes are immutable.
  */
 final class ProtectedObjectMapper extends ObjectMapper {
+    private static final long serialVersionUID = 1L;
 
     private final ObjectMapper src;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -325,7 +325,7 @@ public class SecurityUtility {
         PrivateKey privateKey = loadPrivateKeyFromPemFile(keyFilePath);
 
         SslContextBuilder builder =
-                SslContextBuilder.forServer(privateKey, (X509Certificate[]) certificates).sslProvider(sslProvider);
+                SslContextBuilder.forServer(privateKey, certificates).sslProvider(sslProvider);
         setupCiphers(builder, ciphers);
         setupProtocols(builder, protocols);
         if (StringUtils.isNotBlank(trustCertsFilePath)) {
@@ -548,7 +548,7 @@ public class SecurityUtility {
 
     private static void setupKeyManager(SslContextBuilder builder, PrivateKey privateKey,
             X509Certificate[] certificates) {
-        builder.keyManager(privateKey, (X509Certificate[]) certificates);
+        builder.keyManager(privateKey, certificates);
     }
 
     private static void setupCiphers(SslContextBuilder builder, Set<String> ciphers) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclable.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclable.java
@@ -30,6 +30,7 @@ import java.util.BitSet;
 @Deprecated
 @EqualsAndHashCode(callSuper = true)
 public class ConcurrentBitSetRecyclable extends ConcurrentBitSet {
+    private static final long serialVersionUID = 1L;
 
     private final Handle<ConcurrentBitSetRecyclable> recyclerHandle;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/DnsResolverUtil.java
@@ -74,19 +74,7 @@ public class DnsResolverUtil {
             ttl = Optional.ofNullable(ttlStr)
                     .map(Integer::decode)
                     .filter(i -> i > 0)
-                    .orElseGet(() -> {
-                        try {
-                            if (System.getSecurityManager() == null) {
-                                return JDK_DEFAULT_TTL;
-                            }
-                        } catch (Throwable t) {
-                            log.warn("Cannot use current logic to resolve JDK default DNS TTL settings. Use "
-                                            + "sun.net.inetaddr.ttl and sun.net.inetaddr.negative.ttl system "
-                                            + "properties for setting default values for DNS TTL settings. {}",
-                                    t.getMessage());
-                        }
-                        return DEFAULT_TTL;
-                    });
+                    .orElse(JDK_DEFAULT_TTL);
 
             negativeTtl = Optional.ofNullable(negativeTtlStr)
                     .map(Integer::decode)

--- a/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
+++ b/pulsar-config-validation/src/main/java/org/apache/pulsar/config/validation/ConfigValidation.java
@@ -114,7 +114,7 @@ public class ConfigValidation {
 
             Object value = null;
             try {
-                value = (Object) method.invoke(v);
+                value = method.invoke(v);
             } catch (IllegalArgumentException ex) {
                 value = null;
             }

--- a/pulsar-docs-tools/src/main/java/org/apache/pulsar/docs/tools/BaseGenerateDocumentation.java
+++ b/pulsar-docs-tools/src/main/java/org/apache/pulsar/docs/tools/BaseGenerateDocumentation.java
@@ -164,6 +164,8 @@ public abstract class BaseGenerateDocumentation implements Callable<Integer> {
     }
 
     protected static class CategoryComparator implements Comparator<Pair<Field, FieldContextWrapper>>, Serializable {
+        private static final long serialVersionUID = 1L;
+
         @Override
         public int compare(Pair<Field, FieldContextWrapper> o1, Pair<Field, FieldContextWrapper> o2) {
             FieldContextWrapper o1Context = o1.getValue();

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -581,6 +581,8 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
     }
 
     class MessageBuilderImpl<T> implements TypedMessageBuilder<T> {
+        private static final long serialVersionUID = 1L;
+
         private TypedMessageBuilder<T> underlyingBuilder;
 
         @Override

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSource.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.io.core.SourceContext;
 
 @Slf4j
 public class MultiConsumerPulsarSource<T> extends PushPulsarSource<T> implements MessageListener<T> {
+    private static final long serialVersionUID = 1L;
 
     private final MultiConsumerPulsarSourceConfig pulsarSourceConfig;
     private final ClassLoader functionClassLoader;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -22,8 +22,6 @@ import io.netty.buffer.ByteBuf;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -55,9 +53,7 @@ public class TopicSchema {
 
     public TopicSchema(PulsarClient client, ClassLoader functionsClassloader) {
         this.client = client;
-        this.functionsClassloader = AccessController.doPrivileged(
-                (PrivilegedAction<URLClassLoader>) () -> new URLClassLoader(new URL[0], functionsClassloader)
-        );
+        this.functionsClassloader = new URLClassLoader(new URL[0], functionsClassloader);
     }
 
     /**

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/RawFileKeyReader.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.EncryptionKeyInfo;
  */
 @Data
 public class RawFileKeyReader implements CryptoKeyReader {
+    private static final long serialVersionUID = 1L;
 
     private final String publicKeyFile;
     private final String privateKeyFile;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntime.java
@@ -36,6 +36,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -459,7 +460,7 @@ public class KubernetesRuntime implements Runtime {
 
     private void submitService() throws Exception {
         final V1Service service = createService();
-        log.info("Submitting the following service to k8 {}", coreClient.getApiClient().getJSON().serialize(service));
+        log.info("Submitting the following service to k8 {}", JSON.serialize(service));
 
         String fqfn = FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails());
 
@@ -547,7 +548,7 @@ public class KubernetesRuntime implements Runtime {
                                     Optional.ofNullable(instanceConfig.getFunctionAuthenticationSpec())))));
         }
 
-        log.info("Submitting the following spec to k8 {}", appsClient.getApiClient().getJSON().serialize(statefulSet));
+        log.info("Submitting the following spec to k8 {}", JSON.serialize(statefulSet));
 
         String fqfn = FunctionCommon.getFullyQualifiedName(instanceConfig.getFunctionDetails());
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.client.impl.ConsumerImpl;
 
 @Slf4j
 public class LeaderService implements AutoCloseable, ConsumerEventListener {
+    private static final long serialVersionUID = 1L;
 
     private final String consumerName;
     private final FunctionAssignmentTailer functionAssignmentTailer;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
@@ -776,18 +776,23 @@ public class SchedulerManager implements AutoCloseable {
     }
 
     public static class RebalanceInProgressException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     public static class DrainInProgressException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     public static class TooFewWorkersException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     public static class UnknownWorkerException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     public static class WorkerNotRemovedAfterPriorDrainException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
 
     private static class SchedulerStats {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -428,7 +428,7 @@ public final class WorkerUtils {
     }
 
     public static class NotLeaderAnymore extends Exception {
-
+        private static final long serialVersionUID = 1L;
     }
 
     public static Supplier<Boolean> getIsStillLeaderSupplier(final MembershipManager membershipManager,

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
  * Generic metadata store exception.
  */
 public class MetadataStoreException extends IOException {
+    private static final long serialVersionUID = 1L;
 
     public MetadataStoreException(Throwable t) {
         super(t);
@@ -43,6 +44,8 @@ public class MetadataStoreException extends IOException {
      * Implementation is invalid.
      */
     public static class InvalidImplementationException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public InvalidImplementationException() {
             super((Throwable) null);
         }
@@ -60,6 +63,8 @@ public class MetadataStoreException extends IOException {
      * Key not found in store.
      */
     public static class NotFoundException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public NotFoundException() {
             super((Throwable) null);
         }
@@ -77,6 +82,8 @@ public class MetadataStoreException extends IOException {
      * Key was already in store.
      */
     public static class AlreadyExistsException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public AlreadyExistsException(Throwable t) {
             super(t);
         }
@@ -90,6 +97,8 @@ public class MetadataStoreException extends IOException {
      * Unsuccessful update due to mismatched expected version.
      */
     public static class BadVersionException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public BadVersionException(Throwable t) {
             super(t);
         }
@@ -103,6 +112,8 @@ public class MetadataStoreException extends IOException {
      * Failed to de-serialize the metadata.
      */
     public static class ContentDeserializationException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public ContentDeserializationException(String msg, Throwable t) {
             super(msg, t);
         }
@@ -120,6 +131,8 @@ public class MetadataStoreException extends IOException {
      * A resource lock is already taken by a different instance.
      */
     public static class LockBusyException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public LockBusyException() {
             super((Throwable) null);
         }
@@ -137,6 +150,7 @@ public class MetadataStoreException extends IOException {
      * The store was already closed.
      */
     public static class AlreadyClosedException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
 
         public AlreadyClosedException() {
             super("The metadata store is closed");
@@ -151,6 +165,8 @@ public class MetadataStoreException extends IOException {
     }
 
     public static class InvalidPathException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
         public InvalidPathException(String path) {
             super("Path(" + path + ") is invalid");
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreTableView.java
@@ -32,6 +32,8 @@ import java.util.concurrent.CompletableFuture;
 public interface MetadataStoreTableView<T> {
 
     class ConflictException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
         public ConflictException(String msg) {
             super(msg);
         }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -57,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class AdminProxyHandler extends ProxyServlet {
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(AdminProxyHandler.class);
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -266,7 +266,7 @@ public class LookupProxyHandler {
                     log.warn("[{}] failed to get Partitioned metadata : {}", topicName,
                         t.getMessage(), t);
                     PulsarClientException pce = PulsarClientException.unwrap(t);
-                    writeAndFlush(Commands.newLookupErrorResponse(clientCnx.revertClientExToErrorCode(pce),
+                    writeAndFlush(Commands.newLookupErrorResponse(ClientCnx.revertClientExToErrorCode(pce),
                             t.getMessage(), clientRequestId));
                 } else {
                     writeAndFlush(

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/TargetAddressDeniedException.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/TargetAddressDeniedException.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.proxy.server;
 
 class TargetAddressDeniedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     public TargetAddressDeniedException(String message) {
         super(message);
     }

--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/exceptions/CoordinatorException.java
@@ -45,6 +45,7 @@ public abstract class CoordinatorException extends Exception {
      * Exception is thrown when transaction coordinator not found.
      */
     public static class CoordinatorNotFoundException extends CoordinatorException {
+        private static final long serialVersionUID = 1L;
 
         public CoordinatorNotFoundException(String msg) {
             super(msg);

--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloader.java
@@ -310,12 +310,12 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                 }
                 DataBlockUtils.addVersionInfo(blobBuilder, objectMetadata);
                 Payload indexPayload = Payloads.newInputStreamPayload(indexStream);
-                indexPayload.getContentMetadata().setContentLength((long) indexStream.getStreamSize());
+                indexPayload.getContentMetadata().setContentLength(indexStream.getStreamSize());
                 indexPayload.getContentMetadata().setContentType("application/octet-stream");
 
                 Blob blob = blobBuilder
                         .payload(indexPayload)
-                        .contentLength((long) indexStream.getStreamSize())
+                        .contentLength(indexStream.getStreamSize())
                     .build();
                 writeBlobStore.putBlob(config.getBucket(), blob);
                 promise.complete(null);


### PR DESCRIPTION
## Summary
- Remove 11 redundant casts (Object, int, long, Position, KeyValue, X509Certificate[])
- Add serialVersionUID to 62 Serializable classes missing it
- Replace deprecated AccessController.doPrivileged with direct calls (4 locations)
- Remove deprecated SecurityManager check in DnsResolverUtil
- Fix 6 static method access warnings to use class references instead of instances
- Fix fallthrough comment format in ManagedLedgerImpl switch statement

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repositories
- [ ] Matching PR in forked repository

_This PR is part of a series to fix all compile warnings in production code._