### PR TITLE
[fix][broker]The partitions of the topic was wrongly created even though this cluster was not allowed to access it

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -550,7 +550,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalCreateMissedPartitions(AsyncResponse asyncResponse) {
-        pulsar().getBrokerService().isAllowedCurrentClusterAccess(topicName).thenAccept(allowed -> {
+        pulsar().getBrokerService().isCurrentClusterAllowed(topicName).thenAccept(allowed -> {
             if (!allowed) {
                 resumeAsyncResponseExceptionally(asyncResponse,
                     new RestException(Status.BAD_REQUEST, String.format("Topic [%s] is not allowed to be loaded"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -550,31 +550,39 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalCreateMissedPartitions(AsyncResponse asyncResponse) {
-        getPartitionedTopicMetadataAsync(topicName, false, false).thenAccept(metadata -> {
-            if (metadata != null && metadata.partitions > 0) {
-                validateNamespaceOperationAsync(topicName.getNamespaceObject(),
-                        NamespaceOperation.CREATE_TOPIC)
-                .thenCompose(__ -> tryCreatePartitionsAsync(metadata.partitions)).thenAccept(v -> {
-                    asyncResponse.resume(Response.noContent().build());
-                }).exceptionally(e -> {
-                    log.error()
-                            .attr("topic", topicName)
-                            .log("Failed to create partitions for topic");
-                    resumeAsyncResponseExceptionally(asyncResponse, e);
-                    return null;
-                });
-            } else {
-                throw new RestException(Status.NOT_FOUND, String.format("Topic %s does not exist", topicName));
+        pulsar().getBrokerService().isAllowedCurrentClusterAccess(topicName).thenAccept(allowed -> {
+            if (!allowed) {
+                resumeAsyncResponseExceptionally(asyncResponse,
+                    new RestException(Status.BAD_REQUEST, String.format("Topic [%s] is not allowed to be loaded"
+                        + " up on the current cluster, please recheck replication polices.", topicName)));
             }
-        }).exceptionally(ex -> {
-            // If the exception is not redirect exception we need to log it.
-            if (!isRedirectException(ex)) {
-                log.error()
+            getPartitionedTopicMetadataAsync(topicName, false, false).thenAccept(metadata -> {
+                if (metadata != null && metadata.partitions > 0) {
+                    validateNamespaceOperationAsync(topicName.getNamespaceObject(),
+                        NamespaceOperation.CREATE_TOPIC)
+                        .thenCompose(__ -> tryCreatePartitionsAsync(metadata.partitions)).thenAccept(v -> {
+                            asyncResponse.resume(Response.noContent().build());
+                        }).exceptionally(e -> {
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .log("Failed to create partitions for topic");
+                            resumeAsyncResponseExceptionally(asyncResponse, e);
+                            return null;
+                        });
+                } else {
+                    resumeAsyncResponseExceptionally(asyncResponse,
+                            new RestException(Status.NOT_FOUND, String.format("Topic %s does not exist", topicName)));
+                }
+            }).exceptionally(ex -> {
+                // If the exception is not redirect exception we need to log it.
+                if (!isRedirectException(ex)) {
+                    log.error()
                         .attr("topic", topicName)
                         .log("Failed to create partitions for topic");
-            }
-            resumeAsyncResponseExceptionally(asyncResponse, ex);
-            return null;
+                }
+                resumeAsyncResponseExceptionally(asyncResponse, ex);
+                return null;
+            });
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.ws.rs.WebApplicationException;
@@ -550,11 +551,21 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalCreateMissedPartitions(AsyncResponse asyncResponse) {
+        Consumer<Throwable> errorHandler = ex -> {
+            // If the exception is not redirect exception we need to log it.
+            if (!isRedirectException(ex)) {
+                log.error()
+                        .attr("topic", topicName)
+                        .log("Failed to create partitions for topic");
+            }
+            resumeAsyncResponseExceptionally(asyncResponse, ex);
+        };
         pulsar().getBrokerService().isCurrentClusterAllowed(topicName).thenAccept(allowed -> {
             if (!allowed) {
                 resumeAsyncResponseExceptionally(asyncResponse,
                     new RestException(Status.BAD_REQUEST, String.format("Topic [%s] is not allowed to be loaded"
                         + " up on the current cluster, please recheck replication polices.", topicName)));
+                return;
             }
             getPartitionedTopicMetadataAsync(topicName, false, false).thenAccept(metadata -> {
                 if (metadata != null && metadata.partitions > 0) {
@@ -574,15 +585,12 @@ public class PersistentTopicsBase extends AdminResource {
                             new RestException(Status.NOT_FOUND, String.format("Topic %s does not exist", topicName)));
                 }
             }).exceptionally(ex -> {
-                // If the exception is not redirect exception we need to log it.
-                if (!isRedirectException(ex)) {
-                    log.error()
-                        .attr("topic", topicName)
-                        .log("Failed to create partitions for topic");
-                }
-                resumeAsyncResponseExceptionally(asyncResponse, ex);
+                errorHandler.accept(ex);
                 return null;
             });
+        }).exceptionally(ex -> {
+            errorHandler.accept(ex);
+            return null;
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -94,11 +94,14 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerNotFoun
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.NonAppendableLedgerOffloader;
 import org.apache.bookkeeper.mledger.util.Futures;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.bookie.rackawareness.IsolatedBookieEnsemblePlacementPolicy;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -2076,6 +2079,69 @@ public class BrokerService implements Closeable {
         return result;
     }
 
+    /**
+     * @return Triple [namespace policies, global topic policies, topic policies].
+     */
+    public CompletableFuture<Boolean> isAllowedCurrentClusterAccess(@NonNull TopicName topicName) {
+        final String cluster = getPulsar().getConfig().getClusterName();
+        return getCombinedTopicPolicies(topicName).thenApply(triple -> {
+            Optional<TopicPolicies> topicP = triple.getRight();
+            Optional<TopicPolicies> globalTopicP = triple.getMiddle();
+            Optional<Policies> nsPolicies = triple.getLeft();
+            // Disabled a cluster for a namespace manually.
+            if (nsPolicies.isPresent() && !nsPolicies.get().allowed_clusters.isEmpty()
+                    && !nsPolicies.get().allowed_clusters.contains(cluster)) {
+                return false;
+            }
+            // Manually enabled topic-level replication, which can skip to set a namespace-level replication.
+            if (topicP.isPresent() && CollectionUtils.isNotEmpty(topicP.get().getReplicationClusters())) {
+                if (topicP.get().getReplicationClusters().contains(cluster)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            if (globalTopicP.isPresent() && CollectionUtils.isNotEmpty(globalTopicP.get().getReplicationClusters())) {
+                if (globalTopicP.get().getReplicationClusters().contains(cluster)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            // No settings for replication/allowed_clusters.
+            if (nsPolicies.isEmpty()) {
+                return true;
+            }
+            // Namespace level settings.
+            return nsPolicies.get().replication_clusters.isEmpty()
+                    || nsPolicies.get().replication_clusters.contains(cluster);
+        });
+    }
+
+    /**
+     * @return Triple [namespace policies, global topic policies, topic policies].
+     */
+    public CompletableFuture<Triple<Optional<Policies>, Optional<TopicPolicies>, Optional<TopicPolicies>>>
+    getCombinedTopicPolicies(@NonNull TopicName topicName) {
+        if (topicName == null) {
+            return FutureUtil.failedFuture(new NullPointerException("topicName"));
+        }
+        NamespaceName namespace = topicName.getNamespaceObject();
+        NamespaceResources nsr = pulsar.getPulsarResources().getNamespaceResources();
+        final CompletableFuture<Optional<TopicPolicies>> topicPoliciesFuture =
+                getTopicPoliciesBypassSystemTopic(topicName, TopicPoliciesService.GetType.LOCAL_ONLY);
+        final CompletableFuture<Optional<TopicPolicies>> globalTopicPoliciesFuture =
+                getTopicPoliciesBypassSystemTopic(topicName, TopicPoliciesService.GetType.GLOBAL_ONLY);
+        final CompletableFuture<Optional<Policies>> nsPolicies = nsr.getPoliciesAsync(namespace);
+        return topicPoliciesFuture.thenCombine(globalTopicPoliciesFuture, (topicP, globalTopicP) -> {
+            return new ImmutablePair<>(topicP, globalTopicP);
+        }).thenCombine(nsPolicies, (topicPoliciesPair, np) -> {
+            Optional<TopicPolicies> topicP = topicPoliciesPair.getLeft();
+            Optional<TopicPolicies> globalTopicP = topicPoliciesPair.getRight();
+            return new ImmutableTriple<>(np, globalTopicP, topicP);
+        });
+    }
+
     public CompletableFuture<ManagedLedgerConfig> getManagedLedgerConfig(@NonNull TopicName topicName) {
         if (topicName == null) {
             return FutureUtil.failedFuture(new NullPointerException("topicName"));
@@ -2083,22 +2149,12 @@ public class BrokerService implements Closeable {
         NamespaceName namespace = topicName.getNamespaceObject();
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
 
-        NamespaceResources nsr = pulsar.getPulsarResources().getNamespaceResources();
         LocalPoliciesResources lpr = pulsar.getPulsarResources().getLocalPolicies();
-        final CompletableFuture<Optional<TopicPolicies>> topicPoliciesFuture =
-                getTopicPoliciesBypassSystemTopic(topicName, TopicPoliciesService.GetType.LOCAL_ONLY);
-        final CompletableFuture<Optional<TopicPolicies>> globalTopicPoliciesFuture =
-                getTopicPoliciesBypassSystemTopic(topicName, TopicPoliciesService.GetType.GLOBAL_ONLY);
-        final CompletableFuture<Optional<Policies>> nsPolicies = nsr.getPoliciesAsync(namespace);
         final CompletableFuture<Optional<LocalPolicies>> lcPolicies = lpr.getLocalPoliciesAsync(namespace);
-        return topicPoliciesFuture.thenCombine(globalTopicPoliciesFuture, (topicP, globalTopicP) -> {
-            return new ImmutablePair<>(topicP, globalTopicP);
-        }).thenCombine(nsPolicies, (topicPoliciesPair, np) -> {
-            return new ImmutablePair<>(topicPoliciesPair, np);
-        }).thenCombine(lcPolicies, (combined, localPolicies) -> {
-            Optional<TopicPolicies> topicP = combined.getLeft().getLeft();
-            Optional<TopicPolicies> globalTopicP = combined.getLeft().getRight();
-            Optional<Policies> policies = combined.getRight();
+        return getCombinedTopicPolicies(topicName).thenCombine(lcPolicies, (combined, localPolicies) -> {
+            Optional<Policies> policies = combined.getLeft();
+            Optional<TopicPolicies> globalTopicP = combined.getMiddle();
+            Optional<TopicPolicies> topicP = combined.getRight();
 
             PersistencePolicies persistencePolicies = null;
             RetentionPolicies retentionPolicies = null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4181,8 +4181,7 @@ public class BrokerService implements Closeable {
                     return false;
                 }
             }
-            // No settings for replication/allowed_clusters.
-            return nsPolicies.isEmpty();
+            return true;
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4154,7 +4154,7 @@ public class BrokerService implements Closeable {
     }
 
     /**
-     * @return Triple [namespace policies, global topic policies, topic policies].
+     * @return CompletableFuture<Triple<Optional<Policies>, whether the current cluster is allowed to access the topic.
      */
     public CompletableFuture<Boolean> isCurrentClusterAllowed(@NonNull TopicName topicName) {
         final String cluster = getPulsar().getConfig().getClusterName();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2082,45 +2082,6 @@ public class BrokerService implements Closeable {
     /**
      * @return Triple [namespace policies, global topic policies, topic policies].
      */
-    public CompletableFuture<Boolean> isAllowedCurrentClusterAccess(@NonNull TopicName topicName) {
-        final String cluster = getPulsar().getConfig().getClusterName();
-        return getCombinedTopicPolicies(topicName).thenApply(triple -> {
-            Optional<TopicPolicies> topicP = triple.getRight();
-            Optional<TopicPolicies> globalTopicP = triple.getMiddle();
-            Optional<Policies> nsPolicies = triple.getLeft();
-            // Disabled a cluster for a namespace manually.
-            if (nsPolicies.isPresent() && !nsPolicies.get().allowed_clusters.isEmpty()
-                    && !nsPolicies.get().allowed_clusters.contains(cluster)) {
-                return false;
-            }
-            // Manually enabled topic-level replication, which can skip to set a namespace-level replication.
-            if (topicP.isPresent() && CollectionUtils.isNotEmpty(topicP.get().getReplicationClusters())) {
-                if (topicP.get().getReplicationClusters().contains(cluster)) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-            if (globalTopicP.isPresent() && CollectionUtils.isNotEmpty(globalTopicP.get().getReplicationClusters())) {
-                if (globalTopicP.get().getReplicationClusters().contains(cluster)) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-            // No settings for replication/allowed_clusters.
-            if (nsPolicies.isEmpty()) {
-                return true;
-            }
-            // Namespace level settings.
-            return nsPolicies.get().replication_clusters.isEmpty()
-                    || nsPolicies.get().replication_clusters.contains(cluster);
-        });
-    }
-
-    /**
-     * @return Triple [namespace policies, global topic policies, topic policies].
-     */
     public CompletableFuture<Triple<Optional<Policies>, Optional<TopicPolicies>, Optional<TopicPolicies>>>
     getCombinedTopicPolicies(@NonNull TopicName topicName) {
         if (topicName == null) {
@@ -4190,6 +4151,39 @@ public class BrokerService implements Closeable {
     @VisibleForTesting
     public void setPulsarChannelInitializerFactory(PulsarChannelInitializer.Factory factory) {
         this.pulsarChannelInitFactory = factory;
+    }
+
+    /**
+     * @return Triple [namespace policies, global topic policies, topic policies].
+     */
+    public CompletableFuture<Boolean> isCurrentClusterAllowed(@NonNull TopicName topicName) {
+        final String cluster = getPulsar().getConfig().getClusterName();
+        return getCombinedTopicPolicies(topicName).thenApply(triple -> {
+            Optional<TopicPolicies> topicP = triple.getRight();
+            Optional<TopicPolicies> globalTopicP = triple.getMiddle();
+            Optional<Policies> nsPolicies = triple.getLeft();
+            // Disabled a cluster for a namespace manually.
+            if (nsPolicies.isPresent() && !isCurrentClusterAllowed(topicName.getNamespaceObject(), nsPolicies.get())) {
+                return false;
+            }
+            // Manually enabled topic-level replication, which can skip to set a namespace-level replication.
+            if (topicP.isPresent() && CollectionUtils.isNotEmpty(topicP.get().getReplicationClusters())) {
+                if (topicP.get().getReplicationClusters().contains(cluster)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            if (globalTopicP.isPresent() && CollectionUtils.isNotEmpty(globalTopicP.get().getReplicationClusters())) {
+                if (globalTopicP.get().getReplicationClusters().contains(cluster)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            // No settings for replication/allowed_clusters.
+            return nsPolicies.isEmpty();
+        });
     }
 
     /***

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -149,6 +149,13 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         });
         waitReplicatorStopped(subTopic, pulsar1, pulsar2, true);
 
+        try {
+            admin2.topics().createMissedPartitions(topicName);
+            fail("The action that creates mission partitions should have thrown exception");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("is not allowed to be loaded up"));
+        }
+
         // Remove global policy.
         admin1.topicPolicies(true).removeReplicationClusters(topicName);
         Producer<byte[]> producer2 = client1.newProducer().topic(topicName).create();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -155,6 +155,8 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("is not allowed to be loaded up"));
         }
+        assertFalse(admin2.topics().getList(replicatedNamespace)
+            .contains(TopicName.get(topicName).getPartition(0).toString()));
 
         // Remove global policy.
         admin1.topicPolicies(true).removeReplicationClusters(topicName);


### PR DESCRIPTION
### Motivation

Env:
- `cluster-1` and `cluster-2` share configuration metadata store
- create a partitioned topic `public/default/tp1`
  - The ZK node `/admin/partitioned-topics/{topic}` will be created on the shared configuration metadata store.
  - The topic will enable a binary way replication between `cluster-1` and `cluster-2`
- Remove `cluster-2` from the topic-level `replication policies`
  - The partition `public/default/tp1-partition-0` will be deleted automatically.

Issue: call `pulsar-admin topics create-missed-partitions <topic>`, the partition `public/default/tp1-partition-0` was loaded up again.

### Modifications

Fix the issue

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: x