### PR TITLE
[improve][broker]Part-3 of PIP-433:  always allow replicator to register a new compatible schema

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2754,13 +2754,18 @@ public abstract class NamespacesBase extends AdminResource {
                 "schemaValidationEnforced");
     }
 
-    protected void internalSetIsAllowAutoUpdateSchema(boolean isAllowAutoUpdateSchema) {
+    protected void internalSetIsAllowAutoUpdateSchema(boolean isAllowAutoUpdateSchema,
+                                                      Boolean isAllowAutoUpdateSchemaWithReplicator) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.SCHEMA_COMPATIBILITY_STRATEGY,
                 PolicyOperation.WRITE);
         validatePoliciesReadOnlyAccess();
 
         mutatePolicy((policies) -> {
                     policies.is_allow_auto_update_schema = isAllowAutoUpdateSchema;
+                    if (isAllowAutoUpdateSchemaWithReplicator != null) {
+                        policies.is_allow_auto_update_schema_with_replicator =
+                                isAllowAutoUpdateSchemaWithReplicator;
+                    }
                     return policies;
                 }, (policies) -> policies.is_allow_auto_update_schema,
                 "isAllowAutoUpdateSchema");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -2819,6 +2819,11 @@ public class Namespaces extends NamespacesBase {
             @ApiParam(value = "Flag of whether to allow auto update schema", required = true)
                     boolean isAllowAutoUpdateSchema) {
         validateNamespaceName(tenant, namespace);
+        if (isAllowAutoUpdateSchema && allowAutoUpdateSchemaWithReplicator != null
+                && !allowAutoUpdateSchemaWithReplicator) {
+            throw new RestException(Response.Status.BAD_REQUEST, "Can not enable for all producers but denies for"
+                    + " replicators, which is meaningless");
+        }
         internalSetIsAllowAutoUpdateSchema(isAllowAutoUpdateSchema, allowAutoUpdateSchemaWithReplicator);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -2813,10 +2813,13 @@ public class Namespaces extends NamespacesBase {
     public void setIsAllowAutoUpdateSchema(
             @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace,
+            @QueryParam("allowAutoUpdateSchemaWithReplicator")
+            @ApiParam(value = "Allow replicator to auto update schema")
+                    Boolean allowAutoUpdateSchemaWithReplicator,
             @ApiParam(value = "Flag of whether to allow auto update schema", required = true)
                     boolean isAllowAutoUpdateSchema) {
         validateNamespaceName(tenant, namespace);
-        internalSetIsAllowAutoUpdateSchema(isAllowAutoUpdateSchema);
+        internalSetIsAllowAutoUpdateSchema(isAllowAutoUpdateSchema, allowAutoUpdateSchemaWithReplicator);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -141,6 +141,8 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected volatile boolean isEncryptionRequired = false;
 
     protected volatile Boolean isAllowAutoUpdateSchema;
+    @Getter
+    protected volatile Boolean isAllowAutoUpdateSchemaWithReplicator;
 
     protected volatile PublishRateLimiter topicPublishRateLimiter;
     protected volatile ResourceGroupPublishLimiter resourceGroupPublishLimiter;
@@ -733,6 +735,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
 
     @Override
     public CompletableFuture<SchemaVersion> addSchema(SchemaData schema) {
+        return addSchema(schema, false);
+    }
+
+    @Override
+    public CompletableFuture<SchemaVersion> addSchema(SchemaData schema, boolean isReplicatorProducer) {
         if (schema == null) {
             return CompletableFuture.completedFuture(SchemaVersion.Empty);
         }
@@ -740,7 +747,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         String id = getSchemaId();
         SchemaRegistryService schemaRegistryService = brokerService.pulsar().getSchemaRegistryService();
 
-        if (allowAutoUpdateSchema()) {
+        if (allowAutoUpdateSchema(isReplicatorProducer)) {
             return schemaRegistryService.putSchemaIfAbsent(id, schema, getSchemaCompatibilityStrategy());
         } else {
             return schemaRegistryService.trimDeletedSchemaAndGetList(id).thenCompose(schemaAndMetadataList ->
@@ -756,14 +763,19 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
         }
     }
 
-    private boolean allowAutoUpdateSchema() {
+    private boolean allowAutoUpdateSchema(boolean isReplicatorProducer) {
         if (brokerService.isSystemTopic(topic)) {
             return true;
         }
-        if (isAllowAutoUpdateSchema == null) {
-            return brokerService.pulsar().getConfig().isAllowAutoUpdateSchemaEnabled();
+        // Allowed auto updating.
+        boolean allowSchemaAutoUpdate = isAllowAutoUpdateSchema == null
+                ? brokerService.pulsar().getConfig().isAllowAutoUpdateSchemaEnabled()
+                : isAllowAutoUpdateSchema;
+        if (allowSchemaAutoUpdate) {
+            return true;
         }
-        return isAllowAutoUpdateSchema;
+        // Allowed replicator to update schemas.
+        return isReplicatorProducer && isAllowAutoUpdateSchemaWithReplicator;
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1808,8 +1808,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     }
 
                     disableTcpNoDelayIfNeeded(topicName.toString(), producerName);
-
-                    CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
+                    boolean isReplicatorProducer = Producer.isRemoteOrShadow(producerName,
+                            getBrokerService().getPulsar().getConfig().getReplicatorPrefix());
+                    CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema,
+                            isReplicatorProducer);
 
                     schemaVersionFuture.exceptionallyAsync(exception -> {
                         if (producerFuture.completeExceptionally(exception)) {
@@ -2934,7 +2936,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         service.getTopicIfExists(topicName).thenAccept(topicOpt -> {
             if (topicOpt.isPresent()) {
                 Topic topic = topicOpt.get();
-                CompletableFuture<SchemaVersion> schemaVersionFuture = tryAddSchema(topic, schema);
+                boolean isReplicatorProducer = false;
+                if (commandGetOrCreateSchema.hasProducerName()) {
+                    isReplicatorProducer = Producer.isRemoteOrShadow(commandGetOrCreateSchema.getProducerName(),
+                            getBrokerService().getPulsar().getConfig().getReplicatorPrefix());
+                }
+                CompletableFuture<SchemaVersion> schemaVersionFuture =
+                        tryAddSchema(topic, schema, isReplicatorProducer);
                 schemaVersionFuture.exceptionally(ex -> {
                     ServerError errorCode = BrokerServiceException.getClientErrorCode(ex);
                     String message = ex.getMessage();
@@ -3419,9 +3427,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         });
     }
 
-    private CompletableFuture<SchemaVersion> tryAddSchema(Topic topic, SchemaData schema) {
+    private CompletableFuture<SchemaVersion> tryAddSchema(Topic topic, SchemaData schema,
+                                                          boolean isReplicatorProducer) {
         if (schema != null) {
-            return topic.addSchema(schema);
+            return topic.addSchema(schema, isReplicatorProducer);
         } else {
             return topic.hasSchema().thenCompose((hasSchema) -> {
                 log.debug()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -310,6 +310,14 @@ public interface Topic {
     CompletableFuture<SchemaVersion> addSchema(SchemaData schema);
 
     /**
+     * Add a schema to the topic, with an optional override for replication schema auto-update.
+     * The default implementation preserves existing behavior.
+     */
+    default CompletableFuture<SchemaVersion> addSchema(SchemaData schema, boolean isReplicatorProducer) {
+        return addSchema(schema);
+    }
+
+    /**
      * Delete the schema if this topic has a schema defined for it.
      */
     CompletableFuture<SchemaVersion> deleteSchema();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -180,6 +180,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                         updateTopicPolicyByNamespacePolicy(policies);
                         isEncryptionRequired = policies.encryption_required;
                         isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
+                        isAllowAutoUpdateSchemaWithReplicator =
+                                policies.is_allow_auto_update_schema_with_replicator;
                     }
                     updatePublishRateLimiter();
                     updateResourceGroupLimiter(policies);
@@ -1157,6 +1159,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
         isEncryptionRequired = data.encryption_required;
         isAllowAutoUpdateSchema = data.is_allow_auto_update_schema;
+        isAllowAutoUpdateSchemaWithReplicator = data.is_allow_auto_update_schema_with_replicator;
 
         List<CompletableFuture<Void>> producerCheckFutures = new ArrayList<>(producers.size());
         producers.values().forEach(producer -> producerCheckFutures.add(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -500,6 +500,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     this.isEncryptionRequired = policies.encryption_required;
 
                     isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
+                    isAllowAutoUpdateSchemaWithReplicator = policies.is_allow_auto_update_schema_with_replicator;
                 }, getOrderedExecutor())
                 .thenCompose(ignore -> initTopicPolicy())
                 .thenCompose(ignore -> removeOrphanReplicationCursors())
@@ -3803,6 +3804,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         checkReplicatedSubscriptionControllerState();
         isEncryptionRequired = data.encryption_required;
         isAllowAutoUpdateSchema = data.is_allow_auto_update_schema;
+        isAllowAutoUpdateSchemaWithReplicator = data.is_allow_auto_update_schema_with_replicator;
 
         // Apply policies for components.
         List<CompletableFuture<Void>> applyPolicyTasks = applyUpdatedTopicPolicies();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -26,6 +26,7 @@ import static org.apache.pulsar.common.policies.data.NamespaceIsolationPolicyUnl
 import static org.apache.pulsar.common.policies.data.NamespaceIsolationPolicyUnloadScope.changed;
 import static org.apache.pulsar.common.policies.data.NamespaceIsolationPolicyUnloadScope.none;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -3317,6 +3318,13 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
                 return invocation.callRealMethod();
             }
         }).when(spyTopic).addSchema(any(SchemaData.class));
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                counter.incrementAndGet();
+                return invocation.callRealMethod();
+            }
+        }).when(spyTopic).addSchema(any(SchemaData.class), anyBoolean());
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -3306,6 +3306,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         }
     }
 
+    static final ThreadLocal<Boolean> COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY = new ThreadLocal<>();
+
     private AtomicInteger injectSchemaCheckCounterForTopic(String topicName) {
         final var topics = pulsar.getBrokerService().getTopics();
         AbstractTopic topic = (AbstractTopic) topics.get(topicName).join().get();
@@ -3315,13 +3317,20 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 counter.incrementAndGet();
-                return invocation.callRealMethod();
+                COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY.set(true);
+                try {
+                    return invocation.callRealMethod();
+                }  finally {
+                    COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY.set(false);
+                }
             }
         }).when(spyTopic).addSchema(any(SchemaData.class));
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                counter.incrementAndGet();
+                if (!COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY.get()) {
+                    counter.incrementAndGet();
+                }
                 return invocation.callRealMethod();
             }
         }).when(spyTopic).addSchema(any(SchemaData.class), anyBoolean());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -41,6 +41,7 @@ import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocal;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
@@ -3306,7 +3307,12 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         }
     }
 
-    static final ThreadLocal<Boolean> COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY = new ThreadLocal<>();
+    static final FastThreadLocal<Boolean> COUNTER_AVOID_COUNTING_ADD_SCHEMA_REPEATEDLY = new FastThreadLocal<>() {
+        @Override
+        protected Boolean initialValue() throws Exception {
+            return false;
+        }
+    };
 
     private AtomicInteger injectSchemaCheckCounterForTopic(String topicName) {
         final var topics = pulsar.getBrokerService().getTopics();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
@@ -25,6 +25,7 @@ import org.apache.avro.reflect.AvroDefault;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -300,16 +301,14 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
             Assert.assertTrue(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
         });
 
-        admin.namespaces().setIsAllowAutoUpdateSchema(
-                namespace, true, false);
-        Awaitility.await().untilAsserted(() -> {
-            // namespace level.
-            Policies policies = admin.namespaces().getPolicies(namespace);
-            Assert.assertTrue(policies.is_allow_auto_update_schema);
-            Assert.assertFalse(policies.is_allow_auto_update_schema_with_replicator);
-            // topic level.
-            Assert.assertFalse(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
-        });
+        try {
+            admin.namespaces().setIsAllowAutoUpdateSchema(
+                    namespace, true, false);
+            Assert.fail("Should have thrown exception");
+        } catch (PulsarAdminException e) {
+            Assert.assertTrue(e.getMessage().contains("Can not enable for all producers but denies for replicators,"
+                    + " which is meaningless"));
+        }
 
         admin.namespaces().setIsAllowAutoUpdateSchema(
                 namespace, false, false);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiSchemaAutoUpdateTest.java
@@ -22,11 +22,14 @@ import java.util.Set;
 import lombok.CustomLog;
 import org.apache.avro.reflect.AvroAlias;
 import org.apache.avro.reflect.AvroDefault;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.SchemaAutoUpdateCompatibilityStrategy;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.awaitility.Awaitility;
@@ -279,5 +282,69 @@ public class AdminApiSchemaAutoUpdateTest extends MockedPulsarServiceBaseTest {
     public void testDisabledV1() throws Exception {
         testAutoUpdateDisabled("prop-xyz/ns1", "persistent://prop-xyz/ns1/disabled");
         testAutoUpdateDisabled("prop-xyz/ns2", "non-persistent://prop-xyz/ns2/disabled-np");
+    }
+
+    @Test(timeOut = 60_000)
+    @SuppressWarnings("deprecation")
+    public void testIsAllowAutoUpdateSchemaWithReplicator() throws Exception {
+        final String namespace = BrokerTestUtil.newUniqueName("prop-xyz/ns");
+        admin.namespaces().createNamespace(namespace);
+        final String topic = BrokerTestUtil.newUniqueName(namespace + "/tp");
+        admin.topics().createNonPartitionedTopic(topic);
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topic, false).join().get();
+
+        // By default, it is true.
+        Awaitility.await().untilAsserted(() -> {
+            Assert.assertTrue(admin.namespaces().getPolicies(namespace).is_allow_auto_update_schema_with_replicator);
+            Assert.assertTrue(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
+        });
+
+        admin.namespaces().setIsAllowAutoUpdateSchema(
+                namespace, true, false);
+        Awaitility.await().untilAsserted(() -> {
+            // namespace level.
+            Policies policies = admin.namespaces().getPolicies(namespace);
+            Assert.assertTrue(policies.is_allow_auto_update_schema);
+            Assert.assertFalse(policies.is_allow_auto_update_schema_with_replicator);
+            // topic level.
+            Assert.assertFalse(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
+        });
+
+        admin.namespaces().setIsAllowAutoUpdateSchema(
+                namespace, false, false);
+        Awaitility.await().untilAsserted(() -> {
+            // namespace level.
+            Policies policies = admin.namespaces().getPolicies(namespace);
+            Assert.assertFalse(policies.is_allow_auto_update_schema);
+            Assert.assertFalse(policies.is_allow_auto_update_schema_with_replicator);
+            // topic level.
+            Assert.assertFalse(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
+        });
+
+        admin.namespaces().setIsAllowAutoUpdateSchema(
+                namespace, true, true);
+        Awaitility.await().untilAsserted(() -> {
+            // namespace level.
+            Policies policies = admin.namespaces().getPolicies(namespace);
+            Assert.assertTrue(policies.is_allow_auto_update_schema);
+            Assert.assertTrue(policies.is_allow_auto_update_schema_with_replicator);
+            // topic level.
+            Assert.assertTrue(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
+        });
+
+        admin.namespaces().setIsAllowAutoUpdateSchema(
+                namespace, false, true);
+        Awaitility.await().untilAsserted(() -> {
+            // namespace level.
+            Policies policies = admin.namespaces().getPolicies(namespace);
+            Assert.assertFalse(policies.is_allow_auto_update_schema);
+            Assert.assertTrue(policies.is_allow_auto_update_schema_with_replicator);
+            // topic level.
+            Assert.assertTrue(persistentTopic.getIsAllowAutoUpdateSchemaWithReplicator());
+        });
+
+        // cleanup.
+        admin.topics().delete(topic);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespaceAuthZTest.java
@@ -2141,7 +2141,7 @@ public class NamespaceAuthZTest extends MockedPulsarStandalone {
         execFlag = setAuthorizationPolicyOperationChecker(subject,
                 PolicyName.SCHEMA_COMPATIBILITY_STRATEGY, PolicyOperation.WRITE);
         Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
-                () -> subAdmin.namespaces().setIsAllowAutoUpdateSchema(namespace, true));
+                () -> subAdmin.namespaces().setIsAllowAutoUpdateSchema(namespace, true, true));
         Assert.assertTrue(execFlag.get());
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -249,7 +249,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
                 {true, true},
                 {true, null},
                 {false, true},
-                {false, true},
+                {false, false},
                 {false, null},
         };
     }
@@ -277,8 +277,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
         admin1.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
         admin2.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
         admin1.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, true, null);
-        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema,
-                allowAutoUpdateSchemaWithReplicator);
+        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema, null);
         RetentionPolicies retentionPolicies = new RetentionPolicies(10, 1);
         admin1.namespaces().setRetention(ns, retentionPolicies);
         admin2.namespaces().setRetention(ns, retentionPolicies);
@@ -294,11 +293,7 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             assertTrue(topic1.isAllowAutoUpdateSchema);
             assertTrue(topic1.isAllowAutoUpdateSchemaWithReplicator);
             assertEquals(topic2.isAllowAutoUpdateSchema, isAllowAutoUpdateSchema);
-            if (allowAutoUpdateSchemaWithReplicator != null && !allowAutoUpdateSchemaWithReplicator) {
-                assertFalse(topic2.isAllowAutoUpdateSchemaWithReplicator);
-            } else {
-                assertTrue(topic2.isAllowAutoUpdateSchemaWithReplicator);
-            }
+            assertTrue(topic2.isAllowAutoUpdateSchemaWithReplicator);
             assertEquals(policies1.getRetentionPolicies().get().getRetentionTimeInMinutes(), 10);
             assertEquals(policies2.getRetentionPolicies().get().getRetentionTimeInMinutes(), 10);
         });
