### PR TITLE
Fix missing log4j-layout-template-json in shell distribution

### DIFF
--- a/distribution/shell/build.gradle.kts
+++ b/distribution/shell/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     distLib(project(":pulsar-client-tools"))
     distLib(libs.log4j.core)
     distLib(libs.log4j.web)
+    distLib(libs.log4j.layout.template.json)
     distLib(libs.log4j.slf4j2.impl)
     distLib(libs.simpleclient.log4j2)
     // Bouncy Castle

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -383,6 +383,7 @@ The Apache Software License, Version 2.0
  * Log4J
     - log4j-api-2.25.3.jar
     - log4j-core-2.25.3.jar
+    - log4j-layout-template-json-2.25.3.jar
     - log4j-slf4j2-impl-2.25.3.jar
     - log4j-web-2.25.3.jar
  * OpenTelemetry


### PR DESCRIPTION
## Summary
- Add `log4j-layout-template-json` dependency to the shell distribution (`distribution/shell/build.gradle.kts`)
- The shell distribution (used by `pulsar-admin` and `pulsar-shell`) was missing this dependency, causing `Unable to locate plugin type for JsonTemplateLayout` errors at startup
- The server distribution already included this dependency; this aligns the shell distribution to match

### Documentation
- [x] `doc-not-needed`

### Matching PR in forked repository

_No response_