### PR TITLE
[improve][build] Add Maven publishing conventions for ASF release

### DIFF
--- a/bouncy-castle/bc/build.gradle.kts
+++ b/bouncy-castle/bc/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/bouncy-castle/bc/build.gradle.kts
+++ b/bouncy-castle/bc/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/bouncy-castle/bcfips/build.gradle.kts
+++ b/bouncy-castle/bcfips/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/bouncy-castle/bcfips/build.gradle.kts
+++ b/bouncy-castle/bcfips/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -24,9 +24,6 @@ plugins {
 
 val catalog = the<VersionCatalogsExtension>().named("libs")
 
-group = "org.apache.pulsar"
-version = catalog.findVersion("pulsar").get().requiredVersion
-
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
     options.release.set(17)

--- a/build-logic/conventions/src/main/kotlin/pulsar.nar-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.nar-conventions.gradle.kts
@@ -19,10 +19,12 @@
 
 // Convention plugin for NAR (Nifi Archive) modules.
 // Configures platform module exclusions from runtimeClasspath, forces JAR artifacts
-// for bundled-dependencies, and handles archive name qualification.
+// for bundled-dependencies, handles archive name qualification, and publishes the
+// NAR artifact with an empty POM (no dependencies — everything is bundled).
 
 plugins {
     id("io.github.merlimat.nar")
+    id("pulsar.publish-conventions")
 }
 
 // NAR modules should not bundle Pulsar platform dependencies — they are provided
@@ -90,4 +92,27 @@ if (parentProject != null && parentProject != rootProject && parentProject.paren
     @Suppress("UNCHECKED_CAST")
     val narIdProp = narExt.javaClass.getMethod("getNarId").invoke(narExt) as org.gradle.api.provider.Property<String>
     narIdProp.set(qualifiedName)
+}
+
+// --- NAR publishing: publish only the .nar artifact with an empty POM ---
+// NAR modules bundle all dependencies, so the POM should have no <dependencies> section.
+publishing {
+    publications {
+        named<MavenPublication>("maven") {
+            // Replace component-based artifacts with just the NAR file
+            artifacts.clear()
+            artifact(tasks.named("nar"))
+            pom {
+                packaging = "nar"
+                // Remove all dependencies — NAR bundles everything
+                withXml {
+                    val root = asNode()
+                    root.children().removeAll { node ->
+                        val name = (node as groovy.util.Node).name()
+                        name.toString().contains("dependencies")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/build-logic/conventions/src/main/kotlin/pulsar.public-java-library-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.public-java-library-conventions.gradle.kts
@@ -25,3 +25,45 @@ plugins {
     id("pulsar.java-conventions")
     id("pulsar.publish-conventions")
 }
+
+// Validate that public java-library modules only depend on other published modules
+// in scopes that end up in the published POM (api, implementation, runtimeOnly).
+// Test/compileOnly scoped dependencies are excluded since they don't appear in the POM.
+// NAR modules are not validated here — they bundle all dependencies and have empty POMs.
+run {
+    val publishedScopes = listOf("api", "implementation", "runtimeOnly")
+    val configsToCheck = publishedScopes.mapNotNull { name ->
+        configurations.findByName(name)?.let { name to it }
+    }
+    val currentProjectPath = project.path
+
+    val unpublishedDeps = provider {
+        val errors = mutableListOf<String>()
+        for ((configName, config) in configsToCheck) {
+            for (dep in config.dependencies) {
+                if (dep is ProjectDependency) {
+                    val depPath = dep.path
+                    val depProject = project.rootProject.project(depPath)
+                    if (!depProject.plugins.hasPlugin("maven-publish")) {
+                        errors.add("  - $configName -> $depPath (not published)")
+                    }
+                }
+            }
+        }
+        errors
+    }
+
+    tasks.withType<PublishToMavenRepository>().configureEach {
+        val errorList = unpublishedDeps
+        doFirst {
+            val errors = errorList.get()
+            if (errors.isNotEmpty()) {
+                throw GradleException(
+                    "Published module '$currentProjectPath' depends on unpublished projects:\n" +
+                        errors.joinToString("\n") + "\n" +
+                        "Either publish the dependency or move it to a test/compileOnly scope."
+                )
+            }
+        }
+    }
+}

--- a/build-logic/conventions/src/main/kotlin/pulsar.public-java-library-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.public-java-library-conventions.gradle.kts
@@ -17,16 +17,11 @@
  * under the License.
  */
 
-plugins {
-    id("pulsar.public-java-library-conventions")
-}
+// Convention plugin for public Pulsar Java libraries that are published to Maven repositories.
+// Combines java-conventions (compilation, testing) with publish-conventions (Maven publishing,
+// signing, POM metadata). Internal-only modules should use pulsar.java-conventions directly.
 
-dependencies {
-    implementation(libs.zookeeper)
-    implementation(libs.simpleclient)
-    implementation(libs.simpleclient.hotspot)
-    implementation(libs.simpleclient.servlet)
-    implementation(libs.simpleclient.common)
-    implementation(libs.jetty.server)
-    implementation(libs.jetty.ee8.servlet)
+plugins {
+    id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Convention plugin for publishing Pulsar modules to Maven repositories.
+// Configures maven-publish, GPG signing, POM metadata, sources/javadoc JARs,
+// and a local deploy repository for testing.
+
+plugins {
+    `maven-publish`
+    signing
+}
+
+// --- java-library projects: JAR + sources + javadoc ---
+pluginManager.withPlugin("java-library") {
+    val sourceSets = the<SourceSetContainer>()
+
+    // Match Maven's javadoc configuration: no doclint, don't fail on errors
+    tasks.withType<Javadoc>().configureEach {
+        (options as StandardJavadocDocletOptions).apply {
+            addStringOption("Xdoclint:none", "-quiet")
+        }
+        isFailOnError = false
+    }
+
+    val sourcesJar by tasks.registering(Jar::class) {
+        archiveClassifier.set("sources")
+        from(sourceSets["main"].allJava)
+    }
+
+    val javadocJar by tasks.registering(Jar::class) {
+        archiveClassifier.set("javadoc")
+        from(tasks.named(JavaPlugin.JAVADOC_TASK_NAME))
+    }
+
+    // NAR modules disable the jar task and produce .nar files instead.
+    // Detect the NAR plugin and configure the publication accordingly.
+    val isNarModule = plugins.hasPlugin("io.github.merlimat.nar")
+
+    if (isNarModule) {
+        // NAR modules: publish the .nar artifact with packaging=nar
+        publishing {
+            publications {
+                create<MavenPublication>("maven") {
+                    artifact(tasks.named("nar"))
+                    artifact(sourcesJar)
+                    artifact(javadocJar)
+                    // Set packaging to "nar" in POM
+                    pom.packaging = "nar"
+                }
+            }
+        }
+    } else {
+        // Standard java-library modules: publish from components["java"]
+        publishing {
+            publications {
+                create<MavenPublication>("maven") {
+                    from(components["java"])
+                    artifact(sourcesJar)
+                    artifact(javadocJar)
+
+                    versionMapping {
+                        usage(Usage.JAVA_RUNTIME) {
+                            fromResolutionResult()
+                        }
+                        usage(Usage.JAVA_API) {
+                            fromResolutionOf("runtimeClasspath")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --- java-platform projects (BOM, dependencies): POM-only, no JAR ---
+pluginManager.withPlugin("java-platform") {
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                from(components["javaPlatform"])
+            }
+        }
+    }
+}
+
+// --- Common POM metadata for all publications ---
+run {
+    // Capture values in a local scope so withXml closures don't capture the script object
+    // (which would break configuration cache serialization)
+    val projectName = project.name
+    val projectDescription = project.description
+    val archivesNameValue = the<BasePluginExtension>().archivesName.get()
+    val isPlatformProject = plugins.hasPlugin("java-platform")
+    val localDeployRepoDir = rootProject.layout.buildDirectory.dir("local-deploy-repo")
+
+    publishing {
+        publications {
+            withType<MavenPublication>().configureEach {
+                artifactId = archivesNameValue
+
+                pom {
+                    name.set("Apache Pulsar :: $projectName")
+                    description.set(projectDescription ?: "Apache Pulsar :: $projectName")
+                    url.set("https://pulsar.apache.org")
+                    inceptionYear.set("2017")
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
+                    }
+
+                    organization {
+                        name.set("Apache Software Foundation")
+                        url.set("https://www.apache.org/")
+                    }
+
+                    issueManagement {
+                        system.set("GitHub Issues")
+                        url.set("https://github.com/apache/pulsar/issues")
+                    }
+
+                    scm {
+                        connection.set("scm:git:https://github.com/apache/pulsar.git")
+                        developerConnection.set("scm:git:https://github.com/apache/pulsar.git")
+                        url.set("https://github.com/apache/pulsar")
+                        tag.set("HEAD")
+                    }
+
+                    mailingLists {
+                        mailingList {
+                            name.set("Apache Pulsar developers list")
+                            subscribe.set("dev-subscribe@pulsar.apache.org")
+                            unsubscribe.set("dev-unsubscribe@pulsar.apache.org")
+                            post.set("dev@pulsar.apache.org")
+                            archive.set("https://lists.apache.org/list.html?dev@pulsar.apache.org")
+                        }
+                    }
+
+                    // Clean up POM XML: remove Maven defaults and dependencyManagement
+                    // (resolved versions are inlined via versionMapping)
+                    withXml {
+                        val sb = asString()
+                        var s = sb.toString()
+                        // <scope>compile</scope> is the Maven default — remove for cleaner POM
+                        s = s.replace("<scope>compile</scope>", "")
+                        // Remove dependencyManagement from non-platform POMs
+                        // (platform POMs need it — their dependencies ARE the management section)
+                        if (!isPlatformProject) {
+                            s = s.replace(
+                                Regex(
+                                    "<dependencyManagement>.*?</dependencyManagement>",
+                                    RegexOption.DOT_MATCHES_ALL
+                                ),
+                                ""
+                            )
+                        }
+                        sb.setLength(0)
+                        sb.append(s)
+                        // Re-format the XML
+                        asNode()
+                    }
+                }
+            }
+        }
+
+        // Local Maven repository for testing/comparison
+        repositories {
+            maven {
+                name = "localDeploy"
+                url = uri(localDeployRepoDir)
+            }
+        }
+    }
+}
+
+// --- GPG signing ---
+signing {
+    isRequired = !version.toString().endsWith("-SNAPSHOT")
+
+    val useGpgCmd = providers.gradleProperty("useGpgCmd").orNull?.toBoolean() ?: false
+    if (useGpgCmd) {
+        useGpgCmd()
+    }
+
+    sign(publishing.publications)
+}
+
+// Disable signing tasks when no key is configured (local dev without signing)
+tasks.withType<Sign>().configureEach {
+    enabled = providers.gradleProperty("signing.keyId").isPresent ||
+        providers.gradleProperty("signing.gnupg.keyName").isPresent
+}
+
+// Suppress enforced-platform validation: all java-library modules use
+// enforcedPlatform(":pulsar-dependencies") for internal version alignment,
+// but this should not leak to consumers. The dependencyManagement section
+// is stripped from published POMs via withXml above.
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    suppressedValidationErrors.add("enforced-platform")
+}

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -99,7 +99,7 @@ pluginManager.withPlugin("java-platform") {
     }
 }
 
-// --- Common POM metadata for all publications ---
+// --- Common POM configuration for all publications ---
 run {
     // Capture values in a local scope so withXml closures don't capture the script object
     // (which would break configuration cache serialization)
@@ -107,6 +107,8 @@ run {
     val projectDescription = project.description
     val archivesNameValue = the<BasePluginExtension>().archivesName.get()
     val isPlatformProject = plugins.hasPlugin("java-platform")
+    val isRootProject = project == rootProject
+    val pulsarVersion = version.toString()
     val localDeployRepoDir = rootProject.layout.buildDirectory.dir("local-deploy-repo")
 
     publishing {
@@ -115,48 +117,13 @@ run {
                 artifactId = archivesNameValue
 
                 pom {
-                    name.set("Apache Pulsar :: $projectName")
-                    description.set(projectDescription ?: "Apache Pulsar :: $projectName")
-                    url.set("https://pulsar.apache.org")
-                    inceptionYear.set("2017")
-
-                    licenses {
-                        license {
-                            name.set("The Apache License, Version 2.0")
-                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                            distribution.set("repo")
-                        }
+                    // Per-module name and description
+                    if (!isRootProject) {
+                        name.set("Apache Pulsar :: $projectName")
+                        description.set(projectDescription ?: "Apache Pulsar :: $projectName")
                     }
 
-                    organization {
-                        name.set("Apache Software Foundation")
-                        url.set("https://www.apache.org/")
-                    }
-
-                    issueManagement {
-                        system.set("GitHub Issues")
-                        url.set("https://github.com/apache/pulsar/issues")
-                    }
-
-                    scm {
-                        connection.set("scm:git:https://github.com/apache/pulsar.git")
-                        developerConnection.set("scm:git:https://github.com/apache/pulsar.git")
-                        url.set("https://github.com/apache/pulsar")
-                        tag.set("HEAD")
-                    }
-
-                    mailingLists {
-                        mailingList {
-                            name.set("Apache Pulsar developers list")
-                            subscribe.set("dev-subscribe@pulsar.apache.org")
-                            unsubscribe.set("dev-unsubscribe@pulsar.apache.org")
-                            post.set("dev@pulsar.apache.org")
-                            archive.set("https://lists.apache.org/list.html?dev@pulsar.apache.org")
-                        }
-                    }
-
-                    // Clean up POM XML: remove Maven defaults and dependencyManagement
-                    // (resolved versions are inlined via versionMapping)
+                    // Clean up POM XML and inject <parent> reference
                     withXml {
                         val sb = asString()
                         var s = sb.toString()
@@ -171,6 +138,18 @@ run {
                                     RegexOption.DOT_MATCHES_ALL
                                 ),
                                 ""
+                            )
+                        }
+                        // Inject <parent> reference for child modules (not the root/parent POM itself).
+                        // Metadata (license, SCM, etc.) is inherited from the parent POM.
+                        if (!isRootProject) {
+                            s = s.replace(
+                                "<modelVersion>4.0.0</modelVersion>",
+                                "<modelVersion>4.0.0</modelVersion>\n  <parent>\n" +
+                                    "    <groupId>org.apache.pulsar</groupId>\n" +
+                                    "    <artifactId>pulsar</artifactId>\n" +
+                                    "    <version>$pulsarVersion</version>\n" +
+                                    "  </parent>"
                             )
                         }
                         sb.setLength(0)

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -68,23 +68,6 @@ pluginManager.withPlugin("java-library") {
         }
     }
 
-    // NAR modules disable the jar task and produce .nar files instead.
-    // When the NAR plugin is applied (possibly after this plugin), reconfigure
-    // the publication to use the .nar artifact instead of the jar.
-    pluginManager.withPlugin("io.github.merlimat.nar") {
-        publishing {
-            publications {
-                named<MavenPublication>("maven") {
-                    // Clear the component-based artifacts and use NAR instead
-                    artifacts.clear()
-                    artifact(tasks.named("nar"))
-                    artifact(sourcesJar)
-                    artifact(javadocJar)
-                    pom.packaging = "nar"
-                }
-            }
-        }
-    }
 }
 
 // --- java-platform projects (BOM, dependencies): POM-only, no JAR ---
@@ -196,48 +179,3 @@ tasks.withType<GenerateModuleMetadata>().configureEach {
     suppressedValidationErrors.add("enforced-platform")
 }
 
-// Validate that published modules only depend on other published modules.
-// Dependencies in test/compileOnly scopes are excluded since they don't
-// appear in the published POM.
-if (project != rootProject) {
-    pluginManager.withPlugin("java-library") {
-        val publishedScopes = listOf("api", "implementation", "runtimeOnly")
-        val configsToCheck = publishedScopes.mapNotNull { name ->
-            configurations.findByName(name)?.let { name to it }
-        }
-        val currentProjectPath = project.path
-
-        // Collect unpublished project dependencies at configuration time
-        // (after all plugins/dependencies are declared). Store as plain strings
-        // for configuration cache compatibility.
-        val unpublishedDeps = provider {
-            val errors = mutableListOf<String>()
-            for ((configName, config) in configsToCheck) {
-                for (dep in config.dependencies) {
-                    if (dep is ProjectDependency) {
-                        val depPath = dep.path
-                        val depProject = project.rootProject.project(depPath)
-                        if (!depProject.plugins.hasPlugin("maven-publish")) {
-                            errors.add("  - $configName -> $depPath (not published)")
-                        }
-                    }
-                }
-            }
-            errors
-        }
-
-        tasks.withType<PublishToMavenRepository>().configureEach {
-            val errorList = unpublishedDeps
-            doFirst {
-                val errors = errorList.get()
-                if (errors.isNotEmpty()) {
-                    throw GradleException(
-                        "Published module '$currentProjectPath' depends on unpublished projects:\n" +
-                            errors.joinToString("\n") + "\n" +
-                            "Either publish the dependency or move it to a test/compileOnly scope."
-                    )
-                }
-            }
-        }
-    }
-}

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -195,3 +195,49 @@ tasks.withType<Sign>().configureEach {
 tasks.withType<GenerateModuleMetadata>().configureEach {
     suppressedValidationErrors.add("enforced-platform")
 }
+
+// Validate that published modules only depend on other published modules.
+// Dependencies in test/compileOnly scopes are excluded since they don't
+// appear in the published POM.
+if (project != rootProject) {
+    pluginManager.withPlugin("java-library") {
+        val publishedScopes = listOf("api", "implementation", "runtimeOnly")
+        val configsToCheck = publishedScopes.mapNotNull { name ->
+            configurations.findByName(name)?.let { name to it }
+        }
+        val currentProjectPath = project.path
+
+        // Collect unpublished project dependencies at configuration time
+        // (after all plugins/dependencies are declared). Store as plain strings
+        // for configuration cache compatibility.
+        val unpublishedDeps = provider {
+            val errors = mutableListOf<String>()
+            for ((configName, config) in configsToCheck) {
+                for (dep in config.dependencies) {
+                    if (dep is ProjectDependency) {
+                        val depPath = dep.path
+                        val depProject = project.rootProject.project(depPath)
+                        if (!depProject.plugins.hasPlugin("maven-publish")) {
+                            errors.add("  - $configName -> $depPath (not published)")
+                        }
+                    }
+                }
+            }
+            errors
+        }
+
+        tasks.withType<PublishToMavenRepository>().configureEach {
+            val errorList = unpublishedDeps
+            doFirst {
+                val errors = errorList.get()
+                if (errors.isNotEmpty()) {
+                    throw GradleException(
+                        "Published module '$currentProjectPath' depends on unpublished projects:\n" +
+                            errors.joinToString("\n") + "\n" +
+                            "Either publish the dependency or move it to a test/compileOnly scope."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -48,40 +48,39 @@ pluginManager.withPlugin("java-library") {
         from(tasks.named(JavaPlugin.JAVADOC_TASK_NAME))
     }
 
-    // NAR modules disable the jar task and produce .nar files instead.
-    // Detect the NAR plugin and configure the publication accordingly.
-    val isNarModule = plugins.hasPlugin("io.github.merlimat.nar")
+    // Standard java-library modules: publish from components["java"]
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                from(components["java"])
+                artifact(sourcesJar)
+                artifact(javadocJar)
 
-    if (isNarModule) {
-        // NAR modules: publish the .nar artifact with packaging=nar
-        publishing {
-            publications {
-                create<MavenPublication>("maven") {
-                    artifact(tasks.named("nar"))
-                    artifact(sourcesJar)
-                    artifact(javadocJar)
-                    // Set packaging to "nar" in POM
-                    pom.packaging = "nar"
+                versionMapping {
+                    usage(Usage.JAVA_RUNTIME) {
+                        fromResolutionResult()
+                    }
+                    usage(Usage.JAVA_API) {
+                        fromResolutionOf("runtimeClasspath")
+                    }
                 }
             }
         }
-    } else {
-        // Standard java-library modules: publish from components["java"]
+    }
+
+    // NAR modules disable the jar task and produce .nar files instead.
+    // When the NAR plugin is applied (possibly after this plugin), reconfigure
+    // the publication to use the .nar artifact instead of the jar.
+    pluginManager.withPlugin("io.github.merlimat.nar") {
         publishing {
             publications {
-                create<MavenPublication>("maven") {
-                    from(components["java"])
+                named<MavenPublication>("maven") {
+                    // Clear the component-based artifacts and use NAR instead
+                    artifacts.clear()
+                    artifact(tasks.named("nar"))
                     artifact(sourcesJar)
                     artifact(javadocJar)
-
-                    versionMapping {
-                        usage(Usage.JAVA_RUNTIME) {
-                            fromResolutionResult()
-                        }
-                        usage(Usage.JAVA_API) {
-                            fromResolutionOf("runtimeClasspath")
-                        }
-                    }
+                    pom.packaging = "nar"
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ plugins {
     alias(libs.plugins.crlf) apply false
     alias(libs.plugins.idea.ext)
     alias(libs.plugins.spotless) apply false // workaround for https://github.com/diffplug/spotless/issues/2877
+    `maven-publish`
+    signing
 }
 
 versionCatalogUpdate {
@@ -46,8 +48,7 @@ tasks.named<com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask>("
     }
 }
 
-val catalog = the<VersionCatalogsExtension>().named("libs")
-val pulsarVersion = catalog.findVersion("pulsar").get().requiredVersion
+val pulsarVersion = version.toString()
 
 // ── Apache RAT (Release Audit Tool) ─────────────────────────────────────────
 tasks.named<org.nosphere.apache.rat.RatTask>("rat").configure {
@@ -97,4 +98,88 @@ tasks.register("docker") {
     description = "Build the Pulsar Docker image"
     group = "docker"
     dependsOn(":docker:pulsar-docker-image:dockerBuild")
+}
+
+// ── Parent POM publication ──────────────────────────────────────────────────
+// Publishes org.apache.pulsar:pulsar as a POM-only parent artifact.
+// Child modules reference this via <parent> in their POMs, inheriting
+// shared ASF metadata (license, SCM, organization, etc.).
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            pom {
+                packaging = "pom"
+                name.set("Apache Pulsar")
+                description.set(
+                    "Pulsar is a distributed pub-sub messaging platform with a very " +
+                        "flexible messaging model and an intuitive client API."
+                )
+                url.set("https://pulsar.apache.org")
+                inceptionYear.set("2017")
+
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                organization {
+                    name.set("Apache Software Foundation")
+                    url.set("https://www.apache.org/")
+                }
+
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("https://github.com/apache/pulsar/issues")
+                }
+
+                scm {
+                    connection.set("scm:git:https://github.com/apache/pulsar.git")
+                    developerConnection.set("scm:git:https://github.com/apache/pulsar.git")
+                    url.set("https://github.com/apache/pulsar")
+                    tag.set("HEAD")
+                }
+
+                mailingLists {
+                    mailingList {
+                        name.set("Apache Pulsar developers list")
+                        subscribe.set("dev-subscribe@pulsar.apache.org")
+                        unsubscribe.set("dev-unsubscribe@pulsar.apache.org")
+                        post.set("dev@pulsar.apache.org")
+                        archive.set("https://lists.apache.org/list.html?dev@pulsar.apache.org")
+                    }
+                }
+
+                developers {
+                    developer {
+                        organization.set("Apache Pulsar developers")
+                        organizationUrl.set("https://pulsar.apache.org/")
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "localDeploy"
+            url = uri(layout.buildDirectory.dir("local-deploy-repo"))
+        }
+    }
+}
+
+signing {
+    isRequired = !pulsarVersion.endsWith("-SNAPSHOT")
+    val useGpgCmd = providers.gradleProperty("useGpgCmd").orNull?.toBoolean() ?: false
+    if (useGpgCmd) {
+        useGpgCmd()
+    }
+    sign(publishing.publications)
+}
+
+tasks.withType<Sign>().configureEach {
+    enabled = providers.gradleProperty("signing.keyId").isPresent ||
+        providers.gradleProperty("signing.gnupg.keyName").isPresent
 }

--- a/docker/pulsar/build.gradle.kts
+++ b/docker/pulsar/build.gradle.kts
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-group = "org.apache.pulsar"
-version = the<VersionCatalogsExtension>().named("libs").findVersion("pulsar").get().requiredVersion
-
-
 val pulsarVersion = project.version.toString()
 val dockerOrganization = providers.gradleProperty("docker.organization").getOrElse("apachepulsar")
 val dockerImage = providers.gradleProperty("docker.image").getOrElse("pulsar")

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -Xss2m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError
+
+# repository.apache.org does not support SHA-256/SHA-512 checksums yet
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+group=org.apache.pulsar
+version=4.3.0-SNAPSHOT
+
 org.gradle.configuration-cache=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,6 @@
 # under the License.
 #
 [versions]
-# Core
-pulsar = "4.3.0-SNAPSHOT"
 # Docker
 docker-jdk = "21"
 pulsar-client-python = "3.10.0"

--- a/gradle/setup-test-gpg.sh
+++ b/gradle/setup-test-gpg.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Creates a temporary GPG keyring for testing artifact signing.
+# Does NOT touch ~/.gnupg — uses an isolated keyring in build/tmp-gpg-home.
+#
+# Usage:
+#   source gradle/setup-test-gpg.sh
+#   ./gradlew publishAllPublicationsToLocalDeployRepository \
+#     -PuseGpgCmd=true \
+#     -Psigning.gnupg.keyName=$TEST_GPG_KEY_ID \
+#     -Psigning.gnupg.homeDir=$GNUPGHOME
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+export GNUPGHOME="$PROJECT_DIR/build/tmp-gpg-home"
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+
+echo "Generating temporary GPG key in $GNUPGHOME ..."
+gpg --homedir "$GNUPGHOME" --batch --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 2048
+Name-Real: Test Signing Key
+Name-Email: test@example.com
+Expire-Date: 0
+%commit
+EOF
+
+TEST_GPG_KEY_ID=$(gpg --homedir "$GNUPGHOME" --list-keys --keyid-format long 2>/dev/null \
+    | grep -E '^\s+[0-9A-F]+' | head -1 | awk '{print $1}')
+
+export TEST_GPG_KEY_ID
+
+echo ""
+echo "GPG key created: $TEST_GPG_KEY_ID"
+echo "GNUPGHOME=$GNUPGHOME"
+echo ""
+echo "To publish with signing:"
+echo "  ./gradlew publishAllPublicationsToLocalDeployRepository \\"
+echo "    -PuseGpgCmd=true \\"
+echo "    -Psigning.gnupg.keyName=$TEST_GPG_KEY_ID \\"
+echo "    -Psigning.gnupg.homeDir=$GNUPGHOME"

--- a/jclouds-shaded/build.gradle.kts
+++ b/jclouds-shaded/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.shadow-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // Pin guava to 32.x for jclouds compatibility — jclouds uses TypeToken from

--- a/jclouds-shaded/build.gradle.kts
+++ b/jclouds-shaded/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.shadow-conventions")
-    id("pulsar.publish-conventions")
 }
 
 // Pin guava to 32.x for jclouds compatibility — jclouds uses TypeToken from

--- a/jclouds-shaded/build.gradle.kts
+++ b/jclouds-shaded/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.public-java-library-conventions")
+    id("pulsar.java-conventions")
     id("pulsar.shadow-conventions")
 }
 

--- a/jetty-upgrade/bookkeeper-prometheus-metrics-provider/build.gradle.kts
+++ b/jetty-upgrade/bookkeeper-prometheus-metrics-provider/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/jetty-upgrade/bookkeeper-prometheus-metrics-provider/build.gradle.kts
+++ b/jetty-upgrade/bookkeeper-prometheus-metrics-provider/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/jetty-upgrade/zookeeper-prometheus-metrics/build.gradle.kts
+++ b/jetty-upgrade/zookeeper-prometheus-metrics/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/jetty-upgrade/zookeeper-with-patched-admin/build.gradle.kts
+++ b/jetty-upgrade/zookeeper-with-patched-admin/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.shadow-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/jetty-upgrade/zookeeper-with-patched-admin/build.gradle.kts
+++ b/jetty-upgrade/zookeeper-with-patched-admin/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.shadow-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/managed-ledger/build.gradle.kts
+++ b/managed-ledger/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     alias(libs.plugins.lightproto)
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/managed-ledger/build.gradle.kts
+++ b/managed-ledger/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     alias(libs.plugins.lightproto)
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-bom/build.gradle.kts
+++ b/pulsar-bom/build.gradle.kts
@@ -23,6 +23,7 @@
 
 plugins {
     `java-platform`
+    id("pulsar.publish-conventions")
 }
 
 group = "org.apache.pulsar"

--- a/pulsar-bom/build.gradle.kts
+++ b/pulsar-bom/build.gradle.kts
@@ -26,9 +26,6 @@ plugins {
     id("pulsar.publish-conventions")
 }
 
-group = "org.apache.pulsar"
-version = the<VersionCatalogsExtension>().named("libs").findVersion("pulsar").get().requiredVersion
-
 // Allow the platform to depend on other projects
 javaPlatform {
     allowDependencies()

--- a/pulsar-broker-auth-athenz/build.gradle.kts
+++ b/pulsar-broker-auth-athenz/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker-auth-athenz/build.gradle.kts
+++ b/pulsar-broker-auth-athenz/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-broker-auth-oidc/build.gradle.kts
+++ b/pulsar-broker-auth-oidc/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker-auth-oidc/build.gradle.kts
+++ b/pulsar-broker-auth-oidc/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker-auth-sasl/build.gradle.kts
+++ b/pulsar-broker-auth-sasl/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // Each test class gets its own JVM fork because AuthenticationSasl has static JAAS state

--- a/pulsar-broker-auth-sasl/build.gradle.kts
+++ b/pulsar-broker-auth-sasl/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
-    id("pulsar.publish-conventions")
 }
 
 // Each test class gets its own JVM fork because AuthenticationSasl has static JAAS state

--- a/pulsar-broker-common/build.gradle.kts
+++ b/pulsar-broker-common/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker-common/build.gradle.kts
+++ b/pulsar-broker-common/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("pulsar.test-certs-conventions")
     alias(libs.plugins.protobuf)
     alias(libs.plugins.lightproto)
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -18,11 +18,10 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
     alias(libs.plugins.protobuf)
     alias(libs.plugins.lightproto)
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-cli-utils/build.gradle.kts
+++ b/pulsar-cli-utils/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-cli-utils/build.gradle.kts
+++ b/pulsar-cli-utils/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin-api/build.gradle.kts
+++ b/pulsar-client-admin-api/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin-api/build.gradle.kts
+++ b/pulsar-client-admin-api/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin-shaded/build.gradle.kts
+++ b/pulsar-client-admin-shaded/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.client-shade-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin-shaded/build.gradle.kts
+++ b/pulsar-client-admin-shaded/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.client-shade-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin/build.gradle.kts
+++ b/pulsar-client-admin/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-admin/build.gradle.kts
+++ b/pulsar-client-admin/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-all/build.gradle.kts
+++ b/pulsar-client-all/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.client-shade-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-all/build.gradle.kts
+++ b/pulsar-client-all/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.client-shade-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-api/build.gradle.kts
+++ b/pulsar-client-api/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-api/build.gradle.kts
+++ b/pulsar-client-api/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-auth-athenz/build.gradle.kts
+++ b/pulsar-client-auth-athenz/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-auth-athenz/build.gradle.kts
+++ b/pulsar-client-auth-athenz/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-auth-sasl/build.gradle.kts
+++ b/pulsar-client-auth-sasl/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-auth-sasl/build.gradle.kts
+++ b/pulsar-client-auth-sasl/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-messagecrypto-bc/build.gradle.kts
+++ b/pulsar-client-messagecrypto-bc/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-messagecrypto-bc/build.gradle.kts
+++ b/pulsar-client-messagecrypto-bc/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-shaded/build.gradle.kts
+++ b/pulsar-client-shaded/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.client-shade-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-shaded/build.gradle.kts
+++ b/pulsar-client-shaded/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.client-shade-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-tools-api/build.gradle.kts
+++ b/pulsar-client-tools-api/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-tools-api/build.gradle.kts
+++ b/pulsar-client-tools-api/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-tools-customcommand-example/build.gradle.kts
+++ b/pulsar-client-tools-customcommand-example/build.gradle.kts
@@ -22,6 +22,9 @@ plugins {
     id("pulsar.nar-conventions")
 }
 
+// This is an example module — don't publish to Maven repositories
+tasks.withType<PublishToMavenRepository>().configureEach { enabled = false }
+
 dependencies {
     compileOnly(project(":pulsar-client-tools-api"))
     compileOnly(libs.picocli)

--- a/pulsar-client-tools/build.gradle.kts
+++ b/pulsar-client-tools/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client-tools/build.gradle.kts
+++ b/pulsar-client-tools/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     alias(libs.plugins.protobuf)
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     alias(libs.plugins.protobuf)
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-common/build.gradle.kts
+++ b/pulsar-common/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
     alias(libs.plugins.lightproto)
+    id("pulsar.publish-conventions")
 }
 
 val generatePulsarVersion by tasks.registering {

--- a/pulsar-common/build.gradle.kts
+++ b/pulsar-common/build.gradle.kts
@@ -23,10 +23,9 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
     alias(libs.plugins.lightproto)
-    id("pulsar.publish-conventions")
 }
 
 val generatePulsarVersion by tasks.registering {

--- a/pulsar-config-validation/build.gradle.kts
+++ b/pulsar-config-validation/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-config-validation/build.gradle.kts
+++ b/pulsar-config-validation/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-dependencies/build.gradle.kts
+++ b/pulsar-dependencies/build.gradle.kts
@@ -22,6 +22,7 @@
 // All subprojects consume this via: implementation(enforcedPlatform(project(":pulsar-dependencies")))
 plugins {
     `java-platform`
+    id("pulsar.publish-conventions")
 }
 
 group = "org.apache.pulsar"

--- a/pulsar-dependencies/build.gradle.kts
+++ b/pulsar-dependencies/build.gradle.kts
@@ -25,9 +25,6 @@ plugins {
     id("pulsar.publish-conventions")
 }
 
-group = "org.apache.pulsar"
-version = the<VersionCatalogsExtension>().named("libs").findVersion("pulsar").get().requiredVersion
-
 // Allow declaring constraints on dependencies that also appear as direct dependencies
 javaPlatform {
     allowDependencies()

--- a/pulsar-docs-tools/build.gradle.kts
+++ b/pulsar-docs-tools/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-docs-tools/build.gradle.kts
+++ b/pulsar-docs-tools/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/api-java/build.gradle.kts
+++ b/pulsar-functions/api-java/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/api-java/build.gradle.kts
+++ b/pulsar-functions/api-java/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/instance/build.gradle.kts
+++ b/pulsar-functions/instance/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/instance/build.gradle.kts
+++ b/pulsar-functions/instance/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/java-examples-builtin/build.gradle.kts
+++ b/pulsar-functions/java-examples-builtin/build.gradle.kts
@@ -22,6 +22,9 @@ plugins {
     id("pulsar.nar-conventions")
 }
 
+// This is an example module — don't publish to Maven repositories
+tasks.withType<PublishToMavenRepository>().configureEach { enabled = false }
+
 dependencies {
     implementation(project(":pulsar-functions:pulsar-functions-api-examples"))
 }

--- a/pulsar-functions/localrun-shaded/build.gradle.kts
+++ b/pulsar-functions/localrun-shaded/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.shadow-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/localrun-shaded/build.gradle.kts
+++ b/pulsar-functions/localrun-shaded/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.shadow-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/localrun/build.gradle.kts
+++ b/pulsar-functions/localrun/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/localrun/build.gradle.kts
+++ b/pulsar-functions/localrun/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/proto/build.gradle.kts
+++ b/pulsar-functions/proto/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     alias(libs.plugins.lightproto)
+    id("pulsar.publish-conventions")
 }
 
 // Suppress warnings in LightProto generated code

--- a/pulsar-functions/proto/build.gradle.kts
+++ b/pulsar-functions/proto/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     alias(libs.plugins.lightproto)
-    id("pulsar.publish-conventions")
 }
 
 // Suppress warnings in LightProto generated code

--- a/pulsar-functions/runtime/build.gradle.kts
+++ b/pulsar-functions/runtime/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // Include parent module's test resources (YAML config files used by WorkerApiV2ResourceConfigTest)

--- a/pulsar-functions/runtime/build.gradle.kts
+++ b/pulsar-functions/runtime/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 // Include parent module's test resources (YAML config files used by WorkerApiV2ResourceConfigTest)

--- a/pulsar-functions/secrets/build.gradle.kts
+++ b/pulsar-functions/secrets/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/secrets/build.gradle.kts
+++ b/pulsar-functions/secrets/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/utils/build.gradle.kts
+++ b/pulsar-functions/utils/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/utils/build.gradle.kts
+++ b/pulsar-functions/utils/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-functions/worker/build.gradle.kts
+++ b/pulsar-functions/worker/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // Include parent module's test resources (YAML config files)

--- a/pulsar-functions/worker/build.gradle.kts
+++ b/pulsar-functions/worker/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 // Include parent module's test resources (YAML config files)

--- a/pulsar-io/batch-data-generator/build.gradle.kts
+++ b/pulsar-io/batch-data-generator/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
+    id("pulsar.publish-conventions")
 }
 dependencies {
     implementation(project(":pulsar-io:pulsar-io-core"))

--- a/pulsar-io/batch-data-generator/build.gradle.kts
+++ b/pulsar-io/batch-data-generator/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.public-java-library-conventions")
+    id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
 }
 dependencies {

--- a/pulsar-io/batch-data-generator/build.gradle.kts
+++ b/pulsar-io/batch-data-generator/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.nar-conventions")
-    id("pulsar.publish-conventions")
 }
 dependencies {
     implementation(project(":pulsar-io:pulsar-io-core"))

--- a/pulsar-io/batch-discovery-triggerers/build.gradle.kts
+++ b/pulsar-io/batch-discovery-triggerers/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-io/batch-discovery-triggerers/build.gradle.kts
+++ b/pulsar-io/batch-discovery-triggerers/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-io/common/build.gradle.kts
+++ b/pulsar-io/common/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-io/common/build.gradle.kts
+++ b/pulsar-io/common/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-io/core/build.gradle.kts
+++ b/pulsar-io/core/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-io/core/build.gradle.kts
+++ b/pulsar-io/core/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-io/data-generator/build.gradle.kts
+++ b/pulsar-io/data-generator/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
+    id("pulsar.publish-conventions")
 }
 dependencies {
     implementation(project(":pulsar-io:pulsar-io-core"))

--- a/pulsar-io/data-generator/build.gradle.kts
+++ b/pulsar-io/data-generator/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.public-java-library-conventions")
+    id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
 }
 dependencies {

--- a/pulsar-io/data-generator/build.gradle.kts
+++ b/pulsar-io/data-generator/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.nar-conventions")
-    id("pulsar.publish-conventions")
 }
 dependencies {
     implementation(project(":pulsar-io:pulsar-io-core"))

--- a/pulsar-metadata/build.gradle.kts
+++ b/pulsar-metadata/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-metadata/build.gradle.kts
+++ b/pulsar-metadata/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-opentelemetry/build.gradle.kts
+++ b/pulsar-opentelemetry/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-opentelemetry/build.gradle.kts
+++ b/pulsar-opentelemetry/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/bookkeeper-storage/build.gradle.kts
+++ b/pulsar-package-management/bookkeeper-storage/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/bookkeeper-storage/build.gradle.kts
+++ b/pulsar-package-management/bookkeeper-storage/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/core/build.gradle.kts
+++ b/pulsar-package-management/core/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/core/build.gradle.kts
+++ b/pulsar-package-management/core/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/filesystem-storage/build.gradle.kts
+++ b/pulsar-package-management/filesystem-storage/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-package-management/filesystem-storage/build.gradle.kts
+++ b/pulsar-package-management/filesystem-storage/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-proxy/build.gradle.kts
+++ b/pulsar-proxy/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-proxy/build.gradle.kts
+++ b/pulsar-proxy/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-testclient/build.gradle.kts
+++ b/pulsar-testclient/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.test-certs-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-testclient/build.gradle.kts
+++ b/pulsar-testclient/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.test-certs-conventions")
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-transaction/common/build.gradle.kts
+++ b/pulsar-transaction/common/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // pulsar-transaction-common has no internal Pulsar dependencies

--- a/pulsar-transaction/common/build.gradle.kts
+++ b/pulsar-transaction/common/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 // pulsar-transaction-common has no internal Pulsar dependencies

--- a/pulsar-transaction/coordinator/build.gradle.kts
+++ b/pulsar-transaction/coordinator/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     alias(libs.plugins.lightproto)
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-transaction/coordinator/build.gradle.kts
+++ b/pulsar-transaction/coordinator/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     alias(libs.plugins.lightproto)
-    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-websocket/build.gradle.kts
+++ b/pulsar-websocket/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/pulsar-websocket/build.gradle.kts
+++ b/pulsar-websocket/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/structured-event-log/build.gradle.kts
+++ b/structured-event-log/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/structured-event-log/build.gradle.kts
+++ b/structured-event-log/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/testmocks/build.gradle.kts
+++ b/testmocks/build.gradle.kts
@@ -19,6 +19,7 @@
 
 plugins {
     id("pulsar.java-conventions")
+    id("pulsar.publish-conventions")
 }
 
 dependencies {

--- a/testmocks/build.gradle.kts
+++ b/testmocks/build.gradle.kts
@@ -18,8 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
-    id("pulsar.publish-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/tests/docker-images/java-test-image/build.gradle.kts
+++ b/tests/docker-images/java-test-image/build.gradle.kts
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-group = "org.apache.pulsar"
-version = the<VersionCatalogsExtension>().named("libs").findVersion("pulsar").get().requiredVersion
-
-
 val pulsarVersion = project.version.toString()
 val dockerOrganization = providers.gradleProperty("docker.organization").getOrElse("apachepulsar")
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")

--- a/tests/docker-images/latest-version-image/build.gradle.kts
+++ b/tests/docker-images/latest-version-image/build.gradle.kts
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-group = "org.apache.pulsar"
-version = the<VersionCatalogsExtension>().named("libs").findVersion("pulsar").get().requiredVersion
-
-
 val pulsarVersion = project.version.toString()
 val dockerOrganization = providers.gradleProperty("docker.organization").getOrElse("apachepulsar")
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")

--- a/tiered-storage/file-system/build.gradle.kts
+++ b/tiered-storage/file-system/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
+    id("pulsar.publish-conventions")
 }
 
 // Force Jetty 9 for this module. Hadoop MiniDFSCluster requires Jetty 9 classes

--- a/tiered-storage/file-system/build.gradle.kts
+++ b/tiered-storage/file-system/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.nar-conventions")
-    id("pulsar.publish-conventions")
 }
 
 // Force Jetty 9 for this module. Hadoop MiniDFSCluster requires Jetty 9 classes

--- a/tiered-storage/file-system/build.gradle.kts
+++ b/tiered-storage/file-system/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.public-java-library-conventions")
+    id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
 }
 

--- a/tiered-storage/jcloud/build.gradle.kts
+++ b/tiered-storage/jcloud/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
+    id("pulsar.publish-conventions")
 }
 dependencies {
     compileOnly(project(":managed-ledger"))

--- a/tiered-storage/jcloud/build.gradle.kts
+++ b/tiered-storage/jcloud/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.public-java-library-conventions")
+    id("pulsar.java-conventions")
     id("pulsar.nar-conventions")
 }
 dependencies {

--- a/tiered-storage/jcloud/build.gradle.kts
+++ b/tiered-storage/jcloud/build.gradle.kts
@@ -18,9 +18,8 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
     id("pulsar.nar-conventions")
-    id("pulsar.publish-conventions")
 }
 dependencies {
     compileOnly(project(":managed-ledger"))


### PR DESCRIPTION
### Motivation

The Pulsar build was migrated from Maven to Gradle, but Maven publishing (deploying artifacts to Maven repositories) was not yet implemented. This PR adds the publishing infrastructure so artifacts land at the same Maven coordinates as before (`org.apache.pulsar:*`), with proper POM metadata, GPG signing, sources/javadoc JARs, and Gradle module metadata.

### Modifications

#### Parent POM (`build.gradle.kts`)

The root project publishes `org.apache.pulsar:pulsar` as a POM-only parent artifact containing all shared ASF metadata (license, SCM, organization, mailing lists, developers, issue management). Child module POMs reference this via `<parent>`, inheriting metadata instead of embedding it — matching the Maven build's parent POM structure.

#### Convention plugins (`build-logic/`)

**`pulsar.public-java-library-conventions`** (new) — combined plugin for published Java library modules that applies both `pulsar.java-conventions` and `pulsar.publish-conventions`. Establishes a clear convention boundary: modules using this plugin are public libraries published to Maven, while internal-only modules use just `pulsar.java-conventions`. Includes dependency validation ensuring public modules don't depend on unpublished projects.

**`pulsar.publish-conventions`** (new) — core publishing plugin configuring `maven-publish` and `signing`:

- **java-library modules**: publishes JAR + sources JAR + javadoc JAR + POM + Gradle module metadata (`.module`), with version mapping that inlines resolved dependency versions into the POM
- **java-platform modules** (`pulsar-bom`, `pulsar-dependencies`): publishes POM + Gradle module metadata only (no JAR), with `<packaging>pom</packaging>` and `<dependencyManagement>` entries
- **Shadow/shaded modules** (`pulsar-client-shaded`, `pulsar-client-admin-shaded`, `pulsar-client-all`, etc.): publishes the shadow JAR as the primary artifact
- **Child POM `<parent>` injection**: every child POM gets a `<parent>` reference to the root parent POM via `withXml`
- **POM cleanup**: removes `<scope>compile</scope>` (Maven default) and `<dependencyManagement>` from non-platform POMs
- **GPG signing**: configurable via Gradle properties (`useGpgCmd`, `signing.gnupg.keyName`, `signing.gnupg.homeDir`), disabled by default for local development
- **Local deploy repository**: `build/local-deploy-repo` via `publishAllPublicationsToLocalDeployRepository` task
- **Configuration cache compatible**

**`pulsar.nar-conventions`** (updated) — now applies `pulsar.publish-conventions` and configures NAR-specific publishing:

- Publishes only the `.nar` artifact with `<packaging>nar</packaging>`
- POM has no `<dependencies>` section — NAR bundles everything
- No sources/javadoc JARs (NAR is self-contained)
- Unpublished example NAR modules (`java-examples-builtin`, `client-tools-customcommand-example`) disable publishing explicitly

#### Module changes

- **52 published java-library modules**: use `id("pulsar.public-java-library-conventions")`
- **4 published NAR modules**: use `id("pulsar.java-conventions")` + `id("pulsar.nar-conventions")` — publishing comes from `nar-conventions`
- **2 platform modules** (`pulsar-bom`, `pulsar-dependencies`): use `id("pulsar.publish-conventions")` directly
- **Unpublished modules** (`buildtools`, `tests/*`, `microbench`, `jclouds-shaded`, etc.): use `id("pulsar.java-conventions")`

**Modules changed to internal (no longer published)**:
- `jclouds-shaded` — only referenced by `tiered-storage/jcloud` (a NAR module that bundles it)

#### Project coordinates (`gradle.properties`)

Moved `group` and `version` from the version catalog / `pulsar.java-conventions` to `gradle.properties` — the standard Gradle pattern. Gradle auto-applies these to all projects.

#### Other

- `gradle.properties`: added `systemProp.org.gradle.internal.publish.checksums.insecure=true` for ASF Nexus compatibility
- `gradle/setup-test-gpg.sh`: helper script to create a temporary GPG keyring for testing signing without touching `~/.gnupg`

### Verifying this change

- Ran `./gradlew publishAllPublicationsToLocalDeployRepository` — all 58 modules published successfully (52 java-library + 4 NAR + 2 platform)
- Plus the root parent POM (`org.apache.pulsar:pulsar`)
- Verified parent POM contains all ASF metadata (license, SCM, organization, developers, etc.)
- Verified child POMs have `<parent>` reference and no inline metadata
- Verified `pulsar-bom` produces only `.pom` + `.module` files with `<dependencyManagement>` entries
- Verified `pulsar-client-shaded` publishes 24MB shadow JAR as primary artifact
- Verified NAR modules publish `.nar` with `<packaging>nar</packaging>` and **no `<dependencies>` section**
- Verified `jclouds-shaded` is NOT published
- Verified example NAR modules (`java-examples-builtin`, `client-tools-customcommand-example`) are NOT published
- Verified GPG signing produces `.asc` files when configured with a test key
- Verified Gradle module metadata (`.module` files) published alongside all POMs
- Verified configuration cache compatibility
- Verified unpublished dependency validation: temporarily adding `implementation(project(":buildtools"))` to a published module correctly fails with:
  ```
  Published module ':pulsar-client-api' depends on unpublished projects:
    - implementation -> :buildtools (not published)
  Either publish the dependency or move it to a test/compileOnly scope.
  ```

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`