### PR TITLE
[improve][build] Suppress remaining unchecked warnings in source code

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -133,6 +133,7 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
         });
     }
 
+    @SuppressWarnings("unchecked")
     protected void startProducer() {
         if (isClosingOrClosed()) {
             log.info("[{}] Skip to start new producer because the synchronizer is closed", topicName);
@@ -179,6 +180,7 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
         return producer;
     }
 
+    @SuppressWarnings("unchecked")
     private void startConsumer() {
         if (isClosingOrClosed()) {
             log.info("[{}] Skip to start new consumer because the synchronizer is closed", topicName);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -339,6 +339,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         return createPartitionedTopicAsync(topic, numPartitions, false, properties);
     }
 
+    @SuppressWarnings("unchecked")
     public CompletableFuture<Void> createPartitionedTopicAsync(
             String topic, int numPartitions, boolean createLocalTopicOnly, Map<String, String> properties) {
         checkArgument(numPartitions > 0, "Number of partitions should be more than 0");
@@ -1277,6 +1278,7 @@ public class TopicsImpl extends BaseResource implements Topics {
                 TransactionIsolationLevel.READ_UNCOMMITTED);
     }
 
+    @SuppressWarnings("unchecked")
     private List<Message<byte[]>> getMessagesFromHttpResponse(
             String topic, Response response, boolean showServerMarker,
             TransactionIsolationLevel transactionIsolationLevel) throws Exception {
@@ -1488,6 +1490,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private List<Message<byte[]>> getIndividualMsgsFromBatch(String topic, String msgId, byte[] data,
                                  Map<String, String> properties, MessageMetadata msgMetadataBuilder,
                                                              BrokerEntryMetadata brokerEntryMetadata) {
@@ -1583,6 +1586,7 @@ public class TopicsImpl extends BaseResource implements Topics {
         return sync(() -> analyzeSubscriptionBacklogAsync(topic, subscriptionName, startPosition, terminatePredicate));
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public CompletableFuture<AnalyzeSubscriptionBacklogResult> analyzeSubscriptionBacklogAsync(String topic,
                                                                                 String subscriptionName,

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreProviderImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/PulsarMetadataStateStoreProviderImpl.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 
+@SuppressWarnings("unchecked")
 public class PulsarMetadataStateStoreProviderImpl implements StateStoreProvider {
 
     private static final String METADATA_URL = "METADATA_URL";

--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/AbstractPushSource.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/AbstractPushSource.java
@@ -98,6 +98,7 @@ public abstract class AbstractPushSource<T> {
      * Allows the source to notify errors asynchronously.
      * @param ex
      */
+    @SuppressWarnings("unchecked")
     public void notifyError(Exception ex) {
         consume(new ErrorNotifierRecord(ex));
     }


### PR DESCRIPTION
## Summary
- Add @SuppressWarnings("unchecked") in TopicsImpl, AbstractPushSource, PulsarMetadataStateStoreProviderImpl, and PulsarMetadataEventSynchronizer to eliminate the last unchecked compiler notes from source code

## Documentation
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

## Matching PR in forked repositories
- [ ] Matching PR in forked repository

_This PR is part of a series to fix all compile warnings in production code._