@@ -354,12 +349,36 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             TopicStats topicStats = admin1.topics().getStats(topicName);
             assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 0);
         });
+
+        // Change policies.
+        admin1.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, true, null);
+        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema,
+                allowAutoUpdateSchemaWithReplicator);
+        Awaitility.await().untilAsserted(() -> {
+            assertTrue(topic1.isAllowAutoUpdateSchema);
+            assertTrue(topic1.isAllowAutoUpdateSchemaWithReplicator);
+            assertEquals(topic2.isAllowAutoUpdateSchema, isAllowAutoUpdateSchema);
+            if (allowAutoUpdateSchemaWithReplicator != null && !allowAutoUpdateSchemaWithReplicator) {
+                assertFalse(topic2.isAllowAutoUpdateSchemaWithReplicator);
+            } else {
+                assertTrue(topic2.isAllowAutoUpdateSchemaWithReplicator);
+            }
+        });
+
         TypedMessageBuilderImpl typedMessageBuilder2 = (TypedMessageBuilderImpl) producer1
                 .newMessage(Schema.AVRO(Customer.class)).value(new Customer("Apache", 26));
         MessageImpl message2 = (MessageImpl) typedMessageBuilder2.getMessage();
         message2.getMessageBuilder().setSchemaVersion(schemaVersion2.bytes());
         ClientImplInternalSetter.setMessageSchemaState(message2, "Ready");
         producer1.send(message2);
+        if (allowAutoUpdateSchemaWithReplicator != null && !allowAutoUpdateSchemaWithReplicator) {
+            Thread.sleep(3000);
+            // The message can not be replicated to the remote side.
+            TopicStats topicStats = admin1.topics().getStats(topicName);
+            assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 1);
+            producer1.close();
+            return;
+        }
         Awaitility.await().untilAsserted(() -> {
             TopicStats topicStats = admin1.topics().getStats(topicName);
             assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -40,11 +40,14 @@ import io.netty.channel.Channel;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -67,6 +70,7 @@ import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -96,16 +100,21 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.ClientImplInternalSetter;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
 import org.apache.pulsar.common.api.proto.CommandSendReceipt;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy;
@@ -113,6 +122,7 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.common.policies.data.impl.AutoTopicCreationOverrideImpl;
+import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -231,6 +241,180 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             admin1.topics().delete(topicName);
             admin2.topics().delete(topicName);
         });
+    }
+
+    @DataProvider
+    public Object[][] autoUpdateSchemaParams() {
+        return new Object[][] {
+                {true, true},
+                {true, null},
+                {false, true},
+                {false, true},
+                {false, null},
+        };
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Data
+    private static class Customer {
+        String name;
+        int age;
+    }
+
+    @Test(dataProvider = "autoUpdateSchemaParams")
+    public void testMultipleVersionSchemas(boolean isAllowAutoUpdateSchema,
+                                           Boolean allowAutoUpdateSchemaWithReplicator) throws Exception {
+        final String ns = BrokerTestUtil.newUniqueName("public/ns");
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://" + ns + "/tp_123");
+        final String subscribeName = "s1";
+        admin1.namespaces().createNamespace(ns);
+        admin2.namespaces().createNamespace(ns);
+        admin1.topics().createNonPartitionedTopic(topicName);
+        admin1.namespaces().setNamespaceReplicationClusters(ns,
+                new HashSet<>(Arrays.asList(cluster1, cluster2)), true);
+        waitReplicatorStarted(topicName);
+        admin1.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+        admin2.namespaces().setSchemaCompatibilityStrategy(ns, SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+        admin1.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, true, null);
+        admin2.namespaces().setIsAllowAutoUpdateSchemaAsync(ns, isAllowAutoUpdateSchema,
+                allowAutoUpdateSchemaWithReplicator);
+        RetentionPolicies retentionPolicies = new RetentionPolicies(10, 1);
+        admin1.namespaces().setRetention(ns, retentionPolicies);
+        admin2.namespaces().setRetention(ns, retentionPolicies);
+        PersistentTopic topic1 = (PersistentTopic) broker1.getTopic(topicName, false).join().get();
+        PersistentTopic topic2 = (PersistentTopic) broker2.getTopic(topicName, false).join().get();
+        Awaitility.await().untilAsserted(() -> {
+            HierarchyTopicPolicies policies1 = topic1.getHierarchyTopicPolicies();
+            HierarchyTopicPolicies policies2 = topic2.getHierarchyTopicPolicies();
+            assertEquals(policies1.getSchemaCompatibilityStrategy().get(),
+                    SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+            assertEquals(policies2.getSchemaCompatibilityStrategy().get(),
+                    SchemaCompatibilityStrategy.BACKWARD_TRANSITIVE);
+            assertTrue(topic1.isAllowAutoUpdateSchema);
+            assertTrue(topic1.isAllowAutoUpdateSchemaWithReplicator);
+            assertEquals(topic2.isAllowAutoUpdateSchema, isAllowAutoUpdateSchema);
+            if (allowAutoUpdateSchemaWithReplicator != null && !allowAutoUpdateSchemaWithReplicator) {
+                assertFalse(topic2.isAllowAutoUpdateSchemaWithReplicator);
+            } else {
+                assertTrue(topic2.isAllowAutoUpdateSchemaWithReplicator);
+            }
+            assertEquals(policies1.getRetentionPolicies().get().getRetentionTimeInMinutes(), 10);
+            assertEquals(policies2.getRetentionPolicies().get().getRetentionTimeInMinutes(), 10);
+        });
+        // Build different schemas.
+        HashMap<String, String> schemaProps = new HashMap<>();
+        schemaProps.put("__jsr310ConversionEnabled", "false");
+        schemaProps.put("__alwaysAllowNull", "true");
+        SchemaInfoImpl schemaInfoV1 = new SchemaInfoImpl("", """
+            {
+              "type" : "record",
+              "name" : "Student",
+              "namespace" : "org.apache.pulsar.broker.service.OneWayReplicatorTest",
+              "fields" : [ {
+                "name" : "age",
+                "type" : "int"
+              }]
+            }
+        """.getBytes(StandardCharsets.UTF_8), SchemaType.AVRO, 0, schemaProps);
+        SchemaInfoImpl schemaInfoV2 = new SchemaInfoImpl("", """
+            {
+              "type" : "record",
+              "name" : "Student",
+              "namespace" : "org.apache.pulsar.broker.service.OneWayReplicatorTest",
+              "fields" : [ {
+                "name" : "age",
+                "type" : "int"
+              }, {
+                "name" : "name",
+                "type" : [ "null", "string" ],
+                "default" : null
+              } ]
+            }
+        """.getBytes(StandardCharsets.UTF_8), SchemaType.AVRO, 0, schemaProps);
+        admin1.schemas().createSchema(topicName, schemaInfoV1);
+        admin1.schemas().createSchema(topicName, schemaInfoV2);
+        long longSchemaVersion1 = admin1.schemas().getVersionBySchemaAsync(topicName, schemaInfoV1)
+                .get(2, TimeUnit.SECONDS);
+        long longSchemaVersion2 = admin1.schemas().getVersionBySchemaAsync(topicName, schemaInfoV2)
+                .get(2, TimeUnit.SECONDS);
+        LongSchemaVersion schemaVersion1 = new LongSchemaVersion(longSchemaVersion1);
+        LongSchemaVersion schemaVersion2 = new LongSchemaVersion(longSchemaVersion2);
+
+        // Publish messages with different schemas.
+        ProducerImpl<byte[]> producer1 =
+                (ProducerImpl<byte[]>) client1.newProducer(Schema.AUTO_PRODUCE_BYTES()).topic(topicName).create();
+        TypedMessageBuilderImpl typedMessageBuilder1 = (TypedMessageBuilderImpl) producer1
+                .newMessage(Schema.AVRO(Customer.class)).value(new Customer(null, 16));
+        MessageImpl message1 = (MessageImpl) typedMessageBuilder1.getMessage();
+        message1.getMessageBuilder().setSchemaVersion(schemaVersion1.bytes());
+        ClientImplInternalSetter.setMessageSchemaState(message1, "Ready");
+        producer1.send(message1);
+        Awaitility.await().untilAsserted(() -> {
+            TopicStats topicStats = admin1.topics().getStats(topicName);
+            assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 0);
+        });
+        TypedMessageBuilderImpl typedMessageBuilder2 = (TypedMessageBuilderImpl) producer1
+                .newMessage(Schema.AVRO(Customer.class)).value(new Customer("Apache", 26));
+        MessageImpl message2 = (MessageImpl) typedMessageBuilder2.getMessage();
+        message2.getMessageBuilder().setSchemaVersion(schemaVersion2.bytes());
+        ClientImplInternalSetter.setMessageSchemaState(message2, "Ready");
+        producer1.send(message2);
+        Awaitility.await().untilAsserted(() -> {
+            TopicStats topicStats = admin1.topics().getStats(topicName);
+            assertEquals(topicStats.getReplication().get(cluster2).getReplicationBacklog(), 0);
+        });
+
+        // Verify: the messages were built successfully.
+        admin1.topics().createSubscription(topicName, subscribeName, MessageId.earliest);
+        Consumer<Customer> consumer1 = client1.newConsumer(Schema.AVRO(Customer.class))
+                .subscriptionName(subscribeName).topic(topicName).subscribe();
+        Message<Customer> msg1 = consumer1.receive(5, TimeUnit.SECONDS);
+        assertNotNull(msg1);
+        byte[] bytesVersion1 = msg1.getSchemaVersion();
+        assertEquals(ByteBuffer.wrap(bytesVersion1).getLong(), longSchemaVersion1);
+        assertNull(msg1.getValue().getName());
+        assertEquals(msg1.getValue().getAge(), 16);
+        consumer1.acknowledge(msg1);
+        Message<Customer> msg2 = consumer1.receive(5, TimeUnit.SECONDS);
+        assertNotNull(msg2);
+        byte[] bytesVersion2 = msg2.getSchemaVersion();
+        assertEquals(ByteBuffer.wrap(bytesVersion2).getLong(), longSchemaVersion2);
+        assertEquals(msg2.getValue().getName(), "Apache");
+        assertEquals(msg2.getValue().getAge(), 26);
+        consumer1.acknowledge(msg2);
+
+        admin2.topics().createSubscription(topicName, subscribeName, MessageId.earliest);
+        Consumer<Customer> consumer2 = client2.newConsumer(Schema.AVRO(Customer.class))
+                .subscriptionName(subscribeName).topic(topicName).subscribe();
+        Message<Customer> msg21 = consumer2.receive(5, TimeUnit.SECONDS);
+        assertNotNull(msg21);
+        byte[] bytesVersion21 = msg21.getSchemaVersion();
+        assertEquals(ByteBuffer.wrap(bytesVersion21).getLong(), 0);
+        assertNull(msg21.getValue().getName());
+        assertEquals(msg21.getValue().getAge(), 16);
+        consumer2.acknowledge(msg21);
+        Message<Customer> msg22 = consumer2.receive(5, TimeUnit.SECONDS);
+        if (allowAutoUpdateSchemaWithReplicator != null && !allowAutoUpdateSchemaWithReplicator) {
+            assertNull(msg22);
+        } else {
+            assertNotNull(msg22);
+            byte[] bytesVersion22 = msg22.getSchemaVersion();
+            assertEquals(ByteBuffer.wrap(bytesVersion22).getLong(), 1);
+            assertEquals(msg22.getValue().getName(), "Apache");
+            assertEquals(msg22.getValue().getAge(), 26);
+            consumer2.acknowledge(msg22);
+        }
+
+        // cleanup.
+        consumer1.close();
+        consumer2.close();
+        producer1.close();
+        admin1.namespaces().setNamespaceReplicationClusters(ns,
+                new HashSet<>(Arrays.asList(cluster1)), true);
+        waitReplicatorStopped(pulsar1, pulsar2, topicName);
+        admin1.topics().delete(topicName);
+        admin2.topics().delete(topicName);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -73,6 +73,7 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
         config.setDefaultNumPartitions(1);
     }
 
+    @Override
     @Test(enabled = false)
     public void testDeleteTopicWhenReplicating() throws Exception {
         super.testDeleteTopicWhenReplicating();
@@ -82,6 +83,13 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
     @Test(enabled = false)
     public void testReplicatorProducerStatInTopic() throws Exception {
         super.testReplicatorProducerStatInTopic();
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void testMultipleVersionSchemas(boolean isAllowAutoUpdateSchema,
+                                           Boolean allowAutoUpdateSchemaWithReplicator) throws Exception {
+        super.testDeleteTopicWhenReplicating();
     }
 
     @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalZKTest.java
@@ -100,6 +100,13 @@ public class OneWayReplicatorUsingGlobalZKTest extends OneWayReplicatorTest {
         super.testReplicatorProducerStatInTopic();
     }
 
+    @Override
+    @Test(enabled = false)
+    public void testMultipleVersionSchemas(boolean isAllowAutoUpdateSchema,
+                                           Boolean allowAutoUpdateSchemaWithReplicator) throws Exception {
+        super.testDeleteTopicWhenReplicating();
+    }
+
     @Test(dataProvider = "isPartitioned")
     public void testReplicatorCreateTopic(boolean isPartitioned) throws Exception {
         super.testReplicatorCreateTopic(isPartitioned);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientImplInternalSetter.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ClientImplInternalSetter.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.impl;
+
+public class ClientImplInternalSetter {
+
+    public static void setMessageSchemaState(MessageImpl message, String state) {
+        message.setSchemaState(MessageImpl.SchemaState.valueOf(state));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -332,7 +332,7 @@ public class NegativeAcksTest extends SharedPulsarBaseTest {
      */
     @Test
     public void testNegativeAcksWithBatch() throws Exception {
-        admin.namespaces().setIsAllowAutoUpdateSchema(getNamespace(), true);
+        admin.namespaces().setIsAllowAutoUpdateSchema(getNamespace(), true, true);
         String topic = newTopicName();
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/compatibility/SchemaCompatibilityCheckTest.java
@@ -347,7 +347,7 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().setSchemaCompatibilityStrategy(namespaceName.toString(), schemaCompatibilityStrategy);
         admin.schemas().createSchema(fqtn, Schema.AVRO(Schemas.PersonOne.class).getSchemaInfo());
 
-        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false);
+        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false, true);
         ProducerBuilder<Schemas.PersonTwo> producerThreeBuilder = pulsarClient
                 .newProducer(Schema.AVRO(SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
                         (false).withSupportSchemaVersioning(true).
@@ -359,7 +359,7 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
             Assert.assertTrue(e.getMessage().contains("Schema not found and schema auto updating is disabled."));
         }
 
-        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), true);
+        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), true, true);
         ConsumerBuilder<Schemas.PersonTwo> comsumerBuilder = pulsarClient.newConsumer(Schema.AVRO(
                 SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
                         (false).withSupportSchemaVersioning(true).
@@ -382,7 +382,7 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         producer.close();
         consumerTwo.close();
 
-        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false);
+        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false, true);
 
         producer = producerThreeBuilder.create();
         consumerTwo = comsumerBuilder.subscribe();
@@ -427,7 +427,7 @@ public class SchemaCompatibilityCheckTest extends MockedPulsarServiceBaseTest {
         SchemaInfo schemaInfo = SchemaInfo.builder().type(SchemaType.AVRO).schema(changeSchemaBytes).build();
         admin.schemas().createSchema(fqtn, schemaInfo);
 
-        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false);
+        admin.namespaces().setIsAllowAutoUpdateSchema(namespaceName.toString(), false, true);
         ProducerBuilder<Schemas.PersonOne> producerOneBuilder = pulsarClient
                 .newProducer(Schema.AVRO(Schemas.PersonOne.class))
                 .topic(fqtn);

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -4105,6 +4105,7 @@ public interface Namespaces {
      *
      * @param namespace pulsar namespace name
      * @param isAllowAutoUpdateSchema flag to enable or disable auto update schema
+     * @param allowAutoUpdateSchemaWithReplicator whether replicator can auto update schema
      * @throws NotAuthorizedException
      *             Don't have admin permission
      * @throws NotFoundException
@@ -4112,19 +4113,20 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema)
+    void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema,
+                                    boolean allowAutoUpdateSchemaWithReplicator)
             throws PulsarAdminException;
 
+
     /**
-     * Set whether to allow automatic schema updates asynchronously.
-     * <p/>
-     * The flag is when producer bring a new schema and the schema pass compatibility check
-     * whether allow schema auto registered
+     * Set whether to allow automatic schema updates and replicator schema updates in one call asynchronously.
      *
      * @param namespace pulsar namespace name
      * @param isAllowAutoUpdateSchema flag to enable or disable auto update schema
+     * @param allowAutoUpdateSchemaWithReplicator whether replicator can auto update schema
      */
-    CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(String namespace, boolean isAllowAutoUpdateSchema);
+    CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(String namespace, boolean isAllowAutoUpdateSchema,
+                                                            boolean allowAutoUpdateSchemaWithReplicator);
 
     /**
      * Set the offload configuration for all the topics in a namespace.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -4114,7 +4114,7 @@ public interface Namespaces {
      *             Unexpected error
      */
     void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema,
-                                    boolean allowAutoUpdateSchemaWithReplicator)
+                                    Boolean allowAutoUpdateSchemaWithReplicator)
             throws PulsarAdminException;
 
 
