### PR TITLE
[fix][test] Fix thread resource leaks in tests and PrometheusMetricsProvider

### DIFF
--- a/jetty-upgrade/bookkeeper-prometheus-metrics-provider/src/main/java/org/apache/pulsar/metrics/prometheus/bookkeeper/PrometheusMetricsProvider.java
+++ b/jetty-upgrade/bookkeeper-prometheus-metrics-provider/src/main/java/org/apache/pulsar/metrics/prometheus/bookkeeper/PrometheusMetricsProvider.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.metrics.prometheus.bookkeeper;
 // CHECKSTYLE.OFF: IllegalImport
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.PlatformDependent;
 import io.prometheus.client.Collector;
@@ -170,6 +171,9 @@ public class PrometheusMetricsProvider implements StatsProvider {
             } finally {
                 ThreadRegistry.clear();
             }
+        }
+        if (executor != null) {
+            MoreExecutors.shutdownAndAwaitTermination(executor, 5, TimeUnit.SECONDS);
         }
     }
 

--- a/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
+++ b/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Properties;
 import javax.naming.AuthenticationException;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -55,6 +56,13 @@ public class AuthenticationProviderAthenzTest {
 
         // Specify Athenz configuration file for AuthZpeClient which is used in AuthenticationProviderAthenz
         System.setProperty(ZpeConsts.ZPE_PROP_ATHENZ_CONF, "./src/test/resources/athenz.conf.test");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+        if (provider != null) {
+            provider.close();
+        }
     }
 
     @Test

--- a/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
+++ b/pulsar-metadata/src/test/java/org/apache/bookkeeper/replication/BookKeeperClusterTestCase.java
@@ -28,6 +28,7 @@ import static org.apache.bookkeeper.util.BookKeeperConstants.AVAILABLE_NODE;
 import static org.apache.pulsar.common.util.PortManager.nextLockedFreePort;
 import static org.testng.Assert.assertFalse;
 import com.google.common.base.Stopwatch;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -227,7 +228,7 @@ public abstract class BookKeeperClusterTestCase {
             tearDownException = e;
         }
 
-        executor.shutdownNow();
+        MoreExecutors.shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS);
 
         LOG.info("Tearing down test {} in {} ms.", testName, sw.elapsed(TimeUnit.MILLISECONDS));
         if (tearDownException != null) {

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProviderTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/TransactionMetadataStoreProviderTest.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataSt
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig;
 import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
@@ -70,6 +71,13 @@ public class TransactionMetadataStoreProviderTest {
         this.store = this.provider.openStore(tcId, null, null,
                 null, new MLTransactionMetadataStoreTest.TransactionRecoverTrackerImpl(), 0L,
                 new TxnLogBufferedWriterConfig(), transactionTimer).get();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() throws Exception {
+        if (store != null) {
+            store.closeAsync().get(5, TimeUnit.SECONDS);
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
### Motivation

Thread leak detection in CI ([run #24135406928](https://github.com/apache/pulsar/actions/runs/24135406928)) revealed several thread resource leaks across multiple test classes and one production code issue. This PR addresses the most impactful and fixable leaks.

### Modifications

**Production code fix:**
- **PrometheusMetricsProvider.stop()**: The `ScheduledExecutorService` created in `start()` was never shut down in `stop()`, leaking `metrics-*` threads. Added `MoreExecutors.shutdownAndAwaitTermination()` call.

**Test code fixes:**
- **BookKeeperClusterTestCase**: Replaced bare `executor.shutdownNow()` with `MoreExecutors.shutdownAndAwaitTermination()` to ensure cached thread pool threads have time to terminate. This reduced leaked threads in auditor test groups from ~205 to ~27 (remaining are BookKeeper bookie internal threads).
- **TransactionMetadataStoreProviderTest**: Added `@AfterMethod` to close the `TransactionMetadataStore` which was created in `@BeforeMethod` but never closed, leaking `txn-topic-threads-OrderedExecutor` threads.
- **AuthenticationProviderAthenzTest**: Added `@AfterClass` to close the `AuthenticationProviderAthenz` instance which was created in `@BeforeClass` but never closed.

### Verifying this change

This change is already covered by existing tests. Each fix was verified locally by running the affected test with `THREAD_LEAK_DETECTOR_WAIT_MILLIS=10000`:
- `TestPrometheusMetricsProvider` — no thread leaks after fix (was 5)
- `AuditorBookieTest` — reduced from 205 to 27 leaked threads (remaining are BK bookie internals)
- `TransactionMetadataStoreProviderTest` — no thread leaks after fix (was 6)
- `AuthenticationProviderAthenzTest` — 1 remaining leak from Athenz library singleton (not fixable from Pulsar side)

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment