### PR TITLE
[fix][test] Fix flaky ServerCnxTest.testCreateProducerTimeoutThenCreateSameNamedProducerShouldFail

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2101,7 +2101,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000, invocationCount = 10)
+    @Test(timeOut = 30000)
     public void testCreateProducerTimeoutThenCreateSameNamedProducerShouldFail() throws Exception {
         resetChannel();
         setChannelConnected();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2101,7 +2101,7 @@ public class ServerCnxTest {
         channel.finish();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30000, invocationCount = 10)
     public void testCreateProducerTimeoutThenCreateSameNamedProducerShouldFail() throws Exception {
         resetChannel();
         setChannelConnected();
@@ -2132,6 +2132,13 @@ public class ServerCnxTest {
         ByteBuf createProducer1 = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
                 producerName, Collections.emptyMap(), false);
         channel.writeInbound(createProducer1);
+
+        // Run pending tasks to ensure the producer is registered in the producers map
+        // before the close command is processed. Without this, the close command may not
+        // find the producer (since registration happens in a thenApplyAsync callback),
+        // causing it to skip cancellation and leading to a race between the first and
+        // second producer creation.
+        channel.runPendingTasks();
 
         ByteBuf closeProducer = Commands.newCloseProducer(1 /* producer id */, 2 /* request id */);
         channel.writeInbound(closeProducer);


### PR DESCRIPTION
Fixes #25249

### Motivation

Fix flaky `ServerCnxTest.testCreateProducerTimeoutThenCreateSameNamedProducerShouldFail` that fails intermittently on master.

**Root cause**: When `channel.writeInbound(createProducer1)` was called, the producer registration in the `producers` map happened asynchronously in a `thenApplyAsync` callback on `ctx.executor()`. In `EmbeddedChannel`, these callbacks only execute when `channel.runPendingTasks()` is called. Without draining pending tasks before the close command, `handleCloseProducer` could not find the producer in the map, took the "producer not registered" path, and didn't cancel anything. When both producer creation tasks later ran, they raced on `putIfAbsent` for the same `producerId`, causing one to fail with `CommandError`.

### Modifications

Added `channel.runPendingTasks()` after the first `writeInbound(createProducer1)` to ensure the async callback runs and registers the producer in the `producers` map before the close command is processed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `ServerCnxTest.testCreateProducerTimeoutThenCreateSameNamedProducerShouldFail`. Verified with `invocationCount=10` locally (10/10 passes).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment