### PR TITLE
[improve][build] Upgrade Checkstyle from 10.14.2 to 13.3.0

### DIFF
--- a/buildtools/src/main/resources/pulsar/checkstyle.xml
+++ b/buildtools/src/main/resources/pulsar/checkstyle.xml
@@ -21,7 +21,7 @@
 -->
 <!DOCTYPE module PUBLIC
         "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- This is a checkstyle configuration file. For descriptions of
 what the following rules do, please see the checkstyle configuration

--- a/buildtools/src/main/resources/pulsar/suppressions.xml
+++ b/buildtools/src/main/resources/pulsar/suppressions.xml
@@ -21,7 +21,7 @@
 -->
 <!DOCTYPE suppressions PUBLIC
         "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+        "https://checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <suppressions>
     <suppress checks="JavadocPackage" files=".*[\\/]src[\\/]test[\\/].*"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ java = "17"
 docker-jdk = "21"
 pulsar-client-python = "3.10.0"
 # Code quality
-checkstyle = "10.14.2"
+checkstyle = "13.3.0"
 # Major frameworks
 bookkeeper = "4.17.3"
 zookeeper = "3.9.5"


### PR DESCRIPTION
### Motivation

Upgrade Checkstyle from 10.14.2 to 13.3.0 to get the latest rule improvements, bug fixes, and Java 21 support. The old DTD URLs pointing to `puppycrawl.com` are deprecated and have been updated to `checkstyle.org`.

### Modifications

- Updated Checkstyle version from `10.14.2` to `13.3.0` in `gradle/libs.versions.toml`
- Updated DTD URL in `buildtools/src/main/resources/pulsar/checkstyle.xml` from `http://www.puppycrawl.com/dtds/configuration_1_3.dtd` to `https://checkstyle.org/dtds/configuration_1_3.dtd`
- Updated DTD URL in `buildtools/src/main/resources/pulsar/suppressions.xml` from `http://www.puppycrawl.com/dtds/suppressions_1_1.dtd` to `https://checkstyle.org/dtds/suppressions_1_1.dtd`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally with `./gradlew checkstyleMain checkstyleTest` — all 303 tasks passed successfully.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->