### PR TITLE
[improve][build] Enhance Docker build task to support image pushing

### DIFF
--- a/docker/pulsar/build.gradle.kts
+++ b/docker/pulsar/build.gradle.kts
@@ -26,6 +26,7 @@ val dockerOrganization = providers.gradleProperty("docker.organization").getOrEl
 val dockerImage = providers.gradleProperty("docker.image").getOrElse("pulsar")
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
+val dockerPush = providers.gradleProperty("docker.push").isPresent
 val useWolfi = providers.gradleProperty("docker.wolfi").isPresent
 
 // Resolvable configurations for cross-project artifact dependencies.
@@ -59,7 +60,7 @@ val copyOffloaderTarball by tasks.registering(Copy::class) {
 
 val dockerBuild by tasks.registering(Exec::class) {
     group = "docker"
-    description = "Build the Pulsar Docker image"
+    description = "Build the Pulsar Docker image. Use -Pdocker.push to push the image to registry."
 
     dependsOn(copyTarball, copyOffloaderTarball)
 
@@ -88,6 +89,10 @@ val dockerBuild by tasks.registering(Exec::class) {
 
     if (dockerPlatforms.isNotEmpty()) {
         args.addAll(listOf("--platform", dockerPlatforms))
+    }
+
+    if (dockerPush) {
+        args.add("--push")
     }
 
     args.add(".")


### PR DESCRIPTION
### Motivation

Some Docker registries do not support storing multi-architecture images locally. For multi-arch builds, the `--push` flag must be used to correctly create and push the manifest list to the registry.

Previously, the Gradle Docker build task only supported building images without the ability to push directly. This required users to manually push images after building, which doesn't work correctly for multi-architecture images.

### Modifications

- Add `docker.push` Gradle property to enable image pushing during build
- When `-Pdocker.push` is set, the `--push` flag is added to the `docker build` command
- Update task description to document the new option

### Documentation

- [ ] `doc`
- [x] `doc-required`
- [ ] `doc-not-needed`
- [ ] `doc-complete`