### PR TITLE
[improve][ci] Include XML test reports in CI artifacts and generate HTML index

### DIFF
--- a/.github/actions/copy-test-reports/action.yml
+++ b/.github/actions/copy-test-reports/action.yml
@@ -18,10 +18,11 @@
 #
 
 name: Copy test reports
-description: Aggregates all test reports to ./test-reports and ./surefire-reports directories
+description: Aggregates all test reports to ./test-reports directory and generates an HTML index
 runs:
   using: composite
   steps:
     - run: |
         $GITHUB_WORKSPACE/pulsar-build/pulsar_ci_tool.sh move_test_reports
+        $GITHUB_WORKSPACE/pulsar-build/pulsar_ci_tool.sh generate_test_report_index
       shell: bash

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -241,6 +241,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            build/threaddumps/
             ${{ env.NETTY_LEAK_DUMP_DIR }}/*
             ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
             ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -158,11 +158,11 @@ jobs:
       COLLECT_COVERAGE: "${{ needs.preconditions.outputs.collect_coverage }}"
       CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       TRACE_TEST_RESOURCE_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trace_test_resource_cleanup || 'off' }}
-      TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/target/trace-test-resource-cleanup
+      TRACE_TEST_RESOURCE_CLEANUP_DIR: ${{ github.workspace }}/build/trace-test-resource-cleanup
       THREAD_LEAK_DETECTOR_WAIT_MILLIS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.thread_leak_detector_wait_millis || 10000 }}
-      THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/target/thread-leak-dumps
+      THREAD_LEAK_DETECTOR_DIR: ${{ github.workspace }}/build/thread-leak-dumps
       NETTY_LEAK_DETECTION: "${{ needs.preconditions.outputs.netty_leak_detection }}"
-      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/build/netty-leak-dumps
     runs-on: ubuntu-24.04
     timeout-minutes: 100
     if: ${{ needs.preconditions.outputs.docs_only != 'true' }}

--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -227,6 +227,7 @@ jobs:
         with:
           name: Unit-BROKER_FLAKY-test-reports
           path: |
+            test-reports/
             **/build/reports/tests/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -335,6 +335,7 @@ jobs:
         with:
           name: Unit-${{ matrix.group }}-test-reports
           path: |
+            test-reports/
             **/build/reports/tests/
           retention-days: 7
           if-no-files-found: ignore
@@ -577,6 +578,7 @@ jobs:
         with:
           name: Integration-${{ matrix.upload_name || matrix.group }}-test-reports
           path: |
+            test-reports/
             **/build/reports/tests/
           retention-days: 7
           if-no-files-found: ignore
@@ -793,6 +795,7 @@ jobs:
         with:
           name: System-${{ matrix.group }}-test-reports
           path: |
+            test-reports/
             **/build/reports/tests/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -349,6 +349,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            build/threaddumps/
             ${{ env.NETTY_LEAK_DUMP_DIR }}/*
             ${{ env.TRACE_TEST_RESOURCE_CLEANUP_DIR }}/*
             ${{ env.THREAD_LEAK_DETECTOR_DIR }}/*
@@ -592,6 +593,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            build/threaddumps/
           retention-days: 7
           if-no-files-found: ignore
 
@@ -809,6 +811,7 @@ jobs:
             /tmp/*.hprof
             **/hs_err_*.log
             **/core.*
+            build/threaddumps/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/pulsar-build/pulsar_ci_tool.sh
+++ b/pulsar-build/pulsar_ci_tool.sh
@@ -116,7 +116,7 @@ function ci_generate_test_report_index() {
     if [ -n "${GITHUB_WORKSPACE}" ]; then
       cd "${GITHUB_WORKSPACE}"
     fi
-    local index_file="build/reports/tests/index.html"
+    local index_file="test-reports/index.html"
     mkdir -p "$(dirname "$index_file")"
     local found_reports=()
     while IFS= read -r -d '' report; do
@@ -148,7 +148,7 @@ HEADER
       local rel_path="${report#./}"
       # extract module name (everything before /build/reports/tests/test/index.html)
       local module_name="${rel_path%%/build/reports/tests/test/index.html}"
-      echo "  <li><a href=\"${rel_path}\">${module_name}</a></li>" >> "$index_file"
+      echo "  <li><a href=\"../${rel_path}\">${module_name}</a></li>" >> "$index_file"
     done
     cat >> "$index_file" <<'FOOTER'
 </ul>

--- a/pulsar-build/pulsar_ci_tool.sh
+++ b/pulsar-build/pulsar_ci_tool.sh
@@ -110,6 +110,55 @@ function ci_move_test_reports() {
   )
 }
 
