### PR TITLE
[fix][test] Fix flaky BrokerRegistryIntegrationTest port binding race

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.util.PortManager;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -41,14 +40,14 @@ import org.testng.annotations.Test;
 public class BrokerRegistryIntegrationTest {
 
     private static final String clusterName = "test";
-    private final int zkPort = PortManager.nextFreePort();
-    private final LocalBookkeeperEnsemble bk = new LocalBookkeeperEnsemble(2, zkPort, PortManager::nextFreePort);
+    private LocalBookkeeperEnsemble bk;
     private PulsarService pulsar;
     private BrokerRegistry brokerRegistry;
     private String brokerMetadataPath;
 
     @BeforeClass
     protected void setup() throws Exception {
+        bk = new LocalBookkeeperEnsemble(2, 0, () -> 0);
         bk.start();
         pulsar = new PulsarService(brokerConfig());
         pulsar.start();
@@ -68,7 +67,9 @@ public class BrokerRegistryIntegrationTest {
             pulsar.close();
         }
         final var elapsedMs = System.currentTimeMillis() - startMs;
-        bk.stop();
+        if (bk != null) {
+            bk.stop();
+        }
         if (elapsedMs > 5000) {
             throw new RuntimeException("Broker took " + elapsedMs + "ms to close");
         }


### PR DESCRIPTION
## Motivation

`BrokerRegistryIntegrationTest.setup` is flaky due to a port binding race condition. Ports are allocated at field initialization time via `PortManager.nextFreePort()`, but by the time `@BeforeClass` runs, those ports may have been reused by another test class.

### Stack trace
```
Gradle suite > Gradle test > BrokerRegistryIntegrationTest > setup FAILED
    java.io.IOException: java.net.BindException: Address already in use
        at LocalBookkeeperEnsemble.runZookeeper(LocalBookkeeperEnsemble.java:219)
        at LocalBookkeeperEnsemble.start(LocalBookkeeperEnsemble.java:420)
        at BrokerRegistryIntegrationTest.setup(BrokerRegistryIntegrationTest.java:52)
        Caused by: java.net.BindException: Address already in use

BrokerRegistryIntegrationTest.cleanup FAILED
    java.lang.NullPointerException at BrokerRegistryIntegrationTest.java:71
```

## Modifications

- Move `LocalBookkeeperEnsemble` creation from field initialization to `@BeforeClass`
- Use port `0` for automatic OS port allocation instead of `PortManager.nextFreePort()`
- Add null guard for `bk` in cleanup to handle setup failures gracefully

### Documentation
- [x] `doc-not-needed`