### PR TITLE
[improve][client] PIP-234: Support sharing the memory limit controller across multiple isolated Pulsar client instances

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerMemoryLimitTest.java
@@ -22,8 +22,11 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.SharedPulsarBaseTest;
 import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.api.SizeUnit;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -92,4 +95,99 @@ public class ConsumerMemoryLimitTest extends SharedPulsarBaseTest {
             c1.receive();
         }
     }
+
+    @Test
+    public void testMultiPulsarClientConsumerShareMemoryLimitController() throws Exception {
+        int msgSize = 100;
+        int msgCount = 3;
+        int memoryLimit = msgSize * msgCount;
+        String topic1 = newTopicName();
+        String topic2 = newTopicName();
+        PulsarClientSharedResources sharedResources = PulsarClientSharedResources.builder()
+                .configureMemoryLimitController(
+                        memoryLimitConfig -> memoryLimitConfig.memoryLimit(memoryLimit, SizeUnit.BYTES)).build();
+        @Cleanup
+        PulsarClientImpl pulsarClient =
+                ((PulsarClientImpl) PulsarClient.builder().serviceUrl(getBrokerServiceUrl()).build());
+        @Cleanup
+        PulsarClientImpl pulsarClient1 = ((PulsarClientImpl) PulsarClient.builder().serviceUrl(getBrokerServiceUrl())
+                .sharedResources(sharedResources).build());
+        @Cleanup
+        PulsarClientImpl pulsarClient2 = ((PulsarClientImpl) PulsarClient.builder().serviceUrl(getBrokerServiceUrl())
+                .sharedResources(sharedResources).build());
+
+        Assert.assertSame(pulsarClient1.getMemoryLimitController(), pulsarClient2.getMemoryLimitController());
+
+        @Cleanup
+        Producer<byte[]> topic1Producer =
+                pulsarClient.newProducer().topic(topic1).enableBatching(false).blockIfQueueFull(false).create();
+        @Cleanup
+        Producer<byte[]> topic2Producer =
+                pulsarClient.newProducer().topic(topic2).enableBatching(false).blockIfQueueFull(false).create();
+        ConsumerImpl<byte[]> topic1Consumer =
+                (ConsumerImpl<byte[]>) pulsarClient1.newConsumer().subscriptionName("topic1-sub").topic(topic1)
+                        .autoScaledReceiverQueueSizeEnabled(true).subscribe();
+        ConsumerImpl<byte[]> topic2Consumer =
+                (ConsumerImpl<byte[]>) pulsarClient2.newConsumer().subscriptionName("topic2-sub").topic(topic2)
+                        .autoScaledReceiverQueueSizeEnabled(true).subscribe();
+
+        MemoryLimitController memoryLimitController1 = topic1Consumer.getMemoryLimitController().get();
+        MemoryLimitController memoryLimitController2 = topic2Consumer.getMemoryLimitController().get();
+        Assert.assertSame(memoryLimitController1, memoryLimitController2);
+
+        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 1);
+        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
+
+
+        topic1Producer.send(new byte[msgSize]);
+        Awaitility.await().until(topic1Consumer.scaleReceiverQueueHint::get);
+
+        Message<byte[]> topic1Message = topic1Consumer.receive();
+        Assert.assertNotNull(topic1Message);
+        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 1);
+
+        topic1Consumer.receiveAsync();
+        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 2);
+
+
+        topic2Producer.send(new byte[msgSize]);
+        Awaitility.await().until(topic1Consumer.scaleReceiverQueueHint::get);
+
+        Message<byte[]> topic2Message = topic2Consumer.receive();
+        Assert.assertNotNull(topic2Message);
+        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
+
+        topic2Consumer.receiveAsync();
+        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 2);
+
+
+        // topic1Consumer.receiveAsync() will take one message, so we should send (msgCount + 1) messages.
+        topic1Consumer.setCurrentReceiverQueueSize(msgCount);
+        for (int i = 0; i < msgCount + 1; i++) {
+            topic1Producer.send(new byte[msgSize]);
+        }
+        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 1);
+        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
+        Assert.assertEquals(memoryLimitController1.currentUsage(), memoryLimit);
+
+        // topic2Consumer.receiveAsync() will take one message, so we should send (msgCount + 1) messages.
+        for (int i = 0; i < msgCount + 1; i++) {
+            topic2Producer.send(new byte[msgSize]);
+        }
+        for (int i = 0; i < msgCount; i++) {
+            topic2Message = topic2Consumer.receive();
+            Assert.assertNotNull(topic2Message);
+            Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
+        }
+
+        topic1Consumer.close();
+        Assert.assertEquals(memoryLimitController1.currentUsage(), 0);
+
+        topic2Consumer.receiveAsync();
+        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 2);
+
+        topic2Consumer.close();
+        Assert.assertEquals(memoryLimitController2.currentUsage(), 0);
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerMemoryLimitTest.java
@@ -146,46 +146,53 @@ public class ConsumerMemoryLimitTest extends SharedPulsarBaseTest {
         Assert.assertNotNull(topic1Message);
         Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 1);
 
+        // Trigger ConsumerBase.expectMoreIncomingMessages() method to expand receiverQueueSize.
         topic1Consumer.receiveAsync();
-        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 2);
+        Awaitility.await().until(() -> topic1Consumer.getCurrentReceiverQueueSize() == 2);
 
 
         topic2Producer.send(new byte[msgSize]);
-        Awaitility.await().until(topic1Consumer.scaleReceiverQueueHint::get);
+        Awaitility.await().until(topic2Consumer.scaleReceiverQueueHint::get);
 
         Message<byte[]> topic2Message = topic2Consumer.receive();
         Assert.assertNotNull(topic2Message);
         Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
 
+        // Trigger ConsumerBase.expectMoreIncomingMessages() method to expand receiverQueueSize.
         topic2Consumer.receiveAsync();
