### PR TITLE
[improve][build] Fix final rawtypes, unchecked, and redundant cast warnings

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdProduce.java
@@ -344,7 +344,8 @@ public class CmdProduce extends AbstractCmd {
                             limiter.acquire();
                         }
 
-                        TypedMessageBuilder message = producer.newMessage();
+                        @SuppressWarnings("unchecked")
+                        TypedMessageBuilder<Object> message = (TypedMessageBuilder<Object>) producer.newMessage();
 
                         if (!kvMap.isEmpty()) {
                             message.properties(kvMap);
@@ -359,7 +360,7 @@ public class CmdProduce extends AbstractCmd {
                                 break;
                             case KEY_VALUE_ENCODING_TYPE_SEPARATED:
                             case KEY_VALUE_ENCODING_TYPE_INLINE:
-                                KeyValue kv = new KeyValue<>(
+                                KeyValue<byte[], byte[]> kv = new KeyValue<>(
                                         keyValueKeyBytes,
                                         content);
                                 message.value(kv);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -146,10 +146,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private final CompressionCodec compressor;
 
+    @SuppressWarnings("rawtypes")
     static final AtomicLongFieldUpdater<ProducerImpl> LAST_SEQ_ID_PUBLISHED_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ProducerImpl.class, "lastSequenceIdPublished");
     private volatile long lastSequenceIdPublished;
 
+    @SuppressWarnings("rawtypes")
     static final AtomicLongFieldUpdater<ProducerImpl> LAST_SEQ_ID_PUSHED_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ProducerImpl.class, "lastSequenceIdPushed");
     protected volatile long lastSequenceIdPushed;
@@ -453,6 +455,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             }
         }
 
