### PR TITLE
[improve][test] Suppress deprecation compile warnings in test code

### DIFF
--- a/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
+++ b/bouncy-castle/bcfips-include-test/src/test/java/org/apache/pulsar/client/TlsProducerConsumerBase.java
@@ -69,6 +69,7 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
         conf.setNumExecutorThreadPoolSize(5);
     }
 
+    @SuppressWarnings("deprecation")
     protected void internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         if (pulsarClient != null) {
             pulsarClient.close();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInfoMetadataTest.java
@@ -53,6 +53,7 @@ public class ManagedLedgerInfoMetadataTest {
         };
     }
 
+    @SuppressWarnings("deprecation")
     private ManagedLedgerInfo generateManagedLedgerInfo(long ledgerId, int ledgerInfoNumber) {
         ManagedLedgerInfo managedLedgerInfo = new ManagedLedgerInfo();
         for (int i = 0; i < ledgerInfoNumber; i++) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3479,6 +3479,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
      * @param checkOwnershipFlag
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "checkOwnershipFlag")
     public void recoverMLWithBadVersion(boolean checkOwnershipFlag) throws Exception {
 
@@ -3519,6 +3520,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         log.info("Test completed");
     }
 
+    @SuppressWarnings("deprecation")
     private boolean updateCusorMetadataByCreatingMetadataLedger(MutableObject<ManagedCursorImpl> cursor2)
             throws InterruptedException {
         MutableObject<Boolean> failed = new MutableObject<>();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiterTest.java
@@ -538,6 +538,7 @@ public class InflightReadsLimiterTest {
                 .isEqualTo(maxReadsInFlightSize);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPrometheusMetrics() throws Exception {
         long maxReadsInFlightSize = 100;

--- a/pulsar-broker-auth-oidc/src/test/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDIntegrationTest.java
+++ b/pulsar-broker-auth-oidc/src/test/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDIntegrationTest.java
@@ -87,6 +87,7 @@ public class AuthenticationProviderOpenIDIntegrationTest {
     String issuerK8s;
     WireMockServer server;
 
+    @SuppressWarnings("deprecation")
     @BeforeClass
     void beforeClass() throws IOException {
 
@@ -578,6 +579,7 @@ public class AuthenticationProviderOpenIDIntegrationTest {
      * both kinds of authentication work.
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthenticationProviderListStateSuccess() throws Exception {
         ServiceConfiguration conf = new ServiceConfiguration();

--- a/pulsar-broker-auth-oidc/src/test/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDTest.java
+++ b/pulsar-broker-auth-oidc/src/test/java/org/apache/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDTest.java
@@ -62,6 +62,7 @@ import org.testng.annotations.Test;
 public class AuthenticationProviderOpenIDTest {
 
     // https://www.rfc-editor.org/rfc/rfc7518#section-3.1
+    @SuppressWarnings("deprecation")
     private static final Set<SignatureAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
             SignatureAlgorithm.RS256,
             SignatureAlgorithm.RS384,
@@ -76,6 +77,7 @@ public class AuthenticationProviderOpenIDTest {
         return buildDataProvider(SUPPORTED_ALGORITHMS);
     }
 
+    @SuppressWarnings("deprecation")
     @DataProvider(name = "unsupportedAlgorithms")
     public static Object[][] unsupportedAlgorithms() {
         var unsupportedAlgorithms = Set.of(SignatureAlgorithm.values())
@@ -109,6 +111,7 @@ public class AuthenticationProviderOpenIDTest {
         basicProvider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testNullToken() throws IOException {
         @Cleanup
@@ -124,6 +127,7 @@ public class AuthenticationProviderOpenIDTest {
                 .hasMessage("PublicKey algorithm cannot be null");
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "unsupportedAlgorithms")
     public void testThatUnsupportedAlgsThrowExceptions(SignatureAlgorithm unsupportedAlg) {
         var algorithm = unsupportedAlg.getValue();
@@ -133,6 +137,7 @@ public class AuthenticationProviderOpenIDTest {
                 .hasMessage("Unsupported algorithm: " + algorithm);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "supportedAlgorithms")
     public void testThatSupportedAlgsWork(SignatureAlgorithm alg) throws AuthenticationException {
         KeyPair keyPair = Keys.keyPairFor(alg);
@@ -146,6 +151,7 @@ public class AuthenticationProviderOpenIDTest {
         Assert.assertEquals(expectedValue, actualValue);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testThatSupportedAlgWithMismatchedPublicKeyFromDifferentAlgFamilyFails() throws IOException {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -159,6 +165,7 @@ public class AuthenticationProviderOpenIDTest {
                 .hasMessage("Expected PublicKey alg [ES512] does match actual alg.");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testThatSupportedAlgWithMismatchedPublicKeyFromSameAlgFamilyFails() {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -172,6 +179,7 @@ public class AuthenticationProviderOpenIDTest {
                 .hasMessageStartingWith("JWT algorithm does not match Public Key algorithm");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void ensureExpiredTokenFails() {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -184,6 +192,7 @@ public class AuthenticationProviderOpenIDTest {
                 () -> basicProvider.verifyJWT(keyPair.getPublic(), SignatureAlgorithm.RS256.getValue(), jwt));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void ensureFutureNBFFails() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -197,6 +206,7 @@ public class AuthenticationProviderOpenIDTest {
                 () -> basicProvider.verifyJWT(keyPair.getPublic(), SignatureAlgorithm.RS256.getValue(), jwt));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void ensureWithoutNBFSucceeds() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -211,6 +221,7 @@ public class AuthenticationProviderOpenIDTest {
         basicProvider.verifyJWT(keyPair.getPublic(), SignatureAlgorithm.RS256.getValue(), jwt);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void ensureFutureIATFails() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -224,6 +235,7 @@ public class AuthenticationProviderOpenIDTest {
                 () -> basicProvider.verifyJWT(keyPair.getPublic(), SignatureAlgorithm.RS256.getValue(), jwt));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void ensureRecentlyExpiredTokenWithinConfiguredLeewaySucceeds() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -164,6 +164,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         assertFalse(kerberosWorkDir.exists());
     }
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
@@ -261,6 +262,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
     }
 
     // Test sasl server/client auth.
+    @SuppressWarnings("deprecation")
     @Test
     public void testSaslServerAndClientAuth() throws Exception {
         log.info("-- {} -- start", methodName);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderListTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderListTest.java
@@ -76,6 +76,7 @@ public class AuthenticationProviderListTest {
 
     private AuthenticationProviderList authProvider;
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     public void setUp() throws Exception {
         this.keyPairA = Keys.keyPairFor(SignatureAlgorithm.ES256);
@@ -190,6 +191,7 @@ public class AuthenticationProviderListTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     private AuthenticationState newAuthState(String token, String expectedSubject) throws Exception {
         // Must pass the token to the newAuthState for legacy reasons.
         AuthenticationState authState = authProvider.newAuthState(
@@ -204,6 +206,7 @@ public class AuthenticationProviderListTest {
         return authState;
     }
 
+    @SuppressWarnings("deprecation")
     private void verifyAuthStateExpired(AuthenticationState authState, String expectedSubject)
         throws Exception {
         assertEquals(authState.getAuthRole(), expectedSubject);
@@ -266,6 +269,7 @@ public class AuthenticationProviderListTest {
         verify(requestBB).setAttribute(eq(AuthenticatedDataAttributeName), isA(AuthenticationDataSource.class));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthenticateWithMultipleProviders() throws Exception {
         HttpServletRequest httpRequest = mock(HttpServletRequest.class);
@@ -352,6 +356,7 @@ public class AuthenticationProviderListTest {
                     return subject;
                 }
 
+                @SuppressWarnings("deprecation")
                 @Override
                 public AuthData authenticate(AuthData authData) {
                     return null;
@@ -362,6 +367,7 @@ public class AuthenticationProviderListTest {
                     return null;
                 }
 
+                @SuppressWarnings("deprecation")
                 @Override
                 public boolean isComplete() {
                     return false;
@@ -377,6 +383,7 @@ public class AuthenticationProviderListTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void verifyAuthenticationStateSuccess(AuthenticationState authState, boolean isAsync, String expectedRole)
             throws Exception {
         assertThat(authState).isNotNull();

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderTokenTest.java
@@ -82,6 +82,7 @@ public class AuthenticationProviderTokenTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSerializeSecretKey() {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -102,6 +103,7 @@ public class AuthenticationProviderTokenTest {
         assertEquals(jwt.getBody().getSubject(), SUBJECT);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSerializeKeyPair() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -125,6 +127,7 @@ public class AuthenticationProviderTokenTest {
         assertEquals(jwt.getBody().getSubject(), SUBJECT);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKey() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -235,6 +238,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTrimAuthSecretKeyFilePath() throws Exception {
         String space = " ";
@@ -255,6 +259,7 @@ public class AuthenticationProviderTokenTest {
         provider.initialize(AuthenticationProvider.Context.builder().config(conf).build());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyFromFile() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -291,6 +296,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyFromValidFile() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -326,6 +332,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyFromDataBase64() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -358,6 +365,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyPair() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -397,6 +405,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyPairWithCustomClaim() throws Exception {
         String authRoleClaim = "customClaim";
@@ -422,6 +431,7 @@ public class AuthenticationProviderTokenTest {
         // Use private key to generate token
         PrivateKey privateKey =
                 AuthTokenUtils.decodePrivateKey(Decoders.BASE64.decode(privateKeyStr), SignatureAlgorithm.RS256);
+        @SuppressWarnings("deprecation")
         String token = Jwts.builder()
                 .setClaims(new HashMap<String, Object>() {{
                     put(authRoleClaim, authRole);
@@ -447,6 +457,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthSecretKeyPairWithECDSA() throws Exception {
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
@@ -564,6 +575,7 @@ public class AuthenticationProviderTokenTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test(expectedExceptions = AuthenticationException.class)
     public void testAuthenticateWhenInvalidTokenIsPassed() throws AuthenticationException, IOException {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -825,6 +837,7 @@ public class AuthenticationProviderTokenTest {
         testTokenAudienceWithDifferentConfig(properties, audienceClaim, audiences);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testArrayTypeRoleClaim() throws Exception {
         String authRoleClaim = "customClaim";
@@ -850,6 +863,7 @@ public class AuthenticationProviderTokenTest {
         // Use private key to generate token
         PrivateKey privateKey =
                 AuthTokenUtils.decodePrivateKey(Decoders.BASE64.decode(privateKeyStr), SignatureAlgorithm.RS256);
+        @SuppressWarnings("deprecation")
         String token = Jwts.builder()
                 .setClaims(new HashMap<String, Object>() {{
                     put(authRoleClaim, Arrays.asList(authRole, "other-role"));
@@ -874,6 +888,7 @@ public class AuthenticationProviderTokenTest {
         provider.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTokenSettingPrefix() throws Exception {
         AuthenticationProviderToken provider = new AuthenticationProviderToken();
@@ -913,6 +928,7 @@ public class AuthenticationProviderTokenTest {
                 .getProperty(prefix + AuthenticationProviderToken.CONF_TOKEN_AUDIENCE);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTokenFromHttpParams() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -939,6 +955,7 @@ public class AuthenticationProviderTokenTest {
         assertTrue(doFilter, "Authentication should have passed");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTokenFromHttpHeaders() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -1005,6 +1022,7 @@ public class AuthenticationProviderTokenTest {
         assertNotEquals(firstAuthDataSource, secondAuthDataSource);
     }
 
+    @SuppressWarnings("deprecation")
     private static String createTokenWithAudience(Key signingKey, String audienceClaim, List<String> audience) {
         JwtBuilder builder = Jwts.builder()
                 .setSubject(SUBJECT)
@@ -1021,6 +1039,7 @@ public class AuthenticationProviderTokenTest {
                 Lists.newArrayList(brokerAudience));
     }
 
+    @SuppressWarnings("deprecation")
     private static void testTokenAudienceWithDifferentConfig(Properties properties,
                                                         String audienceClaim, List<String> audiences) throws Exception {
         @Cleanup

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationStateTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authentication/OneStageAuthenticationStateTest.java
@@ -42,6 +42,7 @@ public class OneStageAuthenticationStateTest {
     public static class CountingAuthenticationProvider implements AuthenticationProvider {
         public LongAdder authCallCount = new LongAdder();
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/authorization/MultiRolesTokenAuthorizationProviderTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 public class MultiRolesTokenAuthorizationProviderTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthz() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -84,6 +85,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         }).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithEmptyRoles() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -112,6 +114,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         assertFalse(provider.authorize("test", ads, role -> CompletableFuture.completedFuture(false)).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithSingleRole() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -146,6 +149,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         }).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithoutClaim() throws Exception {
         final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -227,6 +231,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         assertFalse(provider.authorize("test", ads, role -> CompletableFuture.completedFuture(false)).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithCustomRolesClaims() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -267,6 +272,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
         }).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithSuperUser() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -315,6 +321,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
      * -> Returns true (exception is swallowed)
      * Scenario 2: All roles throw subscription prefix mismatch exception -> Returns false
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiRolesAuthzWithSubscriptionPrefixMismatchException() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -370,6 +377,7 @@ public class MultiRolesTokenAuthorizationProviderTest {
      * Single role throws subscription prefix mismatch exception -> Should throw the original exception
      * (Single role keeps original behavior, does not swallow exception)
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testSingleRoleAuthzWithSubscriptionPrefixMismatchException() throws Exception {
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/resources/TopicResourcesTest.java
@@ -151,6 +151,7 @@ public class TopicResourcesTest {
         verify(listener).onTopicEvent("persistent://tenant/name.pace/topic", NotificationType.Created);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBiConsumerListenerNotInvokedAfterDeregistered() {
         BiConsumer listener = mock(BiConsumer.class);

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerStorageForTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerStorageForTest.java
@@ -600,6 +600,7 @@ public class CustomizedManagedLedgerStorageForTest extends ManagedLedgerClientFa
             delegate.trimConsumedLedgersInBackground(promise);
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void rollCurrentLedgerIfFull() {
             delegate.rollCurrentLedgerIfFull();

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/CustomizedManagedLedgerTest.java
@@ -55,6 +55,7 @@ public class CustomizedManagedLedgerTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     protected void doInitConf() throws Exception {
         super.doInitConf();
         conf.setManagedLedgerStorageClassName(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/MockTokenAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/MockTokenAuthenticationProvider.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 public class MockTokenAuthenticationProvider implements AuthenticationProvider {
 
     public static final String KEY = "role";
+    @SuppressWarnings("deprecation")
 
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {
@@ -43,6 +44,7 @@ public class MockTokenAuthenticationProvider implements AuthenticationProvider {
     public String getAuthMethodName() {
         return "mock";
     }
+    @SuppressWarnings("deprecation")
 
     @Override
     public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
@@ -60,6 +62,7 @@ public class MockTokenAuthenticationProvider implements AuthenticationProvider {
     public void close() throws IOException {
         // No ops
     }
+    @SuppressWarnings("deprecation")
 
     public static class MockAuthentication implements Authentication {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
@@ -96,6 +96,7 @@ public class PulsarBrokerStarterTest {
      * method returns a non-null {@link ServiceConfiguration} instance where all required settings are filled in and (2)
      * if the property variables inside the given property file are correctly referred to that returned object.
      */
+    @SuppressWarnings("deprecation")
     public void testLoadConfig() throws SecurityException, NoSuchMethodException, IOException, IllegalArgumentException,
             IllegalAccessException, InvocationTargetException {
 
@@ -172,6 +173,7 @@ public class PulsarBrokerStarterTest {
      * method returns a non-null {@link ServiceConfiguration} instance where all required settings are filled in and (2)
      * if the property variables inside the given property file are correctly referred to that returned object.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLoadBalancerConfig() throws SecurityException, NoSuchMethodException, IOException,
             IllegalArgumentException, IllegalAccessException, InvocationTargetException {
@@ -221,6 +223,7 @@ public class PulsarBrokerStarterTest {
      * method returns a non-null {@link ServiceConfiguration} instance where all required settings are filled in and (2)
      * if the property variables inside the given property file are correctly referred to that returned object.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testGlobalZooKeeperConfig() throws SecurityException, NoSuchMethodException, IOException,
             IllegalArgumentException, IllegalAccessException, InvocationTargetException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerAdditionalServletTest.java
@@ -118,6 +118,7 @@ public class BrokerAdditionalServletTest extends MockedPulsarServiceBaseTest {
         Mockito.when(pulsar.getBrokerAdditionalServlets()).thenReturn(brokerAdditionalServlets);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void test() throws IOException {
         int httpPort = pulsar.getWebService().getListenPortHTTP().get();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/ConfigHelper.java
@@ -35,6 +35,7 @@ public class ConfigHelper {
                 timeBacklogQuota(configuration));
     }
 
+    @SuppressWarnings("deprecation")
     public static BacklogQuota sizeBacklogQuota(ServiceConfiguration configuration) {
         long backlogQuotaBytes = configuration.getBacklogQuotaDefaultLimitGB() > 0
                 ? ((long) (configuration.getBacklogQuotaDefaultLimitGB() * BacklogQuotaImpl.BYTES_IN_GIGABYTE))

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/EmbeddedPulsarCluster.java
@@ -99,6 +99,7 @@ public class EmbeddedPulsarCluster implements AutoCloseable {
         return serviceUrl;
     }
 
+    @SuppressWarnings("deprecation")
     private ServiceConfiguration getConf() {
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setAdvertisedAddress("localhost");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -62,6 +62,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
             {false}
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledTls", timeOut = 240 * 1000)
     public void testAutoClusterFailover(boolean enabledTls) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -480,6 +480,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         setTopicPoliciesAndValidate(admin2, admin3, topic2);
     }
 
+    @SuppressWarnings("deprecation")
     private void setTopicPoliciesAndValidate(PulsarAdmin admin2
             , PulsarAdmin admin3, String topic) throws Exception {
         admin.topics().setMaxUnackedMessagesOnConsumer(topic, 100);
@@ -505,6 +506,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void nonPersistentTopics() throws Exception {
         final String topicName = "nonPersistentTopic";
@@ -1238,6 +1240,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(namespaces2.size(), 0);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPersistentTopicList() throws Exception {
         final String namespace = newUniqueName(defaultTenant + "/ns2");
@@ -3378,6 +3381,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         Awaitility.await().untilAsserted(() -> assertNull(admin.namespaces().getCompactionThreshold(namespace)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 200000)
     public void testCompactionPriority() throws Exception {
         restartClusterAfterTest();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDelayedDeliveryTest.java
@@ -142,6 +142,7 @@ public class AdminApiDelayedDeliveryTest extends MockedPulsarServiceBaseTest {
                 -> assertNull(admin.namespaces().getDelayedDelivery(namespace)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testDelayedDeliveryApplied() throws Exception {
         cleanup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMaxUnackedMessagesTest.java
@@ -125,6 +125,7 @@ public class AdminApiMaxUnackedMessagesTest extends MockedPulsarServiceBaseTest 
                 -> assertNull(admin.namespaces().getMaxUnackedMessagesPerSubscription(namespace)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxUnackedMessagesPerConsumerPriority() throws Exception {
         int brokerLevelPolicy = 3;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiMultiBrokersTest.java
@@ -97,6 +97,7 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30 * 1000, dataProvider = "topicTypes")
     public void testTopicLookup(TopicDomain topicDomain, boolean isPartition) throws Exception {
         PulsarAdmin admin0 = getAllAdmins().get(0);
@@ -130,6 +131,7 @@ public class AdminApiMultiBrokersTest extends MultiBrokerBaseTest {
         Assert.assertEquals(lookupResultSet.size(), 1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(groups = "flaky")
     public void testForceDeletePartitionedTopicWithSub() throws Exception {
         final int numPartitions = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -233,6 +233,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         assertNull(offload3);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testOffloadPoliciesApi() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -256,6 +257,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         assertNull(admin.topics().getOffloadPolicies(topicName));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testOffloadPoliciesAppliedApi() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -405,6 +407,7 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         testOffload(false);
     }
 
+    @SuppressWarnings("deprecation")
     private void testOffload(boolean isPartitioned) throws Exception {
         String topicName = testTopic + UUID.randomUUID().toString();
         int partitionNum = 3;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
@@ -57,6 +57,7 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     private void testAutoUpdateBackward(String namespace, String topicName) throws Exception {
         Assert.assertNull(admin.namespaces().getSchemaAutoUpdateCompatibilityStrategy(namespace));
 
@@ -81,6 +82,7 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     private void testAutoUpdateForward(String namespace, String topicName) throws Exception {
         Assert.assertNull(admin.namespaces().getSchemaAutoUpdateCompatibilityStrategy(namespace));
 
@@ -104,6 +106,7 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void testAutoUpdateFull(String namespace, String topicName) throws Exception {
         Assert.assertNull(admin.namespaces().getSchemaAutoUpdateCompatibilityStrategy(namespace));
 
@@ -131,6 +134,7 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void testAutoUpdateDisabled(String namespace, String topicName) throws Exception {
         Assert.assertNull(admin.namespaces().getSchemaAutoUpdateCompatibilityStrategy(namespace));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaTest.java
@@ -187,6 +187,7 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "version")
     public void testPostSchemaCompatibilityStrategy(ApiVersion version) throws PulsarAdminException {
         String namespace = format("%s%s%s", "schematest", "/",
@@ -401,11 +402,13 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
                 SchemaCompatibilityStrategy.UNDEFINED);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetSchemaAutoUpdateCompatibilityStrategy() throws PulsarAdminException {
         assertNull(admin.namespaces().getSchemaAutoUpdateCompatibilityStrategy(schemaCompatibilityNamespace));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetSchemaCompatibilityStrategyWhenSetSchemaAutoUpdateCompatibilityStrategy()
             throws PulsarAdminException {
@@ -427,6 +430,7 @@ public class AdminApiSchemaTest extends MockedPulsarServiceBaseTest {
                 admin.namespaces().getSchemaCompatibilityStrategy(schemaCompatibilityNamespace)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetSchemaCompatibilityStrategyWhenSetBrokerLevelAndSchemaAutoUpdateCompatibilityStrategy()
             throws PulsarAdminException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaWithAuthTest.java
@@ -51,6 +51,7 @@ import org.testng.annotations.Test;
 /**
  * Unit tests for schema admin api.
  */
+@SuppressWarnings("deprecation")
 @Slf4j
 @Test(groups = "broker-admin")
 public class AdminApiSchemaWithAuthTest extends MockedPulsarServiceBaseTest {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -917,6 +917,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         // otheradmin.namespaces().unload("prop-xyz/use/ns2");
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicName")
     public void persistentTopics(String topicName) throws Exception {
         final String subName = topicName;
@@ -1012,6 +1013,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList("prop-xyz/ns1"), new ArrayList<>());
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicName")
     public void testSkipHoleMessages(String topicName) throws Exception {
         final String subName = topicName;
@@ -1058,6 +1060,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(topicStats.getSubscriptions().get(subName).getMsgBacklog(), msgBacklog - skipNumber);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicType")
     public void testPartitionState(String topicType) throws Exception {
         final String namespace = "prop-xyz/ns1";
@@ -1103,6 +1106,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicType")
     public void testNonPartitionState(String topicType) throws Exception {
         final String namespace = "prop-xyz/ns1";
@@ -1141,6 +1145,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         client.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicNamesForAllTypes")
     public void partitionedTopics(String topicType, String topicName) throws Exception {
         final String namespace = "prop-xyz/ns1";
@@ -2157,6 +2162,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete("persistent://prop-xyz/ns1-bundles/ds2");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeleteSubscription() throws Exception {
         final String subName = "test-sub";
@@ -2971,6 +2977,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         admin.topics().deletePartitionedTopic(topicName);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void persistentTopicsInvalidCursorReset() throws Exception {
         admin.namespaces().setRetention("prop-xyz/ns1", new RetentionPolicies(10, 10));
@@ -3059,6 +3066,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testPersistentTopicsExpireMessages() throws Exception {
         // Force to create a topic
@@ -3146,6 +3154,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         consumer3.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPersistentTopicsExpireMessagesInvalidPartitionIndex() throws Exception {
         // Create a topic
@@ -3178,6 +3187,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testPersistentTopicExpireMessageOnPartitionTopic() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -194,6 +194,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         conf.setClusterName(configClusterName);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void internalConfiguration() throws Exception {
         ServiceConfiguration conf = pulsar.getConfiguration();
@@ -229,6 +230,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
      * (before https://github.com/apache/pulsar/pull/14384) while the Worker already uses the new one.
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void internalConfigurationRetroCompatibility() throws Exception {
         OldInternalConfigurationData oldDataModel = new OldInternalConfigurationData(
@@ -734,6 +736,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                 pulsar.getLeaderElectionService().getCurrentLeader().map(LeaderBroker::getBrokerId).get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void resourceQuotas() throws Exception {
         // get Default Resource Quota
@@ -816,6 +819,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void persistentTopics() throws Exception {
 
@@ -939,6 +943,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
                 false, 10);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void test500Error() throws Exception {
         final String tenant = "prop-xyz";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataTest.java
@@ -272,6 +272,7 @@ public class GetPartitionMetadataTest extends TestRetrySupport {
         doModifyTopicAutoCreation(admin1, pulsar1, allowAutoTopicCreation, allowAutoTopicCreationType,
                 defaultNumPartitions);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "topicDomains")
     public void testAutoCreatingMetadataWhenCallingOldAPI(TopicDomain topicDomain) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MaxUnackedMessagesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/MaxUnackedMessagesTest.java
@@ -47,6 +47,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-admin")
 public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testMaxUnackedMessagesOnSubscriptionApi() throws Exception {
         final String topicName = newTopicName();
@@ -64,6 +65,7 @@ public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
                 -> assertNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName)));
         assertNull(admin.topics().getMaxUnackedMessagesOnSubscription(topicName));
     }
+    @SuppressWarnings("deprecation")
 
     // See https://github.com/apache/pulsar/issues/5438
     @Test(timeOut = 20000)
@@ -158,6 +160,7 @@ public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testMaxUnackedMessagesOnConsumerApi() throws Exception {
         final String topicName = newTopicName();
@@ -176,6 +179,7 @@ public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
         assertNull(admin.topics().getMaxUnackedMessagesOnConsumer(topicName));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testMaxUnackedMessagesOnConsumerAppliedApi() throws Exception {
         final String topicName = newTopicName();
@@ -204,6 +208,7 @@ public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
         assertEquals(max.intValue(), 20);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxUnackedMessagesOnSubApplied() throws Exception {
         final String topicName = newTopicName();
@@ -233,6 +238,7 @@ public class MaxUnackedMessagesTest extends SharedPulsarBaseTest {
                 Integer.valueOf(getConfig().getMaxUnackedMessagesPerSubscription()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testMaxUnackedMessagesOnConsumer() throws Exception {
         final String topicName = newTopicName();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
@@ -2145,6 +2145,7 @@ public class NamespaceAuthZTest extends MockedPulsarStandalone {
         Assert.assertTrue(execFlag.get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     @SneakyThrows
     public void testSchemaAutoUpdateCompatibilityStrategy() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -952,6 +952,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         resetBroker();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSplitBundles() throws Exception {
         URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
@@ -996,6 +997,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         resetBroker();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSplitBundleWithUnDividedRange() throws Exception {
         URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
@@ -1102,6 +1104,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRetention() throws Exception {
         try {
@@ -1192,6 +1195,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         assertEquals(errorCaptor.getValue().getResponse().getStatus(), Response.Status.UNAUTHORIZED.getStatusCode());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testValidateTopicOwnership() throws Exception {
         URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -644,6 +644,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
                 Response.Status.PRECONDITION_FAILED.getStatusCode());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCreatePartitionedTopicHavingNonPartitionTopicWithPartitionSuffix()
             throws KeeperException, InterruptedException {
@@ -1400,6 +1401,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(responseCaptor.getValue().getStatus(), Response.Status.NO_CONTENT.getStatusCode());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetMessageById() throws Exception {
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));
@@ -1438,6 +1440,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetMessageById4SpecialPropsInMsg() throws Exception {
         TenantInfoImpl tenantInfo = new TenantInfoImpl(Set.of("role1", "role2"), Set.of("test"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicMessageTTLTest.java
@@ -68,6 +68,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetThenRemoveMessageTTL() throws Exception {
         admin.topics().setMessageTTL(testTopic, 100);
@@ -85,6 +86,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         Assert.assertNull(messageTTL);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetInvalidMessageTTL() throws Exception {
         try {
@@ -102,6 +104,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetMessageTTL() throws Exception {
         // Check default topic level message TTL.
@@ -117,6 +120,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
         log.info("Message TTL {} get on topic: {}", testTopic, messageTTL);
         Assert.assertEquals(messageTTL.intValue(), 200);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTopicPolicyDisabled() throws Exception {
@@ -184,6 +188,7 @@ public class TopicMessageTTLTest extends MockedPulsarServiceBaseTest {
                 -> Assert.assertNull(admin.namespaces().getNamespaceMessageTTL(myNamespace)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testDifferentLevelPolicyApplied() throws Exception {
         final String topicName = testTopic + UUID.randomUUID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesDisableTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesDisableTest.java
@@ -67,6 +67,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBacklogQuotaDisabled() {
         BacklogQuota backlogQuota = BacklogQuota.builder()
@@ -97,6 +98,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRetentionDisabled() {
         RetentionPolicies retention = new RetentionPolicies();
@@ -117,6 +119,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPersistenceDisabled() {
         PersistencePolicies persistencePolicies = new PersistencePolicies();
@@ -137,6 +140,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDispatchRateDisabled() throws Exception {
         DispatchRate dispatchRate = DispatchRate.builder().build();
@@ -157,6 +161,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSubscriptionDispatchRateDisabled() throws Exception {
         DispatchRate dispatchRate = DispatchRate.builder()
@@ -181,6 +186,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCompactionThresholdDisabled() {
         Long compactionThreshold = 10000L;
@@ -201,6 +207,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxConsumersPerSubscription() throws Exception {
         int maxConsumersPerSubscription = 10;
@@ -228,6 +235,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSubscriptionExpirationTimeDisabled() throws Exception {
         int subscriptionExpirationTime = 10;
@@ -255,6 +263,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPublishRateDisabled() throws Exception {
         PublishRate publishRate = new PublishRate(10000, 1024 * 1024 * 5);
@@ -275,6 +284,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxProducersDisabled() {
         log.info("MaxProducers will set to the topic: {}", testTopic);
@@ -293,6 +303,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxConsumersDisabled() {
         log.info("MaxConsumers will set to the topic: {}", testTopic);
@@ -311,6 +322,7 @@ public class TopicPoliciesDisableTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSubscribeRateDisabled() throws Exception {
         SubscribeRate subscribeRate = new SubscribeRate(10, 30);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicPoliciesTest.java
@@ -3149,6 +3149,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         assertNull(admin.topicPolicies().getMessageTTL(topic));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSubscriptionTypesWithPartitionedTopic() throws Exception {
         final String topic = "persistent://" + myNamespace + "/test-" + UUID.randomUUID();
@@ -4074,6 +4075,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete(topic, true);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUpdateRetentionWithPartialFailure() throws Exception {
         String tpName = BrokerTestUtil.newUniqueName("persistent://" + myNamespace + "/tp");
@@ -4460,6 +4462,7 @@ public class TopicPoliciesTest extends MockedPulsarServiceBaseTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetAppliedOffloadPoliciesWithLegacyNamespacePolicies() throws Exception {
         String topicName = testTopic + UUID.randomUUID().toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsAuthTest.java
@@ -64,10 +64,14 @@ public class TopicsAuthTest extends MockedPulsarServiceBaseTest {
     private final String testTenant = "my-tenant";
     private final String testNamespace = "my-namespace";
     private final String testTopicName = "my-topic";
+@SuppressWarnings("deprecation")
 
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+    @SuppressWarnings("deprecation")
     private static final String ADMIN_TOKEN = Jwts.builder().setSubject("admin").signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
     private static final String PRODUCE_TOKEN = Jwts.builder().setSubject("producer").signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
     private static final String CONSUME_TOKEN = Jwts.builder().setSubject("consumer").signWith(SECRET_KEY).compact();
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionMultiBrokerTest.java
@@ -66,6 +66,7 @@ public class AdminApiTransactionMultiBrokerTest extends TransactionTestBase {
      *     4. Create a admin connected to broker x, and use the admin to call ` getCoordinatorInternalStats`.
      * </p>
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testRedirectOfGetCoordinatorInternalStats() throws Exception {
         PulsarAdmin localAdmin = this.admin;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthenticationServiceTest.java
@@ -54,6 +54,7 @@ public class AuthenticationServiceTest {
 
     private static final String s_authentication_success = "authenticated";
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testAuthenticationHttp() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
@@ -70,6 +71,7 @@ public class AuthenticationServiceTest {
         service.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testAuthenticationHttpWithMultipleProviders() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
@@ -178,6 +180,7 @@ public class AuthenticationServiceTest {
         service.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testHttpRequestWithMultipleProviders() throws Exception {
         ServiceConfiguration config = new ServiceConfiguration();
@@ -256,6 +259,7 @@ public class AuthenticationServiceTest {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
@@ -276,6 +280,7 @@ public class AuthenticationServiceTest {
             return null;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public boolean authenticateHttpRequest(HttpServletRequest request, HttpServletResponse response) {
             String role = getRole(request);
@@ -285,11 +290,13 @@ public class AuthenticationServiceTest {
             throw new RuntimeException("test authentication failed");
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             return authData.getCommandData();
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthenticationState newHttpAuthState(HttpServletRequest request) throws AuthenticationException {
             String role = getRole(request);
@@ -300,6 +307,7 @@ public class AuthenticationServiceTest {
                         return role;
                     }
 
+                    @SuppressWarnings("deprecation")
                     @Override
                     public AuthData authenticate(AuthData authData) throws AuthenticationException {
                         return null;
@@ -310,6 +318,7 @@ public class AuthenticationServiceTest {
                         return new AuthenticationDataCommand(role);
                     }
 
+                    @SuppressWarnings("deprecation")
                     @Override
                     public boolean isComplete() {
                         return true;
@@ -331,6 +340,7 @@ public class AuthenticationServiceTest {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
@@ -340,6 +350,7 @@ public class AuthenticationServiceTest {
             return "auth";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             return s_authentication_success;
@@ -352,6 +363,7 @@ public class AuthenticationServiceTest {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
@@ -361,6 +373,7 @@ public class AuthenticationServiceTest {
             return "customAuthProvider";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             return s_authentication_success;
@@ -373,6 +386,7 @@ public class AuthenticationServiceTest {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
@@ -382,6 +396,7 @@ public class AuthenticationServiceTest {
             return "auth";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             throw new AuthenticationException("I failed");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationWithAuthDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationWithAuthDataTest.java
@@ -60,6 +60,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("deprecation")
 @Test(groups = "broker")
 public class AuthorizationWithAuthDataTest extends MockedPulsarServiceBaseTest {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthentication.java
@@ -46,6 +46,7 @@ public class MockAuthentication implements Authentication {
         return "mock";
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AuthenticationDataProvider getAuthData() throws PulsarClientException {
         return new AuthenticationDataProvider() {
@@ -72,6 +73,7 @@ public class MockAuthentication implements Authentication {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void configure(Map<String, String> authParams) {
         this.user = authParams.get("user");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockAuthenticationProvider.java
@@ -32,6 +32,7 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
     @Override
     public void close() throws IOException {}
 
+    @SuppressWarnings("deprecation")
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {}
 
@@ -41,6 +42,7 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
         return "mock";
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
         String principal = "unknown";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMultiStageAuthenticationState.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMultiStageAuthenticationState.java
@@ -46,6 +46,7 @@ public class MockMultiStageAuthenticationState implements AuthenticationState {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AuthData authenticate(AuthData authData) throws AuthenticationException {
         String data = new String(authData.getBytes(), UTF_8);
@@ -68,6 +69,7 @@ public class MockMultiStageAuthenticationState implements AuthenticationState {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isComplete() {
         return authRole != null;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationState.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockMutableAuthenticationState.java
@@ -45,6 +45,7 @@ public class MockMutableAuthenticationState implements AuthenticationState {
         return authRole;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AuthData authenticate(AuthData authData) throws AuthenticationException {
         return null;
@@ -69,6 +70,7 @@ public class MockMutableAuthenticationState implements AuthenticationState {
         return authenticationDataSource;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean isComplete() {
         return true;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockOIDCIdentityProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockOIDCIdentityProvider.java
@@ -51,6 +51,7 @@ public class MockOIDCIdentityProvider {
     private final WireMockServer server;
     private final PublicKey publicKey;
     private final String audience;
+    @SuppressWarnings("deprecation")
     public MockOIDCIdentityProvider(String clientSecret, String audience, long tokenTTLMillis) {
         this.audience = audience;
         KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -204,6 +204,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         internalSetup();
     }
 
+    @SuppressWarnings("deprecation")
     protected PulsarClient newPulsarClient(String url, int intervalInSecs) throws PulsarClientException {
         ClientBuilder clientBuilder =
                 PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/AbstractBrokerEntryCacheMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/AbstractBrokerEntryCacheMultiBrokerTest.java
@@ -256,6 +256,7 @@ public abstract class AbstractBrokerEntryCacheMultiBrokerTest extends MultiBroke
     }
 
 
+    @SuppressWarnings("deprecation")
     protected PulsarClientImpl createPulsarClient(EventLoopGroup eventLoopGroup, LongSupplier connectionDelaySupplier)
             throws Exception {
         return InjectedClientCnxClientBuilder.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/cache/BrokerEntryCacheTest.java
@@ -300,6 +300,7 @@ public class BrokerEntryCacheTest extends ProducerConsumerBase {
     }
 
     // change enabled to true to run the test
+    @SuppressWarnings("deprecation")
     @Test(enabled = false)
     public void testCatchUpReadsWithFailureProxyDisconnectingAllConnections() throws Exception {
         final String topicName = "persistent://my-property/my-ns/cache-catchup-test-topic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -265,6 +265,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         assertNotSame(array, array2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "delayedTracker")
     public void testMergeSnapshot(final BucketDelayedDeliveryTracker tracker) throws Exception {
         for (int i = 1; i <= 110; i++) {
@@ -318,6 +319,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         tracker2.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "delayedTracker")
     public void testWithBkException(final BucketDelayedDeliveryTracker tracker) throws Exception {
         MockBucketSnapshotStorage mockBucketSnapshotStorage = (MockBucketSnapshotStorage) bucketSnapshotStorage;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoaderTest.java
@@ -64,6 +64,7 @@ public class BrokerInterceptorWithClassLoaderTest {
     @Test
     public void testClassLoaderSwitcher() throws Exception {
         NarClassLoader narLoader = mock(NarClassLoader.class);
+        @SuppressWarnings("deprecation")
         BrokerInterceptor interceptor = new BrokerInterceptor() {
             @Override
             public void beforeSendMessage(Subscription subscription, Entry entry,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/CounterBrokerInterceptor.java
@@ -175,11 +175,13 @@ public class CounterBrokerInterceptor implements BrokerInterceptor {
         messageDispatchCount.incrementAndGet();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void messageAcked(ServerCnx cnx, Consumer consumer,
                               CommandAck ack) {
         messageAckCount.incrementAndGet();
     }
+    @SuppressWarnings("deprecation")
 
     @Override
     public void beforeSendMessage(Subscription subscription,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerStrategyTest.java
@@ -114,6 +114,7 @@ public class ModularLoadManagerStrategyTest {
     }
 
     // Test that least resource usage with weight works correctly.
+    @SuppressWarnings("deprecation")
     public void testLeastResourceUsageWithWeight() {
         BundleData bundleData = new BundleData();
         BrokerData brokerData1 = initBrokerData(10, 100);
@@ -192,6 +193,7 @@ public class ModularLoadManagerStrategyTest {
         assertEquals(strategy.selectBroker(candidates, bundleData, loadData, conf), Optional.of("3"));
     }
 
+    @SuppressWarnings("deprecation")
     public void testLeastResourceUsageWithWeightWithArithmeticException()
             throws NoSuchFieldException, IllegalAccessException {
         BundleData bundleData = new BundleData();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -439,6 +439,7 @@ public class SimpleLoadManagerImplTest {
     }
 
     // Test that bundles belonging to the same namespace are evenly distributed.
+    @SuppressWarnings("deprecation")
     @Test
     public void testEvenBundleDistribution() throws Exception {
         final NamespaceBundle[] bundles = LoadBalancerTestingUtils

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -156,6 +156,7 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static PulsarClient pulsarClient(String url, int intervalInMillis) throws PulsarClientException {
         return
                 PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -692,6 +692,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 admin, lookupUrl.toString(), pulsar1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(enabled = false)
     public static void testUnloadClientReconnectionWithLookup(List<PulsarClient> clients,
                                                               TopicDomain topicDomain,
@@ -786,6 +787,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 pulsar2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(enabled = false)
     public static void testOptimizeUnloadDisable(List<PulsarClient> clients,
                                                  TopicDomain topicDomain,
@@ -1823,6 +1825,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 .get(3, TimeUnit.SECONDS);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(priority = Integer.MIN_VALUE)
     public void testGetMetrics() throws Exception {
         {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -2101,6 +2101,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     private static void waitUntilNewChannelOwner(ServiceUnitStateChannel channel, String oldOwner) {
         Awaitility.await()
                 .pollInterval(200, TimeUnit.MILLISECONDS)
@@ -2115,6 +2116,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     private static void waitUntilOwnerChanges(ServiceUnitStateChannel channel, String serviceUnit, String oldOwner) {
         Awaitility.await()
                 .pollInterval(200, TimeUnit.MILLISECONDS)
@@ -2128,6 +2130,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     private static void waitUntilNewOwner(ServiceUnitStateChannel channel, String serviceUnit, String newOwner) {
         Awaitility.await()
                 .pollInterval(200, TimeUnit.MILLISECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLoadDataTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class BrokerLoadDataTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUpdateBySystemResourceUsage() {
 
@@ -118,6 +119,7 @@ public class BrokerLoadDataTest {
         assertEquals(data, new BrokerLoadData());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUpdateByBrokerLoadData() {
         ServiceConfiguration conf = new ServiceConfiguration();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeightTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeightTest.java
@@ -190,6 +190,7 @@ public class LeastResourceUsageWithWeightTest {
                 1, 1, 1, 1, 1, 1, ctx.brokerConfiguration());
     }
 
+    @SuppressWarnings("deprecation")
     public static LoadManagerContext getContext() {
         var ctx = mock(LoadManagerContext.class);
         var conf = new ServiceConfiguration();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -123,6 +123,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSplitAndOwnBundles() throws Exception {
 
@@ -194,6 +195,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSplitMapWithRefreshedStatMap() throws Exception {
 
@@ -250,6 +252,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testIsServiceUnitDisabled() throws Exception {
 
@@ -274,6 +277,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRemoveOwnershipNamespaceBundle() throws Exception {
 
@@ -428,6 +432,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         System.out.println(withListener);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCreateNamespaceWithDefaultNumberOfBundles() throws Exception {
         OwnershipCache mockOwnershipCache = spy(pulsar.getNamespaceService().getOwnershipCache());
@@ -491,6 +496,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRemoveOwnershipAndSplitBundle() throws Exception {
         OwnershipCache ownershipCache = spy(pulsar.getNamespaceService().getOwnershipCache());
@@ -538,6 +544,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSplitBundleAndRemoveOldBundleFromOwnerShipCache() throws Exception {
         OwnershipCache ownershipCache = spy(pulsar.getNamespaceService().getOwnershipCache());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -125,6 +125,7 @@ public class OwnershipCacheTest {
         assertNotNull(cache.getOwnedBundles());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDisableOwnership() throws Exception {
         OwnershipCache cache = new OwnershipCache(this.pulsar, nsService);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractReplicatorTest.java
@@ -58,6 +58,7 @@ import org.testng.annotations.Test;
 @Test(groups = "broker-replication")
 public class AbstractReplicatorTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRetryStartProducerStoppedByTopicRemove() throws Exception {
         final String localCluster = "localCluster";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerConfigurationTest.java
@@ -40,6 +40,7 @@ public class BacklogQuotaManagerConfigurationTest {
         pulsarService = getPulsarService();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBacklogQuotaDefaultLimitGBConversion() {
         serviceConfiguration.setBacklogQuotaDefaultLimitGB(1.6);
@@ -49,6 +50,7 @@ public class BacklogQuotaManagerConfigurationTest {
         assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBacklogQuotaDefaultLimitPrecedence() {
         serviceConfiguration.setBacklogQuotaDefaultLimitGB(1.6);
@@ -59,6 +61,7 @@ public class BacklogQuotaManagerConfigurationTest {
         assertEquals(backlogQuotaManager.getDefaultQuota().getLimitSize(), 1717986918);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBacklogQuotaDefaultLimitBytes() {
         serviceConfiguration.setBacklogQuotaDefaultLimitGB(0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -223,6 +223,7 @@ public class BacklogQuotaManagerTest {
     /**
      * Readers should not affect backlog quota.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testBacklogQuotaWithReader() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -310,6 +311,7 @@ public class BacklogQuotaManagerTest {
                 admin.topics().getStats(topic1, GetStatsOptions.builder().getPreciseBacklog(getPreciseBacklog).build());
         return stats;
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTriggerBacklogQuotaSizeWithReader() throws Exception {
@@ -380,6 +382,7 @@ public class BacklogQuotaManagerTest {
             reader.close();
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsStatsPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
@@ -557,6 +560,7 @@ public class BacklogQuotaManagerTest {
             assertNotNull(producer2);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsStatsPreciseWithNoBacklog() throws PulsarAdminException,
@@ -632,6 +636,7 @@ public class BacklogQuotaManagerTest {
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
         config.setExposePreciseBacklogInPrometheus(false);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsAgeMetricsPreciseWithoutBacklogQuota() throws Exception {
@@ -695,6 +700,7 @@ public class BacklogQuotaManagerTest {
         }
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsAgeMetricsNoPreciseWithoutBacklogQuota() throws Exception {
@@ -777,6 +783,7 @@ public class BacklogQuotaManagerTest {
         return ((PersistentTopic) pulsar.getBrokerService().getTopicReference(topic1).get())
                 .getManagedLedger().getStats().getEntriesReadTotalCount();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsStatsNotPrecise() throws PulsarAdminException, PulsarClientException, InterruptedException {
@@ -886,6 +893,7 @@ public class BacklogQuotaManagerTest {
             config.setManagedLedgerMaxEntriesPerLedger(MAX_ENTRIES_PER_LEDGER);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void backlogsStatsNotPreciseWithNoBacklog() throws PulsarAdminException,
@@ -1023,6 +1031,7 @@ public class BacklogQuotaManagerTest {
      * and can't do message age check against the quota.
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testTriggerBacklogTimeQuotaWithReader() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1092,6 +1101,7 @@ public class BacklogQuotaManagerTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConsumerBacklogEvictionSizeQuota() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1145,6 +1155,7 @@ public class BacklogQuotaManagerTest {
                 1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConsumerBacklogEvictionTimeQuotaPrecise() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1211,6 +1222,7 @@ public class BacklogQuotaManagerTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 60000)
     public void testConsumerBacklogEvictionTimeQuota() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1280,6 +1292,7 @@ public class BacklogQuotaManagerTest {
                 value -> assertThat(value).isGreaterThanOrEqualTo(delaySeconds));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 60000)
     public void testConsumerBacklogEvictionTimeQuotaWithPartEviction() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1334,6 +1347,7 @@ public class BacklogQuotaManagerTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConsumerBacklogEvictionTimeQuotaWithEmptyLedger() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1549,6 +1563,7 @@ public class BacklogQuotaManagerTest {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConcurrentAckAndEviction() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1620,6 +1635,7 @@ public class BacklogQuotaManagerTest {
         assertTrue(stats.getBacklogSize() <= 10 * 1024, "Storage size is [" + stats.getStorageSize() + "]");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testNoEviction() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1684,6 +1700,7 @@ public class BacklogQuotaManagerTest {
         assertFalse(gotException.get());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testEvictionMulti() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/ns-quota"),
@@ -1786,6 +1803,7 @@ public class BacklogQuotaManagerTest {
         assertTrue(stats.getBacklogSize() <= 15 * 1024, "Storage size is [" + stats.getStorageSize() + "]");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAheadProducerOnHold() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -1828,6 +1846,7 @@ public class BacklogQuotaManagerTest {
                 "Number of producers on topic " + topic1 + " are [" + stats.getPublishers().size() + "]");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAheadProducerOnHoldTimeout() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -1866,6 +1885,7 @@ public class BacklogQuotaManagerTest {
         assertTrue(gotException, "timeout did not occur");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testProducerException() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -1911,6 +1931,7 @@ public class BacklogQuotaManagerTest {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "dedupTestSet")
     public void testProducerExceptionAndThenUnblockSizeQuota(boolean dedupTestSet) throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -1998,6 +2019,7 @@ public class BacklogQuotaManagerTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testProducerExceptionAndThenUnblockTimeQuotaPrecise() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -2064,6 +2086,7 @@ public class BacklogQuotaManagerTest {
         assertFalse(gotException, "unable to publish due to " + sendException);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testProducerExceptionAndThenUnblockTimeQuota() throws Exception {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/quotahold"),
@@ -2129,6 +2152,7 @@ public class BacklogQuotaManagerTest {
         assertFalse(gotException, "unable to publish due to " + sendException);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "backlogQuotaSizeGB", priority = 1)
     public void testBacklogQuotaInGB(boolean backlogQuotaSizeGB) throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTest.java
@@ -96,6 +96,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testCrashBrokerWithoutCursorLedgerLeak() throws Exception {
 
@@ -193,6 +194,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testSkipCorruptDataLedger() throws Exception {
         // Ensure intended state for autoSkipNonRecoverableData
@@ -298,6 +300,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         consumer.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTruncateCorruptDataLedger() throws Exception {
         // Ensure intended state for autoSkipNonRecoverableData
@@ -435,6 +438,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         factory.delete("test");
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testTopicWithWildCardChar() throws Exception {
         @Cleanup
@@ -465,6 +469,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeleteTopicWithMissingData() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("prop/ns");
@@ -510,6 +515,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         assertThrows(PulsarAdminException.ServerSideErrorException.class, () -> admin.topics().delete(topic));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeleteTopicWithoutTopicLoaded() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("prop/ns");
@@ -543,6 +549,7 @@ public class BrokerBkEnsemblesTest extends BkEnsemblesTestBase {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 60_000, dataProvider = "doReloadTopicAfterLedgerFenced")
     public void testConcurrentlyModifyCurrentLedger(boolean doReloadTopicAfterLedgerFenced) throws Exception {
         EventLoopGroup eventLoopGroup = EventLoopUtil.newEventLoopGroup(config.getNumIOThreads(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBookieIsolationTest.java
@@ -126,6 +126,7 @@ public class BrokerBookieIsolationTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testBookieIsolation() throws Exception {
         final String tenant1 = "tenant1";
@@ -306,6 +307,7 @@ public class BrokerBookieIsolationTest {
         return ledgerManager;
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetRackInfoAndAffinityGroupDuringProduce() throws Exception {
         final String tenant1 = "tenant1";
@@ -446,6 +448,7 @@ public class BrokerBookieIsolationTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testStrictBookieIsolation() throws Exception {
         final String tenant1 = "tenant1";
@@ -612,6 +615,7 @@ public class BrokerBookieIsolationTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testBookieIsolationWithSecondaryGroup() throws Exception {
         final String tenant1 = "tenant1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -149,6 +149,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
         Assert.assertTrue(entryMetadata.getBrokerTimestamp() >= sendTime);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testGetMessageById() throws Exception {
         final String topic = newTopicName();
@@ -214,6 +215,7 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
         Assert.assertTrue(entryMetadata.getBrokerTimestamp() >= sendTime);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testBatchMessage() throws Exception {
         final String topic = newTopicName();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -662,6 +662,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             admin.namespaces().deleteNamespace(ns);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTlsDisabled() throws Exception {
@@ -702,6 +703,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             pulsarClient.close();
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTlsEnabled() throws Exception {
@@ -779,6 +781,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             pulsarClient.close();
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTlsEnabledWithoutNonTlsServicePorts() throws Exception {
@@ -1006,6 +1009,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLookupThrottlingForClientByClient() throws Exception {
         final String topicName = "persistent://prop/ns-abc/newTopic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceThrottlingTest.java
@@ -117,6 +117,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLookupThrottlingForClientByBroker0Permit() throws Exception {
 
@@ -161,6 +162,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLookupThrottlingForClientByBroker() throws Exception {
         final String topicName = "persistent://prop/ns-abc/newTopic";
@@ -278,6 +280,7 @@ public class BrokerServiceThrottlingTest extends BrokerTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testLookupThrottlingForClientByBrokerInternalRetry() throws Exception {
         final String topicName = "persistent://prop/ns-abc/newTopic-" + UUID.randomUUID().toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BusyWaitServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BusyWaitServiceTest.java
@@ -44,6 +44,7 @@ public class BusyWaitServiceTest extends BkEnsemblesTestBase {
         config.setManagedLedgerDefaultAckQuorum(1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPublishWithBusyWait() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ClusterMigrationTest.java
@@ -262,6 +262,7 @@ public class ClusterMigrationTest {
      * (11) Restart Broker-1 and connect producer/consumer on cluster-1
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testClusterMigration() throws Exception {
         log.info("--- Starting ReplicatorTest::testClusterMigration ---");
@@ -430,6 +431,7 @@ public class ClusterMigrationTest {
         log.info("Successfully consumed messages by migrated consumers");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testClusterMigrationWithReplicationBacklog() throws Exception {
         log.info("--- Starting ReplicatorTest::testClusterMigrationWithReplicationBacklog ---");
@@ -541,6 +543,7 @@ public class ClusterMigrationTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testClusterMigrationWithResourceCreated() throws Exception {
         log.info("--- Starting testClusterMigrationWithResourceCreated ---");
@@ -650,6 +653,7 @@ public class ClusterMigrationTest {
         client1.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "NamespaceMigrationTopicSubscriptionTypes")
     public void testNamespaceMigration(SubscriptionType subType, boolean isClusterMigrate, boolean isNamespaceMigrate)
             throws Exception {
@@ -921,6 +925,7 @@ public class ClusterMigrationTest {
         client2.close();
     }
 
+    @SuppressWarnings("deprecation")
     public void testMigrationWithReader() throws Exception {
         final String topicName = BrokerTestUtil
                 .newUniqueName("persistent://" + namespace + "/migrationTopic");
@@ -1031,6 +1036,7 @@ public class ClusterMigrationTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "NamespaceMigrationTopicSubscriptionTypes")
     public void testNamespaceMigrationWithReplicationBacklog(SubscriptionType subType, boolean isClusterMigrate,
                                                              boolean isNamespaceMigrate) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/InactiveTopicDeleteTest.java
@@ -393,6 +393,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         super.internalCleanup();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testTopicLevelInActiveTopicApi() throws Exception {
         super.baseSetup();
@@ -419,6 +420,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
                 -> assertNull(admin.topics().getInactiveTopicPolicies(topicName)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testTopicLevelInactivePolicyUpdateAndClean() throws Exception {
         conf.setBrokerDeleteInactiveTopicsEnabled(true);
@@ -497,6 +499,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testDeleteWhenNoSubscriptionsWithTopicLevelPolicies() throws Exception {
         final String namespace = "prop/ns-abc";
@@ -551,6 +554,7 @@ public class InactiveTopicDeleteTest extends BrokerTestBase {
         Assert.assertFalse(admin.topics().getList(namespace).contains(topic));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testInactiveTopicApplied() throws Exception {
         super.baseSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpportunisticStripingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpportunisticStripingTest.java
@@ -54,6 +54,7 @@ public class OpportunisticStripingTest extends BkEnsemblesTestBase {
         config.getProperties().setProperty("bookkeeper_opportunisticStriping", "true");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testOpportunisticStriping() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -81,6 +81,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
      * @param protocol
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "lookupType", timeOut = 10000)
     public void testPeerClusterTopicLookup(String protocol) throws Exception {
 
@@ -187,6 +188,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testPeerClusterInReplicationClusterListChange() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -464,6 +464,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         return res.get();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAddRemoveConsumerNonPartitionedTopic() throws Exception {
         log.info("--- Starting PersistentDispatcherFailoverConsumerTest::testAddRemoveConsumerNonPartitionedTopic ---");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -1001,6 +1001,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         deleteNamespaceWithRetry(namespaceName, false);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMessageExpiryWithTopicMessageTTL() throws Exception {
         int namespaceMessageTTLSecs = 10;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -247,6 +247,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
         setupMLAsyncCallbackMocks();
     }
+    @SuppressWarnings("deprecation")
 
     @AfterMethod(alwaysRun = true)
     public void teardown() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterOverconsumingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterOverconsumingTest.java
@@ -168,6 +168,7 @@ public class PublishRateLimiterOverconsumingTest extends BrokerTestBase {
         };
 
         // create independent clients for producers so that they don't get blocked by throttling
+        @SuppressWarnings("deprecation")
         List<PulsarClient> producerClients = IntStream.range(0, numberOfProducersWithIndependentClients)
                 .mapToObj(i -> {
                     try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -65,6 +65,7 @@ public class RackAwareTest extends BkEnsemblesTestBase {
     public Object[][] forceMinRackNumProvider() {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
+    @SuppressWarnings("deprecation")
 
     @Override
     protected void configurePulsar(ServiceConfiguration config) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatedSubscriptionTest.java
@@ -103,6 +103,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
     /**
      * Tests replicated subscriptions across two regions.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedSubscriptionAcrossTwoRegions() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -204,6 +205,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
     /**
      * Tests replicated subscriptions across two regions and can read successful.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedSubscriptionAcrossTwoRegionsGetLastMessage() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscriptionlastmessage");
@@ -367,6 +369,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
     /**
      * If there's no traffic, the snapshot creation should stop and then resume when traffic comes back.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicationSnapshotStopWhenNoTraffic() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -454,6 +457,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         assertNotEquals(rsc2.getLastCompletedSnapshotId().get(), snapshot2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testReplicatedSubscriptionRestApi1() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -565,6 +569,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
                 String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetReplicatedSubscriptionStatus() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -626,6 +631,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testReplicatedSubscriptionRestApi2() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -740,6 +746,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
                 String.format("numReceivedMessages2 (%d) should be less than %d", numReceivedMessages2, numMessages));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testReplicatedSubscriptionRestApi3() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("geo/replicatedsubscription");
@@ -780,6 +787,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
     /**
      * Tests replicated subscriptions when replicator producer is closed.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedSubscriptionWhenReplicatorProducerIsClosed() throws Exception {
         String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -892,6 +900,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
      *  </p>
      */
     // TODO: this test causes OOME in the CI, need to investigate
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "isTopicPolicyEnabled", enabled = false)
     public void testWriteMarkerTaskOfReplicateSubscriptions(boolean isTopicPolicyEnabled) throws Exception {
         // 1. Prepare resource and use proper configuration.
@@ -959,6 +968,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         pulsar1.getConfiguration().setForceDeleteNamespaceAllowed(false);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedSubscriptionWithCompaction() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar/replicatedsubscription");
@@ -1023,6 +1033,7 @@ public class ReplicatedSubscriptionTest extends ReplicatorTestBase {
         Assert.assertEquals(result, List.of("V2"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedSubscriptionOneWay() throws Exception {
         final String namespace = BrokerTestUtil.newUniqueName("pulsar-r4/replicatedsubscription");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorGlobalNSTest.java
@@ -90,6 +90,7 @@ public class ReplicatorGlobalNSTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test(priority = Integer.MAX_VALUE)
     public void testRemoveLocalClusterOnGlobalNamespace() throws Exception {
         log.info("--- Starting ReplicatorTest::testRemoveLocalClusterOnGlobalNamespace ---");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -80,6 +80,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         return new Object[][] { { DispatchRateType.messageRate }, { DispatchRateType.byteRate } };
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRateLimiterWithOnlyTopicLevel() throws Exception {
         cleanup();
@@ -128,6 +129,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRateLimiterWithOnlyNamespaceLevel() throws Exception {
         cleanup();
@@ -175,6 +177,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRateLimiterWithOnlyBrokerLevel() throws Exception {
         cleanup();
@@ -217,6 +220,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRatePriority() throws Exception {
         cleanup();
@@ -314,6 +318,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRateLimiterDynamicallyChange() throws Exception {
         log.info("--- Starting ReplicatorTest::{} --- ", methodName);
@@ -378,6 +383,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test(dataProvider =  "dispatchRateType")
     public void testReplicatorRateLimiterMessageNotReceivedAllMessages(DispatchRateType dispatchRateType)
             throws Exception {
@@ -466,6 +472,7 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorRateLimiterMessageReceivedAllMessages() throws Exception {
         log.info("--- Starting ReplicatorTest::{} --- ", methodName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRemoveClusterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRemoveClusterTest.java
@@ -69,6 +69,7 @@ public class ReplicatorRemoveClusterTest extends ReplicatorTestBase {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRemoveClusterFromNamespace() throws Exception {
         admin1.tenants().createTenant("pulsar1",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -173,6 +173,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         pulsar1.getConfiguration().setAuthorizationEnabled(false);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testForcefullyTopicDeletion() throws Exception {
         log.info("--- Starting ReplicatorTest::testForcefullyTopicDeletion ---");
@@ -199,7 +200,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         Assert.assertFalse(pulsar1.getBrokerService().getTopics().containsKey(topicName));
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"deprecation", "unchecked"})
     @Test(timeOut = 30000)
     public void testConcurrentReplicator() throws Exception {
 
@@ -1246,6 +1247,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatedCluster() throws Exception {
 
@@ -1297,6 +1299,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
      * </pre>
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testUpdateGlobalTopicPartition() throws Exception {
         log.info("--- Starting ReplicatorTest::testUpdateGlobalTopicPartition ---");
@@ -1343,6 +1346,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         consumer2.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testIncrementPartitionsOfTopicWithReplicatedSubscription() throws Exception {
         final String cluster1 = pulsar1.getConfig().getClusterName();
@@ -1382,6 +1386,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         return new Object[][] { { "persistent://", "/persistent" }, { "non-persistent://", "/non-persistent" } };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicPrefix")
     public void testTopicReplicatedAndProducerCreate(String topicPrefix, String topicName) throws Exception {
         log.info("--- Starting ReplicatorTest::testTopicReplicatedAndProducerCreate ---");
@@ -1425,6 +1430,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         nonPersistentProducer2.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCleanupTopic() throws Exception {
 
@@ -1614,6 +1620,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 pulsarService.getTransactionMetadataStoreService().getStores().size() == coordinatorSize);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testLookupAnotherCluster() throws Exception {
         log.info("--- Starting ReplicatorTest::testLookupAnotherCluster ---");
@@ -1785,6 +1792,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         Assert.assertThrows(PulsarClientException.ProducerBusyException.class, () -> new MessageProducer(url2, dest2));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicatorWithTTL() throws Exception {
         log.info("--- Starting ReplicatorTest::testReplicatorWithTTL ---");
@@ -1929,6 +1937,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testEnableReplicationWithNamespaceAllowedClustersPolices() throws Exception {
         log.info("--- testEnableReplicationWithNamespaceAllowedClustersPolices ---");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -334,6 +334,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
                 BrokerOpenTelemetryTestUtil.getOpenTelemetrySdkBuilderConsumer(metricReader));
     }
 
+    @SuppressWarnings("deprecation")
     public void setConfig3DefaultValue() {
         setConfigDefaults(config3, cluster3, bkEnsemble3);
         config3.setTlsEnabled(true);
@@ -491,6 +492,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         resetConfig3();
         resetConfig4();
     }
+    @SuppressWarnings("deprecation")
 
     protected void updateTenantInfo(String tenant, TenantInfoImpl tenantInfo) throws Exception {
         if (!admin1.tenants().getTenants().contains(tenant)) {
@@ -507,6 +509,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         PulsarClient client;
         Producer<byte[]> producer;
 
+        @SuppressWarnings("deprecation")
         MessageProducer(URL url, final TopicName dest) throws Exception {
             this.url = url;
             this.namespace = dest.getNamespace();
@@ -524,6 +527,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
             }
         }
 
+        @SuppressWarnings("deprecation")
         MessageProducer(URL url, final TopicName dest, boolean batch) throws Exception {
             this.url = url;
             this.namespace = dest.getNamespace();
@@ -596,6 +600,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
             this(url, dest, "sub-id");
         }
 
+        @SuppressWarnings("deprecation")
         MessageConsumer(URL url, final TopicName dest, String subId) throws Exception {
             this.url = url;
             this.namespace = dest.getNamespace();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -1077,6 +1077,7 @@ public class ServerCnxTest {
         channel.finish();
         channel2.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testHandleConsumerAfterClientChannelInactive() throws Exception {
@@ -1118,6 +1119,7 @@ public class ServerCnxTest {
         channel.finish();
         channel2.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void test2ndSubFailedIfDisabledConCheck()
@@ -2639,6 +2641,7 @@ public class ServerCnxTest {
         assertNull(channel.outboundMessages().peek());
         channel.finish();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30000)
     public void testProducerSuccessOnEncryptionRequiredTopic() throws Exception {
@@ -2677,6 +2680,7 @@ public class ServerCnxTest {
 
         channel.finish();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30000)
     public void testProducerFailureOnEncryptionRequiredTopic() throws Exception {
@@ -2717,6 +2721,7 @@ public class ServerCnxTest {
 
         channel.finish();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30000)
     public void testProducerFailureOnEncryptionRequiredOnBroker() throws Exception {
@@ -2759,6 +2764,7 @@ public class ServerCnxTest {
 
         channel.finish();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30000)
     public void testSendSuccessOnEncryptionRequiredTopic() throws Exception {
@@ -2805,6 +2811,7 @@ public class ServerCnxTest {
         assertTrue(getResponse() instanceof CommandSendReceipt);
         channel.finish();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30000)
     public void testSendFailureOnEncryptionRequiredTopic() throws Exception {
@@ -3415,6 +3422,7 @@ public class ServerCnxTest {
             channel.finish();
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testHandleAuthResponseWithoutClientVersion() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
@@ -86,6 +86,7 @@ public class SharedPulsarCluster {
         return instance;
     }
 
+    @SuppressWarnings("deprecation")
     private void start() throws Exception {
         log.info("Starting SharedPulsarCluster");
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesServiceTest.java
@@ -240,6 +240,7 @@ public class SystemTopicBasedTopicPoliciesServiceTest extends MockedPulsarServic
         Assert.assertEquals(policies1, policiesGet1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCacheCleanup() throws Exception {
         final String topic = "persistent://" + NAMESPACE1 + "/test" + UUID.randomUUID();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -133,7 +133,7 @@ public class TopicOwnerTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"deprecation", "unchecked"})
     @SneakyThrows(IllegalAccessException.class)
     private MutableObject<PulsarService> spyLeaderNamespaceServiceForAuthorizedBroker() {
         // Spy leader namespace service to inject authorized broker for namespace-bundle from leader,
@@ -141,6 +141,7 @@ public class TopicOwnerTest {
         // currently. Namespace-bundle ownership contention is an atomic operation through zookeeper.
         NamespaceService leaderNamespaceService = leaderPulsar.getNamespaceService();
         NamespaceService spyLeaderNamespaceService = spy(leaderNamespaceService);
+        @SuppressWarnings("deprecation")
         final MutableObject<PulsarService> leaderAuthorizedBroker = new MutableObject<>();
         Answer<CompletableFuture<Optional<LookupResult>>> answer = invocation -> {
             PulsarService pulsarService = leaderAuthorizedBroker.getValue();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/DelayedDeliveryTest.java
@@ -351,6 +351,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testEnableAndDisableTopicDelayedDelivery() throws Exception {
         String topicName = "persistent://public/default/topic-" + UUID.randomUUID();
@@ -387,6 +388,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
         assertNull(admin.topics().getDelayedDeliveryPolicy(topicName));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testEnableTopicDelayedDelivery() throws Exception {
         final String topicName = "persistent://public/default/test" + UUID.randomUUID().toString();
@@ -650,6 +652,7 @@ public class DelayedDeliveryTest extends ProducerConsumerBase {
             assertTrue(receivedMsgs.contains("msg-" + i));
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testDelayedDeliveryExceedsMaxDelay() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersReadLimitsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersReadLimitsTest.java
@@ -71,6 +71,7 @@ public class PersistentDispatcherMultipleConsumersReadLimitsTest extends Produce
         BrokerTestInterceptor.INSTANCE.reset();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30 * 1000)
     public void testDispatcherMaxReadSizeBytes() throws Exception {
         final String topicName = BrokerTestUtil.newUniqueName(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentSubscriptionTest.java
@@ -82,6 +82,7 @@ public class PersistentSubscriptionTest {
     final TxnID txnID1 = new TxnID(1, 1);
     final TxnID txnID2 = new TxnID(1, 2);
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     public void setup() throws Exception {
         pulsarTestContext = PulsarTestContext.builderForNonStartableContext()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/TopicDuplicationTest.java
@@ -77,6 +77,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         admin.namespaces().removeDeduplicationStatus(myNamespace);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testDuplicationApi() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -96,6 +97,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNull(admin.topics().getDeduplicationEnabled(topicName));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testTopicDuplicationApi2() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -115,6 +117,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertNull(admin.topics().getDeduplicationStatus(topicName));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testTopicDuplicationAppliedApi() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -137,6 +140,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
                 conf.isBrokerDeduplicationEnabled()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 30000)
     public void testDeduplicationPriority() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -214,6 +218,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         }).get();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10000)
     public void testDuplicationSnapshotApi() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();
@@ -310,6 +315,7 @@ public class TopicDuplicationTest extends ProducerConsumerBase {
         assertEquals(position, markDeletedPosition);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 20000)
     public void testDuplicationMethod() throws Exception {
         final String topicName = testTopic + UUID.randomUUID().toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidatorTest.java
@@ -64,6 +64,7 @@ public class SchemaDataValidatorTest {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @DataProvider(name = "clientSchemas")
     public static Object[][] clientSchemas() {
         return new Object[][] {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/AuthenticatedConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/AuthenticatedConsumerStatsTest.java
@@ -58,6 +58,7 @@ public class AuthenticatedConsumerStatsTest extends ConsumerStatsTest{
         tokenPublicKey = "data:;base64," + Base64.getEncoder().encodeToString(encodedPublicKey);
         adminToken = generateToken(kp, "admin");
     }
+    @SuppressWarnings("deprecation")
 
 
     private String generateToken(KeyPair kp, String subject) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -559,6 +559,7 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
         assertEquals(1, consumers.size());
         assertEquals(0, consumers.get(0).getUnackedMessages());
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testKeySharedDrainingHashesConsumerStats() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -47,6 +47,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = "flaky")
 public class MetadataStoreStatsTest extends BrokerTestBase {
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryAuthenticationStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/OpenTelemetryAuthenticationStatsTest.java
@@ -48,6 +48,7 @@ public class OpenTelemetryAuthenticationStatsTest extends BrokerTestBase {
 
     private SecretKey secretKey;
     private AuthenticationProvider provider;
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsLabelsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsLabelsTest.java
@@ -48,6 +48,7 @@ import org.testng.annotations.Test;
 public class PrometheusMetricsLabelsTest extends BrokerTestBase {
 
     private static final Set<String> ALLOWED_CUSTOM_METRIC_LABEL_KEYS = Set.of("sla_tier", "app_owner");
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -112,6 +112,7 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "broker")
 public class PrometheusMetricsTest extends BrokerTestBase {
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     @Override
@@ -1555,6 +1556,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         }
         return null;
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testAuthMetrics() throws IOException, AuthenticationException {
@@ -1619,6 +1621,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         }
         Assert.assertTrue(haveFailed);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testExpiredTokenMetrics() throws Exception {
@@ -1662,6 +1665,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         provider.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testExpiringTokenMetrics() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/TransactionBatchWriterMetricsTest.java
@@ -287,6 +287,7 @@ public class TransactionBatchWriterMetricsTest extends MockedPulsarServiceBaseTe
         }
         return list;
     }
+    @SuppressWarnings("deprecation")
 
     protected PulsarClient newPulsarClient(String url, int intervalInSecs) throws PulsarClientException {
         org.apache.pulsar.client.api.ClientBuilder clientBuilder =

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/systopic/PartitionedSystemTopicTest.java
@@ -112,6 +112,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         reader.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 1000 * 60)
     public void testConsumerCreationWhenEnablingTopicPolicy() throws Exception {
         String tenant = "tenant-" + RandomStringUtils.randomAlphabetic(4).toLowerCase();
@@ -182,6 +183,7 @@ public class PartitionedSystemTopicTest extends BrokerTestBase {
         Assert.assertEquals(config.getLedgerOffloader(), ledgerOffloader);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSystemNamespaceNotCreateChangeEventsTopic() throws Exception {
         admin.brokers().healthcheck();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/testcontext/PulsarTestContext.java
@@ -288,6 +288,7 @@ public class PulsarTestContext implements AutoCloseable {
          * This is used to run tests with smaller thread pools and shorter timeouts by default.
          * You can use <pre>{@code .configCustomizer(null)}</pre> to disable this behavior
          */
+        @SuppressWarnings("deprecation")
         protected void defaultOverrideServiceConfiguration(ServiceConfiguration svcConfig) {
             ServiceConfiguration unconfiguredDefaults = new ServiceConfiguration();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/AuthenticatedTransactionProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/AuthenticatedTransactionProducerConsumerTest.java
@@ -88,6 +88,7 @@ public class AuthenticatedTransactionProducerConsumerTest extends TransactionTes
     }
 
 
+    @SuppressWarnings("deprecation")
     private String generateToken(KeyPair kp, String subject) {
         PrivateKey pkey = kp.getPrivate();
         long expMillis = System.currentTimeMillis() + Duration.ofHours(1).toMillis();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TopicTransactionBufferRecoverTest.java
@@ -502,6 +502,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
         assertTrue(exist);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "enableSnapshotSegment")
     public void clearTransactionBufferSnapshotTest(Boolean enableSnapshotSegment) throws Exception {
         getPulsarServiceList().get(0).getConfig().setTransactionBufferSegmentedSnapshotEnabled(enableSnapshotSegment);
@@ -842,6 +843,7 @@ public class TopicTransactionBufferRecoverTest extends TransactionTestBase {
     }
 
     //Verify the snapshotSegmentProcessor end to end
+    @SuppressWarnings("deprecation")
     @Test
     public void testSnapshotSegment() throws Exception {
         String topic = "persistent://" + NAMESPACE1 + "/testSnapshotSegment";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTest.java
@@ -539,6 +539,7 @@ public class TransactionTest extends TransactionTestBase {
         Assert.assertEquals(txnID1.getMostSigBits(), 0);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSubscriptionRecreateTopic()
             throws PulsarAdminException, NoSuchFieldException, IllegalAccessException, PulsarClientException {
@@ -575,6 +576,7 @@ public class TransactionTest extends TransactionTestBase {
                 Assert.fail();
             }
             PersistentTopic originPersistentTopic = (PersistentTopic) option.get();
+            @SuppressWarnings("deprecation")
             String pendingAckTopicName = MLPendingAckStore
                     .getTransactionPendingAckStoreSuffix(originPersistentTopic.getName(), subName);
 
@@ -1779,6 +1781,7 @@ public class TransactionTest extends TransactionTestBase {
         txn.commit();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeleteNamespace() throws Exception {
         String namespace = TENANT + "/ns-" + RandomStringUtils.randomAlphabetic(5);
@@ -1811,6 +1814,7 @@ public class TransactionTest extends TransactionTestBase {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 10_000)
     public void testTBSnapshotWriter() throws Exception {
         String namespace = TENANT + "/ns-" + RandomStringUtils.randomAlphabetic(5);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/TransactionTestBase.java
@@ -100,6 +100,7 @@ public abstract class TransactionTestBase extends TestRetrySupport {
         return builder.build();
     }
 
+    @SuppressWarnings("deprecation")
     protected void setUpBase(int numBroker, int numPartitionsOfTC, String topic, int numPartitions) throws Exception{
         setBrokerCount(numBroker);
         internalSetup();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TopicTransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TopicTransactionBufferTest.java
@@ -489,6 +489,7 @@ public class TopicTransactionBufferTest extends TransactionTestBase {
      * Send some messages before transaction buffer ready and then send some messages after transaction buffer ready,
      * these messages should be received in order.
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testMessagePublishInOrder() throws Exception {
         // 1. Prepare test environment.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionBufferCloseTest.java
@@ -99,6 +99,7 @@ public class TransactionBufferCloseTest extends TransactionTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private List<TopicName> createAndLoadTopics(boolean isPartition, int partitionCount)
             throws PulsarAdminException, PulsarClientException {
         String namespace = TENANT + "/ns-" + RandomStringUtils.randomAlphabetic(5);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/TransactionStablePositionTest.java
@@ -173,6 +173,7 @@ public class TransactionStablePositionTest extends TransactionTestBase {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "enableTransactionAndState")
     public void testSyncNormalPositionWhenTBRecover(boolean clientEnableTransaction,
                                                     TopicTransactionBufferState.State state) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/TransactionMetaStoreAssignmentTest.java
@@ -108,6 +108,7 @@ public class TransactionMetaStoreAssignmentTest extends TransactionTestBase {
                 });
     }
 
+    @SuppressWarnings("deprecation")
     private PulsarClient buildClient() throws Exception {
         return PulsarClient.builder()
                 .serviceUrlProvider(new ServiceUrlProvider() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -66,6 +66,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(AuthenticatedProducerConsumerTest.class);
 
     private static final String BASIC_CONF_FILE_PATH = "./src/test/resources/authentication/basic/.htpasswd";
+    @SuppressWarnings("deprecation")
 
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
     private static final String ADMIN_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "admin", Optional.empty());
@@ -119,6 +120,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         conf.setNumExecutorThreadPoolSize(5);
         super.init();
     }
+    @SuppressWarnings("deprecation")
 
     protected final void internalSetup(Authentication auth) throws Exception {
         closeAdmin();
@@ -180,6 +182,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         consumer.acknowledgeCumulative(msg);
         consumer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "batch")
     public void testTlsSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
@@ -238,6 +241,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
 
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "batch")
     public void testAnonymousSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
@@ -286,6 +290,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthenticationFilterNegative() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -319,6 +324,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testInternalServerExceptionOnLookup() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -358,6 +364,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
 
         mockZooKeeperGlobal.unsetAlwaysFail();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testDeleteAuthenticationPoliciesOfTopic() throws Exception {
@@ -461,6 +468,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         @Cleanup
         Producer<byte[]> ignored = client.newProducer().topic(topicName).create();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCleanupEmptyTopicAuthenticationMap() throws Exception {
@@ -502,6 +510,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
                     .get().auth_policies.getTopicAuthentication().containsKey(topic));
         });
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCleanupEmptySubscriptionAuthenticationMap() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticationTlsHostnameVerificationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticationTlsHostnameVerificationTest.java
@@ -94,6 +94,7 @@ public class AuthenticationTlsHostnameVerificationTest extends ProducerConsumerB
 
         setupClient();
     }
+    @SuppressWarnings("deprecation")
 
     protected void setupClient() throws Exception {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -813,6 +813,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
 
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     public static class ClientAuthentication implements Authentication {
         String user;
@@ -865,6 +866,7 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         }
 
     }
+    @SuppressWarnings("deprecation")
 
     public static class TestAuthenticationProvider implements AuthenticationProvider {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -1184,6 +1184,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase implements ITe
     }
 
     /**** helper classes. ****/
+    @SuppressWarnings("deprecation")
 
     public static class MockAuthenticationProvider implements AuthenticationProvider {
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationFailureTest.java
@@ -282,6 +282,7 @@ public class ClientDeduplicationFailureTest {
         assertNotNull(prevMessage);
         assertEquals(prevMessage.getSequenceId(), producerThread.getLastSeqId());
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 300000)
     public void testClientDeduplicationWithBkFailure() throws  Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -597,6 +597,7 @@ public class ClientErrorsTest {
         mockBrokerService.resetHandleProducer();
         mockBrokerService.resetHandleCloseProducer();
     }
+    @SuppressWarnings("deprecation")
 
     // failed to connect to partition at sending step if a producer which connects to broker as lazy-loading mode
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCleanupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCleanupTest.java
@@ -34,6 +34,7 @@ public class ConsumerCleanupTest extends SharedPulsarBaseTest {
     public Object[][] ackReceiptEnabled() {
         return new Object[][] { { true }, { false } };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "ackReceiptEnabled")
     public void testAllTimerTaskShouldCanceledAfterConsumerClosed(boolean ackReceiptEnabled)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DeadLetterTopicTest.java
@@ -562,6 +562,7 @@ public class DeadLetterTopicTest extends SharedPulsarBaseTest {
 
         checkConsumer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 20000)
     public void testDeadLetterTopicHasOriginalInfo() throws Exception {
@@ -638,6 +639,7 @@ public class DeadLetterTopicTest extends SharedPulsarBaseTest {
         @Nullable
         private String field3;
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 20000)
     public void testAutoConsumeSchemaDeadLetter() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
@@ -142,6 +142,7 @@ public class InterceptorsTest extends SharedPulsarBaseTest {
         log.info("Send result messageId: {}", messageId2);
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testProducerInterceptorsWithExceptions() throws PulsarClientException {
@@ -172,6 +173,7 @@ public class InterceptorsTest extends SharedPulsarBaseTest {
         Assert.assertNotNull(messageId);
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testProducerInterceptorsWithErrors() throws PulsarClientException {
@@ -202,6 +204,7 @@ public class InterceptorsTest extends SharedPulsarBaseTest {
         Assert.assertNotNull(messageId);
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testProducerInterceptorAccessMessageData() throws PulsarClientException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiRolesTokenAuthorizationProviderTest.java
@@ -49,10 +49,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class MultiRolesTokenAuthorizationProviderTest extends MockedPulsarServiceBaseTest {
+    @SuppressWarnings("deprecation")
 
     private final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
     private final String superUserToken;
     private final String normalUserToken;
+    @SuppressWarnings("deprecation")
 
     public MultiRolesTokenAuthorizationProviderTest() {
         Map<String, Object> claims = new HashMap<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MultiTopicsConsumerTest.java
@@ -143,6 +143,7 @@ public class MultiTopicsConsumerTest extends SharedPulsarBaseTest {
         verify(internalExecutorServiceDelegate, times(0))
                 .schedule(any(Runnable.class), anyLong(), any());
     }
+    @SuppressWarnings("deprecation")
 
     // test that reproduces the issue that PR https://github.com/apache/pulsar/pull/12456 fixes
     // where MultiTopicsConsumerImpl has a data race that causes out-of-order delivery of messages

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MutualAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MutualAuthenticationTest.java
@@ -89,6 +89,7 @@ public class MutualAuthenticationTest extends ProducerConsumerBase {
             return toSend;
         }
     }
+    @SuppressWarnings("deprecation")
 
     public static class MutualAuthentication implements Authentication {
         @Override
@@ -120,6 +121,7 @@ public class MutualAuthenticationTest extends ProducerConsumerBase {
             // noop
         }
     }
+    @SuppressWarnings("deprecation")
 
 
     public static class MutualAuthenticationState implements AuthenticationState {
@@ -159,6 +161,7 @@ public class MutualAuthenticationTest extends ProducerConsumerBase {
             return isComplete;
         }
     }
+    @SuppressWarnings("deprecation")
 
     public static class MutualAuthenticationProvider implements AuthenticationProvider {
         @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -259,6 +259,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
 
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "subscriptionType")
     public void testPartitionedNonPersistentTopicWithTcpLookup(SubscriptionType type) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PartitionedProducerConsumerTest.java
@@ -684,6 +684,7 @@ public class PartitionedProducerConsumerTest extends SharedPulsarBaseTest {
             });
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetPartitionsForTopic() throws Exception {
@@ -911,6 +912,7 @@ public class PartitionedProducerConsumerTest extends SharedPulsarBaseTest {
     *
     * @throws Exception
     */
+    @SuppressWarnings("deprecation")
     @Test
     public void testPartitionedTopicInterceptor() throws Exception {
         log.info("-- Starting {} test --", methodName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerTopicWatcherBackPressureMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PatternConsumerTopicWatcherBackPressureMultipleConsumersTest.java
@@ -71,6 +71,7 @@ public class PatternConsumerTopicWatcherBackPressureMultipleConsumersTest extend
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 60 * 1000)
     public void testPatternConsumerWithLargeAmountOfConcurrentClientConnections()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProducerQueueSizeTest.java
@@ -37,6 +37,7 @@ public class ProducerQueueSizeTest extends SharedPulsarBaseTest {
                 {Boolean.TRUE, Boolean.TRUE},
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "matrix")
     public void testRemoveMaxQueueLimit(boolean blockIfQueueFull, boolean partitioned) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProxyProtocolTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ProxyProtocolTest.java
@@ -40,6 +40,7 @@ public class ProxyProtocolTest extends TlsProducerConsumerBase {
         super.setup();
         internalSetUpForNamespace();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testSniProxyProtocol() throws Exception {
@@ -62,6 +63,7 @@ public class ProxyProtocolTest extends TlsProducerConsumerBase {
         // should be able to create producer successfully
         pulsarClient.newProducer().topic(topicName).create();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testSniProxyProtocolWithInvalidProxyUrl() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -131,6 +131,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         doFindBrokerWithListenerName(true);
         doFindBrokerWithListenerName(false);
     }
+    @SuppressWarnings("deprecation")
 
     private void doFindBrokerWithListenerName(boolean useHttp) throws Exception {
         ClientConfigurationData conf = new ClientConfigurationData();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/RetryTopicTest.java
@@ -361,6 +361,7 @@ public class RetryTopicTest extends SharedPulsarBaseTest {
         message = retryTopicConsumer.receive(2, TimeUnit.SECONDS);
         assertNull(message);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 60000)
     public void testRetryTopicProperties() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ServiceUrlProviderTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "broker-api")
 public class ServiceUrlProviderTest extends SharedPulsarBaseTest {
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCreateClientWithServiceUrlProvider() throws Exception {
@@ -65,6 +66,7 @@ public class ServiceUrlProviderTest extends SharedPulsarBaseTest {
         producer.close();
         consumer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCreateClientWithAutoChangedServiceUrlProvider() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -304,6 +304,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         validatingLogInfo(consumer, producer, true);
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "batch")
     public void testSendTimeout(int batchMessageDelayMs) throws Exception {
@@ -381,6 +382,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         consumer.unsubscribe();
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     private void validatingLogInfo(Consumer<?> consumer, Producer<?> producer, boolean verifyAckCount)
             throws InterruptedException {
@@ -468,6 +470,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
      * This test verifies partitioned topic stats for producer and consumer.
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testPartitionTopicStats() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -565,6 +568,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
 
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testRetryLetterAndDeadLetterStats() throws PulsarClientException, InterruptedException {
@@ -610,6 +614,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
             assertEquals(deadLetterStats.getTotalMsgsSent(), 1);
         });
     }
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeadLetterStats() throws PulsarClientException, InterruptedException {
         final String topicName = "persistent://my-property/my-ns/testDeadLetterStats";
@@ -649,6 +654,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
             assertEquals(dlqStats.getTotalMsgsSent(), 1);
         });
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testPartitionedRetryLetterAndDeadLetterStats()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2856,6 +2856,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 100000)
     public void testCryptoWithChunking() throws Exception {
@@ -4966,6 +4967,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 {false}
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enableBatchSend")
     public void testPublishWithCreateMessageManually(boolean enableBatchSend) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -1272,6 +1272,7 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
         Assert.assertTrue(binaryLookupService.getSchema(TopicName.get(topic),
                 ByteBuffer.allocate(8).putLong(1).array()).get().isPresent());
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetNativeSchemaWithAutoConsumeWithMultiVersion() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
@@ -68,6 +68,7 @@ public abstract class TlsProducerConsumerBase extends ProducerConsumerBase {
         conf.setNumExecutorThreadPoolSize(5);
     }
 
+    @SuppressWarnings("deprecation")
     protected void internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         if (pulsarClient != null) {
             pulsarClient.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -142,6 +142,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
             Assert.fail("Should not fail since certs are sent.");
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 60000)
     public void testTlsCertsFromDynamicStream() throws Exception {
@@ -201,6 +202,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testTlsCertsFromDynamicStreamExpiredAndRenewCert() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -249,6 +251,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     private ByteArrayInputStream createByteInputStream(String filePath) throws IOException {
         try (InputStream inStream = new FileInputStream(filePath)) {
@@ -303,6 +306,7 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         @Cleanup
         Producer<byte[]> ignored = client.newProducer().topic(topicName).create();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testTlsWithFakeAuthentication() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenAuthenticatedProducerConsumerTest.java
@@ -72,6 +72,7 @@ public class TokenAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         adminToken = generateToken(ADMIN_ROLE);
         userToken = generateToken("user");
     }
+    @SuppressWarnings("deprecation")
 
     private String generateToken(String subject) {
         PrivateKey pkey = kp.getPrivate();
@@ -110,6 +111,7 @@ public class TokenAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         conf.setProperties(properties);
         super.init();
     }
+    @SuppressWarnings("deprecation")
 
     // setup both admin and pulsar client
     protected final void clientSetup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenExpirationProduceConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenExpirationProduceConsumerTest.java
@@ -85,9 +85,12 @@ public class TokenExpirationProduceConsumerTest extends TlsProducerConsumerBase 
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
+    @SuppressWarnings("deprecation")
 
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+    @SuppressWarnings("deprecation")
     public static final String ADMIN_TOKEN = Jwts.builder().setSubject("admin").signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
 
     public String getExpireToken(String role, Date date) {
         return Jwts.builder().setSubject(role).signWith(SECRET_KEY)
@@ -114,6 +117,7 @@ public class TokenExpirationProduceConsumerTest extends TlsProducerConsumerBase 
         conf.getProperties().setProperty("tokenSecretKey", "data:;base64,"
                 + Base64.getEncoder().encodeToString(SECRET_KEY.getEncoded()));
     }
+    @SuppressWarnings("deprecation")
 
     private PulsarClient getClient(String token) throws Exception {
         ClientBuilder clientBuilder = PulsarClient.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TokenOauth2AuthenticatedProducerConsumerTest.java
@@ -107,6 +107,7 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
         conf.setProperties(properties);
         super.init();
     }
+    @SuppressWarnings("deprecation")
 
     // setup both admin and pulsar client
     protected final void clientSetup() throws Exception {
@@ -122,6 +123,7 @@ public class TokenOauth2AuthenticatedProducerConsumerTest extends ProducerConsum
                 .statsInterval(0, TimeUnit.SECONDS)
                 .authentication(createAuthentication(path)));
     }
+    @SuppressWarnings("deprecation")
 
     private Authentication createAuthentication(Path path) throws MalformedURLException {
         return AuthenticationFactoryOAuth2.clientCredentials(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
@@ -1127,6 +1127,7 @@ public class TopicReaderTest extends SharedPulsarBaseTest {
 
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 20000)
     public void testHasMessageAvailable() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/UnloadSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/UnloadSubscriptionTest.java
@@ -149,6 +149,7 @@ public class UnloadSubscriptionTest extends SharedPulsarBaseTest {
         consumer1.close();
         consumer2.close();
     }
+    @SuppressWarnings("deprecation")
 
     private static String toString(List<MessageId> messageIds){
         List<String> messageIdStrings = new ArrayList<>(messageIds.size());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AdminApiKeyStoreTlsAuthTest.java
@@ -66,6 +66,7 @@ import org.testng.annotations.Test;
 public class AdminApiKeyStoreTlsAuthTest extends ProducerConsumerBase {
     private final String clusterName = "test";
     Set<String> tlsProtocols = Sets.newConcurrentHashSet();
+    @SuppressWarnings("deprecation")
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
     private static final String CLIENTUSER_TOKEN =
             AuthTokenUtils.createToken(SECRET_KEY, "clientuser", Optional.empty());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConSupports.java
@@ -48,6 +48,7 @@ public abstract class AutoCloseUselessClientConSupports extends MultiBrokerBaseT
     protected int numberOfAdditionalBrokers() {
         return BROKER_COUNT - 1;
     }
+    @SuppressWarnings("deprecation")
 
     @Override
     protected PulsarClient newPulsarClient(String url, int intervalInSecs) throws PulsarClientException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTopicsPatternConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConTopicsPatternConsumerTest.java
@@ -43,6 +43,7 @@ public class AutoCloseUselessClientConTopicsPatternConsumerTest extends AutoClos
         super.pulsarResourcesSetup();
         admin.topics().createNonPartitionedTopic(TOPIC_FULL_NAME);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testConnectionAutoReleaseWhileUsingTopicsPatternConsumer() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -526,6 +526,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testMaxConcurrentTopicLoading() throws Exception {
         final String topicName = "persistent://my-property/my-ns/cocurrentLoadingTopic";
@@ -584,6 +585,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testCloseConnectionOnInternalServerError() throws Exception {
 
@@ -658,6 +660,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
             return timestamp;
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCleanProducer() throws Exception {
@@ -690,6 +693,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      *
      * @throws PulsarClientException
      */
+    @SuppressWarnings("deprecation")
     @Test(expectedExceptions = PulsarClientException.TimeoutException.class)
     public void testOperationTimeout() throws PulsarClientException {
         final String topicName = "persistent://my-property/my-ns/my-topic1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientCnxTest.java
@@ -76,6 +76,7 @@ public class ClientCnxTest extends MockedPulsarServiceBaseTest {
         super.internalCleanup();
         this.executorService.shutdownNow();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testRemoveAndHandlePendingRequestInCnx() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerAckTest.java
@@ -63,6 +63,7 @@ public class ConsumerAckTest extends SharedPulsarBaseTest {
 
     private TransactionImpl transaction;
     private PulsarClient clientWithStats;
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     public void setupConsumerAckTest() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsProducerConsumerTestWithAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsProducerConsumerTestWithAuthTest.java
@@ -61,6 +61,7 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "broker-impl")
 public class KeyStoreTlsProducerConsumerTestWithAuthTest extends ProducerConsumerBase {
+    @SuppressWarnings("deprecation")
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
     private static final String CLIENT_USER_TOKEN =
             AuthTokenUtils.createToken(SECRET_KEY, "clientuser", Optional.empty());
@@ -136,6 +137,7 @@ public class KeyStoreTlsProducerConsumerTestWithAuthTest extends ProducerConsume
         conf.setBrokerClientTlsProtocols(tlsProtocols);
 
     }
+    @SuppressWarnings("deprecation")
 
     protected void internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         if (pulsarClient != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsProducerConsumerTestWithoutAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/KeyStoreTlsProducerConsumerTestWithoutAuthTest.java
@@ -90,6 +90,7 @@ public class KeyStoreTlsProducerConsumerTestWithoutAuthTest extends ProducerCons
         conf.setTlsProtocols(tlsProtocols);
         conf.setNumExecutorThreadPoolSize(5);
     }
+    @SuppressWarnings("deprecation")
 
     protected void internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         if (pulsarClient != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/LookupRetryTest.java
@@ -106,6 +106,7 @@ public class LookupRetryTest extends MockedPulsarServiceBaseTest {
             .lookupTimeout(10, TimeUnit.SECONDS)
             .build();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetPartitionedMetadataRetries() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageChunkingTest.java
@@ -170,6 +170,7 @@ public class MessageChunkingTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
 
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testChunkingWithOrderingKey() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageParserTest.java
@@ -78,6 +78,7 @@ public class MessageParserTest extends MockedPulsarServiceBaseTest {
                 { false, CompressionType.NONE },
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "batchingAndCompression")
     public void testParseMessages(boolean batchEnabled, CompressionType compressionType) throws Exception{

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PatternTopicsConsumerImplAuthTest.java
@@ -379,6 +379,7 @@ public class PatternTopicsConsumerImplAuthTest extends ProducerConsumerBase {
             return isAuthorizedFuture;
         }
     }
+    @SuppressWarnings("deprecation")
 
     public static class ClientAuthentication implements Authentication {
         String user;
@@ -431,6 +432,7 @@ public class PatternTopicsConsumerImplAuthTest extends ProducerConsumerBase {
         }
 
     }
+    @SuppressWarnings("deprecation")
 
     public static class TestAuthenticationProvider implements AuthenticationProvider {
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarMultiHostClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarMultiHostClientTest.java
@@ -51,6 +51,7 @@ public class PulsarMultiHostClientTest extends SharedPulsarBaseTest {
     public void setTestMethodName(Method m) {
         methodName = m.getName();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetPartitionedTopicMetaData() {
@@ -79,6 +80,7 @@ public class PulsarMultiHostClientTest extends SharedPulsarBaseTest {
 
         log.info("-- Exiting {} test --", methodName);
     }
+    @SuppressWarnings("deprecation")
 
     @Test (timeOut = 15000)
     public void testGetPartitionedTopicDataTimeout() {
@@ -113,6 +115,7 @@ public class PulsarMultiHostClientTest extends SharedPulsarBaseTest {
             throw new UncheckedIOException(e);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testMultiHostUrlRetrySuccess() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SchemaDeleteTest.java
@@ -57,6 +57,7 @@ public class SchemaDeleteTest extends MockedPulsarServiceBaseTest {
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void createTopicDeleteTopicCreateTopic() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -158,6 +158,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
      * 1. multi-partition topic, p1, p2 has new message, p3 has no new messages.
      * 2. Call new `refresh` API, it will be completed after read new messages.
      */
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "partition")
     public void testRefreshAPI(int partition) throws Exception {
         // 1. Prepare resource.
@@ -261,6 +262,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         }
         Awaitility.await().untilAsserted(() -> assertTrue(completedExceptionally.get()));
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000)
     public void testTableView() throws Exception {
@@ -327,6 +329,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         });
         assertEquals(tv.keySet(), keys);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000, dataProvider = "topicDomain")
     public void testTableViewUpdatePartitions(String topicDomain) throws Exception {
@@ -368,6 +371,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         });
         assertEquals(tv.keySet(), keys2);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000, dataProvider = "topicDomain")
     public void testPublishNullValue(String topicDomain) throws Exception {
@@ -414,6 +418,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
     public static Object[][] partitioned() {
         return new Object[][] {{true}, {false}};
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000, dataProvider = "partitionedTopic")
     public void testAck(boolean partitionedTopic) throws Exception {
@@ -462,6 +467,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
 
 
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000)
     public void testListen() throws Exception {
@@ -509,6 +515,7 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(mockAction.acceptedCount, 5);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 30 * 1000)
     public void testTableViewWithEncryptedMessages() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1118,6 +1118,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         retryStrategically((test) -> subscription.getNumberOfEntriesInBacklog(false) == 0, 5, 200);
         assertEquals(subscription.getNumberOfEntriesInBacklog(false), 0);
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = testTimeout)
     public void testGetLastMessageId() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -930,6 +930,7 @@ public class TransactionEndToEndTest extends TransactionTestBase {
                 .build()
                 .get();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void txnMetadataHandlerRecoverTest() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -57,6 +57,7 @@ public class ServiceConfigurationTest {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testInit() throws Exception {
         final String zookeeperServer = "localhost:2184";
@@ -274,6 +275,7 @@ public class ServiceConfigurationTest {
             assertEquals(conf.getBookkeeperClientNumIoThreads(), 1);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testSubscriptionTypesEnableWins() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -382,6 +382,7 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(compactedMsgCount, 1);
         Assert.assertEquals(nonCompactedMsgCount, numMessages);
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testLastMessageIdForCompactedLedger() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionRetentionTest.java
@@ -200,6 +200,7 @@ public class CompactionRetentionTest extends MockedPulsarServiceBaseTest {
                 testCompactionCursorRetention(topic)
         );
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCompactionRetentionOnTopicCreationWithTopicPolicies() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -2063,6 +2063,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
             }
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testDeleteCompactedLedger() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/GetLastMessageIdCompactedTest.java
@@ -108,6 +108,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
             return managedLedger.getLedgersInfo().size() == 1;
         });
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetLastMessageIdWhenLedgerEmpty() throws Exception {
@@ -142,6 +143,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
                 .readCompacted(true)
                 .subscribe();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testGetLastMessageIdWhenNoNonEmptyLedgerExists() throws Exception {
@@ -178,6 +180,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
                 {false}
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdBeforeCompaction(boolean enabledBatch) throws Exception {
@@ -212,6 +215,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
         consumer.close();
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompaction(boolean enabledBatch) throws Exception {
@@ -248,6 +252,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
         consumer.close();
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompactionWithCompression(boolean enabledBatch) throws Exception {
@@ -329,6 +334,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
         producer.close();
         reader.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompactionEndWithNullMsg(boolean enabledBatch) throws Exception {
@@ -368,6 +374,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
         consumer.close();
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompactionEndWithNullMsg2(boolean enabledBatch) throws Exception {
@@ -406,6 +413,7 @@ public class GetLastMessageIdCompactedTest extends SharedPulsarBaseTest {
         consumer.close();
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "enabledBatch")
     public void testGetLastMessageIdAfterCompactionAllNullMsg(boolean enabledBatch) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/ServiceUnitStateCompactionTest.java
@@ -323,6 +323,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
             Assert.assertTrue(all.isEmpty());
         }
     }
+    @SuppressWarnings("deprecation")
 
 
     @Test
@@ -520,6 +521,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
             Assert.assertEquals(m.getValue(), testValues.get(2));
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testSlowTableviewAfterCompaction() throws Exception {
@@ -641,6 +643,7 @@ public class ServiceUnitStateCompactionTest extends MockedPulsarServiceBaseTest 
         pulsar2.close();
 
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testSlowReceiveTableviewAfterCompaction() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/StrategicCompactionTest.java
@@ -96,6 +96,7 @@ public class StrategicCompactionTest extends MockedPulsarServiceBaseTest {
     private long compact(String topic) throws ExecutionException, InterruptedException {
         return (long) compactor.compact(topic, strategy).get();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testNumericOrderCompaction() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionE2ESecurityTest.java
@@ -114,6 +114,7 @@ public class PulsarFunctionE2ESecurityTest {
     public Object[][] validRoleName() {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod
     void setup(Method method) throws Exception {
@@ -291,6 +292,7 @@ public class PulsarFunctionE2ESecurityTest {
         PulsarWorkerService workerService = new PulsarWorkerService();
         return workerService;
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String tenant,
                                                          String namespace,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionLocalRunTest.java
@@ -198,6 +198,7 @@ public class PulsarFunctionLocalRunTest {
             pulsarApiExamplesClassLoader = null;
         }
     }
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     void setup(Method method) throws Exception {
@@ -344,6 +345,7 @@ public class PulsarFunctionLocalRunTest {
             }
         }
     }
+    @SuppressWarnings("deprecation")
 
     protected WorkerConfig createWorkerConfig(ServiceConfiguration config) {
 
@@ -387,6 +389,7 @@ public class PulsarFunctionLocalRunTest {
         workerConfig.setAuthorizationEnabled(true);
         return workerConfig;
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String tenant,
                                                          String namespace,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionPublishTest.java
@@ -117,6 +117,7 @@ public class PulsarFunctionPublishTest {
     public Object[][] validRoleName() {
         return new Object[][]{{Boolean.TRUE}, {Boolean.FALSE}};
     }
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod
     void setup(Method method) throws Exception {
@@ -245,6 +246,7 @@ public class PulsarFunctionPublishTest {
             }
         }
     }
+    @SuppressWarnings("deprecation")
 
     private PulsarWorkerService createPulsarFunctionWorker(ServiceConfiguration config) {
 
@@ -291,6 +293,7 @@ public class PulsarFunctionPublishTest {
         PulsarWorkerService workerService = new PulsarWorkerService();
         return workerService;
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String tenant, String namespace, String functionName,
                                                      String sourceTopic, String publishTopic, String subscriptionName) {
@@ -404,6 +407,7 @@ public class PulsarFunctionPublishTest {
 
         tempDirectory.assertThatFunctionDownloadTempFilesHaveBeenDeleted();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testMultipleAddress() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
@@ -91,6 +91,7 @@ public class PulsarFunctionTlsTest {
     protected String testNamespace = testTenant + "/my-ns";
     private PulsarFunctionTestTemporaryDirectory[] tempDirectories =
             new PulsarFunctionTestTemporaryDirectory[BROKER_COUNT];
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     void setup() throws Exception {
@@ -292,6 +293,7 @@ public class PulsarFunctionTlsTest {
             pulsarAdmins[i].functions().deleteFunction(config.getTenant(), config.getNamespace(), config.getName());
         }
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(
         String jarFile,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarWorkerAssignmentTest.java
@@ -341,6 +341,7 @@ public class PulsarWorkerAssignmentTest {
             assertEquals(admin.functions().getFunction(tenant, namespacePortion, functionName).getLogTopic(), logTopic);
         }
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String tenant,
                                                          String namespace,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/AbstractPulsarE2ETest.java
@@ -108,6 +108,7 @@ public abstract class AbstractPulsarE2ETest {
     public Object[][] validRoleName() {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
     }
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     public void setup(Method method) throws Exception {
@@ -275,6 +276,7 @@ public abstract class AbstractPulsarE2ETest {
             }
         }
     }
+    @SuppressWarnings("deprecation")
 
     private PulsarWorkerService createPulsarFunctionWorker(ServiceConfiguration config)
             throws IOException, URISyntaxException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionAdminTest.java
@@ -87,6 +87,7 @@ public class PulsarFunctionAdminTest {
             ResourceUtils.getAbsolutePath("certificate-authority/certs/ca.cert.pem");
 
     private static final Logger log = LoggerFactory.getLogger(PulsarFunctionAdminTest.class);
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod(alwaysRun = true)
     void setup(Method method) throws Exception {
@@ -190,6 +191,7 @@ public class PulsarFunctionAdminTest {
             bkEnsemble = null;
         }
     }
+    @SuppressWarnings("deprecation")
 
     private PulsarWorkerService createPulsarFunctionWorker(ServiceConfiguration config) {
         workerConfig = new WorkerConfig();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionE2ETest.java
@@ -78,6 +78,7 @@ import org.zeroturnaround.zip.ZipUtil;
  */
 @Test(groups = "broker-io")
 public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String tenant, String namespace, String functionName,
                              boolean isBuiltin, String sourceTopic, String sinkTopic, String subscriptionName) {
@@ -321,6 +322,7 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
         consumer.close();
         producer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 20000)
     public void testPulsarFunctionAsyncStatTime() throws Exception {
@@ -1260,6 +1262,7 @@ public class PulsarFunctionE2ETest extends AbstractPulsarE2ETest {
             }
         }, 50, 150));
     }
+    @SuppressWarnings("deprecation")
 
     @Test(timeOut = 20000)
     public void testE2EPulsarFunctionMessagePooled() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
@@ -104,6 +104,7 @@ public class PulsarFunctionTlsTest {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarFunctionTlsTest.class);
     private PulsarFunctionTestTemporaryDirectory tempDirectory;
+    @SuppressWarnings("deprecation")
 
     @BeforeMethod
     void setup(Method method) throws Exception {
@@ -202,6 +203,7 @@ public class PulsarFunctionTlsTest {
             }
         }
     }
+    @SuppressWarnings("deprecation")
 
     private PulsarWorkerService createPulsarFunctionWorker(ServiceConfiguration config,
                                                            PulsarAdmin mockPulsarAdmin) {
@@ -289,6 +291,7 @@ public class PulsarFunctionTlsTest {
         }
 
     }
+    @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(String jarFile,
                                                          String tenant,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -829,6 +829,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 .subscribe();
         consumer.close();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testDeleteTopicAndSchema() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckOnTopicLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaTypeCompatibilityCheckOnTopicLevelTest.java
@@ -221,6 +221,7 @@ public class SchemaTypeCompatibilityCheckOnTopicLevelTest extends MockedPulsarSe
                                 .withPojo(Schemas.PersonThree.class).build()))
                 .topic(topicName).create();
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testUpdateSchemaCompatibilityStrategyRepeatedly()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/security/MockedPulsarStandalone.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/security/MockedPulsarStandalone.java
@@ -73,6 +73,7 @@ public abstract class MockedPulsarStandalone implements AutoCloseable {
         serviceConfiguration.setTlsCertificateFilePath(TLS_EC_SERVER_CERT_PATH);
         serviceConfiguration.setTlsKeyFilePath(TLS_EC_SERVER_KEY_PATH);
     }
+@SuppressWarnings("deprecation")
 
 
     protected static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
@@ -120,6 +121,7 @@ public abstract class MockedPulsarStandalone implements AutoCloseable {
 
 
 
+    @SuppressWarnings("deprecation")
     @SneakyThrows
     protected void loadECTlsCertificateWithFile() {
         serviceConfiguration.setTlsEnabled(true);
@@ -138,6 +140,7 @@ public abstract class MockedPulsarStandalone implements AutoCloseable {
                 MAPPER1.writeValueAsString(brokerClientAuthParams));
     }
 
+    @SuppressWarnings("deprecation")
     @SneakyThrows
     protected void loadECTlsCertificateWithKeyStore() {
         serviceConfiguration.setTlsEnabled(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/auth/tokens/TokensCliUtilsTest.java
@@ -52,6 +52,7 @@ public class TokensCliUtilsTest {
                 {"1y", 31536000}
         };
     }
+    @SuppressWarnings("deprecation")
 
     @Test
     public void testCreateToken() {
@@ -91,6 +92,7 @@ public class TokensCliUtilsTest {
             System.setOut(oldStream);
         }
     }
+    @SuppressWarnings("deprecation")
 
     @Test(dataProvider = "desiredExpireTime")
     public void commandCreateToken_WhenCreatingATokenWithExpiryTime_ShouldHaveTheDesiredExpireTime(String expireTime,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/MockAuthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/MockAuthenticationProvider.java
@@ -32,6 +32,7 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void initialize(ServiceConfiguration config) throws IOException {
 
@@ -43,6 +44,7 @@ public class MockAuthenticationProvider implements AuthenticationProvider {
         return "mockauth";
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
         // Return super user role

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyRoleAuthTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyRoleAuthTest.java
@@ -67,6 +67,7 @@ import org.testng.annotations.Test;
  * 1. testWebSocketProxyProduceConsumeWithAuthorization: Positive test with authorized tokens
  * 2. testWebSocketProxyWithUnauthorizedToken: Negative test with unauthorized tokens
  */
+@SuppressWarnings("deprecation")
 @Test(groups = "websocket")
 public class ProxyRoleAuthTest extends ProducerConsumerBase {
 

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
@@ -310,11 +310,13 @@ public class PulsarAdminBuilderImplTest {
             return "mock-secret";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthenticationDataProvider getAuthData() throws PulsarClientException {
             return null;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             configure(new Gson().toJson(authParams));

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -1557,6 +1557,7 @@ public class PulsarAdminToolTest {
         verify(mockGlobalTopicsPolicies).removeAutoSubscriptionCreation("persistent://prop/ns1/ds1");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void topicsSetOffloadPolicies() throws Exception {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
@@ -1588,6 +1589,7 @@ public class PulsarAdminToolTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void topics() throws Exception {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
@@ -2289,6 +2291,7 @@ public class PulsarAdminToolTest {
                 longThat(new TimestampMatcher()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void nonPersistentTopics() throws Exception {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdTopics.java
@@ -262,6 +262,7 @@ public class TestCmdTopics {
         mockTopics = mock(Topics.class);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetRetentionCmd() throws Exception {
         cmdTopics.run("set-retention public/default/topic -s 2T -t 200d".split("\\s+"));
@@ -269,6 +270,7 @@ public class TestCmdTopics {
                 new RetentionPolicies(200 * 24 * 60, 2 * 1024 * 1024));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetPersistenceWithDefaultMarkDeleteRate() throws Exception {
         // Test that the default value is now -1 (unset) instead of 0
@@ -277,6 +279,7 @@ public class TestCmdTopics {
                 new PersistencePolicies(2, 2, 2, -1.0, null));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetPersistenceWithNegativeMarkDeleteRate() throws Exception {
         // Test that negative values are now allowed (previously would throw exception)
@@ -285,6 +288,7 @@ public class TestCmdTopics {
                 new PersistencePolicies(2, 2, 2, -5.0, null));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetPersistenceWithZeroMarkDeleteRate() throws Exception {
         // Test that zero is still allowed
@@ -293,6 +297,7 @@ public class TestCmdTopics {
                 new PersistencePolicies(2, 2, 2, 0.0, null));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetPersistenceWithPositiveMarkDeleteRate() throws Exception {
         // Test that positive values still work
@@ -301,6 +306,7 @@ public class TestCmdTopics {
                 new PersistencePolicies(2, 2, 2, 10.5, null));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSetPersistenceWithUnsetMarkDeleteRate() throws Exception {
         // Test explicitly setting to -1 (unset)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/MessageRouterTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/MessageRouterTest.java
@@ -33,6 +33,7 @@ public class MessageRouterTest {
 
     public static class TestMessageRouter implements MessageRouter {
 
+        @SuppressWarnings("deprecation")
         @Override
         public int choosePartition(Message<?> msg) {
             return 1234;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -68,6 +68,7 @@ public class BatchMessageIdImplTest {
         assertEquals(msgId, batchMsgId4);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void notEqualsMultiTest() {
         BatchMessageIdImpl batchMsgId = new BatchMessageIdImpl(0, 0, 0, 0);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BuildersTest.java
@@ -54,6 +54,7 @@ public class BuildersTest {
         assertEquals(b2.conf.getServiceUrl(), "pulsar://other-broker:6650");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void enableTlsTest() {
         ClientBuilderImpl builder = (ClientBuilderImpl) PulsarClient.builder().serviceUrl("pulsar://service:6650");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientBuilderImplTest.java
@@ -268,11 +268,13 @@ public class ClientBuilderImplTest {
             return "mock-secret";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthenticationDataProvider getAuthData() throws PulsarClientException {
             return null;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             configure(new Gson().toJson(authParams));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientInitializationTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ClientInitializationTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 public class ClientInitializationTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testInitializeAuthWithTls() throws PulsarClientException {
         Authentication auth = mock(Authentication.class);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -183,6 +183,7 @@ public class MessageIdCompareToTest  {
         assertTrue(topicMessageId2.compareTo(messageIdImpl2) < 0, "Expected to be less than");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiMessageIdEqual() {
         // null
@@ -259,6 +260,7 @@ public class MessageIdCompareToTest  {
         assertNotEquals(item7, item5);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultiMessageIdCompareto() {
         // null

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -87,6 +87,7 @@ public class MultiTopicsConsumerImplTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetStats() throws Exception {
         String topicName = "test-stats";

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ProducerBuilderImplTest.java
@@ -369,17 +369,20 @@ public class ProducerBuilderImplTest {
         producerBuilderImpl.sendTimeout(-1, TimeUnit.SECONDS);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalid() {
         producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
             "maxPendingMessagesAcrossPartitions needs to be >= maxPendingMessages")
     public void testProducerBuilderImplWhenMaxPendingMessagesAcrossPartitionsPropertyIsInvalidErrorMessages() {
         producerBuilderImpl.maxPendingMessagesAcrossPartitions(-1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testProducerBuilderImplWhenNumericPropertiesAreValid() {
         producerBuilderImpl.batchingMaxPublishDelay(1, TimeUnit.SECONDS);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
@@ -54,6 +54,7 @@ public class TopicMessageIdImplTest {
         assertNotEquals(topicMsgId1, topicMsgId2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testDeprecatedMethods() {
         BatchMessageIdImpl msgId = new BatchMessageIdImpl(1, 2, 3, 4);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationTokenTest.java
@@ -66,6 +66,7 @@ public class AuthenticationTokenTest {
         authToken.close();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAuthTokenClientConfig() throws Exception {
         ClientConfigurationData clientConfig = new ClientConfigurationData();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/MockAuthentication.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/MockAuthentication.java
@@ -33,11 +33,13 @@ public class MockAuthentication implements Authentication {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AuthenticationDataProvider getAuthData() throws PulsarClientException {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void configure(Map<String, String> authParams) {
         authParamsMap = authParams;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/MockEncodedAuthenticationParameterSupport.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/MockEncodedAuthenticationParameterSupport.java
@@ -46,11 +46,13 @@ public class MockEncodedAuthenticationParameterSupport implements Authentication
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public AuthenticationDataProvider getAuthData() throws PulsarClientException {
         return null;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void configure(Map<String, String> authParams) {
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
@@ -60,6 +60,7 @@ public class AuthenticationFactoryOAuth2Test {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testClientCredentials() throws IOException {
         URL issuerUrl = new URL("http://localhost");

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/protocol/ByteBufPairTest.java
@@ -54,6 +54,7 @@ public class ByteBufPairTest {
         assertEquals(b2.refCnt(), 0);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testEncoder() throws Exception {
         ByteBuf b1 = Unpooled.wrappedBuffer("hello".getBytes());

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclableTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/ConcurrentBitSetRecyclableTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 public class ConcurrentBitSetRecyclableTest {
 
+    @SuppressWarnings("deprecation")
     @Test(priority = 0)
     public void testRecycle() {
         ConcurrentBitSetRecyclable bitset1 = ConcurrentBitSetRecyclable.create();
@@ -36,6 +37,7 @@ public class ConcurrentBitSetRecyclableTest {
         Assert.assertNotSame(bitset3, bitset1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(priority = 1)
     public void testGenerateByBitSet() {
         BitSet bitSet = new BitSet();

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -177,6 +177,7 @@ public class JavaInstanceRunnableTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testFunctionAsyncTime() throws Exception {
         FunctionDetails functionDetails = FunctionDetails.newBuilder()
@@ -222,6 +223,7 @@ public class JavaInstanceRunnableTest {
         verify(record, times(1)).ack();
     }
 
+    @SuppressWarnings("deprecation")
     @NonNull
     private JavaInstanceRunnable getJavaInstanceRunnable(boolean autoAck,
                org.apache.pulsar.functions.proto.Function.ProcessingGuarantees processingGuarantees) throws Exception {

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerBuilderFactoryTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ProducerBuilderFactoryTest.java
@@ -128,6 +128,7 @@ public class ProducerBuilderFactoryTest {
         verifyNoMoreInteractions(producerBuilder);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCreateProducerBuilderWithAdvancedProducerConfig() {
         ProducerConfig producerConfig = new ProducerConfig();
@@ -180,6 +181,7 @@ public class ProducerBuilderFactoryTest {
         verifyNoMoreInteractions(producerBuilder);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCreateProducerBuilderWithBatchingDisabled() {
         ProducerConfig producerConfig = new ProducerConfig();

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarFunctionRecordTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarFunctionRecordTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 public class PulsarFunctionRecordTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAck() {
         Record record = mock(Record.class);

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/windowing/WindowFunctionExecutorTest.java
@@ -145,6 +145,7 @@ public class WindowFunctionExecutorTest {
         verify(record, times(1)).ack();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testWindowFunctionWithAtleastOnce() throws Exception {
 

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/auth/KubernetesSecretsTokenAuthProviderTest.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 
 public class KubernetesSecretsTokenAuthProviderTest {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConfigureAuthDataStatefulSet() {
         byte[] testBytes = new byte[]{0, 1, 2, 3, 4};
@@ -78,6 +79,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
                 .get(0).getVolumeMounts().get(0).getMountPath(), "/etc/auth");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConfigureAuthDataStatefulSetNoCa() {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
@@ -110,6 +112,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
                 .get(0).getVolumeMounts().get(0).getMountPath(), "/etc/auth");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCacheAuthData() throws ApiException {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
@@ -138,6 +141,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
         Assert.assertTrue(StringUtils.isNotBlank(new String(functionAuthData.get().getData())));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void configureAuthenticationConfig() {
         byte[] testBytes = new byte[]{0, 1, 2, 3, 4};
@@ -155,6 +159,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
         Assert.assertEquals(authenticationConfig.getTlsTrustCertsFilePath(), "/etc/auth/ca.pem");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void configureAuthenticationConfigNoCa() {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);
@@ -172,6 +177,7 @@ public class KubernetesSecretsTokenAuthProviderTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUpdateAuthData() throws Exception {
         CoreV1Api coreV1Api = mock(CoreV1Api.class);

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/RuntimeUtilsTest.java
@@ -59,6 +59,7 @@ public class RuntimeUtilsTest {
         Assert.assertEquals(result[2], "-Dfoo=\"bar foo\"");
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "k8sRuntime")
     public void getGoInstanceCmd(boolean k8sRuntime) throws IOException {
         HashMap<String, String> goInstanceConfig;

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/FunctionConfigUtilsTest.java
@@ -73,6 +73,7 @@ public class FunctionConfigUtilsTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAutoAckConvertFailed() {
 
@@ -85,6 +86,7 @@ public class FunctionConfigUtilsTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConvertBackFidelity() throws JSONException {
         FunctionConfig functionConfig = new FunctionConfig();
@@ -131,6 +133,7 @@ public class FunctionConfigUtilsTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConvertWindow() {
         FunctionConfig functionConfig = new FunctionConfig();
@@ -528,6 +531,7 @@ public class FunctionConfigUtilsTest {
         );
     }
 
+    @SuppressWarnings("deprecation")
     private FunctionConfig createFunctionConfig() {
         FunctionConfig functionConfig = new FunctionConfig();
         functionConfig.setTenant("test-tenant");
@@ -593,6 +597,7 @@ public class FunctionConfigUtilsTest {
         assertFalse(detailsJson.contains("forwardSourceMessageProperty"));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testFunctionConfigConvertFromDetails() {
         String name = "test1";

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/SinkConfigUtilsTest.java
@@ -88,6 +88,7 @@ public class SinkConfigUtilsTest {
 
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testAutoAckConvertFailed() throws IOException {
 
@@ -101,6 +102,7 @@ public class SinkConfigUtilsTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConvertBackFidelity() throws IOException, JSONException  {
         SinkConfig sinkConfig = new SinkConfig();
@@ -595,6 +597,7 @@ public class SinkConfigUtilsTest {
                 .contains("Could not validate sink config: Field 'configParameter' cannot be null!"));
     }
 
+    @SuppressWarnings("deprecation")
     private SinkConfig createSinkConfig() {
         SinkConfig sinkConfig = new SinkConfig();
         sinkConfig.setTenant("test-tenant");

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -962,6 +962,7 @@ public class FunctionRuntimeManagerTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testFunctionRuntimeFactoryConfigsBackwardsCompatibility() throws Exception {
 
@@ -1147,6 +1148,7 @@ public class FunctionRuntimeManagerTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testKubernetesFunctionInstancesRestart() throws Exception {
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImplTest.java
@@ -323,6 +323,7 @@ public class FunctionsImplTest {
                         .originalPrincipal("test-non-admin-user").build()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testIsSuperUser() throws PulsarAdminException {
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -167,6 +167,7 @@ public class FunctionApiV2ResourceTest extends AbstractFunctionApiResourceTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetFunctionSuccess() throws IOException {
         mockInstanceUtils();

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/FunctionApiV3ResourceTest.java
@@ -261,6 +261,7 @@ public class FunctionApiV3ResourceTest extends AbstractFunctionApiResourceTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetFunctionSuccess() throws IOException {
         mockInstanceUtils();

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v3/SourceApiV3ResourceTest.java
@@ -1304,6 +1304,7 @@ public class SourceApiV3ResourceTest extends AbstractFunctionsResourceTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetSourceSuccess() {
         when(mockedManager.containsFunction(eq(TENANT), eq(NAMESPACE), eq(source))).thenReturn(true);

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTaskTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTaskTest.java
@@ -61,6 +61,7 @@ public class AuditorCheckAllLedgersTaskTest extends BookKeeperClusterTestCase {
         baseConf.setAutoRecoveryDaemonEnabled(false);
     }
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     @Override
     public void setUp() throws Exception {

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorLedgerCheckerTest.java
@@ -127,6 +127,7 @@ public class AuditorLedgerCheckerTest extends BookKeeperClusterTestCase {
                 .setLedgerManagerFactoryClassName(ledgerManagerFactoryClass);
     }
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     public void setUp() throws Exception {
         super.setUp();

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorPlacementPolicyCheckTest.java
@@ -101,6 +101,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         super.tearDown();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPlacementPolicyCheckWithBookiesFromDifferentRacks() throws Exception {
         int numOfBookies = 5;
@@ -216,6 +217,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPlacementPolicyCheckWithLedgersNotAdheringToPlacementPolicy() throws Exception {
         int numOfBookies = 5;
@@ -299,6 +301,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPlacementPolicyCheckWithLedgersNotAdheringToPlacementPolicyAndNotMarkToUnderreplication()
             throws Exception {
@@ -371,6 +374,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         assertEquals(unnderReplicateLedgerId, -1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPlacementPolicyCheckWithLedgersNotAdheringToPlacementPolicyAndMarkToUnderreplication()
             throws Exception {
@@ -454,6 +458,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         testPlacementPolicyCheckWithURLedgers(false);
     }
 
+    @SuppressWarnings("deprecation")
     public void testPlacementPolicyCheckWithURLedgers(boolean timeElapsed) throws Exception {
         int numOfBookies = 4;
         /*
@@ -578,6 +583,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testPlacementPolicyCheckWithLedgersNotAdheringToPolicyWithMultipleSegments() throws Exception {
         int numOfBookies = 7;
@@ -682,6 +688,7 @@ public class AuditorPlacementPolicyCheckTest extends BookKeeperClusterTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testZoneawarePlacementPolicyCheck() throws Exception {
         int numOfBookies = 6;

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/AuditorReplicasCheckTest.java
@@ -227,6 +227,7 @@ public class AuditorReplicasCheckTest extends BookKeeperClusterTestCase {
         lm.createLedgerMetadata(ledgerId, initMeta).get();
     }
 
+    @SuppressWarnings("deprecation")
     private void runTestScenario(MultiKeyMap<String, AvailabilityOfEntriesOfLedger> returnAvailabilityOfEntriesOfLedger,
             MultiKeyMap<String, Integer> errorReturnValueForGetAvailabilityOfEntriesOfLedger,
             int expectedNumLedgersFoundHavingNoReplicaOfAnEntry,

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookieLedgerIndexTest.java
@@ -79,6 +79,7 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
         Class.forName("org.apache.pulsar.metadata.bookkeeper.PulsarMetadataBookieDriver");
     }
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     public void setUp() throws Exception {
         super.setUp();
@@ -148,7 +149,6 @@ public class BookieLedgerIndexTest extends BookKeeperClusterTestCase {
     /**
      * Verify ledger index with failed bookies and throws exception.
      */
-    @SuppressWarnings("deprecation")
 //    @Test
 //    public void testWithoutZookeeper() throws Exception {
 //        // This test case is for ledger metadata that stored in ZooKeeper. As

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/TestReplicationWorker.java
@@ -991,6 +991,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         testRepairedNotAdheringPlacementPolicyLedgerFragments(RackawareEnsemblePlacementPolicy.class, null);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReplicationStats() throws Exception {
         BiConsumer<Boolean, ReplicationWorker> checkReplicationStats = (first, rw) -> {
@@ -1033,6 +1034,7 @@ public class TestReplicationWorker extends BookKeeperClusterTestCase {
         testRepairedNotAdheringPlacementPolicyLedgerFragments(
                 RackawareEnsemblePlacementPolicy.class, checkReplicationStats);
     }
+    @SuppressWarnings("deprecation")
 
     private void testRepairedNotAdheringPlacementPolicyLedgerFragments(
             Class<? extends EnsemblePlacementPolicy> placementPolicyClass,

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BacklogQuotaCompatibilityTest.java
@@ -59,6 +59,7 @@ public class BacklogQuotaCompatibilityTest {
         Assert.assertEquals(readBacklogQuota.getPolicy(), testPolicy);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testV28ClientSetV28BrokerRead() throws Exception {
         Policies writePolicy = new Policies();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -77,6 +77,7 @@ public abstract class BaseMetadataStoreTest extends TestRetrySupport {
         mockZkStoreRef = MetadataStoreFactory.create(mockZkUrl, MetadataStoreConfig.builder().build());
     }
 
+    @SuppressWarnings("deprecation")
     @AfterClass(alwaysRun = true)
     @Override
     public void cleanup() throws Exception {

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/TestZKServer.java
@@ -102,6 +102,7 @@ public class TestZKServer implements AutoCloseable {
         return zkServer;
     }
 
+    @SuppressWarnings("deprecation")
     @SneakyThrows
     private static <T> T readField(Class clazz, String field, Object object) {
         Field declaredField = clazz.getDeclaredField(field);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -94,6 +94,7 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
     private String urLedgerPath;
     private ExecutorService executor;
 
+    @SuppressWarnings("deprecation")
     private void methodSetup(Supplier<String> urlSupplier) throws Exception {
         this.executor = Executors.newSingleThreadExecutor();
         String ledgersRoot = "/ledgers-" + UUID.randomUUID();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -360,6 +360,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testNetworkDelayWithBkZkManager() throws Throwable {
         final String zksConnectionString = zks.getConnectionString();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStoreTest.java
@@ -48,6 +48,7 @@ public class RocksdbMetadataStoreTest {
         Assert.assertEquals(l, RocksdbMetadataStore.toLong(RocksdbMetadataStore.toBytes(l)));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMetaValue() throws Exception {
         RocksdbMetadataStore.MetaValue metaValue = new RocksdbMetadataStore.MetaValue();

--- a/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageTest.java
+++ b/pulsar-package-management/bookkeeper-storage/src/test/java/org/apache/pulsar/packages/management/storage/bookkeeper/BookKeeperPackagesStorageTest.java
@@ -90,6 +90,7 @@ public class BookKeeperPackagesStorageTest extends BookKeeperClusterTestCase {
         assertEquals(testData, readResult);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 60000)
     public void testReadWriteLargeDataOperations() throws ExecutionException, InterruptedException {
         byte[] data = RandomUtils.nextBytes(8192 * 3 + 4096);

--- a/pulsar-package-management/filesystem-storage/src/test/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorageTest.java
+++ b/pulsar-package-management/filesystem-storage/src/test/java/org/apache/pulsar/packages/management/storage/filesystem/FileSystemPackagesStorageTest.java
@@ -85,6 +85,7 @@ public class FileSystemPackagesStorageTest {
         assertEquals(testData, readResult);
     }
 
+    @SuppressWarnings("deprecation")
     @Test(timeOut = 60000)
     public void testReadWriteLargeDataOperations() throws ExecutionException, InterruptedException {
         byte[] data = RandomUtils.nextBytes(8192 * 3 + 4096);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/client/impl/AutoCloseUselessClientConProxyTest.java
@@ -52,6 +52,7 @@ public class AutoCloseUselessClientConProxyTest extends AutoCloseUselessClientCo
     private PulsarClient proxiedClient;
     private AtomicInteger connectionCreationCounter = new AtomicInteger(0);
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void additionalSetup() throws Exception {
         proxyConfig = new ProxyConfiguration();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAdditionalServletTest.java
@@ -115,6 +115,7 @@ public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
     }
 
     // this is for nar package test
+    @SuppressWarnings("deprecation")
     private void addServletNar() {
         Properties properties = new Properties();
         properties.setProperty("basePath", "/metrics-prometheus/broker");
@@ -200,6 +201,7 @@ public class ProxyAdditionalServletTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void test() throws IOException {
         int httpPort = proxyWebServer.getListenPortHTTP().get();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
@@ -233,6 +233,7 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @SuppressWarnings("deprecation")
     protected final PulsarClient createPulsarClient(Authentication auth, String lookupUrl) throws Exception {
         closeAdmin();
         admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticationTest.java
@@ -110,6 +110,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
             return "BasicAuthentication";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthenticationDataProvider getAuthData() throws PulsarClientException {
             try {
@@ -119,6 +120,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
             }
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             this.authParam = String.format("{\"entityType\": \"%s\", \"expiryTime\": \"%s\"}",
@@ -171,6 +173,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
             return authRole;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthData authenticate(AuthData authData) throws AuthenticationException {
             return null; // Authentication complete
@@ -186,6 +189,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
             return authenticationDataSource;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public boolean isComplete() {
             return authRole != null;
@@ -203,6 +207,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyConfigurationTest.java
@@ -118,6 +118,7 @@ public class ProxyConfigurationTest {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testConvert() throws IOException {
         File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsWithAuthTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsWithAuthTest.java
@@ -115,6 +115,7 @@ public class ProxyKeyStoreTlsWithAuthTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     protected PulsarClient internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         ClientBuilder clientBuilder = PulsarClient.builder()
                 .serviceUrl(lookupUrl)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsWithoutAuthTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyKeyStoreTlsWithoutAuthTest.java
@@ -92,6 +92,7 @@ public class ProxyKeyStoreTlsWithoutAuthTest extends MockedPulsarServiceBaseTest
         proxyService.start();
     }
 
+    @SuppressWarnings("deprecation")
     protected PulsarClient internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
         ClientBuilder clientBuilder = PulsarClient.builder()
                 .serviceUrl(lookupUrl)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyParserTest.java
@@ -220,6 +220,7 @@ public class ProxyParserTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testProtocolVersionAdvertisement() throws Exception {
         final String topic = "persistent://public/default/protocol-version-advertisement";

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRefreshAuthTest.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 @Slf4j
 public class ProxyRefreshAuthTest extends ProducerConsumerBase {
     private static final String CLUSTER_NAME = "proxy-authorization";
+    @SuppressWarnings("deprecation")
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
 
     private ProxyService proxyService;
@@ -160,6 +161,7 @@ public class ProxyRefreshAuthTest extends ProducerConsumerBase {
         return new Object[]{true, false};
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "forwardAuthDataProvider")
     public void testAuthDataRefresh(boolean forwardAuthData) throws Exception {
         log.info("-- Starting {} test --", methodName);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
@@ -94,6 +94,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
             return "BasicAuthentication";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public AuthenticationDataProvider getAuthData() throws PulsarClientException {
             try {
@@ -103,6 +104,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
             }
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             this.authParam = authParams.get("authParam");
@@ -120,6 +122,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
         public void close() throws IOException {
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
@@ -129,6 +132,7 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
             return "BasicAuthentication";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             if (authData.hasDataFromCommand()) {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyServiceStarterTest.java
@@ -234,6 +234,7 @@ public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
             return "org.apache.pulsar.proxy.server.ProxyConfigurationTest.ExceptionAuthentication1";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             // no-op
@@ -257,6 +258,7 @@ public class ProxyServiceStarterTest extends MockedPulsarServiceBaseTest {
             return "org.apache.pulsar.proxy.server.ProxyConfigurationTest.ExceptionAuthentication2";
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
             // no-op

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -263,6 +263,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
     /**
      * test auto create partitioned topic by proxy.
      **/
+    @SuppressWarnings("deprecation")
     @Test
     public void testAutoCreateTopic() throws Exception{
         TopicType originalAllowAutoTopicCreationType = pulsar.getConfiguration().getAllowAutoTopicCreationType();
@@ -559,6 +560,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete(topic);
     }
 
+    @SuppressWarnings("deprecation")
     private PulsarClient getClientActiveConsumerChangeNotSupported(ClientConfigurationData conf)
             throws Exception {
         ThreadFactory threadFactory = new DefaultThreadFactory("pulsar-client-io", Thread.currentThread().isDaemon());

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -66,6 +66,7 @@ import org.testng.collections.Maps;
 public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(ProxyWithAuthorizationTest.class);
     private static final String CLUSTER_NAME = "proxy-authorization";
+@SuppressWarnings("deprecation")
 
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
     private static final String CLIENT_TOKEN = AuthTokenUtils.createToken(SECRET_KEY, "Client", Optional.empty());
@@ -534,6 +535,7 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         };
     }
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "tlsTransportWithAuth")
     public void testProxyTlsTransportWithAuth(Authentication auth) throws Exception {
         log.info("-- Starting {} test --", methodName);

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithJwtAuthorizationTest.java
@@ -72,11 +72,16 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
     private static final String PROXY_ROLE = "proxy";
     private static final String BROKER_ROLE = "broker";
     private static final String CLIENT_ROLE = "client";
+    @SuppressWarnings("deprecation")
     private static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+@SuppressWarnings("deprecation")
 
     private static final String ADMIN_TOKEN = Jwts.builder().setSubject(ADMIN_ROLE).signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
     private static final String PROXY_TOKEN = Jwts.builder().setSubject(PROXY_ROLE).signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
     private static final String BROKER_TOKEN = Jwts.builder().setSubject(BROKER_ROLE).signWith(SECRET_KEY).compact();
+    @SuppressWarnings("deprecation")
     private static final String CLIENT_TOKEN = Jwts.builder().setSubject(CLIENT_ROLE).signWith(SECRET_KEY).compact();
 
     private ProxyService proxyService;
@@ -490,6 +495,7 @@ public class ProxyWithJwtAuthorizationTest extends ProducerConsumerBase {
                 .authentication(AuthenticationFactory.token(ADMIN_TOKEN)).build());
     }
 
+    @SuppressWarnings("deprecation")
     private PulsarClient createPulsarClient(String proxyServiceUrl, ClientBuilder clientBuilder)
             throws PulsarClientException {
         return clientBuilder.serviceUrl(proxyServiceUrl).statsInterval(0, TimeUnit.SECONDS)

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -155,6 +155,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testDiscoveryService() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -204,6 +205,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @SuppressWarnings("deprecation")
     protected final PulsarClient createPulsarClient(Authentication auth, String lookupUrl) throws Exception {
         closeAdmin();
         admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/Oauth2PerformanceTransactionTest.java
@@ -124,6 +124,7 @@ public class Oauth2PerformanceTransactionTest extends ProducerConsumerBase {
     }
 
     // setup both admin and pulsar client
+    @SuppressWarnings("deprecation")
     protected final void clientSetup() throws Exception {
         Path path = Paths.get(CREDENTIALS_FILE).toAbsolutePath();
         log.info("Credentials File path: {}", path);

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerfClientUtilsTest.java
@@ -40,6 +40,7 @@ public class PerfClientUtilsTest {
             return null;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void configure(Map<String, String> authParams) {
         }

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceTransactionTest.java
@@ -90,6 +90,7 @@ public class PerformanceTransactionTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTxnPerf() throws Exception {
         String argString = "--topics-c %s --topics-p %s -threads 1 -ntxn 50 -u %s -ss %s -rs -np 1 -au %s";

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/WebSocketHttpServletRequestWrapperTest.java
@@ -64,6 +64,7 @@ public class WebSocketHttpServletRequestWrapperTest {
                 BEARER_TOKEN);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void mockRequestTest() throws Exception {
         WebSocketProxyConfiguration config = PulsarConfigurationLoader.create(

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/admin/WebSocketWebResourceTest.java
@@ -66,6 +66,7 @@ public class WebSocketWebResourceTest {
     @Mock
     private UriInfo uri;
 
+    @SuppressWarnings("deprecation")
     @BeforeMethod
     public void setup(Method method) throws Exception {
         MockitoAnnotations.openMocks(this);

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/MockManagedLedger.java
@@ -342,6 +342,7 @@ public class MockManagedLedger implements ManagedLedger {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void rollCurrentLedgerIfFull() {
 


### PR DESCRIPTION
## Motivation

Suppress `deprecation` compiler warnings in test code. Test code intentionally tests deprecated APIs to ensure backward compatibility — these warnings are expected and cannot be fixed by migrating away from the deprecated API.

This is part of a series to clean up test compile warnings (following production code cleanup in #25414-#25422).

## Changes

- Add `@SuppressWarnings("deprecation")` at method or variable level for tests that exercise deprecated APIs
- Common deprecated APIs tested: `SignatureAlgorithm`, `statsInterval()`, `enableTls()`, various admin API methods
- Scope suppressions narrowly to the method or variable, never at class level

Affects ~247 files across all modules.

## Verifying this change

- `./gradlew compileTestJava` passes cleanly
- `deprecation` warning count drops to zero

### Does this pull request potentially affect one of the following areas?

- [x] *Test code only*

### Documentation

- [x] `doc-not-needed` — test-only changes