@@ -4126,7 +4126,7 @@ public interface Namespaces {
      * @param allowAutoUpdateSchemaWithReplicator whether replicator can auto update schema
      */
     CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(String namespace, boolean isAllowAutoUpdateSchema,
-                                                            boolean allowAutoUpdateSchemaWithReplicator);
+                                                            Boolean allowAutoUpdateSchemaWithReplicator);
 
     /**
      * Set the offload configuration for all the topics in a namespace.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -119,6 +119,9 @@ public class Policies {
     public Boolean is_allow_auto_update_schema = null;
 
     @SuppressWarnings("checkstyle:MemberName")
+    public Boolean is_allow_auto_update_schema_with_replicator = true;
+
+    @SuppressWarnings("checkstyle:MemberName")
     public boolean schema_validation_enforced = false;
 
     @SuppressWarnings("checkstyle:MemberName")
@@ -169,6 +172,7 @@ public class Policies {
                 schema_validation_enforced,
                 schema_compatibility_strategy,
                 is_allow_auto_update_schema,
+                is_allow_auto_update_schema_with_replicator,
                 offload_policies,
                 subscription_types_enabled,
                 allowed_topic_property_keys_for_metrics,
@@ -218,6 +222,8 @@ public class Policies {
                     && schema_validation_enforced == other.schema_validation_enforced
                     && schema_compatibility_strategy == other.schema_compatibility_strategy
                     && is_allow_auto_update_schema == other.is_allow_auto_update_schema
+                    && is_allow_auto_update_schema_with_replicator
+                        == other.is_allow_auto_update_schema_with_replicator
                     && Objects.equals(offload_policies, other.offload_policies)
                     && Objects.equals(subscription_types_enabled, other.subscription_types_enabled)
                     && Objects.equals(allowed_topic_property_keys_for_metrics,

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -222,8 +222,8 @@ public class Policies {
                     && schema_validation_enforced == other.schema_validation_enforced
                     && schema_compatibility_strategy == other.schema_compatibility_strategy
                     && is_allow_auto_update_schema == other.is_allow_auto_update_schema
-                    && is_allow_auto_update_schema_with_replicator
-                        == other.is_allow_auto_update_schema_with_replicator
+                    && Objects.equals(is_allow_auto_update_schema_with_replicator,
+                        other.is_allow_auto_update_schema_with_replicator)
                     && Objects.equals(offload_policies, other.offload_policies)
                     && Objects.equals(subscription_types_enabled, other.subscription_types_enabled)
                     && Objects.equals(allowed_topic_property_keys_for_metrics,

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1783,15 +1783,19 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema)
+    public void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema,
+                                           boolean allowAutoUpdateSchemaWithReplicator)
             throws PulsarAdminException {
-        sync(() -> setIsAllowAutoUpdateSchemaAsync(namespace, isAllowAutoUpdateSchema));
+        sync(() -> setIsAllowAutoUpdateSchemaAsync(namespace, isAllowAutoUpdateSchema,
+                allowAutoUpdateSchemaWithReplicator));
     }
 
     @Override
-    public CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(String namespace, boolean isAllowAutoUpdateSchema) {
+    public CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(
+            String namespace, boolean isAllowAutoUpdateSchema, boolean allowAutoUpdateSchemaWithReplicator) {
         NamespaceName ns = NamespaceName.get(namespace);
-        WebTarget path = namespacePath(ns, "isAllowAutoUpdateSchema");
+        WebTarget path = namespacePath(ns, "isAllowAutoUpdateSchema")
+                .queryParam("allowAutoUpdateSchemaWithReplicator", allowAutoUpdateSchemaWithReplicator);
         return asyncPostRequest(path, Entity.entity(isAllowAutoUpdateSchema, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1784,7 +1784,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void setIsAllowAutoUpdateSchema(String namespace, boolean isAllowAutoUpdateSchema,
-                                           boolean allowAutoUpdateSchemaWithReplicator)
+                                           Boolean allowAutoUpdateSchemaWithReplicator)
             throws PulsarAdminException {
         sync(() -> setIsAllowAutoUpdateSchemaAsync(namespace, isAllowAutoUpdateSchema,
                 allowAutoUpdateSchemaWithReplicator));
@@ -1792,10 +1792,12 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public CompletableFuture<Void> setIsAllowAutoUpdateSchemaAsync(
-            String namespace, boolean isAllowAutoUpdateSchema, boolean allowAutoUpdateSchemaWithReplicator) {
+            String namespace, boolean isAllowAutoUpdateSchema, Boolean allowAutoUpdateSchemaWithReplicator) {
         NamespaceName ns = NamespaceName.get(namespace);
-        WebTarget path = namespacePath(ns, "isAllowAutoUpdateSchema")
-                .queryParam("allowAutoUpdateSchemaWithReplicator", allowAutoUpdateSchemaWithReplicator);
+        WebTarget path = namespacePath(ns, "isAllowAutoUpdateSchema");
+        if (allowAutoUpdateSchemaWithReplicator != null) {
+            path = path.queryParam("allowAutoUpdateSchemaWithReplicator", allowAutoUpdateSchemaWithReplicator);
+        }
         return asyncPostRequest(path, Entity.entity(isAllowAutoUpdateSchema, MediaType.APPLICATION_JSON));
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2163,11 +2163,11 @@ public class CmdNamespaces extends CmdBase {
         @Option(names = { "--disable", "-d" }, description = "Disable schema validation enforced")
         private boolean disable = false;
 
-        @Option(names = { "--disable-for-replicator" },
+        @Option(names = { "--enable-for-replicator" },
                 description = "By default, brokers always allow replicator to register new compatible schemas even"
                 + " when auto updates are disabled, if you want to disable replicators to register compatible schemas,"
-                + " please set it to true")
-        private boolean disableForReplicator;
+                + " please set it to false")
+        private Boolean enableForReplicator;
 
         @Override
         void run() throws PulsarAdminException {
@@ -2176,7 +2176,7 @@ public class CmdNamespaces extends CmdBase {
             if (enable == disable) {
                 throw new ParameterException("Need to specify either --enable or --disable");
             }
-            getAdmin().namespaces().setIsAllowAutoUpdateSchema(namespace, enable, !disableForReplicator);
+            getAdmin().namespaces().setIsAllowAutoUpdateSchema(namespace, enable, enableForReplicator);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2163,6 +2163,12 @@ public class CmdNamespaces extends CmdBase {
         @Option(names = { "--disable", "-d" }, description = "Disable schema validation enforced")
         private boolean disable = false;
 
+        @Option(names = { "--disable-for-replicator" },
+                description = "By default, brokers always allow replicator to register new compatible schemas even"
+                + " when auto updates are disabled, if you want to disable replicators to register compatible schemas,"
+                + " please set it to true")
+        private boolean disableForReplicator;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(namespaceName);
@@ -2170,7 +2176,7 @@ public class CmdNamespaces extends CmdBase {
             if (enable == disable) {
                 throw new ParameterException("Need to specify either --enable or --disable");
             }
-            getAdmin().namespaces().setIsAllowAutoUpdateSchema(namespace, enable);
+            getAdmin().namespaces().setIsAllowAutoUpdateSchema(namespace, enable, !disableForReplicator);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -2176,6 +2176,9 @@ public class CmdNamespaces extends CmdBase {
             if (enable == disable) {
                 throw new ParameterException("Need to specify either --enable or --disable");
             }
+            if (enable && enableForReplicator != null && !enableForReplicator) {
+                throw new ParameterException("Can not enable for all producers but denies for replicators");
+            }
             getAdmin().namespaces().setIsAllowAutoUpdateSchema(namespace, enable, enableForReplicator);
         }
     }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaces.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaces.java
@@ -62,18 +62,18 @@ public class TestCmdNamespaces {
 
         cmd.run("set-is-allow-auto-update-schema public/default --disable"
                 .split("\\s+"));
-        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, true);
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, null);
 
         cmd.run("set-is-allow-auto-update-schema public/default --enable"
                 .split("\\s+"));
-        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, true);
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, null);
 
-        cmd.run("set-is-allow-auto-update-schema public/default --disable --disable-for-replicator"
+        cmd.run("set-is-allow-auto-update-schema public/default --disable --enable-for-replicator"
                 .split("\\s+"));
-        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, false);
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, Boolean.TRUE);
 
-        cmd.run("set-is-allow-auto-update-schema public/default --enable --disable-for-replicator"
+        cmd.run("set-is-allow-auto-update-schema public/default --enable --enable-for-replicator"
                 .split("\\s+"));
-        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, false);
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, Boolean.TRUE);
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaces.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdNamespaces.java
@@ -50,4 +50,30 @@ public class TestCmdNamespaces {
         verify(namespaces, times(1)).setRetention("public/default",
                 new RetentionPolicies(200 * 24 * 60, 2 * 1024 * 1024));
    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testSetIsAllowAutoUpdateSchemaCmd() throws Exception {
+        Namespaces namespaces = mock(Namespaces.class);
+        PulsarAdmin admin = mock(PulsarAdmin.class);
+        when(admin.namespaces()).thenReturn(namespaces);
+
+        CmdNamespaces cmd = new CmdNamespaces(() -> admin);
+
+        cmd.run("set-is-allow-auto-update-schema public/default --disable"
+                .split("\\s+"));
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, true);
+
+        cmd.run("set-is-allow-auto-update-schema public/default --enable"
+                .split("\\s+"));
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, true);
+
+        cmd.run("set-is-allow-auto-update-schema public/default --disable --disable-for-replicator"
+                .split("\\s+"));
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", false, false);
+
+        cmd.run("set-is-allow-auto-update-schema public/default --enable --disable-for-replicator"
+                .split("\\s+"));
+        verify(namespaces, times(1)).setIsAllowAutoUpdateSchema("public/default", true, false);
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -977,7 +977,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                     cnx.getRemoteEndpointProtocolVersion(), producerName, topic)));
         }
         long requestId = client.newRequestId();
-        ByteBuf request = Commands.newGetOrCreateSchema(requestId, topic, schemaInfo);
+        ByteBuf request = Commands.newGetOrCreateSchema(requestId, topic, producerName, schemaInfo);
         log.info("GetOrCreateSchema request");
         return cnx.sendGetOrCreateSchema(request, requestId);
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -1361,10 +1361,12 @@ public class Commands {
         return serializeWithSize(newGetSchemaResponseErrorCommand(requestId, error, errorMessage));
     }
 
-    public static ByteBuf newGetOrCreateSchema(long requestId, String topic, SchemaInfo schemaInfo) {
+    public static ByteBuf newGetOrCreateSchema(long requestId, String topic, String producerName,
+                                               SchemaInfo schemaInfo) {
         BaseCommand cmd = localCmd(Type.GET_OR_CREATE_SCHEMA);
         Schema schema = cmd.setGetOrCreateSchema()
                 .setRequestId(requestId)
+                .setProducerName(producerName)
                 .setTopic(topic)
                 .setSchema();
         convertSchema(schemaInfo, schema);

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -851,9 +851,10 @@ message CommandGetSchemaResponse {
 }
 
 message CommandGetOrCreateSchema {
-    required uint64 request_id = 1;
-    required string topic      = 2;
-    required Schema schema     = 3;
+    required uint64 request_id      = 1;
+    required string topic           = 2;
+    required Schema schema          = 3;
+    optional string producerName    = 4;
 }
 
 message CommandGetOrCreateSchemaResponse {


### PR DESCRIPTION
### Motivation

This is part-3 of PIP-433, see the goal 1 in [PIP-433](https://github.com/apache/pulsar/blob/master/pip/pip-433.md)


### Modifications

 always allow the replicator to register a new compatible schema, users can turn off this function


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->