### PR TITLE
[fix][test] Fix flaky ReplicatorTest.testResumptionAfterBacklogRelaxed

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -1056,8 +1056,10 @@ public class ReplicatorTest extends ReplicatorTestBase {
         // Consumer will now drain 1 message and the replication backlog will be cleared
         consumer2.receive(1);
 
-        // Wait until the 2nd message got delivered to consumer
-        consumer2.receive(1);
+        // Wait until the 2nd message got delivered to consumer.
+        // Use a longer timeout because the replicator needs time to detect that the backlog quota
+        // has been relaxed (checked every TIME_TO_CHECK_BACKLOG_QUOTA seconds) and resume replication.
+        consumer2.receive(1, TIME_TO_CHECK_BACKLOG_QUOTA * 4);
 
         Awaitility.await().untilAsserted(() -> assertEquals(replicator.computeStats().replicationBacklog, 0));
         metrics = metricReader1.collectAllMetrics();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -617,6 +617,10 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
         }
 
         void receive(int messages) throws Exception {
+            receive(messages, 10);
+        }
+
+        void receive(int messages, int timeoutSeconds) throws Exception {
             log.info("Start receiving messages");
             Message<byte[]> msg;
 
@@ -624,7 +628,7 @@ public abstract class ReplicatorTestBase extends TestRetrySupport {
 
             int i = 0;
             while (i < messages) {
-                msg = consumer.receive(10, TimeUnit.SECONDS);
+                msg = consumer.receive(timeoutSeconds, TimeUnit.SECONDS);
                 assertNotNull(msg);
                 consumer.acknowledge(msg);
 


### PR DESCRIPTION
### Motivation

`ReplicatorTest.testResumptionAfterBacklogRelaxed` is a known flaky test that has been reported multiple times:
- #24789
- #24508
- #788
- #614

The test fails intermittently at line 1060 where `consumer2.receive(1)` waits for a replicated message with a fixed **10-second timeout** (hardcoded in `MessageConsumer.receive()`). After the consumer drains the first message, the replicator needs:

1. Up to **5 seconds** for the backlog quota checker to run (`TIME_TO_CHECK_BACKLOG_QUOTA = 5`)
2. Time for the replicator to resume (reconnect producer)
3. Time for the message to be replicated and delivered

On a loaded CI machine, 10 seconds is insufficient for all of these steps to complete.

### Modifications

- Added `receive(int messages, int timeoutSeconds)` overload to `MessageConsumer` in `ReplicatorTestBase.java`, allowing callers to specify a custom receive timeout instead of the default 10 seconds.
- Changed `testResumptionAfterBacklogRelaxed` to use `consumer2.receive(1, TIME_TO_CHECK_BACKLOG_QUOTA * 4)` (20 seconds) when waiting for the replicated message after quota relaxation, giving the replicator sufficient time to detect the relaxed quota and resume replication.

### Verifying this change

This change is already covered by existing tests.

Verified locally by running the test with `@Test(invocationCount = 10)` — all 21 executions (10 invocations × 2 data provider variants + 1) passed successfully.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment