### PR TITLE
[fix][broker]Producer with AUTO_PRODUCE schema failed to reconnect, which caused by schema incompatible

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
@@ -99,8 +99,8 @@ public class OneWayReplicatorSchemaValidationEnforcedTest extends OneWayReplicat
         });
     }
 
-    @Test(timeOut = 30000, invocationCount = 1)
-    public void testReplicationReconnectWithSchemaValidationEnforced2() throws Exception {
+    @Test(timeOut = 30000)
+    public void testReplicationReconnectWithSchemaValidationEnforced() throws Exception {
         Schema<MyClass> myClassSchema = Schema.AVRO(MyClass.class);
         final String topicName =
                 BrokerTestUtil.newUniqueName("persistent://" + sourceClusterAlwaysSchemaCompatibleNamespace + "/tp_");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorSchemaValidationEnforcedTest.java
@@ -24,7 +24,6 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
@@ -79,7 +78,7 @@ public class OneWayReplicatorSchemaValidationEnforcedTest extends OneWayReplicat
         admin2.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
 
         // consume from the remote cluster (r2)
-        Consumer<MyClass> consumer2 = client2.newConsumer(myClassSchema)
+        org.apache.pulsar.client.api.Consumer<MyClass> consumer2 = client2.newConsumer(myClassSchema)
                 .topic(topicName).subscriptionName("sub").subscribe();
 
         // produce to local cluster (r1)
@@ -98,6 +97,27 @@ public class OneWayReplicatorSchemaValidationEnforcedTest extends OneWayReplicat
             assertThat(receivedBody.getField2()).isEqualTo("test");
             assertThat(receivedBody.getField3()).isEqualTo(123456789L);
         });
+    }
+
+    @Test(timeOut = 30000, invocationCount = 1)
+    public void testReplicationReconnectWithSchemaValidationEnforced2() throws Exception {
+        Schema<MyClass> myClassSchema = Schema.AVRO(MyClass.class);
+        final String topicName =
+                BrokerTestUtil.newUniqueName("persistent://" + sourceClusterAlwaysSchemaCompatibleNamespace + "/tp_");
+        // With the creation of the topic, replication will be initiated.
+        // The schema that the internal producer of replication holes will be "Auto_producer -> bytes".
+        admin1.topics().createNonPartitionedTopic(topicName);
+        waitReplicatorStarted(topicName);
+        // Registers new scheme on the remote-side.
+        admin2.schemas().createSchema(topicName, myClassSchema.getSchemaInfo());
+        // After a reconnection, the schema that the internal producer of replication holes should be
+        // "Auto_producer -> myClassSchema".
+        ServerCnx serverCnx2 = (ServerCnx) pulsar2.getBrokerService().getTopic(topicName, false).get().get()
+                .getProducers().values().iterator().next().getCnx();
+        serverCnx2.ctx().channel().close();
+        // Verify: the producer reconnected successfully.
+        Thread.sleep(2000);
+        waitReplicatorStarted(topicName);
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -86,6 +86,7 @@ import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
 import org.apache.pulsar.client.impl.metrics.Unit;
 import org.apache.pulsar.client.impl.metrics.UpDownCounter;
+import org.apache.pulsar.client.impl.schema.AutoProduceBytesSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
@@ -2018,6 +2019,16 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 // drops the producer on its side
                 cnx.channel().close();
                 future.complete(null);
+                return null;
+            }
+
+            if (cause instanceof PulsarClientException.IncompatibleSchemaException
+                    && schema instanceof AutoProduceBytesSchema autoProduceBytesSchema
+                    && !autoProduceBytesSchema.hasUserProvidedSchema()) {
+                client.reloadSchemaForAutoProduceProducer(topic, autoProduceBytesSchema)
+                    .thenAccept(__ -> {
+                        future.completeExceptionally(cause);
+                    });
                 return null;
             }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -2026,7 +2026,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     && schema instanceof AutoProduceBytesSchema autoProduceBytesSchema
                     && !autoProduceBytesSchema.hasUserProvidedSchema()) {
                 client.reloadSchemaForAutoProduceProducer(topic, autoProduceBytesSchema)
-                    .thenAccept(__ -> {
+                    .whenComplete((__, throwable) -> {
                         future.completeExceptionally(cause);
                     });
                 return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -421,24 +421,27 @@ public class PulsarClientImpl implements PulsarClient {
             if (autoProduceBytesSchema.hasUserProvidedSchema()) {
                 return createProducerAsync(topic, conf, schema, interceptors);
             }
-            return lookup.getSchema(TopicName.get(conf.getTopicName()))
-                    .thenCompose(schemaInfoOptional -> {
-                        if (schemaInfoOptional.isPresent()) {
-                            SchemaInfo schemaInfo = schemaInfoOptional.get();
-                            if (schemaInfo.getType() == SchemaType.PROTOBUF) {
-                                autoProduceBytesSchema.setSchema(new GenericAvroSchema(schemaInfo));
-                            } else {
-                                autoProduceBytesSchema.setSchema(Schema.getSchema(schemaInfo));
-                            }
-                        } else {
-                            autoProduceBytesSchema.setSchema(Schema.BYTES);
-                        }
-                        return createProducerAsync(topic, conf, schema, interceptors);
-                    });
+            return reloadSchemaForAutoProduceProducer(topic, autoProduceBytesSchema)
+                    .thenCompose(schemaInfoOptional -> createProducerAsync(topic, conf, schema, interceptors));
         } else {
             return createProducerAsync(topic, conf, schema, interceptors);
         }
 
+    }
+
+    public CompletableFuture<Void> reloadSchemaForAutoProduceProducer(String topic, AutoProduceBytesSchema autoSchema) {
+        return lookup.getSchema(TopicName.get(topic)).thenAccept(schemaInfoOptional -> {
+            if (schemaInfoOptional.isPresent()) {
+                SchemaInfo schemaInfo = schemaInfoOptional.get();
+                if (schemaInfo.getType() == SchemaType.PROTOBUF) {
+                    autoSchema.setSchema(new GenericAvroSchema(schemaInfo));
+                } else {
+                    autoSchema.setSchema(Schema.getSchema(schemaInfo));
+                }
+            } else {
+                autoSchema.setSchema(Schema.BYTES);
+            }
+        });
     }
 
     private CompletableFuture<Integer> checkPartitions(String topic, boolean forceNoPartitioned,


### PR DESCRIPTION
### Motivation

**Background**
- Under schema-validation-enforced settings
- Create a producer with `AUTO_PRODUCE` schema
  - The producer started.
- Registers a new schema to the topic by Admin
- The producer reconnects
  - **(Highlight)Issue**:  the producer could reconnect with stale `AutoProduceBytesSchema (BYTES)`, which then became incompatible with the schema already registered on the cluster.

You can reproduce the issue with the new test `testReplicationReconnectWithSchemaValidationEnforced`

### Modifications

The goal is to make replication recover automatically: when an `IncompatibleSchemaException` occurs, refresh the topic schema and retry producer creation so the replication pipeline can resume.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x