### PR TITLE
[fix][test] Fix flaky ManagedLedgerTest.testNoRetention

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2309,8 +2309,10 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         c1 = ml.openCursor("c1noretention");
         ml.addEntry("shortmessage".getBytes());
         c1.skipEntries(1, IndividualDeletedEntries.Exclude);
-        // sleep for trim
-        Thread.sleep(1000);
+        // Explicitly trigger trimming and wait for it to complete
+        CompletableFuture<Void> trimFuture = new CompletableFuture<>();
+        ml.trimConsumedLedgersInBackground(trimFuture);
+        trimFuture.join();
         ml.close();
 
         assertTrue(ml.getLedgersInfoAsList().size() <= 1);


### PR DESCRIPTION
## Motivation

`ManagedLedgerTest.testNoRetention` is flaky because it relies on `Thread.sleep(1000)` for the async ledger trimming to complete, which is not always sufficient.

### Stack trace
```
ManagedLedgerTest > testNoRetention FAILED
    java.lang.AssertionError: expected [true] but found [false]
        at org.testng.Assert.fail(Assert.java:110)
        at org.testng.Assert.failNotEquals(Assert.java:1577)
        at org.testng.Assert.assertTrue(Assert.java:56)
        at org.testng.Assert.assertTrue(Assert.java:66)
        at ManagedLedgerTest.testNoRetention(ManagedLedgerTest.java:2316)
```

## Modifications

Replace `Thread.sleep(1000)` with explicit `trimConsumedLedgersInBackground(CompletableFuture)` + `join()` to deterministically wait for ledger trimming to complete before asserting.

### Documentation
- [x] `doc-not-needed`