### PR TITLE
[fix][ml] Fix concurrent cursor properties update race

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -423,6 +423,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             final Function<Map<String, String>, Map<String, String>> updateFunction) {
         CompletableFuture<Void> updateCursorPropertiesResult = new CompletableFuture<>();
 
+        final Stat lastCursorLedgerStat = ManagedCursorImpl.this.cursorLedgerStat;
+
         Map<String, String> newProperties = updateFunction.apply(ManagedCursorImpl.this.cursorProperties);
         if (!isDurable()) {
             this.cursorProperties = Collections.unmodifiableMap(newProperties);
@@ -434,7 +436,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         copy.copyFrom(ManagedCursorImpl.this.managedCursorInfo);
         copy.clearCursorProperties();
         copy.addAllCursorProperties(buildStringPropertiesMap(newProperties));
-        final Stat lastCursorLedgerStat = ManagedCursorImpl.this.cursorLedgerStat;
+
         ledger.getStore().asyncUpdateCursorInfo(ledger.getName(),
                 name, copy, lastCursorLedgerStat, new MetaStoreCallback<>() {
                     @Override


### PR DESCRIPTION
Fixes #25390

### Motivation

The test `ManagedCursorPropertiesTest.testUpdateCursorPropertiesConcurrent` is flaky. The test performs 3 property updates concurrently. It happens that an update is lost, and then the test fails.

It seems the changes in #22411 introduced the flakiness. Before the PR, the order of lines in `ManagedCursorImpl.computeCursorProperties()` was:

```java
final Stat lastCursorLedgerStat = ManagedCursorImpl.this.cursorLedgerStat;
Map<String, String> newProperties = updateFunction.apply(ManagedCursorImpl.this.cursorProperties);
...
ledger.getStore().asyncUpdateCursorInfo(...)
```

In the PR, it was changed to:

```java
Map<String, String> newProperties = updateFunction.apply(ManagedCursorImpl.this.cursorProperties);
...
final Stat lastCursorLedgerStat = ManagedCursorImpl.this.cursorLedgerStat;
ledger.getStore().asyncUpdateCursorInfo(...)
```

`cursorLedgerStat` contains the version that is used when updating in the MetadataStore and that is checked against the current version of the stored data. If the `cursorLedgerStat`/version is read after the `newProperties` are calculated, an update applied on outdated cursor properties may succeed. 
If the order is changed back again, and the `cursorLedgerStat`/version is read before `newProperties` are calculated, this should not happen anymore.

### Modifications

This PR changes back the order to what it was before #22411. The test introduced in #22411 still passes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/pdolif/pulsar/pull/22