### PR TITLE
[fix][admin] Refactor namespace migration operation to async in rest api

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -3085,22 +3085,15 @@ public abstract class NamespacesBase extends AdminResource {
                 });
     }
 
-    protected void internalEnableMigration(boolean migrated) {
-        validateSuperUserAccess();
-        try {
-            getLocalPolicies().setLocalPoliciesWithCreate(namespaceName, oldPolicies -> oldPolicies.map(
-                    policies -> new LocalPolicies(policies.bundles,
-                            policies.bookieAffinityGroup,
-                            policies.namespaceAntiAffinityGroup,
-                            migrated))
-                    .orElseGet(() -> new LocalPolicies(getDefaultBundleData(), null, null, migrated)));
-            log.info("Successfully updated migration on namespace {}", namespaceName);
-        } catch (RestException re) {
-            throw re;
-        } catch (Exception e) {
-            log.error("Failed to update migration on namespace {}", namespaceName, e);
-            throw new RestException(e);
-        }
+    protected CompletableFuture<Void> internalEnableMigrationAsync(boolean migrated) {
+        return validateSuperUserAccessAsync().thenCompose(__ -> getDefaultBundleDataAsync().thenCompose(
+                        defaultBundleData -> getLocalPolicies().setLocalPoliciesWithCreateAsync(namespaceName,
+                                oldPolicies -> oldPolicies.map(
+                                                policies -> new LocalPolicies(policies.bundles,
+                                                        policies.bookieAffinityGroup,
+                                                        policies.namespaceAntiAffinityGroup, migrated))
+                                        .orElseGet(() -> new LocalPolicies(defaultBundleData, null, null, migrated)))))
+                .thenAccept(__ -> log.info("Successfully updated migration on namespace {}", namespaceName));
     }
 
     protected Policies getDefaultPolicesIfNull(Policies policies) {
@@ -3185,19 +3178,6 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.ALLOW_CLUSTERS, PolicyOperation.READ)
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenApply(policies -> policies.allowed_clusters);
-    }
-
-    // TODO remove this sync method after async refactor
-    @Deprecated
-    private BundlesData getDefaultBundleData() {
-        try {
-            return getDefaultBundleDataAsync().get(config().getMetadataStoreOperationTimeoutSeconds(),
-                    TimeUnit.SECONDS);
-        } catch (Exception e) {
-            log.error("[{}] Failed to get namespace-policy configuration for namespace {}", clientAppId(),
-                    namespaceName, e);
-            throw new RestException(e);
-        }
     }
 
     private CompletableFuture<BundlesData> getDefaultBundleDataAsync() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -3161,11 +3161,19 @@ public class Namespaces extends NamespacesBase {
             @ApiResponse(code = 200, message = "Operation successful"),
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist") })
-    public void enableMigration(@PathParam("tenant") String tenant,
+    public void enableMigration(@Suspended AsyncResponse asyncResponse,
+                                @PathParam("tenant") String tenant,
                                 @PathParam("namespace") String namespace,
                                 boolean migrated) {
         validateNamespaceName(tenant, namespace);
-        internalEnableMigration(migrated);
+        internalEnableMigrationAsync(migrated)
+                .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(ex -> {
+                    log.error("[{}] Failed to update migration, tenant: {}, namespace: {}",
+                            clientAppId(), tenant, namespace, ex);
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 
     @POST

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -23,8 +23,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.testng.Assert.*;
-
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -353,7 +356,8 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
 
         // 2.set enable migration
         boolean enableMigrationReq = true;
-        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, enableMigrationReq));
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs,
+                enableMigrationReq));
 
         // 3.query namespace num bundles, should be conf.getDefaultNumberOfNamespaceBundles()
         BundlesData bundlesData = (BundlesData) asyncRequests(
@@ -377,7 +381,8 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
 
         // 2.set enable migration
         boolean enableMigrationReq = true;
-        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, enableMigrationReq));
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs,
+                enableMigrationReq));
 
         // 3.query namespace num bundles, should be policies.bundles, which we set before
         BundlesData bundlesData = (BundlesData) asyncRequests(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesV2Test.java
@@ -23,10 +23,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -355,7 +353,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
 
         // 2.set enable migration
         boolean enableMigrationReq = true;
-        namespaces.enableMigration(testTenant, enableMigrationGroupNs, enableMigrationReq);
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, enableMigrationReq));
 
         // 3.query namespace num bundles, should be conf.getDefaultNumberOfNamespaceBundles()
         BundlesData bundlesData = (BundlesData) asyncRequests(
@@ -379,7 +377,7 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
 
         // 2.set enable migration
         boolean enableMigrationReq = true;
-        namespaces.enableMigration(testTenant, enableMigrationGroupNs, enableMigrationReq);
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, enableMigrationReq));
 
         // 3.query namespace num bundles, should be policies.bundles, which we set before
         BundlesData bundlesData = (BundlesData) asyncRequests(
@@ -497,6 +495,24 @@ public class NamespacesV2Test extends MockedPulsarServiceBaseTest {
                 namespacesWithAntiAffinityGroup.stream().map(ns -> NamespaceName.get(testTenant, ns))
                         .map(NamespaceName::toString).toList();
         assertEquals(namespacesResp, namespacesWithFullPath);
+    }
+
+    @Test
+    public void testEnableMigrationAndDisableMigration() throws Exception {
+        String enableMigrationGroupNs = "test-enable-migration-disable-migration-ns";
+        asyncRequests(response -> namespaces.createNamespace(response, testTenant, enableMigrationGroupNs, null));
+
+        // Enable migration
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, true));
+        Policies policiesResp = (Policies) asyncRequests(
+                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
+        assertTrue(policiesResp.migrated);
+
+        // Disable migration
+        asyncRequests(response -> namespaces.enableMigration(response, testTenant, enableMigrationGroupNs, false));
+        policiesResp = (Policies) asyncRequests(
+                response -> namespaces.getPolicies(response, testTenant, enableMigrationGroupNs));
+        assertFalse(policiesResp.migrated);
     }
 
 }


### PR DESCRIPTION
### Motivation

It is not recommended to use sync operations in NIO threads, which would block other operations and degrade the overall performance of the system.

### Modifications

Refactor namespace migration sync operation to async in rest api, and add tests.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/oneby-wang/pulsar/pull/30