### PR TITLE
[fix][ci] Fix CodeQL workflow and upgrade codeql-action to v4

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: ${{ env.JDK_DISTRIBUTION }}
-          java-version: 17
+          java-version: 21
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
@@ -77,6 +77,6 @@ jobs:
         run: ./gradlew assemble
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -872,7 +872,7 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ env.CODEQL_LANGUAGE }}
 
@@ -880,7 +880,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ env.CODEQL_LANGUAGE }}"
 


### PR DESCRIPTION
## Summary
- Update JDK from 17 to 21 in the standalone CodeQL workflow (`codeql.yaml`) to match the CI workflow and Gradle cache-update workflow. The CodeQL workflow has been consistently failing since `configure-on-demand` was enabled on March 31.
- Upgrade all `github/codeql-action` references from v3 to v4 across both `codeql.yaml` and `pulsar-ci.yaml`, as v3 will be deprecated in December 2026.

## Matching PR in forked repository

_No response_