### PR TITLE
[improve][test] Speed up HealthCheckTest by sharing cluster across test methods

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/HealthCheckTest.java
@@ -18,10 +18,6 @@
  */
 package org.apache.pulsar.tests.integration.cli;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import org.apache.pulsar.tests.TestRetrySupport;
 import org.apache.pulsar.tests.integration.containers.BKContainer;
@@ -30,19 +26,15 @@ import org.apache.pulsar.tests.integration.docker.ContainerExecException;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
 import org.apache.pulsar.tests.integration.topologies.PulsarCluster;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
  * Test the healthcheck command.
  */
 public class HealthCheckTest extends TestRetrySupport {
-
-    private static final Logger log = LoggerFactory.getLogger(HealthCheckTest.class);
 
     private final PulsarClusterSpec spec = PulsarClusterSpec.builder()
         .clusterName("HealthCheckTest-" + UUID.randomUUID().toString().substring(0, 8))
@@ -52,14 +44,16 @@ public class HealthCheckTest extends TestRetrySupport {
 
     private PulsarCluster pulsarCluster = null;
 
-    @BeforeMethod(alwaysRun = true)
+    @Override
+    @BeforeClass(alwaysRun = true)
     public final void setup() throws Exception {
         incrementSetupNumber();
         pulsarCluster = PulsarCluster.forSpec(spec);
         pulsarCluster.start();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @Override
+    @AfterClass(alwaysRun = true)
     public final void cleanup() {
         markCurrentSetupNumberCleaned();
         if (pulsarCluster != null) {
@@ -91,28 +85,24 @@ public class HealthCheckTest extends TestRetrySupport {
     @Test
     public void testZooKeeperDown() throws Exception {
         pulsarCluster.getZooKeeper().execCmd("pkill", "-STOP", "java");
-        assertHealthcheckFailure();
+        try {
+            assertHealthcheckFailure();
+        } finally {
+            pulsarCluster.getZooKeeper().execCmd("pkill", "-CONT", "java");
+        }
     }
-
-    // Disabled until PulsarAdmin can time out (#2891)
-    // @Test
-    // public void testBrokerDown() throws Exception {
-    //     for (BrokerContainer b : pulsarCluster.getBrokers()) {
-    //         b.execCmd("pkill", "-STOP", "java");
-    //     }
-    //     assertHealthcheckFailure();
-    // }
 
     @Test
     public void testBookKeeperDown() throws Exception {
         for (BKContainer b : pulsarCluster.getBookies()) {
             b.execCmd("pkill", "-STOP", "java");
         }
-        assertHealthcheckFailure();
-    }
-
-    private static Map<String, String> parseOutput(String output) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(output, new TypeReference<HashMap<String, String>>() {});
+        try {
+            assertHealthcheckFailure();
+        } finally {
+            for (BKContainer b : pulsarCluster.getBookies()) {
+                b.execCmd("pkill", "-CONT", "java");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Switch `HealthCheckTest` from `@BeforeMethod`/`@AfterMethod` to `@BeforeClass`/`@AfterClass` so the Docker-based PulsarCluster is started once instead of once per test method
- Add `SIGCONT` (`pkill -CONT`) in `finally` blocks for destructive tests (`testZooKeeperDown`, `testBookKeeperDown`) to resume stopped processes and keep the cluster usable
- Properly override `TestRetrySupport.setup()`/`cleanup()` and remove unused imports/dead code

This reduces the test from ~5 minutes (3 full cluster start/stop cycles) to ~2 minutes (1 cycle).

### Motivation
`HealthCheckTest` was one of the slowest integration tests. Each of its 3 test methods was spinning up an entire PulsarCluster (ZooKeeper + BookKeeper + Broker containers) and tearing it down, even though the tests themselves are trivial healthcheck CLI calls.

### Documentation
- [ ] `doc-required`

(If you update the description, also update the determine of the documentation)

- [ ] `doc-not-needed`
  (Please explain why)

- [x] `doc` (Your PR doesn't need any doc update)

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

---

- [ ] `ready-to-test`

area/test