### PR TITLE
[fix][test] Fix flaky testClear in BucketDelayedDeliveryTrackerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -151,6 +151,10 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                     new BucketDelayedDeliveryTracker(dispatcher, timer, 100000, clock,
                             true, bucketSnapshotStorage, 20, TimeUnit.HOURS.toMillis(1), 5, 100)
             }};
+            case "testClear" -> new Object[][]{{
+                    new BucketDelayedDeliveryTracker(dispatcher, timer, 100000, clock,
+                            true, bucketSnapshotStorage, 1000, TimeUnit.MILLISECONDS.toMillis(100), -1, 50)
+            }};
             default -> new Object[][]{{
                     new BucketDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, bucketSnapshotStorage, 1000, TimeUnit.MILLISECONDS.toMillis(100), -1, 50)


### PR DESCRIPTION
## Motivation
Fix flaky test `testClear` in `BucketDelayedDeliveryTrackerTest`.

The test schedules many delayed messages rapidly with the default `tickTimeMillis` of 1ms (from the `default` data provider case). This overwhelms the `HashedWheelTimer`, causing `RejectedExecutionException` during `timer.newTimeout()`.

## Modifications
Added a dedicated data provider case for `testClear` with a larger `tickTimeMillis` (100ms) to prevent `HashedWheelTimer` overload, while keeping the same bucket configuration.

## Documentation
- [x] `doc-not-needed`

## Matching PR in forked repository
_No response_