### PR TITLE
[improve][build] Fix Lombok, varargs, and other compile warnings

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPool.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/web/WebExecutorThreadPool.java
@@ -32,7 +32,7 @@ public class WebExecutorThreadPool extends ExecutorThreadPool {
     }
 
     public WebExecutorThreadPool(int maxThreads, String namePrefix, int queueCapacity) {
-        super(maxThreads, Math.min(8, maxThreads), new BlockingArrayQueue<>(queueCapacity, queueCapacity));
+        super(maxThreads, Math.min(8, maxThreads), new BlockingArrayQueue<>(queueCapacity));
         this.threadFactory = new DefaultThreadFactory(namePrefix);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -78,7 +78,6 @@ public abstract class AbstractReplicator implements Replicator {
     protected static final AtomicReferenceFieldUpdater<AbstractReplicator, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(AbstractReplicator.class, State.class, "state");
     @VisibleForTesting
-    @Getter
     protected volatile State state = State.Disconnected;
 
     private volatile Attributes attributes = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -243,6 +243,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private Optional<DispatchRateLimiter> dispatchRateLimiter = Optional.empty();
     private final Object dispatchRateLimiterLock = new Object();
     private Optional<SubscribeRateLimiter> subscribeRateLimiter = Optional.empty();
+    private final Object subscribeRateLimiterLock = new Object();
     @Getter
     private final long backloggedCursorThresholdEntries;
     public static final int MESSAGE_RATE_BACKOFF_MS = 1000;
@@ -674,7 +675,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     public void updateSubscribeRateLimiter() {
         SubscribeRate subscribeRate = getSubscribeRate();
-        synchronized (subscribeRateLimiter) {
+        synchronized (subscribeRateLimiterLock) {
             if (isSubscribeRateEnabled(subscribeRate)) {
                 if (subscribeRateLimiter.isPresent()) {
                     this.subscribeRateLimiter.get().onSubscribeRateUpdate(subscribeRate);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -721,7 +721,7 @@ public abstract class PulsarWebResource {
                                             .port(webUrl.get().getPort())
                                             .replaceQueryParam("authoritative", newAuthoritative);
                                     if (!ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
-                                        uriBuilder.replaceQueryParam("destinationBroker", null);
+                                        uriBuilder.replaceQueryParam("destinationBroker", (Object[]) null);
                                     }
                                     URI redirect = uriBuilder.build();
                                     log.debug("{} is not a service unit owned", bundle);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/utils/ReflectionUtils.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/utils/ReflectionUtils.java
@@ -32,8 +32,8 @@ public class ReflectionUtils {
     public static <T> T newBuilder(String className) {
         return catchExceptions(
                 () -> (T) ReflectionUtils.getStaticMethod(
-                        className, "builder", null)
-                        .invoke(null, null));
+                        className, "builder", (Class<?>[]) null)
+                        .invoke(null, (Object[]) null));
     }
 
     static <T> T catchExceptions(SupplierWithException<T> s) {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/Resources.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/functions/Resources.java
@@ -35,10 +35,13 @@ public class Resources {
     private static final Resources DEFAULT = new Resources();
 
     // Default cpu is 1 core
+    @Builder.Default
     private Double cpu = 1d;
     // Default memory is 1GB
+    @Builder.Default
     private Long ram = 1073741824L;
     // Default disk is 10GB
+    @Builder.Default
     private Long disk = 10737418240L;
 
     public static Resources getDefaultResources() {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/impl/MinAvailablePolicy.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/impl/MinAvailablePolicy.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.policies.impl;
 import java.util.SortedSet;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.pulsar.common.policies.AutoFailoverPolicy;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
@@ -30,6 +31,7 @@ import org.apache.pulsar.common.policies.data.BrokerStatus;
  * Implementation of min available policy.
  */
 @Data
+@EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
 public class MinAvailablePolicy extends AutoFailoverPolicy {
     private static final String MIN_LIMIT_KEY = "min_limit";

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -51,6 +51,7 @@ public class TopicPolicies implements Cloneable {
     private List<SubType> subscriptionTypesEnabled = new ArrayList<>();
     private List<String> replicationClusters;
     private List<String> shadowTopics;
+    @Builder.Default
     private Boolean isGlobal = false;
     private PersistencePolicies persistence;
     private RetentionPolicies retentionPolicies;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/NonPersistentTopicStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/NonPersistentTopicStatsImpl.java
@@ -33,7 +33,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.Getter;
 import org.apache.pulsar.common.policies.data.NonPersistentPublisherStats;
 import org.apache.pulsar.common.policies.data.NonPersistentReplicatorStats;
 import org.apache.pulsar.common.policies.data.NonPersistentSubscriptionStats;
@@ -51,7 +50,6 @@ public class NonPersistentTopicStatsImpl extends TopicStatsImpl implements NonPe
      * for non-persistent topic: broker drops msg if publisher publishes messages more than configured max inflight
      * messages per connection.
      **/
-    @Getter
     public double msgDropRate;
 
     @JsonIgnore

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SinkStatsManager.java
@@ -24,7 +24,6 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
-import lombok.Getter;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 
 public class SinkStatsManager extends ComponentStatsManager {
@@ -82,10 +81,8 @@ public class SinkStatsManager extends ComponentStatsManager {
     private Counter.Child statTotalSinkExceptionsChild1min;
     private Counter.Child statTotalWrittenChild1min;
 
-    @Getter
     private EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> latestSystemExceptions =
             EvictingQueue.create(10);
-    @Getter
     private EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> latestSinkExceptions =
             EvictingQueue.create(10);
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/SourceStatsManager.java
@@ -24,7 +24,6 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
-import lombok.Getter;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 
 public class SourceStatsManager extends ComponentStatsManager {
@@ -82,10 +81,8 @@ public class SourceStatsManager extends ComponentStatsManager {
     private Counter.Child statTotalSourceExceptionsChild1min;
     private Counter.Child statTotalWrittenChild1min;
 
-    @Getter
     private EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> latestSystemExceptions =
             EvictingQueue.create(10);
-    @Getter
     private EvictingQueue<InstanceCommunication.FunctionStatus.ExceptionInformation> latestSourceExceptions =
             EvictingQueue.create(10);
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/MultiConsumerPulsarSourceConfig.java
@@ -23,10 +23,12 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class MultiConsumerPulsarSourceConfig extends PulsarSourceConfig {
 
     private Map<String, ConsumerConfig> topicSchema = new TreeMap<>();

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSourceConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/SingleConsumerPulsarSourceConfig.java
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.pulsar.common.functions.ConsumerConfig;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Data
+@EqualsAndHashCode(callSuper = false)
 public class SingleConsumerPulsarSourceConfig extends PulsarSourceConfig {
 
     private String topic;

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
@@ -908,6 +909,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     @Deprecated
     @Data
+    @EqualsAndHashCode(callSuper = false)
     /**
      * @Deprecated in favor for using functionRuntimeFactoryClassName and functionRuntimeFactoryConfigs
      * for specifying the function runtime and configs to use
@@ -924,6 +926,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     @Deprecated
     @Data
+    @EqualsAndHashCode(callSuper = false)
     /**
      * @Deprecated in favor for using functionRuntimeFactoryClassName and functionRuntimeFactoryConfigs
      * for specifying the function runtime and configs to use
@@ -940,6 +943,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
 
     @Deprecated
     @Data
+    @EqualsAndHashCode(callSuper = false)
     /**
      * @Deprecated in favor for using functionRuntimeFactoryClassName and functionRuntimeFactoryConfigs
      * for specifying the function runtime and configs to use

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -124,13 +124,11 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
     }
 
     @VisibleForTesting
-    @SneakyThrows
     public ZKMetadataStore(ZooKeeper zkc) {
         this(zkc, MetadataStoreConfig.builder().build());
     }
 
     @VisibleForTesting
-    @SneakyThrows
     public ZKMetadataStore(ZooKeeper zkc, MetadataStoreConfig config) {
         this(zkc, config, false);
     }


### PR DESCRIPTION
## Summary
- Add @Builder.Default to initialized fields in @Builder classes (Resources, TopicPolicies)
- Add @EqualsAndHashCode(callSuper=false) to @Data classes extending non-Object types
- Remove redundant @Getter on fields that already have manual getters
- Remove ineffective @SneakyThrows on delegating constructors (ZKMetadataStore)
- Add explicit casts for non-varargs calls (ReflectionUtils, PulsarWebResource)
- Replace synchronized on value-based Optional with dedicated lock (PersistentTopic)
- Replace deprecated BlockingArrayQueue two-arg constructor (WebExecutorThreadPool)

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repositories
- [ ] Matching PR in forked repository

_This PR is part of a series to fix all compile warnings in production code._