### PR TITLE
[fix][test] Fix flaky MembershipManagerTest.testCheckFailuresSomeFailures

### DIFF
--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/MembershipManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/MembershipManagerTest.java
@@ -236,6 +236,9 @@ public class MembershipManagerTest {
         functionRuntimeManager.setAssignment(assignment1);
         functionRuntimeManager.setAssignment(assignment2);
 
+        // Clear any invocations from setup
+        Mockito.clearInvocations(functionRuntimeManager, schedulerManager);
+
         membershipManager.checkFailures(functionMetaDataManager, functionRuntimeManager, schedulerManager);
 
         verify(schedulerManager, times(0)).schedule();
@@ -244,6 +247,9 @@ public class MembershipManagerTest {
         Instance instance = createInstance(function2, 0);
         String instanceId = FunctionCommon.getFullyQualifiedInstanceId(instance);
         assertNotNull(membershipManager.unsignedFunctionDurations.get(instanceId));
+
+        // Clear invocations before second checkFailures
+        Mockito.clearInvocations(functionRuntimeManager, schedulerManager);
 
         membershipManager.unsignedFunctionDurations.put(instanceId,
                 membershipManager.unsignedFunctionDurations.get(instanceId) - 30001);


### PR DESCRIPTION
## Motivation

`MembershipManagerTest.testCheckFailuresSomeFailures` is flaky because accumulated Mockito spy invocations from setup and the first `checkFailures` call leak into subsequent verification blocks.

### Stack trace
```
MembershipManagerTest > testCheckFailuresSomeFailures FAILED
    java.lang.AssertionError at MembershipManagerTest.java:240
```

## Modifications

Add `Mockito.clearInvocations(functionRuntimeManager, schedulerManager)` in two places:
1. After setup/`setAssignment` calls and before the first `checkFailures` call
2. Before the second `checkFailures` call

This ensures each `verify(times(...))` assertion only counts invocations from its own test section.

### Documentation
- [x] `doc-not-needed`