### PR TITLE
[improve][all] Upgraded Jackson to 2.21 LTS and fixed a few gradle assemble warnings

### DIFF
--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -41,7 +41,11 @@ configurations.all {
     // (EnumResolver.constructUsingToString signature changed in 2.19+).
     resolutionStrategy.eachDependency {
         if (requested.group.startsWith("com.fasterxml.jackson")) {
-            useVersion(catalog.findVersion("jackson").get().requiredVersion)
+            if (requested.name == "jackson-annotations") {
+                useVersion(catalog.findVersion("jackson-annotations").get().requiredVersion)
+            } else {
+                useVersion(catalog.findVersion("jackson").get().requiredVersion)
+            }
         }
     }
 }

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -249,17 +249,17 @@ The Apache Software License, Version 2.0
      - info.picocli-picocli-shell-jline3-4.7.5.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.18.6.jar
-     - com.fasterxml.jackson.core-jackson-core-2.18.6.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.18.6.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.6.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.6.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.6.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.21.jar
+     - com.fasterxml.jackson.core-jackson-core-2.21.2.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.21.2.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.21.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.21.2.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.21.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.21.2.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.21.2.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.21.2.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.21.2.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.21.2.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.3.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.59.2.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -313,17 +313,17 @@ The Apache Software License, Version 2.0
      - picocli-4.7.5.jar
      - picocli-shell-jline3-4.7.5.jar
  * Jackson
-     - jackson-annotations-2.18.6.jar
-     - jackson-core-2.18.6.jar
-     - jackson-databind-2.18.6.jar
-     - jackson-dataformat-yaml-2.18.6.jar
-     - jackson-jaxrs-base-2.18.6.jar
-     - jackson-jaxrs-json-provider-2.18.6.jar
-     - jackson-module-jaxb-annotations-2.18.6.jar
-     - jackson-module-jsonSchema-2.18.6.jar
-     - jackson-datatype-jdk8-2.18.6.jar
-     - jackson-datatype-jsr310-2.18.6.jar
-     - jackson-module-parameter-names-2.18.6.jar
+     - jackson-annotations-2.21.jar
+     - jackson-core-2.21.2.jar
+     - jackson-databind-2.21.2.jar
+     - jackson-dataformat-yaml-2.21.2.jar
+     - jackson-jaxrs-base-2.21.2.jar
+     - jackson-jaxrs-json-provider-2.21.2.jar
+     - jackson-module-jaxb-annotations-2.21.2.jar
+     - jackson-module-jsonSchema-2.21.2.jar
+     - jackson-datatype-jdk8-2.21.2.jar
+     - jackson-datatype-jsr310-2.21.2.jar
+     - jackson-module-parameter-names-2.21.2.jar
  * Caffeine -- caffeine-3.2.3.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,8 @@ netty = "4.1.132.Final"
 netty-iouring = "0.0.26.Final"
 jetty = "12.1.6"
 jersey = "2.42"
-jackson = "2.18.6"
+jackson = "2.21.2"
+jackson-annotations = "2.21"
 protobuf = "3.25.5"
 grpc = "1.75.0"
 slf4j = "2.0.17"
@@ -189,7 +190,7 @@ slog = { module = "io.github.merlimat.slog:slog", version.ref = "slog" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 # Jackson
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-annotations" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-module-parameter-names = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names", version.ref = "jackson" }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -442,6 +442,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     }
 
+    @SuppressWarnings("unchecked")
     public CompletableFuture<Void> reloadSchemaForAutoProduceProducer(String topic, AutoProduceBytesSchema autoSchema) {
         return lookup.getSchema(TopicName.get(topic)).thenAccept(schemaInfoOptional -> {
             if (schemaInfoOptional.isPresent()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -36,7 +36,7 @@ public final class ConfigurationDataUtils {
         // forward compatibility for the properties may go away in the future
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
-        mapper.setSerializationInclusion(Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(Include.NON_NULL);
         return mapper;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -50,7 +50,7 @@ public class JSONSchema<T> extends AvroBaseStructSchema<T> {
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         // keep backwards compatibility, don't accept unknown enum values
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         return mapper;
     }
 
@@ -111,7 +111,6 @@ public class JSONSchema<T> extends AvroBaseStructSchema<T> {
 
     /**
      * Clears the caches tied to the ObjectMapper instances and replaces the singleton ObjectMapper instance.
-     *
      * This can be used in tests to ensure that classloaders and class references don't leak across tests.
      */
     public static void clearCaches() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
@@ -100,7 +99,8 @@ public final class FieldParser {
 
         if (to.isEnum()) {
             // Converting string to enum
-            DeserializationConfig deserializationConfig = ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig();
+            DeserializationConfig deserializationConfig =
+                    ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig();
             // No replacement API available in Jackson 2.x
             AnnotatedClass annotatedEnum = AnnotatedClassResolver.resolve(
                     deserializationConfig,

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -21,6 +21,10 @@ package org.apache.pulsar.common.util;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
 import com.fasterxml.jackson.databind.util.EnumResolver;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -96,9 +100,14 @@ public final class FieldParser {
 
         if (to.isEnum()) {
             // Converting string to enum
-            @SuppressWarnings("deprecation") // No replacement API available in Jackson 2.x
-            EnumResolver r = EnumResolver.constructUsingToString(
-                ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig(), to);
+            DeserializationConfig deserializationConfig = ObjectMapperFactory.getMapper().getObjectMapper().getDeserializationConfig();
+            // No replacement API available in Jackson 2.x
+            AnnotatedClass annotatedEnum = AnnotatedClassResolver.resolve(
+                    deserializationConfig,
+                    deserializationConfig.getTypeFactory().constructType(to),
+                    deserializationConfig
+            );
+            EnumResolver r = EnumResolver.constructUsingToString(deserializationConfig, annotatedEnum);
             T value = (T) r.findEnum((String) from);
             if (value == null) {
                 throw new RuntimeException("Invalid value '" + from + "' for enum " + to);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
+import lombok.Getter;
 import org.apache.pulsar.client.admin.internal.data.AuthPoliciesImpl;
 import org.apache.pulsar.common.functions.FunctionConfig;
 import org.apache.pulsar.common.functions.FunctionState;
@@ -116,6 +117,7 @@ import org.apache.pulsar.policies.data.loadbalancer.LoadReportDeserializer;
 @CustomLog
 public class ObjectMapperFactory {
     public static class MapperReference {
+        @Getter
         private final ObjectMapper objectMapper;
         private final ObjectWriter objectWriter;
         private final ObjectReader objectReader;
@@ -124,10 +126,6 @@ public class ObjectMapperFactory {
             this.objectMapper = objectMapper;
             this.objectWriter = objectMapper.writer();
             this.objectReader = objectMapper.reader();
-        }
-
-        public ObjectMapper getObjectMapper() {
-            return objectMapper;
         }
 
         public ObjectWriter writer() {
@@ -155,7 +153,7 @@ public class ObjectMapperFactory {
     private static ObjectMapper createObjectMapperWithIncludeAlways() {
         return MAPPER_REFERENCE
                 .get().getObjectMapper().copy()
-                .setSerializationInclusion(Include.ALWAYS);
+                .setDefaultPropertyInclusion(Include.ALWAYS);
     }
 
     public static ObjectMapper create() {
@@ -170,7 +168,7 @@ public class ObjectMapperFactory {
         // forward compatibility for the properties may go away in the future
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
-        mapper.setSerializationInclusion(Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(Include.NON_NULL);
 
         // enable Jackson Java 8 support modules
         // https://github.com/FasterXML/jackson-modules-java8
@@ -271,7 +269,6 @@ public class ObjectMapperFactory {
 
     /**
      * Clears the caches tied to the ObjectMapper instances and replaces the singleton ObjectMapper instance.
-     *
      * This can be used in tests to ensure that classloaders and class references don't leak across tests.
      */
     public static void clearCaches() {


### PR DESCRIPTION
Main Issue: Upgraded Jackson to 2.21 LTS

### Motivation

The currently used Jackson version 2.18.6 is vulnerable and older. Also, the user generating a new pulsar sink with a higher Jackson version encounters an error due to a signature change in a few Jackson classes.

### Modifications

* Upgraded all Jackson libraries to version 2.21.0 and `jackson-annotations` to 2.21 (that doesn't have a patch version anymore)

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment