### PR TITLE
[fix][test] Fix flaky TopicFromMessageTest by using unique topic names

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicFromMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicFromMessageTest.java
@@ -57,12 +57,13 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
 
     @Test(timeOut = TEST_TIMEOUT)
     public void testSingleTopicConsumerNoBatchShortName() throws Exception {
+        final String topic = "topic-" + System.nanoTime();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("topic1").subscriptionName("sub1").subscribe();
+                .topic(topic).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic("topic1").enableBatching(false).create()) {
+                .topic(topic).enableBatching(false).create()) {
             producer.send("foobar".getBytes());
-            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/topic1");
+            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/" + topic);
         }
     }
 
@@ -80,16 +81,18 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
 
     @Test(timeOut = TEST_TIMEOUT)
     public void testMultiTopicConsumerNoBatchShortName() throws Exception {
+        final String topic1 = "topic-" + System.nanoTime() + "-1";
+        final String topic2 = "topic-" + System.nanoTime() + "-2";
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topics(Lists.newArrayList("topic1", "topic2")).subscriptionName("sub1").subscribe();
+                .topics(Lists.newArrayList(topic1, topic2)).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer1 = pulsarClient.newProducer()
-                .topic("topic1").enableBatching(false).create();
+                .topic(topic1).enableBatching(false).create();
              Producer<byte[]> producer2 = pulsarClient.newProducer()
-                .topic("topic2").enableBatching(false).create()) {
+                .topic(topic2).enableBatching(false).create()) {
 
             Set<String> topicSet = new HashSet<>();
-            topicSet.add("persistent://public/default/topic1");
-            topicSet.add("persistent://public/default/topic2");
+            topicSet.add("persistent://public/default/" + topic1);
+            topicSet.add("persistent://public/default/" + topic2);
             producer1.send("foobar".getBytes());
             producer2.send("foobar".getBytes());
             Assert.assertTrue(topicSet.remove(consumer.receive().getTopicName()));
@@ -99,24 +102,27 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
 
     @Test(timeOut = TEST_TIMEOUT)
     public void testSingleTopicConsumerBatchShortName() throws Exception {
+        final String topic = "topic-" + System.nanoTime();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("topic1").subscriptionName("sub1").subscribe();
+                .topic(topic).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic("topic1").enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create()) {
+                .topic(topic).enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create()) {
             producer.send("foobar".getBytes());
 
-            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/topic1");
+            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/" + topic);
         }
     }
 
     @Test(timeOut = TEST_TIMEOUT)
     public void testMultiTopicConsumerBatchShortName() throws Exception {
+        final String topic1 = "topic-" + System.nanoTime() + "-1";
+        final String topic2 = "topic-" + System.nanoTime() + "-2";
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topics(Lists.newArrayList("topic1", "topic2")).subscriptionName("sub1").subscribe();
+                .topics(Lists.newArrayList(topic1, topic2)).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer1 = pulsarClient.newProducer()
-                .topic("topic1").enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create();
+                .topic(topic1).enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create();
              Producer<byte[]> producer2 = pulsarClient.newProducer()
-                .topic("topic2").enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create()) {
+                .topic(topic2).enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create()) {
 
             producer1.send("foobar".getBytes());
             producer2.send("foobar".getBytes());
@@ -126,7 +132,7 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
             String topicNameY = consumer.receive().getTopicName();
             Object[] actualTopicNames = new Object[]{topicNameX, topicNameY};
             Object[] expectedTopicNames =
-                    new Object[]{"persistent://public/default/topic1", "persistent://public/default/topic2"};
+                    new Object[]{"persistent://public/default/" + topic1, "persistent://public/default/" + topic2};
             Assert.assertEqualsNoOrder(actualTopicNames, expectedTopicNames);
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicFromMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicFromMessageTest.java
@@ -22,12 +22,9 @@ import com.google.common.collect.Lists;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.pulsar.broker.service.SharedPulsarBaseTest;
-import org.apache.pulsar.broker.service.SharedPulsarCluster;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
@@ -36,39 +33,8 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
     private static final long TEST_TIMEOUT = 90000; // 1.5 min
     private static final int BATCHING_MAX_MESSAGES_THRESHOLD = 2;
 
-    @Override
-    @BeforeClass(alwaysRun = true)
-    public void setupSharedCluster() throws Exception {
-        super.setupSharedCluster();
-        // These tests use short topic names (e.g. "topic1") which resolve to public/default
-        try {
-            admin.tenants().createTenant("public",
-                    new TenantInfoImpl(Set.of(), Set.of(SharedPulsarCluster.CLUSTER_NAME)));
-        } catch (Exception e) {
-            // tenant may already exist
-        }
-        try {
-            admin.namespaces().createNamespace("public/default",
-                    Set.of(SharedPulsarCluster.CLUSTER_NAME));
-        } catch (Exception e) {
-            // namespace may already exist
-        }
-    }
-
     @Test(timeOut = TEST_TIMEOUT)
-    public void testSingleTopicConsumerNoBatchShortName() throws Exception {
-        final String topic = "topic-" + System.nanoTime();
-        try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic(topic).subscriptionName("sub1").subscribe();
-             Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic(topic).enableBatching(false).create()) {
-            producer.send("foobar".getBytes());
-            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/" + topic);
-        }
-    }
-
-    @Test(timeOut = TEST_TIMEOUT)
-    public void testSingleTopicConsumerNoBatchFullName() throws Exception {
+    public void testSingleTopicConsumerNoBatch() throws Exception {
         final String topic = newTopicName();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(topic).subscriptionName("sub1").subscribe();
@@ -80,9 +46,9 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
     }
 
     @Test(timeOut = TEST_TIMEOUT)
-    public void testMultiTopicConsumerNoBatchShortName() throws Exception {
-        final String topic1 = "topic-" + System.nanoTime() + "-1";
-        final String topic2 = "topic-" + System.nanoTime() + "-2";
+    public void testMultiTopicConsumerNoBatch() throws Exception {
+        final String topic1 = newTopicName();
+        final String topic2 = newTopicName();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topics(Lists.newArrayList(topic1, topic2)).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer1 = pulsarClient.newProducer()
@@ -91,8 +57,8 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
                 .topic(topic2).enableBatching(false).create()) {
 
             Set<String> topicSet = new HashSet<>();
-            topicSet.add("persistent://public/default/" + topic1);
-            topicSet.add("persistent://public/default/" + topic2);
+            topicSet.add(topic1);
+            topicSet.add(topic2);
             producer1.send("foobar".getBytes());
             producer2.send("foobar".getBytes());
             Assert.assertTrue(topicSet.remove(consumer.receive().getTopicName()));
@@ -101,22 +67,22 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
     }
 
     @Test(timeOut = TEST_TIMEOUT)
-    public void testSingleTopicConsumerBatchShortName() throws Exception {
-        final String topic = "topic-" + System.nanoTime();
+    public void testSingleTopicConsumerBatch() throws Exception {
+        final String topic = newTopicName();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(topic).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer = pulsarClient.newProducer()
                 .topic(topic).enableBatching(true).batchingMaxMessages(BATCHING_MAX_MESSAGES_THRESHOLD).create()) {
             producer.send("foobar".getBytes());
 
-            Assert.assertEquals(consumer.receive().getTopicName(), "persistent://public/default/" + topic);
+            Assert.assertEquals(consumer.receive().getTopicName(), topic);
         }
     }
 
     @Test(timeOut = TEST_TIMEOUT)
-    public void testMultiTopicConsumerBatchShortName() throws Exception {
-        final String topic1 = "topic-" + System.nanoTime() + "-1";
-        final String topic2 = "topic-" + System.nanoTime() + "-2";
+    public void testMultiTopicConsumerBatch() throws Exception {
+        final String topic1 = newTopicName();
+        final String topic2 = newTopicName();
         try (Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topics(Lists.newArrayList(topic1, topic2)).subscriptionName("sub1").subscribe();
              Producer<byte[]> producer1 = pulsarClient.newProducer()
@@ -131,8 +97,7 @@ public class TopicFromMessageTest extends SharedPulsarBaseTest {
             String topicNameX = consumer.receive().getTopicName();
             String topicNameY = consumer.receive().getTopicName();
             Object[] actualTopicNames = new Object[]{topicNameX, topicNameY};
-            Object[] expectedTopicNames =
-                    new Object[]{"persistent://public/default/" + topic1, "persistent://public/default/" + topic2};
+            Object[] expectedTopicNames = new Object[]{topic1, topic2};
             Assert.assertEqualsNoOrder(actualTopicNames, expectedTopicNames);
         }
     }


### PR DESCRIPTION
## Summary
- Fix flaky `TopicFromMessageTest` tests (e.g. `testMultiTopicConsumerNoBatchShortName`)
- All tests shared hardcoded topic names (`topic1`, `topic2`) with the same subscription `sub1` on a shared broker, causing leftover messages from prior runs to bleed into subsequent tests
- Use unique topic names per test to ensure complete isolation while still testing short name resolution

## Test plan
- [ ] Verify all `TopicFromMessageTest` methods pass