### PR TITLE
[fix][test] Fix flaky ConsumerBatchReceiveTest.testBatchReceiveAndRedeliveryNonPartitionedTopic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerBatchReceiveTest.java
@@ -629,10 +629,11 @@ public class ConsumerBatchReceiveTest extends SharedPulsarBaseTest {
                     Assert.assertNotNull(message.getValue());
                     log.info("Get message {} from batch", message.getValue());
                 }
+                consumer.acknowledge(messages);
             }
-            consumer.acknowledge(messages);
         } while (messageReceived < expected * 2);
-        Assert.assertEquals(expected * 2, messageReceived);
+        Assert.assertTrue(messageReceived >= expected * 2,
+                "Expected at least " + (expected * 2) + " messages but received " + messageReceived);
     }
 
 


### PR DESCRIPTION
## Motivation

`ConsumerBatchReceiveTest.testBatchReceiveAndRedeliveryNonPartitionedTopic` is flaky due to two issues:
1. `consumer.acknowledge(messages)` is called outside the null check, causing NPE when `batchReceive()` returns null
2. Strict equality assertion fails because ack timeout redelivery can cause extra messages beyond the expected count

### Stack trace
```
ConsumerBatchReceiveTest > testBatchReceiveAndRedeliveryNonPartitionedTopic[54] FAILED
    java.lang.AssertionError: expected [202] but found [200]
        at org.testng.Assert.fail(Assert.java:110)
        at org.testng.Assert.failNotEquals(Assert.java:1577)
        at org.testng.Assert.assertEqualsImpl(Assert.java:149)
        at org.testng.Assert.assertEquals(Assert.java:131)
        at ConsumerBatchReceiveTest.batchReceiveAndRedelivery(ConsumerBatchReceiveTest.java:635)
```

## Modifications

- Move `consumer.acknowledge(messages)` inside the `if (messages != null)` block
- Change `assertEquals(expected * 2, messageReceived)` to `assertTrue(messageReceived >= expected * 2)` since redelivery can produce extra messages

### Documentation
- [x] `doc-not-needed`