### PR TITLE
[improve][build] Fix and enable configure-on-demand for Gradle builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,6 @@ import com.github.vlsi.gradle.git.dsl.gitignore
 import org.jetbrains.gradle.ext.copyright
 import org.jetbrains.gradle.ext.settings
 
-buildscript {
-    // The license plugin pulls in plexus-utils:2.0.6 which conflicts with
-    // the Shadow plugin's plexus-utils:4.0.2 (missing 4-arg matchPath method).
-    // Force the newer version to avoid NoSuchMethodError at shading time.
-    configurations.classpath {
-        resolutionStrategy.force("org.codehaus.plexus:plexus-utils:4.0.2")
-    }
-}
-
 plugins {
     alias(libs.plugins.rat)
     alias(libs.plugins.version.catalog.update)

--- a/distribution/offloaders/build.gradle.kts
+++ b/distribution/offloaders/build.gradle.kts
@@ -43,12 +43,6 @@ dependencies {
     offloaderNars(project(":tiered-storage:tiered-storage-file-system"))
 }
 
-// Consumable configuration exposing the offloader distribution tarball
-val offloaderDistElements by configurations.creating {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-}
-
 val offloaderDistTar by tasks.registering(Tar::class) {
     val baseDir = "apache-pulsar-offloaders-${pulsarVersion}"
 
@@ -72,8 +66,13 @@ val offloaderDistTar by tasks.registering(Tar::class) {
     }
 }
 
-artifacts {
-    add("offloaderDistElements", offloaderDistTar)
+// Consumable configuration exposing the offloader distribution tarball
+val offloaderDistElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    outgoing {
+        artifact(offloaderDistTar)
+    }
 }
 
 tasks.named("assemble") {

--- a/distribution/offloaders/build.gradle.kts
+++ b/distribution/offloaders/build.gradle.kts
@@ -43,6 +43,12 @@ dependencies {
     offloaderNars(project(":tiered-storage:tiered-storage-file-system"))
 }
 
+// Consumable configuration exposing the offloader distribution tarball
+val offloaderDistElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
 val offloaderDistTar by tasks.registering(Tar::class) {
     val baseDir = "apache-pulsar-offloaders-${pulsarVersion}"
 
@@ -64,6 +70,10 @@ val offloaderDistTar by tasks.registering(Tar::class) {
     from(offloaderNars) {
         into("${baseDir}/offloaders")
     }
+}
+
+artifacts {
+    add("offloaderDistElements", offloaderDistTar)
 }
 
 tasks.named("assemble") {

--- a/distribution/server/build.gradle.kts
+++ b/distribution/server/build.gradle.kts
@@ -26,6 +26,9 @@ tasks.named("compileJava") { enabled = false }
 tasks.named("compileTestJava") { enabled = false }
 tasks.named("jar") { enabled = false }
 
+evaluationDependsOn(":pulsar-functions:pulsar-functions-runtime-all")
+evaluationDependsOn(":pulsar-functions:pulsar-functions-api-examples")
+
 val bookkeeperVersion: String = libs.versions.bookkeeper.get()
 val zookeeperVersion: String = libs.versions.zookeeper.get()
 val kotlinStdlibVersion: String = libs.versions.kotlin.stdlib.get()

--- a/distribution/server/build.gradle.kts
+++ b/distribution/server/build.gradle.kts
@@ -197,12 +197,6 @@ dependencies {
 val pulsarVersion = project.version.toString()
 val rootDir = rootProject.projectDir
 
-// Consumable configuration exposing the server distribution tarball
-val serverDistElements by configurations.creating {
-    isCanBeConsumed = true
-    isCanBeResolved = false
-}
-
 val serverDistTar by tasks.registering(Tar::class) {
     archiveBaseName.set("apache-pulsar")
     archiveVersion.set(pulsarVersion)
@@ -343,8 +337,13 @@ val serverDistTar by tasks.registering(Tar::class) {
     }
 }
 
-artifacts {
-    add("serverDistElements", serverDistTar)
+// Consumable configuration exposing the server distribution tarball
+val serverDistElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    outgoing {
+        artifact(serverDistTar)
+    }
 }
 
 tasks.named("assemble") {

--- a/distribution/server/build.gradle.kts
+++ b/distribution/server/build.gradle.kts
@@ -26,9 +26,6 @@ tasks.named("compileJava") { enabled = false }
 tasks.named("compileTestJava") { enabled = false }
 tasks.named("jar") { enabled = false }
 
-evaluationDependsOn(":pulsar-functions:pulsar-functions-runtime-all")
-evaluationDependsOn(":pulsar-functions:pulsar-functions-api-examples")
-
 val bookkeeperVersion: String = libs.versions.bookkeeper.get()
 val zookeeperVersion: String = libs.versions.zookeeper.get()
 val kotlinStdlibVersion: String = libs.versions.kotlin.stdlib.get()
@@ -76,6 +73,20 @@ val distLib by configurations.creating {
     exclude(group = "com.google.android", module = "annotations")
     // Annotation libraries not needed at runtime
     exclude(group = "org.codehaus.mojo", module = "animal-sniffer-annotations")
+}
+
+// Resolvable configurations for cross-project artifact dependencies.
+// Using configurations instead of direct task references (project().tasks.named())
+// ensures compatibility with Gradle's configure-on-demand feature.
+val runtimeAllShadowJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+val apiExamplesJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
 }
 
 dependencies {
@@ -177,10 +188,20 @@ dependencies {
 
     // pulsar-broker-common test jar is included in Maven server dist
     // but requires test-fixtures support in pulsar-broker-common; skipped for now
+
+    // Cross-project artifact dependencies for the server distribution tarball
+    runtimeAllShadowJar(project(path = ":pulsar-functions:pulsar-functions-runtime-all", configuration = "shadowJarElements"))
+    apiExamplesJar(project(":pulsar-functions:pulsar-functions-api-examples"))
 }
 
 val pulsarVersion = project.version.toString()
 val rootDir = rootProject.projectDir
+
+// Consumable configuration exposing the server distribution tarball
+val serverDistElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
 
 val serverDistTar by tasks.registering(Tar::class) {
     archiveBaseName.set("apache-pulsar")
@@ -297,13 +318,13 @@ val serverDistTar by tasks.registering(Tar::class) {
     }
 
     // Java instance JAR (runtime-all fat jar, produced by Shadow plugin)
-    from(project(":pulsar-functions:pulsar-functions-runtime-all").tasks.named("shadowJar")) {
+    from(runtimeAllShadowJar) {
         into("${baseDir}/instances")
         rename(".*", "java-instance.jar")
     }
 
     // Java examples JAR
-    from(project(":pulsar-functions:pulsar-functions-api-examples").tasks.named("jar")) {
+    from(apiExamplesJar) {
         into("${baseDir}/examples")
         rename(".*", "api-examples.jar")
     }
@@ -320,6 +341,10 @@ val serverDistTar by tasks.registering(Tar::class) {
     into("${baseDir}/instances/deps") {
         from(files())
     }
+}
+
+artifacts {
+    add("serverDistElements", serverDistTar)
 }
 
 tasks.named("assemble") {

--- a/docker/pulsar/build.gradle.kts
+++ b/docker/pulsar/build.gradle.kts
@@ -28,22 +28,32 @@ val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 val useWolfi = providers.gradleProperty("docker.wolfi").isPresent
 
-evaluationDependsOn(":distribution:pulsar-server-distribution")
-evaluationDependsOn(":distribution:pulsar-offloader-distribution")
-val serverDistTask = project(":distribution:pulsar-server-distribution").tasks.named("serverDistTar")
-val offloaderDistTask = project(":distribution:pulsar-offloader-distribution").tasks.named("offloaderDistTar")
+// Resolvable configurations for cross-project artifact dependencies.
+// Using configurations instead of direct task references (project().tasks.named())
+// ensures compatibility with Gradle's configure-on-demand feature.
+val serverDist by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+val offloaderDist by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    serverDist(project(path = ":distribution:pulsar-server-distribution", configuration = "serverDistElements"))
+    offloaderDist(project(path = ":distribution:pulsar-offloader-distribution", configuration = "offloaderDistElements"))
+}
 
 // Copy the server tarball into target/ (Docker build context)
 val copyTarball by tasks.registering(Copy::class) {
-    dependsOn(serverDistTask)
-    from(serverDistTask.map { (it as Tar).archiveFile })
+    from(serverDist)
     into(layout.buildDirectory.dir("target"))
 }
 
 // Copy offloader tarball into build context
 val copyOffloaderTarball by tasks.registering(Copy::class) {
-    dependsOn(offloaderDistTask)
-    from(offloaderDistTask.map { (it as Tar).archiveFile })
+    from(offloaderDist)
     into(layout.buildDirectory.dir("target"))
 }
 

--- a/docker/pulsar/build.gradle.kts
+++ b/docker/pulsar/build.gradle.kts
@@ -28,6 +28,8 @@ val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 val useWolfi = providers.gradleProperty("docker.wolfi").isPresent
 
+evaluationDependsOn(":distribution:pulsar-server-distribution")
+evaluationDependsOn(":distribution:pulsar-offloader-distribution")
 val serverDistTask = project(":distribution:pulsar-server-distribution").tasks.named("serverDistTar")
 val offloaderDistTask = project(":distribution:pulsar-offloader-distribution").tasks.named("offloaderDistTar")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@
 #
 
 org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -Xss2m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -135,6 +135,11 @@ dependencies {
     }
 }
 
+// Ensure parent projects are configured before resolving cross-project task references.
+// Required for --configure-on-demand: the Kotlin DSL needs parent ClassLoaderScopes to be locked.
+evaluationDependsOn(":pulsar-io")
+evaluationDependsOn(":pulsar-functions")
+
 // NAR/JAR files needed by broker tests (mirrors Maven's maven-dependency-plugin config).
 tasks.withType<Test> {
     dependsOn(

--- a/pulsar-functions/runtime-all/build.gradle.kts
+++ b/pulsar-functions/runtime-all/build.gradle.kts
@@ -51,10 +51,9 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 val shadowJarElements by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
-}
-
-artifacts {
-    add("shadowJarElements", tasks.named("shadowJar"))
+    outgoing {
+        artifact(tasks.named("shadowJar"))
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/pulsar-functions/runtime-all/build.gradle.kts
+++ b/pulsar-functions/runtime-all/build.gradle.kts
@@ -45,6 +45,18 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
     exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
 }
 
+// Consumable configuration exposing the shadow jar for cross-project dependencies.
+// Unlike pulsar.shadow-conventions (which replaces runtimeElements), this project
+// uses the Shadow plugin directly, so we create a dedicated configuration.
+val shadowJarElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+artifacts {
+    add("shadowJarElements", tasks.named("shadowJar"))
+}
+
 tasks.withType<Test>().configureEach {
     dependsOn(tasks.named("shadowJar"))
 }

--- a/tests/docker-images/java-test-image/build.gradle.kts
+++ b/tests/docker-images/java-test-image/build.gradle.kts
@@ -26,18 +26,31 @@ val dockerOrganization = providers.gradleProperty("docker.organization").getOrEl
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 
-// Dependencies: base pulsar image, java-test-functions jar, buildtools jar
-evaluationDependsOn(":docker:pulsar-docker-image")
-evaluationDependsOn(":tests:java-test-functions")
-evaluationDependsOn(":buildtools")
-val pulsarDockerBuild = project(":docker:pulsar-docker-image").tasks.named("dockerBuild")
-val testFunctionsJar = project(":tests:java-test-functions").tasks.named("shadowJar")
-val buildtoolsJar = project(":buildtools").tasks.named("jar")
+// Ensure the parent project is configured before resolving cross-project task references.
+// Required for --configure-on-demand: the Kotlin DSL needs parent ClassLoaderScopes to be locked.
+evaluationDependsOn(":docker")
+
+// Resolvable configurations for cross-project artifact dependencies.
+// Using configurations instead of direct task references (project().tasks.named())
+// ensures compatibility with Gradle's configure-on-demand feature.
+val testFunctionsJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+val buildtoolsJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+
+dependencies {
+    testFunctionsJar(project(":tests:java-test-functions"))
+    buildtoolsJar(project(":buildtools"))
+}
 
 // Prepare the build context in build/target/
 val prepareBuildContext by tasks.registering(Sync::class) {
-    dependsOn(testFunctionsJar, buildtoolsJar)
-
     // Copy scripts from docker/pulsar/scripts and latest-version-image/scripts
     from("${rootDir}/docker/pulsar/scripts") {
         into("scripts")
@@ -57,12 +70,12 @@ val prepareBuildContext by tasks.registering(Sync::class) {
     }
 
     // Copy java-test-functions.jar
-    from(testFunctionsJar.map { (it as Jar).archiveFile }) {
+    from(testFunctionsJar) {
         rename { "java-test-functions.jar" }
     }
 
     // Copy buildtools.jar
-    from(buildtoolsJar.map { (it as Jar).archiveFile }) {
+    from(buildtoolsJar) {
         rename { "buildtools.jar" }
     }
 
@@ -73,7 +86,7 @@ val dockerBuild by tasks.registering(Exec::class) {
     group = "docker"
     description = "Build the java-test-image Docker image"
 
-    dependsOn(pulsarDockerBuild, prepareBuildContext)
+    dependsOn(":docker:pulsar-docker-image:dockerBuild", prepareBuildContext)
 
     val imageName = "${dockerOrganization}/java-test-image:${dockerTag}"
     val pulsarImage = "${dockerOrganization}/pulsar:${dockerTag}"

--- a/tests/docker-images/java-test-image/build.gradle.kts
+++ b/tests/docker-images/java-test-image/build.gradle.kts
@@ -27,6 +27,9 @@ val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 
 // Dependencies: base pulsar image, java-test-functions jar, buildtools jar
+evaluationDependsOn(":docker:pulsar-docker-image")
+evaluationDependsOn(":tests:java-test-functions")
+evaluationDependsOn(":buildtools")
 val pulsarDockerBuild = project(":docker:pulsar-docker-image").tasks.named("dockerBuild")
 val testFunctionsJar = project(":tests:java-test-functions").tasks.named("shadowJar")
 val buildtoolsJar = project(":buildtools").tasks.named("jar")

--- a/tests/docker-images/latest-version-image/build.gradle.kts
+++ b/tests/docker-images/latest-version-image/build.gradle.kts
@@ -28,6 +28,10 @@ val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 val golangImage = providers.gradleProperty("docker.golang.image").getOrElse("golang:1.24-alpine")
 
 // Dependencies: pulsar image, java-test-functions jar, java-test-plugins jar, buildtools jar
+evaluationDependsOn(":docker:pulsar-docker-image")
+evaluationDependsOn(":tests:java-test-functions")
+evaluationDependsOn(":tests:java-test-plugins")
+evaluationDependsOn(":buildtools")
 val pulsarDockerBuild = project(":docker:pulsar-docker-image").tasks.named("dockerBuild")
 val testFunctionsJar = project(":tests:java-test-functions").tasks.named("shadowJar")
 val testPluginsJar = project(":tests:java-test-plugins").tasks.named("jar")

--- a/tests/docker-images/latest-version-image/build.gradle.kts
+++ b/tests/docker-images/latest-version-image/build.gradle.kts
@@ -27,20 +27,37 @@ val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
 val golangImage = providers.gradleProperty("docker.golang.image").getOrElse("golang:1.24-alpine")
 
-// Dependencies: pulsar image, java-test-functions jar, java-test-plugins jar, buildtools jar
-evaluationDependsOn(":docker:pulsar-docker-image")
-evaluationDependsOn(":tests:java-test-functions")
-evaluationDependsOn(":tests:java-test-plugins")
-evaluationDependsOn(":buildtools")
-val pulsarDockerBuild = project(":docker:pulsar-docker-image").tasks.named("dockerBuild")
-val testFunctionsJar = project(":tests:java-test-functions").tasks.named("shadowJar")
-val testPluginsJar = project(":tests:java-test-plugins").tasks.named("jar")
-val buildtoolsJar = project(":buildtools").tasks.named("jar")
+// Ensure the parent project is configured before resolving cross-project task references.
+// Required for --configure-on-demand: the Kotlin DSL needs parent ClassLoaderScopes to be locked.
+evaluationDependsOn(":docker")
+
+// Resolvable configurations for cross-project artifact dependencies.
+// Using configurations instead of direct task references (project().tasks.named())
+// ensures compatibility with Gradle's configure-on-demand feature.
+val testFunctionsJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+val testPluginsJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+val buildtoolsJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+
+dependencies {
+    testFunctionsJar(project(":tests:java-test-functions"))
+    testPluginsJar(project(":tests:java-test-plugins"))
+    buildtoolsJar(project(":buildtools"))
+}
 
 // Prepare the build context in target/ (to match Dockerfile COPY paths)
 val prepareBuildContext by tasks.registering(Sync::class) {
-    dependsOn(testFunctionsJar, testPluginsJar, buildtoolsJar)
-
     // Copy pulsar-function-go source
     from("${rootDir}/pulsar-function-go") {
         into("pulsar-function-go")
@@ -52,18 +69,18 @@ val prepareBuildContext by tasks.registering(Sync::class) {
     }
 
     // Copy java-test-functions.jar
-    from(testFunctionsJar.map { (it as Jar).archiveFile }) {
+    from(testFunctionsJar) {
         rename { "java-test-functions.jar" }
     }
 
     // Copy java-test-plugins as .nar
-    from(testPluginsJar.map { (it as Jar).archiveFile }) {
+    from(testPluginsJar) {
         rename { "java-test-plugins.nar" }
         into("plugins")
     }
 
     // Copy buildtools.jar
-    from(buildtoolsJar.map { (it as Jar).archiveFile }) {
+    from(buildtoolsJar) {
         rename { "buildtools.jar" }
     }
 
@@ -74,7 +91,7 @@ val dockerBuild by tasks.registering(Exec::class) {
     group = "docker"
     description = "Build the pulsar-test-latest-version Docker image"
 
-    dependsOn(pulsarDockerBuild, prepareBuildContext)
+    dependsOn(":docker:pulsar-docker-image:dockerBuild", prepareBuildContext)
 
     val imageName = "${dockerOrganization}/pulsar-test-latest-version:${dockerTag}"
     val pulsarImage = "${dockerOrganization}/pulsar:${dockerTag}"


### PR DESCRIPTION
### Motivation

When running Gradle with `--configure-on-demand` (or `org.gradle.configureondemand=true`), the build fails because cross-project task references attempt to access tasks in projects that haven't been configured yet.

Two distinct failure patterns were identified:
1. **ClassLoaderScope errors**: `pulsar-broker`'s test tasks declare cross-project task dependencies via `dependsOn` strings referencing child projects under `pulsar-io` and `pulsar-functions`. With configure-on-demand, the parent project's `ClassLoaderScope` was never locked, causing a configuration error.
2. **"Task not found" errors**: Docker image and distribution build scripts use `project(":other").tasks.named("task")` to reference tasks in other projects. With configure-on-demand, the target projects haven't been configured when these references are evaluated.

### Modifications

**ClassLoaderScope fix (parent project locking):**
- Added `evaluationDependsOn` for parent projects (`:pulsar-io`, `:pulsar-functions`, `:docker`) where the Kotlin DSL needs parent ClassLoaderScopes to be locked before child projects can be configured.

**Cross-project artifact sharing via consumable/resolvable configurations:**

Replaced all `project(":other").tasks.named("task")` cross-project task references with the Gradle-idiomatic [consumable/resolvable configuration pattern](https://docs.gradle.org/current/userguide/how_to_share_outputs_between_projects.html):

*Producer side* — added consumable configurations that expose artifacts:
- `distribution/server/build.gradle.kts` → `serverDistElements` (exposes `serverDistTar`)
- `distribution/offloaders/build.gradle.kts` → `offloaderDistElements` (exposes `offloaderDistTar`)
- `pulsar-functions/runtime-all/build.gradle.kts` → `shadowJarElements` (exposes `shadowJar`)

*Consumer side* — replaced direct task references with resolvable configurations + project dependencies:
- `docker/pulsar/build.gradle.kts` → `serverDist`, `offloaderDist` configurations
- `distribution/server/build.gradle.kts` → `runtimeAllShadowJar`, `apiExamplesJar` configurations
- `tests/docker-images/java-test-image/build.gradle.kts` → `testFunctionsJar`, `buildtoolsJar` configurations
- `tests/docker-images/latest-version-image/build.gradle.kts` → `testFunctionsJar`, `testPluginsJar`, `buildtoolsJar` configurations

For `dockerBuild` task dependency (Exec task with no artifact output), string task paths are used in `dependsOn`.

**Build configuration:**
- Enabled configure-on-demand by default in `gradle.properties` (`org.gradle.configureondemand=true`).
- Removed the `buildscript` block from root `build.gradle.kts` as it is incompatible with the build-logic composite build pattern and configure-on-demand.

### Verifying this change

This change is already covered by existing tests. The fix can be verified by running:
```
./gradlew :pulsar-broker:test --dry-run
./gradlew :tests:java-test-image:dockerBuild --dry-run
./gradlew :tests:latest-version-image:dockerBuild --dry-run
./gradlew :docker:pulsar-docker-image:dockerBuild --dry-run
./gradlew :distribution:pulsar-server-distribution:serverDistTar --dry-run
```
which previously failed and now succeed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`