### PR TITLE
[fix][test] Fix flaky testMsgDropStat in NonPersistentTopicTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -59,7 +59,6 @@ import org.apache.pulsar.broker.stats.OpenTelemetryProducerStats;
 import org.apache.pulsar.broker.testcontext.PulsarTestContext;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MultiTopicsConsumerImpl;
 import org.apache.pulsar.client.impl.PartitionedProducerImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
@@ -886,30 +885,31 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             ExecutorService executor = Executors.newFixedThreadPool(threads);
             byte[] msgData = "testData".getBytes();
 
+            NonPersistentTopic topic =
+                    (NonPersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
+
             /*
-             * Trigger at least one publisher drop through concurrent send() calls.
+             * Send concurrent bursts until publisher AND subscription drop rates are all > 0.
              *
-             * Uses CyclicBarrier to ensure all threads send simultaneously, creating overlap.
-             * With maxConcurrentNonPersistentMessagePerConnection = 0, ServerCnx#handleSend
-             * drops any send while another is in-flight, returning MessageId with entryId = -1.
-             * Awaitility repeats whole bursts (bounded to 20s) until a drop is observed.
+             * Each burst uses a CyclicBarrier so all threads send simultaneously. With
+             * maxConcurrentNonPersistentMessagePerConnection = 0, ServerCnx drops overlapping
+             * sends (publisher drops). Once subscriber queues (size 1) are full, the dispatcher
+             * also drops delivered messages (subscription drops).
+             *
+             * IMPORTANT: updateRates() calls Rate.calculateRate() which resets counters via
+             * sumThenReset(). We must keep sending fresh bursts so each updateRates() call
+             * sees new drops, rather than retrying with stale (reset) counters.
              */
-            AtomicBoolean publisherDropSeen = new AtomicBoolean(false);
-            Awaitility.await().atMost(Duration.ofSeconds(20)).until(() -> {
+            Awaitility.await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofMillis(100)).until(() -> {
                 CyclicBarrier barrier = new CyclicBarrier(threads);
                 CountDownLatch completionLatch = new CountDownLatch(threads);
                 AtomicReference<Throwable> error = new AtomicReference<>();
-                publisherDropSeen.set(false);
 
                 for (int i = 0; i < threads; i++) {
                     executor.submit(() -> {
                         try {
                             barrier.await();
-                            MessageId msgId = producer.send(msgData);
-                            // Publisher drop is signaled by MessageIdImpl.entryId == -1
-                            if (msgId instanceof MessageIdImpl && ((MessageIdImpl) msgId).getEntryId() == -1) {
-                                publisherDropSeen.set(true);
-                            }
+                            producer.send(msgData);
                         } catch (Throwable t) {
                             if (t instanceof InterruptedException) {
                                 Thread.currentThread().interrupt();
@@ -921,27 +921,23 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
                     });
                 }
 
-                // Wait for all sends to complete.
-                assertTrue(completionLatch.await(20, TimeUnit.SECONDS));
+                completionLatch.await(20, TimeUnit.SECONDS);
+                if (error.get() != null) {
+                    return false;
+                }
 
-                assertNull(error.get(), "Concurrent send encountered an exception");
-                return publisherDropSeen.get();
-            });
-
-            assertTrue(publisherDropSeen.get(), "Expected at least one publisher drop (entryId == -1)");
-
-            NonPersistentTopic topic =
-                    (NonPersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
-
-            Awaitility.await().ignoreExceptions().untilAsserted(() -> {
                 pulsar.getBrokerService().updateRates();
                 NonPersistentTopicStats stats = topic.getStats(false, false, false);
+                if (stats.getPublishers().isEmpty()) {
+                    return false;
+                }
                 NonPersistentPublisherStats npStats = stats.getPublishers().get(0);
                 NonPersistentSubscriptionStats sub1Stats = stats.getSubscriptions().get("subscriber-1");
                 NonPersistentSubscriptionStats sub2Stats = stats.getSubscriptions().get("subscriber-2");
-                assertTrue(npStats.getMsgDropRate() > 0);
-                assertTrue(sub1Stats.getMsgDropRate() > 0);
-                assertTrue(sub2Stats.getMsgDropRate() > 0);
+                return sub1Stats != null && sub2Stats != null
+                        && npStats.getMsgDropRate() > 0
+                        && sub1Stats.getMsgDropRate() > 0
+                        && sub2Stats.getMsgDropRate() > 0;
             });
 
         } finally {


### PR DESCRIPTION
## Motivation
Fix flaky test `testMsgDropStat` in `NonPersistentTopicTest`.

The test had two separate Awaitility loops: one to trigger publisher drops and another to verify drop rates via stats. This was inherently racy because `Rate.calculateRate()` calls `countAdder.sumThenReset()`, which destructively resets the drop counters. When the second loop retried after a counter reset, it would see 0 drops even though drops had occurred.

## Modifications
Combined both Awaitility loops into a single loop that:
1. Sends fresh concurrent bursts (using CyclicBarrier for simultaneous sends)
2. Calls `updateRates()` and checks all drop rates in the same iteration

This ensures each `updateRates()` call sees freshly-accumulated drops rather than stale (reset) counters.

## Documentation
- [x] `doc-not-needed`

## Matching PR in forked repository
_No response_