### PR TITLE
[fix][test] Fix flaky PulsarFunctionsJavaThreadTest by adding retry to getFunctionStats

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -1251,6 +1251,14 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
     }
 
     private void getFunctionStats(String functionName, int numMessages) throws Exception {
+        Awaitility.await()
+                .pollInterval(Duration.ofSeconds(1))
+                .atMost(Duration.ofSeconds(15))
+                .ignoreExceptions()
+                .untilAsserted(() -> doGetFunctionStats(functionName, numMessages));
+    }
+
+    private void doGetFunctionStats(String functionName, int numMessages) throws Exception {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
                 PulsarCluster.ADMIN_SCRIPT,
                 "functions",


### PR DESCRIPTION
## Motivation

`PulsarFunctionsJavaThreadTest.testJavaExclamationCustomBatchingFunction` is flaky because `getFunctionStats()` has no retry logic — unlike `getFunctionStatus()` which wraps its logic in `Awaitility.await()`. When function stats aren't available yet (metrics not collected, stats endpoint not ready), the `pulsar-admin functions stats` command fails with a non-zero exit code.

### Stack trace
```
PulsarFunctionsJavaThreadTest > testJavaExclamationCustomBatchingFunction FAILED
    org.apache.pulsar.tests.integration.docker.ContainerExecException:
        /pulsar/bin/pulsar-admin functions stats --tenant public --namespace default
        --name test-exclamation-fn-nnolxtaf failed on <container> with error code 1
        at DockerUtils$2.onComplete(DockerUtils.java:281)
```

## Modifications

Wrap `getFunctionStats()` in `Awaitility.await()` with `pollInterval(1s)` and `atMost(15s)`, matching the existing pattern used by `getFunctionStatus()`. The actual assertions are moved to a `doGetFunctionStats()` method.

### Documentation
- [x] `doc-not-needed`