### PR TITLE
[improve][ci] Run filesystem offload tests also on Java 25 since Hadoop has been upgraded to 3.5.0

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestFileSystemOffload.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestFileSystemOffload.java
@@ -22,21 +22,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
 public class TestFileSystemOffload extends TestBaseOffload {
-
-    @BeforeClass
-    public void checkJavaVersion() {
-        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_25)) {
-            throw new SkipException("Filesystem Offload is incompatible with Java 25");
-        }
-    }
 
     @Test(dataProvider =  "ServiceAndAdminUrls")
     public void testPublishOffloadAndConsumeViaCLI(Supplier<String> serviceUrl, Supplier<String> adminUrl)

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestOffloadDeletionFS.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/offload/TestOffloadDeletionFS.java
@@ -25,24 +25,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.tests.integration.docker.ContainerExecException;
 import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Slf4j
 public class TestOffloadDeletionFS extends TestBaseOffload {
-
-    @BeforeClass
-    public void checkJavaVersion() {
-        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_25)) {
-            throw new SkipException("Filesystem Offload is incompatible with Java 25");
-        }
-    }
 
     @Override
     protected int getEntrySize() {

--- a/tiered-storage/file-system/build.gradle.kts
+++ b/tiered-storage/file-system/build.gradle.kts
@@ -81,12 +81,3 @@ dependencies {
     testImplementation("org.eclipse.jetty:jetty-servlet:9.4.58.v20250814")
     testImplementation("org.eclipse.jetty:jetty-util:9.4.58.v20250814")
 }
-
-// Hadoop 3.4.x is incompatible with Java 25
-val testJavaVersion = providers.gradleProperty("testJavaVersion")
-val effectiveTestJava = testJavaVersion
-    .orElse(provider { JavaVersion.current().majorVersion })
-    .map { it.toInt() }
-tasks.withType<Test>().configureEach {
-    enabled = effectiveTestJava.get() < 25
-}


### PR DESCRIPTION
### Motivation

Hadoop has been upgraded to 3.5.0, which is compatible with Java 25. The filesystem offload tests were previously skipped on Java 25 due to Hadoop 3.4.x incompatibility. Now that the dependency has been upgraded, these skip conditions are no longer needed.

### Modifications

- Removed the `@BeforeClass` Java version check that skipped tests on Java 25 in `TestFileSystemOffload` and `TestOffloadDeletionFS`.
- Removed the unused imports (`JavaVersion`, `SystemUtils`, `SkipException`, `BeforeClass`) from both test classes.
- Removed the Gradle `Test` task disabling logic in `tiered-storage/file-system/build.gradle.kts` that prevented tests from running on Java 25.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

The existing filesystem offload integration tests (`TestFileSystemOffload`, `TestOffloadDeletionFS`) and the `tiered-storage/file-system` unit tests will now run on Java 25, verifying the Hadoop 3.5.0 compatibility.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment