### PR TITLE
[fix][test] Fix flaky IsolatedBookieEnsemblePlacementPolicyTest.testBookieInfoChange

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -385,6 +385,11 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
+        // Wait for the async cache load triggered by initialize() to complete
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertNotNull(isolationPolicy.getBookieMappingCache()
+                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
+
         List<BookieId> ensemble = isolationPolicy.newEnsemble(2, 2, 2,
                 Collections.emptyMap(), new HashSet<>()).getResult();
         assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE1).toBookieId()));


### PR DESCRIPTION
## Motivation

`IsolatedBookieEnsemblePlacementPolicyTest.testBookieInfoChange` is flaky because `initialize()` loads the bookie rack configuration asynchronously. When `newEnsemble()` runs before the async load completes, `cachedRackConfiguration` is null, no bookie isolation is applied, and the ensemble may include bookies from the wrong group.

### Stack trace
```
IsolatedBookieEnsemblePlacementPolicyTest > testBookieInfoChange FAILED
    java.lang.AssertionError: expected [true] but found [false]
        at org.testng.Assert.fail(Assert.java:110)
        at org.testng.Assert.failNotEquals(Assert.java:1577)
        at org.testng.Assert.assertTrue(Assert.java:56)
        at org.testng.Assert.assertTrue(Assert.java:66)
        at IsolatedBookieEnsemblePlacementPolicyTest.testBookieInfoChange(IsolatedBookieEnsemblePlacementPolicyTest.java:390)
```

## Modifications

Add an Awaitility wait after `initialize()` to ensure the async cache load has completed before calling `newEnsemble()`.

### Documentation
- [x] `doc-not-needed`