### PR TITLE
[improve][build] Use public Gradle build scans for PRs

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Setup Gradle
+description: Sets up Gradle with Develocity or public build scan publishing by default
+inputs:
+  develocity-access-key:
+    description: 'Develocity access key for authenticated build scans'
+    required: false
+    default: ''
+  build-scan-publish:
+    description: 'Whether to publish build scans or use Develocity when the access key is set'
+    required: false
+    default: 'true'
+  cache-read-only:
+    description: 'Whether the Gradle cache is read-only'
+    required: false
+    default: ${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}
+  add-job-summary:
+    description: 'When to add a job summary'
+    required: false
+    default: 'always'
+runs:
+  using: composite
+  steps:
+    - name: Setup Gradle with Develocity
+      if: ${{ inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true' }}
+      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      with:
+        develocity-injection-enabled: true
+        develocity-url: https://develocity.apache.org
+        develocity-access-key: ${{ inputs.develocity-access-key }}
+        cache-read-only: ${{ inputs.cache-read-only }}
+        add-job-summary: ${{ inputs.add-job-summary }}
+
+    - name: Setup Gradle
+      if: ${{ !(inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true') }}
+      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      with:
+        build-scan-publish: ${{ inputs.build-scan-publish }}
+        build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+        build-scan-terms-of-use-agree: 'yes'
+        cache-read-only: ${{ inputs.cache-read-only }}
+        add-job-summary: ${{ inputs.add-job-summary }}

--- a/.github/actions/ssh-access/action.yml
+++ b/.github/actions/ssh-access/action.yml
@@ -138,7 +138,8 @@ runs:
             if command -v upterm &>/dev/null; then
                 shopt -s nullglob
                 echo "SSH connection information"
-                upterm session current --admin-socket ~/.upterm/*.sock || {
+                export UPTERM_ADMIN_SOCKET=$(find $HOME/.upterm $XDG_RUNTIME_DIR/upterm /run/user/$(id -u)/upterm -name "*.sock" | head -n 1)
+                upterm session current || {
                     echo "upterm isn't running. Not waiting any longer."
                     exit 0
                 }
@@ -146,7 +147,7 @@ runs:
                 echo "Waiting $timeout seconds..."
                 sleep $timeout
                 echo "Keep waiting as long as there's a connected session"
-                while upterm session current --admin-socket ~/.upterm/*.sock|grep Connected &>/dev/null; do
+                while upterm session current|grep Connected &>/dev/null; do
                     sleep 30
                 done
                 echo "No session is connected. Not waiting any longer."

--- a/.github/workflows/ci-go-functions.yaml
+++ b/.github/workflows/ci-go-functions.yaml
@@ -31,9 +31,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  MAVEN_OPTS: -Xss1500k -Xmx1024m -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.serviceUnavailableRetryStrategy.class=standard -Dmaven.wagon.rto=60000
-
 jobs:
   preconditions:
     name: Preconditions

--- a/.github/workflows/ci-gradle-cache-update.yaml
+++ b/.github/workflows/ci-gradle-cache-update.yaml
@@ -65,7 +65,10 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: false
 
       - name: Run Gradle build
         run: |

--- a/.github/workflows/ci-semantic-pull-request.yml
+++ b/.github/workflows/ci-semantic-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
     name: Check pull request title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.2
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -62,10 +62,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: true
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,10 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     permissions:

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -166,7 +166,6 @@ jobs:
     env:
       JOB_NAME: Flaky tests suite
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       TRACE_TEST_RESOURCE_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trace_test_resource_cleanup || 'off' }}
       TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
@@ -203,11 +202,10 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache-read-only: false
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
 
       - name: Run unit test group BROKER_FLAKY
         run: |

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -219,13 +219,6 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
 
-      - name: Publish Test Report
-        uses: apache/pulsar-test-infra/action-junit-report@master
-        if: ${{ always() }}
-        with:
-          report_paths: 'test-reports/TEST-*.xml'
-          annotate_only: 'true'
-
       - name: Report detected thread leaks
         if: ${{ always() }}
         run: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -149,7 +149,6 @@ jobs:
     name: Build and License check
     env:
       JOB_NAME: Build and License check
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -176,15 +175,12 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: false
 
       - name: Build, check licenses and code style
-        # --no-configuration-cache: Shadow plugin's filesMatching { filter { } } lambdas
-        # capture Gradle script references that can't be serialized by the configuration cache.
         run: >-
           ./gradlew assemble rat spotlessCheck checkstyleMain checkstyleTest
           --no-configuration-cache
@@ -232,7 +228,6 @@ jobs:
     name: CI - Unit - ${{ matrix.name }}
     env:
       JOB_NAME: CI - Unit - ${{ matrix.name }}
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       TRACE_TEST_RESOURCE_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trace_test_resource_cleanup || 'off' }}
       TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/build/trace-test-resource-cleanup
@@ -303,11 +298,9 @@ jobs:
           java-version: ${{ matrix.jdk || env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Restore build outputs from build job
         uses: actions/download-artifact@v8
@@ -393,7 +386,6 @@ jobs:
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
@@ -409,11 +401,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Build with Gradle
         run: ./gradlew assemble
@@ -425,7 +415,6 @@ jobs:
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
@@ -448,11 +437,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Restore build outputs from build job
         uses: actions/download-artifact@v8
@@ -493,7 +480,6 @@ jobs:
     env:
       JOB_NAME: CI - Integration - ${{ matrix.name }}
       PULSAR_TEST_IMAGE_NAME: apachepulsar/java-test-image:latest
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     strategy:
       fail-fast: false
@@ -562,11 +548,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Restore build outputs from build job
         uses: actions/download-artifact@v8
@@ -661,7 +645,6 @@ jobs:
     needs: ['preconditions', 'build-and-license-check']
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     steps:
       - name: checkout
@@ -684,11 +667,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Restore build outputs from build job
         uses: actions/download-artifact@v8
@@ -754,7 +735,6 @@ jobs:
     env:
       JOB_NAME: CI - System - ${{ matrix.name }}
       PULSAR_TEST_IMAGE_NAME: apachepulsar/pulsar-test-latest-version:latest
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
     strategy:
       fail-fast: false
@@ -802,11 +782,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Restore build outputs from build job
         uses: actions/download-artifact@v8
@@ -893,7 +871,6 @@ jobs:
       contents: read
       security-events: write
     env:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       CODEQL_LANGUAGE: java-kotlin
     steps:
@@ -918,11 +895,9 @@ jobs:
           java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+        uses: ./.github/actions/setup-gradle
         with:
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          add-job-summary: always
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -327,13 +327,6 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
 
-      - name: Publish Test Report
-        uses: apache/pulsar-test-infra/action-junit-report@master
-        if: ${{ always() }}
-        with:
-          report_paths: 'test-reports/TEST-*.xml'
-          annotate_only: 'true'
-
       - name: Report detected thread leaks
         if: ${{ always() }}
         run: |
@@ -593,13 +586,6 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
 
-      - name: Publish Test Report
-        uses: apache/pulsar-test-infra/action-junit-report@master
-        if: ${{ always() }}
-        with:
-          report_paths: 'test-reports/TEST-*.xml'
-          annotate_only: 'true'
-
       - name: Upload test reports
         uses: actions/upload-artifact@v7
         if: ${{ !success() }}
@@ -814,13 +800,6 @@ jobs:
       - name: Aggregate test reports to ./test-reports directory
         if: ${{ always() }}
         uses: ./.github/actions/copy-test-reports
-
-      - name: Publish Test Report
-        uses: apache/pulsar-test-infra/action-junit-report@master
-        if: ${{ always() }}
-        with:
-          report_paths: 'test-reports/TEST-*.xml'
-          annotate_only: 'true'
 
       - name: Upload test reports
         uses: actions/upload-artifact@v7

--- a/pulsar-build/run_unit_group_gradle.sh
+++ b/pulsar-build/run_unit_group_gradle.sh
@@ -45,9 +45,6 @@ function gradle_test() {
       continue_args="--continue"
     fi
     echo "::group::Run tests for " "$@"
-    # --no-configuration-cache: required because the Shadow plugin's filesMatching { filter { } }
-    # lambdas in shaded JAR builds capture Gradle script references that can't be serialized.
-    # This is a known Shadow plugin limitation tracked upstream.
     ./gradlew --no-configuration-cache $continue_args "$@" $failfast_args "${COMMANDLINE_ARGS[@]}"
     echo "::endgroup::"
     set +x


### PR DESCRIPTION
### Motivation

When PRs are submitted from forks, the `DEVELOCITY_ACCESS_KEY` secret is not available, so Gradle build scans are not published. This change introduces a fallback to public Gradle build scans using the terms-of-service agreement flow, ensuring build scan links are available for all PR builds regardless of secret access.

### Modifications

- Created a new composite action `.github/actions/setup-gradle/action.yml` that centralizes Gradle setup logic:
  - When `develocity-access-key` is provided and `build-scan-publish` is `true`: uses Develocity injection with the Apache Develocity server
  - Otherwise: falls back to public build scan publishing with terms-of-service acceptance
  - Accepts passthrough inputs: `cache-read-only`, `add-job-summary`, `build-scan-publish`
  - `cache-read-only` defaults based on whether the current ref is the default branch (`github.event.repository.default_branch`)
  - `add-job-summary` defaults to `always`
- Updated all 4 workflow files (12 total usages) to use the new composite action:
  - `pulsar-ci.yaml` (9 usages)
  - `pulsar-ci-flaky.yaml` (1 usage)
  - `codeql.yaml` (1 usage)
  - `ci-gradle-cache-update.yaml` (1 usage)
- Removed `DEVELOCITY_ACCESS_KEY` environment variable declarations from job-level env blocks — the secret is now passed directly as the action input
- Removed `action-junit-report` steps since build scans provide test reporting
- Fixed `ssh-access` action to use `UPTERM_ADMIN_SOCKET` environment variable instead of `--admin-socket` flag with glob pattern
- Removed redundant comments in `run_unit_group_gradle.sh`
- Upgraded `amannn/action-semantic-pull-request` from v5.5.2 to v6.1.1 (pinned to commit hash). The v6.0.0 breaking change is internal only (Node.js 24 / ESM upgrade), no action API changes.
- Removed unused `MAVEN_OPTS` env block from `ci-go-functions.yaml`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests — CI workflow runs will validate that Gradle setup works correctly with and without the Develocity access key.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: https://github.com/lhotari/pulsar/pull/new/lh-use-build-scans-for-prs