### PR TITLE
[fix][test] Fix flaky FunctionRuntimeManagerTest.testExternallyManagedRuntimeUpdate

### DIFF
--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -742,6 +742,9 @@ public class FunctionRuntimeManagerTest {
                     .get("worker-2").get("test-tenant/test-namespace/func-1:0"), assignment2);
             assertNull(functionRuntimeManager.functionRuntimeInfos.get("test-tenant/test-namespace/func-1:0"));
 
+            // Clear invocations to ensure the next verify block starts fresh
+            Mockito.clearInvocations(functionActioner);
+
             /** Test transfer from other worker to me **/
 
             Assignment assignment3 = createAssignment("worker-1", function1, 0);


### PR DESCRIPTION
## Motivation

`FunctionRuntimeManagerTest.testExternallyManagedRuntimeUpdate` is flaky because accumulated Mockito spy invocations from the first test section leak into the second verification block.

### Stack trace
```
FunctionRuntimeManagerTest > testExternallyManagedRuntimeUpdate FAILED
    org.mockito.exceptions.verification.NeverWantedButInvoked
        at FunctionRuntimeManagerTest.java:720
```

## Modifications

Add `Mockito.clearInvocations(functionActioner)` between the two verification blocks ("transfer from me to other worker" and "transfer from other worker to me") so that `verify(times(0))` assertions in the second block are not affected by invocations from the first block.

### Documentation
- [x] `doc-not-needed`