### PR TITLE
[improve][ci] Replace trivy-action with sandboxed-trivy-action

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -658,25 +658,25 @@ jobs:
           src/check-binary-license.sh ./distribution/server/build/distributions/apache-pulsar-*-bin.tar.gz
           src/check-binary-license.sh ./distribution/shell/build/distributions/apache-pulsar-shell-*-bin.tar.gz
 
-#      - name: Run Trivy container scan
-#        id: trivy_scan
-#        uses: aquasecurity/trivy-action@v0.35.0
-#        if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
-#        continue-on-error: true
-#        with:
-#          image-ref: "apachepulsar/pulsar:latest"
-#          scanners: vuln
-#          severity: CRITICAL,HIGH,MEDIUM,LOW
-#          limit-severities-for-sarif: true
-#          format: 'sarif'
-#          output: 'trivy-results.sarif'
-#
-#      - name: Upload Trivy scan results to GitHub Security tab
-#        uses: github/codeql-action/upload-sarif@v3
-#        if: ${{ steps.trivy_scan.outcome == 'success' && github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
-#        continue-on-error: true
-#        with:
-#          sarif_file: 'trivy-results.sarif'
+      - name: Run Trivy container scan
+        id: trivy_scan
+        uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb
+        if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
+        continue-on-error: true
+        with:
+          image-ref: "apachepulsar/pulsar:latest"
+          scanners: vuln
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          limit-severities-for-sarif: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ steps.trivy_scan.outcome == 'success' && github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
+        continue-on-error: true
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - name: Save docker image to file
         run: |

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -673,7 +673,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: ${{ steps.trivy_scan.outcome == 'success' && github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -664,7 +664,8 @@ jobs:
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:
-          image-ref: "apachepulsar/pulsar:latest"
+          scan-type: 'image'
+          scan-ref: "apachepulsar/pulsar:latest"
           scanners: vuln
           severity: CRITICAL,HIGH,MEDIUM,LOW
           limit-severities-for-sarif: true


### PR DESCRIPTION
### Motivation

The `aquasecurity/trivy-action` was previously commented out in the CI workflow. This PR replaces it with `lhotari/sandboxed-trivy-action`, which runs Trivy in a sandboxed environment for improved security.

### Modifications

- Uncommented the Trivy container scan and SARIF upload steps in `.github/workflows/pulsar-ci.yaml`
- Replaced `aquasecurity/trivy-action@v0.35.0` with `lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment