### PR TITLE
[improve] Add context map to log4j2 pattern layouts

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -38,7 +38,7 @@
                  filePattern="${sys:pulsar.test.logging.file}-%i.log"
                  immediateFlush="${sys:pulsar.test.logging.file.immediateFlush}"
                  createOnDemand="true">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="10MB"/>
       </Policies>

--- a/conf/functions_log4j2.xml
+++ b/conf/functions_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -58,7 +58,7 @@ Configuration:
       - name: Console
         target: SYSTEM_OUT
         PatternLayout:
-          Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+          Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
       - name: ConsoleJson
         target: SYSTEM_OUT
         JsonTemplateLayout:
@@ -71,7 +71,7 @@ Configuration:
       filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}-%d{MM-dd-yyyy}-%i.log.gz"
       immediateFlush: ${sys:pulsar.log.immediateFlush}
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
       Policies:
         TimeBasedTriggeringPolicy:
           interval: 1

--- a/microbench/src/main/resources/log4j2.xml
+++ b/microbench/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-broker/src/test/resources/log4j2.xml
+++ b/pulsar-broker/src/test/resources/log4j2.xml
@@ -30,14 +30,14 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
     </Console>
     <RollingFile name="FILE"
                  fileName="${sys:pulsar.test.logging.file}"
                  filePattern="${sys:pulsar.test.logging.file}-%i.log"
                  immediateFlush="${sys:pulsar.test.logging.file.immediateFlush}"
                  createOnDemand="true">
-      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
       <Policies>
         <SizeBasedTriggeringPolicy size="10MB"/>
       </Policies>

--- a/pulsar-client-admin/src/test/resources/log4j2.xml
+++ b/pulsar-client-admin/src/test/resources/log4j2.xml
@@ -25,7 +25,7 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/pulsar-functions/localrun/src/main/resources/log4j2.xml
+++ b/pulsar-functions/localrun/src/main/resources/log4j2.xml
@@ -22,7 +22,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -40,7 +40,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
         </Console>
         <RollingFile>
@@ -49,7 +49,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>
@@ -82,7 +82,7 @@
             <filePattern>${sys:pulsar.function.log.dir}/${sys:pulsar.function.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz</filePattern>
             <immediateFlush>true</immediateFlush>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -36,7 +36,7 @@
             <name>Console</name>
             <target>SYSTEM_OUT</target>
             <PatternLayout>
-                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n</Pattern>
+                <Pattern>%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n</Pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/pulsar-proxy/src/test/resources/log4j2.xml
+++ b/pulsar-proxy/src/test/resources/log4j2.xml
@@ -25,7 +25,7 @@
   <Appenders>
     <!-- setting follow="true" is required for using ConsoleCaptor to validate log messages -->
     <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
-      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m%n"/>
+      <PatternLayout pattern="%d{ISO8601} - %-5p - [%t:%c{1}] - %m %X%n"/>
     </Console>
   </Appenders>
   <Loggers>

--- a/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
+++ b/tiered-storage/jcloud/src/test/resources/log4j2-test.yml
@@ -33,12 +33,12 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg%n"
+        Pattern: "%d{ISO8601_OFFSET_DATE_TIME_HHMM} [%t] %-5level %logger{36} - %msg %X%n"
     File:
       name: File
       fileName: ${filename}
       PatternLayout:
-        Pattern: "%d %p %c{1.} [%t] %m%n"
+        Pattern: "%d %p %c{1.} [%t] %m %X%n"
       Filters:
         ThresholdFilter:
           level: error


### PR DESCRIPTION
## Summary
- Add `%X` (ThreadContext/MDC map) to all log4j2 PatternLayout configurations
- This ensures structured logging attributes are rendered in text-based log output
- Required for slog (PIP-467) to display structured attributes in the default log format
- Updates 11 log4j2 configuration files across the project

## Test plan
- [ ] Verify log output includes structured attributes when using slog
- [ ] Existing log format is unchanged for messages without structured attributes (empty `%X` renders as `{}`)