### PR TITLE
[fix][test] Fix flaky ExtensibleLoadManagerTest.startBroker timeout

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -135,33 +135,40 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
 
     @BeforeMethod(alwaysRun = true)
     public void startBroker() {
-        if (pulsarCluster != null) {
-            pulsarCluster.getBrokers().forEach(brokerContainer -> {
-                if (!brokerContainer.isRunning()) {
-                    brokerContainer.start();
-                }
-            });
-            String topicName = "persistent://" + DEFAULT_NAMESPACE + "/startBrokerCheck";
-            Awaitility.await().atMost(120, TimeUnit.SECONDS).ignoreExceptions().until(
-                    () -> {
-                        for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
-                            try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(
-                                    brokerContainer.getHttpServiceUrl()).build()) {
-                                if (admin.brokers().getActiveBrokers(clusterName).size() != NUM_BROKERS) {
-                                    return false;
-                                }
-                                try {
-                                    admin.topics().createPartitionedTopic(topicName, 10);
-                                } catch (PulsarAdminException.ConflictException e) {
-                                    // expected
-                                }
-                                admin.lookups().lookupPartitionedTopic(topicName);
-                            }
-                        }
-                        return true;
-                    }
-            );
+        if (pulsarCluster == null) {
+            return;
         }
+        pulsarCluster.getBrokers().forEach(brokerContainer -> {
+            if (!brokerContainer.isRunning()) {
+                brokerContainer.start();
+            }
+        });
+        String topicName = "persistent://" + DEFAULT_NAMESPACE + "/startBrokerCheck";
+        Awaitility.await().atMost(180, TimeUnit.SECONDS).until(
+                () -> {
+                    for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
+                        try (PulsarAdmin brokerAdmin = PulsarAdmin.builder().serviceHttpUrl(
+                                brokerContainer.getHttpServiceUrl()).build()) {
+                            if (brokerAdmin.brokers().getActiveBrokers(clusterName).size() != NUM_BROKERS) {
+                                log.info("Broker {} does not see {} active brokers yet",
+                                        brokerContainer.getHostName(), NUM_BROKERS);
+                                return false;
+                            }
+                            try {
+                                brokerAdmin.topics().createPartitionedTopic(topicName, 10);
+                            } catch (PulsarAdminException.ConflictException e) {
+                                // expected - topic already exists
+                            }
+                            brokerAdmin.lookups().lookupPartitionedTopic(topicName);
+                        } catch (Exception e) {
+                            log.warn("Broker {} is not ready yet: {}",
+                                    brokerContainer.getHostName(), e.getMessage());
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+        );
     }
 
     @Test(timeOut = 40 * 1000)


### PR DESCRIPTION
Fixes #21875

### Motivation

Fix flaky `ExtensibleLoadManagerTest.startBroker` that times out when restarting brokers after `testStopBroker` or `testIsolationPolicy`.

The root cause is that after a broker is stopped and its container is restarted, the `ServiceUnitStateTableViewImpl` channel fails to start due to a compacted ledger read error ("Invalid unknown tag type: 4", a known issue per PIP-429). The broker process crashes and restarts 2-3 times inside the Docker container before succeeding. The previous 120-second timeout was insufficient for this crash-restart cycle.

Additionally, `ignoreExceptions()` was hiding all errors, making these failures impossible to debug from test logs.

### Modifications

- Replace `ignoreExceptions()` with explicit try-catch and logging inside the Awaitility condition, so errors are visible in test logs while still allowing retries
- Add informational logging when brokers don't see the expected number of active brokers
- Increase the Awaitility timeout from 120 to 180 seconds to accommodate broker crash-restart cycles
- Minor: early return when `pulsarCluster` is null, rename shadowed variable

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing integration tests in the `pulsar-loadbalance` test group.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment