### PR TITLE
[fix][test] Fix flaky LeaderElectionServiceTest and PersistentDispatcherFailoverConsumerTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
@@ -66,7 +66,7 @@ public class LeaderElectionServiceTest {
         log.info("---- bk stopped ----");
     }
 
-    @Test
+    @Test(invocationCount = 10)
     public void anErrorShouldBeThrowBeforeLeaderElected() throws PulsarServerException, PulsarClientException,
             PulsarAdminException {
         final String clusterName = "elect-test";
@@ -80,12 +80,15 @@ public class LeaderElectionServiceTest {
         config.setMetadataStoreUrl("zk:127.0.0.1:" + bkEnsemble.getZookeeperPort());
         @Cleanup
         PulsarService pulsar = spyWithClassAndConstructorArgs(MockPulsarService.class, config);
-        pulsar.start();
 
         // mock pulsar.getLeaderElectionService() in a thread safe way
+        // This must be set up before start() to avoid UnfinishedStubbingException
+        // caused by background threads interacting with the spy during stubbing setup.
         AtomicReference<LeaderElectionService> leaderElectionServiceReference = new AtomicReference<>();
         Mockito.doAnswer(invocation -> leaderElectionServiceReference.get())
                 .when(pulsar).getLeaderElectionService();
+
+        pulsar.start();
 
         // broker and webService is started, but leaderElectionService not ready
         final String tenant = "elect";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LeaderElectionServiceTest.java
@@ -66,7 +66,7 @@ public class LeaderElectionServiceTest {
         log.info("---- bk stopped ----");
     }
 
-    @Test(invocationCount = 10)
+    @Test
     public void anErrorShouldBeThrowBeforeLeaderElected() throws PulsarServerException, PulsarClientException,
             PulsarAdminException {
         final String clusterName = "elect-test";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -295,7 +295,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         verify(channelCtx, times(1)).writeAndFlush(any(), any());
     }
 
-    @Test(invocationCount = 10)
+    @Test
     public void testAddRemoveConsumer() throws Exception {
         log.info("--- Starting PersistentDispatcherFailoverConsumerTest::testAddConsumer ---");
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -112,6 +112,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         svcConfig.setClusterName("pulsar-cluster");
         svcConfig.setSystemTopicEnabled(false);
         svcConfig.setTopicLevelPoliciesEnabled(false);
+        svcConfig.setActiveConsumerFailoverDelayTimeMillis(0);
         pulsarTestContext = PulsarTestContext.builderForNonStartableContext()
                 .config(svcConfig)
                 .spyByDefault()
@@ -294,7 +295,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         verify(channelCtx, times(1)).writeAndFlush(any(), any());
     }
 
-    @Test
+    @Test(invocationCount = 10)
     public void testAddRemoveConsumer() throws Exception {
         log.info("--- Starting PersistentDispatcherFailoverConsumerTest::testAddConsumer ---");
 


### PR DESCRIPTION
Fixes #21287

### Motivation

Two flaky tests have race conditions that cause intermittent failures:

1. **LeaderElectionServiceTest.anErrorShouldBeThrowBeforeLeaderElected**: The test sets up a Mockito `doAnswer` stub on the `pulsar` spy *after* `pulsar.start()`. Since `start()` launches background threads that interact with the spy, Mockito's internal stubbing state can be corrupted by concurrent access, leading to `UnfinishedStubbingException`. This is a well-known Mockito thread-safety limitation during stub setup.

2. **PersistentDispatcherFailoverConsumerTest.testAddRemoveConsumer**: The test uses the default `activeConsumerFailoverDelayTimeMillis=1000`, which causes `PersistentDispatcherSingleActiveConsumer.scheduleReadOnActiveConsumer()` to schedule consumer change notifications asynchronously via a 1000ms delayed task. When a consumer is removed shortly after another consumer change, the previous delayed task's `readOnActiveConsumerTask` field may still be non-null, causing the new notification to be silently dropped (early return at the `readOnActiveConsumerTask != null` check). This results in `assertNotNull(change)` failing on the `consumerChanges.poll()` call.

### Modifications

1. **LeaderElectionServiceTest**: Move the `Mockito.doAnswer(...).when(pulsar).getLeaderElectionService()` stub setup to *before* `pulsar.start()`. This ensures no background threads interact with the spy during stubbing. The test intent is fully preserved because `MockPulsarService` overrides `startLeaderElectionService()` to be a no-op, so `getLeaderElectionService()` would return null both with and without the stub during startup.

2. **PersistentDispatcherFailoverConsumerTest**: Set `activeConsumerFailoverDelayTimeMillis=0` in the test's `ServiceConfiguration`. This makes consumer change notifications synchronous (taking the `delay <= 0` branch in `scheduleReadOnActiveConsumer`), eliminating the race condition. The test's intent — verifying consumer ordering and active consumer change notifications — is fully preserved. The failover delay was never part of what this test was designed to verify; it was simply the default config value.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests. Both verified with invocationCount=10 locally (10/10 passes).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment