### PR TITLE
[fix][test] Fix flaky testRetentionSize in ManagedLedgerTest

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2490,8 +2490,9 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         for (int i = 0; i < totalMessage; i++) {
             position = ml.addEntry(message);
         }
-        // all ledgers are not delete yet since no entry has been acked for c1
-        assertEquals(ml.getLedgersInfoAsList().size(), totalMessage);
+        // all ledgers are not deleted yet since no entry has been acked for c1
+        // Use >= because the current (empty) ledger may or may not have been created yet
+        assertTrue(ml.getLedgersInfoAsList().size() >= totalMessage);
 
         List<Entry> entryList = c1.readEntries(totalMessage);
         if (null != position) {


### PR DESCRIPTION
## Motivation
Fix flaky test `testRetentionSize` in `ManagedLedgerTest`.

The test asserts the exact ledger count (`assertEquals`) after adding messages, but the current (empty) ledger may or may not have been created yet by the time the assertion runs, causing intermittent failures.

## Modifications
Changed `assertEquals(ml.getLedgersInfoAsList().size(), totalMessage)` to `assertTrue(ml.getLedgersInfoAsList().size() >= totalMessage)` to account for the race between ledger creation and the assertion.

## Documentation
- [x] `doc-not-needed`

## Matching PR in forked repository
_No response_