-        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 2);
+        Awaitility.await().until(() -> topic2Consumer.getCurrentReceiverQueueSize() == 2);
 
 
         // topic1Consumer.receiveAsync() will take one message, so we should send (msgCount + 1) messages.
+        // Trigger ConsumerBase.reduceCurrentReceiverQueueSize() method to reduce receiverQueueSize.
         topic1Consumer.setCurrentReceiverQueueSize(msgCount);
         for (int i = 0; i < msgCount + 1; i++) {
             topic1Producer.send(new byte[msgSize]);
         }
-        Assert.assertEquals(topic1Consumer.getCurrentReceiverQueueSize(), 1);
-        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
-        Assert.assertEquals(memoryLimitController1.currentUsage(), memoryLimit);
+        Awaitility.await().until(() -> memoryLimitController1.currentUsage() == memoryLimit);
+        Awaitility.await().until(() -> topic1Consumer.getCurrentReceiverQueueSize() == 1);
+        Awaitility.await().until(() -> topic2Consumer.getCurrentReceiverQueueSize() == 1);
 
         // topic2Consumer.receiveAsync() will take one message, so we should send (msgCount + 1) messages.
         for (int i = 0; i < msgCount + 1; i++) {
             topic2Producer.send(new byte[msgSize]);
         }
+        // topic2Consumer will not expand receiverQueueSize due to memory limit reached.
         for (int i = 0; i < msgCount; i++) {
             topic2Message = topic2Consumer.receive();
             Assert.assertNotNull(topic2Message);
             Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 1);
         }
 
+        // Close topic1Consumer to clear release memory.
         topic1Consumer.close();
         Assert.assertEquals(memoryLimitController1.currentUsage(), 0);
 
+        // Trigger ConsumerBase.expectMoreIncomingMessages() method to expand receiverQueueSize.
         topic2Consumer.receiveAsync();
-        Assert.assertEquals(topic2Consumer.getCurrentReceiverQueueSize(), 2);
+        Awaitility.await().until(() -> topic2Consumer.getCurrentReceiverQueueSize() == 2);
 
+        // Close topic1Consumer to clear release memory.
         topic2Consumer.close();
         Assert.assertEquals(memoryLimitController2.currentUsage(), 0);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
@@ -251,14 +251,14 @@ public class ProducerMemoryLimitTest extends ProducerConsumerBase {
 
         Producer<byte[]> producer1 = pulsarClient1.newProducer()
                 .topic("testProducerShareMemoryLimitController")
-                .sendTimeout(10, TimeUnit.SECONDS)
+                .sendTimeout(20, TimeUnit.SECONDS)
                 .maxPendingMessages(0)
                 .blockIfQueueFull(false)
                 .enableBatching(false)
                 .create();
-        Producer<byte[]> producer2 =  pulsarClient2.newProducer()
+        Producer<byte[]> producer2 = pulsarClient2.newProducer()
                 .topic("testProducerShareMemoryLimitController")
-                .sendTimeout(10, TimeUnit.SECONDS)
+                .sendTimeout(20, TimeUnit.SECONDS)
                 .maxPendingMessages(0)
                 .blockIfQueueFull(false)
                 .enableBatching(false)
@@ -267,24 +267,30 @@ public class ProducerMemoryLimitTest extends ProducerConsumerBase {
         this.stopBroker();
 
         byte[] msgBytes = new byte[msgSize];
+        int halfMsgCount = msgCount / 2;
+        int producer1MemoryUsage = halfMsgCount * msgSize;
         for (int i = 0; i < msgCount / 2; i++) {
             producer1.sendAsync(msgBytes);
         }
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .until(() -> pulsarClient1.getMemoryLimitController().currentUsage() == memoryLimit / 2);
+                .until(() -> pulsarClient1.getMemoryLimitController().currentUsage() == producer1MemoryUsage);
 
-        for (int i = 0; i < msgCount / 2; i++) {
+        // The MemoryLimitController.tryReserveMemory() method returns false only when currentUsage > memoryLimit.
+        int producer2MsgCount = halfMsgCount + 1;
+        int producer2MemoryUsage = producer2MsgCount * msgSize;
+        int totalMemoryUsage = producer1MemoryUsage + producer2MemoryUsage;
+        for (int i = 0; i < producer2MsgCount; i++) {
             producer2.sendAsync(msgBytes);
         }
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == memoryLimit);
+                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == totalMemoryUsage);
 
         try {
             producer1.send(msgBytes);
             Assert.fail("producer can not send message due to memory limit exceeded");
         } catch (PulsarClientException.MemoryBufferIsFullError ex) {
             long currentUsage = pulsarClient1.getMemoryLimitController().currentUsage();
-            Assert.assertEquals(currentUsage, memoryLimit);
+            Assert.assertEquals(currentUsage, totalMemoryUsage);
         }
 
         try {
@@ -292,17 +298,17 @@ public class ProducerMemoryLimitTest extends ProducerConsumerBase {
             Assert.fail("producer can not send message due to memory limit exceeded");
         } catch (PulsarClientException.MemoryBufferIsFullError ex) {
             long currentUsage = pulsarClient2.getMemoryLimitController().currentUsage();
-            Assert.assertEquals(currentUsage, memoryLimit);
+            Assert.assertEquals(currentUsage, totalMemoryUsage);
         }
 
         producer1.close();
-        Assert.assertEquals(pulsarClient1.getMemoryLimitController().currentUsage(), memoryLimit / 2);
+        Assert.assertEquals(pulsarClient1.getMemoryLimitController().currentUsage(), producer2MemoryUsage);
 
-        for (int i = 0; i < msgCount / 2; i++) {
+        for (int i = 0; i < halfMsgCount; i++) {
             producer2.sendAsync(msgBytes);
         }
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
-                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == memoryLimit);
+                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == totalMemoryUsage);
 
         producer2.close();
         Assert.assertEquals(pulsarClient1.getMemoryLimitController().currentUsage(), 0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -240,24 +241,22 @@ public class ProducerMemoryLimitTest extends ProducerConsumerBase {
                 .configureMemoryLimitController(
                         memoryLimitConfig -> memoryLimitConfig.memoryLimit(memoryLimit, SizeUnit.BYTES)).build();
         @Cleanup
-        PulsarClientImpl pulsarClient1 =
-                ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
-                        .sharedResources(sharedResources).build());
+        PulsarClientImpl pulsarClient1 = ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
+                .sharedResources(sharedResources).build());
         @Cleanup
-        PulsarClientImpl pulsarClient2 =
-                ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
-                        .sharedResources(sharedResources).build());
+        PulsarClientImpl pulsarClient2 = ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
+                .sharedResources(sharedResources).build());
 
         Assert.assertSame(pulsarClient1.getMemoryLimitController(), pulsarClient2.getMemoryLimitController());
 
