### PR TITLE
[improve][test] Fix cast, static, removal, and varargs compile warnings in test code

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -834,7 +834,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedCursor cursor = ledger.openCursor("c1");
 
         for (int i = 0; i < 100; i++) {
-            ledger.addEntry(new byte[(int) (1024)]);
+            ledger.addEntry(new byte[1024]);
         }
 
         // Since https://github.com/apache/pulsar/pull/23931 improved the performance of delivery, the consumer

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -545,8 +545,8 @@ public class InflightReadsLimiterTest {
         InflightReadsLimiter limiter = new InflightReadsLimiter(maxReadsInFlightSize, ACQUIRE_QUEUE_SIZE,
                 ACQUIRE_TIMEOUT_MILLIS, mock(ScheduledExecutorService.class), OpenTelemetry.noop());
 
-        Assertions.assertThat(limiter.PULSAR_ML_READS_BUFFER_SIZE.get()).isZero();
-        Assertions.assertThat(limiter.PULSAR_ML_READS_AVAILABLE_BUFFER_SIZE.get())
+        Assertions.assertThat(InflightReadsLimiter.PULSAR_ML_READS_BUFFER_SIZE.get()).isZero();
+        Assertions.assertThat(InflightReadsLimiter.PULSAR_ML_READS_AVAILABLE_BUFFER_SIZE.get())
                 .isEqualTo(maxReadsInFlightSize);
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/ZooKeeperUtil.java
@@ -170,7 +170,7 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
         for (final Thread t : allthreads) {
             if (t.getName().contains("SyncThread:0")) {
                 Thread sleeper = new Thread() {
-                    @SuppressWarnings("deprecation")
+                    @SuppressWarnings({"deprecation", "removal"})
                     public void run() {
                         try {
                             t.suspend();

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsClient.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsClient.java
@@ -143,6 +143,7 @@ public class PrometheusMetricsClient {
         }
 
         @SafeVarargs
+        @SuppressWarnings("varargs")
         public final Metric findSingleMetricByNameAndLabels(String metricName, Pair<String, String>... nameValuePairs) {
             List<Metric> metricByNameAndLabels = findByNameAndLabels(metricName, nameValuePairs);
             if (metricByNameAndLabels.size() != 1) {

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/NonEntryCacheKeySharedSubscriptionV30Test.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/NonEntryCacheKeySharedSubscriptionV30Test.java
@@ -133,9 +133,9 @@ public class NonEntryCacheKeySharedSubscriptionV30Test extends ProducerConsumerB
         //  - ack all messages that consumer1 or consumer2 received.
         //  - do not ack messages that consumer2 received.
         ackAllMessages(consumer1, consumer2);
-        Position mdPosition = (Position) cursor.getMarkDeletedPosition();
-        Position readPosition = (Position) cursor.getReadPosition();
-        Position lastConfirmed = (Position) ml.getLastConfirmedEntry();
+        Position mdPosition = cursor.getMarkDeletedPosition();
+        Position readPosition = cursor.getReadPosition();
+        Position lastConfirmed = ml.getLastConfirmedEntry();
         assertTrue(readPosition.compareTo(lastConfirmed) >= 0);
         Position firstWaitingAckPos = ml.getNextValidPosition(mdPosition);
         log.info("md-pos {}:{}", mdPosition.getLedgerId(), mdPosition.getEntryId());
@@ -223,9 +223,9 @@ public class NonEntryCacheKeySharedSubscriptionV30Test extends ProducerConsumerB
             }
             log.info("recent-joined-consumers {} {}", i, dispatcher.getRecentlyJoinedConsumers().size());
             if (dispatcher.getRecentlyJoinedConsumers().size() > 0) {
-                Position mdPosition2 = (Position) cursor.getMarkDeletedPosition();
-                Position readPosition2 = (Position) cursor.getReadPosition();
-                Position lastConfirmed2 = (Position) ml.getLastConfirmedEntry();
+                Position mdPosition2 = cursor.getMarkDeletedPosition();
+                Position readPosition2 = cursor.getReadPosition();
+                Position lastConfirmed2 = ml.getLastConfirmedEntry();
                 assertTrue(readPosition.compareTo(lastConfirmed) >= 0);
                 Position firstWaitingAckPos2 = ml.getNextValidPosition(mdPosition);
                 if (readPosition2.compareTo(firstWaitingAckPos) > 0) {
@@ -272,9 +272,9 @@ public class NonEntryCacheKeySharedSubscriptionV30Test extends ProducerConsumerB
         Position posAfter = null;
         for (Map.Entry<org.apache.pulsar.broker.service.Consumer, Position> entry : map.entrySet()) {
             if (posPre == null) {
-                posPre = (Position) entry.getValue();
+                posPre = entry.getValue();
             } else {
-                posAfter = (Position) entry.getValue();
+                posAfter = entry.getValue();
             }
             if (posPre != null && posAfter != null) {
                 if (posPre.compareTo(posAfter) > 0) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -1030,7 +1030,7 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
         String statUrl = baseUrl + topic + "/stats";
         WebTarget webTarget = client.target(statUrl);
         Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        Response response = (Response) invocationBuilder.get();
+        Response response = invocationBuilder.get();
         String responseStr = response.readEntity(String.class);
         final Gson gson = new Gson();
         final ProxyTopicStat data = gson.fromJson(responseStr, ProxyTopicStat.class);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestRunMain.java
@@ -102,7 +102,7 @@ public class TestRunMain {
         boolean prevValue = PulsarAdminTool.allowSystemExit;
         PulsarAdminTool.allowSystemExit = false;
 
-        String argStr = argStr = argStrTemp.format(argStrTemp, testConfigFile.getAbsolutePath(),
+        String argStr = String.format(argStrTemp, testConfigFile.getAbsolutePath(),
                 "--tls-trust-cert-path " + tlsTrustCertsFilePathInArg);
         PulsarAdminTool tool = PulsarAdminTool.execute(argStr.split(" "));
         assertNotNull(tool);

--- a/pulsar-client/src/test/java/org/apache/pulsar/common/schema/KeyValueTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/common/schema/KeyValueTest.java
@@ -70,7 +70,7 @@ public class KeyValueTest {
             put(StringSchema.utf8(), Arrays.asList("my string"));
             put(ByteSchema.of(), Arrays.asList((byte) 32767, (byte) -32768));
             put(ShortSchema.of(), Arrays.asList((short) 32767, (short) -32768));
-            put(IntSchema.of(), Arrays.asList((int) 423412424, (int) -41243432));
+            put(IntSchema.of(), Arrays.asList(423412424, -41243432));
             put(LongSchema.of(), Arrays.asList(922337203685477580L, -922337203685477581L));
             put(FloatSchema.of(), Arrays.asList(5678567.12312f, -5678567.12341f));
             put(DoubleSchema.of(), Arrays.asList(5678567.12312d, -5678567.12341d));

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OldPolicies.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OldPolicies.java
@@ -53,4 +53,9 @@ public class OldPolicies {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(authPolicies, replicationClusters, backlogQuotaMap, persistence, latencyStatsSampleRate);
+    }
+
 }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/batch/BatchSourceExecutorTest.java
@@ -369,43 +369,43 @@ public class BatchSourceExecutorTest {
   @Test
   public void testLifeCycle() throws Exception {
     batchSourceExecutor.open(config, context);
-    Assert.assertEquals(testBatchSource.getDiscoverCount(), 0);
+    Assert.assertEquals(TestBatchSource.getDiscoverCount(), 0);
     triggerQueue.put("trigger");
     completedQueue.take();
-    Assert.assertEquals(testBatchSource.getDiscoverCount(), 1);
+    Assert.assertEquals(TestBatchSource.getDiscoverCount(), 1);
     for (int i = 0; i < 5; ++i) {
       batchSourceExecutor.read();
     }
-    Assert.assertEquals(testBatchSource.getRecordCount(), 6);
-    Assert.assertEquals(testBatchSource.getDiscoverCount(), 1);
+    Assert.assertEquals(TestBatchSource.getRecordCount(), 6);
+    Assert.assertEquals(TestBatchSource.getDiscoverCount(), 1);
 
     awaitDiscoverNotInProgress();
     triggerQueue.put("trigger");
     completedQueue.take();
-    Assert.assertTrue(testBatchSource.getDiscoverCount() == 2);
+    Assert.assertTrue(TestBatchSource.getDiscoverCount() == 2);
     batchSourceExecutor.close();
-    Assert.assertEquals(testBatchSource.getCloseCount(), 1);
+    Assert.assertEquals(TestBatchSource.getCloseCount(), 1);
   }
 
   @Test
   public void testPushLifeCycle() throws Exception {
     batchSourceExecutor.open(pushConfig, context);
-    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 0);
+    Assert.assertEquals(TestBatchPushSource.getDiscoverCount(), 0);
     triggerQueue.put("trigger");
     completedQueue.take();
-    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 1);
+    Assert.assertEquals(TestBatchPushSource.getDiscoverCount(), 1);
     for (int i = 0; i < 5; ++i) {
       batchSourceExecutor.read();
     }
-    Assert.assertEquals(testBatchPushSource.getRecordCount(), 5);
-    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 1);
+    Assert.assertEquals(TestBatchPushSource.getRecordCount(), 5);
+    Assert.assertEquals(TestBatchPushSource.getDiscoverCount(), 1);
 
     awaitDiscoverNotInProgress();
     triggerQueue.put("trigger");
     completedQueue.take();
-    Assert.assertEquals(testBatchPushSource.getDiscoverCount(), 2);
+    Assert.assertEquals(TestBatchPushSource.getDiscoverCount(), 2);
     batchSourceExecutor.close();
-    Assert.assertEquals(testBatchPushSource.getCloseCount(), 1);
+    Assert.assertEquals(TestBatchPushSource.getCloseCount(), 1);
   }
 
   @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = "discovery failed")

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/ZooKeeperUtil.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/ZooKeeperUtil.java
@@ -171,7 +171,7 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
         for (final Thread t : allthreads) {
             if (t.getName().contains("SyncThread:0")) {
                 Thread sleeper = new Thread() {
-                    @SuppressWarnings("deprecation")
+                    @SuppressWarnings({"deprecation", "removal"})
                     public void run() {
                         try {
                             t.suspend();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/ZKSessionTest.java
@@ -93,7 +93,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertEquals(e, SessionEvent.SessionLost);
 
         zks.start();
-        boolean zkServerReady = zks.waitForServerUp(zks.getConnectionString(), 30_000);
+        boolean zkServerReady = TestZKServer.waitForServerUp(zks.getConnectionString(), 30_000);
         assertTrue(zkServerReady);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.Reconnected);
@@ -127,7 +127,7 @@ public class ZKSessionTest extends BaseMetadataStoreTest {
         assertEquals(e, SessionEvent.SessionLost);
 
         zks.start();
-        boolean zkServerReady = zks.waitForServerUp(zks.getConnectionString(), 30_000);
+        boolean zkServerReady = TestZKServer.waitForServerUp(zks.getConnectionString(), 30_000);
         assertTrue(zkServerReady);
         e = sessionEvents.poll(10, TimeUnit.SECONDS);
         assertEquals(e, SessionEvent.Reconnected);

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/ZooKeeperUtil.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/bookkeeper/test/ZooKeeperUtil.java
@@ -110,6 +110,7 @@ public class ZooKeeperUtil implements ZooKeeperCluster {
             final Thread t = var5[var7];
             if (t.getName().contains("SyncThread:0")) {
                 Thread sleeper = new Thread() {
+                    @SuppressWarnings({"deprecation", "removal"})
                     public void run() {
                         try {
                             t.suspend();

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockHeaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/DataBlockHeaderTest.java
@@ -41,7 +41,7 @@ public class DataBlockHeaderTest {
             firstEntryId);
 
         // verify get methods
-        assertEquals(dataBlockHeader.getBlockMagicWord(), DataBlockHeaderImpl.MAGIC_WORD);
+        assertEquals(DataBlockHeaderImpl.getBlockMagicWord(), DataBlockHeaderImpl.MAGIC_WORD);
         assertEquals(dataBlockHeader.getBlockLength(), blockLength);
         assertEquals(dataBlockHeader.getFirstEntryId(), firstEntryId);
 


### PR DESCRIPTION
## Motivation

Fix compiler warnings in test code for small warning categories: `cast`, `static`, `removal`, `varargs`, and `overrides`.

This is part of a series to clean up test compile warnings (following production code cleanup in #25414-#25422).

## Changes

- **cast**: Remove redundant casts that the compiler can infer
- **static**: Access static methods via class name instead of instance
- **removal**: Add `@SuppressWarnings({"deprecation","removal"})` for `Thread.suspend()`/`Thread.resume()` in test utilities (these deprecated-for-removal APIs have no alternative for the test use case)
- **overrides**: Fix missing `hashCode()` override to match `equals()` in `OldPolicies`

## Verifying this change

- `./gradlew compileTestJava` passes cleanly
- Warning count for these categories drops to zero

### Does this pull request potentially affect one of the following areas?

- [x] *Test code only*

### Documentation

- [x] `doc-not-needed` — test-only changes