+        @SuppressWarnings("unchecked")
         private void onSendComplete(Throwable e, SendCallback sendCallback, MessageImpl<?> msg) {
             long createdAt = (sendCallback instanceof ProducerImpl.DefaultSendMessageCallback)
                     ? ((DefaultSendMessageCallback) sendCallback).createdAt : this.createdAt;
@@ -851,7 +854,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     @VisibleForTesting
-    boolean populateMessageSchema(MessageImpl msg, SendCallback callback) {
+    boolean populateMessageSchema(MessageImpl<?> msg, SendCallback callback) {
         MessageMetadata msgMetadataBuilder = msg.getMessageBuilder();
         if (msg.getSchemaInternal() == schema) {
             schemaVersion.ifPresent(v -> msgMetadataBuilder.setSchemaVersion(v));
@@ -886,7 +889,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return true;
     }
 
-    private boolean rePopulateMessageSchema(MessageImpl msg) {
+    private boolean rePopulateMessageSchema(MessageImpl<?> msg) {
         byte[] schemaVersion = schemaCache.get(msg.getSchemaHash());
         if (schemaVersion == null) {
             return false;
@@ -900,7 +903,8 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         return true;
     }
 
-    private void tryRegisterSchema(ClientCnx cnx, final MessageImpl msg, SendCallback callback, long expectedCnxEpoch) {
+    private void tryRegisterSchema(ClientCnx cnx, final MessageImpl<?> msg, SendCallback callback,
+                                    long expectedCnxEpoch) {
         if (!changeToRegisteringSchemaState()) {
             return;
         }
@@ -1938,7 +1942,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         // Deprecated (PIP-464): This backward-compatible path sends old Jackson JsonSchema
                         // format to brokers below protocol v13 (Pulsar < 2.1). Scheduled for removal in a
                         // future major release.
-                        JSONSchema jsonSchema = (JSONSchema) schema;
+                        JSONSchema<?> jsonSchema = (JSONSchema<?>) schema;
                         schemaInfo = jsonSchema.getBackwardsCompatibleJsonSchemaInfo();
                     } else {
                         schemaInfo = schema.getSchemaInfo();
@@ -2560,7 +2564,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
      * Note: Since the current method accesses & modifies {@link #pendingMessages}, you should acquire a lock on
      *       {@link ProducerImpl} before calling method.
      */
-    private void recoverProcessOpSendMsgFrom(ClientCnx cnx, MessageImpl latestMsgAttemptedRegisteredSchema,
+    private void recoverProcessOpSendMsgFrom(ClientCnx cnx, MessageImpl<?> latestMsgAttemptedRegisteredSchema,
                                              boolean failedIncompatibleSchema, long expectedEpoch) {
         if (expectedEpoch != this.connectionHandler.getEpoch() || cnx() == null) {
             // In this case, the cnx passed to this method is no longer the active connection. This method will get
@@ -2572,7 +2576,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         final boolean stripChecksum = cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion();
         Iterator<OpSendMsg> msgIterator = pendingMessages.iterator();
-        MessageImpl loopStartAt = latestMsgAttemptedRegisteredSchema;
+        MessageImpl<?> loopStartAt = latestMsgAttemptedRegisteredSchema;
         OpSendMsg loopEndDueToSchemaRegisterNeeded = null;
         boolean pausedSendingToPreservePublishOrderOnSchemaRegFailure = false;
         while (msgIterator.hasNext()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
@@ -59,6 +59,7 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
         }
     }
 
+    @SuppressWarnings("rawtypes")
     static class ThreadPoolResourceConfig extends NamedResourceConfig<ThreadPoolConfig> implements ThreadPoolConfig {
         int numberOfThreads = Runtime.getRuntime().availableProcessors();
         boolean daemon = Thread.currentThread().isDaemon();

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AbstractSinkRecord.java
@@ -101,9 +101,13 @@ public abstract class AbstractSinkRecord<T> implements Record<T> {
                 // see PIP-85
                 if (record.getMessage().isPresent()
                         && record.getMessage().get().getReaderSchema().isPresent()) {
-                    schema = (Schema<T>) record.getMessage().get().getReaderSchema().get();
+                    @SuppressWarnings("unchecked")
+                    Schema<T> readerSchema = (Schema<T>) record.getMessage().get().getReaderSchema().get();
+                    schema = readerSchema;
                 } else {
-                    schema = (Schema<T>) ((AutoConsumeSchema) schema).getInternalSchema();
+                    @SuppressWarnings("unchecked")
+                    Schema<T> internalSchema = (Schema<T>) ((AutoConsumeSchema) schema).getInternalSchema();
+                    schema = internalSchema;
                 }
             }
             return schema;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
@@ -52,7 +52,7 @@ public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
     }
 
     @Override
-    public int choosePartition(Message msg, TopicMetadata metadata) {
+    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
         // if key is specified, we should use key as routing;
         // if key is not specified and no sequence id is provided, not an effectively-once publish, use the default
         // round-robin routing.

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -420,7 +420,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     }
 
     @VisibleForTesting
-    void handleResult(Record srcRecord, JavaExecutionResult result) throws Exception {
+    void handleResult(Record<?> srcRecord, JavaExecutionResult result) throws Exception {
         if (result.getUserException() != null) {
             Throwable t = result.getUserException();
             log.warn("Encountered exception when processing message {}",
@@ -481,7 +481,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
     }
 
-    private OutputRecordSinkRecord encodeWithRecordSchemaAndDecodeWithSinkSchema(Record srcRecord, Record record) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private OutputRecordSinkRecord<?> encodeWithRecordSchemaAndDecodeWithSinkSchema(
+            Record<?> srcRecord, Record<?> record) {
         AbstractSinkRecord<?> sinkRecord;
         Schema encodingSchema = record.getSchema();
         boolean isKeyValueSeparated = false;
@@ -521,8 +523,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         return new OutputRecordSinkRecord(srcRecord, record, decoded, finalSchema);
     }
 
-    private Record readInput() throws Exception {
-        Record record;
+    private Record<?> readInput() throws Exception {
+        Record<?> record;
         if (componentType == org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.SOURCE) {
             Thread.currentThread().setContextClassLoader(componentClassLoader);
         }
@@ -773,6 +775,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         context.updateLoggers();
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private void setupInput(ContextImpl contextImpl) throws Exception {
 
         SourceSpec sourceSpec = this.instanceConfig.getFunctionDetails().getSource();
@@ -924,6 +927,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
      * @param secretsProvider - the secrets provider that will convert secret's values into config values.
      * @param configs - the connector configuration map, which will be mutated.
      */
+    @SuppressWarnings("unchecked")
     private static void interpolateSecretsIntoConfigs(SecretsProvider secretsProvider,
                                                       Map<String, Object> configs) {
         for (Map.Entry<String, Object> entry : configs.entrySet()) {
@@ -1024,6 +1028,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     }
 
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private void setupOutput(ContextImpl contextImpl) throws Exception {
 
         SinkSpec sinkSpec = this.instanceConfig.getFunctionDetails().getSink();
@@ -1097,6 +1102,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static <T> Schema<T> getSinkSchema(Record<?> record, Class<T> clazz) {
         SchemaType type = getSchemaTypeOrDefault(record, clazz);
         switch (type) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreProviderImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/BKStateStoreProviderImpl.java
@@ -181,6 +181,7 @@ public class BKStateStoreProviderImpl implements StateStoreProvider {
         throw new IOException("Failed to open state table for function " + tenant + "/" + namespace + "/" + name);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends StateStore> T getStateStore(String tenant, String namespace, String name) throws Exception {
         // we defer creation of the state table until a java instance is running here.

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreProviderImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreProviderImpl.java
@@ -56,6 +56,7 @@ public class PulsarMetadataStateStoreProviderImpl implements StateStoreProvider 
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public DefaultStateStore getStateStore(String tenant, String namespace, String name) throws Exception {
         return new PulsarMetadataStateStoreImpl(store, prefix, tenant, namespace, name);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionCollectorRegistryImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/stats/FunctionCollectorRegistryImpl.java
@@ -26,9 +26,11 @@ public class FunctionCollectorRegistryImpl extends FunctionCollectorRegistry {
 
     private final Map<String, Collector> namesToCollectors = new HashMap<String, Collector>();
 
-    public Collector registerIfNotExist(String metricName, Collector collector) {
+    @Override
+    public <T extends Collector> T registerIfNotExist(String metricName, T collector) {
         synchronized (this) {
-            Collector existingCollector = namesToCollectors.get(metricName);
+            @SuppressWarnings("unchecked")
+            T existingCollector = (T) namesToCollectors.get(metricName);
             if (existingCollector == null) {
                 namesToCollectors.put(metricName, collector);
                 super.register(collector);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -291,6 +291,7 @@ public class PulsarSink<T> implements Sink<T> {
         }
 
         if (sinkRecord.getSourceRecord() instanceof PulsarRecord) {
+            @SuppressWarnings("unchecked")
             PulsarRecord<T> pulsarRecord = (PulsarRecord<T>) sinkRecord.getSourceRecord();
             // forward user properties to sink-topic
             msg.property("__pfn_input_topic__", pulsarRecord.getTopicName().get())

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutor.java
@@ -65,6 +65,7 @@ public class WindowFunctionExecutor<T, X> implements Function<T, X> {
         this.start();
     }
 
+    @SuppressWarnings("unchecked")
     private void initializeUserFunction(WindowConfig windowConfig) {
         String actualWindowFunctionClassName = windowConfig.getActualWindowFunctionClassName();
         ClassLoader clsLoader = Thread.currentThread().getContextClassLoader();
@@ -75,12 +76,12 @@ public class WindowFunctionExecutor<T, X> implements Function<T, X> {
             Class<?>[] typeArgs = TypeResolver.resolveRawArguments(
                     java.util.function.Function.class, userClassObject.getClass());
             if (typeArgs[0].equals(Collection.class)) {
-                bareWindowFunction = (java.util.function.Function) userClassObject;
+                bareWindowFunction = (java.util.function.Function<Collection<T>, X>) userClassObject;
             } else {
                 throw new IllegalArgumentException("Window function must take a collection as input");
             }
         } else if (userClassObject instanceof WindowFunction) {
-            windowFunction = (WindowFunction) userClassObject;
+            windowFunction = (WindowFunction<T, X>) userClassObject;
         } else {
             throw new IllegalArgumentException("Window function does not implement the correct interface");
         }
@@ -125,6 +126,7 @@ public class WindowFunctionExecutor<T, X> implements Function<T, X> {
         return manager;
     }
 
+    @SuppressWarnings("unchecked")
     private TimestampExtractor<T> getTimeStampExtractor(WindowConfig windowConfig) {
 
         Class<?> theCls;
@@ -279,6 +281,7 @@ public class WindowFunctionExecutor<T, X> implements Function<T, X> {
         return this.timestampExtractor != null;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public X process(T input, Context context) throws Exception {
         if (!this.initialized) {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/WindowImpl.java
@@ -79,7 +79,7 @@ public class WindowImpl<T> implements Window<T> {
             return false;
         }
 
-        WindowImpl that = (WindowImpl) o;
+        WindowImpl<?> that = (WindowImpl<?>) o;
 
         if (tuples != null ? !tuples.equals(that.tuples) : that.tuples != null) {
             return false;

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/evictors/WatermarkCountEvictionPolicy.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/windowing/evictors/WatermarkCountEvictionPolicy.java
@@ -37,6 +37,7 @@ public class WatermarkCountEvictionPolicy<T>
     protected final AtomicLong currentCount;
     private EvictionContext context;
 
+    @SuppressWarnings("rawtypes")
     private static final AtomicLongFieldUpdater<WatermarkCountEvictionPolicy> PROCESSED_UPDATER =
             AtomicLongFieldUpdater.newUpdater(WatermarkCountEvictionPolicy.class, "processed");
     private volatile long processed;

--- a/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
+++ b/pulsar-functions/localrun/src/main/java/org/apache/pulsar/functions/LocalRunner.java
@@ -598,6 +598,7 @@ public class LocalRunner implements AutoCloseable {
         statusCheckTimer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
+                @SuppressWarnings({"unchecked", "rawtypes"})
                 CompletableFuture<String>[] futures = new CompletableFuture[spawners.size()];
                 int index = 0;
                 for (RuntimeSpawner spawner : spawners) {

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -100,6 +100,7 @@ public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicati
 
     private static final Pattern ID_EXTRACTION_PATTERN = Pattern.compile("urL(\\d+)$");
 
+    @SuppressWarnings("rawtypes")
     private final AbstractConfiguration conf;
     private final String basePath;
     private final String urLedgerPath;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarMetadataBookieDriver.java
@@ -39,6 +39,7 @@ public class PulsarMetadataBookieDriver extends AbstractMetadataDriver implement
         // cause <clinit> to be invoked
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     protected void initialize(AbstractConfiguration serverConfiguration) throws MetadataException {
         super.initialize(serverConfiguration);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -421,6 +421,7 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         int keysLen = encryptionKeyMap.size();
         final String[] keyNameArray = new String[keysLen];
         final byte[][] keyValueArray = new byte[keysLen][];
+        @SuppressWarnings({"unchecked", "rawtypes"})
         final List<KeyValue>[] keyMetadataArray = new List[keysLen];
         // Format keys.
         int index = 0;


### PR DESCRIPTION
## Summary
- Fix remaining raw types in JavaInstanceRunnable, ProducerImpl, CmdProduce, WindowFunctionExecutor, and PulsarClientSharedResourcesBuilderImpl
- Add @SuppressWarnings for unavoidable raw types from external APIs (BookKeeper AbstractConfiguration, AtomicLongFieldUpdater)
- Remove redundant String cast in ComponentImpl

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repositories
- [ ] Matching PR in forked repository

_This PR is part of a series to fix all compile warnings in production code._