+# generates a top-level index.html that links to each module's HTML test report
+function ci_generate_test_report_index() {
+  (
+    if [ -n "${GITHUB_WORKSPACE}" ]; then
+      cd "${GITHUB_WORKSPACE}"
+    fi
+    local index_file="build/reports/tests/index.html"
+    mkdir -p "$(dirname "$index_file")"
+    local found_reports=()
+    while IFS= read -r -d '' report; do
+      found_reports+=("$report")
+    done < <(find . -path '*/build/reports/tests/test/index.html' -not -path './build/*' -print0 | sort -z)
+    if [ ${#found_reports[@]} -eq 0 ]; then
+      echo "No HTML test reports found."
+      return 0
+    fi
+    cat > "$index_file" <<'HEADER'
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Test Reports Index</title>
+<style>
+body { font-family: sans-serif; margin: 2em; }
+a { text-decoration: none; color: #0366d6; }
+a:hover { text-decoration: underline; }
+li { margin: 0.3em 0; }
+</style>
+</head>
+<body>
+<h1>Test Reports</h1>
+<ul>
+HEADER
+    for report in "${found_reports[@]}"; do
+      # strip leading ./
+      local rel_path="${report#./}"
+      # extract module name (everything before /build/reports/tests/test/index.html)
+      local module_name="${rel_path%%/build/reports/tests/test/index.html}"
+      echo "  <li><a href=\"${rel_path}\">${module_name}</a></li>" >> "$index_file"
+    done
+    cat >> "$index_file" <<'FOOTER'
+</ul>
+</body>
+</html>
+FOOTER
+    echo "Generated test report index at $index_file with ${#found_reports[@]} module(s)."
+  )
+}
+
 ci_report_netty_leaks() {
   if [ -z "$NETTY_LEAK_DUMP_DIR" ]; then
     echo "NETTY_LEAK_DUMP_DIR isn't set"

--- a/pulsar-build/pulsar_ci_tool.sh
+++ b/pulsar-build/pulsar_ci_tool.sh
@@ -35,11 +35,21 @@ function ci_list_functions() {
 # prints thread dumps for all running JVMs
 # used in CI when a job gets cancelled because of a job timeout
 function ci_print_thread_dumps() {
+  local dump_dir=""
+  if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+    dump_dir="${GITHUB_WORKSPACE}/build/threaddumps"
+    mkdir -p "$dump_dir"
+  fi
   for java_pid in $(jps -q -J-XX:+PerfDisableSharedMem); do
     echo "----------------------- pid $java_pid -----------------------"
     cat /proc/$java_pid/cmdline | xargs -0 echo
     jcmd $java_pid Thread.print -l
     jcmd $java_pid GC.heap_info
+    if [ -n "$dump_dir" ]; then
+      cat /proc/$java_pid/cmdline | xargs -0 echo > "$dump_dir/cmdline_$java_pid.txt"
+      jcmd $java_pid Thread.print -l > "$dump_dir/threaddump_$java_pid.txt"
+      jcmd $java_pid GC.heap_info > "$dump_dir/heapinfo_$java_pid.txt"
+    fi
   done
   return 0
 }


### PR DESCRIPTION
### Motivation

The CI pipeline generates JUnit XML test reports via Gradle's built-in Test task and aggregates them to a `test-reports/` directory, but only HTML reports are uploaded as artifacts. This makes it difficult for automation tools (like Claude Code skills) to programmatically download and parse test results to investigate failures.

Additionally, when browsing uploaded HTML test report artifacts, there's no top-level index linking to each module's report, making navigation tedious. Thread dumps collected on cancellation are only printed to stdout and not saved as downloadable artifacts.

### Modifications

- Include aggregated XML test reports (`test-reports/`) in the existing test report artifact uploads across all CI test jobs (unit, integration, system, flaky)
- Add a `ci_generate_test_report_index()` function to `pulsar_ci_tool.sh` that generates a top-level `index.html` in `test-reports/` linking to each module's HTML test report
- Call the index generator from the `copy-test-reports` action
- Fix stale "surefire-reports" reference in the `copy-test-reports` action description
- Update `ci_print_thread_dumps()` to save thread dumps, command lines, and heap info to separate files per JVM pid under `build/threaddumps/` when running in GitHub Actions
- Include `build/threaddumps/` in the dumps artifact uploads across all CI test jobs
- Align `pulsar-ci-flaky.yaml` env var paths from `target/` to `build/` to match `pulsar-ci.yaml`

### Verifying this change

This change is a trivial CI improvement without any test coverage needed.

- Verified locally that `ci_generate_test_report_index()` correctly finds module HTML reports and generates a valid `index.html` with relative links
- XML test reports are already generated by Gradle by default at `build/test-results/test/TEST-*.xml` and collected by the existing `ci_move_test_reports()` function

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment