### PR TITLE
[improve][test] Fix rawtypes compile warnings in test code

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/InflightReadsLimiterIntegrationTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/InflightReadsLimiterIntegrationTest.java
@@ -102,7 +102,7 @@ public class InflightReadsLimiterIntegrationTest extends MockedBookKeeperTestCas
         LedgerHandle currentLedger = ml.currentLedger;
         LedgerHandle spyCurrentLedger = Mockito.spy(currentLedger);
         ml.currentLedger = spyCurrentLedger;
-        Answer answer = invocation -> {
+        Answer<?> answer = invocation -> {
             long firstEntry = (long) invocation.getArguments()[0];
             log.info("reading entry: {}", firstEntry);
             if (firstEntry == start1) {
@@ -112,7 +112,7 @@ public class InflightReadsLimiterIntegrationTest extends MockedBookKeeperTestCas
                 Object res = invocation.callRealMethod();
                 return res;
             } else if (secondReadEntries.contains(firstEntry)) {
-                final CompletableFuture res = new CompletableFuture<>();
+                final CompletableFuture<Object> res = new CompletableFuture<>();
                 threadFactory.newThread(() -> {
                     try {
                         readCompleteSignal2.await();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -1077,7 +1077,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         final int messages = 100;
         final int consumers = 5;
 
-        List<Future<AtomicBoolean>> futures = new ArrayList();
+        List<Future<AtomicBoolean>> futures = new ArrayList<>();
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         final CyclicBarrier barrier = new CyclicBarrier(consumers + 1);
@@ -2372,7 +2372,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         final int messages = 100;
         final int consumers = 10;
 
-        List<Future<Void>> futures = new ArrayList();
+        List<Future<Void>> futures = new ArrayList<>();
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newCachedThreadPool();
         final CyclicBarrier barrier = new CyclicBarrier(consumers + 1);
@@ -3115,7 +3115,7 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ledger.addEntry("entry4".getBytes(Encoding));
 
         // 1. Replay empty position set should return empty entry set
-        Set<Position> positions = new HashSet();
+        Set<Position> positions = new HashSet<>();
         assertTrue(c1.replayEntries(positions).isEmpty());
 
         positions.add(p1);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -187,7 +187,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         final AtomicBoolean done = new AtomicBoolean();
         final CyclicBarrier barrier = new CyclicBarrier(numProducers + numConsumers + 1);
 
-        List<Future<?>> futures = new ArrayList();
+        List<Future<?>> futures = new ArrayList<>();
 
         for (int i = 0; i < numProducers; i++) {
             futures.add(executor.submit(() -> {
@@ -266,7 +266,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         final AtomicBoolean done = new AtomicBoolean();
         final CyclicBarrier barrier = new CyclicBarrier(numProducers + numConsumers + 1);
 
-        List<Future<?>> futures = new ArrayList();
+        List<Future<?>> futures = new ArrayList<>();
         List<Position> positions = new CopyOnWriteArrayList<>();
 
         for (int i = 0; i < numProducers; i++) {
@@ -375,12 +375,12 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         mlConfig.setMetadataMaxEntriesPerLedger(10);
         ManagedLedger ledger = factory.open("ml-markdelete-ledger", mlConfig);
 
-        final List<Position> addedEntries = new ArrayList();
+        final List<Position> addedEntries = new ArrayList<>();
 
         int numCursors = 10;
         final CyclicBarrier barrier = new CyclicBarrier(numCursors);
 
-        List<ManagedCursor> cursors = new ArrayList();
+        List<ManagedCursor> cursors = new ArrayList<>();
         for (int i = 0; i < numCursors; i++) {
             cursors.add(ledger.openCursor(String.format("c%d", i)));
         }
@@ -390,7 +390,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
             addedEntries.add(pos);
         }
 
-        List<Future<?>> futures = new ArrayList();
+        List<Future<?>> futures = new ArrayList<>();
 
         for (ManagedCursor cursor : cursors) {
             futures.add(executor.submit(() -> {
@@ -424,7 +424,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         ManagedLedger ledger = factory.open("my_test_ledger" + testName, config);
         ManagedCursor cursor = ledger.openCursor("c1");
 
-        List<Position> positions = new ArrayList();
+        List<Position> positions = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
             Position p = ledger.addEntry("entry".getBytes());
@@ -432,7 +432,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         }
 
         final CountDownLatch counter = new CountDownLatch(positions.size());
-        final AtomicReference<Exception> gotException = new AtomicReference();
+        final AtomicReference<Exception> gotException = new AtomicReference<>();
 
         for (Position p : positions) {
             cursor.asyncDelete(p, new DeleteCallback() {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -1493,7 +1493,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
 
         c2.close();
         ledger.deleteCursor("c2");
-        assertEquals(Sets.newHashSet(ledger.getCursors()), new HashSet());
+        assertEquals(Sets.newHashSet(ledger.getCursors()), new HashSet<>());
     }
 
     @Test
@@ -1621,7 +1621,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     public void ledgersList() throws Exception {
         MetaStore store = factory.getMetaStore();
 
-        assertEquals(Sets.newHashSet(store.getManagedLedgers()), new HashSet());
+        assertEquals(Sets.newHashSet(store.getManagedLedgers()), new HashSet<>());
         ManagedLedger ledger1 = factory.open("ledger1");
         assertEquals(Sets.newHashSet(store.getManagedLedgers()), Sets.newHashSet("ledger1"));
         ManagedLedger ledger2 = factory.open("ledger2");
@@ -1629,7 +1629,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ledger1.delete();
         assertEquals(Sets.newHashSet(store.getManagedLedgers()), Sets.newHashSet("ledger2"));
         ledger2.delete();
-        assertEquals(Sets.newHashSet(store.getManagedLedgers()), new HashSet());
+        assertEquals(Sets.newHashSet(store.getManagedLedgers()), new HashSet<>());
     }
 
     @Test
@@ -3225,7 +3225,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         latch.await(config.getMetadataOperationsTimeoutSeconds() + 2, TimeUnit.SECONDS);
         assertEquals(response.get(), BKException.Code.TimeoutException);
         assertTrue(ctxHolder.get() instanceof CompletableFuture);
-        CompletableFuture ledgerCreateHook = (CompletableFuture) ctxHolder.get();
+        CompletableFuture<?> ledgerCreateHook = (CompletableFuture<?>) ctxHolder.get();
         assertTrue(ledgerCreateHook.isCompletedExceptionally());
 
         ledger.close();
@@ -3650,7 +3650,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(config.getProperties().get("key"), "value");
     }
 
-    private void setFieldValue(Class clazz, Object classObj, String fieldName, Object fieldValue) throws Exception {
+    private void setFieldValue(Class<?> clazz, Object classObj, String fieldName, Object fieldValue) throws Exception {
         Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(classObj, fieldValue);
@@ -4530,7 +4530,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             BlockingQueue<Runnable> queue =  WhiteboxImpl.getInternalState(boundedScheduledExecutorService, "queue");
             for (Runnable r : queue) {
                 if (r instanceof FutureTask) {
-                    FutureTask futureTask = (FutureTask) r;
+                    FutureTask<?> futureTask = (FutureTask<?>) r;
                     if (!futureTask.isCancelled() && !futureTask.isDone()) {
                         taskCounter++;
                     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixReadTest.java
@@ -254,7 +254,7 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
         }
         config.setRetentionTime(0, TimeUnit.MILLISECONDS);
         config.setRetentionSizeInMB(0);
-        CompletableFuture trimFuture = new CompletableFuture();
+        CompletableFuture<Void> trimFuture = new CompletableFuture<>();
         ledger.trimConsumedLedgersInBackground(trimFuture);
         trimFuture.join();
         Awaitility.await().untilAsserted(() -> {
@@ -381,7 +381,7 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
 
     static class MockOffloadReadHandle implements ReadHandle, OffloadedLedgerHandle {
         final long id;
-        final List<ByteBuf> entries = new ArrayList();
+        final List<ByteBuf> entries = new ArrayList<>();
         final LedgerMetadata metadata;
         long lastAccessTimestamp = System.currentTimeMillis();
 
@@ -413,7 +413,7 @@ public class OffloadPrefixReadTest extends MockedBookKeeperTestCase {
 
         @Override
         public CompletableFuture<LedgerEntries> readAsync(long firstEntry, long lastEntry) {
-            List<LedgerEntry> readEntries = new ArrayList();
+            List<LedgerEntry> readEntries = new ArrayList<>();
             for (long eid = firstEntry; eid <= lastEntry; eid++) {
                 ByteBuf buf = entries.get((int) eid).retainedSlice();
                 readEntries.add(LedgerEntryImpl.create(id, eid, buf.readableBytes(), buf));

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/MangedLedgerInterceptorImpl2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/MangedLedgerInterceptorImpl2Test.java
@@ -57,9 +57,9 @@ public class MangedLedgerInterceptorImpl2Test extends MockedBookKeeperTestCase {
 
         // Registry interceptor.
         ManagedLedgerConfig config = new ManagedLedgerConfig();
-        Set<ManagedLedgerPayloadProcessor> processors = new HashSet();
+        Set<ManagedLedgerPayloadProcessor> processors = new HashSet<>();
         processors.add(new TestPayloadProcessor());
-        ManagedLedgerInterceptor interceptor = new ManagedLedgerInterceptorImpl(new HashSet(), processors);
+        ManagedLedgerInterceptor interceptor = new ManagedLedgerInterceptorImpl(new HashSet<>(), processors);
         config.setManagedLedgerInterceptor(interceptor);
         config.setMaxEntriesPerLedger(100);
 

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/NonEntryCacheKeySharedSubscriptionV30Test.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/NonEntryCacheKeySharedSubscriptionV30Test.java
@@ -149,11 +149,11 @@ public class NonEntryCacheKeySharedSubscriptionV30Test extends ProducerConsumerB
         LedgerHandle spyFirstLedger = spy(firstLedger);
         CountDownLatch replyReadSignal = new CountDownLatch(1);
         AtomicBoolean replayReadWasTriggered = new AtomicBoolean();
-        Answer answer = invocation -> {
+        Answer<?> answer = invocation -> {
             long firstEntry = (long) invocation.getArguments()[0];
             if (firstEntry == firstWaitingAckPos.getEntryId()) {
                 replayReadWasTriggered.set(true);
-                final CompletableFuture res = new CompletableFuture<>();
+                final CompletableFuture<Object> res = new CompletableFuture<>();
                 threadFactory.newThread(() -> {
                     try {
                         replyReadSignal.await();
@@ -246,6 +246,7 @@ public class NonEntryCacheKeySharedSubscriptionV30Test extends ProducerConsumerB
         consumerList.get(consumerList.size() - 1).join();
 
         synchronized (dispatcher) {
+            @SuppressWarnings("rawtypes")
             LinkedHashMap recentJoinedConsumers = dispatcher.getRecentlyJoinedConsumers();
             assertTrue(verifyMapItemsAreInOrder(recentJoinedConsumers));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
@@ -375,7 +375,7 @@ public class PulsarBrokerStarterTest {
             ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baoStream));
 
-            Class argumentsClass = Class.forName("org.apache.pulsar.PulsarBrokerStarter$StarterArguments");
+            Class<?> argumentsClass = Class.forName("org.apache.pulsar.PulsarBrokerStarter$StarterArguments");
             PulsarBrokerStarter.main(new String[]{"-g"});
 
             String message = baoStream.toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarClusterMetadataTeardownTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarClusterMetadataTeardownTest.java
@@ -34,7 +34,7 @@ public class PulsarClusterMetadataTeardownTest {
             ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baoStream));
 
-            Class argumentsClass =
+            Class<?> argumentsClass =
                     Class.forName("org.apache.pulsar.PulsarClusterMetadataTeardown$Arguments");
 
             PulsarClusterMetadataTeardown.main(new String[]{"-zk", "zk", "-g"});

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarVersionStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarVersionStarterTest.java
@@ -34,7 +34,7 @@ public class PulsarVersionStarterTest {
             ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baoStream));
 
-            Class argumentsClass =
+            Class<?> argumentsClass =
                     Class.forName("org.apache.pulsar.PulsarVersionStarter$Arguments");
 
             PulsarVersionStarter.main(new String[]{"-g"});

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/LedgerLostAndSkipNonRecoverableTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/LedgerLostAndSkipNonRecoverableTest.java
@@ -92,7 +92,7 @@ public class LedgerLostAndSkipNonRecoverableTest extends SharedPulsarBaseTest {
         ConsumerAndReceivedMessages consumerAndReceivedMessages1 =
                 waitConsumeAndAllMessages(topicName, subName, enabledBatch, false);
         List<MessageIdImpl>[] messageIds = consumerAndReceivedMessages1.messageIds;
-        Consumer consumer = consumerAndReceivedMessages1.consumer;
+        Consumer<?> consumer = consumerAndReceivedMessages1.consumer;
         MessageIdImpl individualPosition = messageIds[1].get(messageCountPerEntry - 1);
         MessageIdImpl expectedMarkDeletedPosition =
                 new MessageIdImpl(messageIds[0].get(0).getLedgerId(), messageIds[0].get(0).getEntryId(), -1);
@@ -153,7 +153,7 @@ public class LedgerLostAndSkipNonRecoverableTest extends SharedPulsarBaseTest {
 
     private List<MessageIdImpl>[] sendManyMessages(String topicName, int ledgerCount, int messageCountPerLedger,
                                                    int messageCountPerEntry) throws Exception {
-        List<MessageIdImpl>[] messageIds = new List[ledgerCount];
+        @SuppressWarnings({"unchecked", "rawtypes"})        List<MessageIdImpl>[] messageIds = new List[ledgerCount];
         for (int i = 0; i < ledgerCount; i++){
             admin.topics().unload(topicName);
             if (messageCountPerEntry == 1) {
@@ -221,9 +221,9 @@ public class LedgerLostAndSkipNonRecoverableTest extends SharedPulsarBaseTest {
                                                             final boolean enabledBatch,
                                                             boolean ack) throws Exception {
         List<MessageIdImpl> messageIds = new ArrayList<>();
-        final Consumer consumer = createConsumer(topicName, subName, enabledBatch);
+        final Consumer<?> consumer = createConsumer(topicName, subName, enabledBatch);
         while (true){
-            Message message = consumer.receive(5, TimeUnit.SECONDS);
+            Message<?> message = consumer.receive(5, TimeUnit.SECONDS);
             if (message != null){
                 messageIds.add((MessageIdImpl) message.getMessageId());
                 if (ack) {
@@ -239,13 +239,14 @@ public class LedgerLostAndSkipNonRecoverableTest extends SharedPulsarBaseTest {
 
     @AllArgsConstructor
     private static class ConsumerAndReceivedMessages {
-        private Consumer consumer;
+        private Consumer<?> consumer;
         private List<MessageIdImpl>[] messageIds;
     }
 
     private List<MessageIdImpl>[] sortMessageId(List<MessageIdImpl> messageIds, boolean enabledBatch){
         Map<Long, List<MessageIdImpl>> map = messageIds.stream().collect(Collectors.groupingBy(v -> v.getLedgerId()));
         TreeMap<Long, List<MessageIdImpl>> sortedMap = new TreeMap<>(map);
+        @SuppressWarnings({"unchecked", "rawtypes"})
         List<MessageIdImpl>[] res = new List[sortedMap.size()];
         Iterator<Map.Entry<Long, List<MessageIdImpl>>> iterator = sortedMap.entrySet().iterator();
         for (int i = 0; i < sortedMap.size(); i++){

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -2623,7 +2623,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://testTenant/ns1/max-subscriptions-per-topic";
 
         admin.topics().createPartitionedTopic(topic, 3);
-        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
         producer.close();
 
         // create subscription
@@ -2662,9 +2662,9 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         producer = pulsarClient.newProducer().topic(topic).create();
         producer.close();
 
-        Consumer consumer1 = null;
-        Consumer consumer2 = null;
-        Consumer consumer3 = null;
+        Consumer<?> consumer1 = null;
+        Consumer<?> consumer2 = null;
+        Consumer<?> consumer3 = null;
 
         try {
             consumer1 = pulsarClient.newConsumer().subscriptionName("test-sub1").topic(topic).subscribe();
@@ -3268,14 +3268,14 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         AbstractTopic topic = (AbstractTopic) topics.get(topicName).join().get();
         AbstractTopic spyTopic = Mockito.spy(topic);
         AtomicInteger counter = new AtomicInteger();
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 counter.incrementAndGet();
                 return invocation.callRealMethod();
             }
         }).when(spyTopic).addSchema(any(SchemaData.class));
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 counter.incrementAndGet();
@@ -3797,7 +3797,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         admin.topics().analyzeSubscriptionBacklog(topic, subscription, Optional.of(MessageIdImpl.earliest));
         for (int i = 0; i < 10; i++) {
             Awaitility.await().untilAsserted(() -> {
-                Message m = consumer.receive();
+                Message<?> m = consumer.receive();
                 assertNotNull(m);
                 consumer.acknowledge(m);
             });
@@ -4162,7 +4162,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     public void testDeletePatchyPartitionedTopic() throws Exception {
         final String topic = BrokerTestUtil.newUniqueName(defaultNamespace + "/tp");
         admin.topics().createPartitionedTopic(topic, 2);
-        Producer producer = pulsarClient.newProducer().topic(TopicName.get(topic).getPartition(0).toString())
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(TopicName.get(topic).getPartition(0).toString())
                 .create();
         // Mock a scenario that "-partition-1" has been removed due to topic GC.
         pulsar.getBrokerService().getTopic(TopicName.get(topic).getPartition(1).toString(), false)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
@@ -190,6 +190,7 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
     class DummyProducerBuilder<T> extends ProducerBuilderImpl<T> {
         // This is a dummy producer builder to test the health check timeout
         // the producer constructed by this builder will not send any message
+        @SuppressWarnings("rawtypes")
         public DummyProducerBuilder(PulsarClientImpl client, Schema schema) {
             super(client, schema);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
@@ -162,7 +162,7 @@ public class AdminApiMaxUnackedMessagesTest extends MockedPulsarServiceBaseTest 
         org.apache.pulsar.broker.service.Consumer serverConsumer =
                 persistentTopic.getSubscription("sub").getConsumers().get(0);
         assertEquals(serverConsumer.getMaxUnackedMessages(), topicLevelPolicy);
-        List<Message> msgs = consumeMsg(consumer, 3);
+        List<Message<?>> msgs = consumeMsg(consumer, 3);
         assertEquals(msgs.size(), 1);
         //disable topic-level limiter
         admin.topics().setMaxUnackedMessagesOnConsumer(topic, 0);
@@ -196,10 +196,10 @@ public class AdminApiMaxUnackedMessagesTest extends MockedPulsarServiceBaseTest 
 
     }
 
-    private List<Message> consumeMsg(Consumer<?> consumer, int msgNum) throws Exception {
-        List<Message> list = new ArrayList<>();
+    private List<Message<?>> consumeMsg(Consumer<?> consumer, int msgNum) throws Exception {
+        List<Message<?>> list = new ArrayList<>();
         for (int i = 0; i < msgNum; i++) {
-            Message message = consumer.receive(1500, TimeUnit.MILLISECONDS);
+            Message<?> message = consumer.receive(1500, TimeUnit.MILLISECONDS);
             if (message == null) {
                 break;
             }
@@ -208,8 +208,8 @@ public class AdminApiMaxUnackedMessagesTest extends MockedPulsarServiceBaseTest 
         return list;
     }
 
-    private void ackMsgs(Consumer<?> consumer, List<Message> msgs) throws Exception {
-        for (Message msg : msgs) {
+    private void ackMsgs(Consumer<?> consumer, List<Message<?>> msgs) throws Exception {
+        for (Message<?> msg : msgs) {
             consumer.acknowledge(msg);
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -250,7 +250,7 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
         String namespace = format("%s%s%s", "schematest", "/",
                 "test");
         String topicName = "persistent://" + namespace + "/test-key-value-schema";
-        Schema keyValueSchema = Schema.KeyValue(Schema.AVRO(Foo.class), Schema.AVRO(Foo.class));
+        Schema<?> keyValueSchema = Schema.KeyValue(Schema.AVRO(Foo.class), Schema.AVRO(Foo.class));
         admin.schemas().createSchema(topicName, keyValueSchema.getSchemaInfo());
         SchemaInfo schemaInfo = admin.schemas().getSchemaInfo(topicName);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaValidationEnforcedTest.java
@@ -82,7 +82,7 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
         } catch (PulsarAdminException.NotFoundException e) {
             assertEquals(e.getMessage(), "Schema not found");
         }
-        try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
+        try (Producer<byte[]> p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
         }
     }
@@ -110,7 +110,7 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
                 .build();
         PostSchemaPayload postSchemaPayload = new PostSchemaPayload("STRING", "", properties);
         admin.schemas().createSchema(topicName, postSchemaPayload);
-        try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
+        try (Producer<byte[]> p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
         }
         assertSchemaInfoEquals(admin.schemas().getSchemaInfo(topicName), schemaInfo);
@@ -138,7 +138,7 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
         } catch (PulsarAdminException.NotFoundException e) {
             assertEquals(e.getMessage(), "Schema not found");
         }
-        try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
+        try (Producer<byte[]> p = pulsarClient.newProducer().topic(topicName).create()) {
             p.send("test schemaValidationEnforced".getBytes());
         }
     }
@@ -169,7 +169,7 @@ public class AdminApiSchemaValidationEnforcedTest extends MockedPulsarServiceBas
                 .build();
         PostSchemaPayload postSchemaPayload = new PostSchemaPayload("STRING", "", properties);
         admin.schemas().createSchema(topicName, postSchemaPayload);
-        try (Producer p = pulsarClient.newProducer().topic(topicName).create()) {
+        try (Producer<byte[]> p = pulsarClient.newProducer().topic(topicName).create()) {
             fail("Client no schema, but topic has schema, should fail");
         }  catch (PulsarClientException e) {
             assertTrue(e.getMessage().contains("IncompatibleSchemaException"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -355,7 +355,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // clear caches to load data from metadata-store again
         MetadataCacheImpl<ClusterData> clusterCache = (MetadataCacheImpl<ClusterData>) pulsar.getPulsarResources()
                 .getClusterResources().getCache();
-        MetadataCacheImpl isolationPolicyCache = (MetadataCacheImpl) pulsar.getPulsarResources()
+        MetadataCacheImpl<?> isolationPolicyCache = (MetadataCacheImpl<?>) pulsar.getPulsarResources()
                 .getNamespaceResources().getIsolationPolicies().getCache();
         AbstractMetadataStore store = (AbstractMetadataStore) clusterCache.getStore();
         clusterCache.invalidateAll();
@@ -962,7 +962,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
 
         AsyncResponse response1 = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> responseCaptor = ArgumentCaptor.forClass(RestException.class);
-        CompletableFuture<List<String>> future = new CompletableFuture();
+        CompletableFuture<List<String>> future = new CompletableFuture<>();
         future.completeExceptionally(new RuntimeException("500 error contains error message"));
         NamespaceService namespaceService = pulsar.getNamespaceService();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AnalyzeBacklogSubscriptionTest.java
@@ -105,7 +105,7 @@ public class AnalyzeBacklogSubscriptionTest extends SharedPulsarBaseTest {
         verifyBacklog(topic, "from-middle", numEntries / 2, numMessages / 2);
 
 
-        try (Consumer consumer = pulsarClient
+        try (Consumer<?> consumer = pulsarClient
                 .newConsumer()
                 .topic(topic)
                 // we want to wait for the server to process acks, in order to not have a flaky test
@@ -113,11 +113,11 @@ public class AnalyzeBacklogSubscriptionTest extends SharedPulsarBaseTest {
                 .subscriptionName(subName)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscribe()) {
-            Message receive1 = consumer.receive();
-            Message receive2 = consumer.receive();
-            Message receive3 = consumer.receive();
-            Message receive4 = consumer.receive();
-            Message receive5 = consumer.receive();
+            Message<?> receive1 = consumer.receive();
+            Message<?> receive2 = consumer.receive();
+            Message<?> receive3 = consumer.receive();
+            Message<?> receive4 = consumer.receive();
+            Message<?> receive5 = consumer.receive();
 
             verifyBacklog(topic, subName, numEntries, numMessages);
 
@@ -141,7 +141,7 @@ public class AnalyzeBacklogSubscriptionTest extends SharedPulsarBaseTest {
 
             int count = numMessages - 5;
             while (count-- > 0) {
-                Message m = consumer.receive();
+                Message<?> m = consumer.receive();
                 consumer.acknowledge(m);
             }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -206,7 +206,7 @@ public class CreateSubscriptionTest extends SharedPulsarBaseTest {
         for (int i = 0; i < 10; i++) {
             producer.send("msg".getBytes(StandardCharsets.UTF_8));
         }
-        Message message = consumer.receive(1, TimeUnit.SECONDS);
+        Message<?> message = consumer.receive(1, TimeUnit.SECONDS);
         assertNotNull(message);
         consumer.acknowledge(message);
         MessageIdImpl messageId = (MessageIdImpl) message.getMessageId();
@@ -319,7 +319,7 @@ public class CreateSubscriptionTest extends SharedPulsarBaseTest {
         Map<String, String> mapShared = new HashMap<>();
         mapShared.put("6", "7");
         // open two consumers with a Shared Subscription
-        Consumer consumerShared1 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
+        Consumer<?> consumerShared1 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
                 .subscriptionMode(subscriptionMode)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionProperties(mapShared)
@@ -332,7 +332,7 @@ public class CreateSubscriptionTest extends SharedPulsarBaseTest {
         // add a new consumer, the properties are not updated
         Map<String, String> mapShared2 = new HashMap<>();
         mapShared2.put("8", "9");
-        Consumer consumerShared2 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
+        Consumer<?> consumerShared2 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
                 .subscriptionMode(subscriptionMode)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionProperties(mapShared2)
@@ -344,7 +344,7 @@ public class CreateSubscriptionTest extends SharedPulsarBaseTest {
         // add a third consumer, the properties are NOT updated
         Map<String, String> mapShared3 = new HashMap<>();
         mapShared3.put("10", "11");
-        Consumer consumerShared3 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
+        Consumer<?> consumerShared3 = pulsarClient.newConsumer().topic(topic).receiverQueueSize(1)
                 .subscriptionMode(subscriptionMode)
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionProperties(mapShared3)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -56,7 +56,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         admin.tenants().createTenant(this.testTenant, tenantInfo);
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Set.of(testCluster));
         admin.topics().createPartitionedTopic(testTopic, 2);
-        Producer producer = pulsarClient.newProducer().topic(testTenant + "/" + testNamespace + "/"
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(testTenant + "/" + testNamespace + "/"
                 + "dummy-topic").create();
         producer.close();
         waitForZooKeeperWatchers();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -156,7 +156,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().createNamespace(testTenant + "/" + testNamespace, Set.of("test"));
         admin.namespaces().createNamespace(myNamespaceV1);
         admin.topics().createPartitionedTopic(testTopic, testTopicPartitions);
-        Producer producer = pulsarClient.newProducer().topic(testTopic).create();
+        Producer<?> producer = pulsarClient.newProducer().topic(testTopic).create();
         producer.close();
         waitForZooKeeperWatchers();
     }
@@ -496,7 +496,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String httpPath = "/admin/v2/persistent/" + namespace + "/" + TopicName.get(topic).getLocalName()
                 + "/maxConsumers";
         admin.topics().createNonPartitionedTopic(topic);
-        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        Producer<?> producer = pulsarClient.newProducer().topic(topic).create();
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopics().get(topic).get().get();
 
@@ -577,7 +577,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String httpPath = "/admin/v2/persistent/" + namespace + "/" + TopicName.get(topic).getLocalName()
                 + "/maxConsumers";
         admin.topics().createNonPartitionedTopic(topic);
-        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        Producer<?> producer = pulsarClient.newProducer().topic(topic).create();
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopics().get(topic).get().get();
 
@@ -2392,19 +2392,19 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         PulsarClient pulsarClient2 = newPulsarClient(lookupUrl.toString(), 0);
         PulsarClient pulsarClient3 = newPulsarClient(lookupUrl.toString(), 0);
 
-        Consumer consumer1 = pulsarClient1.newConsumer().subscriptionName("sub1")
+        Consumer<?> consumer1 = pulsarClient1.newConsumer().subscriptionName("sub1")
                 .topic(persistenceTopic).consumerName("test").subscribe();
         Assert.assertNotNull(consumer1);
         consumer1.close();
         pulsarClient1.shutdown();
 
-        Consumer consumer2 = pulsarClient2.newConsumer().subscriptionName("sub1")
+        Consumer<?> consumer2 = pulsarClient2.newConsumer().subscriptionName("sub1")
                 .topic(persistenceTopic).consumerName("test").subscribe();
         Assert.assertNotNull(consumer2);
         consumer2.close();
         pulsarClient2.shutdown();
 
-        Consumer consumer3 = null;
+        Consumer<?> consumer3 = null;
 
         try {
             consumer3 = pulsarClient3.newConsumer().subscriptionName("sub1")
@@ -2797,8 +2797,8 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         // init cache
         pulsarClient.newProducer().topic(topic).create().close();
         int maxSubInNamespace = 2;
-        List<Consumer> consumers = new ArrayList<>();
-        ConsumerBuilder consumerBuilder = pulsarClient.newConsumer().subscriptionMode(subMode)
+        List<Consumer<?>> consumers = new ArrayList<>();
+        ConsumerBuilder<?> consumerBuilder = pulsarClient.newConsumer().subscriptionMode(subMode)
                 .subscriptionType(SubscriptionType.Shared).topic(topic);
         admin.namespaces().setMaxSubscriptionsPerTopic(myNamespace, maxSubInNamespace);
         Awaitility.await().untilAsserted(()
@@ -2816,7 +2816,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         //fail fast
         assertTrue(System.currentTimeMillis() - start < 3000);
         //clean
-        for (Consumer consumer : consumers) {
+        for (Consumer<?> consumer : consumers) {
             consumer.close();
         }
     }
@@ -2896,7 +2896,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         // init cache
         @Cleanup
-        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
         //default value is null
         assertNull(admin.namespaces().getMaxUnackedMessagesPerSubscription(myNamespace));
         int msgNum = 100;
@@ -2957,7 +2957,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         assertEquals(messages.size(), defaultMaxUnackedMsgOnBroker);
     }
 
-    private void produceMsg(Producer producer, int msgNum) throws Exception{
+    private void produceMsg(Producer<byte[]> producer, int msgNum) throws Exception{
         for (int i = 0; i < msgNum; i++) {
             producer.send("msg".getBytes());
         }
@@ -3280,12 +3280,12 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         conf.setMaxConsumersPerSubscription(maxConsumerPerSubInBroker);
         final String topic = "non-persistent://" + myNamespace + "/test-" + UUID.randomUUID();
         admin.topics().createPartitionedTopic(topic, 3);
-        Producer producer = pulsarClient.newProducer().topic(topic).create();
+        Producer<?> producer = pulsarClient.newProducer().topic(topic).create();
         final String subName = "my-sub";
-        ConsumerBuilder builder = pulsarClient.newConsumer()
+        ConsumerBuilder<?> builder = pulsarClient.newConsumer()
                 .subscriptionType(SubscriptionType.Shared)
                 .subscriptionName(subName).topic(topic);
-        Consumer consumer = builder.subscribe();
+        Consumer<?> consumer = builder.subscribe();
 
         try {
             builder.subscribe();
@@ -3300,7 +3300,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
             assertEquals(admin.namespaces().getMaxConsumersPerSubscription(myNamespace).intValue(),
                     maxConsumerPerSubInNs);
         });
-        Consumer consumer2 = builder.subscribe();
+        Consumer<?> consumer2 = builder.subscribe();
         try {
             builder.subscribe();
             fail("should fail");
@@ -3315,7 +3315,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
             assertEquals(admin.topicPolicies().getMaxConsumersPerSubscription(topic).intValue(),
                     maxConsumerPerSubInTopic);
         });
-        Consumer consumer3 = builder.subscribe();
+        Consumer<?> consumer3 = builder.subscribe();
         try {
             builder.subscribe();
             fail("should fail");
@@ -3512,13 +3512,13 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<Long> future = (CompletableFuture<Long>) field.get(persistentTopic);
         Awaitility.await().untilAsserted(() -> assertTrue(future.isDone()));
 
-        Consumer consumer = pulsarClient.newConsumer()
+        Consumer<?> consumer = pulsarClient.newConsumer()
                 .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                 .readCompacted(true)
                 .topic(topicPoliciesTopic).subscriptionName("sub").subscribe();
         int count = 0;
         while (true) {
-            Message message = consumer.receive(1, TimeUnit.SECONDS);
+            Message<?> message = consumer.receive(1, TimeUnit.SECONDS);
             if (message != null) {
                 count++;
                 consumer.acknowledge(message);
@@ -3547,7 +3547,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
                 .topic(topicPoliciesTopic).subscriptionName("sub").subscribe();
         count = 0;
         while (true) {
-            Message message = consumer.receive(1, TimeUnit.SECONDS);
+            Message<?> message = consumer.receive(1, TimeUnit.SECONDS);
             if (message != null) {
                 count++;
                 consumer.acknowledge(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -1039,7 +1039,7 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         for (int i = 0; i < 4 * n; i++) {
             Message<byte[]> peekMsg = peekMsgs.get(i);
-            MessageImpl peekMsgImpl = (MessageImpl) peekMsg;
+            MessageImpl<?> peekMsgImpl = (MessageImpl<?>) peekMsg;
             MessageMetadata metadata = peekMsgImpl.getMessageBuilder();
             if (metadata.hasMarkerType()) {
                 assertTrue(metadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -759,7 +759,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         };
     }
 
-    protected ServiceProducer getServiceProducer(ProducerImpl clientProducer, String topicName) {
+    protected ServiceProducer getServiceProducer(ProducerImpl<?> clientProducer, String topicName) {
         PersistentTopic persistentTopic =
                 (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
         org.apache.pulsar.broker.service.Producer serviceProducer =
@@ -788,7 +788,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
 
     private static void reconnectAllConnections(PulsarClientImpl c) throws Exception {
         ConnectionPool pool = c.getCnxPool();
-        Method closeAllConnections = ConnectionPool.class.getDeclaredMethod("closeAllConnections", new Class[]{});
+        Method closeAllConnections = ConnectionPool.class.getDeclaredMethod("closeAllConnections", new Class<?>[]{});
         closeAllConnections.setAccessible(true);
         closeAllConnections.invoke(pool, new Object[]{});
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheRollingRestartTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheRollingRestartTest.java
@@ -154,6 +154,7 @@ public class BrokerEntryCacheRollingRestartTest extends AbstractBrokerEntryCache
                 .create();
 
         // Create consumers in paused state with receiver queue size of 50
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<Long>[] consumers = new Consumer[numConsumers];
         List<PulsarClient> consumerPulsarClients = new ArrayList<>();
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheTest.java
@@ -160,6 +160,7 @@ public class BrokerEntryCacheTest extends ProducerConsumerBase {
                 .create();
 
         // Create consumers on the tail (reading from latest)
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<Long>[] consumers = new Consumer[numConsumers];
         for (int i = 0; i < numConsumers; i++) {
             consumers[i] = pulsarClient.newConsumer(Schema.INT64)
@@ -331,6 +332,7 @@ public class BrokerEntryCacheTest extends ProducerConsumerBase {
                 .create();
 
         // Create consumers in paused state with receiver queue size of 50
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<Long>[] consumers = new Consumer[numConsumers];
         for (int i = 0; i < numConsumers; i++) {
             consumers[i] = pulsarClient.newConsumer(Schema.INT64)
@@ -491,6 +493,7 @@ public class BrokerEntryCacheTest extends ProducerConsumerBase {
                 .create();
 
         // Create consumers on the tail (reading from latest)
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<Long>[] consumers = new Consumer[numConsumers];
         for (int i = 0; i < numConsumers; i++) {
             consumers[i] = pulsarClient.newConsumer(Schema.INT64)
@@ -602,6 +605,7 @@ public class BrokerEntryCacheTest extends ProducerConsumerBase {
                 .create();
 
         // Create consumers on the tail (reading from latest)
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<Long>[] consumers = new Consumer[numConsumers];
         for (int i = 0; i < numConsumers; i++) {
             consumers[i] = pulsarClient.newConsumer(Schema.INT64)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/MinimumBacklogCacheStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/MinimumBacklogCacheStrategyTest.java
@@ -86,6 +86,7 @@ public class MinimumBacklogCacheStrategyTest extends ProducerConsumerBase {
         final String topicName = "cache-read";
         final String sub1 = "sub";
         int totalSub = 10;
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Consumer<byte[]>[] consumers = new Consumer[totalSub];
 
         for (int i = 0; i < totalSub; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ExceptionsBrokerInterceptorTest.java
@@ -84,7 +84,7 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+        ConsumerImpl<?> consumer = (ConsumerImpl) pulsarClient
                 .newConsumer()
                 .topic(topic)
                 .subscriptionName(subName)
@@ -100,7 +100,7 @@ public class ExceptionsBrokerInterceptorTest extends ProducerConsumerBase {
         }
 
         int receiveCounter = 0;
-        Message message;
+        Message<?> message;
         while ((message = consumer.receive(3, TimeUnit.SECONDS)) != null) {
             receiveCounter++;
             consumer.acknowledge(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -233,7 +233,7 @@ public class ModularLoadManagerStrategyTest {
     }
 
     public void testRoundRobinBrokerSelector() throws IllegalAccessException {
-        Set<String> brokers = new LinkedHashSet(Arrays.asList("1", "2", "3"));
+        Set<String> brokers = new LinkedHashSet<>(Arrays.asList("1", "2", "3"));
         int n = brokers.size();
         RoundRobinBrokerSelector strategy = new RoundRobinBrokerSelector();
 
@@ -245,13 +245,13 @@ public class ModularLoadManagerStrategyTest {
             assertEquals(strategy.selectBroker(brokers, null, null, null), Optional.of(id));
         }
 
-        Set<String> brokers2 = new LinkedHashSet(Arrays.asList("2", "3", "1"));
+        Set<String> brokers2 = new LinkedHashSet<>(Arrays.asList("2", "3", "1"));
         for (; i < 20; i++) {
             String id = (i % n) + 1 + "";
             assertEquals(strategy.selectBroker(brokers2, null, null, null), Optional.of(id));
         }
 
-        Set<String> brokers3 = new LinkedHashSet(Arrays.asList("1", "2", "4"));
+        Set<String> brokers3 = new LinkedHashSet<>(Arrays.asList("1", "2", "4"));
         assertEquals(strategy.selectBroker(brokers3, null, null, null), Optional.of("4"));
         assertEquals(strategy.selectBroker(brokers3, null, null, null), Optional.of("1"));
         assertEquals(strategy.selectBroker(brokers3, null, null, null), Optional.of("2"));
@@ -259,7 +259,7 @@ public class ModularLoadManagerStrategyTest {
         assertEquals(strategy.selectBroker(brokers3, null, null, null), Optional.of("1"));
         assertEquals(strategy.selectBroker(brokers3, null, null, null), Optional.of("2"));
 
-        Set<String> brokers4 = new LinkedHashSet(Arrays.asList("2", "4"));
+        Set<String> brokers4 = new LinkedHashSet<>(Arrays.asList("2", "4"));
         assertEquals(strategy.selectBroker(brokers4, null, null, null), Optional.of("2"));
         assertEquals(strategy.selectBroker(brokers4, null, null, null), Optional.of("4"));
         assertEquals(strategy.selectBroker(brokers4, null, null, null), Optional.of("2"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -359,7 +359,9 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         NamespaceBundle bundle = pulsar1.getNamespaceService().getBundle(topicName);
         primaryLoadManager.assign(Optional.empty(), bundle, LookupOptions.builder().build()).get();
 
+        @SuppressWarnings("rawtypes")
         CompletableFuture future1 = new CompletableFuture();
+        @SuppressWarnings("rawtypes")
         CompletableFuture future2 = new CompletableFuture();
         try {
             pulsar1.getBrokerService().getTopics().put(topicName.toString(), future1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -289,7 +289,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         assertEquals(6, errorCnt);
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future startFuture = executor.submit(() -> {
+        Future<?> startFuture = executor.submit(() -> {
             try {
                 channel.start();
             } catch (PulsarServerException e) {
@@ -304,7 +304,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
                 ServiceUnitStateChannelImpl.ChannelState.LeaderElectionServiceStarted, true);
         assertNotNull(channel.getChannelOwnerAsync().get(2, TimeUnit.SECONDS).get());
 
-        Future closeFuture = executor.submit(() -> {
+        Future<?> closeFuture = executor.submit(() -> {
             try {
                 channel.close();
             } catch (PulsarServerException e) {
@@ -812,7 +812,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     public void handleBrokerCreationEventTest() throws IllegalAccessException {
         var cleanupJobs = getCleanupJobs(channel1);
         String broker = brokerId2;
-        var future = new CompletableFuture();
+        var future = new CompletableFuture<Void>();
         cleanupJobs.put(broker, future);
         ((ServiceUnitStateChannelImpl) channel1).handleBrokerRegistrationEvent(broker, NotificationType.Created);
         Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
@@ -1842,7 +1842,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         // case 5: the owner lookup gets delayed
         FieldUtils.writeDeclaredField(channel1,
                 "inFlightStateWaitingTimeInMillis", 1000, true);
-        var delayedFuture = new CompletableFuture();
+        var delayedFuture = new CompletableFuture<Object>();
         doReturn(delayedFuture).when(registry).lookupAsync(eq(broker));
         CompletableFuture.runAsync(() -> {
             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundlesTest.java
@@ -288,8 +288,8 @@ public class TopKBundlesTest {
     public void testPartitionSort() {
 
         Random rand = new Random();
-        List<Map.Entry<String, ? extends Comparable>> actual = new ArrayList<>();
-        List<Map.Entry<String, ? extends Comparable>> expected = new ArrayList<>();
+        @SuppressWarnings("rawtypes") List<Map.Entry<String, ? extends Comparable>> actual = new ArrayList<>();
+        @SuppressWarnings("rawtypes") List<Map.Entry<String, ? extends Comparable>> expected = new ArrayList<>();
 
         for (int j = 0; j < 100; j++) {
             Map<String, Integer> map = new HashMap<>();
@@ -337,7 +337,7 @@ public class TopKBundlesTest {
             s.cacheSize = 75000000 - (rnd.nextInt(4 * 75000));
             stats.add(s);
         }
-        List<Map.Entry<String, ? extends Comparable>> bundleEntries = new ArrayList<>();
+        @SuppressWarnings("rawtypes") List<Map.Entry<String, ? extends Comparable>> bundleEntries = new ArrayList<>();
 
         for (NamespaceBundleStats s : stats) {
             bundleEntries.add(Map.entry("bundle-" + s.msgThroughputIn, s));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/BrokerLoadDataReporterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/BrokerLoadDataReporterTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class BrokerLoadDataReporterTest {
     PulsarService pulsar;
+    @SuppressWarnings("rawtypes")
     LoadDataStore store;
     BrokerService brokerService;
     PulsarStats pulsarStats;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/TopBundleLoadDataReporterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/TopBundleLoadDataReporterTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class TopBundleLoadDataReporterTest {
     PulsarService pulsar;
+    @SuppressWarnings("rawtypes")
     LoadDataStore store;
     BrokerService brokerService;
     PulsarStats pulsarStats;
@@ -132,7 +133,7 @@ public class TopBundleLoadDataReporterTest {
         expected.update(bundleStats, 0);
         assertEquals(target.generateLoadData(), expected.getLoadData());
 
-        doReturn(new HashMap()).when(brokerService).getBundleStats();
+        doReturn(new HashMap<>()).when(brokerService).getBundleStats();
         FieldUtils.writeDeclaredField(target, "lastBundleStatsUpdatedAt", 0L, true);
         expected = new TopKBundles(pulsar);
         assertEquals(target.generateLoadData(), expected.getLoadData());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/SplitSchedulerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/SplitSchedulerTest.java
@@ -104,7 +104,7 @@ public class SplitSchedulerTest {
 
     @Test(timeOut = 30 * 1000)
     public void testExecuteSuccess() {
-        AtomicReference<List<Metrics>> reference = new AtomicReference();
+        AtomicReference<List<Metrics>> reference = new AtomicReference<>();
         SplitCounter counter = new SplitCounter();
         SplitManager manager = mock(SplitManager.class);
         SplitScheduler scheduler = new SplitScheduler(pulsar, channel, manager, counter, reference, context, strategy);
@@ -134,7 +134,7 @@ public class SplitSchedulerTest {
 
     @Test(timeOut = 30 * 1000)
     public void testExecuteFailure() {
-        AtomicReference<List<Metrics>> reference = new AtomicReference();
+        AtomicReference<List<Metrics>> reference = new AtomicReference<>();
         SplitCounter counter = new SplitCounter();
         SplitManager manager = new SplitManager(counter);
         SplitScheduler scheduler = new SplitScheduler(pulsar, channel, manager, counter, reference, context, strategy);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/DefaultNamespaceBundleSplitStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/DefaultNamespaceBundleSplitStrategyTest.java
@@ -120,7 +120,7 @@ public class DefaultNamespaceBundleSplitStrategyTest {
         doReturn(namespaceBundleFactory).when(namespaceService).getNamespaceBundleFactory();
         doReturn(brokerRegistry).when(loadManagerContext).brokerRegistry();
         doReturn(broker).when(brokerRegistry).getBrokerId();
-        doReturn(new AtomicReference(loadManagerWrapper)).when(pulsar).getLoadManager();
+        doReturn(new AtomicReference<>(loadManagerWrapper)).when(pulsar).getLoadManager();
         doReturn(loadManager).when(loadManagerWrapper).get();
         doReturn(channel).when(loadManager).getServiceUnitStateChannel();
         doReturn(true).when(channel).isOwner(any());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -1149,7 +1149,7 @@ public class ModularLoadManagerImplTest {
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(pulsar1.getBrokerServiceUrl()).build();
 
         // create a lot of topic to fully distributed among bundles.
-        List<Consumer> consumers = new ArrayList<>();
+        List<Consumer<?>> consumers = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             String topicNameI = topicName + i;
             admin1.topics().createPartitionedTopic(topicNameI, 20);
@@ -1175,7 +1175,7 @@ public class ModularLoadManagerImplTest {
         primaryLoadManager.updateAll();
         Assert.assertFalse(loadData.getBundleData().containsKey(bundleKey));
 
-        for (Consumer consumer : consumers) {
+        for (Consumer<?> consumer : consumers) {
             consumer.close();
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -486,7 +486,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Mock an error when calling "replicator.disconnect()"
         AtomicBoolean closeFailed = new AtomicBoolean(true);
         final ProducerImpl mockProducer = Mockito.mock(ProducerImpl.class);
-        final AtomicReference<ProducerImpl> originalProducer1 = new AtomicReference();
+        final AtomicReference<ProducerImpl<?>> originalProducer1 = new AtomicReference<>();
         doAnswer(invocation -> {
             if (closeFailed.get()) {
                 return CompletableFuture.failedFuture(new Exception("mocked ex"));
@@ -501,8 +501,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         // Verify: After "replicator.producer.closeAsync()" retry again, the "replicator.producer" will be closed
         // successful.
         closeFailed.set(false);
-        AtomicReference<PersistentTopic> topic2 = new AtomicReference();
-        AtomicReference<PersistentReplicator> replicator2 = new AtomicReference();
+        AtomicReference<PersistentTopic> topic2 = new AtomicReference<>();
+        AtomicReference<PersistentReplicator> replicator2 = new AtomicReference<>();
         Awaitility.await().untilAsserted(() -> {
             topic2.set((PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false).join().get());
             replicator2.set((PersistentReplicator) topic2.get().getReplicators().values().iterator().next());
@@ -548,9 +548,9 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
 
         // Inject producer decorator.
         doAnswer(invocation -> {
-            Schema schema = (Schema) invocation.getArguments()[0];
+            Schema<?> schema = (Schema) invocation.getArguments()[0];
             ProducerBuilderImpl<?> producerBuilder = (ProducerBuilderImpl) internalClient.newProducer(schema);
-            ProducerBuilder spyProducerBuilder = spy(producerBuilder);
+            ProducerBuilder<?> spyProducerBuilder = spy(producerBuilder);
             doAnswer(ignore -> {
                 CompletableFuture<Producer> producerFuture = new CompletableFuture<>();
                 producerBuilder.createAsync().whenComplete((p, t) -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1710,7 +1710,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         when(pulsarClientMock.getCnxPool()).thenReturn(connectionPool);
         when(pulsarClientMock.newProducer(any())).thenAnswer(
                 invocation -> {
-                    ProducerBuilderImpl producerBuilder =
+                    @SuppressWarnings("rawtypes")                    ProducerBuilderImpl producerBuilder =
                             new ProducerBuilderImpl(pulsarClientMock, invocation.getArgument(0)) {
                                 @Override
                                 public CompletableFuture<org.apache.pulsar.client.api.Producer> createAsync() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
@@ -341,13 +341,13 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         // Since the cluster1 was not crash, all messages will be replicated to the cluster2.
         consumer1.close();
         final PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString()).build();
-        final Consumer consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
+        final Consumer<?> consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
                 .subscriptionName(subscriptionName).replicateSubscriptionState(isReplicatedSubscription).subscribe();
 
         // Verify all messages will be consumed.
         Awaitility.await().untilAsserted(() -> {
             while (true) {
-                Message message = consumer2.receive(2, TimeUnit.SECONDS);
+                Message<?> message = consumer2.receive(2, TimeUnit.SECONDS);
                 if (message != null) {
                     receivedMessages.add(message.getValue().toString());
                     consumer2.acknowledge(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicGCTest.java
@@ -88,7 +88,7 @@ public class TopicGCTest extends ProducerConsumerBase {
         };
     }
 
-    private void setSubscribeTopic(ConsumerBuilder consumerBuilder, SubscribeTopicType subscribeTopicType,
+    private void setSubscribeTopic(ConsumerBuilder<?> consumerBuilder, SubscribeTopicType subscribeTopicType,
                                    String topicName, String topicPattern) {
         if (subscribeTopicType.equals(SubscribeTopicType.MULTI_PARTITIONED_TOPIC)) {
             consumerBuilder.topic(topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionalReplicateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TransactionalReplicateSubscriptionTest.java
@@ -156,13 +156,13 @@ public class TransactionalReplicateSubscriptionTest extends ReplicatorTestBase {
         // Since the cluster1 was not crash, all messages will be replicated to the cluster2.
         consumer1.close();
         final PulsarClient client2 = PulsarClient.builder().serviceUrl(url2.toString()).build();
-        final Consumer consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
+        final Consumer<?> consumer2 = client2.newConsumer(Schema.AUTO_CONSUME()).topic(topicName)
                 .subscriptionName(subscriptionName).replicateSubscriptionState(isReplicatedSubscription).subscribe();
 
         // Verify all messages will be consumed.
         Awaitility.await().untilAsserted(() -> {
             while (true) {
-                Message message = consumer2.receive(2, TimeUnit.SECONDS);
+                Message<?> message = consumer2.receive(2, TimeUnit.SECONDS);
                 if (message != null) {
                     receivedMessages.add(message.getValue().toString());
                     consumer2.acknowledge(message);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
@@ -91,7 +91,7 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
         injectedTask.setEntries(Collections.emptyList());
         InFlightTask spyTask = spy(injectedTask);
         replicator.inFlightTasks.add(spyTask);
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 counter.incrementAndGet();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicProtectedMethodsTest.java
@@ -96,7 +96,7 @@ public class PersistentTopicProtectedMethodsTest extends ProducerConsumerBase {
             // moving the cursor's mark-delete position past the LAC (e.g., 10:-1 vs 9:1).
             assertTrue(cursor.getMarkDeletedPosition().compareTo(ml.getLastConfirmedEntry()) >= 0);
         });
-        CompletableFuture completableFuture = new CompletableFuture();
+        CompletableFuture completableFuture = new CompletableFuture<>();
         ml.trimConsumedLedgersInBackground(completableFuture);
         completableFuture.join();
         Awaitility.await().untilAsserted(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -331,7 +331,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         NamespaceBundle bundle = pulsar.getNamespaceService().getBundle(TopicName.get(topicName));
         pulsar.getNamespaceService().unloadNamespaceBundle(bundle, 5, TimeUnit.SECONDS).get();
 
-        for (Producer producer : producerSet) {
+        for (Producer<byte[]> producer : producerSet) {
             producer.close();
         }
     }
@@ -360,7 +360,7 @@ public class PersistentTopicTest extends BrokerTestBase {
          * The other 19 calls: get the cached value which related {@link PersistentTopic#closeFutures}.
          */
         assertTrue(futureMap.size() <= 3);
-        for (List list : futureMap.values()){
+        for (List<?> list : futureMap.values()){
             if (list.size() == 1){
                 // This is the first call, the future is the return value of `topic.close`.
             } else {
@@ -589,7 +589,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         doReturn(brokerService).when(pulsar).getBrokerService();
 
         // Create a sub, and send one message.
-        Consumer consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(fullyTopicName).subscriptionName("sub1")
+        Consumer<?> consumer1 = pulsarClient.newConsumer(Schema.STRING).topic(fullyTopicName).subscriptionName("sub1")
                 .subscribe();
         consumer1.close();
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(fullyTopicName).create();
@@ -618,7 +618,7 @@ public class PersistentTopicTest extends BrokerTestBase {
         }
 
         // Assert topic works after deleting failure.
-        Consumer consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(fullyTopicName).subscriptionName("sub1")
+        Consumer<?> consumer2 = pulsarClient.newConsumer(Schema.STRING).topic(fullyTopicName).subscriptionName("sub1")
                 .subscribe();
         org.testng.Assert.assertEquals("1", consumer2.receive(2, TimeUnit.SECONDS).getValue());
         consumer2.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -99,7 +99,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         NamespaceEventsSystemTopicFactory systemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
         TopicPoliciesSystemTopicClient systemTopicClientForNamespace = systemTopicFactory
                 .createTopicPoliciesSystemTopicClient(NamespaceName.get(ns));
-        SystemTopicClient.Reader reader = systemTopicClientForNamespace.newReader();
+        SystemTopicClient.Reader<?> reader = systemTopicClientForNamespace.newReader();
 
         int partitions = admin.topics().getPartitionedTopicMetadata(
                 String.format("persistent://%s/%s", ns, SystemTopicNames.NAMESPACE_EVENTS_LOCAL_NAME)).partitions;
@@ -326,8 +326,8 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         NamespaceEventsSystemTopicFactory systemTopicFactory = new NamespaceEventsSystemTopicFactory(pulsarClient);
         TopicPoliciesSystemTopicClient systemTopicClientForNamespace = systemTopicFactory
                 .createTopicPoliciesSystemTopicClient(NamespaceName.get(ns));
-        SystemTopicClient.Reader reader1 = systemTopicClientForNamespace.newReader();
-        SystemTopicClient.Reader reader2 = systemTopicClientForNamespace.newReader();
+        SystemTopicClient.Reader<?> reader1 = systemTopicClientForNamespace.newReader();
+        SystemTopicClient.Reader<?> reader2 = systemTopicClientForNamespace.newReader();
 
         conf.setMaxSameAddressProducersPerTopic(1);
         admin.namespaces().setMaxProducersPerTopic(ns, 1);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/tools/BrokerToolTest.java
@@ -47,7 +47,7 @@ public class BrokerToolTest {
 
             String message = baoStream.toString();
 
-            Class argumentsClass = Class.forName("org.apache.pulsar.broker.tools.LoadReportCommand");
+            Class<?> argumentsClass = Class.forName("org.apache.pulsar.broker.tools.LoadReportCommand");
             Field[] fields = argumentsClass.getDeclaredFields();
             for (Field field : fields) {
                 boolean fieldHasAnno = field.isAnnotationPresent(Option.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/SegmentAbortedTxnProcessorTest.java
@@ -157,7 +157,7 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
         Field taskQueueField = SnapshotSegmentAbortedTxnProcessorImpl.PersistentWorker.class
                 .getDeclaredField("taskQueue");
         taskQueueField.setAccessible(true);
-        Queue queue = (Queue) taskQueueField.get(persistentWorker);
+        Queue<?> queue = (Queue<?>) taskQueueField.get(persistentWorker);
         Awaitility.await().untilAsserted(() -> assertEquals(queue.size(), 0));
     }
 
@@ -193,8 +193,9 @@ public class SegmentAbortedTxnProcessorTest extends TransactionTestBase {
         Field taskQueueField = SnapshotSegmentAbortedTxnProcessorImpl.PersistentWorker.class
                 .getDeclaredField("taskQueue");
         taskQueueField.setAccessible(true);
-        Supplier task = CompletableFuture::new;
-        Queue queue = (Queue) taskQueueField.get(persistentWorker);
+        Supplier<?> task = CompletableFuture::new;
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Queue<Object> queue = (Queue) taskQueueField.get(persistentWorker);
         queue.add(new MutablePair<>(SnapshotSegmentAbortedTxnProcessorImpl.PersistentWorker.OperationType.WriteSegment,
                 new MutablePair<>(new CompletableFuture<>(), task)));
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -254,7 +254,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
     }
 
     private void makeTBSnapshotReaderTimeoutIfFirstRead(TopicName topicName) throws Exception {
-        SystemTopicClient.Reader mockReader = mock(SystemTopicClient.Reader.class);
+        SystemTopicClient.Reader<?> mockReader = mock(SystemTopicClient.Reader.class);
         AtomicBoolean isFirstCallOfMethodHasMoreEvents = new AtomicBoolean();
         AtomicBoolean isFirstCallOfMethodHasReadNext = new AtomicBoolean();
         AtomicBoolean isFirstCallOfMethodHasReadNextAsync = new AtomicBoolean();
@@ -276,7 +276,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         }).when(mockReader).readNext();
 
         doAnswer(invocation -> {
-            CompletableFuture<Message> future = new CompletableFuture<>();
+            CompletableFuture<Message<?>> future = new CompletableFuture<>();
             new Thread(() -> {
                 if (isFirstCallOfMethodHasReadNextAsync.compareAndSet(false, true)){
                     // Just stuck the thread.
@@ -296,9 +296,9 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
 
         for (PulsarService pulsarService : pulsarServiceList){
             // Init prop: lastMessageIdInBroker.
-            final SystemTopicTxnBufferSnapshotService tbSnapshotService =
+            final SystemTopicTxnBufferSnapshotService<?> tbSnapshotService =
                     pulsarService.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService();
-            SystemTopicTxnBufferSnapshotService spyTbSnapshotService = spy(tbSnapshotService);
+            SystemTopicTxnBufferSnapshotService<?> spyTbSnapshotService = spy(tbSnapshotService);
             doAnswer(invocation -> CompletableFuture.completedFuture(mockReader))
                     .when(spyTbSnapshotService).createReader(topicName);
             Field field =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionConsumeTest.java
@@ -295,7 +295,7 @@ public class TransactionConsumeTest extends TransactionTestBase {
         dispatcher.readMoreEntries();
 
         // shared consumer should not receive the redelivered aborted transaction messages
-        Message message = sharedConsumer.receive(5, TimeUnit.SECONDS);
+        Message<?> message = sharedConsumer.receive(5, TimeUnit.SECONDS);
         Assert.assertNull(message);
 
         log.info("TransactionConsumeTest testMessageRedelivery finish.");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -1425,7 +1425,7 @@ public class TransactionTest extends TransactionTestBase {
                 .subscriptionName(subName)
                 .subscribe();
         List<MessageId> messageIds = new ArrayList<>();
-        for (Message message : messageList) {
+        for (Message<?> message : messageList) {
             messageIds.add(message.getMessageId());
         }
         for (int i = 0; i < 4; i++) {
@@ -1559,7 +1559,7 @@ public class TransactionTest extends TransactionTestBase {
         when(executorProvider.getExecutor(any(Object.class))).thenReturn(executorService);
         // Mock pendingAckStore.
         PendingAckStore pendingAckStore = mock(PendingAckStore.class);
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 executorService.execute(()->{
@@ -1825,26 +1825,35 @@ public class TransactionTest extends TransactionTestBase {
         // inject a failed writer future
         CompletableFuture<SystemTopicClient.Writer<?>> writerFuture = new CompletableFuture<>();
         for (PulsarService pulsarService : pulsarServiceList) {
+            @SuppressWarnings("rawtypes")
             SystemTopicTxnBufferSnapshotService bufferSnapshotService =
                     pulsarService.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotService();
+            @SuppressWarnings({"unchecked", "rawtypes"})
             ConcurrentHashMap<NamespaceName, ReferenceCountedWriter> writerMap1 =
-                    ((ConcurrentHashMap<NamespaceName, ReferenceCountedWriter>) field.get(bufferSnapshotService));
+                    ((ConcurrentHashMap) field.get(bufferSnapshotService));
+            @SuppressWarnings("rawtypes")
             ReferenceCountedWriter failedCountedWriter =
                     new ReferenceCountedWriter(NamespaceName.get(namespace), writerFuture, bufferSnapshotService);
             writerMap1.put(NamespaceName.get(namespace), failedCountedWriter);
 
+            @SuppressWarnings("rawtypes")
             SystemTopicTxnBufferSnapshotService segmentSnapshotService =
                     pulsarService.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotSegmentService();
+            @SuppressWarnings({"unchecked", "rawtypes"})
             ConcurrentHashMap<NamespaceName, ReferenceCountedWriter> writerMap2 =
-                    ((ConcurrentHashMap<NamespaceName, ReferenceCountedWriter>) field.get(segmentSnapshotService));
+                    ((ConcurrentHashMap) field.get(segmentSnapshotService));
+            @SuppressWarnings("rawtypes")
             ReferenceCountedWriter failedCountedWriter2 =
                     new ReferenceCountedWriter(NamespaceName.get(namespace), writerFuture, segmentSnapshotService);
             writerMap2.put(NamespaceName.get(namespace), failedCountedWriter2);
 
+            @SuppressWarnings("rawtypes")
             SystemTopicTxnBufferSnapshotService indexSnapshotService =
                     pulsarService.getTransactionBufferSnapshotServiceFactory().getTxnBufferSnapshotIndexService();
+            @SuppressWarnings({"unchecked", "rawtypes"})
             ConcurrentHashMap<NamespaceName, ReferenceCountedWriter> writerMap3 =
-                    ((ConcurrentHashMap<NamespaceName, ReferenceCountedWriter>) field.get(indexSnapshotService));
+                    ((ConcurrentHashMap) field.get(indexSnapshotService));
+            @SuppressWarnings("rawtypes")
             ReferenceCountedWriter failedCountedWriter3 =
                     new ReferenceCountedWriter(NamespaceName.get(namespace), writerFuture, indexSnapshotService);
             writerMap3.put(NamespaceName.get(namespace), failedCountedWriter3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreTest.java
@@ -230,7 +230,7 @@ public class MLPendingAckStoreTest extends TransactionTestBase {
         when(pendingAckHandle.changeToReadyState()).thenReturn(true);
         // Process controller, mark the replay task already finish.
         final AtomicInteger processController = new AtomicInteger();
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 processController.incrementAndGet();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletWithPulsarServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/plugin/servlet/AdditionalServletWithPulsarServiceTest.java
@@ -49,6 +49,7 @@ public class AdditionalServletWithPulsarServiceTest {
         NarClassLoader mockLoader = mock(NarClassLoader.class);
         when(mockLoader.getServiceDefinition(eq(AdditionalServletUtils.ADDITIONAL_SERVLET_FILE)))
                 .thenReturn(ObjectMapperFactory.getYamlMapper().writer().writeValueAsString(def));
+        @SuppressWarnings("rawtypes")
         Class additionalServletClass = MockAdditionalServletWithClassLoader.class;
         when(mockLoader.loadClass(eq(MockAdditionalServletWithClassLoader.class.getName())))
                 .thenReturn(additionalServletClass);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerConsumerBase.java
@@ -77,7 +77,7 @@ public abstract class ProducerConsumerBase extends MockedPulsarServiceBaseTest {
     protected <T> ReceivedMessages<T> receiveAndAckMessages(
             BiFunction<MessageId, T, Boolean> ackPredicate,
             Consumer<T>...consumers) throws Exception {
-        ReceivedMessages receivedMessages = new ReceivedMessages();
+        ReceivedMessages<T> receivedMessages = new ReceivedMessages<>();
         receiveMessagesInThreads((consumer, msg) -> {
             T v = msg.getValue();
             MessageId messageId = msg.getMessageId();

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1813,6 +1813,7 @@ public class PulsarAdminToolTest {
         verify(mockTopics).peekMessages("persistent://myprop/ns1/ds1", "sub1", 3,
                 false, TransactionIsolationLevel.READ_COMMITTED);
 
+        @SuppressWarnings("rawtypes")
         MessageImpl message = mock(MessageImpl.class);
         when(message.getData()).thenReturn(new byte[]{});
         when(message.getMessageId()).thenReturn(new MessageIdImpl(1L, 1L, 1));
@@ -2581,7 +2582,7 @@ public class PulsarAdminToolTest {
         cmdSchemas.run(split("extract -j " + jarFile + " -c " + className + " -t json persistent://tn1/ns1/tp1"));
         File file = new File(jarFile);
         ClassLoader cl = new URLClassLoader(new URL[]{file.toURI().toURL()});
-        Class cls = cl.loadClass(className);
+        Class<?> cls = cl.loadClass(className);
         SchemaDefinition<Object> schemaDefinition =
                 SchemaDefinition.builder()
                         .withPojo(cls)

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolForceBatchNum.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolForceBatchNum.java
@@ -66,6 +66,7 @@ public class PulsarClientToolForceBatchNum extends PulsarClientTool{
         replaceProducerCommand(produceCommand);
     }
 
+    @SuppressWarnings("rawtypes")
     private ClientBuilder mockClientBuilder(ClientBuilder newBuilder) throws Exception {
         PulsarClientImpl client = (PulsarClientImpl) newBuilder.build();
         ProducerBuilder<byte[]> producerBuilder = client.newProducer()

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageContainerImplTest.java
@@ -145,7 +145,7 @@ public class BatchMessageContainerImplTest {
 
     @Test
     public void testMessagesSize() throws Exception {
-        ProducerImpl producer = mock(ProducerImpl.class);
+        ProducerImpl<?> producer = mock(ProducerImpl.class);
 
         final ProducerConfigurationData producerConfigurationData = new ProducerConfigurationData();
         producerConfigurationData.setCompressionType(CompressionType.NONE);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
@@ -107,7 +107,7 @@ public class BuildersTest {
             ".* must be specified but they cannot be specified at the same time.*")
     public void shouldNotSetTwoOptAtTheSameTime() throws Exception {
         PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
-        try (Reader reader = client.newReader().topic("abc").startMessageId(MessageId.latest)
+        try (Reader<?> reader = client.newReader().topic("abc").startMessageId(MessageId.latest)
                 .startMessageFromRollbackDuration(10, TimeUnit.HOURS).create()) {
             // no-op
         } finally {
@@ -119,7 +119,7 @@ public class BuildersTest {
             ".* must be specified but they cannot be specified at the same time.*")
     public void shouldSetOneStartOpt() throws Exception {
         PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
-        try (Reader reader = client.newReader().topic("abc").create()) {
+        try (Reader<?> reader = client.newReader().topic("abc").create()) {
             // no-op
         } finally {
             client.close();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -252,7 +252,7 @@ public class ClientCnxTest {
         long consumerId = 1;
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         when(pulsarClient.getConfiguration()).thenReturn(conf);
-        ConsumerImpl consumer = mock(ConsumerImpl.class);
+        ConsumerImpl<?> consumer = mock(ConsumerImpl.class);
         when(consumer.getClient()).thenReturn(pulsarClient);
         cnx.registerConsumer(consumerId, consumer);
         assertEquals(cnx.consumers.size(), 1);
@@ -276,7 +276,7 @@ public class ClientCnxTest {
         long producerId = 1;
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         when(pulsarClient.getConfiguration()).thenReturn(conf);
-        ProducerImpl producer = mock(ProducerImpl.class);
+        ProducerImpl<?> producer = mock(ProducerImpl.class);
         when(producer.getClient()).thenReturn(pulsarClient);
         cnx.registerProducer(producerId, producer);
         assertEquals(cnx.producers.size(), 1);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -70,6 +70,7 @@ public class ConsumerImplTest {
         createConsumer(consumerConf);
     }
 
+    @SuppressWarnings("rawtypes")
     private void createConsumer(ConsumerConfigurationData consumerConf) {
         executorProvider = new ExecutorProvider(1, "ConsumerImplTest");
         internalExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -149,6 +150,7 @@ public class ConsumerImplTest {
     @Test(invocationTimeOut = 1000)
     public void testNotifyPendingReceivedCallback_InterceptorsWorksWithPrefetchDisabled() {
         CompletableFuture<Message<byte[]>> receiveFuture = new CompletableFuture<>();
+        @SuppressWarnings("rawtypes")
         MessageImpl message = mock(MessageImpl.class);
         ConsumerImpl<byte[]> spy = spy(consumer);
 
@@ -167,6 +169,7 @@ public class ConsumerImplTest {
     @Test(invocationTimeOut = 1000)
     public void testNotifyPendingReceivedCallback_WorkNormally() {
         CompletableFuture<Message<byte[]>> receiveFuture = new CompletableFuture<>();
+        @SuppressWarnings("rawtypes")
         MessageImpl message = mock(MessageImpl.class);
         ConsumerImpl<byte[]> spy = spy(consumer);
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
@@ -121,7 +121,7 @@ public class MessageImplTest {
         bar.setField1(true);
 
         // // Check kv.encoding.type default, not set value
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("default");
         MessageImpl<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> msg = MessageImpl.create(
@@ -150,7 +150,7 @@ public class MessageImplTest {
         bar.setField1(true);
 
         // Check kv.encoding.type INLINE
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("inline");
         MessageImpl<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> msg = MessageImpl.create(
@@ -178,7 +178,7 @@ public class MessageImplTest {
         bar.setField1(true);
 
         // Check kv.encoding.type SPRAERATE
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("separated");
         builder.setPartitionKey(Base64.getEncoder().encodeToString(fooSchema.encode(foo)));
@@ -212,7 +212,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("default");
         builder.setSchemaVersion(new byte[10]);
@@ -248,7 +248,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("separated");
         builder.setSchemaVersion(new byte[10]);
@@ -286,7 +286,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("default");
         builder.setSchemaVersion(new byte[10]);
@@ -322,7 +322,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("separated");
         builder.setSchemaVersion(new byte[10]);
@@ -360,7 +360,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("default");
         builder.setSchemaVersion(new byte[10]);
@@ -396,7 +396,7 @@ public class MessageImplTest {
         SchemaTestUtils.Bar bar = new SchemaTestUtils.Bar();
         bar.setField1(true);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         MessageMetadata builder = new MessageMetadata()
                 .setProducerName("separated");
         builder.setSchemaVersion(new byte[10]);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -107,11 +107,13 @@ public class MultiTopicsConsumerImplTest {
         @Cleanup
         PulsarClientImpl clientImpl = new PulsarClientImpl(conf, eventLoopGroup);
 
+        @SuppressWarnings("rawtypes")
         ConsumerConfigurationData consumerConfData = new ConsumerConfigurationData();
         consumerConfData.setTopicNames(Sets.newHashSet(topicName));
 
         assertEquals(Long.parseLong("100"), clientImpl.getConfiguration().getStatsIntervalSeconds());
 
+        @SuppressWarnings("rawtypes")
         MultiTopicsConsumerImpl impl = new MultiTopicsConsumerImpl(
             clientImpl, consumerConfData,
             executorProvider, null, Schema.BYTES, null, true);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -65,12 +65,16 @@ public class PartitionedProducerImplTest {
 
     private static final String TOPIC_NAME = "testTopicName";
     private PulsarClientImpl client;
+    @SuppressWarnings("rawtypes")
     private ProducerBuilderImpl producerBuilderImpl;
+    @SuppressWarnings("rawtypes")
     private Schema schema;
     private ProducerInterceptors producerInterceptors;
-    private CompletableFuture<Producer> producerCreatedFuture;
+    @SuppressWarnings("rawtypes")
+    private CompletableFuture producerCreatedFuture;
 
     @BeforeMethod(alwaysRun = true)
+    @SuppressWarnings("rawtypes")
     public void setup() {
         client = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
@@ -164,6 +168,7 @@ public class PartitionedProducerImplTest {
         assertNotEquals(actualHashList, expectedHashList);
     }
 
+    @SuppressWarnings("rawtypes")
     private MessageRouter getMessageRouter(ProducerConfigurationData producerConfigurationData)
             throws NoSuchFieldException, IllegalAccessException {
         PartitionedProducerImpl impl = new PartitionedProducerImpl(
@@ -205,7 +210,7 @@ public class PartitionedProducerImplTest {
 
         assertEquals(Long.parseLong("100"), clientImpl.getConfiguration().getStatsIntervalSeconds());
 
-        PartitionedProducerImpl impl = new PartitionedProducerImpl(
+        PartitionedProducerImpl<?> impl = new PartitionedProducerImpl<>(
             clientImpl, topicName, producerConfData,
             1, null, null, null);
 
@@ -265,14 +270,14 @@ public class PartitionedProducerImplTest {
         producerConfData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
         producerConfData.setCustomMessageRouter(new CustomMessageRouter());
 
-        PartitionedProducerImpl partitionedProducerImpl = new PartitionedProducerImpl(
+        PartitionedProducerImpl<?> partitionedProducerImpl = new PartitionedProducerImpl<>(
                 clientImpl, topicName, producerConfData, 1, null, null, null);
 
         assertEquals(partitionedProducerImpl.getNumOfPartitions(), 1);
 
         String nonPartitionedTopicName = "test-get-num-of-partitions-for-non-partitioned-topic";
         ProducerConfigurationData producerConfDataNonPartitioned = new ProducerConfigurationData();
-        ProducerImpl producerImpl = new ProducerImpl(clientImpl, nonPartitionedTopicName,
+        ProducerImpl<?> producerImpl = new ProducerImpl<>(clientImpl, nonPartitionedTopicName,
                 producerConfDataNonPartitioned, null, 0, null, null, Optional.empty());
         assertEquals(producerImpl.getNumOfPartitions(), 0);
     }
@@ -296,21 +301,21 @@ public class PartitionedProducerImplTest {
         producerConfData.setMessageRoutingMode(MessageRoutingMode.CustomPartition);
         producerConfData.setCustomMessageRouter(new CustomMessageRouter());
         producerConfData.setMaxPendingMessages(10);
-        PartitionedProducerImpl partitionedProducerImpl = new PartitionedProducerImpl(
+        PartitionedProducerImpl<?> partitionedProducerImpl = new PartitionedProducerImpl<>(
                 clientImpl, topicName, producerConfData, 1, null, null, null);
         assertEquals(partitionedProducerImpl.getConfiguration().getMaxPendingMessages(), 10);
 
         // Test set MaxPendingMessagesAcrossPartitions=5
         producerConfData.setMaxPendingMessages(ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES);
         producerConfData.setMaxPendingMessagesAcrossPartitions(5);
-        partitionedProducerImpl = new PartitionedProducerImpl(
+        partitionedProducerImpl = new PartitionedProducerImpl<>(
                 clientImpl, topicName, producerConfData, 1, null, null, null);
         assertEquals(partitionedProducerImpl.getConfiguration().getMaxPendingMessages(), 5);
 
         // Test set maxPendingMessage=10 and MaxPendingMessagesAcrossPartitions=10 with 2 partitions
         producerConfData.setMaxPendingMessages(10);
         producerConfData.setMaxPendingMessagesAcrossPartitions(10);
-        partitionedProducerImpl = new PartitionedProducerImpl(
+        partitionedProducerImpl = new PartitionedProducerImpl<>(
                 clientImpl, topicName, producerConfData, 2, null, null, null);
         assertEquals(partitionedProducerImpl.getConfiguration().getMaxPendingMessages(), 5);
     }
@@ -334,12 +339,12 @@ public class PartitionedProducerImplTest {
         producerConfData.setCustomMessageRouter(new CustomMessageRouter());
         producerConfData.setAutoUpdatePartitionsIntervalSeconds(1, TimeUnit.MILLISECONDS);
 
-        PartitionedProducerImpl impl = new PartitionedProducerImpl(
+        PartitionedProducerImpl<?> impl = new PartitionedProducerImpl<>(
                 clientImpl, topicName, producerConfData, 1, null, null, null);
 
         impl.setState(HandlerState.State.Ready);
         Thread.sleep(1000);
-        CompletableFuture future = impl.getPartitionsAutoUpdateFuture();
+        CompletableFuture<?> future = impl.getPartitionsAutoUpdateFuture();
 
         // When null is returned in method thenCompose we will encounter an NPE exception.
         // Because the returned value will be applied to the next stage.

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PartitionedProducerImplTest.java
@@ -45,7 +45,6 @@ import lombok.Cleanup;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.MessageRoutingMode;
-import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueueTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueueTest.java
@@ -50,6 +50,7 @@ public class PatternConsumerUpdateQueueTest {
                 null, null);
     }
 
+    @SuppressWarnings("rawtypes")
     private QueueInstance createInstance(CompletableFuture<Void> customizedRecheckFuture,
                                          CompletableFuture<Void> customizedPartialUpdateFuture,
                                          CompletableFuture<Void> customizedConsumerInitFuture,
@@ -77,8 +78,8 @@ public class PatternConsumerUpdateQueueTest {
             when(topicsChangeListener.onTopicsRemoved(anyCollection())).thenReturn(customizedPartialUpdateFuture);
         } else {
             CompletableFuture<Void> ex = FutureUtil.failedFuture(new RuntimeException("Failed topics changed event"));
-            Answer answer = invocationOnMock -> {
-                Collection inputCollection = invocationOnMock.getArgument(0, Collection.class);
+            Answer<?> answer = invocationOnMock -> {
+                Collection<?> inputCollection = invocationOnMock.getArgument(0, Collection.class);
                 if (successTopics.containsAll(inputCollection)) {
                     return customizedPartialUpdateFuture;
                 } else if (errorTopics.containsAll(inputCollection)) {
@@ -103,7 +104,7 @@ public class PatternConsumerUpdateQueueTest {
     @AllArgsConstructor
     private static class QueueInstance implements Closeable {
         private PatternConsumerUpdateQueue queue;
-        private PatternMultiTopicsConsumerImpl mockedConsumer;
+        private PatternMultiTopicsConsumerImpl<?> mockedConsumer;
         private PatternMultiTopicsConsumerImpl.TopicsChangedListener mockedListener;
 
         @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewBuilderImplTest.java
@@ -44,13 +44,13 @@ public class TableViewBuilderImplTest {
 
     private static final String TOPIC_NAME = "testTopicName";
     private PulsarClientImpl client;
-    private TableViewBuilderImpl tableViewBuilderImpl;
+    private TableViewBuilderImpl<?> tableViewBuilderImpl;
     private CompletableFuture readNextFuture;
 
     @BeforeClass(alwaysRun = true)
     public void setup() {
-        Reader reader = mock(Reader.class);
-        readNextFuture = new CompletableFuture();
+        Reader<?> reader = mock(Reader.class);
+        readNextFuture = new CompletableFuture<>();
         when(reader.readNextAsync()).thenReturn(readNextFuture);
         client = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
@@ -72,7 +72,7 @@ public class TableViewBuilderImplTest {
 
     @Test
     public void testTableViewBuilderImpl() throws PulsarClientException {
-        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+        TableView<?> tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
             .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
             .subscriptionName("testSubscriptionName")
             .cryptoKeyReader(mock(CryptoKeyReader.class))
@@ -84,7 +84,7 @@ public class TableViewBuilderImplTest {
 
     @Test
     public void testTableViewBuilderImplWhenOnlyTopicNameIsSet() throws PulsarClientException {
-        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+        TableView<?> tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
             .create();
 
         assertNotNull(tableView);
@@ -118,7 +118,7 @@ public class TableViewBuilderImplTest {
 
     @Test
     public void testTableViewBuilderImplWithCryptoKeyReader() throws PulsarClientException {
-        TableView tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
+        TableView<?> tableView = tableViewBuilderImpl.topic(TOPIC_NAME)
             .cryptoKeyReader(mock(CryptoKeyReader.class))
             .create();
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TableViewImplTest.java
@@ -48,7 +48,7 @@ public class TableViewImplTest {
     @Test
     public void testTableViewImpl() {
         data.setCryptoKeyReader(mock(CryptoKeyReader.class));
-        TableView tableView = new TableViewImpl(client, Schema.BYTES, data);
+        TableView<?> tableView = new TableViewImpl<>(client, Schema.BYTES, data);
 
         assertNotNull(tableView);
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -138,7 +138,8 @@ public class TypedMessageBuilderImplTest {
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = new KeyValue<>(foo, bar);
 
         // Check kv.encoding.type SEPARATED
-        TypedMessageBuilderImpl<?> typedMessageBuilder = (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.value(keyValue);
+        TypedMessageBuilderImpl<?> typedMessageBuilder =
+                (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.value(keyValue);
         Method method = TypedMessageBuilderImpl.class.getDeclaredMethod("beforeSend");
         method.setAccessible(true);
         method.invoke(typedMessageBuilder);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TypedMessageBuilderImplTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 public class TypedMessageBuilderImplTest {
 
     @Mock
-    protected ProducerBase producerBase;
+    protected ProducerBase<?> producerBase;
 
     @Test
     public void testDefaultValue() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
@@ -55,6 +55,7 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
         SchemaTestUtils.Foo foo = new SchemaTestUtils.Foo();
@@ -65,8 +66,8 @@ public class TypedMessageBuilderImplTest {
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = new KeyValue<>(foo, bar);
 
         // Check kv.encoding.type default, not set value
-        TypedMessageBuilderImpl<KeyValue>  typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.value(keyValue);
+        TypedMessageBuilderImpl<KeyValue<?, ?>>  typedMessageBuilder =
+                (TypedMessageBuilderImpl<KeyValue<?, ?>>) typedMessageBuilderImpl.value(keyValue);
         Method method = TypedMessageBuilderImpl.class.getDeclaredMethod("beforeSend");
         method.setAccessible(true);
         method.invoke(typedMessageBuilder);
@@ -90,7 +91,8 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.INLINE);
-        TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl (producerBase, keyValueSchema);
+        @SuppressWarnings("rawtypes")
+        TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
         SchemaTestUtils.Foo foo = new SchemaTestUtils.Foo();
         foo.setField1("field1");
@@ -100,8 +102,8 @@ public class TypedMessageBuilderImplTest {
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = new KeyValue<>(foo, bar);
 
         // Check kv.encoding.type INLINE
-        TypedMessageBuilderImpl<KeyValue> typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.value(keyValue);
+        TypedMessageBuilderImpl<KeyValue<?, ?>> typedMessageBuilder =
+                (TypedMessageBuilderImpl<KeyValue<?, ?>>) typedMessageBuilderImpl.value(keyValue);
         Method method = TypedMessageBuilderImpl.class.getDeclaredMethod("beforeSend");
         method.setAccessible(true);
         method.invoke(typedMessageBuilder);
@@ -125,7 +127,8 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.SEPARATED);
-        TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl (producerBase, keyValueSchema);
+        @SuppressWarnings("rawtypes")
+        TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
         SchemaTestUtils.Foo foo = new SchemaTestUtils.Foo();
         foo.setField1("field1");
@@ -135,7 +138,7 @@ public class TypedMessageBuilderImplTest {
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = new KeyValue<>(foo, bar);
 
         // Check kv.encoding.type SEPARATED
-        TypedMessageBuilderImpl typedMessageBuilder = (TypedMessageBuilderImpl) typedMessageBuilderImpl.value(keyValue);
+        TypedMessageBuilderImpl<?> typedMessageBuilder = (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.value(keyValue);
         Method method = TypedMessageBuilderImpl.class.getDeclaredMethod("beforeSend");
         method.setAccessible(true);
         method.invoke(typedMessageBuilder);
@@ -159,10 +162,11 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
-        TypedMessageBuilderImpl typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.key("default");
+        TypedMessageBuilderImpl<?> typedMessageBuilder =
+                (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.key("default");
         assertEquals(typedMessageBuilder.getKey(), "default");
         assertFalse(typedMessageBuilder.getMetadataBuilder().isPartitionKeyB64Encoded());
     }
@@ -178,10 +182,11 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.INLINE);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
-        TypedMessageBuilderImpl typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.key("inline");
+        TypedMessageBuilderImpl<?> typedMessageBuilder =
+                (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.key("inline");
         assertEquals(typedMessageBuilder.getKey(), "inline");
         assertFalse(typedMessageBuilder.getMetadataBuilder().isPartitionKeyB64Encoded());
     }
@@ -197,12 +202,13 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.SEPARATED);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
 
         try {
-            TypedMessageBuilderImpl typedMessageBuilder =
-                    (TypedMessageBuilderImpl) typedMessageBuilderImpl.key("separated");
+            TypedMessageBuilderImpl<?> typedMessageBuilder =
+                    (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.key("separated");
             fail("This should fail");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage()
@@ -221,10 +227,11 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
-        TypedMessageBuilderImpl typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.keyBytes("default".getBytes());
+        TypedMessageBuilderImpl<?> typedMessageBuilder =
+                (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.keyBytes("default".getBytes());
         assertEquals(typedMessageBuilder.getKey(), Base64.getEncoder().encodeToString("default".getBytes()));
         assertTrue(typedMessageBuilder.getMetadataBuilder().isPartitionKeyB64Encoded());
     }
@@ -240,10 +247,11 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.INLINE);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
-        TypedMessageBuilderImpl typedMessageBuilder =
-                (TypedMessageBuilderImpl) typedMessageBuilderImpl.keyBytes("inline".getBytes());
+        TypedMessageBuilderImpl<?> typedMessageBuilder =
+                (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.keyBytes("inline".getBytes());
         assertEquals(typedMessageBuilder.getKey(), Base64.getEncoder().encodeToString("inline".getBytes()));
         assertTrue(typedMessageBuilder.getMetadataBuilder().isPartitionKeyB64Encoded());
     }
@@ -259,12 +267,13 @@ public class TypedMessageBuilderImplTest {
 
         Schema<KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar>> keyValueSchema =
                 Schema.KeyValue(fooSchema, barSchema, KeyValueEncodingType.SEPARATED);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilderImpl typedMessageBuilderImpl = new TypedMessageBuilderImpl(producerBase, keyValueSchema);
 
 
         try {
-            TypedMessageBuilderImpl typedMessageBuilder =
-                    (TypedMessageBuilderImpl) typedMessageBuilderImpl.keyBytes("separated".getBytes());
+            TypedMessageBuilderImpl<?> typedMessageBuilder =
+                    (TypedMessageBuilderImpl<?>) typedMessageBuilderImpl.keyBytes("separated".getBytes());
             fail("This should fail");
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage()

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -100,7 +100,7 @@ public class ConfigurationDataUtilsTest {
 
     @Test
     public void testLoadConsumerConfigurationData() {
-        ConsumerConfigurationData confData = new ConsumerConfigurationData();
+        ConsumerConfigurationData<?> confData = new ConsumerConfigurationData();
         confData.setSubscriptionName("unknown-subscription");
         confData.setPriorityLevel(10000);
         confData.setConsumerName("unknown-consumer");
@@ -117,7 +117,7 @@ public class ConfigurationDataUtilsTest {
 
     @Test
     public void testLoadReaderConfigurationData() {
-        ReaderConfigurationData confData = new ReaderConfigurationData();
+        ReaderConfigurationData<?> confData = new ReaderConfigurationData();
         confData.setTopicName("unknown");
         confData.setReceiverQueueSize(1000000);
         confData.setReaderName("unknown-reader");
@@ -132,7 +132,7 @@ public class ConfigurationDataUtilsTest {
 
     @Test
     public void testLoadConfigurationDataWithUnknownFields() {
-        ReaderConfigurationData confData = new ReaderConfigurationData();
+        ReaderConfigurationData<?> confData = new ReaderConfigurationData();
         confData.setTopicName("unknown");
         confData.setReceiverQueueSize(1000000);
         confData.setReaderName("unknown-reader");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
@@ -46,7 +46,7 @@ import org.testng.annotations.Test;
 @Slf4j
 public class KeyValueSchemaInfoTest {
 
-    private static final Map<String, String> FOO_PROPERTIES = new HashMap() {
+    private static final Map<String, String> FOO_PROPERTIES = new HashMap<>() {
 
         private static final long serialVersionUID = 58641844834472929L;
 
@@ -58,7 +58,7 @@ public class KeyValueSchemaInfoTest {
 
     };
 
-    private static final Map<String, String> BAR_PROPERTIES = new HashMap() {
+    private static final Map<String, String> BAR_PROPERTIES = new HashMap<>() {
 
         private static final long serialVersionUID = 58641844834472929L;
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
@@ -249,7 +249,7 @@ public class KeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         Assert.assertTrue(encodeBytes.length > 0);
 
         KeyValue<Foo, Bar> keyValue = (KeyValue<Foo, Bar>) keyValueSchema.decode(encodeBytes);
@@ -277,7 +277,7 @@ public class KeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         Assert.assertTrue(encodeBytes.length > 0);
 
         KeyValue<Foo, Bar> keyValue = (KeyValue<Foo, Bar>) keyValueSchema.decode(encodeBytes);
@@ -306,7 +306,7 @@ public class KeyValueSchemaTest {
         foo.setColor(Color.RED);
 
         // Check kv.encoding.type default not set value
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         Assert.assertTrue(encodeBytes.length > 0);
 
         KeyValue<Foo, Bar> keyValue = (KeyValue<Foo, Bar>) keyValueSchema.decode(encodeBytes);
@@ -338,7 +338,7 @@ public class KeyValueSchemaTest {
         foo.setColor(Color.RED);
 
         // Check kv.encoding.type INLINE
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         Assert.assertTrue(encodeBytes.length > 0);
         KeyValue<Foo, Bar>  keyValue = (KeyValue<Foo, Bar>) keyValueSchema.decode(encodeBytes);
         Foo fooBack = keyValue.getKey();
@@ -367,7 +367,7 @@ public class KeyValueSchemaTest {
         foo.setColor(Color.RED);
 
         // Check kv.encoding.type SEPARATED
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         Assert.assertTrue(encodeBytes.length > 0);
         try {
             keyValueSchema.decode(encodeBytes);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
@@ -55,7 +55,7 @@ public class PrimitiveSchemaTest {
         // we are not using a static initialization block, see here:
         // https://github.com/apache/pulsar/issues/11037
 
-        final Map<Schema, List<Object>> testData = new HashMap() {
+        final Map<Schema<?>, List<Object>> testData = new HashMap<>() {
             {
                 put(BooleanSchema.of(), Arrays.asList(false, true));
                 put(StringSchema.utf8(), Arrays.asList("my string"));
@@ -82,7 +82,7 @@ public class PrimitiveSchemaTest {
             }
         };
 
-        final Map<Schema, List<Object>> testData2 = new HashMap() {
+        final Map<Schema<?>, List<Object>> testData2 = new HashMap<>() {
             {
                 put(Schema.BOOL, Arrays.asList(false, true));
                 put(Schema.STRING, Arrays.asList("my string"));
@@ -108,10 +108,10 @@ public class PrimitiveSchemaTest {
             }
         };
 
-        for (Schema schema : testData.keySet()) {
+        for (Schema<?> schema : testData.keySet()) {
             assertNotNull(schema);
         }
-        for (Schema schema : testData2.keySet()) {
+        for (Schema<?> schema : testData2.keySet()) {
             assertNotNull(schema);
         }
 
@@ -119,7 +119,7 @@ public class PrimitiveSchemaTest {
     }
 
     @Test(dataProvider = "schemas")
-    public void allSchemasShouldSupportNull(Map<Schema, List<Object>> testData) {
+    public void allSchemasShouldSupportNull(Map<Schema<?>, List<Object>> testData) {
         for (Schema<?> schema : testData.keySet()) {
             byte[] bytes = null;
             ByteBuf byteBuf =  null;
@@ -137,6 +137,7 @@ public class PrimitiveSchemaTest {
     }
 
     @Test(dataProvider = "schemas")
+    @SuppressWarnings("rawtypes")
     public void allSchemasShouldRoundtripInput(Map<Schema, List<Object>> testData) {
         for (Map.Entry<Schema, List<Object>> test : testData.entrySet()) {
             log.info("Test schema {}", test.getKey());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SchemaBuilderTest.java
@@ -164,6 +164,7 @@ public class SchemaBuilderTest {
         SchemaInfo schemaInfo = recordSchemaBuilder.build(
             SchemaType.AVRO
         );
+        @SuppressWarnings("rawtypes")
         GenericSchema schema = Schema.generic(schemaInfo);
         GenericRecord record = schema.newRecordBuilder()
             .set("intField", 32)
@@ -503,7 +504,7 @@ public class SchemaBuilderTest {
      * @param decoder the schema used for reading
      * @param writer the schema used for writing
      */
-    private static void injectWriterSchema(Schema decoder, Schema writer) {
+    private static void injectWriterSchema(Schema<?> decoder, Schema<?> writer) {
         AvroSchema<?> avroSchema = (AvroSchema<?>) decoder;
         avroSchema.setReader(new MultiVersionAvroReader<>(
                 AvroSchema.of(SchemaDefinition.

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningAvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningAvroSchemaTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 
 public class SupportVersioningAvroSchemaTest {
     private MultiVersionSchemaInfoProvider multiVersionSchemaInfoProvider;
-    private AvroSchema schema;
+    private AvroSchema<?> schema;
     private GenericAvroSchema genericAvroSchema;
     private AvroSchema<SchemaTestUtils.FooV2> avroFooV2Schema;
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningKeyValueSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/SupportVersioningKeyValueSchemaTest.java
@@ -56,7 +56,7 @@ public class SupportVersioningKeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(SchemaTestUtils.Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = keyValueSchema.decode(
                 encodeBytes, new byte[10]);
         Assert.assertEquals(keyValue.getKey().getField1(), foo.getField1());
@@ -94,7 +94,7 @@ public class SupportVersioningKeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(SchemaTestUtils.Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = ((KeyValueSchemaImpl) keyValueSchema).decode(
                 fooSchema.encode(foo), encodeBytes, new byte[10]);
         Assert.assertTrue(keyValue.getValue().isField1());
@@ -122,7 +122,7 @@ public class SupportVersioningKeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(SchemaTestUtils.Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = keyValueSchema.decode(
                 encodeBytes, new byte[10]);
         Assert.assertEquals(keyValue.getKey().getField1(), foo.getField1());
@@ -155,7 +155,7 @@ public class SupportVersioningKeyValueSchemaTest {
         foo.setField4(bar);
         foo.setColor(SchemaTestUtils.Color.RED);
 
-        byte[] encodeBytes = keyValueSchema.encode(new KeyValue(foo, bar));
+        byte[] encodeBytes = keyValueSchema.encode(new KeyValue<>(foo, bar));
         KeyValue<SchemaTestUtils.Foo, SchemaTestUtils.Bar> keyValue = ((KeyValueSchemaImpl) keyValueSchema).decode(
                 fooSchema.encode(foo), encodeBytes, new byte[10]);
         Assert.assertTrue(keyValue.getValue().isField1());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReaderTest.java
@@ -36,9 +36,13 @@ public class GenericAvroReaderTest {
 
     private Foo foo;
     private FooV2 fooV2;
+    @SuppressWarnings("rawtypes")
     private AvroSchema fooSchemaNotNull;
+    @SuppressWarnings("rawtypes")
     private AvroSchema fooSchema;
+    @SuppressWarnings("rawtypes")
     private AvroSchema fooV2Schema;
+    @SuppressWarnings("rawtypes")
     private AvroSchema fooOffsetSchema;
 
     @BeforeMethod

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
@@ -37,7 +37,7 @@ public class GenericProtobufNativeReaderTest {
     private TestMessage message;
     private GenericRecord genericmessage;
     private GenericProtobufNativeSchema genericProtobufNativeSchema;
-    private ProtobufNativeSchema clazzBasedProtobufNativeSchema;
+    private ProtobufNativeSchema<?> clazzBasedProtobufNativeSchema;
 
 
     @BeforeMethod

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncDualMemoryLimiterUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncDualMemoryLimiterUtilTest.java
@@ -245,7 +245,8 @@ public class AsyncDualMemoryLimiterUtilTest {
         });
 
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
-            io.netty.util.concurrent.GenericFutureListener listener = invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
             listenerCalled.set(true);
             // Simulate successful write
             listener.operationComplete(channelFuture);
@@ -415,13 +416,15 @@ public class AsyncDualMemoryLimiterUtilTest {
 
         when(ctx.writeAndFlush(any(ByteBuf.class))).thenReturn(channelFuture);
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
-            io.netty.util.concurrent.GenericFutureListener listener = invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
             listener.operationComplete(channelFuture);
             return channelFuture;
         });
         when(channelFuture.isSuccess()).thenReturn(true);
 
         int numRequests = 10;
+        @SuppressWarnings({"unchecked", "rawtypes"})
         CompletableFuture<Void>[] futures = new CompletableFuture[numRequests];
 
         for (int i = 0; i < numRequests; i++) {
@@ -451,7 +454,8 @@ public class AsyncDualMemoryLimiterUtilTest {
 
         when(ctx.writeAndFlush(any(ByteBuf.class))).thenReturn(channelFuture);
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
-            io.netty.util.concurrent.GenericFutureListener listener = invocation.getArgument(0);
+            @SuppressWarnings("unchecked")
+            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
             // Simulate write failure
             when(channelFuture.isSuccess()).thenReturn(false);
             when(channelFuture.cause()).thenReturn(new RuntimeException("Write to socket failed"));
@@ -482,6 +486,7 @@ public class AsyncDualMemoryLimiterUtilTest {
     @Test
     public void testWithPermitsFutureMultipleConcurrent() throws Exception {
         int numOperations = 20;
+        @SuppressWarnings({"unchecked", "rawtypes"})
         CompletableFuture<String>[] futures = new CompletableFuture[numOperations];
         AtomicInteger releaseCount = new AtomicInteger(0);
 

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncDualMemoryLimiterUtilTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncDualMemoryLimiterUtilTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.GenericFutureListener;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -246,7 +247,7 @@ public class AsyncDualMemoryLimiterUtilTest {
 
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
             @SuppressWarnings("unchecked")
-            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
+            GenericFutureListener<ChannelFuture> listener = invocation.getArgument(0);
             listenerCalled.set(true);
             // Simulate successful write
             listener.operationComplete(channelFuture);
@@ -417,7 +418,7 @@ public class AsyncDualMemoryLimiterUtilTest {
         when(ctx.writeAndFlush(any(ByteBuf.class))).thenReturn(channelFuture);
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
             @SuppressWarnings("unchecked")
-            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
+            GenericFutureListener<ChannelFuture> listener = invocation.getArgument(0);
             listener.operationComplete(channelFuture);
             return channelFuture;
         });
@@ -455,7 +456,7 @@ public class AsyncDualMemoryLimiterUtilTest {
         when(ctx.writeAndFlush(any(ByteBuf.class))).thenReturn(channelFuture);
         when(channelFuture.addListener(any())).thenAnswer(invocation -> {
             @SuppressWarnings("unchecked")
-            io.netty.util.concurrent.GenericFutureListener<io.netty.channel.ChannelFuture> listener = invocation.getArgument(0);
+            GenericFutureListener<ChannelFuture> listener = invocation.getArgument(0);
             // Simulate write failure
             when(channelFuture.isSuccess()).thenReturn(false);
             when(channelFuture.cause()).thenReturn(new RuntimeException("Write to socket failed"));

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncSemaphoreImplTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/semaphore/AsyncSemaphoreImplTest.java
@@ -360,7 +360,7 @@ public class AsyncSemaphoreImplTest {
         }
 
         // Wait for all threads to complete
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
                 .get(30, TimeUnit.SECONDS);
     }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -88,6 +88,7 @@ public class ContextImplTest {
     private PulsarClientImpl client;
     private PulsarAdmin pulsarAdmin;
     private ContextImpl context;
+    @SuppressWarnings("rawtypes")
     private Producer producer;
     private ProducerCache producerCache;
 
@@ -107,9 +108,9 @@ public class ContextImplTest {
         when(client.getConfiguration()).thenReturn(new ClientConfigurationData());
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(client.getCnxPool()).thenReturn(connectionPool);
-        when(client.newProducer()).thenAnswer(invocation -> new ProducerBuilderImpl(client, Schema.BYTES));
+        when(client.newProducer()).thenAnswer(invocation -> new ProducerBuilderImpl<>(client, Schema.BYTES));
         when(client.newProducer(any())).thenAnswer(
-                invocation -> new ProducerBuilderImpl(client, invocation.getArgument(0)));
+                invocation -> new ProducerBuilderImpl<>(client, invocation.getArgument(0)));
         when(client.createProducerAsync(any(ProducerConfigurationData.class), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(producer));
         when(client.getSchema(anyString())).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
@@ -118,6 +119,7 @@ public class ContextImplTest {
         clientBuilder = mock(ClientBuilder.class);
         when(clientBuilder.build()).thenReturn(client);
 
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilder messageBuilder = spy(new TypedMessageBuilderImpl(mock(ProducerBase.class), Schema.STRING));
         doReturn(new CompletableFuture<>()).when(messageBuilder).sendAsync();
         when(producer.newMessage()).thenReturn(messageBuilder);
@@ -357,6 +359,7 @@ public class ContextImplTest {
         when(consumer2.getTopic()).thenReturn(TopicName.get("second").toString());
         List<Consumer<?>> consumersList = Lists.newArrayList(consumer1, consumer2);
 
+        @SuppressWarnings("rawtypes")
         MultiTopicsConsumerImpl mtc = Mockito.mock(MultiTopicsConsumerImpl.class);
         when(mtc.getConsumers()).thenReturn(consumersList);
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -188,7 +188,7 @@ public class JavaInstanceRunnableTest {
         javaInstanceRunnable.setStats(manager);
         JavaExecutionResult javaExecutionResult = new JavaExecutionResult();
         Thread.sleep(500);
-        Record record = mock(Record.class);
+        Record<?> record = mock(Record.class);
         javaInstanceRunnable.handleResult(record, javaExecutionResult);
         ArgumentCaptor<Long> timeCaptor = ArgumentCaptor.forClass(Long.class);
         verify(manager).processTimeEnd(timeCaptor.capture());
@@ -200,7 +200,7 @@ public class JavaInstanceRunnableTest {
         JavaExecutionResult javaExecutionResult = new JavaExecutionResult();
 
         // ProcessingGuarantees == MANUAL, not need ack.
-        Record record = mock(Record.class);
+        Record<?> record = mock(Record.class);
         getJavaInstanceRunnable(true, org.apache.pulsar.functions.proto.Function.ProcessingGuarantees.MANUAL)
                 .handleResult(record, javaExecutionResult);
         verify(record, times(0)).ack();
@@ -409,7 +409,7 @@ public class JavaInstanceRunnableTest {
         }
 
         @Override
-        public void open(Map config, SourceContext sourceContext) throws Exception {
+        public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
             context = sourceContext;
             queue = new LinkedBlockingQueue<>();
         }
@@ -448,7 +448,7 @@ public class JavaInstanceRunnableTest {
         SinkContext context;
 
         @Override
-        public void open(Map config, SinkContext sinkContext) throws Exception {
+        public void open(Map<String, Object> config, SinkContext sinkContext) throws Exception {
             this.context = sinkContext;
         }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerBuilderFactoryTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerBuilderFactoryTest.java
@@ -52,7 +52,7 @@ import org.testng.annotations.Test;
 
 public class ProducerBuilderFactoryTest {
     private PulsarClient pulsarClient;
-    private ProducerBuilder producerBuilder;
+    private ProducerBuilder<?> producerBuilder;
 
     @BeforeMethod
     public void setup() {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerCacheTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerCacheTest.java
@@ -33,7 +33,7 @@ public class ProducerCacheTest {
     @Test
     public void shouldTolerateAlreadyClosedExceptionInClose() {
         ProducerCache cache = new ProducerCache();
-        Producer producer = mock(Producer.class);
+        Producer<?> producer = mock(Producer.class);
         when(producer.flushAsync()).thenReturn(CompletableFuture.completedFuture(null));
         when(producer.closeAsync()).thenReturn(
                 CompletableFuture.failedFuture(new PulsarClientException.AlreadyClosedException("Already closed")));
@@ -45,7 +45,7 @@ public class ProducerCacheTest {
     @Test
     public void shouldTolerateRuntimeExceptionInClose() {
         ProducerCache cache = new ProducerCache();
-        Producer producer = mock(Producer.class);
+        Producer<?> producer = mock(Producer.class);
         when(producer.flushAsync()).thenReturn(CompletableFuture.completedFuture(null));
         when(producer.closeAsync()).thenThrow(new RuntimeException("Some exception"));
         cache.getOrCreateProducer(ProducerCache.CacheArea.CONTEXT_CACHE, "topic", "key",
@@ -56,7 +56,7 @@ public class ProducerCacheTest {
     @Test
     public void shouldTolerateRuntimeExceptionInFlush() {
         ProducerCache cache = new ProducerCache();
-        Producer producer = mock(Producer.class);
+        Producer<?> producer = mock(Producer.class);
         when(producer.flushAsync()).thenThrow(new RuntimeException("Some exception"));
         when(producer.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
         cache.getOrCreateProducer(ProducerCache.CacheArea.CONTEXT_CACHE, "topic", "key",
@@ -67,7 +67,7 @@ public class ProducerCacheTest {
     @Test
     public void shouldCompleteFlushBeforeCloseAndWaitForClosing() {
         ProducerCache cache = new ProducerCache();
-        Producer producer = mock(Producer.class);
+        Producer<?> producer = mock(Producer.class);
         AtomicBoolean flushCompleted = new AtomicBoolean(false);
         when(producer.flushAsync()).thenReturn(CompletableFuture.supplyAsync(() -> {
             try {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/SinkRecordTest.java
@@ -29,10 +29,11 @@ import org.testng.annotations.Test;
 public class SinkRecordTest {
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void testCustomAck() {
 
         PulsarRecord pulsarRecord = Mockito.mock(PulsarRecord.class);
-        SinkRecord sinkRecord = new SinkRecord<>(pulsarRecord, new Object());
+        SinkRecord sinkRecord = new SinkRecord(pulsarRecord, new Object());
 
         sinkRecord.cumulativeAck();
         Mockito.verify(pulsarRecord, Mockito.times(1)).cumulativeAck();

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/state/BKStateStoreImplTest.java
@@ -118,6 +118,7 @@ public class BKStateStoreImplTest {
 
     @Test
     public void testGetStateValue() throws Exception {
+        @SuppressWarnings("rawtypes")
         KeyValue returnedKeyValue = mock(KeyValue.class);
         ByteBuf returnedValue = Unpooled.copiedBuffer("test-value", UTF_8);
         when(returnedKeyValue.value()).thenReturn(returnedValue);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/sink/PulsarSinkTest.java
@@ -100,17 +100,17 @@ public class PulsarSinkTest {
         PulsarClientImpl pulsarClient = mock(PulsarClientImpl.class);
         ConnectionPool connectionPool = mock(ConnectionPool.class);
         when(pulsarClient.getCnxPool()).thenReturn(connectionPool);
-        ConsumerBuilder consumerBuilder = mock(ConsumerBuilder.class);
+        ConsumerBuilder<?> consumerBuilder = mock(ConsumerBuilder.class);
         doReturn(consumerBuilder).when(consumerBuilder).topics(anyList());
         doReturn(consumerBuilder).when(consumerBuilder).subscriptionName(anyString());
         doReturn(consumerBuilder).when(consumerBuilder).subscriptionType(any());
         doReturn(consumerBuilder).when(consumerBuilder).ackTimeout(anyLong(), any());
-        Consumer consumer = mock(Consumer.class);
+        Consumer<?> consumer = mock(Consumer.class);
         doReturn(consumer).when(consumerBuilder).subscribe();
         doReturn(consumerBuilder).when(pulsarClient).newConsumer(any());
         doReturn(CompletableFuture.completedFuture(Optional.empty())).when(pulsarClient).getSchema(anyString());
 
-        ProducerBuilder producerBuilder = mock(ProducerBuilder.class);
+        ProducerBuilder<?> producerBuilder = mock(ProducerBuilder.class);
         doReturn(producerBuilder).when(producerBuilder).blockIfQueueFull(anyBoolean());
         doReturn(producerBuilder).when(producerBuilder).enableBatching(anyBoolean());
         doReturn(producerBuilder).when(producerBuilder).batchingMaxPublishDelay(anyLong(), any());
@@ -124,12 +124,12 @@ public class PulsarSinkTest {
         doReturn(producerBuilder).when(producerBuilder).properties(any());
         doReturn(producerBuilder).when(producerBuilder).sendTimeout(anyInt(), any());
 
-        CompletableFuture completableFuture = new CompletableFuture<>();
+        CompletableFuture<MessageId> completableFuture = new CompletableFuture<>();
         completableFuture.complete(mock(MessageId.class));
-        TypedMessageBuilder typedMessageBuilder = mock(TypedMessageBuilder.class);
+        TypedMessageBuilder<?> typedMessageBuilder = mock(TypedMessageBuilder.class);
         doReturn(completableFuture).when(typedMessageBuilder).sendAsync();
 
-        Producer producer = mock(Producer.class);
+        Producer<?> producer = mock(Producer.class);
         doReturn(producer).when(producerBuilder).create();
         doReturn(typedMessageBuilder).when(producer).newMessage();
         doReturn(typedMessageBuilder).when(producer).newMessage(any(Schema.class));
@@ -190,12 +190,12 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSink pulsarSink =
-                new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<?> pulsarSink =
+                new PulsarSink<>(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
 
         try {
-            Schema schema = pulsarSink.initializeSchema();
+            Schema<?> schema = pulsarSink.initializeSchema();
             assertNull(schema);
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -210,8 +210,8 @@ public class PulsarSinkTest {
         // set type to be inconsistent to that of SerDe
         pulsarConfig.setTypeClassName(Integer.class.getName());
         pulsarConfig.setSerdeClassName(TestSerDe.class.getName());
-        PulsarSink pulsarSink =
-                new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<?> pulsarSink =
+                new PulsarSink<>(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
         try {
             pulsarSink.initializeSchema();
@@ -235,8 +235,8 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
-        PulsarSink pulsarSink =
-                new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<?> pulsarSink =
+                new PulsarSink<>(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
 
         try {
@@ -256,8 +256,8 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(String.class.getName());
         pulsarConfig.setSerdeClassName(TopicSchema.DEFAULT_SERDE);
-        PulsarSink pulsarSink =
-                new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<?> pulsarSink =
+                new PulsarSink<>(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
 
         try {
@@ -274,8 +274,8 @@ public class PulsarSinkTest {
         // set type to void
         pulsarConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
         pulsarConfig.setSerdeClassName(ComplexSerDe.class.getName());
-        PulsarSink pulsarSink =
-                new PulsarSink(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<?> pulsarSink =
+                new PulsarSink<>(getPulsarClient(), pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
 
         try {
@@ -294,7 +294,7 @@ public class PulsarSinkTest {
         PulsarSinkConfig pulsarSinkConfig = getPulsarConfigs();
         pulsarSinkConfig.setSerdeClassName(null);
         pulsarSinkConfig.setTypeClassName(GenericRecord.class.getName());
-        PulsarSink sink = new PulsarSink(
+        PulsarSink<?> sink = new PulsarSink<>(
             pulsarClient, pulsarSinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
         Schema<?> schema = sink.initializeSchema();
@@ -303,7 +303,7 @@ public class PulsarSinkTest {
         // generic record type (default serde and no schema type)
         pulsarSinkConfig = getPulsarConfigs();
         pulsarSinkConfig.setTypeClassName(GenericRecord.class.getName());
-        sink = new PulsarSink(
+        sink = new PulsarSink<>(
             pulsarClient, pulsarSinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
         schema = sink.initializeSchema();
@@ -314,7 +314,7 @@ public class PulsarSinkTest {
         pulsarSinkConfig.setSerdeClassName(null);
         pulsarSinkConfig.setSchemaType(SchemaType.AVRO.toString());
         pulsarSinkConfig.setTypeClassName(GenericRecord.class.getName());
-        sink = new PulsarSink(
+        sink = new PulsarSink<>(
             pulsarClient, pulsarSinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
         schema = sink.initializeSchema();
@@ -325,7 +325,7 @@ public class PulsarSinkTest {
         pulsarSinkConfig.setSerdeClassName(null);
         pulsarSinkConfig.setSchemaType(SchemaType.AUTO_CONSUME.toString());
         pulsarSinkConfig.setTypeClassName(GenericRecord.class.getName());
-        sink = new PulsarSink(
+        sink = new PulsarSink<>(
             pulsarClient, pulsarSinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
         schema = sink.initializeSchema();
@@ -335,7 +335,7 @@ public class PulsarSinkTest {
         pulsarSinkConfig = getPulsarConfigs();
         pulsarSinkConfig.setSchemaType(SchemaType.AUTO_CONSUME.toString());
         pulsarSinkConfig.setTypeClassName(GenericRecord.class.getName());
-        sink = new PulsarSink(
+        sink = new PulsarSink<>(
             pulsarClient, pulsarSinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
         schema = sink.initializeSchema();
@@ -343,6 +343,7 @@ public class PulsarSinkTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void testSinkAndMessageRouting() throws Exception {
 
         String[] topics = {"topic-1", "topic-2", "topic-3", null};
@@ -354,8 +355,8 @@ public class PulsarSinkTest {
         /** test MANUAL **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(ProcessingGuarantees.MANUAL);
-        PulsarSink pulsarSink =
-                new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        PulsarSink<String> pulsarSink =
+                new PulsarSink<>(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                         Thread.currentThread().getContextClassLoader(), producerCache);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
@@ -394,7 +395,7 @@ public class PulsarSinkTest {
         /** test At-least-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(ProcessingGuarantees.ATLEAST_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        pulsarSink = new PulsarSink<>(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                 Thread.currentThread().getContextClassLoader(), producerCache);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
@@ -428,7 +429,7 @@ public class PulsarSinkTest {
         /** test At-most-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(ProcessingGuarantees.ATMOST_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        pulsarSink = new PulsarSink<>(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                 Thread.currentThread().getContextClassLoader(), producerCache);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
@@ -468,7 +469,7 @@ public class PulsarSinkTest {
         /** test Effectively-once **/
         pulsarClient = getPulsarClient();
         pulsarConfig.setProcessingGuarantees(FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE);
-        pulsarSink = new PulsarSink(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
+        pulsarSink = new PulsarSink<>(pulsarClient, pulsarConfig, new HashMap<>(), mock(ComponentStatsManager.class),
                 Thread.currentThread().getContextClassLoader(), producerCache);
 
         pulsarSink.open(new HashMap<>(), mock(SinkContext.class));
@@ -550,6 +551,7 @@ public class PulsarSinkTest {
         testWriteGenericRecords(ProcessingGuarantees.EFFECTIVELY_ONCE);
     }
 
+    @SuppressWarnings("rawtypes")
     private void testWriteGenericRecords(ProcessingGuarantees guarantees) throws Exception {
         String defaultTopic = "default";
 
@@ -559,7 +561,7 @@ public class PulsarSinkTest {
         sinkConfig.setProcessingGuarantees(guarantees);
 
         PulsarClient client = getPulsarClient();
-        PulsarSink pulsarSink = new PulsarSink(
+        PulsarSink<GenericRecord> pulsarSink = new PulsarSink<>(
             client, sinkConfig, new HashMap<>(), mock(ComponentStatsManager.class),
             Thread.currentThread().getContextClassLoader(), producerCache);
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarFunctionRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarFunctionRecordTest.java
@@ -30,10 +30,10 @@ public class PulsarFunctionRecordTest {
 
     @Test
     public void testAck() {
-        Record record = mock(Record.class);
+        Record<?> record = mock(Record.class);
         Function.FunctionDetails functionDetails = Function.FunctionDetails.newBuilder().setAutoAck(true)
                 .setProcessingGuarantees(Function.ProcessingGuarantees.ATMOST_ONCE).build();
-        PulsarFunctionRecord pulsarFunctionRecord = new PulsarFunctionRecord<>(record, functionDetails);
+        PulsarFunctionRecord<?> pulsarFunctionRecord = new PulsarFunctionRecord<>(record, functionDetails);
         pulsarFunctionRecord.ack();
         verify(record, times(0)).ack();
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
@@ -136,6 +136,7 @@ public class WindowFunctionExecutorTest {
         windowConfig.setProcessingGuarantees(WindowConfig.ProcessingGuarantees.ATMOST_ONCE);
         doReturn(Optional.of(new Gson().fromJson(new Gson().toJson(windowConfig), Map.class))).when(context)
                 .getUserConfigValue(WindowConfig.WINDOW_CONFIG_KEY);
+        @SuppressWarnings("rawtypes")
         Record record = mock(Record.class);
         when(context.getCurrentRecord()).thenReturn(record);
         doReturn(Optional.of("test-topic")).when(record).getTopicName();
@@ -150,6 +151,7 @@ public class WindowFunctionExecutorTest {
 
         WindowConfig config = new WindowConfig();
         config.setProcessingGuarantees(WindowConfig.ProcessingGuarantees.ATLEAST_ONCE);
+        @SuppressWarnings("rawtypes")
         WindowFunctionExecutor windowFunctionExecutor = spy(WindowFunctionExecutor.class);
         windowFunctionExecutor.windowConfig = config;
         doNothing().when(windowFunctionExecutor).initialize(any());
@@ -253,6 +255,7 @@ public class WindowFunctionExecutorTest {
         windowConfig.setLateDataTopic("$late");
         doReturn(Optional.of(new Gson().fromJson(new Gson().toJson(windowConfig), Map.class)))
                 .when(context).getUserConfigValue(WindowConfig.WINDOW_CONFIG_KEY);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilder typedMessageBuilder = mock(TypedMessageBuilder.class);
         when(typedMessageBuilder.value(any())).thenReturn(typedMessageBuilder);
         when(typedMessageBuilder.sendAsync()).thenReturn(CompletableFuture.anyOf());

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowManagerTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowManagerTest.java
@@ -171,6 +171,7 @@ public class WindowManagerTest {
         assertEquals(seq(1, threshold - windowLength), listener.onExpiryEvents);
     }
 
+    @SuppressWarnings("rawtypes")
     private void testEvictBeforeWatermarkForWatermarkEvictionPolicy(EvictionPolicy
                                                                             watermarkEvictionPolicy,
                                                                     int windowLength) throws
@@ -386,43 +387,43 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(631));
 
         assertEquals(3, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
                 new EventImpl<>(4, 618, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null)
         }), listener.allOnActivationEvents.get(2));
 
         assertEquals(Collections.emptyList(), listener.allOnActivationExpiredEvents.get(0));
         assertEquals(Collections.emptyList(), listener.allOnActivationExpiredEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
         }), listener.allOnActivationExpiredEvents.get(2));
 
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
         }), listener.allOnActivationNewEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null)
         }), listener.allOnActivationNewEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(5, 626, null)
         }), listener.allOnActivationNewEvents.get(2));
 
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
@@ -438,44 +439,44 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(834));
 
         assertEquals(3, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(7, 825, null),
                 new EventImpl<>(8, 826, null),
                 new EventImpl<>(9, 827, null)
         }), listener.allOnActivationEvents.get(2));
 
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null)
         }), listener.allOnActivationExpiredEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(5, 626, null)
         }), listener.allOnActivationExpiredEvents.get(1));
         assertEquals(Collections.emptyList(), listener.allOnActivationExpiredEvents.get(2));
 
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationNewEvents.get(0));
         assertEquals(Collections.emptyList(), listener.allOnActivationNewEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(7, 825, null),
                 new EventImpl<>(8, 826, null),
                 new EventImpl<>(9, 827, null)
         }), listener.allOnActivationNewEvents.get(2));
 
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null)
         }), listener.allOnExpiryEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(5, 626, null)
         }), listener.allOnExpiryEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(6, 636, null)
         }), listener.allOnExpiryEvents.get(2));
     }
@@ -499,17 +500,17 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(631));
 
         assertEquals(3, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
                 new EventImpl<>(4, 618, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(3, 607, null),
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null)
@@ -525,22 +526,22 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(674));
         assertEquals(4, listener.allOnActivationEvents.size());
         // same set of events part of three windows
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(6, 636, null)
         }), listener.allOnActivationEvents.get(2));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(7, 665, null),
                 new EventImpl<>(8, 666, null),
                 new EventImpl<>(9, 667, null)
@@ -568,12 +569,12 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(631));
 
         assertEquals(2, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(3, 607, null),
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 625, null),
@@ -592,10 +593,10 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(674));
         assertEquals(2, listener.allOnActivationEvents.size());
         // same set of events part of three windows
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(9, 665, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(9, 665, null),
                 new EventImpl<>(10, 666, null),
                 new EventImpl<>(11, 667, null),
@@ -625,23 +626,23 @@ public class WindowManagerTest {
 
         windowManager.add(new WaterMarkEvent<Integer>(20));
         assertEquals(5, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 10, null),
                 new EventImpl<>(2, 10, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(3, 11, null),
                 new EventImpl<>(4, 12, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(5, 12, null),
                 new EventImpl<>(6, 12, null)
         }), listener.allOnActivationEvents.get(2));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(7, 12, null),
                 new EventImpl<>(8, 13, null)
         }), listener.allOnActivationEvents.get(3));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(9, 14, null),
                 new EventImpl<>(10, 15, null)
         }), listener.allOnActivationEvents.get(4));
@@ -669,31 +670,31 @@ public class WindowManagerTest {
 
         windowManager.add(new WaterMarkEvent<Integer>(20));
         assertEquals(5, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 10, null),
                 new EventImpl<>(2, 10, null)
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 10, null),
                 new EventImpl<>(2, 10, null),
                 new EventImpl<>(3, 11, null),
                 new EventImpl<>(4, 12, null)
         }), listener.allOnActivationEvents.get(1));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(2, 10, null),
                 new EventImpl<>(3, 11, null),
                 new EventImpl<>(4, 12, null),
                 new EventImpl<>(5, 12, null),
                 new EventImpl<>(6, 12, null)
         }), listener.allOnActivationEvents.get(2));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 12, null),
                 new EventImpl<>(5, 12, null),
                 new EventImpl<>(6, 12, null),
                 new EventImpl<>(7, 12, null),
                 new EventImpl<>(8, 13, null)
         }), listener.allOnActivationEvents.get(3));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(6, 12, null),
                 new EventImpl<>(7, 12, null),
                 new EventImpl<>(8, 13, null),
@@ -722,19 +723,19 @@ public class WindowManagerTest {
         // send a watermark event, which should trigger three windows.
         windowManager.add(new WaterMarkEvent<Integer>(631));
         assertEquals(3, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
                 new EventImpl<>(4, 618, null),
         }), listener.allOnActivationEvents.get(1));
         // out of order events should be processed upto the lag
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(7, 629, null)
@@ -774,12 +775,12 @@ public class WindowManagerTest {
         windowManager.add(new WaterMarkEvent<Integer>(631));
 
         assertEquals(3, listener.allOnActivationEvents.size());
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
         }), listener.allOnActivationEvents.get(0));
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),
@@ -787,7 +788,7 @@ public class WindowManagerTest {
         }), listener.allOnActivationEvents.get(1));
 
         // out of order events should be processed upto the lag
-        assertEquals(Arrays.asList(new Event[]{
+        assertEquals(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(4, 618, null),
                 new EventImpl<>(5, 626, null),
                 new EventImpl<>(6, 629, null)
@@ -795,7 +796,7 @@ public class WindowManagerTest {
 
         // events 8, 9, 10 should not be scanned at all since TimeEvictionPolicy lag 5s should break
         // the WindowManager scan loop early.
-        assertEquals(new HashSet<>(Arrays.asList(new Event[]{
+        assertEquals(new HashSet<>(Arrays.asList(new Event<?>[]{
                 new EventImpl<>(1, 603, null),
                 new EventImpl<>(2, 605, null),
                 new EventImpl<>(3, 607, null),

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/kubernetes/KubernetesRuntimeTest.java
@@ -1013,7 +1013,7 @@ public class KubernetesRuntimeTest {
         assertEquals(args.size(), totalArgs,
                 "Actual args : " + StringUtils.join(args, " "));
 
-        HashMap goInstanceConfig = new ObjectMapper().readValue(args.get(7).replaceAll("^\'|\'$",
+        HashMap<?, ?> goInstanceConfig = new ObjectMapper().readValue(args.get(7).replaceAll("^\'|\'$",
                 ""), HashMap.class);
 
         assertEquals(args.get(0), "chmod");

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionMetaDataManagerTest.java
@@ -64,7 +64,9 @@ public class FunctionMetaDataManagerTest {
         when(builder.sendTimeout(anyInt(), any(TimeUnit.class))).thenReturn(builder);
         when(builder.accessMode(any())).thenReturn(builder);
 
+        @SuppressWarnings("rawtypes")
         Producer producer = mock(Producer.class);
+        @SuppressWarnings("rawtypes")
         TypedMessageBuilder messageBuilder = mock(TypedMessageBuilder.class);
         when(messageBuilder.key(anyString())).thenReturn(messageBuilder);
         doAnswer(invocation -> {
@@ -304,6 +306,7 @@ public class FunctionMetaDataManagerTest {
         Request.ServiceRequest serviceRequest =
                 Request.ServiceRequest.newBuilder().setServiceRequestType(
                 Request.ServiceRequest.ServiceRequestType.UPDATE).build();
+        @SuppressWarnings("rawtypes")
         Message msg = mock(Message.class);
         doReturn(serviceRequest.toByteArray()).when(msg).getData();
         functionMetaDataManager.processMetaDataTopicMessage(msg);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionWorkerStarterTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionWorkerStarterTest.java
@@ -34,7 +34,7 @@ public class FunctionWorkerStarterTest {
             ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baoStream));
 
-            Class argumentsClass =
+            Class<?> argumentsClass =
                     Class.forName("org.apache.pulsar.functions.worker.FunctionWorkerStarter$WorkerArguments");
 
             FunctionWorkerStarter.main(new String[]{"-g"});

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/LeaderServiceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/LeaderServiceTest.java
@@ -52,14 +52,15 @@ public class LeaderServiceTest {
     AtomicReference<ConsumerEventListener> listenerHolder;
     private LeaderService leaderService;
     private PulsarClientImpl mockClient;
+    @SuppressWarnings("rawtypes")
     private ConsumerImpl mockConsumer;
     private FunctionAssignmentTailer functionAssignmentTailer;
     private SchedulerManager schedulerManager;
     private FunctionRuntimeManager functionRuntimeManager;
     private FunctionMetaDataManager functionMetadataManager;
-    private CompletableFuture metadataManagerInitFuture;
-    private CompletableFuture runtimeManagerInitFuture;
-    private CompletableFuture readToTheEndAndExitFuture;
+    private CompletableFuture<Void> metadataManagerInitFuture;
+    private CompletableFuture<Void> runtimeManagerInitFuture;
+    private CompletableFuture<Void> readToTheEndAndExitFuture;
     private MembershipManager membershipManager;
 
     public LeaderServiceTest() {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -79,6 +79,7 @@ public class SchedulerManagerTest {
     private FunctionRuntimeManager functionRuntimeManager;
     private MembershipManager membershipManager;
     private CompletableFuture<MessageId> completableFuture;
+    @SuppressWarnings("rawtypes")
     private Producer producer;
     private TypedMessageBuilder<byte[]> message;
     private ScheduledExecutorService executor;

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
@@ -79,6 +79,7 @@ public class WorkerUtilsTest {
         verify(builder, times(1)).producerName(eq("test-producer"));
         verify(builder, times(1)).accessMode(eq(ProducerAccessMode.Exclusive));
 
+        @SuppressWarnings("rawtypes")
         CompletableFuture completableFuture = new CompletableFuture();
         completableFuture.completeExceptionally(new PulsarClientException.ProducerFencedException("test"));
         when(builder.createAsync()).thenReturn(completableFuture);

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/AbstractFunctionsResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/AbstractFunctionsResourceTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractFunctionsResourceTest {
     private static final String SYSTEM_PROPERTY_NAME_INVALID_NAR_FILE_PATH = "pulsar-io-invalid.nar.path";
     private static final String SYSTEM_PROPERTY_NAME_FUNCTIONS_API_EXAMPLES_NAR_FILE_PATH =
             "pulsar-functions-api-examples.nar.path";
-    protected static Map<String, MockedStatic> mockStaticContexts = new HashMap<>();
+    protected static Map<String, MockedStatic<?>> mockStaticContexts = new HashMap<>();
 
     static {
         TOPICS_TO_SER_DE_CLASS_NAME.put("test_src", DEFAULT_SERDE);
@@ -234,8 +234,9 @@ public abstract class AbstractFunctionsResourceTest {
         mockStatic(classStatic, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS), consumer);
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> void mockStatic(Class<T> classStatic, MockSettings mockSettings, Consumer<MockedStatic<T>> consumer) {
-        final MockedStatic<T> mockedStatic = mockStaticContexts.computeIfAbsent(classStatic.getName(),
+        final MockedStatic<T> mockedStatic = (MockedStatic) mockStaticContexts.computeIfAbsent(classStatic.getName(),
                 name -> Mockito.mockStatic(classStatic, mockSettings));
         consumer.accept(mockedStatic);
     }

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
@@ -769,7 +769,7 @@ public abstract class BookKeeperClusterTestCase {
         return tester;
     }
 
-    public void setMetastoreImplClass(AbstractConfiguration conf) {
+    public void setMetastoreImplClass(AbstractConfiguration<?> conf) {
         conf.setMetastoreImplClass(InMemoryMetaStore.class.getName());
     }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/DualMetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/DualMetadataCacheTest.java
@@ -514,7 +514,7 @@ public class DualMetadataCacheTest extends BaseMetadataStoreTest {
                 MetadataStoreConfig.builder().build());
 
         // Create cache with custom config
-        MetadataCacheConfig cacheConfig = MetadataCacheConfig.builder()
+        MetadataCacheConfig<TestObject> cacheConfig = MetadataCacheConfig.<TestObject>builder()
                 .refreshAfterWriteMillis(1000)
                 .build();
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -531,7 +531,7 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
                         .mandatoryStop(Duration.ofSeconds(3))).build());
 
         MetadataCache<MyClass> cacheRef = cache;
-        if (cache instanceof DualMetadataCache dc) {
+        if (cache instanceof DualMetadataCache<?> dc) {
             cacheRef = (MetadataCache<MyClass>) dc.getMetadataCache().get();
         }
 

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -103,7 +103,7 @@ public class TestZKServer implements AutoCloseable {
     }
 
     @SneakyThrows
-    private static <T> T readField(Class clazz, String field, Object object) {
+    private static <T> T readField(Class<?> clazz, String field, Object object) {
         Field declaredField = clazz.getDeclaredField(field);
         boolean accessible = declaredField.isAccessible();
         if (!accessible) {

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -197,7 +197,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
          *   2. Store the param-context and param-position of callback function for verify.
          */
         // Create TxLogBufferedWriter.
-        TxnLogBufferedWriter txnLogBufferedWriter =  new TxnLogBufferedWriter<Integer>(
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter =  new TxnLogBufferedWriter<>(
                     managedLedger, ((ManagedLedgerImpl) managedLedger).getExecutor(), transactionTimer,
                     dataSerializer, batchedWriteMaxRecords, batchedWriteMaxSize,
                     batchedWriteMaxDelayInMillis, batchEnabled, DISABLED_BUFFERED_WRITER_METRICS);
@@ -396,7 +396,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         SumStrDataSerializer dataSerializer = new SumStrDataSerializer();
         // Cache the data flush to Bookie for Asserts.
         List<Integer> dataArrayFlushedToBookie = Collections.synchronizedList(new ArrayList<>());
-        Mockito.doAnswer(new Answer() {
+        Mockito.doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
@@ -410,7 +410,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
             }
         }).when(managedLedger).asyncAddEntry(Mockito.any(ByteBuf.class), Mockito.any(), Mockito.any());
         // Test threshold: writeMaxDelayInMillis (use timer).
-        TxnLogBufferedWriter txnLogBufferedWriter1 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter1 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
                 transactionTimer, dataSerializer, 32, 1024 * 4,
                 100, true, DISABLED_BUFFERED_WRITER_METRICS);
         TxnLogBufferedWriter.AddDataCallback callback = Mockito.mock(TxnLogBufferedWriter.AddDataCallback.class);
@@ -423,7 +423,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         txnLogBufferedWriter1.close().get();
 
         // Test threshold: batchedWriteMaxRecords.
-        TxnLogBufferedWriter txnLogBufferedWriter2 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter2 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
                 transactionTimer, dataSerializer, 32, 1024 * 4,
                 10000, true, DISABLED_BUFFERED_WRITER_METRICS);
         for (int i = 0; i < 32; i++){
@@ -434,7 +434,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         txnLogBufferedWriter2.close();
 
         // Test threshold: batchedWriteMaxSize.
-        TxnLogBufferedWriter txnLogBufferedWriter3 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter3 = new TxnLogBufferedWriter<>(managedLedger, topicExecutor,
                 transactionTimer, dataSerializer, 1024, 64 * 4,
                 10000, true, DISABLED_BUFFERED_WRITER_METRICS);
         for (int i = 0; i < 64; i++){
@@ -471,7 +471,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         // Mock managed ledger and write counter.
         MockedManagedLedger mockedManagedLedger = mockManagedLedgerWithWriteCounter(mlName);
         // Start tests.
-        TxnLogBufferedWriter txnLogBufferedWriter = new TxnLogBufferedWriter<>(mockedManagedLedger.managedLedger,
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter = new TxnLogBufferedWriter<>(mockedManagedLedger.managedLedger,
                 threadPoolExecutor, transactionTimer, dataSerializer, 2, 1024 * 4,
                 1, true, DISABLED_BUFFERED_WRITER_METRICS);
         TxnLogBufferedWriter.AddDataCallback callback = Mockito.mock(TxnLogBufferedWriter.AddDataCallback.class);
@@ -908,6 +908,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
     @Test
     public void testFailWhenAddData() throws Exception {
         int batchedWriteMaxSize = 1024;
+        @SuppressWarnings("rawtypes")
         TxnLogBufferedWriter.DataSerializer dataSerializer =
                 new WrongDataSerializer(batchedWriteMaxSize, true, true, true);
         int writeCount = 100;
@@ -1026,7 +1027,7 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         AtomicInteger writeCounter = new AtomicInteger();
         ManagedLedger managedLedger = Mockito.mock(ManagedLedger.class);
         Mockito.when(managedLedger.getName()).thenReturn(mlName);
-        Mockito.doAnswer(new Answer() {
+        Mockito.doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 writeCounter.incrementAndGet();

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/TxnLogBufferedWriterTest.java
@@ -471,7 +471,8 @@ public class TxnLogBufferedWriterTest extends MockedBookKeeperTestCase {
         // Mock managed ledger and write counter.
         MockedManagedLedger mockedManagedLedger = mockManagedLedgerWithWriteCounter(mlName);
         // Start tests.
-        TxnLogBufferedWriter<Integer> txnLogBufferedWriter = new TxnLogBufferedWriter<>(mockedManagedLedger.managedLedger,
+        TxnLogBufferedWriter<Integer> txnLogBufferedWriter = new TxnLogBufferedWriter<>(
+                mockedManagedLedger.managedLedger,
                 threadPoolExecutor, transactionTimer, dataSerializer, 2, 1024 * 4,
                 1, true, DISABLED_BUFFERED_WRITER_METRICS);
         TxnLogBufferedWriter.AddDataCallback callback = Mockito.mock(TxnLogBufferedWriter.AddDataCallback.class);


### PR DESCRIPTION
## Motivation

Fix `rawtypes` compiler warnings in test code by adding proper generic type parameters to raw types.

This is part of a series to clean up test compile warnings (following production code cleanup in #25414-#25422).

## Changes

- Add proper type parameters: `Class` → `Class<?>`, `Producer` → `Producer<?>`, `Consumer` → `Consumer<?>`, `Message` → `Message<?>`, `Schema` → `Schema<?>`, `List` → `List<?>`, etc.
- Use diamond operator `<>` where type can be inferred
- Add `@SuppressWarnings("rawtypes")` at method level only where fixing raw types would cascade into unchecked/type-erasure compile errors (e.g., TestNG DataProvider methods returning `Object[][]`)

Affects ~99 files across all modules.

## Verifying this change

- `./gradlew compileTestJava` passes cleanly
- `rawtypes` warning count drops significantly

### Does this pull request potentially affect one of the following areas?

- [x] *Test code only*

### Documentation

- [x] `doc-not-needed` — test-only changes