-        ProducerImpl<byte[]> producer1 = (ProducerImpl<byte[]>) pulsarClient1.newProducer()
+        Producer<byte[]> producer1 = pulsarClient1.newProducer()
                 .topic("testProducerShareMemoryLimitController")
                 .sendTimeout(10, TimeUnit.SECONDS)
                 .maxPendingMessages(0)
                 .blockIfQueueFull(false)
                 .enableBatching(false)
                 .create();
-        ProducerImpl<byte[]> producer2 = (ProducerImpl<byte[]>) pulsarClient2.newProducer()
+        Producer<byte[]> producer2 =  pulsarClient2.newProducer()
                 .topic("testProducerShareMemoryLimitController")
                 .sendTimeout(10, TimeUnit.SECONDS)
                 .maxPendingMessages(0)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ProducerMemoryLimitTest.java
@@ -33,7 +33,9 @@ import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.api.SizeUnit;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -227,6 +229,84 @@ public class ProducerMemoryLimitTest extends ProducerConsumerBase {
         PulsarClientImpl clientImpl = (PulsarClientImpl) this.pulsarClient;
         final MemoryLimitController memoryLimitController = clientImpl.getMemoryLimitController();
         Assert.assertEquals(memoryLimitController.currentUsage(), 0);
+    }
+
+    @Test(timeOut = 15000)
+    public void testMultiPulsarClientProducerShareMemoryLimitController() throws Exception {
+        int msgSize = 100;
+        int msgCount = 6;
+        int memoryLimit = msgSize * msgCount;
+        PulsarClientSharedResources sharedResources = PulsarClientSharedResources.builder()
+                .configureMemoryLimitController(
+                        memoryLimitConfig -> memoryLimitConfig.memoryLimit(memoryLimit, SizeUnit.BYTES)).build();
+        @Cleanup
+        PulsarClientImpl pulsarClient1 =
+                ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
+                        .sharedResources(sharedResources).build());
+        @Cleanup
+        PulsarClientImpl pulsarClient2 =
+                ((PulsarClientImpl) PulsarClient.builder().serviceUrl(lookupUrl.toString())
+                        .sharedResources(sharedResources).build());
+
+        Assert.assertSame(pulsarClient1.getMemoryLimitController(), pulsarClient2.getMemoryLimitController());
+
+        ProducerImpl<byte[]> producer1 = (ProducerImpl<byte[]>) pulsarClient1.newProducer()
+                .topic("testProducerShareMemoryLimitController")
+                .sendTimeout(10, TimeUnit.SECONDS)
+                .maxPendingMessages(0)
+                .blockIfQueueFull(false)
+                .enableBatching(false)
+                .create();
+        ProducerImpl<byte[]> producer2 = (ProducerImpl<byte[]>) pulsarClient2.newProducer()
+                .topic("testProducerShareMemoryLimitController")
+                .sendTimeout(10, TimeUnit.SECONDS)
+                .maxPendingMessages(0)
+                .blockIfQueueFull(false)
+                .enableBatching(false)
+                .create();
+
+        this.stopBroker();
+
+        byte[] msgBytes = new byte[msgSize];
+        for (int i = 0; i < msgCount / 2; i++) {
+            producer1.sendAsync(msgBytes);
+        }
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> pulsarClient1.getMemoryLimitController().currentUsage() == memoryLimit / 2);
+
+        for (int i = 0; i < msgCount / 2; i++) {
+            producer2.sendAsync(msgBytes);
+        }
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == memoryLimit);
+
+        try {
+            producer1.send(msgBytes);
+            Assert.fail("producer can not send message due to memory limit exceeded");
+        } catch (PulsarClientException.MemoryBufferIsFullError ex) {
+            long currentUsage = pulsarClient1.getMemoryLimitController().currentUsage();
+            Assert.assertEquals(currentUsage, memoryLimit);
+        }
+
+        try {
+            producer2.send(msgBytes);
+            Assert.fail("producer can not send message due to memory limit exceeded");
+        } catch (PulsarClientException.MemoryBufferIsFullError ex) {
+            long currentUsage = pulsarClient2.getMemoryLimitController().currentUsage();
+            Assert.assertEquals(currentUsage, memoryLimit);
+        }
+
+        producer1.close();
+        Assert.assertEquals(pulsarClient1.getMemoryLimitController().currentUsage(), memoryLimit / 2);
+
+        for (int i = 0; i < msgCount / 2; i++) {
+            producer2.sendAsync(msgBytes);
+        }
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> pulsarClient2.getMemoryLimitController().currentUsage() == memoryLimit);
+
+        producer2.close();
+        Assert.assertEquals(pulsarClient1.getMemoryLimitController().currentUsage(), 0);
     }
 
     private void initClientWithMemoryLimit() throws PulsarClientException {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PulsarTestClient.java
@@ -91,7 +91,7 @@ public class PulsarTestClient extends PulsarClientImpl {
     private PulsarTestClient(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, ConnectionPool cnxPool,
                              AtomicReference<Supplier<ClientCnx>> clientCnxSupplierReference)
             throws PulsarClientException {
-        super(conf, eventLoopGroup, cnxPool, null, null, null, null, null, new DnsResolverGroupImpl(conf));
+        super(conf, eventLoopGroup, cnxPool, null, null, null, null, null, new DnsResolverGroupImpl(conf), null);
         // workaround initialization order issue so that ClientCnx can be created in this class
         clientCnxSupplierReference.set(this::createClientCnx);
     }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.api;
+
+
+public interface MemoryLimitConfig {
+
+    MemoryLimitConfig memoryLimit(long memoryLimit);
+
+    MemoryLimitConfig triggerThreshold(long triggerThreshold);
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
@@ -22,8 +22,6 @@ package org.apache.pulsar.client.api;
 
 public interface MemoryLimitConfig {
 
-    MemoryLimitConfig memoryLimit(long memoryLimit);
-
-    MemoryLimitConfig triggerThreshold(long triggerThreshold);
+    MemoryLimitConfig memoryLimit(long memoryLimit, SizeUnit unit);
 
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MemoryLimitConfig.java
@@ -19,9 +19,20 @@
 
 package org.apache.pulsar.client.api;
 
-
+/**
+ * Configuration interface for memory limit settings.
+ */
 public interface MemoryLimitConfig {
 
+    /**
+     * Configure a limit on the amount of direct memory that will be allocated by this shared client instance.
+     * <p>
+     * See also {@link ClientBuilder#memoryLimit(long, SizeUnit)}.
+     *
+     * @param memoryLimit the memory limit value, setting this to 0 will disable the limit
+     * @param unit        the memory limit size unit
+     * @return the memory limit configuration instance for chained calls
+     */
     MemoryLimitConfig memoryLimit(long memoryLimit, SizeUnit unit);
 
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/OpenTelemetryConfig.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/OpenTelemetryConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.api;
+
+
+import io.opentelemetry.api.OpenTelemetry;
+
+public interface OpenTelemetryConfig {
+
+    OpenTelemetryConfig openTelemetry(OpenTelemetry openTelemetry);
+
+}

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/OpenTelemetryConfig.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/OpenTelemetryConfig.java
@@ -22,8 +22,19 @@ package org.apache.pulsar.client.api;
 
 import io.opentelemetry.api.OpenTelemetry;
 
+/**
+ * Configuration interface for open telemetry settings.
+ */
 public interface OpenTelemetryConfig {
 
+    /**
+     * Configure OpenTelemetry for this shared client instance.
+     * <p>
+     * See also {@link ClientBuilder#openTelemetry(OpenTelemetry)}.
+     *
+     * @param openTelemetry the open telemetry instance
+     * @return the open telemetry configuration instance for chained calls
+     */
     OpenTelemetryConfig openTelemetry(OpenTelemetry openTelemetry);
 
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResources.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResources.java
@@ -71,7 +71,12 @@ public interface PulsarClientSharedResources extends AutoCloseable {
         // pulsar-lookup threadpool
         LookupExecutor(SharedResourceType.ThreadPool),
         // DNS resolver and cache that must be shared together with eventLoopGroup
-        DnsResolver(SharedResourceType.DnsResolver);
+        DnsResolver(SharedResourceType.DnsResolver),
+        // pulsar client global memory limit controller
+        MemoryLimitController(SharedResourceType.MemoryLimitController),
+        // pulsar client global open telemetry instance
+        OpenTelemetry(SharedResourceType.OpenTelemetry)
+        ;
 
         private final SharedResourceType type;
 
@@ -88,7 +93,9 @@ public interface PulsarClientSharedResources extends AutoCloseable {
         EventLoopGroup,
         ThreadPool,
         Timer,
-        DnsResolver;
+        DnsResolver,
+        MemoryLimitController,
+        OpenTelemetry;
     }
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import static org.apache.pulsar.client.api.PulsarClientSharedResources.SharedResource;
+import io.opentelemetry.api.OpenTelemetry;
 import java.util.Collection;
 import java.util.function.Consumer;
 
@@ -118,5 +119,9 @@ public interface PulsarClientSharedResourcesBuilder {
      * @return this builder instance for method chaining
      */
     PulsarClientSharedResourcesBuilder configureTimer(Consumer<TimerConfig> configurer);
+
+    PulsarClientSharedResourcesBuilder configureMemoryLimitController(Consumer<MemoryLimitConfig> configurer);
+
+    PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetry> configurer);
 
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.api;
 
 import static org.apache.pulsar.client.api.PulsarClientSharedResources.SharedResource;
-import io.opentelemetry.api.OpenTelemetry;
 import java.util.Collection;
 import java.util.function.Consumer;
 
@@ -134,6 +133,6 @@ public interface PulsarClientSharedResourcesBuilder {
      * @param configurer a consumer that configures the open telemetry settings
      * @return this builder instance for method chaining
      */
-    PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetry> configurer);
+    PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetryConfig> configurer);
 
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientSharedResourcesBuilder.java
@@ -120,8 +120,20 @@ public interface PulsarClientSharedResourcesBuilder {
      */
     PulsarClientSharedResourcesBuilder configureTimer(Consumer<TimerConfig> configurer);
 
+    /**
+     * Configures the memory limit settings.
+     *
+     * @param configurer a consumer that configures the memory limit settings
+     * @return this builder instance for method chaining
+     */
     PulsarClientSharedResourcesBuilder configureMemoryLimitController(Consumer<MemoryLimitConfig> configurer);
 
+    /**
+     * Configures the open telemetry settings.
+     *
+     * @param configurer a consumer that configures the open telemetry settings
+     * @return this builder instance for method chaining
+     */
     PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetry> configurer);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
@@ -29,22 +30,24 @@ public class MemoryLimitController {
 
     private final long memoryLimit;
     private final long triggerThreshold;
-    private final Runnable trigger;
+    private final CopyOnWriteArraySet<Runnable> triggers = new CopyOnWriteArraySet<>();
     private final AtomicLong currentUsage = new AtomicLong();
     private final ReentrantLock mutex = new ReentrantLock(false);
     private final Condition condition = mutex.newCondition();
     private final AtomicBoolean triggerRunning = new AtomicBoolean(false);
 
     public MemoryLimitController(long memoryLimitBytes) {
+        this(memoryLimitBytes, 0);
+    }
+
+    public MemoryLimitController(long memoryLimitBytes, long triggerThreshold) {
         this.memoryLimit = memoryLimitBytes;
-        triggerThreshold = 0;
-        trigger = null;
+        this.triggerThreshold = triggerThreshold;
     }
 
     public MemoryLimitController(long memoryLimitBytes, long triggerThreshold, Runnable trigger) {
-        this.memoryLimit = memoryLimitBytes;
-        this.triggerThreshold = triggerThreshold;
-        this.trigger = trigger;
+        this(memoryLimitBytes, triggerThreshold);
+        this.triggers.add(trigger);
     }
 
     public void forceReserveMemory(long size) {
@@ -88,10 +91,12 @@ public class MemoryLimitController {
     }
 
     private void checkTrigger(long prevUsage, long newUsage) {
-        if (newUsage >= triggerThreshold && prevUsage < triggerThreshold && trigger != null) {
+        if (newUsage >= triggerThreshold && prevUsage < triggerThreshold && !triggers.isEmpty()) {
             if (triggerRunning.compareAndSet(false, true)) {
                 try {
-                    trigger.run();
+                    for (Runnable trigger : triggers) {
+                        trigger.run();
+                    }
                 } finally {
                     triggerRunning.set(false);
                 }
@@ -151,5 +156,13 @@ public class MemoryLimitController {
 
     public long memoryLimit() {
         return memoryLimit;
+    }
+
+    public void registerTrigger(Runnable trigger) {
+        triggers.add(trigger);
+    }
+
+    public void deregisterTrigger(Runnable trigger) {
+        triggers.remove(trigger);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -294,7 +294,7 @@ public class PulsarClientImpl implements PulsarClient {
                             this.memoryLimitTrigger);
             // Only create memory buffer metrics if memory limit controller is local and memory limiting is enabled.
             if (memoryLimitController == null && this.memoryLimitController.isMemoryLimited()) {
-                this.memoryBufferStats = new MemoryBufferStats(instrumentProvider, this.memoryLimitController);
+                this.memoryBufferStats = new MemoryBufferStats(this.instrumentProvider, this.memoryLimitController);
             } else {
                 this.memoryBufferStats = null;
             }
@@ -990,21 +990,11 @@ public class PulsarClientImpl implements PulsarClient {
             }
 
             if (memoryBufferStats != null) {
-                try {
-                    memoryBufferStats.close();
-                } catch (Throwable t) {
-                    log.warn("Failed to close memoryBufferStats", t);
-                    throwable = t;
-                }
+                memoryBufferStats.close();
             }
 
             if (memoryLimitController != null) {
-                try {
-                    memoryLimitController.deregisterTrigger(memoryLimitTrigger);
-                } catch (Throwable t) {
-                    log.warn("Failed to deregister trigger memoryBufferStats", t);
-                    throwable = t;
-                }
+                memoryLimitController.deregisterTrigger(memoryLimitTrigger);
             }
 
             if (conf != null && conf.getAuthentication() != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -106,7 +106,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
     private static final int CLOSE_TIMEOUT_SECONDS = 60;
-    private static final double THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING = 0.95;
+    static final double THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING = 0.95;
 
     // default limits for producers when memory limit controller is disabled
     private static final int NO_MEMORY_LIMIT_DEFAULT_MAX_PENDING_MESSAGES = 1000;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -106,7 +106,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
     private static final int CLOSE_TIMEOUT_SECONDS = 60;
-    static final double THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING = 0.95;
+    protected static final double THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING = 0.95;
 
     // default limits for producers when memory limit controller is disabled
     private static final int NO_MEMORY_LIMIT_DEFAULT_MAX_PENDING_MESSAGES = 1000;
@@ -288,10 +288,14 @@ public class PulsarClientImpl implements PulsarClient {
                 }
             }
 
-            this.memoryLimitController = memoryLimitController != null ? memoryLimitController :
-                    new MemoryLimitController(conf.getMemoryLimitBytes(),
-                            (long) (conf.getMemoryLimitBytes() * THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING),
-                            this.memoryLimitTrigger);
+            if (memoryLimitController == null) {
+                this.memoryLimitController = new MemoryLimitController(conf.getMemoryLimitBytes(),
+                        (long) (conf.getMemoryLimitBytes() * THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING),
+                        this.memoryLimitTrigger);
+            } else {
+                this.memoryLimitController = memoryLimitController;
+                this.memoryLimitController.registerTrigger(this.memoryLimitTrigger);
+            }
             // Only create memory buffer metrics if memory limit controller is local and memory limiting is enabled.
             if (memoryLimitController == null && this.memoryLimitController.isMemoryLimited()) {
                 this.memoryBufferStats = new MemoryBufferStats(this.instrumentProvider, this.memoryLimitController);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -171,23 +171,25 @@ public class PulsarClientImpl implements PulsarClient {
     @Getter
     private TransactionCoordinatorClientImpl tcClient;
 
+    private final Runnable memoryLimitTrigger = this::reduceConsumerReceiverQueueSize;
+
     public PulsarClientImpl(ClientConfigurationData conf) throws PulsarClientException {
-        this(conf, null, null, null, null, null, null, null, null);
+        this(conf, null, null, null, null, null, null, null, null, null);
     }
 
     public PulsarClientImpl(ClientConfigurationData conf, EventLoopGroup eventLoopGroup) throws PulsarClientException {
-        this(conf, eventLoopGroup, null, null, null, null, null, null, null);
+        this(conf, eventLoopGroup, null, null, null, null, null, null, null, null);
     }
 
     public PulsarClientImpl(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, ConnectionPool cnxPool)
             throws PulsarClientException {
-        this(conf, eventLoopGroup, cnxPool, null, null, null, null, null, null);
+        this(conf, eventLoopGroup, cnxPool, null, null, null, null, null, null, null);
     }
 
     public PulsarClientImpl(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, ConnectionPool cnxPool,
                             Timer timer)
             throws PulsarClientException {
-        this(conf, eventLoopGroup, cnxPool, timer, null, null, null, null, null);
+        this(conf, eventLoopGroup, cnxPool, timer, null, null, null, null, null, null);
     }
 
     public PulsarClientImpl(ClientConfigurationData conf, EventLoopGroup eventLoopGroup, ConnectionPool connectionPool,
@@ -196,7 +198,7 @@ public class PulsarClientImpl implements PulsarClient {
                             ScheduledExecutorProvider scheduledExecutorProvider)
             throws PulsarClientException {
         this(conf, eventLoopGroup, connectionPool, timer, externalExecutorProvider, internalExecutorProvider,
-                scheduledExecutorProvider, null, null);
+                scheduledExecutorProvider, null, null, null);
     }
 
     @Builder(builderClassName = "PulsarClientImplBuilder")
@@ -205,8 +207,8 @@ public class PulsarClientImpl implements PulsarClient {
                      ExecutorProvider internalExecutorProvider,
                      ScheduledExecutorProvider scheduledExecutorProvider,
                      ExecutorProvider lookupExecutorProvider,
-                     DnsResolverGroupImpl dnsResolverGroup) throws PulsarClientException {
-
+                     DnsResolverGroupImpl dnsResolverGroup,
+                     MemoryLimitController memoryLimitController) throws PulsarClientException {
         EventLoopGroup eventLoopGroupReference = null;
         ConnectionPool connectionPoolReference = null;
         try {
@@ -286,12 +288,13 @@ public class PulsarClientImpl implements PulsarClient {
                 }
             }
 
-            memoryLimitController = new MemoryLimitController(conf.getMemoryLimitBytes(),
-                    (long) (conf.getMemoryLimitBytes() * THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING),
-                    this::reduceConsumerReceiverQueueSize);
-            // Only create memory buffer metrics if memory limiting is enabled
-            if (memoryLimitController.isMemoryLimited()) {
-                memoryBufferStats = new MemoryBufferStats(instrumentProvider, memoryLimitController);
+            this.memoryLimitController = memoryLimitController != null ? memoryLimitController :
+                    new MemoryLimitController(conf.getMemoryLimitBytes(),
+                            (long) (conf.getMemoryLimitBytes() * THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING),
+                            this.memoryLimitTrigger);
+            // Only create memory buffer metrics if memory limit controller is local and memory limiting is enabled.
+            if (memoryLimitController == null && this.memoryLimitController.isMemoryLimited()) {
+                memoryBufferStats = new MemoryBufferStats(instrumentProvider, this.memoryLimitController);
             } else {
                 memoryBufferStats = null;
             }
@@ -985,6 +988,7 @@ public class PulsarClientImpl implements PulsarClient {
             } catch (PulsarClientException e) {
                 throwable = e;
             }
+
             if (memoryBufferStats != null) {
                 try {
                     memoryBufferStats.close();
@@ -993,6 +997,8 @@ public class PulsarClientImpl implements PulsarClient {
                     throwable = t;
                 }
             }
+            this.memoryLimitController.deregisterTrigger(memoryLimitTrigger);
+
             if (conf != null && conf.getAuthentication() != null) {
                 try {
                     conf.getAuthentication().close();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -294,9 +294,9 @@ public class PulsarClientImpl implements PulsarClient {
                             this.memoryLimitTrigger);
             // Only create memory buffer metrics if memory limit controller is local and memory limiting is enabled.
             if (memoryLimitController == null && this.memoryLimitController.isMemoryLimited()) {
-                memoryBufferStats = new MemoryBufferStats(instrumentProvider, this.memoryLimitController);
+                this.memoryBufferStats = new MemoryBufferStats(instrumentProvider, this.memoryLimitController);
             } else {
-                memoryBufferStats = null;
+                this.memoryBufferStats = null;
             }
             state.set(State.Open);
         } catch (Throwable t) {
@@ -997,7 +997,15 @@ public class PulsarClientImpl implements PulsarClient {
                     throwable = t;
                 }
             }
-            this.memoryLimitController.deregisterTrigger(memoryLimitTrigger);
+
+            if (memoryLimitController != null) {
+                try {
+                    memoryLimitController.deregisterTrigger(memoryLimitTrigger);
+                } catch (Throwable t) {
+                    log.warn("Failed to deregister trigger memoryBufferStats", t);
+                    throwable = t;
+                }
+            }
 
             if (conf != null && conf.getAuthentication() != null) {
                 try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -994,7 +994,12 @@ public class PulsarClientImpl implements PulsarClient {
             }
 
             if (memoryBufferStats != null) {
-                memoryBufferStats.close();
+                try {
+                    memoryBufferStats.close();
+                } catch (Throwable t) {
+                    log.warn("Failed to close memoryBufferStats", t);
+                    throwable = t;
+                }
             }
 
             if (memoryLimitController != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
@@ -20,10 +20,13 @@ package org.apache.pulsar.client.impl;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.HashedWheelTimer;
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
@@ -145,5 +148,21 @@ class PulsarClientResourcesConfigurer {
             resourceConfig = new PulsarClientSharedResourcesBuilderImpl.DnsResolverResourceConfig();
         }
         return new DnsResolverGroupImpl(resourceConfig);
+    }
+
+    static MemoryLimitController createMemoryLimitControllerWithResourceConfig(
+            PulsarClientSharedResourcesBuilderImpl.MemoryLimitResourceConfig resourceConfig) {
+        if (resourceConfig == null) {
+            resourceConfig = new PulsarClientSharedResourcesBuilderImpl.MemoryLimitResourceConfig();
+        }
+        return new MemoryLimitController(resourceConfig.memoryLimit, resourceConfig.triggerThreshold);
+    }
+
+    static InstrumentProvider createInstrumentProviderWithResourceConfig(
+            PulsarClientSharedResourcesBuilderImpl.OpenTelemetryResourceConfig resourceConfig) {
+        // Use global openTelemetry instance if not configured.
+        OpenTelemetry openTelemetry =
+                Optional.ofNullable(resourceConfig).map(config -> config.openTelemetry).orElse(null);
+        return new InstrumentProvider(openTelemetry);
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
@@ -155,7 +155,11 @@ class PulsarClientResourcesConfigurer {
         if (resourceConfig == null) {
             resourceConfig = new PulsarClientSharedResourcesBuilderImpl.MemoryLimitResourceConfig();
         }
-        return new MemoryLimitController(resourceConfig.memoryLimit, resourceConfig.triggerThreshold);
+        // Keep the same logic with PulsarClientImpl
+        long memoryLimit = resourceConfig.memoryLimit;
+        long triggerThreshold =
+                (long) (memoryLimit * PulsarClientImpl.THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING);
+        return new MemoryLimitController(memoryLimit, triggerThreshold);
     }
 
     static InstrumentProvider createInstrumentProviderWithResourceConfig(

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientResourcesConfigurer.java
@@ -155,8 +155,8 @@ class PulsarClientResourcesConfigurer {
         if (resourceConfig == null) {
             resourceConfig = new PulsarClientSharedResourcesBuilderImpl.MemoryLimitResourceConfig();
         }
-        // Keep the same logic with PulsarClientImpl
         long memoryLimit = resourceConfig.memoryLimit;
+        // Keep the same logic with PulsarClientImpl's memory limit settings.
         long triggerThreshold =
                 (long) (memoryLimit * PulsarClientImpl.THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING);
         return new MemoryLimitController(memoryLimit, triggerThreshold);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
@@ -320,7 +320,7 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
     }
 
     @Override
-    public PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetry> configurer) {
+    public PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetryConfig> configurer) {
         configurer.accept(getOrCreateConfig(PulsarClientSharedResources.SharedResource.OpenTelemetry));
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.Lists;
+import io.opentelemetry.api.OpenTelemetry;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.pulsar.client.api.DnsResolverConfig;
 import org.apache.pulsar.client.api.EventLoopGroupConfig;
+import org.apache.pulsar.client.api.MemoryLimitConfig;
+import org.apache.pulsar.client.api.OpenTelemetryConfig;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.api.PulsarClientSharedResourcesBuilder;
 import org.apache.pulsar.client.api.ThreadPoolConfig;
@@ -202,6 +205,41 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
         }
     }
 
+    static class MemoryLimitResourceConfig implements ResourceConfig, MemoryLimitConfig {
+        long memoryLimit;
+        long triggerThreshold;
+
+        public MemoryLimitResourceConfig() {
+        }
+
+        @Override
+        public MemoryLimitConfig memoryLimit(long memoryLimit) {
+            this.memoryLimit = memoryLimit;
+            return this;
+        }
+
+        @Override
+        public MemoryLimitConfig triggerThreshold(long triggerThreshold) {
+            this.triggerThreshold = triggerThreshold;
+            return this;
+        }
+
+    }
+
+    static class OpenTelemetryResourceConfig implements ResourceConfig, OpenTelemetryConfig {
+        OpenTelemetry openTelemetry;
+
+        public OpenTelemetryResourceConfig() {
+        }
+
+        @Override
+        public OpenTelemetryConfig openTelemetry(OpenTelemetry openTelemetry) {
+            this.openTelemetry = openTelemetry;
+            return this;
+        }
+
+    }
+
     @Override
     public PulsarClientSharedResourcesBuilder resourceTypes(
             PulsarClientSharedResources.SharedResource... sharedResource) {
@@ -242,6 +280,10 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
                     return new ThreadPoolResourceConfig();
                 case Timer:
                     return new TimerResourceConfig();
+                case MemoryLimitController:
+                    return new MemoryLimitResourceConfig();
+                case OpenTelemetry:
+                    return new OpenTelemetryResourceConfig();
                 default:
                     throw new IllegalArgumentException("Unknown resource type: " + sharedResource.getType());
             }
@@ -274,6 +316,18 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
     @Override
     public PulsarClientSharedResourcesBuilder configureTimer(Consumer<TimerConfig> configurer) {
         configurer.accept(getOrCreateConfig(PulsarClientSharedResources.SharedResource.Timer));
+        return this;
+    }
+
+    @Override
+    public PulsarClientSharedResourcesBuilder configureMemoryLimitController(Consumer<MemoryLimitConfig> configurer) {
+        configurer.accept(getOrCreateConfig(PulsarClientSharedResources.SharedResource.MemoryLimitController));
+        return this;
+    }
+
+    @Override
+    public PulsarClientSharedResourcesBuilder configureOpenTelemetry(Consumer<OpenTelemetry> configurer) {
+        configurer.accept(getOrCreateConfig(PulsarClientSharedResources.SharedResource.OpenTelemetry));
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesBuilderImpl.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.MemoryLimitConfig;
 import org.apache.pulsar.client.api.OpenTelemetryConfig;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.api.PulsarClientSharedResourcesBuilder;
+import org.apache.pulsar.client.api.SizeUnit;
 import org.apache.pulsar.client.api.ThreadPoolConfig;
 import org.apache.pulsar.client.api.TimerConfig;
 import org.apache.pulsar.common.util.netty.DnsResolverUtil;
@@ -207,20 +208,13 @@ public class PulsarClientSharedResourcesBuilderImpl implements PulsarClientShare
 
     static class MemoryLimitResourceConfig implements ResourceConfig, MemoryLimitConfig {
         long memoryLimit;
-        long triggerThreshold;
 
         public MemoryLimitResourceConfig() {
         }
 
         @Override
-        public MemoryLimitConfig memoryLimit(long memoryLimit) {
-            this.memoryLimit = memoryLimit;
-            return this;
-        }
-
-        @Override
-        public MemoryLimitConfig triggerThreshold(long triggerThreshold) {
-            this.triggerThreshold = triggerThreshold;
+        public MemoryLimitConfig memoryLimit(long memoryLimit, SizeUnit unit) {
+            this.memoryLimit = unit.toBytes(memoryLimit);
             return this;
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
@@ -21,8 +21,10 @@ package org.apache.pulsar.client.impl;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createDnsResolverGroupWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createEventLoopGroupWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createExternalExecutorProviderWithResourceConfig;
+import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createInstrumentProviderWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createInternalExecutorProviderWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createLookupExecutorProviderWithResourceConfig;
+import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createMemoryLimitControllerWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createScheduledExecutorProviderWithResourceConfig;
 import static org.apache.pulsar.client.impl.PulsarClientResourcesConfigurer.createTimer;
 import io.netty.channel.EventLoopGroup;
@@ -33,6 +35,8 @@ import java.util.Set;
 import lombok.Getter;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.client.impl.metrics.MemoryBufferStats;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
@@ -47,6 +51,9 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
     private final Timer timer;
     private final ExecutorProvider lookupExecutorProvider;
     private final DnsResolverGroupImpl dnsResolverGroup;
+    private final MemoryLimitController memoryLimitController;
+    private final InstrumentProvider instrumentProvider;
+    private final MemoryBufferStats memoryBufferStats;
 
     public PulsarClientSharedResourcesImpl(Set<SharedResource> sharedResources,
                                            Map<SharedResource, PulsarClientSharedResourcesBuilderImpl.ResourceConfig>
@@ -91,6 +98,21 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
                 ? createDnsResolverGroupWithResourceConfig(
                 getResourceConfig(resourceConfigs, SharedResource.DnsResolver))
                 : null;
+        this.memoryLimitController = this.sharedResources.contains(SharedResource.MemoryLimitController)
+                ? createMemoryLimitControllerWithResourceConfig(
+                getResourceConfig(resourceConfigs, SharedResource.MemoryLimitController))
+                : null;
+        this.instrumentProvider = this.sharedResources.contains(SharedResource.OpenTelemetry)
+                ? createInstrumentProviderWithResourceConfig(
+                getResourceConfig(resourceConfigs, SharedResource.OpenTelemetry))
+                : null;
+        // Only create memory buffer metrics if memory limiting is enabled.
+        if (this.memoryLimitController != null && this.memoryLimitController.isMemoryLimited()
+                && this.instrumentProvider != null) {
+            this.memoryBufferStats = new MemoryBufferStats(this.instrumentProvider, this.memoryLimitController);
+        } else {
+            this.memoryBufferStats = null;
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -132,6 +154,9 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
         if (ioEventLoopGroup != null) {
             EventLoopUtil.shutdownGracefully(ioEventLoopGroup);
         }
+        if (memoryBufferStats != null) {
+            memoryBufferStats.close();
+        }
     }
 
     public void applyTo(PulsarClientImpl.PulsarClientImplBuilder instanceBuilder) {
@@ -155,6 +180,9 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
         }
         if (ioEventLoopGroup != null) {
             instanceBuilder.eventLoopGroup(ioEventLoopGroup);
+        }
+        if (memoryLimitController != null) {
+            instanceBuilder.memoryLimitController(memoryLimitController);
         }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
@@ -33,6 +33,7 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
@@ -41,6 +42,7 @@ import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
+@Slf4j
 @Getter
 public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResources {
     Set<SharedResource> sharedResources;
@@ -155,7 +157,11 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
             EventLoopUtil.shutdownGracefully(ioEventLoopGroup);
         }
         if (memoryBufferStats != null) {
-            memoryBufferStats.close();
+            try {
+                memoryBufferStats.close();
+            } catch (Throwable t) {
+                log.warn("Failed to close shared memoryBufferStats", t);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25212

### Motivation

https://github.com/apache/pulsar/issues/19074 enables sharing of Pulsar client resources across multiple isolated Pulsar client instances, but this solution lacks limiting the total amount of memory across all of the Pulsar client instances. This PR introduces a shared `MemoryLimitController` solution for PIP-234.

### Modifications

1. Modify `MemoryLimitController` to support registering multiple trigger callbacks and deregistering the callback when the client instance gets closed.
2. Add shared `MemoryLimitController` in `PulsarClientSharedResources` and `PulsarClientSharedResourcesBuilder`, then apply the shared `MemoryLimitController` to `PulsarClientImplBuilder`.
4. Add tests to verify the code change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/oneby-wang/pulsar/pull/29