### PR TITLE
[improve][build] Fix remaining rawtypes, unchecked, and deprecation warnings

### DIFF
--- a/pulsar-broker-auth-athenz/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenz.java
+++ b/pulsar-broker-auth-athenz/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenz.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("deprecation") // Implements deprecated AuthenticationProvider methods
 public class AuthenticationProviderAthenz implements AuthenticationProvider {
 
     private static final String DOMAIN_NAME_LIST = "athenzDomainNames";

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderSasl.java
@@ -68,6 +68,7 @@ import org.apache.pulsar.common.stats.CacheMetricsCollector;
  * provider, the authentication is multi-stage.
  */
 @Slf4j
+@SuppressWarnings("deprecation") // Implements deprecated AuthenticationProvider/AuthenticationState methods
 public class AuthenticationProviderSasl implements AuthenticationProvider {
 
     private Pattern allowedIdsPattern;

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationState.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslAuthenticationState.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.common.api.AuthData;
  * It tell broker whether the authentication is completed or not,
  */
 @Slf4j
+@SuppressWarnings("deprecation") // Implements deprecated AuthenticationState methods for SASL multi-stage auth
 public class SaslAuthenticationState implements AuthenticationState {
     private final long stateId;
     private static final AtomicLong stateIdGenerator = new AtomicLong(0L);

--- a/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleTokenSigner.java
+++ b/pulsar-broker-auth-sasl/src/main/java/org/apache/pulsar/broker/authentication/SaslRoleTokenSigner.java
@@ -20,9 +20,9 @@ package org.apache.pulsar.broker.authentication;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import javax.naming.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.Base64;
 
 @Slf4j
 public class SaslRoleTokenSigner {
@@ -97,7 +97,7 @@ public class SaslRoleTokenSigner {
 
             md.update(secret);
             byte[] digest = md.digest();
-            return new Base64(0).encodeToString(digest);
+            return Base64.getEncoder().encodeToString(digest);
         } catch (NoSuchAlgorithmException ex) {
             throw new RuntimeException("It should not happen, " + ex.getMessage(), ex);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/client/impl/schema/SchemaUtils.java
@@ -64,7 +64,7 @@ public final class SchemaUtils {
     /**
      * Keeps a map between {@link SchemaType} to a list of java classes that can be used to represent them.
      */
-    private static final Map<SchemaType, List<Class>> SCHEMA_TYPE_CLASSES = new HashMap<>();
+    private static final Map<SchemaType, List<Class<?>>> SCHEMA_TYPE_CLASSES = new HashMap<>();
 
     /**
      * Maps the java classes to the corresponding {@link SchemaType}.
@@ -109,8 +109,8 @@ public final class SchemaUtils {
                 SchemaType.BYTES,
                 Arrays.asList(byte[].class, ByteBuffer.class, ByteBuf.class));
         // build the reverse mapping
-        SCHEMA_TYPE_CLASSES.forEach(
-                (type, classes) -> classes.forEach(clz -> JAVA_CLASS_SCHEMA_TYPES.put(clz, type)));
+        SCHEMA_TYPE_CLASSES
+                .forEach((type, classes) -> classes.forEach(clz -> JAVA_CLASS_SCHEMA_TYPES.put(clz, type)));
     }
 
     public static void validateFieldSchema(String name,
@@ -120,7 +120,7 @@ public final class SchemaUtils {
             return;
         }
 
-        List<Class> expectedClasses = SCHEMA_TYPE_CLASSES.get(type);
+        List<Class<?>> expectedClasses = SCHEMA_TYPE_CLASSES.get(type);
 
         if (null == expectedClasses) {
             throw new RuntimeException("Invalid Java object for schema type " + type
@@ -392,6 +392,7 @@ public final class SchemaUtils {
      * @param serializedProperties serialized properties
      * @return the deserialized properties
      */
+    @SuppressWarnings("unchecked") // Gson deserializer returns Map<String, String> via SCHEMA_PROPERTIES_DESERIALIZER
     public static Map<String, String> deserializeSchemaProperties(String serializedProperties) {
         GsonBuilder gsonBuilder = new GsonBuilder()
             .registerTypeHierarchyAdapter(Map.class, SCHEMA_PROPERTIES_DESERIALIZER);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.common.util.DateFormatter;
  * Consumer statistics.
  */
 @Data
+@SuppressWarnings("deprecation") // Implements deprecated ConsumerStats fields for backward compatibility
 public class ConsumerStatsImpl implements ConsumerStats {
     /** the app id. */
     public String appId;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ReplicatorStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ReplicatorStatsImpl.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.common.policies.data.ReplicatorStats;
  * Statistics about a replicator.
  */
 @Data
+@SuppressWarnings("deprecation") // Implements deprecated ReplicatorStats rate fields for backward compatibility
 public class ReplicatorStatsImpl implements ReplicatorStats {
 
     /** Total rate of messages received from the remote cluster (msg/s). */

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicCompactionStrategy.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/topics/TopicCompactionStrategy.java
@@ -52,7 +52,7 @@ import org.apache.pulsar.common.classification.InterfaceStability;
 public interface TopicCompactionStrategy<T> {
 
     String TABLE_VIEW_TAG = "table-view";
-    Map<String, TopicCompactionStrategy> INSTANCES = new ConcurrentHashMap<>();
+    Map<String, TopicCompactionStrategy<?>> INSTANCES = new ConcurrentHashMap<>();
 
     /**
      * Returns the schema object for this strategy.
@@ -73,14 +73,16 @@ public interface TopicCompactionStrategy<T> {
     }
 
 
-    static TopicCompactionStrategy load(String tag, String topicCompactionStrategyClassName) {
+    @SuppressWarnings("unchecked") // Instance created via reflection; caller is responsible for type safety
+    static <T> TopicCompactionStrategy<T> load(String tag, String topicCompactionStrategyClassName) {
         if (topicCompactionStrategyClassName == null) {
             return null;
         }
 
         try {
             Class<?> clazz = Class.forName(topicCompactionStrategyClassName);
-            TopicCompactionStrategy instance = (TopicCompactionStrategy) clazz.getDeclaredConstructor().newInstance();
+            TopicCompactionStrategy<T> instance =
+                    (TopicCompactionStrategy<T>) clazz.getDeclaredConstructor().newInstance();
             INSTANCES.put(tag, instance);
             return instance;
         } catch (Exception e) {
@@ -89,7 +91,8 @@ public interface TopicCompactionStrategy<T> {
         }
     }
 
-    static TopicCompactionStrategy getInstance(String tag) {
-        return INSTANCES.get(tag);
+    @SuppressWarnings("unchecked") // Caller is responsible for type safety
+    static <T> TopicCompactionStrategy<T> getInstance(String tag) {
+        return (TopicCompactionStrategy<T>) INSTANCES.get(tag);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -96,6 +96,7 @@ public final class FieldParser {
 
         if (to.isEnum()) {
             // Converting string to enum
+            @SuppressWarnings("deprecation") // No replacement API available in Jackson 2.x
             EnumResolver r = EnumResolver.constructUsingToString(
                 ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig(), to);
             T value = (T) r.findEnum((String) from);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ProtectedObjectMapper.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ProtectedObjectMapper.java
@@ -66,6 +66,7 @@ import java.util.TimeZone;
  * {@link com.fasterxml.jackson.databind.ObjectReader} instances instead of the {@link ObjectMapper} since
  * those classes are immutable.
  */
+@SuppressWarnings("deprecation") // Overrides deprecated ObjectMapper methods to block mutation
 final class ProtectedObjectMapper extends ObjectMapper {
 
     private final ObjectMapper src;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
@@ -194,6 +194,7 @@ public class EventLoopUtil {
         }
     }
 
+    @SuppressWarnings("deprecation") // EpollMode is deprecated in newer Netty but no replacement API exists yet
     public static void enableTriggeredMode(ServerBootstrap bootstrap) {
         if (Epoll.isAvailable()) {
             bootstrap.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);


### PR DESCRIPTION
## Summary
- Fix raw types in TopicCompactionStrategy and SchemaUtils
- Add @SuppressWarnings("deprecation") where deprecated APIs must be used (ProtectedObjectMapper overrides, stats impl classes, auth provider interfaces, Netty EpollMode, Jackson EnumResolver)
- Replace deprecated commons-codec Base64 with java.util.Base64

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repositories
- [ ] Matching PR in forked repository

_This PR is part of a series to fix all compile warnings in production code._