### PR TITLE
[improve] PIP-467: Convert pulsar-client module logging from SLF4J to slog

### DIFF
--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.slog)
     api(project(":managed-ledger"))
     api(project(":pulsar-broker-common"))
     implementation(project(":pulsar-client-original"))

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -279,10 +279,7 @@ public class RawReaderImpl implements RawReader {
                 return;
             }
             MessageIdData messageId = commandMessage.getMessageId();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Received raw message: {}/{}/{}", topic, subscription,
-                        messageId.getEntryId(), messageId.getLedgerId(), messageId.getPartition());
-            }
+            log.debug().attr("messageId", messageId).log("Received raw message");
 
             incomingRawMessages.add(
                 new RawMessageAndCnx(new RawMessageImpl(messageId, headersAndPayload), cnx));

--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation(libs.commons.lang3)
     implementation(libs.asynchttpclient)
     implementation(libs.netty.reactive.streams)
-    implementation(libs.slf4j.api)
+    implementation(libs.slog)
     implementation(libs.commons.codec)
     implementation(libs.sketches.core)
     implementation(libs.gson)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AbstractBatchMessageContainer.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.client.impl;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.common.api.proto.CompressionType;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
@@ -30,7 +30,7 @@ import org.apache.pulsar.common.protocol.Commands;
 /**
  * Batch message container framework.
  */
-@Slf4j
+@CustomLog
 public abstract class AbstractBatchMessageContainer implements BatchMessageContainerBase {
 
     protected CompressionType compressionType;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AutoClusterFailover.java
@@ -30,9 +30,9 @@ import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AutoClusterFailoverBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -40,7 +40,7 @@ import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 
-@Slf4j
+@CustomLog
 @Data
 public class AutoClusterFailover implements ServiceUrlProvider {
     private PulsarClientImpl pulsarClient;
@@ -142,7 +142,7 @@ public class AutoClusterFailover implements ServiceUrlProvider {
             }
             return true;
         } catch (Exception e) {
-            log.warn("Failed to probe available, url: {}", url, e);
+            log.warn().attr("url", url).exception(e).log("Failed to probe available, url");
             return false;
         }
     }
@@ -173,8 +173,10 @@ public class AutoClusterFailover implements ServiceUrlProvider {
             pulsarClient.reloadLookUp();
             currentPulsarServiceUrl = target;
         } catch (IOException e) {
-            log.error("Current Pulsar service is {}, "
-                    + "failed to switch back to {} ", currentPulsarServiceUrl, target, e);
+            log.error().attr("currentPulsarServiceUrl", currentPulsarServiceUrl)
+                    .attr("target", target)
+                    .exception(e)
+                    .log("Failed to switch back to primary Pulsar service");
         }
     }
 
@@ -194,10 +196,11 @@ public class AutoClusterFailover implements ServiceUrlProvider {
         } else if (currentTimestamp - failedTimestamp >= failoverDelayNs) {
             for (String targetServiceUrl : targetServiceUrls) {
                 if (probeAvailable(targetServiceUrl)) {
-                    log.info("Current Pulsar service is {}, it has been down for {} ms, "
-                                    + "switch to the service {}. The current service down at {}",
-                            currentPulsarServiceUrl, nanosToMillis(currentTimestamp - failedTimestamp),
-                            targetServiceUrl, failedTimestamp);
+                    log.info().attr("currentServiceUrl", currentPulsarServiceUrl)
+                            .attr("downTimeMs", nanosToMillis(currentTimestamp - failedTimestamp))
+                            .attr("targetServiceUrl", targetServiceUrl)
+                            .attr("failedTimestamp", failedTimestamp)
+                            .log("Switching to target service after current service went down");
                     updateServiceUrl(targetServiceUrl,
                             authentications != null ? authentications.get(targetServiceUrl) : null,
                             tlsTrustCertsFilePaths != null ? tlsTrustCertsFilePaths.get(targetServiceUrl) : null,
@@ -206,10 +209,10 @@ public class AutoClusterFailover implements ServiceUrlProvider {
                     failedTimestamp = -1;
                     break;
                 } else {
-                    log.warn("Current Pulsar service is {}, it has been down for {} ms. "
-                                    + "Failed to switch to service {}, "
-                                    + "because it is not available, continue to probe next pulsar service.",
-                        currentPulsarServiceUrl, nanosToMillis(currentTimestamp - failedTimestamp), targetServiceUrl);
+                    log.warn().attr("currentServiceUrl", currentPulsarServiceUrl)
+                            .attr("downTimeMs", nanosToMillis(currentTimestamp - failedTimestamp))
+                            .attr("targetServiceUrl", targetServiceUrl)
+                            .log("Target service is not available, continue probing next service");
                 }
             }
         }
@@ -230,19 +233,19 @@ public class AutoClusterFailover implements ServiceUrlProvider {
             failedTimestamp = currentTimestamp;
         } else if (currentTimestamp - failedTimestamp >= failoverDelayNs) {
             if (probeAvailable(targetServiceUrl)) {
-                log.info("Current Pulsar service is {}, it has been down for {} ms, "
-                                + "switch to the service {}. The current service down at {}",
-                        currentPulsarServiceUrl, nanosToMillis(currentTimestamp - failedTimestamp),
-                        targetServiceUrl, failedTimestamp);
+                log.info().attr("currentServiceUrl", currentPulsarServiceUrl)
+                        .attr("downTimeMs", nanosToMillis(currentTimestamp - failedTimestamp))
+                        .attr("targetServiceUrl", targetServiceUrl)
+                        .attr("failedTimestamp", failedTimestamp)
+                        .log("Switching to target service after current service went down");
                 updateServiceUrl(targetServiceUrl, authentication, tlsTrustCertsFilePath,
                         tlsTrustStorePath, tlsTrustStorePassword);
                 failedTimestamp = -1;
             } else {
-                log.error("Current Pulsar service is {}, it has been down for {} ms. "
-                                + "Failed to switch to service {}, "
-                                + "because it is not available",
-                        currentPulsarServiceUrl, nanosToMillis(currentTimestamp - failedTimestamp),
-                        targetServiceUrl);
+                log.error().attr("currentServiceUrl", currentPulsarServiceUrl)
+                        .attr("downTimeMs", nanosToMillis(currentTimestamp - failedTimestamp))
+                        .attr("targetServiceUrl", targetServiceUrl)
+                        .log("Target service is not available, failed to switch");
             }
         }
     }
@@ -261,10 +264,10 @@ public class AutoClusterFailover implements ServiceUrlProvider {
         if (recoverTimestamp == -1) {
             recoverTimestamp = currentTimestamp;
         } else if (currentTimestamp - recoverTimestamp >= switchBackDelayNs) {
-            log.info("Current Pulsar service is secondary: {}, "
-                            + "the primary service: {} has been recover for {} ms, "
-                            + "switch back to the primary service",
-                    currentPulsarServiceUrl, target, nanosToMillis(currentTimestamp - recoverTimestamp));
+            log.info().attr("secondaryServiceUrl", currentPulsarServiceUrl)
+                    .attr("primaryServiceUrl", target)
+                    .attr("recoveredMs", nanosToMillis(currentTimestamp - recoverTimestamp))
+                    .log("Primary service has recovered, switching back");
             updateServiceUrl(target, authentication, tlsTrustCertsFilePath, tlsTrustStorePath, tlsTrustStorePassword);
             recoverTimestamp = -1;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -35,8 +36,6 @@ import org.apache.pulsar.common.api.proto.CompressionType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.protocol.Commands;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Default batch message container.
@@ -47,6 +46,7 @@ import org.slf4j.LoggerFactory;
  * batched into single batch message:
  * [(k1, v1), (k2, v1), (k3, v1), (k1, v2), (k2, v2), (k3, v2), (k1, v3), (k2, v3), (k3, v3)]
  */
+@CustomLog
 class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     protected MessageMetadata messageMetadata = new MessageMetadata();
@@ -87,11 +87,10 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] add message to batch, num messages in batch so far {}", topicName,
-                    producer.getProducerName(), numMessagesInBatch);
-        }
+            log.debug().attr("topic", topicName)
+                    .attr("producerName", producer.getProducerName())
+                    .attr("numMessagesInBatch", numMessagesInBatch)
+                    .log("add message to batch");
 
         if (++numMessagesInBatch == 1) {
             try {
@@ -110,7 +109,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                     currentTxnidLeastBits = msg.getMessageBuilder().getTxnidLeastBits();
                 }
             } catch (Throwable e) {
-                log.error("construct first message failed, exception is ", e);
+                log.error().exception(e).log("construct first message failed, exception is ");
                 if (producer != null) {
                     producer.semaphoreRelease(getNumMessagesInBatch());
                     producer.client.getMemoryLimitController().releaseMemory(msg.getUncompressedSize()
@@ -250,8 +249,11 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
                 batchedMessageMetadataAndPayload = null;
             }
         } catch (Throwable t) {
-            log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topicName,
-                    producer.getProducerName(), lowestSequenceId, t);
+            log.warn().attr("topic", topicName)
+                    .attr("producerName", producer.getProducerName())
+                    .attr("lowestSequenceId", lowestSequenceId)
+                    .exception(t)
+                    .log("Got exception while completing the callback for msg");
         }
         clear();
     }
@@ -323,14 +325,15 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
         ByteBufPair cmd = producer.sendMessage(producer.producerId, messageMetadata.getSequenceId(),
                 messageMetadata.getHighestSequenceId(), numMessagesInBatch, messageMetadata, encryptedPayload);
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] Build batch msg seq:{}, highest-seq:{}, numMessagesInBatch: {}, uncompressedSize: {},"
-                            + " payloadSize: {}", topicName, producer.getProducerName(),
-                    messageMetadata.getSequenceId(), messageMetadata.getNumMessagesInBatch(),
-                    messageMetadata.getHighestSequenceId(),
-                    messageMetadata.getUncompressedSize(), encryptedPayload.readableBytes());
-        }
+            log.debug(e -> e.attr("topic", topicName)
+                    .attr("producerName", producer.getProducerName())
+                    .attr("seq", messageMetadata.getSequenceId())
+                    .attr("numMessagesInBatch", messageMetadata.getNumMessagesInBatch())
+                    .attr("highestSeq", messageMetadata.getHighestSequenceId())
+                    .attr("uncompressedsize", messageMetadata.getUncompressedSize())
+                    .attr("payloadsize", encryptedPayload.readableBytes())
+                    .log("Build batch message")
+            );
 
         OpSendMsg op = OpSendMsg.create(producer.rpcLatencyHistogram, messages, cmd, messageMetadata.getSequenceId(),
                 messageMetadata.getHighestSequenceId(), firstCallback, batchAllocatedSizeBytes);
@@ -375,6 +378,4 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         }
         return Arrays.equals(msg.getSchemaVersion(), messageMetadata.getSchemaVersion());
     }
-
-    private static final Logger log = LoggerFactory.getLogger(BatchMessageContainerImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -88,7 +88,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
             log.debug().attr("topic", topicName)
-                    .attr("producerName", producer.getProducerName())
+                    .attr("producerName", () -> producer != null ? producer.getProducerName() : null)
                     .attr("numMessagesInBatch", numMessagesInBatch)
                     .log("add message to batch");
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageKeyBasedContainer.java
@@ -24,8 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 
 /**
  * Key based batch message container.
@@ -36,16 +35,17 @@ import org.slf4j.LoggerFactory;
  * batched into multiple batch messages:
  * [(k1, v1), (k1, v2), (k1, v3)], [(k2, v1), (k2, v2), (k2, v3)], [(k3, v1), (k3, v2), (k3, v3)]
  */
+@CustomLog
 class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
 
     private final Map<String, BatchMessageContainerImpl> batches = new HashMap<>();
 
     @Override
     public boolean add(MessageImpl<?> msg, SendCallback callback) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] add message to batch, num messages in batch so far is {}", topicName,
-                    producer.getProducerName(), numMessagesInBatch);
-        }
+            log.debug().attr("topic", topicName)
+                    .attr("producerName", producer.getProducerName())
+                    .attr("numMessagesInBatch", numMessagesInBatch)
+                    .log("add message to batch");
         String key = getKey(msg);
         final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(key,
                 __ -> new BatchMessageContainerImpl(producer));
@@ -147,7 +147,5 @@ class BatchMessageKeyBasedContainer extends AbstractBatchMessageContainer {
         }
         return msg.getKey();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(BatchMessageKeyBasedContainer.class);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -34,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
@@ -50,9 +51,8 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class BinaryProtoLookupService implements LookupService {
 
     private final PulsarClientImpl client;
@@ -186,10 +186,8 @@ public class BinaryProtoLookupService implements LookupService {
             clientCnx.newLookup(request, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     // lookup failed
-                    log.warn("[{}] failed to send lookup request : {}", topicName, t.getMessage());
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Lookup response exception: {}", topicName, t);
-                    }
+                    log.warn().attr("topic", topicName).exceptionMessage(t).log("failed to send lookup request");
+                        log.debug().attr("topic", topicName).exception(t).log("Lookup response exception");
                     addressFuture.completeExceptionally(t);
                 } else {
                     URI uri = null;
@@ -213,13 +211,15 @@ public class BinaryProtoLookupService implements LookupService {
                                     Throwable cause = FutureUtil.unwrapCompletionException(lookupException);
                                     // lookup failed
                                     if (redirectCount > 0) {
-                                        if (log.isDebugEnabled()) {
-                                            log.debug("[{}] lookup redirection failed ({}) : {}", topicName,
-                                                    redirectCount, cause.getMessage());
-                                        }
+                                            log.debug().attr("topic", topicName)
+                                                    .attr("redirectCount", redirectCount)
+                                                    .exceptionMessage(cause)
+                                                    .log("lookup redirection failed");
                                     } else {
-                                        log.warn("[{}] lookup failed : {}", topicName,
-                                                cause.getMessage(), cause);
+                                        log.warn().attr("topic", topicName)
+                                                .exceptionMessage(cause)
+                                                .exception(cause)
+                                                .log("lookup failed");
                                     }
                                     addressFuture.completeExceptionally(cause);
                                     return null;
@@ -239,8 +239,11 @@ public class BinaryProtoLookupService implements LookupService {
 
                     } catch (Exception parseUrlException) {
                         // Failed to parse url
-                        log.warn("[{}] invalid url {} : {}", topicName, uri, parseUrlException.getMessage(),
-                            parseUrlException);
+                        log.warn().attr("topicName", topicName)
+                                .attr("url", uri)
+                                .exceptionMessage(parseUrlException)
+                                .exception(parseUrlException)
+                                .log("invalid url");
                         addressFuture.completeExceptionally(parseUrlException);
                     }
                 }
@@ -264,9 +267,13 @@ public class BinaryProtoLookupService implements LookupService {
             boolean finalAutoCreationEnabled = metadataAutoCreationEnabled;
             if (!metadataAutoCreationEnabled && !clientCnx.isSupportsGetPartitionedMetadataWithoutAutoCreation()) {
                 if (useFallbackForNonPIP344Brokers) {
-                    log.info("[{}] Using original behavior of getPartitionedTopicMetadata(topic) in "
-                            + "getPartitionedTopicMetadata(topic, false) "
-                            + "since the target broker does not support PIP-344 and fallback is enabled.", topicName);
+                    log.info().attr("topicName", topicName)
+                            .log("Using original behavior of"
+                                    + " getPartitionedTopicMetadata(topic) in"
+                                    + " getPartitionedTopicMetadata(topic,"
+                                    + " false) since the target broker does"
+                                    + " not support PIP-344 and fallback"
+                                    + " is enabled.");
                     finalAutoCreationEnabled = true;
                 } else {
                     partitionFuture.completeExceptionally(
@@ -284,8 +291,10 @@ public class BinaryProtoLookupService implements LookupService {
             clientCnx.newLookup(request, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     histoGetTopicMetadata.recordFailure(System.nanoTime() - startTime);
-                    log.warn("[{}] failed to get Partitioned metadata : {}", topicName,
-                        t.getMessage(), t);
+                    log.warn().attr("topicName", topicName)
+                            .exceptionMessage(t)
+                            .exception(t)
+                            .log("failed to get Partitioned metadata");
                     partitionFuture.completeExceptionally(t);
                 } else {
                     try {
@@ -324,8 +333,10 @@ public class BinaryProtoLookupService implements LookupService {
             clientCnx.sendGetSchema(request, requestId).whenComplete((r, t) -> {
                 if (t != null) {
                     histoGetSchema.recordFailure(System.nanoTime() - startTime);
-                    log.warn("[{}] failed to get schema : {}", topicName,
-                        t.getMessage(), t);
+                    log.warn().attr("topicName", topicName)
+                            .exceptionMessage(t)
+                            .exception(t)
+                            .log("failed to get schema");
                     schemaFuture.completeExceptionally(t);
                 } else {
                     histoGetSchema.recordSuccess(System.nanoTime() - startTime);
@@ -393,10 +404,9 @@ public class BinaryProtoLookupService implements LookupService {
                     getTopicsResultFuture.completeExceptionally(t);
                 } else {
                     histoListTopics.recordSuccess(System.nanoTime() - startTime);
-                    if (log.isDebugEnabled()) {
-                        log.debug("[namespace: {}] Success get topics list in request: {}",
-                                namespace, requestId);
-                    }
+                        log.debug().attr("namespace", namespace)
+                                .attr("request", requestId)
+                                .log("[namespace: ] Success get topics list in request");
                     getTopicsResultFuture.complete(r);
                 }
                 client.getCnxPool().releaseConnection(clientCnx);
@@ -412,8 +422,11 @@ public class BinaryProtoLookupService implements LookupService {
             }
 
             ((ScheduledExecutorService) scheduleExecutor).schedule(() -> {
-                log.warn("[namespace: {}] Could not get connection while getTopicsUnderNamespace -- Will try again in"
-                                + " {} ms", namespace, nextDelay);
+                log.warn().attr("namespace", namespace)
+                        .attr("nextDelayMs", nextDelay)
+                        .log("Could not get connection"
+                                + " while getTopicsUnderNamespace"
+                                + " -- Will try again later");
                 remainingTime.addAndGet(-nextDelay);
                 getTopicsUnderNamespace(namespace, backoff, remainingTime, getTopicsResultFuture,
                         mode, topicsPattern, topicsHash, properties);
@@ -458,6 +471,4 @@ public class BinaryProtoLookupService implements LookupService {
         }
 
     }
-
-    private static final Logger log = LoggerFactory.getLogger(BinaryProtoLookupService.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.client.impl.TransactionMetaStoreHandler.getExcep
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -49,7 +50,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.Authentication;
@@ -106,8 +106,6 @@ import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Channel handler for the Pulsar client.
@@ -117,6 +115,11 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("unchecked")
 public class ClientCnx extends PulsarHandler {
+
+    private static final Logger LOG = Logger.get(ClientCnx.class);
+
+    // Derived instance logger with channel context, set in channelActive().
+    private Logger log = LOG;
 
     protected final Authentication authentication;
     protected State state;
@@ -290,28 +293,26 @@ public class ClientCnx extends PulsarHandler {
         connectionsOpenedCounter.increment();
         this.localAddress = ctx.channel().localAddress();
         this.remoteAddress = ctx.channel().remoteAddress();
+        this.log = LOG.with().attr("channel", ctx.channel()).build();
 
         this.timeoutTask = this.eventLoopGroup
                 .scheduleAtFixedRate(catchingAndLoggingThrowables(this::checkRequestTimeout), operationTimeoutMs,
                         operationTimeoutMs, TimeUnit.MILLISECONDS);
 
         if (proxyToTargetBrokerAddress == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("{} Connected to broker", ctx.channel());
-            }
+                log.debug("Connected to broker");
         } else {
-            log.info("{} Connected through proxy to target broker at {}", ctx.channel(), proxyToTargetBrokerAddress);
+            log.info().attr("proxyToTargetBrokerAddress", proxyToTargetBrokerAddress)
+                    .log("Connected through proxy to target broker");
         }
         // Send CONNECT command
         ctx.writeAndFlush(newConnectCommand())
                 .addListener(future -> {
                     if (future.isSuccess()) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Complete: {}", future.isSuccess());
-                        }
+                            log.debug().attr("success", future.isSuccess()).log("Complete");
                         state = State.SentConnectFrame;
                     } else {
-                        log.warn("Error during handshake", future.cause());
+                        log.warn().exception(future.cause()).log("Error during handshake");
                         ctx.close();
                     }
                 });
@@ -332,7 +333,7 @@ public class ClientCnx extends PulsarHandler {
         super.channelInactive(ctx);
         connectionsClosedCounter.increment();
         lastDisconnectedTimestamp = System.currentTimeMillis();
-        log.info("{} Disconnected", ctx.channel());
+        log.info("Disconnected");
         if (!connectionFuture.isDone()) {
             connectionFuture.completeExceptionally(new PulsarClientException("Connection already closed"));
         }
@@ -369,15 +370,13 @@ public class ClientCnx extends PulsarHandler {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (state != State.Failed) {
             // No need to report stack trace for known exceptions that happen in disconnections
-            log.warn("[{}] Got exception {}", remoteAddress,
-                    ClientCnx.isKnownException(cause) ? cause : ExceptionUtils.getStackTrace(cause));
+            log.warn().exception(cause)
+                    .log("Got exception");
             state = State.Failed;
         } else {
             // At default info level, suppress all subsequent exceptions that are thrown when the connection has already
             // failed
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Got exception: {}", remoteAddress, cause.getMessage(), cause);
-            }
+                log.debug().exception(cause).log("Got exception");
         }
 
         ctx.close();
@@ -396,16 +395,15 @@ public class ClientCnx extends PulsarHandler {
     protected void handleConnected(CommandConnected connected) {
         checkArgument(state == State.SentConnectFrame || state == State.Connecting);
         if (connected.hasMaxMessageSize()) {
-            if (log.isDebugEnabled()) {
-                log.debug("{} Connection has max message size setting, replace old frameDecoder with "
-                          + "server frame size {}", ctx.channel(), connected.getMaxMessageSize());
-            }
+                log.debug()
+                        .attr("size", connected.getMaxMessageSize())
+                        .log("Connection has max message size setting,"
+                                + " replace old frameDecoder with"
+                                + " server frame size");
             maxMessageSize = connected.getMaxMessageSize();
             FrameDecoderUtil.replaceFrameDecoder(ctx.pipeline(), connected.getMaxMessageSize());
         }
-        if (log.isDebugEnabled()) {
-            log.debug("{} Connection is ready", ctx.channel());
-        }
+            log.debug("Connection is ready");
 
         supportsTopicWatchers =
             connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatchers();
@@ -432,7 +430,9 @@ public class ClientCnx extends PulsarHandler {
             try {
                 authenticationDataProvider = authentication.getAuthData(remoteHostName);
             } catch (PulsarClientException e) {
-                log.error("{} Error when refreshing authentication data provider: {}", ctx.channel(), e);
+                log.error()
+                        .exception(e)
+                        .log("Error when refreshing authentication data provider");
                 connectionFuture.completeExceptionally(e);
                 return;
             }
@@ -449,15 +449,15 @@ public class ClientCnx extends PulsarHandler {
                     authData,
                     this.protocolVersion,
                     clientVersion);
-
-            if (log.isDebugEnabled()) {
-                log.debug("{} Mutual auth {}", ctx.channel(), authentication.getAuthMethodName());
-            }
+                log.debug()
+                        .attr("auth", authentication.getAuthMethodName())
+                        .log("Mutual auth");
 
             ctx.writeAndFlush(request).addListener(writeFuture -> {
                 if (!writeFuture.isSuccess()) {
-                    log.warn("{} Failed to send request for mutual auth to broker: {}", ctx.channel(),
-                        writeFuture.cause().getMessage());
+                    log.warn()
+                            .exceptionMessage(writeFuture.cause())
+                            .log("Failed to send request for mutual auth to broker");
                     connectionFuture.completeExceptionally(writeFuture.cause());
                 }
             });
@@ -466,7 +466,7 @@ public class ClientCnx extends PulsarHandler {
                 state = State.Connecting;
             }
         } catch (Exception e) {
-            log.error("{} Error mutual verify: {}", ctx.channel(), e);
+            log.error().exception(e).log("Error mutual verify");
             connectionFuture.completeExceptionally(e);
             return;
         }
@@ -488,27 +488,31 @@ public class ClientCnx extends PulsarHandler {
         ProducerImpl<?> producer = producers.get(producerId);
         if (ledgerId == -1 && entryId == -1) {
             if (producer == null) {
-                log.warn("{} Message with sequence-id {}-{} published by producer [id:{}, name:{}] has been dropped",
-                        ctx.channel(), sequenceId, highestSequenceId, producerId, "null");
+                log.warn()
+                        .attr("sequenceId", sequenceId)
+                        .attr("highestSequenceId", highestSequenceId)
+                        .attr("producerId", producerId)
+                        .attr("name", "null")
+                        .log("Message published by producer has been dropped");
             } else {
                 producer.printWarnLogWhenCanNotDetermineDeduplication(ctx.channel(), sequenceId, highestSequenceId);
             }
 
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("{} Got receipt for producer: [id:{}, name:{}] -- sequence-id: {}-{} -- entry-id: {}:{}",
-                        ctx.channel(), producerId, producer.getProducerName(), sequenceId, highestSequenceId,
-                        ledgerId, entryId);
-            }
+                log.debug().attr("producerId", producerId)
+                        .attr("producerName", producer.getProducerName())
+                        .attr("sequenceId", sequenceId).attr("highestSequenceId", highestSequenceId)
+                        .attr("ledgerId", ledgerId).attr("entryId", entryId)
+                        .log("Got receipt for producer");
         }
 
         if (producer != null) {
             producer.ackReceived(this, sequenceId, highestSequenceId, ledgerId, entryId);
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Producer is {} already closed, ignore published message [{}-{}]", producerId, ledgerId,
-                        entryId);
-            }
+                log.debug().attr("producerId", producerId)
+                        .attr("ledgerId", ledgerId)
+                        .attr("entryId", entryId)
+                        .log("Producer is already closed, ignore published message [-]");
         }
     }
 
@@ -527,8 +531,9 @@ public class ClientCnx extends PulsarHandler {
             }
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("AckResponse has complete when receive response! requestId : {}, consumerId : {}",
-                    ackResponse.getRequestId(), ackResponse.hasConsumerId());
+            log.warn().attr("requestId", ackResponse.getRequestId())
+                    .attr("consumerid", ackResponse.hasConsumerId())
+                    .log("AckResponse has already completed when receiving response");
         }
     }
 
@@ -536,10 +541,8 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleMessage(CommandMessage cmdMessage, ByteBuf headersAndPayload) {
         checkArgument(state == State.Ready);
-
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received a message from the server: {}", ctx.channel(), cmdMessage);
-        }
+            log.debug().attr("cmdMessage", cmdMessage)
+                    .log("Received a message from the server");
         ConsumerImpl<?> consumer = consumers.get(cmdMessage.getConsumerId());
         if (consumer != null) {
             consumer.messageReceived(cmdMessage, headersAndPayload, this);
@@ -549,10 +552,8 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleActiveConsumerChange(CommandActiveConsumerChange change) {
         checkArgument(state == State.Ready);
-
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received a consumer group change message from the server : {}", ctx.channel(), change);
-        }
+            log.debug().attr("change", change)
+                    .log("Received a consumer group change message from the server");
         ConsumerImpl<?> consumer = consumers.get(change.getConsumerId());
         if (consumer != null) {
             consumer.activeConsumerChanged(change.isIsActive());
@@ -562,28 +563,24 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleSuccess(CommandSuccess success) {
         checkArgument(state == State.Ready);
-
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received success response from server: {}", ctx.channel(), success.getRequestId());
-        }
+            log.debug().attr("requestId", success.getRequestId())
+                    .log("Received success response from server");
         long requestId = success.getRequestId();
         CompletableFuture<?> requestFuture = pendingRequests.remove(requestId);
         if (requestFuture != null) {
             requestFuture.complete(null);
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());
+            log.warn().attr("requestId", success.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
     @Override
     protected void handleGetLastMessageIdSuccess(CommandGetLastMessageIdResponse success) {
         checkArgument(state == State.Ready);
-
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received success GetLastMessageId response from server: {}",
-                    ctx.channel(), success.getRequestId());
-        }
+            log.debug().attr("requestId", success.getRequestId())
+                    .log("Received success GetLastMessageId response from server");
         long requestId = success.getRequestId();
         CompletableFuture<CommandGetLastMessageIdResponse> requestFuture =
                 (CompletableFuture<CommandGetLastMessageIdResponse>) pendingRequests.remove(requestId);
@@ -591,18 +588,17 @@ public class ClientCnx extends PulsarHandler {
             requestFuture.complete(new CommandGetLastMessageIdResponse().copyFrom(success));
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());
+            log.warn().attr("requestId", success.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
     @Override
     protected void handleProducerSuccess(CommandProducerSuccess success) {
         checkArgument(state == State.Ready);
-
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received producer success response from server: {} - producer-name: {}", ctx.channel(),
-                    success.getRequestId(), success.getProducerName());
-        }
+            log.debug().attr("requestId", success.getRequestId())
+                    .attr("producerName", success.getProducerName())
+                    .log("Received producer success response from server");
         long requestId = success.getRequestId();
         if (!success.isProducerReady()) {
             // We got a success operation but the producer is not ready. This means that the producer has been queued up
@@ -610,8 +606,10 @@ public class ClientCnx extends PulsarHandler {
             // we have received a response, in order to avoid the timeout.
             TimedCompletableFuture<?> requestFuture = pendingRequests.get(requestId);
             if (requestFuture != null) {
-                log.info("{} Producer {} has been queued up at broker. request: {}", ctx.channel(),
-                        success.getProducerName(), requestId);
+                log.info()
+                        .attr("producerName", success.getProducerName())
+                        .attr("requestId", requestId)
+                        .log("Producer has been queued up at broker");
                 requestFuture.markAsResponded();
             }
             return;
@@ -627,26 +625,28 @@ public class ClientCnx extends PulsarHandler {
             requestFuture.complete(pr);
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());
+            log.warn().attr("requestId", success.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
     @Override
     protected void handleLookupResponse(CommandLookupTopicResponse lookupResult) {
-        if (log.isDebugEnabled()) {
+        log.debug(e -> {
             CommandLookupTopicResponse.LookupType response =
                     lookupResult.hasResponse() ? lookupResult.getResponse() : null;
-            log.debug("Received Broker lookup response: {} {}", lookupResult.getRequestId(), response);
-        }
+            e.attr("requestId", lookupResult.getRequestId()).attr("response", response)
+                    .log("Received Broker lookup response");
+        });
 
         long requestId = lookupResult.getRequestId();
         CompletableFuture<LookupDataResult> requestFuture = getAndRemovePendingLookupRequest(requestId);
 
         if (requestFuture != null) {
             if (requestFuture.isCompletedExceptionally()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("{} Request {} already timed-out", ctx.channel(), lookupResult.getRequestId());
-                }
+                log.debug()
+                        .attr("requestId", lookupResult.getRequestId())
+                        .log("Request already timed-out");
                 return;
             }
             // Complete future with exception if : Result.response=fail/null
@@ -667,28 +667,29 @@ public class ClientCnx extends PulsarHandler {
                 requestFuture.complete(new LookupDataResult(lookupResult));
             }
         } else {
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), lookupResult.getRequestId());
+            log.warn().attr("requestId", lookupResult.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
     @Override
     protected void handlePartitionResponse(CommandPartitionedTopicMetadataResponse lookupResult) {
-        if (log.isDebugEnabled()) {
+        log.debug(e -> {
             CommandPartitionedTopicMetadataResponse.LookupType response =
                     lookupResult.hasResponse() ? lookupResult.getResponse() : null;
             int partitions = lookupResult.hasPartitions() ? lookupResult.getPartitions() : -1;
-            log.debug("Received Broker Partition response: {} {} {}", lookupResult.getRequestId(), response,
-                    partitions);
-        }
+            e.attr("requestId", lookupResult.getRequestId()).attr("response", response)
+                    .attr("partitions", partitions).log("Received Broker Partition response");
+        });
 
         long requestId = lookupResult.getRequestId();
         CompletableFuture<LookupDataResult> requestFuture = getAndRemovePendingLookupRequest(requestId);
 
         if (requestFuture != null) {
             if (requestFuture.isCompletedExceptionally()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("{} Request {} already timed-out", ctx.channel(), lookupResult.getRequestId());
-                }
+                log.debug()
+                        .attr("requestId", lookupResult.getRequestId())
+                        .log("Request already timed-out");
                 return;
             }
             // Complete future with exception if : Result.response=fail/null
@@ -709,7 +710,8 @@ public class ClientCnx extends PulsarHandler {
                 requestFuture.complete(new LookupDataResult(lookupResult.getPartitions()));
             }
         } else {
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), lookupResult.getRequestId());
+            log.warn().attr("requestId", lookupResult.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
@@ -717,7 +719,8 @@ public class ClientCnx extends PulsarHandler {
     protected void handleReachedEndOfTopic(CommandReachedEndOfTopic commandReachedEndOfTopic) {
         final long consumerId = commandReachedEndOfTopic.getConsumerId();
 
-        log.info("[{}] Broker notification reached the end of topic: {}", remoteAddress, consumerId);
+        log.info().attr("consumerId", consumerId)
+                .log("Broker notification reached the end of topic");
 
         ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
@@ -737,13 +740,18 @@ public class ClientCnx extends PulsarHandler {
         HandlerState resource = commandTopicMigrated.getResourceType() == ResourceType.Producer
                 ? producers.get(resourceId)
                 : consumers.get(resourceId);
-        log.info("{} is migrated to {}/{}", commandTopicMigrated.getResourceType().name(), serviceUrl, serviceUrlTls);
+        log.info().attr("resourceType", commandTopicMigrated.getResourceType().name())
+                .attr("serviceUrl", serviceUrl)
+                .attr("serviceUrlTls", serviceUrlTls)
+                .log("Resource migrated to new service url");
         if (resource != null) {
             try {
                 resource.setRedirectedClusterURI(serviceUrl, serviceUrlTls);
             } catch (URISyntaxException e) {
-                log.info("[{}] Invalid redirect url {}/{} for {}", remoteAddress, serviceUrl, serviceUrlTls,
-                        resourceId);
+                log.info().attr("serviceUrl", serviceUrl)
+                        .attr("serviceUrlTls", serviceUrlTls)
+                        .attr("resourceId", resourceId)
+                        .log("Invalid redirect URL");
             }
         }
     }
@@ -769,8 +777,10 @@ public class ClientCnx extends PulsarHandler {
                     addPendingLookupRequests(newId, newFuture);
                     ctx.writeAndFlush(firstOneWaiting.getRight().getLeft()).addListener(writeFuture -> {
                         if (!writeFuture.isSuccess()) {
-                            log.warn("{} Failed to send request {} to broker: {}", ctx.channel(), newId,
-                                writeFuture.cause().getMessage());
+                            log.warn()
+                                    .attr("requestId", newId)
+                                    .exceptionMessage(writeFuture.cause())
+                                    .log("Failed to send request to broker");
                             getAndRemovePendingLookupRequest(newId);
                             newFuture.completeExceptionally(writeFuture.cause());
                         }
@@ -787,15 +797,16 @@ public class ClientCnx extends PulsarHandler {
 
     @Override
     protected void handleSendError(CommandSendError sendError) {
-        log.warn("{} Received send error from server: {} : {}", ctx.channel(), sendError.getError(),
-                sendError.getMessage());
+        log.warn().attr("error", sendError.getError())
+                .attr("message", sendError.getMessage()).log("Received send error from server");
 
         long producerId = sendError.getProducerId();
         long sequenceId = sendError.getSequenceId();
 
         ProducerImpl<?> producer = producers.get(producerId);
         if (producer == null) {
-            log.warn("{} Producer with id {} not found while handling send error", ctx.channel(), producerId);
+            log.warn().attr("producerId", producerId)
+                    .log("Producer not found while handling send error");
             return;
         }
 
@@ -819,19 +830,19 @@ public class ClientCnx extends PulsarHandler {
     protected void handleError(CommandError error) {
         checkArgument(state == State.SentConnectFrame || state == State.Ready);
 
-        log.warn("{} Received error from server: {}", ctx.channel(), error.getMessage());
+        log.warn().attr("message", error.getMessage())
+                .log("Received error from server");
         long requestId = error.getRequestId();
         if (error.getError() == ServerError.ProducerBlockedQuotaExceededError) {
-            log.warn("{} Producer creation has been blocked because backlog quota exceeded for producer topic",
-                    ctx.channel());
+            log.warn("Producer creation has been blocked because backlog quota exceeded for producer topic");
         }
         if (error.getError() == ServerError.AuthenticationError) {
             connectionFuture.completeExceptionally(
                     new PulsarClientException.AuthenticationException(error.getMessage()));
-            log.error("{} Failed to authenticate the client", ctx.channel());
+            log.error("Failed to authenticate the client");
         }
         if (error.getError() == ServerError.NotAllowedError) {
-            log.error("Get not allowed error, {}", error.getMessage());
+            log.error().attr("message", error.getMessage()).log("Get not allowed error");
             connectionFuture.completeExceptionally(new PulsarClientException.NotAllowedException(error.getMessage()));
         }
         CompletableFuture<?> requestFuture = pendingRequests.remove(requestId);
@@ -841,17 +852,22 @@ public class ClientCnx extends PulsarHandler {
                                              buildError(error.getRequestId(), error.getMessage())));
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), error.getRequestId());
+            log.warn().attr("requestId", error.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
     @Override
     protected void handleCloseProducer(CommandCloseProducer closeProducer) {
         final long producerId = closeProducer.getProducerId();
-        log.info("[{}] Broker notification of closed producer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
-                remoteAddress, producerId,
-                closeProducer.hasAssignedBrokerServiceUrl() ? closeProducer.getAssignedBrokerServiceUrl() : null,
-                closeProducer.hasAssignedBrokerServiceUrlTls() ? closeProducer.getAssignedBrokerServiceUrlTls() : null);
+        log.info().attr("producerId", producerId)
+                .attr("assignedBrokerUrl",
+                        closeProducer.hasAssignedBrokerServiceUrl()
+                                ? closeProducer.getAssignedBrokerServiceUrl() : null)
+                .attr("assignedBrokerUrlTls",
+                        closeProducer.hasAssignedBrokerServiceUrlTls()
+                                ? closeProducer.getAssignedBrokerServiceUrlTls() : null)
+                .log("Broker notification of closed producer");
         ProducerImpl<?> producer = producers.remove(producerId);
         if (producer != null) {
             String brokerServiceUrl = getBrokerServiceUrl(closeProducer, producer);
@@ -860,7 +876,8 @@ public class ClientCnx extends PulsarHandler {
             Optional<Long> initialConnectionDelayMs = hostUri.map(__ -> 0L);
             producer.connectionClosed(this, initialConnectionDelayMs, hostUri);
         } else {
-            log.warn("[{}] Producer with id {} not found while closing producer", remoteAddress, producerId);
+            log.warn().attr("producerId", producerId)
+                    .log("Producer not found while closing producer");
         }
     }
 
@@ -878,10 +895,14 @@ public class ClientCnx extends PulsarHandler {
     @Override
     protected void handleCloseConsumer(CommandCloseConsumer closeConsumer) {
         final long consumerId = closeConsumer.getConsumerId();
-        log.info("[{}] Broker notification of closed consumer: {}, assignedBrokerUrl: {}, assignedBrokerUrlTls: {}",
-                remoteAddress, consumerId,
-                closeConsumer.hasAssignedBrokerServiceUrl() ? closeConsumer.getAssignedBrokerServiceUrl() : null,
-                closeConsumer.hasAssignedBrokerServiceUrlTls() ? closeConsumer.getAssignedBrokerServiceUrlTls() : null);
+        log.info().attr("consumerId", consumerId)
+                .attr("assignedBrokerUrl",
+                        closeConsumer.hasAssignedBrokerServiceUrl()
+                                ? closeConsumer.getAssignedBrokerServiceUrl() : null)
+                .attr("assignedBrokerUrlTls",
+                        closeConsumer.hasAssignedBrokerServiceUrlTls()
+                                ? closeConsumer.getAssignedBrokerServiceUrlTls() : null)
+                .log("Broker notification of closed consumer");
         ConsumerImpl<?> consumer = consumers.remove(consumerId);
         if (consumer != null) {
             String brokerServiceUrl = getBrokerServiceUrl(closeConsumer, consumer);
@@ -890,7 +911,8 @@ public class ClientCnx extends PulsarHandler {
             Optional<Long> initialConnectionDelayMs = hostUri.map(__ -> 0L);
             consumer.connectionClosed(this, initialConnectionDelayMs, hostUri);
         } else {
-            log.warn("[{}] Consumer with id {} not found while closing consumer", remoteAddress, consumerId);
+            log.warn().attr("consumerId", consumerId)
+                    .log("Consumer not found while closing consumer");
         }
     }
 
@@ -911,7 +933,10 @@ public class ClientCnx extends PulsarHandler {
                 return Optional.of(new URI(url));
             }
         } catch (URISyntaxException e) {
-            log.warn("[{}] Invalid redirect URL {}, requestId {}: ", remoteAddress, url, requestId, e);
+            log.warn().attr("url", url)
+                    .attr("requestId", requestId)
+                    .exception(e)
+                    .log("Invalid redirect URL");
         }
         return Optional.empty();
     }
@@ -935,24 +960,22 @@ public class ClientCnx extends PulsarHandler {
             addPendingLookupRequests(requestId, future);
             ctx.writeAndFlush(request).addListener(writeFuture -> {
                 if (!writeFuture.isSuccess()) {
-                    log.warn("{} Failed to send request {} to broker: {}", ctx.channel(), requestId,
-                        writeFuture.cause().getMessage());
+                    log.warn()
+                            .attr("requestId", requestId)
+                            .exceptionMessage(writeFuture.cause())
+                            .log("Failed to send request to broker");
                     getAndRemovePendingLookupRequest(requestId);
                     future.completeExceptionally(writeFuture.cause());
                 }
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("{} Failed to add lookup-request into pending queue", requestId);
-            }
+            log.debug().attr("requestId", requestId).log("Failed to add lookup-request into pending queue");
 
             if (maxLookupRequestSemaphore.tryAcquire()) {
                 waitingLookupRequests.add(Pair.of(requestId, Pair.of(request, future)));
             } else {
                 request.release();
-                if (log.isDebugEnabled()) {
-                    log.debug("{} Failed to add lookup-request into waiting queue", requestId);
-                }
+                log.debug().attr("requestId", requestId).log("Failed to add lookup-request into waiting queue");
                 future.completeExceptionally(new PulsarClientException.TooManyRequestsException(String.format(
                     "Requests number out of config: There are {%s} lookup requests outstanding and {%s} requests"
                             + " pending.",
@@ -984,10 +1007,10 @@ public class ClientCnx extends PulsarHandler {
         List<String> topics = success.getTopicsList();
 
 
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received get topics of namespace success response from server: {} - topics.size: {}",
-                ctx.channel(), success.getRequestId(), topics.size());
-        }
+        log.debug()
+                .attr("requestId", success.getRequestId())
+                .attr("topicsCount", topics.size())
+                .log("Received get topics of namespace success response from server");
 
         CompletableFuture<GetTopicsResult> requestFuture =
                 (CompletableFuture<GetTopicsResult>) pendingRequests.remove(requestId);
@@ -998,7 +1021,8 @@ public class ClientCnx extends PulsarHandler {
                     success.isChanged()));
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), success.getRequestId());
+            log.warn().attr("requestId", success.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
@@ -1012,7 +1036,8 @@ public class ClientCnx extends PulsarHandler {
                 (CompletableFuture<CommandGetSchemaResponse>) pendingRequests.remove(requestId);
         if (future == null) {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), requestId);
+            log.warn().attr("requestId", requestId)
+                    .log("Received unknown request id from server");
             return;
         }
         future.complete(new CommandGetSchemaResponse().copyFrom(commandGetSchemaResponse));
@@ -1026,7 +1051,8 @@ public class ClientCnx extends PulsarHandler {
                 (CompletableFuture<CommandGetOrCreateSchemaResponse>) pendingRequests.remove(requestId);
         if (future == null) {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}", ctx.channel(), requestId);
+            log.warn().attr("requestId", requestId)
+                    .log("Received unknown request id from server");
             return;
         }
         future.complete(new CommandGetOrCreateSchemaResponse().copyFrom(commandGetOrCreateSchemaResponse));
@@ -1061,8 +1087,10 @@ public class ClientCnx extends PulsarHandler {
             ctx.writeAndFlush(requestMessage).addListener(writeFuture -> {
                 if (!writeFuture.isSuccess()) {
                     if (pendingRequests.remove(requestId, future) && !future.isDone()) {
-                        log.warn("{} Failed to send {} to broker: {}", ctx.channel(),
-                                requestType.getDescription(), writeFuture.cause().getMessage());
+                        log.warn()
+                                .attr("send", requestType.getDescription())
+                                .exceptionMessage(writeFuture.cause())
+                                .log("Failed to send to broker");
                         future.completeExceptionally(writeFuture.cause());
                     }
                 }
@@ -1178,10 +1206,9 @@ public class ClientCnx extends PulsarHandler {
     protected void handleTcClientConnectResponse(CommandTcClientConnectResponse response) {
         checkArgument(state == State.Ready);
 
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received tc client connect response "
-                    + "from server: {}", ctx.channel(), response.getRequestId());
-        }
+        log.debug()
+                .attr("requestId", response.getRequestId())
+                .log("Received tc client connect response from server");
         long requestId = response.getRequestId();
         CompletableFuture<?> requestFuture = pendingRequests.remove(requestId);
 
@@ -1190,14 +1217,16 @@ public class ClientCnx extends PulsarHandler {
                 requestFuture.complete(null);
             } else {
                 ServerError error = response.getError();
-                log.error("Got tc client connect response for request: {}, error: {}, errorMessage: {}",
-                        response.getRequestId(), response.getError(), response.getMessage());
+                log.error().attr("requestId", response.getRequestId())
+                        .attr("error", response.getError())
+                        .attr("message", response.getMessage())
+                        .log("Got tc client connect response error");
                 requestFuture.completeExceptionally(getExceptionByServerError(error, response.getMessage()));
             }
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("Tc client connect command has been completed and get response for request: {}",
-                    response.getRequestId());
+            log.warn().attr("requestId", response.getRequestId())
+                    .log("Tc client connect command has been completed and get response for request");
         }
     }
 
@@ -1249,10 +1278,9 @@ public class ClientCnx extends PulsarHandler {
     protected void handleCommandWatchTopicListSuccess(CommandWatchTopicListSuccess commandWatchTopicListSuccess) {
         checkArgument(state == State.Ready);
 
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received watchTopicListSuccess response from server: {}",
-                    ctx.channel(), commandWatchTopicListSuccess.getRequestId());
-        }
+        log.debug()
+                .attr("requestId", commandWatchTopicListSuccess.getRequestId())
+                .log("Received watchTopicListSuccess response from server");
         long requestId = commandWatchTopicListSuccess.getRequestId();
         CompletableFuture<CommandWatchTopicListSuccess> requestFuture =
                 (CompletableFuture<CommandWatchTopicListSuccess>) pendingRequests.remove(requestId);
@@ -1260,8 +1288,8 @@ public class ClientCnx extends PulsarHandler {
             requestFuture.complete(new CommandWatchTopicListSuccess().copyFrom(commandWatchTopicListSuccess));
         } else {
             duplicatedResponseCounter.incrementAndGet();
-            log.warn("{} Received unknown request id from server: {}",
-                    ctx.channel(), commandWatchTopicListSuccess.getRequestId());
+            log.warn().attr("requestId", commandWatchTopicListSuccess.getRequestId())
+                    .log("Received unknown request id from server");
         }
     }
 
@@ -1269,16 +1297,16 @@ public class ClientCnx extends PulsarHandler {
     protected void handleCommandWatchTopicUpdate(CommandWatchTopicUpdate commandWatchTopicUpdate) {
         checkArgument(state == State.Ready);
 
-        if (log.isDebugEnabled()) {
-            log.debug("{} Received watchTopicUpdate command from server: {}",
-                    ctx.channel(), commandWatchTopicUpdate.getWatcherId());
-        }
+        log.debug()
+                .attr("watcherId", commandWatchTopicUpdate.getWatcherId())
+                .log("Received watchTopicUpdate command from server");
         long watcherId = commandWatchTopicUpdate.getWatcherId();
         TopicListWatcher watcher = topicListWatchers.get(watcherId);
         if (watcher != null) {
             watcher.handleCommandWatchTopicUpdate(commandWatchTopicUpdate);
         } else {
-            log.warn("{} Received topic list update for unknown watcher from server: {}", ctx.channel(), watcherId);
+            log.warn().attr("watcherId", watcherId)
+                    .log("Received topic list update for unknown watcher from server");
         }
     }
 
@@ -1295,7 +1323,8 @@ public class ClientCnx extends PulsarHandler {
      */
     private void checkServerError(ServerError error, String errMsg) {
         if (ServerError.ServiceNotReady.equals(error)) {
-            log.error("{} Close connection because received internal-server error {}", ctx.channel(), errMsg);
+            log.error().attr("error", errMsg)
+                    .log("Close connection because received internal-server error");
             ctx.close();
         } else if (ServerError.TooManyRequests.equals(error)) {
             incrementRejectsAndMaybeClose();
@@ -1309,8 +1338,9 @@ public class ClientCnx extends PulsarHandler {
             eventLoopGroup.schedule(() -> NUMBER_OF_REJECTED_REQUESTS_UPDATER.set(ClientCnx.this, 0),
                                     rejectedRequestResetTimeSec, TimeUnit.SECONDS);
         } else if (rejectedRequests >= maxNumberOfRejectedRequestPerConnection) {
-            log.error("{} Close connection because received {} rejected request in {} seconds ", ctx.channel(),
-                      NUMBER_OF_REJECTED_REQUESTS_UPDATER.get(ClientCnx.this), rejectedRequestResetTimeSec);
+            log.error().attr("received", NUMBER_OF_REJECTED_REQUESTS_UPDATER.get(ClientCnx.this))
+                    .attr("rejectedRequestResetTimeSec", rejectedRequestResetTimeSec)
+                    .log("Close connection because received rejected request in seconds");
             ctx.close();
         }
     }
@@ -1480,22 +1510,20 @@ public class ClientCnx extends PulsarHandler {
                     && !requestFuture.hasGotResponse()) {
                 pendingRequests.remove(request.requestId, requestFuture);
                 if (!requestFuture.isDone()) {
-                    String timeoutMessage = String.format(
-                            "%s timeout {'durationMs': '%d', 'reqId':'%d', 'remote':'%s', 'local':'%s'}",
-                            request.requestType.getDescription(), operationTimeoutMs,
-                            request.requestId, remoteAddress, localAddress);
+                    String timeoutMessage = request.requestType.getDescription() + " timeout";
                     if (requestFuture.completeExceptionally(new TimeoutException(timeoutMessage))) {
                         if (request.requestType == RequestType.Lookup) {
                             incrementRejectsAndMaybeClose();
                         }
-                        log.warn("{} {}", ctx.channel(), timeoutMessage);
+                        log.warn().attr("requestType", request.requestType.getDescription())
+                                .attr("durationMs", operationTimeoutMs)
+                                .attr("requestId", request.requestId)
+                                .log("Request timed out");
                     }
                 }
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ClientCnx.class);
 
     /**
      * Check client connection is now free. This method will not change the state to idle.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Optional;
@@ -33,10 +34,9 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.HandlerState.State;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.Backoff;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConnectionHandler {
+    private static final Logger LOG = Logger.get(ConnectionHandler.class);
     private static final AtomicReferenceFieldUpdater<ConnectionHandler, ClientCnx> CLIENT_CNX_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(ConnectionHandler.class, ClientCnx.class, "clientCnx");
     @SuppressWarnings("unused")
@@ -46,6 +46,7 @@ public class ConnectionHandler {
     // Since the `clientCnx` variable will be set to null at some times, it is necessary to save this value here.
     private volatile int maxMessageSize = Commands.DEFAULT_MAX_MESSAGE_SIZE;
 
+    private final Logger log;
     protected final HandlerState state;
     protected final Backoff backoff;
     private static final AtomicLongFieldUpdater<ConnectionHandler> EPOCH_UPDATER = AtomicLongFieldUpdater
@@ -83,6 +84,11 @@ public class ConnectionHandler {
         this.randomKeyForSelectConnection = state.client.getCnxPool().genRandomKeyToSelectCon();
         this.connection = connection;
         this.backoff = backoff;
+        this.log = LOG.with()
+                .attr("topic", state.topic)
+                .attr("handler", state.getHandlerName())
+                .attr("state", () -> state.getState())
+                .build();
         CLIENT_CNX_UPDATER.set(this, null);
     }
 
@@ -92,21 +98,18 @@ public class ConnectionHandler {
 
     protected void grabCnx(Optional<URI> hostURI) {
         if (!duringConnect.compareAndSet(false, true)) {
-            log.info("[{}] [{}] Skip grabbing the connection since there is a pending connection",
-                    state.topic, state.getHandlerName());
+            log.info().log("Skip grabbing the connection since there is a pending connection");
             return;
         }
 
         if (CLIENT_CNX_UPDATER.get(this) != null) {
-            log.warn("[{}] [{}] Client cnx already set, ignoring reconnection request",
-                    state.topic, state.getHandlerName());
+            log.warn().log("Client cnx already set, ignoring reconnection request");
             return;
         }
 
         if (!isValidStateForReconnection()) {
             // Ignore connection closed when we are shutting down
-            log.info("[{}] [{}] Ignoring reconnection request (state: {})",
-                    state.topic, state.getHandlerName(), state.getState());
+            log.info("Ignoring reconnection request");
             return;
         }
 
@@ -144,7 +147,8 @@ public class ConnectionHandler {
                     .thenAccept(__ -> duringConnect.set(false))
                     .exceptionally(this::handleConnectionError);
         } catch (Throwable t) {
-            log.warn("[{}] [{}] Exception thrown while getting connection: ", state.topic, state.getHandlerName(), t);
+            log.warn().exception(t)
+                    .log("Exception thrown while getting connection");
             reconnectLater(t);
         }
     }
@@ -152,8 +156,8 @@ public class ConnectionHandler {
     private Void handleConnectionError(Throwable exception) {
         boolean toRetry = true;
         try {
-            log.warn("[{}] [{}] Error connecting to broker: {}",
-                    state.topic, state.getHandlerName(), exception.getMessage());
+            log.warn().exceptionMessage(exception)
+                    .log("Error connecting to broker");
             if (exception instanceof PulsarClientException) {
                 toRetry = connection.connectionFailed((PulsarClientException) exception);
             } else if (exception.getCause() instanceof PulsarClientException) {
@@ -162,8 +166,8 @@ public class ConnectionHandler {
                 toRetry = connection.connectionFailed(new PulsarClientException(exception));
             }
         } catch (Throwable throwable) {
-            log.error("[{}] [{}] Unexpected exception after the connection",
-                    state.topic, state.getHandlerName(), throwable);
+            log.error().exception(throwable)
+                    .log("Unexpected exception after the connection");
         }
         if (toRetry) {
             reconnectLater(exception);
@@ -175,22 +179,20 @@ public class ConnectionHandler {
         CLIENT_CNX_UPDATER.set(this, null);
         duringConnect.set(false);
         if (!isValidStateForReconnection()) {
-            log.info("[{}] [{}] Ignoring reconnection request (state: {})",
-                    state.topic, state.getHandlerName(), state.getState());
+            log.info("Ignoring reconnection request");
             return;
         }
         long delayMs = backoff.next().toMillis();
-        log.warn("[{}] [{}] Could not get connection to broker: {} -- Will try again in {} s",
-                state.topic, state.getHandlerName(),
-                exception.getMessage(), delayMs / 1000.0);
+        log.warn().exceptionMessage(exception)
+                .attr("delaySec", delayMs / 1000.0)
+                .log("Could not get connection to broker - Will try again");
         if (state.changeToConnecting()) {
             state.client.timer().newTimeout(timeout -> {
-                log.info("[{}] [{}] Reconnecting after connection was closed", state.topic, state.getHandlerName());
+                log.info("Reconnecting after connection was closed");
                 grabCnx();
             }, delayMs, TimeUnit.MILLISECONDS);
         } else {
-            log.info("[{}] [{}] Ignoring reconnection request (state: {})",
-                    state.topic, state.getHandlerName(), state.getState());
+            log.info("Ignoring reconnection request");
         }
     }
 
@@ -204,16 +206,18 @@ public class ConnectionHandler {
         state.client.getCnxPool().releaseConnection(cnx);
         if (CLIENT_CNX_UPDATER.compareAndSet(this, cnx, null)) {
             if (!state.changeToConnecting()) {
-                log.info("[{}] [{}] Ignoring reconnection request (state: {})",
-                        state.topic, state.getHandlerName(), state.getState());
+                log.info("Ignoring reconnection request");
                 return;
             }
             long delayMs = initialConnectionDelayMs.orElseGet(() -> backoff.next().toMillis());
-            log.info("[{}] [{}] Closed connection {} -- Will try again in {} s, hostUrl: {}",
-                    state.topic, state.getHandlerName(), cnx.channel(), delayMs / 1000.0, hostUrl.orElse(null));
+            log.info().attr("connection", cnx.channel())
+                    .attr("delaySec", delayMs / 1000.0)
+                    .attr("hostUrl", hostUrl.orElse(null))
+                    .log("Closed connection - Will try again");
             state.client.timer().newTimeout(timeout -> {
-                log.info("[{}] [{}] Reconnecting after {} s timeout, hostUrl: {}",
-                        state.topic, state.getHandlerName(), delayMs / 1000.0, hostUrl.orElse(null));
+                log.info().attr("delaySec", delayMs / 1000.0)
+                        .attr("hostUrl", hostUrl.orElse(null))
+                        .log("Reconnecting after timeout");
                 grabCnx(hostUrl);
             }, delayMs, TimeUnit.MILLISECONDS);
         }
@@ -266,6 +270,4 @@ public class ConnectionHandler {
     public long getEpoch() {
         return epoch;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ConnectionHandler.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -288,7 +288,8 @@ public class ConnectionPool implements AutoCloseable {
     }
 
     private CompletableFuture<ClientCnx> createConnection(Key key) {
-            log.debug().attr("logicalAddress", key.logicalAddress).log("Connection for not found in cache");
+            log.debug().attr("logicalAddress", key.logicalAddress)
+                    .log("Connection was not found in cache for logical address");
 
         final CompletableFuture<ClientCnx> cnxFuture = new CompletableFuture<>();
         // Trigger async connect to broker

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
@@ -61,9 +62,8 @@ import org.apache.pulsar.client.impl.metrics.Unit;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ConnectionPool implements AutoCloseable {
 
     public static final int IDLE_DETECTION_INTERVAL_SECONDS_MIN = 15;
@@ -174,7 +174,7 @@ public class ConnectionPool implements AutoCloseable {
                 try {
                     doMarkAndReleaseUselessConnections();
                 } catch (Exception e) {
-                    log.error("Auto release useless connections failure.", e);
+                    log.error().exception(e).log("Auto release useless connections failure.");
                 }
             }, idleDetectionIntervalSeconds, idleDetectionIntervalSeconds, TimeUnit.SECONDS);
         }
@@ -288,20 +288,16 @@ public class ConnectionPool implements AutoCloseable {
     }
 
     private CompletableFuture<ClientCnx> createConnection(Key key) {
-        if (log.isDebugEnabled()) {
-            log.debug("Connection for {} not found in cache", key.logicalAddress);
-        }
+            log.debug().attr("logicalAddress", key.logicalAddress).log("Connection for not found in cache");
 
         final CompletableFuture<ClientCnx> cnxFuture = new CompletableFuture<>();
         // Trigger async connect to broker
         createConnection(key.logicalAddress, key.physicalAddress).thenAccept(channel -> {
-            log.info("[{}] Connected to server", channel);
+            log.info().attr("channel", channel).log("Connected to server");
 
             channel.closeFuture().addListener(v -> {
                 // Remove connection from pool when it gets closed
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing closed connection from pool: {}", v);
-                }
+                    log.debug().attr("pool", v).log("Removing closed connection from pool");
                 pool.remove(key, cnxFuture);
             });
 
@@ -309,21 +305,20 @@ public class ConnectionPool implements AutoCloseable {
             // complete
             final ClientCnx cnx = (ClientCnx) channel.pipeline().get("handler");
             if (!channel.isActive() || cnx == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Connection was already closed by the time we got notified", channel);
-                }
+                    log.debug().attr("channel", channel)
+                            .log("Connection was already closed by the time we got notified");
                 cnxFuture.completeExceptionally(new ChannelException("Connection already closed"));
                 return;
             }
 
             cnx.connectionFuture().thenRun(() -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Connection handshake completed", cnx.channel());
-                }
+                    log.debug().attr("channel", cnx.channel()).log("Connection handshake completed");
                 cnxFuture.complete(cnx);
             }).exceptionally(exception -> {
                 connectionsHandshakeFailureCounter.increment();
-                log.warn("[{}] Connection handshake failed: {}", cnx.channel(), exception.getMessage());
+                log.warn().attr("channel", cnx.channel())
+                        .exceptionMessage(exception)
+                        .log("Connection handshake failed");
                 cnxFuture.completeExceptionally(exception);
                 // this cleanupConnection may happen before that the
                 // CompletableFuture is cached into the "pool" map,
@@ -336,7 +331,9 @@ public class ConnectionPool implements AutoCloseable {
         }).exceptionally(exception -> {
             connectionsTcpFailureCounter.increment();
             eventLoopGroup.execute(() -> {
-                log.warn("Failed to open connection to {} : {}", key.physicalAddress, exception.getMessage());
+                log.warn().attr("physicalAddress", key.physicalAddress)
+                        .exceptionMessage(exception)
+                        .log("Failed to open connection to");
                 pool.remove(key, cnxFuture);
                 cnxFuture.completeExceptionally(new PulsarClientException(exception));
             });
@@ -368,7 +365,7 @@ public class ConnectionPool implements AutoCloseable {
                             isSniProxy ? unresolvedPhysicalAddress : null)
             );
         } catch (URISyntaxException e) {
-            log.error("Invalid Proxy url {}", clientConfig.getProxyServiceUrl(), e);
+            log.error().attr("url", clientConfig.getProxyServiceUrl()).exception(e).log("Invalid Proxy url");
             return FutureUtil
                     .failedFuture(new InvalidServiceURL("Invalid url " + clientConfig.getProxyServiceUrl(), e));
         }
@@ -454,9 +451,7 @@ public class ConnectionPool implements AutoCloseable {
         if (maxConnectionsPerHosts == 0) {
             //Disable pooling
             if (cnx.channel().isActive()) {
-                if (log.isDebugEnabled()) {
                     log.debug("close connection due to pooling disabled.");
-                }
                 cnx.close();
             }
         }
@@ -480,8 +475,6 @@ public class ConnectionPool implements AutoCloseable {
     int getPoolSize() {
         return pool.size();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ConnectionPool.class);
 
     public void doMarkAndReleaseUselessConnections(){
         if (!autoReleaseIdleConnectionsEnabled){

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -71,10 +72,11 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T> {
+    private static final Logger LOG = Logger.get(ConsumerBase.class);
+    protected final Logger log;
+
     protected static final int INITIAL_RECEIVER_QUEUE_SIZE = 1;
     protected static final double MEMORY_THRESHOLD_FOR_RECEIVER_QUEUE_SIZE_EXPANSION = 0.75;
 
@@ -143,6 +145,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         this.consumerName =
                 conf.getConsumerName() == null ? RandomStringUtils.insecure().nextAlphanumeric(5)
                         : conf.getConsumerName();
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("subscription", subscription)
+                .attr("consumerName", consumerName)
+                .build();
         this.subscribeFuture = subscribeFuture;
         this.listener = conf.getMessageListener();
         this.decryptFailListener = conf.getDecryptFailListener();
@@ -170,10 +177,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                         .messagesFromMultiTopicsEnabled(userBatchReceivePolicy.isMessagesFromMultiTopicsEnabled())
                         .timeout((int) userBatchReceivePolicy.getTimeoutMs(), TimeUnit.MILLISECONDS)
                         .build();
-                log.warn("BatchReceivePolicy maxNumMessages: {} is greater than maxReceiverQueueSize: {}, "
-                                + "reset to maxReceiverQueueSize. batchReceivePolicy: {}",
-                        userBatchReceivePolicy.getMaxNumMessages(), this.maxReceiverQueueSize,
-                        this.batchReceivePolicy.toString());
+                log.warn().attr("maxnummessages", userBatchReceivePolicy.getMaxNumMessages())
+                        .attr("maxreceiverqueuesize", this.maxReceiverQueueSize)
+                        .attr("batchreceivepolicy", this.batchReceivePolicy.toString())
+                        .log("BatchReceivePolicy maxNumMessages is greater than"
+                                + " maxReceiverQueueSize, reset to maxReceiverQueueSize");
             } else if (userBatchReceivePolicy.getMaxNumMessages() <= 0
                     && userBatchReceivePolicy.getMaxNumBytes() <= 0) {
                 this.batchReceivePolicy = BatchReceivePolicy.builder()
@@ -182,10 +190,11 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                         .messagesFromMultiTopicsEnabled(userBatchReceivePolicy.isMessagesFromMultiTopicsEnabled())
                         .timeout((int) userBatchReceivePolicy.getTimeoutMs(), TimeUnit.MILLISECONDS)
                         .build();
-                log.warn("BatchReceivePolicy maxNumMessages: {} or maxNumBytes: {} is less than 0. "
-                                + "Reset to DEFAULT_POLICY. batchReceivePolicy: {}",
-                        userBatchReceivePolicy.getMaxNumMessages(), userBatchReceivePolicy.getMaxNumBytes(),
-                        this.batchReceivePolicy.toString());
+                log.warn().attr("maxnummessages", userBatchReceivePolicy.getMaxNumMessages())
+                        .attr("maxnumbytes", userBatchReceivePolicy.getMaxNumBytes())
+                        .attr("batchreceivepolicy", this.batchReceivePolicy.toString())
+                        .log("BatchReceivePolicy maxNumMessages or maxNumBytes"
+                                + " is less than 0, reset to DEFAULT_POLICY");
             } else {
                 this.batchReceivePolicy = conf.getBatchReceivePolicy();
             }
@@ -342,9 +351,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected void completePendingReceive(CompletableFuture<Message<T>> receivedFuture, Message<T> message) {
         getInternalExecutor(message).execute(() -> {
             if (!receivedFuture.complete(message)) {
-                log.warn("Race condition detected. receive future was already completed (cancelled={}) and message was "
-                                + "dropped. message={}",
-                        receivedFuture.isCancelled(), message);
+                log.warn().attr("cancelled", receivedFuture.isCancelled())
+                        .attr("message", message)
+                        .log("Race condition detected, receive future was already completed and message was dropped");
             }
         });
     }
@@ -1108,9 +1117,10 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
 
     protected void completePendingBatchReceive(CompletableFuture<Messages<T>> future, Messages<T> messages) {
         if (!future.complete(messages)) {
-            log.warn("Race condition detected. batch receive future was already completed (cancelled={}) and messages"
-                            + " were dropped. messages={}",
-                    future.isCancelled(), messages);
+            log.warn().attr("cancelled", future.isCancelled())
+                    .attr("messages", messages)
+                    .log("Race condition detected, batch receive future was"
+                            + " already completed and messages were dropped");
         }
     }
 
@@ -1153,8 +1163,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                         // (allowing multi-threaded calls to poll()), then ensure that the polled item is completed
                         // to avoid blocking user code
 
-                        log.error("Race condition in consumer {} (should not cause data loss). "
-                                + " Concurrent operations on pendingBatchReceives is not safe", this.consumerName);
+                        log.error("Race condition in consumer (should not cause"
+                                        + " data loss), concurrent operations on"
+                                        + " pendingBatchReceives is not safe");
                         if (removed != null && !removed.future.isDone()) {
                             completeOpBatchReceive(removed);
                         }
@@ -1200,13 +1211,12 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                         MESSAGE_LISTENER_QUEUE_SIZE_UPDATER.incrementAndGet(this);
                         messageListenerExecutor.execute(msg, () -> callMessageListener(finalMsg));
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] [{}] Message has been cleared from the queue", topic, subscription);
-                        }
+                            log.debug("Message has been cleared from the queue");
                     }
                 } while (msg != null);
             } catch (PulsarClientException e) {
-                log.warn("[{}] [{}] Failed to dequeue the message for listener", topic, subscription, e);
+                log.warn().exception(e)
+                        .log("Failed to dequeue the message for listener");
             }
         });
     }
@@ -1223,18 +1233,13 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         try {
             State state = getState();
             if (state == State.Closing || state == State.Closed) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Consumer has been closed. Skipping message {}.", topic, subscription,
-                            msg.getMessageId());
-                }
+                    log.debug().attr("messageId", msg.getMessageId())
+                            .log("Consumer has been closed. Skipping message.");
                 msg.release();
                 return;
             }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Calling message listener for message {}", topic, subscription,
-                        msg.getMessageId());
-            }
+                log.debug().attr("messageId", msg.getMessageId())
+                        .log("Calling message listener for message");
             ConsumerImpl<T> receivedConsumer = (msg instanceof TopicMessageImpl)
                     ? ((TopicMessageImpl<T>) msg).receivedByconsumer : (ConsumerImpl<T>) this;
 
@@ -1242,10 +1247,8 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             if (receivedConsumer != this) {
                 State receivedByConsumerState = receivedConsumer.getState();
                 if (receivedByConsumerState == State.Closing || receivedByConsumerState == State.Closed) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Consumer that received the message has been closed. Skipping message {}.",
-                                topic, subscription, msg.getMessageId());
-                    }
+                        log.debug().attr("messageId", msg.getMessageId())
+                                .log("Consumer that received the message has been closed. Skipping message.");
                     msg.release();
                     return;
                 }
@@ -1259,10 +1262,8 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
             MessageImpl<T> innerMessage = (MessageImpl<T>) (msg instanceof TopicMessageImpl
                     ? ((TopicMessageImpl<T>) msg).getMessage() : msg);
             if (!receivedConsumer.isValidConsumerEpoch(innerMessage)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Skipping processing message since the consumer epoch is not valid. {}", topic,
-                            subscription, msg.getMessageId());
-                }
+                    log.debug().attr("messageId", msg.getMessageId())
+                            .log("Skipping processing message since the consumer epoch is not valid.");
                 return;
             }
 
@@ -1281,8 +1282,9 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                 listener.received(ConsumerBase.this, msg);
             }
         } catch (Throwable t) {
-            log.error("[{}][{}] Message listener error in processing message: {}", topic, subscription,
-                    msg.getMessageId(), t);
+            log.error().attr("messageId", msg.getMessageId())
+                    .exception(t)
+                    .log("Message listener error in processing message");
         } finally {
             MESSAGE_LISTENER_QUEUE_SIZE_UPDATER.decrementAndGet(this);
         }
@@ -1389,8 +1391,10 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
                 || getSubType() == CommandSubscribe.SubType.Exclusive)
                 && message.getConsumerEpoch() != DEFAULT_CONSUMER_EPOCH
                 && message.getConsumerEpoch() < CONSUMER_EPOCH.get(this)) {
-            log.info("Consumer filter old epoch message, topic : [{}], messageId : [{}], messageConsumerEpoch : [{}], "
-                    + "consumerEpoch : [{}]", topic, message.getMessageId(), message.getConsumerEpoch(), consumerEpoch);
+            log.info().attr("messageId", message.getMessageId())
+                    .attr("messageConsumerEpoch", message.getConsumerEpoch())
+                    .attr("consumerEpoch", consumerEpoch)
+                    .log("Consumer filter old epoch message");
             message.release();
             return false;
         }
@@ -1409,6 +1413,4 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     CompletableFuture<Consumer<T>> getSubscribeFuture() {
         return subscribeFuture;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerBase.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -29,9 +29,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
@@ -64,7 +64,7 @@ import org.apache.pulsar.client.util.RetryMessageUtil;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 
-@Slf4j
+@CustomLog
 @Getter(AccessLevel.PUBLIC)
 public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Iterables;
 import com.scurrilous.circe.checksum.Crc32cIntChecksum;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Recycler;
@@ -138,10 +139,11 @@ import org.apache.pulsar.common.util.SafeCollectionUtils;
 import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.apache.pulsar.common.util.collections.ConcurrentBitSet;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandler.Connection {
+    private static final Logger LOG = Logger.get(ConsumerImpl.class);
+    protected final Logger log;
+
     private static final int MAX_REDELIVER_UNACKNOWLEDGED = 1000;
 
     final long consumerId;
@@ -297,12 +299,23 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         super(client, topic, conf, conf.getReceiverQueueSize(), executorProvider, subscribeFuture, schema,
                 interceptors);
         this.consumerId = client.newConsumerId();
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("subscription", subscription)
+                .attr("consumerName", consumerName)
+                .attr("consumerId", () -> consumerId)
+                .attr("channel", () -> {
+                    ClientCnx c = cnx();
+                    return c != null ? c.ctx().channel() : null;
+                })
+                .build();
 
         TopicName topicName = TopicName.get(topic);
         if (!topicName.isPersistent() && conf.getSubscriptionMode().equals(SubscriptionMode.Durable)) {
             conf.setSubscriptionMode(SubscriptionMode.NonDurable);
-            log.warn("[{}] Cannot create a [Durable] subscription for a NonPersistentTopic, "
-                    + "will use [NonDurable] to subscribe. Subscription name: {}", topic, conf.getSubscriptionName());
+            log.warn("Cannot create a [Durable] subscription for a"
+                            + " NonPersistentTopic, will use [NonDurable]"
+                            + " to subscribe");
         }
         this.subscriptionMode = conf.getSubscriptionMode();
         if (startMessageId != null) {
@@ -355,7 +368,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                             String.format("[%s] [%s]", topic, subscription),
                             false);
                 } catch (Exception e) {
-                    log.error("MessageCryptoBc may not included in the jar. e:", e);
+                    log.error().exception(e).log("MessageCryptoBc may not be included in the jar");
                     msgCryptoBc = null;
                 }
                 this.msgCrypto = msgCryptoBc;
@@ -476,11 +489,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 closeConsumerTasks();
                 deregisterFromClientCnx();
                 client.cleanupConsumer(this);
-                log.info("[{}][{}] Successfully unsubscribed from topic", topic, subscription);
+                log.info("Successfully unsubscribed from topic");
                 setState(State.Closed);
                 unsubscribeFuture.complete(null);
             }).exceptionally(e -> {
-                log.error("[{}][{}] Failed to unsubscribe: {}", topic, subscription, e.getCause().getMessage());
+                log.error().exceptionMessage(e.getCause())
+                        .log("Failed to unsubscribe");
                 setState(State.Ready);
                 unsubscribeFuture.completeExceptionally(
                         PulsarClientException.wrap(e.getCause(),
@@ -779,8 +793,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
         MessageId finalMessageId = messageId;
         result.exceptionally(ex -> {
-            log.error("Send to retry letter topic exception with topic: {}, messageId: {}",
-                    this.deadLetterPolicy.getRetryLetterTopic(), finalMessageId, ex);
+            log.error().attr("retryLetterTopic", this.deadLetterPolicy.getRetryLetterTopic())
+                    .attr("messageid", finalMessageId)
+                    .exception(ex)
+                    .log("Send to retry letter topic exception");
             Set<MessageId> messageIds = Collections.singleton(finalMessageId);
             unAckedMessageTracker.remove(finalMessageId);
             redeliverUnacknowledgedMessages(messageIds);
@@ -867,8 +883,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             return CompletableFuture.completedFuture(null);
         }
 
-        log.info("[{}][{}] Subscribing to topic on cnx {}, consumerId {}",
-                topic, subscription, cnx.ctx().channel(), consumerId);
+        log.info("Subscribing to topic");
 
         long requestId = client.newRequestId();
         if (seekStatus.get() != SeekStatus.NOT_STARTED) {
@@ -963,8 +978,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     future.complete(null);
                     return null;
                 }
-                log.warn("[{}][{}] Failed to subscribe to topic on {}", topic,
-                        subscription, cnx.channel().remoteAddress());
+                log.warn("Failed to subscribe to topic");
 
                 if (e.getCause() instanceof PulsarClientException.TimeoutException) {
                     // Creating the consumer has timed out. We need to ensure the broker closes the consumer
@@ -1027,22 +1041,22 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         //  * Regular consumer after topic is manually delete and with
         //    auto-topic-creation set to false
         // No more retries are needed in this case.
-        final String cnxStr = cnx == null ? "null" : String.valueOf(cnx.channel().remoteAddress());
-        log.warn("[{}][{}] {} Closed consumer because get an error that does not support to retry: {} {}",
-                topic, subscription, cnxStr, t.getClass().getName(), t.getMessage());
+        log.warn().attr("errorType", t.getClass().getName())
+                .exceptionMessage(t)
+                .log("Closed consumer because of unrecoverable error");
         closeAsync().whenComplete((__, ex) -> {
             if (ex == null) {
                 fail(t);
                 return;
             }
-            log.error("[{}][{}] {} Failed to close consumer after got an error that does not support to retry: {} {}",
-                topic, subscription, cnxStr, t.getClass().getName(), t.getMessage());
+            log.error().attr("errorType", t.getClass().getName())
+                    .exceptionMessage(t)
+                    .log("Failed to close consumer after unrecoverable error");
         });
     }
 
     protected void consumerIsReconnectedToBroker(ClientCnx cnx, int currentQueueSize) {
-        log.info("[{}][{}] Subscribed to topic on {} -- consumer: {}", topic, subscription,
-                cnx.channel().remoteAddress(), consumerId);
+        log.info("Subscribed to topic");
 
         AVAILABLE_PERMITS_UPDATER.set(this, 0);
     }
@@ -1100,22 +1114,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
      */
     private void sendFlowPermitsToBroker(ClientCnx cnx, int numMessages) {
         if (cnx != null && numMessages > 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Adding {} additional permits", topic, subscription, numMessages);
-            }
-            if (log.isDebugEnabled()) {
-                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages))
-                        .addListener(writeFuture -> {
-                            if (!writeFuture.isSuccess()) {
-                                log.debug("Consumer {} failed to send {} permits to broker: {}",
-                                        consumerId, numMessages, writeFuture.cause().getMessage());
-                            } else {
-                                log.debug("Consumer {} sent {} permits to broker", consumerId, numMessages);
-                            }
-                        });
-            } else {
-                cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages), cnx.ctx().voidPromise());
-            }
+            log.debug().attr("addingPermits", numMessages).log("Adding additional permits");
+            cnx.ctx().writeAndFlush(Commands.newFlow(consumerId, numMessages), cnx.ctx().voidPromise());
         }
     }
 
@@ -1128,10 +1128,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (subscribeFuture.completeExceptionally(exception)) {
                 fail(exception);
                 if (nonRetriableError) {
-                    log.info("[{}] Consumer creation failed for consumer {} with unretriableError {}",
-                            topic, consumerId, exception.getMessage());
+                    log.info().exceptionMessage(exception)
+                            .log("Consumer creation failed for consumer with unretriableError");
                 } else {
-                    log.info("[{}] Consumer creation failed for consumer {} after timeout", topic, consumerId);
+                    log.info("Consumer creation failed for consumer after timeout");
                 }
                 closeConsumerTasks();
                 deregisterFromClientCnx();
@@ -1159,21 +1159,21 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (retryLetterProducer != null) {
             closeFutures.add(retryLetterProducer.thenCompose(p -> p.closeAsync()).whenComplete((ignore, ex) -> {
                 if (ex != null) {
-                    log.warn("Exception ignored in closing retryLetterProducer of consumer", ex);
+                    log.warn().exception(ex).log("Exception ignored in closing retryLetterProducer");
                 }
             }));
         }
         if (deadLetterProducer != null) {
             closeFutures.add(deadLetterProducer.thenCompose(p -> p.closeAsync()).whenComplete((ignore, ex) -> {
                 if (ex != null) {
-                    log.warn("Exception ignored in closing deadLetterProducer of consumer", ex);
+                    log.warn().exception(ex).log("Exception ignored in closing deadLetterProducer of consumer");
                 }
             }));
         }
         if (schema != null) {
             closeFutures.add(schema.closeAsync().whenComplete((ignore, ex) -> {
                 if (ex != null) {
-                    log.warn("Exception ignored in closing schema of consumer", ex);
+                    log.warn().exception(ex).log("Exception ignored in closing schema of consumer");
                 }
             }));
         }
@@ -1189,7 +1189,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         consumersClosedCounter.increment();
 
         if (!isConnected()) {
-            log.info("[{}] [{}] Closed Consumer (not connected)", topic, subscription);
+            log.info("Closed Consumer (not connected)");
             setState(State.Closed);
             closeConsumerTasks();
             deregisterFromClientCnx();
@@ -1215,7 +1215,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 final ChannelHandlerContext ctx = cnx.ctx();
                 boolean ignoreException = ctx == null || !ctx.channel().isActive();
                 if (ignoreException && exception != null) {
-                    log.debug("Exception ignored in closing consumer", exception);
+                    log.debug().exception(exception).log("Exception ignored in closing consumer");
                 }
                 cleanupAtClose(closeFuture, ignoreException ? null : exception);
                 return null;
@@ -1226,7 +1226,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     private void cleanupAtClose(CompletableFuture<Void> closeFuture, Throwable exception) {
-        log.info("[{}] [{}] Closed consumer", topic, subscription);
+        log.info("Closed consumer");
         setState(State.Closed);
         closeConsumerTasks();
         deregisterFromClientCnx();
@@ -1293,9 +1293,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                                   final int redeliveryCount,
                                                   final long consumerEpoch,
                                                   final boolean isEncrypted) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] processing message num - {} in batch", subscription, consumerName, index);
-        }
+        log.debug().attr("index", index)
+                .log("processing message num - in batch");
 
         ByteBuf singleMessagePayload = null;
         try {
@@ -1308,10 +1307,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (this.topicName.isPersistent() && isSameEntry(messageId) && isPriorBatchIndex(index)) {
                 // If we are receiving a batch message, we need to discard messages that were prior
                 // to the startMessageId
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Ignoring message from before the startMessageId: {}", subscription,
-                            consumerName, startMessageId);
-                }
+                log.debug().attr("startMessageId", startMessageId)
+                        .log("Ignoring message from before the startMessageId");
                 return null;
             }
 
@@ -1411,7 +1408,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
             });
         } catch (Throwable throwable) {
-            log.warn("[{}] [{}] unable to obtain message in batch", subscription, consumerName, throwable);
+            log.warn().exception(throwable)
+                    .log("unable to obtain message in batch");
             discardCorruptedMessage(messageId, cnx(), ValidationError.BatchDeSerializeError);
         } finally {
             entryContext.recycle();
@@ -1440,10 +1438,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (cmdMessage.hasConsumerEpoch()) {
             consumerEpoch = cmdMessage.getConsumerEpoch();
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Received message: {}:{}", topic, subscription, messageId.getLedgerId(),
-                    messageId.getEntryId());
-        }
+        log.debug().attr("messageId", messageId)
+                .log("Received message");
 
         if (!verifyChecksum(headersAndPayload, messageId)) {
             // discard message with checksum error
@@ -1467,10 +1463,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         MessageIdImpl msgId = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), getPartitionIndex());
         if (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch()
                 && acknowledgmentsGroupingTracker.isDuplicate(msgId)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Ignoring message as it was already being acked earlier by same consumer {}/{}",
-                        topic, subscription, consumerName, msgId);
-            }
+            log.debug().attr("messageId", msgId)
+                    .log("Ignoring message as it was already being acked earlier by same consumer");
 
             increaseAvailablePermits(cnx, numMessages);
             return;
@@ -1515,11 +1509,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 }
 
                 // last chunk received: so, stitch chunked-messages and clear up chunkedMsgBuffer
-                if (log.isDebugEnabled()) {
-                    log.debug("Chunked message completed chunkId {}, total-chunks {}, msgId {} sequenceId {}",
-                            msgMetadata.getChunkId(), msgMetadata.getNumChunksFromMsg(), msgId,
-                            msgMetadata.getSequenceId());
-                }
+                log.debug().attr("chunkid", msgMetadata.getChunkId())
+                        .attr("totalChunks", msgMetadata.getNumChunksFromMsg())
+                        .attr("msgid", msgId)
+                        .attr("sequenceid", msgMetadata.getSequenceId())
+                        .log("Chunked message completed chunkId, total-chunks, msgId sequenceId");
 
                 // remove buffer from the map, set the chunk message id
                 ChunkedMessageCtx chunkedMsgCtx = chunkedMessagesMap.remove(msgMetadata.getUuid());
@@ -1536,10 +1530,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             // If the topic is non-persistent, we should not ignore any messages.
             if (this.topicName.isPersistent() && isSameEntry(msgId) && isPriorEntryIndex(messageId.getEntryId())) {
                 // We need to discard entries that were prior to startMessageId
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Ignoring message from before the startMessageId: {}", subscription,
-                            consumerName, startMessageId);
-                }
+                log.debug().attr("startMessageId", startMessageId)
+                        .log("Ignoring message from before the startMessageId");
 
                 uncompressedPayload.release();
                 return;
@@ -1660,10 +1652,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             //     Chunk-6 sequence ID: 0, chunk ID: 3, msgID: 1:6
             // We should filter and ack chunk-4 and chunk-5.
             if (chunkedMsgCtx != null && msgMetadata.getChunkId() <= chunkedMsgCtx.lastChunkedMessageId) {
-                log.warn("[{}] Receive a duplicated chunk message with messageId [{}], last-chunk-Id [{}], "
-                                + "chunkId [{}], sequenceId [{}]",
-                        msgMetadata.getProducerName(), msgId, chunkedMsgCtx.lastChunkedMessageId,
-                        msgMetadata.getChunkId(), msgMetadata.getSequenceId());
+                log.warn().attr("producerName", msgMetadata.getProducerName())
+                        .attr("msgId", msgId)
+                        .attr("lastChunkedMessageId", chunkedMsgCtx.lastChunkedMessageId)
+                        .attr("chunkId", msgMetadata.getChunkId())
+                        .attr("sequenceId", msgMetadata.getSequenceId())
+                        .log("Receive a duplicated chunk message with"
+                                + " messageId, last-chunk-Id,"
+                                + " chunkId, sequenceId");
                 compressedPayload.release();
                 // Just like the above logic of receiving the first chunk again. We only ack this chunk in the message
                 // duplication case.
@@ -1676,10 +1672,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 return null;
             }
             // means we lost the first chunk: should never happen
-            log.info("[{}] [{}] Received unexpected chunk messageId {}, last-chunk-id = {}, chunkId = {}, uuid = {}",
-                    topic, subscription, msgId,
-                    (chunkedMsgCtx != null ? chunkedMsgCtx.lastChunkedMessageId : null), msgMetadata.getChunkId(),
-                    msgMetadata.getUuid());
+            log.info().attr("messageId", msgId)
+                    .attr("lastChunkId", (chunkedMsgCtx != null ? chunkedMsgCtx.lastChunkedMessageId : null))
+                    .attr("chunkId", msgMetadata.getChunkId())
+                    .attr("uuid", msgMetadata.getUuid())
+                    .log("Received unexpected chunk messageId");
             if (chunkedMsgCtx != null) {
                 if (chunkedMsgCtx.chunkedMsgBuffer != null) {
                     ReferenceCountUtil.safeRelease(chunkedMsgCtx.chunkedMsgBuffer);
@@ -1821,7 +1818,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 ackBitSet.recycle();
             }
         } catch (IllegalStateException e) {
-            log.warn("[{}] [{}] unable to obtain message in batch", subscription, consumerName, e);
+            log.warn().exception(e)
+                    .log("unable to obtain message in batch");
             discardCorruptedMessage(messageId, cnx, ValidationError.BatchDeSerializeError);
         }
 
@@ -1835,10 +1833,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] enqueued messages in batch. queue size - {}, available queue size - {}", subscription,
-                    consumerName, incomingMessages.size(), incomingMessages.remainingCapacity());
-        }
+        log.debug().attr("size", incomingMessages.size())
+                .attr("remainingCapacity", incomingMessages.remainingCapacity())
+                .log("enqueued messages in batch. queue size -, available queue size");
 
         if (skippedMessages > 0) {
             increaseAvailablePermits(cnx, skippedMessages);
@@ -1928,9 +1925,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         int available = AVAILABLE_PERMITS_UPDATER.addAndGet(this, delta);
         while (available >= getCurrentReceiverQueueSize() / 2 && !paused) {
             if (AVAILABLE_PERMITS_UPDATER.compareAndSet(this, available, 0)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Sending permit-cmd to broker with available permits = {}", topic, available);
-                }
+                log.debug().attr("available", available)
+                        .log("Sending permit-cmd to broker with available permits =");
                 sendFlowPermitsToBroker(currentCnx, available);
                 break;
             } else {
@@ -1948,10 +1944,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         checkArgument(newSize > 0, "receiver queue size should larger than 0");
         int oldSize = CURRENT_RECEIVER_QUEUE_SIZE_UPDATER.getAndSet(this, newSize);
         int delta = newSize - oldSize;
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] update currentReceiverQueueSize from {} to {}, increaseAvailablePermits by {}",
-                    topic, subscription, oldSize, newSize, delta);
-        }
+        log.debug().attr("oldSize", oldSize)
+                .attr("newSize", newSize)
+                .attr("delta", delta)
+                .log("update currentReceiverQueueSize from to, increaseAvailablePermits by");
         increaseAvailablePermits(delta);
     }
 
@@ -2051,47 +2047,44 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         switch (conf.getCryptoFailureAction()) {
         case CONSUME:
             if (cryptoReaderNotExist) {
-                log.warn("[{}][{}][{}] CryptoKeyReader interface is not implemented. Consuming encrypted message.",
-                        topic, subscription, consumerName);
+                log.warn("CryptoKeyReader interface is not implemented. Consuming encrypted message.");
             } else {
                 // Note, batch message will fail to consume even if config is set to consume
-                log.warn("[{}][{}][{}][{}] Decryption failed. Consuming encrypted message since config is set to"
-                        + " consume.", topic, subscription, consumerName, messageId);
+                log.warn().attr("messageId", messageId)
+                        .log("Decryption failed. Consuming encrypted message since config is set to consume.");
             }
             return DecryptResult.failure(payload.retain());
         case DISCARD:
             if (cryptoReaderNotExist) {
-                log.warn(
-                        "[{}][{}][{}] Skipping decryption since CryptoKeyReader interface is not implemented and"
-                                + " config is set to discard message with batch size {}",
-                        topic, subscription, consumerName, batchSize);
+                log.warn().attr("size", batchSize)
+                        .log("Skipping decryption since CryptoKeyReader"
+                                + " interface is not implemented and config"
+                                + " is set to discard message with batch"
+                                + " size");
             } else {
-                log.warn(
-                        "[{}][{}][{}][{}-{}-{}] Discarding message since decryption failed "
-                                + "and config is set to discard",
-                        topic, subscription, consumerName, messageId.getLedgerId(), messageId.getEntryId(),
-                        messageId.getBatchIndex());
+                log.warn().attr("ledgerId", messageId.getLedgerId())
+                        .attr("entryId", messageId.getEntryId())
+                        .attr("batchIndex", messageId.getBatchIndex())
+                        .log("[--] Discarding message since decryption failed " + "and config is set to discard");
             }
             discardMessage(messageId, currentCnx, ValidationError.DecryptionError, batchSize);
             return DecryptResult.discard();
         case FAIL:
             if (cryptoReaderNotExist) {
-                log.error(
-                        "[{}][{}][{}][{}-{}-{}] Message delivery failed since CryptoKeyReader interface is not"
-                                + " implemented to consume encrypted message",
-                        topic, subscription, consumerName, messageId.getLedgerId(), messageId.getEntryId(),
-                        partitionIndex);
+                log.error().attr("messageId", messageId)
+                        .log("Message delivery failed since"
+                                + " CryptoKeyReader interface is not"
+                                + " implemented to consume encrypted"
+                                + " message");
             } else {
-                log.error("[{}][{}][{}][{}-{}-{}] Message delivery failed since unable to decrypt incoming message",
-                        topic, subscription, consumerName, messageId.getLedgerId(), messageId.getEntryId(),
-                        partitionIndex);
+                log.error().attr("messageId", messageId)
+                        .log("Message delivery failed since unable to decrypt incoming message");
             }
             MessageId m = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), partitionIndex);
             unAckedMessageTracker.add(m, redeliveryCount);
             return DecryptResult.discard();
         default:
-            log.warn("[{}][{}][{}] Invalid crypto failure state found, continue message consumption.", topic,
-                    subscription, consumerName);
+            log.warn("Invalid crypto failure state found, continue message consumption.");
             return DecryptResult.failure(payload.retain());
         }
     }
@@ -2104,8 +2097,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         int payloadSize = payload.readableBytes();
         if (checkMaxMessageSize && payloadSize > getConnectionHandler().getMaxMessageSize()) {
             // payload size is itself corrupted since it cannot be bigger than the MaxMessageSize
-            log.error("[{}][{}] Got corrupted payload message size {} at {}", topic, subscription, payloadSize,
-                    messageId);
+            log.error().attr("size", payloadSize)
+                    .attr("messageId", messageId)
+                    .log("Got corrupted payload message size at");
             discardCorruptedMessage(messageId, currentCnx, ValidationError.UncompressedSizeCorruption);
             return null;
         }
@@ -2113,8 +2107,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             ByteBuf uncompressedPayload = codec.decode(payload, uncompressedSize);
             return uncompressedPayload;
         } catch (IOException e) {
-            log.error("[{}][{}] Failed to decompress message with {} at {}: {}", topic, subscription, compressionType,
-                    messageId, e.getMessage(), e);
+            log.error().attr("compressionType", compressionType)
+                    .attr("messageId", messageId)
+                    .exceptionMessage(e)
+                    .exception(e)
+                    .log("Failed to decompress message with at");
             discardCorruptedMessage(messageId, currentCnx, ValidationError.DecompressionError);
             return null;
         }
@@ -2126,11 +2123,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             int checksum = Commands.readChecksum(headersAndPayload);
             int computedChecksum = Crc32cIntChecksum.computeChecksum(headersAndPayload);
             if (checksum != computedChecksum) {
-                log.error(
-                        "[{}][{}] Checksum mismatch for message at {}:{}. Received checksum: 0x{},"
-                                + " Computed checksum: 0x{}",
-                        topic, subscription, messageId.getLedgerId(), messageId.getEntryId(),
-                        Long.toHexString(checksum), Integer.toHexString(computedChecksum));
+                log.error().attr("messageId", messageId)
+                        .attr("receivedChecksum", "0x" + Long.toHexString(checksum))
+                        .attr("computedChecksum", "0x" + Integer.toHexString(computedChecksum))
+                        .log("Checksum mismatch for message");
                 return false;
             }
         }
@@ -2140,8 +2136,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private void discardCorruptedMessage(MessageIdImpl messageId, ClientCnx currentCnx,
                                          ValidationError validationError) {
-        log.error("[{}][{}] Discarding corrupted message at {}:{}", topic, subscription, messageId.getLedgerId(),
-                messageId.getEntryId());
+        log.error().attr("messageId", messageId)
+                .log("Discarding corrupted message");
         ByteBuf cmd = Commands.newAck(consumerId, messageId.getLedgerId(), messageId.getEntryId(), null,
                 AckType.Individual, validationError, Collections.emptyMap(), -1);
         currentCnx.ctx().writeAndFlush(cmd, currentCnx.ctx().voidPromise());
@@ -2151,8 +2147,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private void discardCorruptedMessage(MessageIdData messageId, ClientCnx currentCnx,
             ValidationError validationError) {
-        log.error("[{}][{}] Discarding corrupted message at {}:{}", topic, subscription, messageId.getLedgerId(),
-                messageId.getEntryId());
+        log.error().attr("messageId", messageId)
+                .log("Discarding corrupted message");
         discardMessage(messageId, currentCnx, validationError, 1);
     }
 
@@ -2206,10 +2202,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             // V1 don't support redeliverUnacknowledgedMessages
             if (cnx != null && cnx.getRemoteEndpointProtocolVersion() < ProtocolVersion.v2.getValue()) {
                 if ((getState() == State.Connecting)) {
-                    log.warn("[{}] Client Connection needs to be established "
-                            + "for redelivery of unacknowledged messages", this);
+                    log.warn("Client Connection needs to be established"
+                                    + " for redelivery of unacknowledged"
+                                    + " messages");
                 } else {
-                    log.warn("[{}] Reconnecting the client to redeliver the messages.", this);
+                    log.warn("Reconnecting the client to redeliver the messages.");
                     cnx.ctx().close();
                 }
 
@@ -2242,13 +2239,13 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 if (currentSize > 0) {
                     increaseAvailablePermits(cnx, currentSize);
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] [{}] Redeliver unacked messages and send {} permits", subscription, topic,
-                            consumerName, currentSize);
-                }
+                log.debug().attr("send", currentSize)
+                        .log("Redeliver unacked messages and send permits");
             } else {
-                log.warn("[{}] Send redeliver messages command but the client is reconnect or close, "
-                        + "so don't need to send redeliver command to broker", this);
+                log.warn("Send redeliver messages command but the"
+                                + " client is reconnect or close, so don't"
+                                + " need to send redeliver command to"
+                                + " broker");
             }
         }
     }
@@ -2279,16 +2276,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (messagesFromQueue > 0) {
                 increaseAvailablePermits(cnx, messagesFromQueue);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] [{}] Redeliver unacked messages and increase {} permits", subscription, topic,
-                        consumerName, messagesFromQueue);
-            }
+            log.debug().attr("increase", messagesFromQueue)
+                    .log("Redeliver unacked messages and increase permits");
             return;
         }
         if (cnx == null || (getState() == State.Connecting)) {
-            log.warn("[{}] Client Connection needs to be established for redelivery of unacknowledged messages", this);
+            log.warn("Client Connection needs to be established for redelivery of unacknowledged messages");
         } else {
-            log.warn("[{}] Reconnecting the client to redeliver the messages.", this);
+            log.warn("Reconnecting the client to redeliver the messages.");
             cnx.ctx().close();
         }
     }
@@ -2297,9 +2292,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     protected void updateAutoScaleReceiverQueueHint() {
         boolean prev = scaleReceiverQueueHint.getAndSet(
                 getAvailablePermits() + incomingMessages.size() >= getCurrentReceiverQueueSize());
-        if (log.isDebugEnabled() && prev != scaleReceiverQueueHint.get()) {
-            log.debug("updateAutoScaleReceiverQueueHint {} -> {}", prev, scaleReceiverQueueHint.get());
-        }
+        log.debug().attr("updateautoscalereceiverqueuehint", prev)
+                .attr("get", scaleReceiverQueueHint.get())
+                .log("updateAutoScaleReceiverQueueHint ->");
     }
 
     @Override
@@ -2356,10 +2351,12 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                     possibleSendToDeadLetterTopicMessages.remove(messageId);
                                     acknowledgeAsync(messageId).whenComplete((v, ex) -> {
                                         if (ex != null) {
-                                            log.warn(
-                                                    "[{}] [{}] [{}] Failed to acknowledge the message {} of the "
-                                                            + "original topic but send to the DLQ successfully.",
-                                                    topicName, subscription, consumerName, messageId, ex);
+                                            log.warn().attr("messageId", messageId)
+                                                    .exception(ex)
+                                                    .log("Failed to acknowledge the"
+                                                            + " message of the original topic"
+                                                            + " but send to the DLQ"
+                                                            + " successfully.");
                                             result.complete(false);
                                         } else {
                                             result.complete(true);
@@ -2367,28 +2364,33 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                                     });
                                 }).exceptionally(ex -> {
                                     if (ex instanceof PulsarClientException.ProducerQueueIsFullError) {
-                                        log.warn(
-                                                "[{}] [{}] [{}] Failed to send DLQ message to {} "
-                                                        + "with ProducerQueueIsFullError for message id {}: {}",
-                                                topicName, subscription, consumerName,
-                                                deadLetterPolicy.getDeadLetterTopic(), messageId, ex.getMessage());
+                                        log.warn().attr("deadLetterTopic", deadLetterPolicy.getDeadLetterTopic())
+                                                .attr("messageId", messageId)
+                                                .exceptionMessage(ex)
+                                                .log("Failed to send DLQ message to"
+                                                        + " with ProducerQueueIsFullError"
+                                                        + " for message id");
                                     } else {
-                                        log.warn("[{}] [{}] [{}] Failed to send DLQ message to {} for message id {}",
-                                                topicName, subscription, consumerName,
-                                                deadLetterPolicy.getDeadLetterTopic(), messageId, ex);
+                                        log.warn().attr("deadLetterTopic", deadLetterPolicy.getDeadLetterTopic())
+                                                .attr("messageId", messageId)
+                                                .exception(ex)
+                                                .log("Failed to send DLQ message to for message id");
                                     }
                                     result.complete(false);
                                     return null;
                                 });
                     } catch (Exception e) {
-                        log.warn("[{}] [{}] [{}] Failed to process DLQ message to {} for message id {}",
-                                topicName, subscription, consumerName, deadLetterPolicy.getDeadLetterTopic(), messageId,
-                                e);
+                        log.warn().attr("deadLetterTopic", deadLetterPolicy.getDeadLetterTopic())
+                                .attr("messageId", messageId)
+                                .exception(e)
+                                .log("Failed to process DLQ message to for message id");
                         result.complete(false);
                     }
                 }
             }, internalPinnedExecutor).exceptionally(ex -> {
-                log.error("Dead letter producer exception with topic: {}", deadLetterPolicy.getDeadLetterTopic(), ex);
+                log.error().attr("topic", deadLetterPolicy.getDeadLetterTopic())
+                        .exception(ex)
+                        .log("Dead letter producer exception with topic");
                 result.complete(false);
                 return null;
             });
@@ -2436,9 +2438,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         CompletableFuture<Producer<byte[]>> newProducer = builder.createAsync();
                         newProducer.whenComplete((producer, ex) -> {
                             if (ex != null) {
-                                log.error("[{}] [{}] [{}] Failed to create dead letter producer for topic {}",
-                                        topicName, subscription, consumerName, deadLetterPolicy.getDeadLetterTopic(),
-                                        ex);
+                                log.error().attr("deadLetterTopic", deadLetterPolicy.getDeadLetterTopic())
+                                        .exception(ex)
+                                        .log("Failed to create dead letter producer");
                                 deadLetterProducerFailureCount++;
                             } else {
                                 deadLetterProducerFailureCount = 0;
@@ -2474,7 +2476,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             CompletableFuture<Producer<byte[]>> newProducer = new CompletableFuture<>();
             ScheduledExecutorService executor =
                     (ScheduledExecutorService) client.getScheduledExecutorProvider().getExecutor(this);
-            log.info("Creating {} with backoff time of {} ms", logDescription.get(), backoffTimeMillis);
+            log.info().attr("creating", logDescription.get())
+                    .attr("backoffTimeMillis", backoffTimeMillis)
+                    .log("Creating with backoff time of ms");
             executor.schedule(() -> {
                 FutureUtil.completeAfter(newProducer, producerSupplier.get());
             }, backoffTimeMillis, TimeUnit.MILLISECONDS);
@@ -2501,9 +2505,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         CompletableFuture<Producer<byte[]>> newProducer = builder.createAsync();
                         newProducer.whenComplete((producer, ex) -> {
                             if (ex != null) {
-                                log.error("[{}] [{}] [{}] Failed to create retry letter producer for topic {}",
-                                        topicName, subscription, consumerName, deadLetterPolicy.getRetryLetterTopic(),
-                                        ex);
+                                log.error().attr("retryLetterTopic", deadLetterPolicy.getRetryLetterTopic())
+                                        .exception(ex)
+                                        .log("Failed to create retry letter producer");
                                 retryLetterProducerFailureCount++;
                             } else {
                                 retryLetterProducerFailureCount = 0;
@@ -2579,8 +2583,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             final String message = String.format(
                     "[%s][%s] attempting to seek operation that is already in progress (seek by %s)",
                     topic, subscription, seekBy);
-            log.warn("[{}][{}] Attempting to seek operation that is already in progress, cancelling {}",
-                    topic, subscription, seekBy);
+            log.warn().attr("cancelling", seekBy)
+                    .log("Attempting to seek operation that is already in progress, cancelling");
             return FutureUtil.failedFuture(new IllegalStateException(message));
         }
         seekFuture = new CompletableFuture<>();
@@ -2594,12 +2598,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (isConnected() && cnx != null) {
             MessageIdAdv originSeekMessageId = seekMessageId;
             seekMessageId = (MessageIdAdv) seekId;
-            log.info("[{}][{}] Seeking subscription to {}", topic, subscription, seekBy);
+            log.info().attr("seekBy", seekBy)
+                    .log("Seeking subscription to");
 
             final boolean originalHasSoughtByTimestamp = hasSoughtByTimestamp;
             hasSoughtByTimestamp = (seekTimestamp != null);
             cnx.sendRequestWithId(seek, requestId).thenRun(() -> {
-                log.info("[{}][{}] Successfully reset subscription to {}", topic, subscription, seekBy);
+                log.info().attr("seekBy", seekBy)
+                        .log("Successfully reset subscription to");
                 acknowledgmentsGroupingTracker.flushAndClean();
 
                 lastDequeuedMessageId = MessageId.earliest;
@@ -2622,7 +2628,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }).exceptionally(e -> {
                 seekMessageId = originSeekMessageId;
                 hasSoughtByTimestamp = originalHasSoughtByTimestamp;
-                log.error("[{}][{}] Failed to reset subscription: {}", topic, subscription, e.getCause().getMessage());
+                log.error().exceptionMessage(e.getCause())
+                        .log("Failed to reset subscription");
 
                 failSeek(
                         PulsarClientException.wrap(e.getCause(),
@@ -2641,8 +2648,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             }
 
             ((ScheduledExecutorService) client.getScheduledExecutorProvider().getExecutor()).schedule(() -> {
-                log.warn("[{}] [{}] Could not get connection while seek -- Will try again in {} ms",
-                        topic, getHandlerName(), nextDelay);
+                log.warn().attr("handler", getHandlerName())
+                        .attr("nextDelay", nextDelay)
+                        .log("Could not get connection while seek -- Will try again in ms");
                 remainingTime.addAndGet(-nextDelay);
                 seekAsyncInternal(requestId, seek, seekId, seekTimestamp, seekBy, backoff, remainingTime);
             }, nextDelay, TimeUnit.MILLISECONDS);
@@ -2747,7 +2755,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         completehasMessageAvailableWithValue(booleanFuture, resetIncludeHead);
                     }
                 }).exceptionally(ex -> {
-                    log.error("[{}][{}] Failed getLastMessageId command", topic, subscription, ex);
+                    log.error().exception(ex)
+                            .log("Failed getLastMessageId command");
                     booleanFuture.completeExceptionally(ex.getCause());
                     return null;
                 });
@@ -2765,7 +2774,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 completehasMessageAvailableWithValue(booleanFuture,
                         hasMoreMessages(lastMessageIdInBroker, startMessageId, resetIncludeHead));
             }).exceptionally(e -> {
-                log.error("[{}][{}] Failed getLastMessageId command", topic, subscription);
+                log.error("Failed getLastMessageId command");
                 booleanFuture.completeExceptionally(e.getCause());
                 return null;
             });
@@ -2782,7 +2791,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 completehasMessageAvailableWithValue(booleanFuture,
                         hasMoreMessages(lastMessageIdInBroker, lastDequeuedMessageId, false));
             }).exceptionally(e -> {
-                log.error("[{}][{}] Failed getLastMessageId command", topic, subscription);
+                log.error("Failed getLastMessageId command");
                 booleanFuture.completeExceptionally(e.getCause());
                 return null;
             });
@@ -2865,9 +2874,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
             long requestId = client.newRequestId();
             ByteBuf getLastIdCmd = Commands.newGetLastMessageId(consumerId, requestId);
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Get topic last message Id", topic, subscription);
-            }
+            log.debug().log("Get topic last message Id");
 
             cnx.sendGetLastMessageId(getLastIdCmd, requestId).thenAccept(cmd -> {
                 MessageIdData lastMessageId = cmd.getLastMessageId();
@@ -2876,10 +2883,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     markDeletePosition = new MessageIdImpl(cmd.getConsumerMarkDeletePosition().getLedgerId(),
                             cmd.getConsumerMarkDeletePosition().getEntryId(), -1);
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Successfully getLastMessageId {}:{}",
-                        topic, subscription, lastMessageId.getLedgerId(), lastMessageId.getEntryId());
-                }
+                log.debug().attr("lastMessageId", lastMessageId)
+                        .log("Successfully getLastMessageId");
 
                 MessageId lastMsgId = lastMessageId.getBatchIndex() <= 0
                         ? new MessageIdImpl(lastMessageId.getLedgerId(),
@@ -2889,7 +2894,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
                 future.complete(new GetLastMessageIdResponse(lastMsgId, markDeletePosition));
             }).exceptionally(e -> {
-                log.error("[{}][{}] Failed getLastMessageId command", topic, subscription);
+                log.error("Failed getLastMessageId command");
                 future.completeExceptionally(
                     PulsarClientException.wrap(e.getCause(),
                         String.format("The subscription %s of the topic %s gets the last message id was failed",
@@ -2910,8 +2915,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 return;
             }
 
-            log.warn("[{}] [{}] Could not get connection while getLastMessageId -- Will try again in {} ms",
-                    topic, getHandlerName(), nextDelay);
+            log.warn().attr("nextDelayMs", nextDelay)
+                    .log("Could not get connection while getLastMessageId -- Will try again after delay");
             ((ScheduledExecutorService) client.getScheduledExecutorProvider().getExecutor()).schedule(() -> {
                 remainingTime.addAndGet(-nextDelay);
                 internalGetLastMessageIdAsync(backoff, remainingTime, future);
@@ -2985,7 +2990,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     void setTerminated() {
-        log.info("[{}] [{}] [{}] Consumer has reached the end of topic", subscription, topic, consumerName);
+        log.info("Consumer has reached the end of topic");
         hasReachedEndOfTopic = true;
         if (listener != null) {
             // Propagate notification to listener
@@ -3038,8 +3043,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             clientCnx.registerConsumer(consumerId, this);
             if (conf.isAckReceiptEnabled()
                     && !Commands.peerSupportsAckReceipt(clientCnx.getRemoteEndpointProtocolVersion())) {
-                log.warn("Server don't support ack for receipt! "
-                        + "ProtoVersion >=17 support! nowVersion : {}", clientCnx.getRemoteEndpointProtocolVersion());
+                log.warn().attr("nowversion", clientCnx.getRemoteEndpointProtocolVersion())
+                        .log("Server don't support ack for receipt! " + "ProtoVersion >=17 support! nowVersion");
             }
         }
         ClientCnx previousClientCnx = clientCnxUsedForConsumerRegistration.getAndSet(clientCnx);
@@ -3140,7 +3145,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     continue;
                 }
                 if (autoAck) {
-                    log.info("Removing chunk message-id {}", msgId);
+                    log.info().attr("messageId", msgId).log("Removing chunk message-id");
                     doAcknowledge(msgId, AckType.Individual, Collections.emptyMap(), null);
                 } else {
                     trackMessage(msgId);
@@ -3317,8 +3322,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         super.setRedirectedClusterURI(serviceUrl, serviceUrlTls);
         acknowledgmentsGroupingTracker.flushAndClean();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerImpl.class);
 
     @VisibleForTesting
     enum SeekStatus {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -101,7 +101,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             } catch (Throwable e) {
                 if (consumer != null) {
                     log.warn().attr("topic", consumer.getTopic())
-                            .attr("consumername", consumer.getConsumerName())
+                            .attr("consumerName", consumer.getConsumerName())
                             .exception(e)
                             .log("Error executing interceptor beforeConsume callback topic: consumerName");
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -65,7 +65,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             } catch (Throwable e) {
                 if (consumer != null) {
                     log.warn().attr("topic", consumer.getTopic())
-                            .attr("consumername", consumer.getConsumerName())
+                            .attr("consumerName", consumer.getConsumerName())
                             .exception(e)
                             .log("Error executing interceptor beforeConsume callback topic: consumerName");
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -22,21 +22,19 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerInterceptor;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A container that hold the list {@link org.apache.pulsar.client.api.ConsumerInterceptor} and wraps calls to the chain
  * of custom interceptors.
  */
+@CustomLog
 public class ConsumerInterceptors<T> implements Closeable {
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerInterceptors.class);
 
     private final List<ConsumerInterceptor<T>> interceptors;
 
@@ -66,10 +64,12 @@ public class ConsumerInterceptors<T> implements Closeable {
                 interceptorMessage = interceptors.get(i).onArrival(consumer, interceptorMessage);
             } catch (Throwable e) {
                 if (consumer != null) {
-                    log.warn("Error executing interceptor beforeConsume callback topic: {} consumerName: {}",
-                            consumer.getTopic(), consumer.getConsumerName(), e);
+                    log.warn().attr("topic", consumer.getTopic())
+                            .attr("consumername", consumer.getConsumerName())
+                            .exception(e)
+                            .log("Error executing interceptor beforeConsume callback topic: consumerName");
                 } else {
-                    log.warn("Error executing interceptor beforeConsume callback", e);
+                    log.warn().exception(e).log("Error executing interceptor beforeConsume callback");
                 }
             }
         }
@@ -100,10 +100,12 @@ public class ConsumerInterceptors<T> implements Closeable {
                 interceptorMessage = interceptors.get(i).beforeConsume(consumer, interceptorMessage);
             } catch (Throwable e) {
                 if (consumer != null) {
-                    log.warn("Error executing interceptor beforeConsume callback topic: {} consumerName: {}",
-                            consumer.getTopic(), consumer.getConsumerName(), e);
+                    log.warn().attr("topic", consumer.getTopic())
+                            .attr("consumername", consumer.getConsumerName())
+                            .exception(e)
+                            .log("Error executing interceptor beforeConsume callback topic: consumerName");
                 } else {
-                    log.warn("Error executing interceptor beforeConsume callback", e);
+                    log.warn().exception(e).log("Error executing interceptor beforeConsume callback");
                 }
             }
         }
@@ -128,7 +130,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).onAcknowledge(consumer, messageId, exception);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onAcknowledge callback ", e);
+                log.warn().exception(e).log("Error executing interceptor onAcknowledge callback ");
             }
         }
     }
@@ -151,7 +153,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).onAcknowledgeCumulative(consumer, messageId, exception);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onAcknowledgeCumulative callback ", e);
+                log.warn().exception(e).log("Error executing interceptor onAcknowledgeCumulative callback ");
             }
         }
     }
@@ -173,7 +175,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).onNegativeAcksSend(consumer, messageIds);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onNegativeAcksSend callback", e);
+                log.warn().exception(e).log("Error executing interceptor onNegativeAcksSend callback");
             }
         }
     }
@@ -195,7 +197,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).onAckTimeoutSend(consumer, messageIds);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onAckTimeoutSend callback", e);
+                log.warn().exception(e).log("Error executing interceptor onAckTimeoutSend callback");
             }
         }
     }
@@ -205,7 +207,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).onPartitionsChange(topicName, partitions);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onPartitionsChange callback", e);
+                log.warn().exception(e).log("Error executing interceptor onPartitionsChange callback");
             }
         }
     }
@@ -216,7 +218,7 @@ public class ConsumerInterceptors<T> implements Closeable {
             try {
                 interceptors.get(i).close();
             } catch (Throwable e) {
-                log.error("Fail to close consumer interceptor ", e);
+                log.error().exception(e).log("Fail to close consumer interceptor ");
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -169,8 +169,8 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                 log.error().attr("topic", consumerImpl.getTopic())
                         .attr("subscription", consumerImpl.subscription)
                         .attr("consumerName", consumerImpl.consumerName)
-                        .exceptionMessage(e)
-                        .log("operation");
+                        .exception(e)
+                        .log("Failed to update consumer stats");
             } finally {
                 // schedule the next stat info
                 statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsRecorderImpl.java
@@ -30,16 +30,16 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.ProducerStats;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("deprecation")
+@CustomLog
 public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
 
     private static final long serialVersionUID = 1L;
@@ -116,10 +116,12 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                 .without(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
         try {
-            log.info("Starting Pulsar consumer status recorder with config: {}", w.writeValueAsString(conf));
-            log.info("Pulsar client config: {}", w.writeValueAsString(pulsarClient.getConfiguration()));
+            log.info().attr("config", w.writeValueAsString(conf))
+                    .log("Starting Pulsar consumer status recorder with config");
+            log.info().attr("config", w.writeValueAsString(pulsarClient.getConfiguration()))
+                    .log("Pulsar client config");
         } catch (IOException e) {
-            log.error("Failed to dump config info", e);
+            log.error().exception(e).log("Failed to dump config info");
         }
 
         stat = (timeout) -> {
@@ -150,20 +152,25 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
                 int prefetchQueueSize = consumerImpl.incomingMessages.size();
                 if ((currentNumMsgsReceived | currentNumBytesReceived | currentNumReceiveFailed | currentNumAcksSent
                         | currentNumAcksFailed | prefetchQueueSize) != 0) {
-                    log.info(
-                            "[{}] [{}] [{}] Prefetched messages: {} --- "
-                                    + "Consume throughput received: {} msgs/s --- {} Mbit/s --- "
-                                    + "Ack sent rate: {} ack/s --- " + "Failed messages: {} --- batch messages: {} ---"
-                                    + "Failed acks: {}",
-                            consumerImpl.getTopic(), consumerImpl.getSubscription(), consumerImpl.consumerName,
-                            prefetchQueueSize, THROUGHPUT_FORMAT.format(receivedMsgsRate),
-                            THROUGHPUT_FORMAT.format(receivedBytesRate * 8 / 1024 / 1024),
-                            THROUGHPUT_FORMAT.format(currentNumAcksSent / elapsed), currentNumReceiveFailed,
-                            currentNumBatchReceiveFailed, currentNumAcksFailed);
+                    log.info().attr("topic", consumerImpl.getTopic())
+                            .attr("subscription", consumerImpl.getSubscription())
+                            .attr("consumerName", consumerImpl.consumerName)
+                            .attr("prefetchedMessages", prefetchQueueSize)
+                            .attr("receivedMsgRate", THROUGHPUT_FORMAT.format(receivedMsgsRate))
+                            .attr("receivedBytesRateMbps",
+                                    THROUGHPUT_FORMAT.format(receivedBytesRate * 8 / 1024 / 1024))
+                            .attr("ackSentRate", THROUGHPUT_FORMAT.format(currentNumAcksSent / elapsed))
+                            .attr("failedMessages", currentNumReceiveFailed)
+                            .attr("failedBatchMessages", currentNumBatchReceiveFailed)
+                            .attr("failedAcks", currentNumAcksFailed)
+                            .log("Consumer stats");
                 }
             } catch (Exception e) {
-                log.error("[{}] [{}] [{}]: {}", consumerImpl.getTopic(), consumerImpl.subscription
-                        , consumerImpl.consumerName, e.getMessage());
+                log.error().attr("topic", consumerImpl.getTopic())
+                        .attr("subscription", consumerImpl.subscription)
+                        .attr("consumerName", consumerImpl.consumerName)
+                        .exceptionMessage(e)
+                        .log("operation");
             } finally {
                 // schedule the next stat info
                 statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);
@@ -356,6 +363,4 @@ public class ConsumerStatsRecorderImpl implements ConsumerStatsRecorder {
     public double getRateBytesReceived() {
         return receivedBytesRate;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerStatsRecorderImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ControlledClusterFailover.java
@@ -35,9 +35,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
@@ -57,7 +57,7 @@ import org.asynchttpclient.Response;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
 import org.jspecify.annotations.Nullable;
 
-@Slf4j
+@CustomLog
 public class ControlledClusterFailover implements ServiceUrlProvider {
     private static final int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 10;
     private static final int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
@@ -137,8 +137,9 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
                 if (controlledConfiguration != null
                         && !Strings.isNullOrEmpty(controlledConfiguration.getServiceUrl())
                         && !controlledConfiguration.equals(currentControlledConfiguration)) {
-                    log.info("Switch Pulsar service url from {} to {}",
-                            currentControlledConfiguration, controlledConfiguration.toString());
+                    log.info().attr("currentConfig", currentControlledConfiguration)
+                            .attr("newConfig", controlledConfiguration.toString())
+                            .log("Switching Pulsar service url");
 
                     Authentication authentication = null;
                     if (!Strings.isNullOrEmpty(controlledConfiguration.authPluginClassName)
@@ -164,8 +165,10 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
                     currentControlledConfiguration = controlledConfiguration;
                 }
             } catch (IOException e) {
-                log.error("Failed to switch new Pulsar url, current: {}, new: {}",
-                        currentControlledConfiguration, controlledConfiguration, e);
+                log.error().attr("current", currentControlledConfiguration)
+                        .attr("new", controlledConfiguration)
+                        .exception(e)
+                        .log("Failed to switch Pulsar service url");
             }
         }), interval, interval, TimeUnit.MILLISECONDS);
     }
@@ -188,9 +191,9 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
                 String content = response.getResponseBody(StandardCharsets.UTF_8);
                 return ObjectMapperFactory.getMapper().reader().readValue(content, ControlledConfiguration.class);
             }
-            log.warn("Failed to fetch controlled configuration, status code: {}", statusCode);
+            log.warn().attr("code", statusCode).log("Failed to fetch controlled configuration, status code");
         } catch (InterruptedException | ExecutionException e) {
-            log.error("Failed to fetch controlled configuration ", e);
+            log.error().exception(e).log("Failed to fetch controlled configuration ");
         }
 
         return null;
@@ -208,7 +211,7 @@ public class ControlledClusterFailover implements ServiceUrlProvider {
             try {
                 return ObjectMapperFactory.getMapper().writer().writeValueAsString(this);
             } catch (JsonProcessingException e) {
-                log.warn("Failed to write as json. ", e);
+                log.warn().exception(e).log("Failed to write as json. ");
                 return null;
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultCryptoKeyReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/DefaultCryptoKeyReader.java
@@ -22,17 +22,15 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.url.URL;
 import org.apache.pulsar.client.impl.conf.DefaultCryptoKeyReaderConfigurationData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class DefaultCryptoKeyReader implements CryptoKeyReader {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultCryptoKeyReader.class);
 
     private static final String APPLICATION_X_PEM_FILE = "application/x-pem-file";
 
@@ -59,12 +57,12 @@ public class DefaultCryptoKeyReader implements CryptoKeyReader {
         String publicKey = publicKeys.getOrDefault(keyName, defaultPublicKey);
 
         if (publicKey == null) {
-            LOG.warn("Public key named {} is not set", keyName);
+            log.warn().attr("keyName", keyName).log("Public key is not set");
         } else {
             try {
                 keyInfo.setKey(loadKey(publicKey));
             } catch (Exception e) {
-                LOG.error("Failed to load public key named {}", keyName, e);
+                log.error().attr("keyName", keyName).exception(e).log("Failed to load public key");
             }
         }
 
@@ -77,12 +75,12 @@ public class DefaultCryptoKeyReader implements CryptoKeyReader {
         String privateKey = privateKeys.getOrDefault(keyName, defaultPrivateKey);
 
         if (privateKey == null) {
-            LOG.warn("Private key named {} is not set", keyName);
+            log.warn().attr("keyName", keyName).log("Private key is not set");
         } else {
             try {
                 keyInfo.setKey(loadKey(privateKey));
             } catch (Exception e) {
-                LOG.error("Failed to load private key named {}", keyName, e);
+                log.error().attr("keyName", keyName).exception(e).log("Failed to load private key");
             }
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pulsar.client.impl;
 
+import io.github.merlimat.slog.Logger;
 import io.netty.channel.Channel;
 import io.netty.util.ReferenceCountUtil;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
@@ -32,9 +32,11 @@ import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.Markers;
 
-@Slf4j
 @SuppressWarnings("unchecked")
 public class GeoReplicationProducerImpl extends ProducerImpl{
+
+    private static final Logger LOG = Logger.get(GeoReplicationProducerImpl.class);
+    private final Logger log;
 
     public static final String MSG_PROP_REPL_SOURCE_POSITION = "__MSG_PROP_REPL_SOURCE_POSITION";
     public static final String MSG_PROP_IS_REPL_MARKER = "__MSG_PROP_IS_REPL_MARKER";
@@ -50,6 +52,10 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                                       Schema schema, ProducerInterceptors interceptors,
                                       Optional overrideProducerName) {
         super(client, topic, conf, producerCreatedFuture, partitionIndex, schema, interceptors, overrideProducerName);
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("producerName", () -> producerName)
+                .build();
         isPersistentTopic = TopicName.get(topic).isPersistent();
     }
 
@@ -68,9 +74,10 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         synchronized (this) {
             OpSendMsg op = pendingMessages.peek();
             if (op == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Got ack for timed out msg {}:{}", topic, producerName, seq, highSeq);
-                }
+                    log.debug()
+                            .attr("seq", seq)
+                            .attr("highSeq", highSeq)
+                            .log("Got ack for timed out msg");
                 return;
             }
             // Replicator send markers also, use sequenceId to check the marker send-receipt.
@@ -112,20 +119,22 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                 && (pendingLId < lastPersistedSourceLedgerId || (pendingLId.longValue() == lastPersistedSourceLedgerId
                   && pendingEId.longValue() <= lastPersistedSourceEntryId))) {
             if (MessageImpl.SchemaState.Broken.equals(op.msg.getSchemaState())) {
-                log.error("[{}] [{}] Replication is paused because the schema is incompatible with the remote"
-                                + " cluster, please modify the schema compatibility for the remote cluster."
-                                + " Latest published entry {}:{}, Entry who has incompatible schema: {}:{},"
-                                + " latest persisted source entry: {}:{}, pending queue size: {}.",
-                        topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,
-                        lastPersistedSourceLedgerId, lastPersistedSourceEntryId, pendingMessages.messagesCount());
+                log.error()
+                        .attr("sourceLedgerId", sourceLId).attr("sourceEntryId", sourceEId)
+                        .attr("pendingLedgerId", pendingLId).attr("pendingEntryId", pendingEId)
+                        .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
+                        .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
+                        .attr("pendingQueueSize", pendingMessages.messagesCount())
+                        .log("Replication is paused because the schema is incompatible with the remote"
+                                + " cluster, please modify the schema compatibility for the remote cluster");
                 return;
             }
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Received an msg send receipt[pending send is repeated due to repl cursor rewind]:"
-                                + " source entry {}:{}, pending send: {}:{}, latest persisted: {}:{}",
-                        topic, producerName, sourceLId, sourceEId, pendingLId, pendingEId,
-                        lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
-            }
+                log.debug()
+                        .attr("sourceLedgerId", sourceLId).attr("sourceEntryId", sourceEId)
+                        .attr("pendingLedgerId", pendingLId).attr("pendingEntryId", pendingEId)
+                        .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
+                        .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
+                        .log("Received msg send receipt, pending send is repeated due to repl cursor rewind");
             removeAndApplyCallback(op, sourceLId, sourceEId, targetLId, targetEid, false);
             ackReceived(cnx, sourceLId, sourceEId, targetLId, targetEid);
             return;
@@ -138,24 +147,24 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //  - The second time: producer call Send-Command-1.
         if (sourceLId < lastPersistedSourceLedgerId
                 || (sourceLId == lastPersistedSourceLedgerId  && sourceEId <= lastPersistedSourceEntryId)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Received an msg send receipt[repeated]: source entry {}:{}, latest persisted:"
-                                + " {}:{}",
-                        topic, producerName, sourceLId, sourceEId,
-                        lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
-            }
+                log.debug()
+                        .attr("entry", sourceLId)
+                        .attr("sourceEId", sourceEId)
+                        .attr("lastPersistedSourceLedgerId", lastPersistedSourceLedgerId)
+                        .attr("lastPersistedSourceEntryId", lastPersistedSourceEntryId)
+                        .log("Received repeated msg send receipt");
             return;
         }
 
         // Case-3, which is expected.
         if (pendingLId != null && pendingEId != null && sourceLId == pendingLId.longValue()
                 && sourceEId == pendingEId.longValue()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Received an msg send receipt[expected]: source entry {}:{}, target entry:"
-                                + " {}:{}",
-                        topic, producerName, sourceLId, sourceEId,
-                        targetLId, targetEid);
-            }
+                log.debug()
+                        .attr("entry", sourceLId)
+                        .attr("sourceEId", sourceEId)
+                        .attr("targetLId", targetLId)
+                        .attr("targetEid", targetEid)
+                        .log("Received expected msg send receipt");
             lastPersistedSourceLedgerId = sourceLId;
             lastPersistedSourceEntryId = sourceEId;
             removeAndApplyCallback(op, sourceLId, sourceEId, targetLId, targetEid, false);
@@ -165,14 +174,14 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         // Case-4: Received an out-of-order msg send receipt, and the first item in pending queue is a marker.
         if (op.msg.getMessageBuilder().hasMarkerType()
                 && Markers.isReplicationMarker(op.msg.getMessageBuilder().getMarkerType())) {
-            log.warn("[{}] [{}] Received an out-of-order msg send receipt because enabled replicated subscription,"
-                    + " which is expected, it always happens when repeatedly publishing a pair of mixed"
-                    + " replication marker messages and user messages."
-                    + " source position {}:{}, pending send[marker type: {}]: {}:{}, latest persisted: {}:{}."
-                    + " Drop the pending publish marker command because it is a marker and it almost no effect.",
-                    topic, producerName, sourceLId, sourceEId,
-                    MarkerType.valueOf(op.msg.getMessageBuilder().getMarkerType()), pendingLId, pendingEId,
-                    lastPersistedSourceLedgerId, lastPersistedSourceEntryId);
+            log.warn()
+                    .attr("sourceLedgerId", sourceLId).attr("sourceEntryId", sourceEId)
+                    .attr("markerType", MarkerType.valueOf(op.msg.getMessageBuilder().getMarkerType()))
+                    .attr("pendingLedgerId", pendingLId).attr("pendingEntryId", pendingEId)
+                    .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
+                    .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
+                    .log("Received out-of-order msg send receipt due to replicated subscription,"
+                            + " dropping pending marker command");
             // Drop pending marker. The next ack receipt of this marker message will be dropped after it come in.
             ackReceivedReplMarker(cnx, op, op.sequenceId, -1 /*non-batch message*/, -1, -1);
             // Handle the current send receipt.
@@ -183,10 +192,14 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         // Case-5: Unexpected
         //   5-1: got null source cluster's entry position, which is unexpected.
         //   5-2: unknown error, which is unexpected.
-        log.error("[{}] [{}] Received an msg send receipt[error]: source entry {}:{}, target entry: {}:{},"
-                + " pending send: {}:{}, latest persisted: {}:{}, queue-size: {}",
-                topic, producerName, sourceLId, sourceEId, targetLId, targetEid, pendingLId, pendingEId,
-                lastPersistedSourceLedgerId, lastPersistedSourceEntryId, pendingMessages.messagesCount());
+        log.error()
+                .attr("sourceLedgerId", sourceLId).attr("sourceEntryId", sourceEId)
+                .attr("targetLedgerId", targetLId).attr("targetEntryId", targetEid)
+                .attr("pendingLedgerId", pendingLId).attr("pendingEntryId", pendingEId)
+                .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
+                .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
+                .attr("queueSize", pendingMessages.messagesCount())
+                .log("Received unexpected msg send receipt");
         cnx.channel().close();
     }
 
@@ -196,11 +209,13 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         long lastSeqPersisted = LAST_SEQ_ID_PUBLISHED_UPDATER.get(this);
         if (lastSeqPersisted != 0 && seq <= lastSeqPersisted) {
             // Ignoring the ack since it's referring to a message that has already timed out.
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Received an repl marker send receipt[repeated]. seq: {}, seqPersisted: {},"
-                                + " isSourceMarker: {}, target entry: {}:{}",
-                        topic, producerName, seq, lastSeqPersisted, isSourceMarker, ledgerId, entryId);
-            }
+                log.debug()
+                        .attr("seq", seq)
+                        .attr("lastSeqPersisted", lastSeqPersisted)
+                        .attr("issourcemarker", isSourceMarker)
+                        .attr("entry", ledgerId)
+                        .attr("entryId", entryId)
+                        .log("Received repeated repl marker send receipt");
             return;
         }
 
@@ -209,11 +224,13 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         //   and condition: the current pending msg is also a marker.
         boolean pendingMsgIsReplMarker = isReplicationMarker(op);
         if (pendingMsgIsReplMarker && seq == op.sequenceId) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Received an repl marker send receipt[expected]. seq: {}, seqPersisted: {},"
-                                + " isReplMarker: {}, target entry: {}:{}",
-                        topic, producerName, seq, lastSeqPersisted, isSourceMarker, ledgerId, entryId);
-            }
+                log.debug()
+                        .attr("seq", seq)
+                        .attr("lastSeqPersisted", lastSeqPersisted)
+                        .attr("isreplmarker", isSourceMarker)
+                        .attr("entry", ledgerId)
+                        .attr("entryId", entryId)
+                        .log("Received expected repl marker send receipt");
             long calculatedSeq = getHighestSequenceId(op);
             LAST_SEQ_ID_PUBLISHED_UPDATER.getAndUpdate(this, last -> Math.max(last, calculatedSeq));
             removeAndApplyCallback(op, seq, isSourceMarker, ledgerId, entryId, true);
@@ -252,9 +269,14 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
             // application
             op.sendComplete(null);
         } catch (Throwable t) {
-            log.warn("[{}] [{}] Got exception while completing the callback for -- source-message: {}:{} --"
-                            + " target-msg: {}:{} -- isMarker: {}",
-                    topic, producerName, lIdSent, eIdSent, ledgerId, entryId, isMarker, t);
+            log.warn()
+                    .attr("sourceMessage", lIdSent)
+                    .attr("eIdSent", eIdSent)
+                    .attr("targetMsg", ledgerId)
+                    .attr("entryId", entryId)
+                    .attr("ismarker", isMarker)
+                    .exception(t)
+                    .log("Got exception while completing the callback");
         }
         ReferenceCountUtil.safeRelease(op.cmd);
         op.recycle();
@@ -267,9 +289,15 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
 
     @Override
     public void printWarnLogWhenCanNotDetermineDeduplication(Channel channel, long sourceLId, long sourceEId) {
-        log.warn("[{}] producer [id:{}, name:{}, channel: {}] message with source entry {}-{} published by has been"
-            + " dropped because Broker can not determine whether is duplicate or not",
-            topic, producerId, producerName, channel, sourceLId, sourceEId);
+        log.warn()
+                .attr("producerId", producerId)
+                .attr("name", producerName)
+                .attr("channel", channel)
+                .attr("entry", sourceLId)
+                .attr("sourceEId", sourceEId)
+                .log("Message published by producer has been dropped"
+                        + " because broker cannot determine whether"
+                        + " it is duplicate");
     }
 
     private boolean isReplicationMarker(long highestSeq) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
@@ -60,7 +60,7 @@ import org.asynchttpclient.SslEngineFactory;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
 
 
-@Slf4j
+@CustomLog
 public class HttpClient implements Closeable {
 
     private static final String ORIGINAL_PRINCIPAL_HEADER = "X-Original-Principal";
@@ -140,7 +140,7 @@ public class HttpClient implements Closeable {
         AsyncHttpClientConfig config = confBuilder.build();
         httpClient = new DefaultAsyncHttpClient(config);
 
-        log.debug("Using HTTP url: {}", conf.getServiceUrl());
+        log.debug().attr("url", conf.getServiceUrl()).log("Using HTTP url");
     }
 
     String getServiceUrl() {
@@ -185,8 +185,9 @@ public class HttpClient implements Closeable {
                 if (ex != null) {
                     serviceNameResolver.markHostAvailability(
                             InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()), false);
-                    log.warn("[{}] Failed to perform http request at authentication stage: {}",
-                        requestUrl, ex.getMessage());
+                    log.warn().attr("requestUrl", requestUrl)
+                            .exceptionMessage(ex)
+                            .log("Failed to perform http request at authentication stage");
                     future.completeExceptionally(new PulsarClientException(ex));
                     return;
                 }
@@ -202,7 +203,9 @@ public class HttpClient implements Closeable {
                     try {
                         headers = authentication.newRequestHeader(requestUrl, authData, respHeaders);
                     } catch (Exception e) {
-                        log.warn("[{}] Error during HTTP get headers: {}", requestUrl, e.getMessage());
+                        log.warn().attr("requestUrl", requestUrl)
+                                .exceptionMessage(e)
+                                .log("Error during HTTP get headers");
                         future.completeExceptionally(new PulsarClientException(e));
                         return;
                     }
@@ -220,7 +223,9 @@ public class HttpClient implements Closeable {
                     if (t != null) {
                         serviceNameResolver.markHostAvailability(
                                 InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()), false);
-                        log.warn("[{}] Failed to perform http request: {}", requestUrl, t.getMessage());
+                        log.warn().attr("requestUrl", requestUrl)
+                                .exceptionMessage(t)
+                                .log("Failed to perform http request");
                         future.completeExceptionally(new PulsarClientException(t));
                         return;
                     }
@@ -243,12 +248,14 @@ public class HttpClient implements Closeable {
                                 }
                             } catch (IOException e) {
                                 // ignore
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Failed to parse error response: {}", requestUrl, responseBody);
-                                }
+                                    log.debug().attr("requestUrl", requestUrl)
+                                            .attr("response", responseBody)
+                                            .log("Failed to parse error response");
                             }
                         }
-                        log.warn("[{}] HTTP get request failed: {}", requestUrl, errorReason);
+                        log.warn().attr("requestUrl", requestUrl)
+                                .attr("failed", errorReason)
+                                .log("HTTP get request failed");
                         Exception e;
                         if (response2.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                             e = new NotFoundException("Not found: " + errorReason);
@@ -264,13 +271,15 @@ public class HttpClient implements Closeable {
                                 response2.getResponseBodyAsBytes(), clazz);
                         future.complete(data);
                     } catch (Exception e) {
-                        log.warn("[{}] Error during HTTP get request: {}", requestUrl, e.getMessage());
+                        log.warn().attr("requestUrl", requestUrl)
+                                .exceptionMessage(e)
+                                .log("Error during HTTP get request");
                         future.completeExceptionally(new PulsarClientException(e));
                     }
                 });
             });
         } catch (Exception e) {
-            log.warn("[{}]PulsarClientImpl: {}", path, e.getMessage());
+            log.warn().attr("path", path).exceptionMessage(e).log("PulsarClientImpl");
             if (e instanceof PulsarClientException) {
                 future.completeExceptionally(e);
             } else {
@@ -310,7 +319,7 @@ public class HttpClient implements Closeable {
         try {
             this.sslFactory.update();
         } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
+            log.error().exception(e).log("Failed to refresh SSL context");
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpLookupService.java
@@ -31,6 +31,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.NotFoundException;
@@ -52,9 +53,8 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class HttpLookupService implements LookupService {
 
     private final HttpClient httpClient;
@@ -110,8 +110,8 @@ public class HttpLookupService implements LookupService {
             lookupProperties = httpClient.clientConf.getLookupProperties();
         }
         if (lookupProperties != null && !lookupProperties.isEmpty()) {
-            log.warn("Lookup properties aren't supported for http lookup service. lookupProperties: {}",
-                    lookupProperties);
+            log.warn().attr("lookupProperties", lookupProperties)
+                    .log("Lookup properties aren't supported for http lookup service. lookupProperties");
         }
         String path = BasePath + topicName.getLookupName();
         path = StringUtils.isBlank(listenerName) ? path : path + "?listenerName=" + Codec.encode(listenerName);
@@ -145,7 +145,10 @@ public class HttpLookupService implements LookupService {
                         false /* HTTP lookups never use the proxy */));
             } catch (Exception e) {
                 // Failed to parse url
-                log.warn("[{}] Lookup Failed due to invalid url {}, {}", topicName, uri, e.getMessage());
+                log.warn().attr("topicName", topicName)
+                        .attr("url", uri)
+                        .exceptionMessage(e)
+                        .log("Lookup Failed due to invalid url");
                 return FutureUtil.failedFuture(e);
             }
         });
@@ -201,7 +204,9 @@ public class HttpLookupService implements LookupService {
                 future.complete(new GetTopicsResult(topics));
             }).exceptionally(ex -> {
                 Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.warn("Failed to getTopicsUnderNamespace namespace {} {}.", namespace, cause.getMessage());
+                log.warn().attr("namespace", namespace)
+                        .exceptionMessage(cause)
+                        .log("Failed to getTopicsUnderNamespace namespace.");
                 future.completeExceptionally(cause);
                 return null;
             });
@@ -255,10 +260,10 @@ public class HttpLookupService implements LookupService {
             if (cause instanceof NotFoundException) {
                 future.complete(Optional.empty());
             } else {
-                log.warn("Failed to get schema for topic {} version {}",
-                        topicName,
-                        version != null ? Base64.getEncoder().encodeToString(version) : null,
-                        cause);
+                log.warn().attr("topic", topicName)
+                        .attr("version", version != null ? Base64.getEncoder().encodeToString(version) : null)
+                        .exception(cause)
+                        .log("Failed to get schema for topic version");
                 future.completeExceptionally(cause);
             }
             return null;
@@ -277,6 +282,4 @@ public class HttpLookupService implements LookupService {
     public void close() throws Exception {
         httpClient.close();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(HttpLookupService.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MemoryLimitController.java
@@ -23,9 +23,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 
-@Slf4j
+@CustomLog
 public class MemoryLimitController {
 
     private final long memoryLimit;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicConsumerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicConsumerStatsRecorderImpl.java
@@ -20,15 +20,15 @@ package org.apache.pulsar.client.impl;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerStats;
 import org.apache.pulsar.client.api.MultiTopicConsumerStats;
 import org.apache.pulsar.client.api.ProducerStats;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("deprecation")
+@CustomLog
 public class MultiTopicConsumerStatsRecorderImpl extends ConsumerStatsRecorderImpl implements MultiTopicConsumerStats {
 
     private static final long serialVersionUID = 1L;
@@ -76,6 +76,4 @@ public class MultiTopicConsumerStatsRecorderImpl extends ConsumerStatsRecorderIm
                 consumerStats.getRetryLetterProducerStats()));
         return retryLetterStats;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(MultiTopicConsumerStatsRecorderImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Lists;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.io.IOException;
@@ -79,10 +80,10 @@ import org.apache.pulsar.common.util.CompletableFutureCancellationHandler;
 import org.apache.pulsar.common.util.ExceptionHandler;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
+    private static final Logger LOG = Logger.get(MultiTopicsConsumerImpl.class);
+    private final Logger log;
 
     public static final String DUMMY_TOPIC_NAME_PREFIX = "MultiTopicsConsumer-";
 
@@ -141,6 +142,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             long startMessageRollbackDurationInSec) {
         super(client, singleTopic, conf, Math.max(2, conf.getReceiverQueueSize()), executorProvider, subscribeFuture,
                 schema, interceptors);
+        this.log = LOG.with()
+                .attr("topic", singleTopic)
+                .attr("subscription", subscription)
+                .attr("consumerName", consumerName)
+                .attr("state", () -> getState())
+                .build();
         if (interceptors != null) {
            this.internalConsumerInterceptors = getInternalConsumerInterceptors(interceptors);
         } else {
@@ -191,16 +198,17 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 setState(State.Ready);
                 // We have successfully created N consumers, so we can start receiving messages now
                 startReceivingMessages(new ArrayList<>(consumers.values()));
-                log.info("[{}] [{}] Created topics consumer with {} sub-consumers",
-                    topic, subscription, allTopicPartitionsNumber.get());
+                log.info().attr("allTopicPartitionsNumber", allTopicPartitionsNumber.get())
+                        .log("Created topics consumer with sub-consumers");
                 subscribeFuture().complete(MultiTopicsConsumerImpl.this);
             })
             .exceptionally(ex -> {
-                log.warn("[{}] Failed to subscribe topics: {}, closing consumer", topic, ex.getMessage());
+                log.warn().exceptionMessage(ex)
+                        .log("Failed to subscribe topics, closing consumer");
                 closeAsync().whenComplete((res, closeEx) -> {
                     if (closeEx != null) {
-                        log.error("[{}] Failed to unsubscribe after failed consumer creation: {}",
-                                topic, closeEx.getMessage());
+                        log.error().exceptionMessage(closeEx)
+                                .log("Failed to unsubscribe after failed consumer creation");
                     }
                     subscribeFuture.completeExceptionally(ex);
                 });
@@ -219,7 +227,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
         for (String topic : topics) {
             if (!TopicName.isValid(topic)) {
-                log.warn("Received invalid topic name: {}", topic);
+                LOG.warn().attr("topic", topic).log("Received invalid topic name");
                 return false;
             }
             topicNames.add(TopicName.get(topic));
@@ -229,16 +237,16 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         if (topicNames.size() == topics.size()) {
             return true;
         } else {
-            log.warn("Topic names not unique. unique/all : {}/{}", topicNames.size(), topics.size());
+            LOG.warn().attr("uniqueCount", topicNames.size())
+                    .attr("totalCount", topics.size())
+                    .log("Topic names not unique");
             return false;
         }
     }
 
     private void startReceivingMessages(List<ConsumerImpl<T>> newConsumers) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] startReceivingMessages for {} new consumers in topics consumer, state: {}",
-                topic, newConsumers.size(), getState());
-        }
+            log.debug().attr("consumersCount", newConsumers.size())
+                    .log("startReceivingMessages for new consumers");
 
         if (getState() == State.Ready) {
             newConsumers.forEach(consumer -> {
@@ -251,7 +259,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     private void receiveMessageFromConsumer(ConsumerImpl<T> consumer, boolean batchReceive) {
         if (duringSeek) {
-            log.info("[{}] Pause receiving messages for topic {} due to seek", subscription, consumer.getTopic());
+            log.info().attr("topic", consumer.getTopic())
+                    .log("Pause receiving messages for topic due to seek");
             return;
         }
         CompletableFuture<List<Message<T>>> messagesFuture;
@@ -261,10 +270,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             messagesFuture = consumer.receiveAsync().thenApply(Collections::singletonList);
         }
         messagesFuture.thenAcceptAsync(messages -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Receive message from sub consumer:{}",
-                    topic, subscription, consumer.getTopic());
-            }
+                log.debug().attr("topic", consumer.getTopic())
+                        .log("Receive message from sub consumer");
             // Stop to process the remaining message after the consumer is closed.
             if (getState() == State.Closed) {
                 return;
@@ -280,8 +287,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 } else if (!isValidEpoch) {
                     consumer.increaseAvailablePermits(cnx);
                 } else if (skipDueToSeek) {
-                    log.info("[{}] [{}] Skip processing message {} received during seek", topic, subscription,
-                            msg.getMessageId());
+                    log.info().attr("messageId", msg.getMessageId())
+                            .log("Skip processing message received during seek");
                 }
             });
 
@@ -309,7 +316,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 // ignore the exception that happens when the consumer is closed
                 return null;
             }
-            log.error("Receive operation failed on consumer {} - Retrying later", consumer, ex);
+            log.error().attr("topic", consumer.getTopic())
+                    .exception(ex)
+                    .log("Receive operation failed on consumer - Retrying later");
             ((ScheduledExecutorService) client.getScheduledExecutorProvider().getExecutor())
                     .schedule(() -> receiveMessageFromConsumer(consumer, true), 10, TimeUnit.SECONDS);
             return null;
@@ -320,11 +329,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     private void messageReceived(ConsumerImpl<T> consumer, Message<T> message) {
         checkArgument(message instanceof MessageImpl);
         TopicMessageImpl<T> topicMessage = new TopicMessageImpl<>(consumer.getTopic(), message, consumer);
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Received message from topics-consumer {}",
-                    topic, subscription, message.getMessageId());
-        }
+            log.debug().attr("messageId", message.getMessageId())
+                    .log("Received message from topics-consumer");
 
         // if asyncReceive is waiting : return message to callback without adding to incomingMessages queue
         CompletableFuture<Message<T>> receivedFuture = nextPendingReceive();
@@ -574,8 +580,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     public void negativeAcknowledge(MessageId messageId) {
         if (getState() != State.Ready) {
-            log.warn("[{}] [{}] Cannot negative acknowledge message {} - consumer is not ready (state: {})",
-                    topic, subscription, messageId, getState());
+            log.warn().attr("messageId", messageId)
+                    .log("Cannot negative acknowledge message - consumer is not ready");
             return;
         }
         checkArgument(messageId instanceof TopicMessageId);
@@ -587,8 +593,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     public void negativeAcknowledge(Message<?> message) {
         if (getState() != State.Ready) {
-            log.warn("[{}] [{}] Cannot negative acknowledge message {} - consumer is not ready (state: {})",
-                    topic, subscription, message.getMessageId(), getState());
+            log.warn().attr("messageId", message.getMessageId())
+                    .log("Cannot negative acknowledge message - consumer is not ready (state: )");
             return;
         }
         MessageId messageId = message.getMessageId();
@@ -614,8 +620,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             .thenComposeAsync((r) -> {
                 setState(State.Closed);
                 cleanupMultiConsumer();
-                log.info("[{}] [{}] [{}] Unsubscribed Topics Consumer",
-                        topic, subscription, consumerName);
+                log.info("Unsubscribed Topics Consumer");
                 // fail all pending-receive futures to notify application
                 return failPendingReceive();
             }, internalPinnedExecutor)
@@ -625,8 +630,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 } else {
                     setState(State.Failed);
                     unsubscribeFuture.completeExceptionally(ex);
-                    log.error("[{}] [{}] [{}] Could not unsubscribe Topics Consumer",
-                        topic, subscription, consumerName, ex.getCause());
+                    log.error().exception(ex.getCause())
+                            .log("Could not unsubscribe Topics Consumer");
                 }
             });
 
@@ -653,8 +658,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             .map(consumer -> consumer.closeAsync().exceptionally(t -> {
                 Throwable cause = FutureUtil.unwrapCompletionException(t);
                 if (!(cause instanceof PulsarClientException.AlreadyClosedException)) {
-                    log.warn("[{}] [{}] Error closing individual consumer", consumer.getTopic(),
-                            consumer.getSubscription(), cause);
+                    log.warn().attr("topic", consumer.getTopic())
+                            .exception(cause)
+                            .log("Error closing individual consumer");
                 }
                 return null;
             })).collect(Collectors.toList());
@@ -663,7 +669,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             .thenComposeAsync((r) -> {
                 setState(State.Closed);
                 cleanupMultiConsumer();
-                log.info("[{}] [{}] Closed Topics Consumer", topic, subscription);
+                log.info("Closed Topics Consumer");
                 // fail all pending-receive futures to notify application
                 return failPendingReceive();
             }, internalPinnedExecutor)
@@ -673,8 +679,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 } else {
                     setState(State.Failed);
                     closeFuture.completeExceptionally(ex);
-                    log.error("[{}] [{}] Could not close Topics Consumer", topic, subscription,
-                        ex.getCause());
+                    log.error().exception(ex.getCause())
+                            .log("Could not close Topics Consumer");
                 }
             });
 
@@ -858,7 +864,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     private void afterSeek(CompletableFuture<Void> seekFuture, @Nullable Throwable throwable) {
         duringSeek = false;
-        log.info("[{}] Resume receiving messages for {} since seek is done", subscription, consumers.keySet());
+        log.info().attr("keySet", consumers.keySet())
+                .log("Resume receiving messages for since seek is done");
         startReceivingMessages(new ArrayList<>(consumers.values()));
         if (throwable == null) {
             seekFuture.complete(null);
@@ -1003,7 +1010,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 .thenAccept(metadata -> subscribeTopicPartitions(subscribeResult, fullTopicName, metadata.partitions,
                     createTopicIfDoesNotExist))
                 .exceptionally(ex1 -> {
-                    log.warn("[{}] Failed to get partitioned topic metadata: {}", fullTopicName, ex1.getMessage());
+                    log.warn().attr("topic", fullTopicName)
+                            .exceptionMessage(ex1)
+                            .log("Failed to get partitioned topic metadata");
                     subscribeResult.completeExceptionally(ex1);
                     return null;
                 });
@@ -1035,8 +1044,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         future.thenCompose(c -> ((MultiTopicsConsumerImpl<T>) c).subscribeAsync(topicName, numPartitions))
             .thenRun(()-> subscribeFuture.complete(consumer))
             .exceptionally(e -> {
-                log.warn("Failed subscription for createPartitionedConsumer: {} {}, e:{}",
-                    topicName, numPartitions,  e);
+                LOG.warn().attr("topic", topicName)
+                        .attr("numPartitions", numPartitions)
+                        .exceptionMessage(e)
+                        .log("Failed subscription for createPartitionedConsumer");
                 consumer.cleanupMultiConsumer();
                 subscribeFuture.completeExceptionally(
                     PulsarClientException.wrap(((Throwable) e).getCause(),
@@ -1092,9 +1103,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                             String topicName,
                                             int numPartitions,
                                             boolean createIfDoesNotExist) {
-        if (log.isDebugEnabled()) {
-            log.debug("Subscribe to topic {} metadata.partitions: {}", topicName, numPartitions);
-        }
+            log.debug().attr("topic", topicName)
+                    .attr("metadataPartitions", numPartitions)
+                    .log("Subscribe to topic metadata.partitions");
 
         CompletableFuture<Void> subscribeAllPartitionsFuture;
         if (numPartitions != PartitionedTopicMetadata.NON_PARTITIONED) {
@@ -1175,14 +1186,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                                 .collect(Collectors.toList()));
 
                 subscribeResult.complete(null);
-                log.info("[{}] [{}] Success subscribe new topic {} in topics consumer, partitions: {},"
-                                + " allTopicPartitionsNumber: {}",
-                    topic, subscription, topicName, numPartitions, allTopicPartitionsNumber.get());
+                log.info().attr("topic", topicName).attr("partitions", numPartitions)
+                        .attr("allTopicPartitionsNumber", allTopicPartitionsNumber.get())
+                        .log("Successfully subscribed to new topic in multi-topics consumer");
                 return;
             })
             .exceptionally(ex -> {
-                log.warn("[{}] Failed to subscribe for topic [{}] in topics consumer {}", topic, topicName,
-                        ex.getMessage());
+                log.warn().attr("topic", topicName)
+                        .exceptionMessage(ex)
+                        .log("Failed to subscribe for topic in topics consumer");
                 handleSubscribeOneTopicError(topicName, ex, subscribeResult);
                 return null;
             });
@@ -1211,7 +1223,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     protected void handleSubscribeOneTopicError(String topicName,
                                               Throwable error,
                                               CompletableFuture<Void> subscribeFuture) {
-        log.warn("[{}] Failed to subscribe for topic [{}] in topics consumer {}", topic, topicName, error.getMessage());
+        log.warn().attr("topic", topicName)
+                .exceptionMessage(error)
+                .log("Failed to subscribe for topic in topics consumer");
         client.externalExecutorProvider().getExecutor().execute(() -> {
             AtomicInteger toCloseNum = new AtomicInteger(0);
             List<ConsumerImpl> filterConsumers = consumers.values().stream().filter(consumer1 -> {
@@ -1236,8 +1250,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     allTopicPartitionsNumber.decrementAndGet();
                     consumers.remove(consumer2.getTopic());
                     if (toCloseNum.decrementAndGet() == 0) {
-                        log.warn("[{}] Failed to subscribe for topic [{}] in topics consumer, subscribe error: {}",
-                            topic, topicName, error.getMessage());
+                        log.warn().attr("topic", topicName)
+                                .exceptionMessage(error)
+                                .log("Failed to subscribe for topic in topics consumer, subscribe error");
                         removeTopic(topicName);
                         subscribeFuture.completeExceptionally(error);
                     }
@@ -1290,13 +1305,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     }
 
                     unsubscribeFuture.complete(null);
-                    log.info("[{}] [{}] [{}] Unsubscribed Topics Consumer, allTopicPartitionsNumber: {}",
-                        topicName, subscription, consumerName, allTopicPartitionsNumber);
+                    log.info().attr("topic", topicName)
+                            .attr("allTopicPartitionsNumber", allTopicPartitionsNumber)
+                            .log("Unsubscribed Topics Consumer");
                 } else {
                     unsubscribeFuture.completeExceptionally(ex);
                     setState(State.Failed);
-                    log.error("[{}] [{}] [{}] Could not unsubscribe Topics Consumer",
-                        topicName, subscription, consumerName, ex.getCause());
+                    log.error().attr("topic", topicName)
+                            .exception(ex.getCause())
+                            .log("Could not unsubscribe Topics Consumer");
                 }
             });
 
@@ -1361,18 +1378,17 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 future.complete(null);
                 return future;
             }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}]  run onTopicsExtended: {}, size: {}",
-                    topic, topicsExtended.toString(), topicsExtended.size());
-            }
+                log.debug().attr("topicsExtended", topicsExtended)
+                        .attr("count", topicsExtended.size())
+                        .log("Running onTopicsExtended");
 
             List<CompletableFuture<Void>> futureList = Lists.newArrayListWithExpectedSize(topicsExtended.size());
             topicsExtended.forEach(topic -> futureList.add(subscribeIncreasedTopicPartitions(topic)));
             FutureUtil.waitForAll(futureList)
                 .thenAccept(finalFuture -> future.complete(null))
                 .exceptionally(ex -> {
-                    log.warn("[{}] Failed to subscribe increased topics partitions: {}", topic, ex.getMessage());
+                    log.warn().exceptionMessage(ex)
+                            .log("Failed to subscribe increased topics partitions");
                     future.completeExceptionally(ex);
                     return null;
                 });
@@ -1388,11 +1404,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         return client.getPartitionsForTopic(topicName, false).thenCompose(list -> {
             int currentPartitionNumber = Long.valueOf(list.stream()
                     .filter(t -> TopicName.get(t).isPartitioned()).count()).intValue();
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] partitions number. old: {}, new: {}",
-                    topicName, oldPartitionNumber, currentPartitionNumber);
-            }
+                log.debug().attr("topic", topicName)
+                        .attr("old", oldPartitionNumber)
+                        .attr("new", currentPartitionNumber)
+                        .log("Topic partitions changed");
 
             if (oldPartitionNumber == currentPartitionNumber) {
                 // topic partition number not changed
@@ -1440,12 +1455,16 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                         startReceivingMessages(newConsumerList);
                     });
             } else {
-                log.error("[{}] not support shrink topic partitions. old: {}, new: {}",
-                    topicName, oldPartitionNumber, currentPartitionNumber);
+                log.error().attr("topic", topicName)
+                        .attr("old", oldPartitionNumber)
+                        .attr("new", currentPartitionNumber)
+                        .log("Shrinking topic partitions is not supported");
                 return FutureUtil.failedFuture(new NotSupportedException("not support shrink topic partitions"));
             }
         }).exceptionally(throwable -> {
-            log.warn("Failed to get partitions for topic to determine if new partitions are added", throwable);
+            log.warn().exception(throwable)
+                    .log("Failed to get partitions for topic to determine"
+                            + " if new partitions are added");
             return null;
         });
     }
@@ -1455,22 +1474,20 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         ConsumerImpl<T> consumer = consumers.compute(internalTopicName, (__, existingConsumer) -> {
             if (existingConsumer != null) {
                 if (existingConsumer.subscribeFuture().isCompletedExceptionally()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Closing and replacing existing consumer that wasn't completed successfully "
-                                + "for {}", topic, subscription, internalTopicName);
-                    }
+                        log.debug().attr("internalTopicName", internalTopicName)
+                                .log("Closing and replacing existing consumer"
+                                        + " that wasn't completed successfully"
+                                        + " for");
                     existingConsumer.closeAsync();
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Reusing existing consumer for {}", topic, subscription, internalTopicName);
-                    }
+                        log.debug().attr("internalTopicName", internalTopicName)
+                                .log("Reusing existing consumer for");
                     return existingConsumer;
                 }
             }
             // create the new consumer
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Creating consumer for {}", topic, subscription, internalTopicName);
-            }
+                log.debug().attr("internalTopicName", internalTopicName)
+                        .log("Creating consumer for");
             return newConsumerSupplier.get();
         });
         // return the subscribe future
@@ -1484,10 +1501,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 if (timeout.isCancelled() || getState() != State.Ready) {
                     return;
                 }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] run partitionsAutoUpdateTimerTask", topic);
-                }
+                    log.debug("run partitionsAutoUpdateTimerTask");
 
                 // if last auto update not completed yet, do nothing.
                 if (partitionsAutoUpdateFuture == null || partitionsAutoUpdateFuture.isDone()) {
@@ -1495,8 +1509,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                             topicsPartitionChangedListener.onTopicsExtended(partitionedTopics.keySet());
                 }
             } catch (Throwable th) {
-                log.warn("Encountered error in partition auto update timer task for multi-topic consumer."
-                        + " Another task will be scheduled.", th);
+                log.warn().exception(th)
+                        .log("Encountered error in partition auto update"
+                                + " timer task for multi-topic consumer."
+                                + " Another task will be scheduled.");
             } finally {
                 // schedule the next re-check task
                 partitionsAutoUpdateTimeout = client.timer()
@@ -1529,7 +1545,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     try {
                         messageId = future.get();
                     } catch (Exception e) {
-                        log.warn("[{}] Exception when topic {} getLastMessageId.", key, e);
+                        log.warn().attr("key", key).exception(e).log("Exception during topic getLastMessageId");
                         messageId = MessageId.earliest;
                     }
                     builder.put(key, messageId);
@@ -1552,8 +1568,6 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         });
     }
 
-    private static final Logger log = LoggerFactory.getLogger(MultiTopicsConsumerImpl.class);
-
     public static boolean isIllegalMultiTopicsMessageId(MessageId messageId) {
         //only support earliest/latest
         return !messageId.equals(MessageId.earliest) && !messageId.equals(MessageId.latest);
@@ -1563,8 +1577,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         if (msg != null) {
             acknowledgeCumulativeAsync(msg)
                     .exceptionally(ex -> {
-                        log.warn("[{}][{}] acknowledge message {} cumulative fail.", topic, subscription,
-                                msg.getMessageId(), ex);
+                        log.warn().attr("messageId", msg.getMessageId())
+                                .exception(ex)
+                                .log("acknowledge message cumulative fail");
                         return null;
                     });
         }
@@ -1573,10 +1588,9 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
     @Override
     protected void setCurrentReceiverQueueSize(int newSize) {
         checkArgument(newSize > 0, "receiver queue size should larger than 0");
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] setMaxReceiverQueueSize={}, previous={}", topic, subscription,
-                    newSize, getCurrentReceiverQueueSize());
-        }
+            log.debug().attr("newSize", newSize)
+                    .attr("previousSize", getCurrentReceiverQueueSize())
+                    .log("Set max receiver queue size");
         CURRENT_RECEIVER_QUEUE_SIZE_UPDATER.set(this, newSize);
         resumeReceivingFromPausedConsumersIfNeeded();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.client.impl;
 
 
+import io.github.merlimat.slog.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
@@ -48,8 +48,9 @@ import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.util.CompletableFutureCancellationHandler;
 
-@Slf4j
 public class MultiTopicsReaderImpl<T> implements Reader<T> {
+    private static final Logger LOG = Logger.get(MultiTopicsReaderImpl.class);
+    private final Logger log;
 
     private final MultiTopicsConsumerImpl<T> multiTopicsConsumer;
 
@@ -91,8 +92,9 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
                     final MessageId messageId = msg.getMessageId();
                     readerListener.received(MultiTopicsReaderImpl.this, msg);
                     consumer.acknowledgeCumulativeAsync(messageId).exceptionally(ex -> {
-                        log.error("[{}][{}] auto acknowledge message {} cumulative fail.", getTopic(),
-                                getMultiTopicsConsumer().getSubscription(), messageId, ex);
+                        log.error().attr("messageId", messageId)
+                                .exception(ex)
+                                .log("auto acknowledge message cumulative fail");
                         return null;
                     });
                 }
@@ -114,8 +116,9 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
                     final MessageId messageId = msg.getMessageId();
                     readerDecryptFailListener.received(MultiTopicsReaderImpl.this, msg);
                     consumer.acknowledgeCumulativeAsync(messageId).exceptionally(ex -> {
-                        log.error("[{}][{}] auto acknowledge decrypt fail message {} cumulative fail.", getTopic(),
-                                getMultiTopicsConsumer().getSubscription(), messageId, ex);
+                        log.error().attr("messageId", messageId)
+                                .exception(ex)
+                                .log("auto acknowledge decrypt fail message cumulative fail");
                         return null;
                     });
                 }
@@ -160,6 +163,10 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
                 consumerFuture, schema, consumerInterceptors, true,
                 readerConfiguration.getStartMessageId(),
                 readerConfiguration.getStartMessageFromRollbackDurationInSec());
+        this.log = LOG.with()
+                .attr("topic", () -> getTopic())
+                .attr("subscription", () -> getMultiTopicsConsumer().getSubscription())
+                .build();
     }
 
     @Override
@@ -187,8 +194,9 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         CompletableFuture<Message<T>> result = originalFuture.thenApply(msg -> {
             multiTopicsConsumer.acknowledgeCumulativeAsync(msg)
                     .exceptionally(ex -> {
-                        log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
-                                getMultiTopicsConsumer().getSubscription(), msg.getMessageId(), ex);
+                        log.warn().attr("messageId", msg.getMessageId())
+                                .exception(ex)
+                                .log("acknowledge message cumulative fail");
                         return null;
                     });
             return msg;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/NegativeAcksTracker.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
@@ -38,11 +39,9 @@ import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.util.collections.Long2ObjectMap;
 import org.apache.pulsar.common.util.collections.Long2ObjectOpenHashMap;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 class NegativeAcksTracker implements Closeable {
-    private static final Logger log = LoggerFactory.getLogger(NegativeAcksTracker.class);
 
     // timestamp -> ledgerId -> entryId, no need to batch index, if different messages have
     // different timestamp, there will be multiple entries in the map
@@ -135,7 +134,9 @@ class NegativeAcksTracker implements Closeable {
         // in which we may acquire the lock of consumer, leading to potential deadlock.
         if (!messagesToRedeliver.isEmpty()) {
             consumer.onNegativeAcksSend(messagesToRedeliver);
-            log.info("[{}] {} messages will be re-delivered", consumer, messagesToRedeliver.size());
+            log.info().attr("consumer", consumer)
+                    .attr("count", messagesToRedeliver.size())
+                    .log("messages will be re-delivered");
             consumer.redeliverUnacknowledgedMessages(messagesToRedeliver);
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES;
 import static org.apache.pulsar.client.impl.conf.ProducerConfigurationData.DEFAULT_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.util.Collection;
@@ -55,12 +56,11 @@ import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
-    private static final Logger log = LoggerFactory.getLogger(PartitionedProducerImpl.class);
+    private static final Logger LOG = Logger.get(PartitionedProducerImpl.class);
+    private final Logger log;
 
     private final Map<Integer, ProducerImpl<T>> producers = new ConcurrentHashMap<>();
     private final MessageRouter routerPolicy;
@@ -78,6 +78,10 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                                    int numPartitions, CompletableFuture<Producer<T>> producerCreatedFuture,
                                    Schema<T> schema, ProducerInterceptors interceptors) {
         super(client, topic, conf, producerCreatedFuture, schema, interceptors);
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("producerName", () -> overrideProducerName)
+                .build();
         this.topicMetadata = new TopicMetadataImpl(numPartitions);
         this.routerPolicy = getMessageRouter();
         stats = client.getConfiguration().getStatsIntervalSeconds() > 0
@@ -162,7 +166,9 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
         final BiConsumer<Boolean, Throwable> afterCreatingProducer = (failFast, createException) -> {
             final Runnable closeRunnable = () -> {
-                log.error("[{}] Could not create partitioned producer.", topic, createFail.get().getCause());
+                log.error()
+                        .exception(createFail.get().getCause())
+                        .log("Could not create partitioned producer.");
                 closeAsync().handle((ok, closeException) -> {
                     producerCreatedFuture().completeExceptionally(createFail.get());
                     client.cleanupProducer(this);
@@ -185,7 +191,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             if (completed.incrementAndGet() == indexList.size()) {
                 if (createFail.get() == null) {
                     setState(State.Ready);
-                    log.info("[{}] Created partitioned producer", topic);
+                    log.info("Created partitioned producer");
                     producerCreatedFuture().complete(PartitionedProducerImpl.this);
                 } else {
                     closeRunnable.run();
@@ -243,19 +249,24 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             final ProducerImpl<T> newProducer = createProducer(partition, Optional.ofNullable(overrideProducerName));
             final State createState = newProducer.producerCreatedFuture().handle((prod, createException) -> {
                 if (createException != null) {
-                    log.error("[{}] Could not create internal producer. partitionIndex: {}", topic, partition,
-                            createException);
+                    log.error()
+                            .attr("partitionIndex", partition)
+                            .exception(createException)
+                            .log("Could not create internal producer");
                     try {
                         producers.remove(partition, newProducer);
                         newProducer.close();
                     } catch (PulsarClientException e) {
-                        log.error("[{}] Could not close internal producer. partitionIndex: {}", topic, partition, e);
+                        log.error()
+                                .attr("partitionIndex", partition)
+                                .exception(e)
+                                .log("Could not close internal producer");
                     }
                     return State.Failed;
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Created internal producer. partitionIndex: {}", topic, partition);
-                }
+                    log.debug()
+                            .attr("partitionIndex", partition)
+                            .log("Created internal producer");
                 return State.Ready;
             }).join();
             if (createState == State.Failed) {
@@ -338,12 +349,14 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                         if (closeFail.get() == null) {
                             setState(State.Closed);
                             closeFuture.complete(null);
-                            log.info("[{}] Closed Partitioned Producer", topic);
+                            log.info("Closed Partitioned Producer");
                             client.cleanupProducer(this);
                         } else {
                             setState(State.Failed);
                             closeFuture.completeExceptionally(closeFail.get());
-                            log.error("[{}] Could not close Partitioned Producer", topic, closeFail.get().getCause());
+                            log.error()
+                                    .exception(closeFail.get().getCause())
+                                    .log("Could not close Partitioned Producer");
                         }
                     }
 
@@ -392,11 +405,10 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             client.getPartitionsForTopic(topic, false).thenCompose(list -> {
                 int oldPartitionNumber = topicMetadata.numPartitions();
                 int currentPartitionNumber = list.size();
-
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] partitions number. old: {}, new: {}",
-                            topic, oldPartitionNumber, currentPartitionNumber);
-                }
+                    log.debug()
+                            .attr("old", oldPartitionNumber)
+                            .attr("new", currentPartitionNumber)
+                            .log("Topic partitions changed");
 
                 if (oldPartitionNumber == currentPartitionNumber) {
                     // topic partition number not changed
@@ -423,19 +435,20 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
                         FutureUtil.waitForAll(futureList)
                                 .thenAccept(finalFuture -> {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug(
-                                                "[{}] success create producers for extended partitions."
-                                                        + " old: {}, new: {}",
-                                                topic, oldPartitionNumber, currentPartitionNumber);
-                                    }
+                                        log.debug()
+                                                .attr("old", oldPartitionNumber)
+                                                .attr("new", currentPartitionNumber)
+                                                .log("success create producers for"
+                                                        + " extended partitions");
                                     topicMetadata = new TopicMetadataImpl(currentPartitionNumber);
                                     future.complete(null);
                                 })
                                 .exceptionally(ex -> {
                                     // error happened, remove
-                                    log.warn("[{}] fail create producers for extended partitions. old: {}, new: {}",
-                                            topic, oldPartitionNumber, currentPartitionNumber);
+                                    log.warn()
+                                            .attr("old", oldPartitionNumber)
+                                            .attr("new", currentPartitionNumber)
+                                            .log("Failed to create producers for extended partitions");
                                     IntStream.range(oldPartitionNumber, producers.size())
                                             .forEach(i -> producers.remove(i).closeAsync());
                                     future.completeExceptionally(ex);
@@ -446,13 +459,15 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                         return future;
                     }
                 } else {
-                    log.error("[{}] not support shrink topic partitions. old: {}, new: {}",
-                            topic, oldPartitionNumber, currentPartitionNumber);
+                    log.error()
+                            .attr("old", oldPartitionNumber)
+                            .attr("new", currentPartitionNumber)
+                            .log("Shrinking topic partitions is not supported");
                     future.completeExceptionally(new NotSupportedException("not support shrink topic partitions"));
                 }
                 return future;
             }).exceptionally(throwable -> {
-                log.error("[{}] Auto getting partitions failed", topic, throwable);
+                log.error().exception(throwable).log("Auto getting partitions failed");
                 future.completeExceptionally(throwable);
                 return null;
             });
@@ -468,10 +483,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                 if (timeout.isCancelled() || getState() != State.Ready) {
                     return;
                 }
-
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] run partitionsAutoUpdateTimerTask for partitioned producer", topic);
-                }
+                    log.debug("run partitionsAutoUpdateTimerTask for partitioned producer");
 
                 // if last auto update not completed yet, do nothing.
                 if (partitionsAutoUpdateFuture == null || partitionsAutoUpdateFuture.isDone()) {
@@ -479,8 +491,10 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
                             topicsPartitionChangedListener.onTopicsExtended(List.of(topic));
                 }
             } catch (Throwable th) {
-                log.warn("Encountered error in partition auto update timer task for partition producer."
-                        + " Another task will be scheduled.", th);
+                log.warn().exception(th)
+                        .log("Encountered error in partition auto update"
+                                + " timer task for partition producer."
+                                + " Another task will be scheduled.");
             } finally {
                 // schedule the next re-check task
                 partitionsAutoUpdateTimeout = client.timer()

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedTopicProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedTopicProducerStatsRecorderImpl.java
@@ -22,12 +22,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.DoubleAdder;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PartitionedTopicProducerStats;
 import org.apache.pulsar.client.api.ProducerStats;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("deprecation")
+@CustomLog
 public class PartitionedTopicProducerStatsRecorderImpl extends ProducerStatsRecorderImpl
         implements PartitionedTopicProducerStats {
 
@@ -83,6 +83,4 @@ public class PartitionedTopicProducerStatsRecorderImpl extends ProducerStatsReco
     public int getPendingQueueSize() {
         return pendingQueueSize;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PartitionedTopicProducerStatsRecorderImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternConsumerUpdateQueue.java
@@ -20,11 +20,11 @@ package org.apache.pulsar.client.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.merlimat.slog.Logger;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
 
@@ -45,9 +45,10 @@ import org.apache.pulsar.common.api.proto.CommandWatchTopicListSuccess;
  * When you are using this client connect to the broker whose version < 2.11, there is only one scenario: [3] and all
  *   the event will run in the same thread.
  */
-@Slf4j
 @SuppressFBWarnings("EI_EXPOSE_REP2")
 public class PatternConsumerUpdateQueue {
+    private static final Logger LOG = Logger.get(PatternConsumerUpdateQueue.class);
+    private final Logger log;
     private final LinkedBlockingQueue<UpdateTask> pendingTasks;
 
     private final PatternMultiTopicsConsumerImpl<?> patternConsumer;
@@ -149,6 +150,9 @@ public class PatternConsumerUpdateQueue {
         this.patternConsumer = patternConsumer;
         this.topicsChangeListener = topicsChangeListener;
         this.pendingTasks = new LinkedBlockingQueue<>();
+        this.log = LOG.with()
+                .attr("subscription", () -> patternConsumer.getSubscription())
+                .build();
         // To avoid subscribing and topics changed events execute concurrently, let the change events starts after the
         // subscribing task.
         doAppend(InitTask.INSTANCE);
@@ -169,9 +173,8 @@ public class PatternConsumerUpdateQueue {
     }
 
     synchronized void doAppend(UpdateTask task) {
-        if (log.isDebugEnabled()) {
-            log.debug("Pattern consumer [{}] try to append task. {}", patternConsumer.getSubscription(), task);
-        }
+            log.debug().attr("task", task)
+                    .log("Pattern consumer try to append task");
         // Once there is a recheck task in queue, it means other tasks can be skipped.
         if (recheckTaskInQueue) {
             return;
@@ -222,8 +225,8 @@ public class PatternConsumerUpdateQueue {
                     synchronized (PatternConsumerUpdateQueue.this) {
                         this.closed = true;
                         patternConsumer.closeAsync().exceptionally(ex2 -> {
-                            log.error("Pattern consumer failed to close, this error may left orphan consumers."
-                                    + " Subscription: {}", patternConsumer.getSubscription());
+                            log.error()
+                                    .log("Pattern consumer failed to close, this error may leave orphan consumers");
                             return null;
                         });
                     }
@@ -251,9 +254,10 @@ public class PatternConsumerUpdateQueue {
                             String localHash = patternConsumer.getLocalStateTopicsHash();
                             String brokerHash = topicsAddedOrRemovedTask.topicsHash;
                             if (brokerHash != null && brokerHash.length() > 0 && !brokerHash.equals(localHash)) {
-                                log.info("[{}][{}] Hash mismatch detected (local: {}, broker: {}). Triggering "
-                                                + "reconciliation.", patternConsumer.getPattern().inputPattern(),
-                                        patternConsumer.getSubscription(), localHash, brokerHash);
+                                log.info().attr("pattern", patternConsumer.getPattern().inputPattern())
+                                        .attr("local", localHash)
+                                        .attr("broker", brokerHash)
+                                        .log("Hash mismatch detected, triggering reconciliation");
                                 appendRecheckOp();
                             }
                         });
@@ -275,15 +279,13 @@ public class PatternConsumerUpdateQueue {
                 throw new RuntimeException("Un-support UpdateSubscriptionType");
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Pattern consumer [{}] starting task. {}", patternConsumer.getSubscription(), task);
-        }
+            log.debug().attr("task", task)
+                    .log("Pattern consumer starting task");
         // Trigger next pending task.
         taskInProgress = Pair.of(task.type, newTaskFuture);
         newTaskFuture.thenAccept(ignore -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Pattern consumer [{}] task finished. {}", patternConsumer.getSubscription(), task);
-            }
+                log.debug().attr("finished", task)
+                        .log("Pattern consumer task finished");
             triggerNextTask();
         }).exceptionally(ex -> {
             /**
@@ -291,8 +293,9 @@ public class PatternConsumerUpdateQueue {
              * - Skip if there is already a recheck task in queue.
              * - Skip if the last recheck task has been executed after the current time.
              */
-            log.error("Pattern consumer [{}] task finished. {}. But it failed", patternConsumer.getSubscription(),
-                    task, ex);
+            log.error().attr("task", task)
+                    .exception(ex)
+                    .log("Pattern consumer task failed");
             // Skip if there is already a recheck task in queue.
             synchronized (PatternConsumerUpdateQueue.this) {
                 if (recheckTaskInQueue || PatternConsumerUpdateQueue.this.closed) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.TimerTask;
 import java.util.ArrayList;
@@ -50,10 +51,10 @@ import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.topics.TopicList;
 import org.apache.pulsar.common.topics.TopicsPattern;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T> implements TimerTask {
+    private static final Logger LOG = Logger.get(PatternMultiTopicsConsumerImpl.class);
+    private final Logger log;
     private final TopicsPattern topicsPattern;
     final TopicsChangedListener topicsChangeListener;
     private final Mode subscriptionMode;
@@ -82,6 +83,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                           ConsumerInterceptors<T> interceptors) {
         super(client, conf, executorProvider, subscribeFuture, schema, interceptors,
                 false /* createTopicIfDoesNotExist */);
+        this.log = LOG.with()
+                .attr("subscription", conf.getSubscriptionName())
+                .build();
         this.topicsPattern = topicsPattern;
         this.subscriptionMode = subscriptionMode;
         this.namespaceName = topicsPattern.namespace();
@@ -96,16 +100,16 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                             this::getNextRecheckPatternEpoch);
                     watcherFuture.whenComplete((watcher, ex) -> {
                         if (closed) {
-                            log.warn("Pattern consumer [{}] was closed while creating topic list watcher",
-                                    conf.getSubscriptionName(), ex);
+                            log.warn().exception(ex)
+                                    .log("Pattern consumer was closed while creating topic list watcher");
                         } else if (ex != null) {
                             if (ex instanceof PulsarClientException.NotAllowedException) {
                                 // create info message when topic watchers aren't supported
-                                log.info("Pattern consumer [{}] unable to create topic list watcher. {}",
-                                        conf.getSubscriptionName(), ex.getMessage());
+                                log.info().exceptionMessage(ex)
+                                        .log("Pattern consumer unable to create topic list watcher");
                             } else {
-                                log.warn("Pattern consumer [{}] unable to create topic list watcher.",
-                                        conf.getSubscriptionName(), ex);
+                                log.warn().exception(ex)
+                                        .log("Pattern consumer unable to create topic list watcher");
                             }
                         }
                         scheduleRecheckTopics();
@@ -113,8 +117,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 }
             });
         } else {
-            log.debug("Pattern consumer [{}] not creating topic list watcher for subscription mode {}",
-                    conf.getSubscriptionName(), subscriptionMode);
+            log.debug().attr("mode", subscriptionMode)
+                    .log("Pattern consumer not creating topic list watcher for subscription mode");
             topicListWatcher = null;
             watcherFuture.complete(null);
             subscribeFuture.whenComplete((__, ex) -> {
@@ -172,8 +176,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
 
         return recheckFuture.handle((__, ex) -> {
             if (ex != null) {
-                log.info("[{}][{}] Pattern consumer failed to recheck topics changes: {}",
-                        getPattern().inputPattern(), getSubscription(), ex.getMessage());
+                log.info().attr("inputPattern", getPattern().inputPattern())
+                        .exceptionMessage(ex)
+                        .log("Pattern consumer failed to recheck topics changes");
             }
             scheduleRecheckTopics();
             return null;
@@ -240,18 +245,15 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                         if (recheckPatternEpoch.get() > epoch) {
                             return CompletableFuture.completedFuture(null);
                         }
-                        if (log.isDebugEnabled()) {
-                            log.debug("Pattern consumer [{}] get topics under namespace {}, "
-                                    + "topics.size: {}, "
-                                    + "topicsHash: {}, filtered: {}",
-                                    getSubscription(), namespaceName,
-                                    getTopicsResult.getTopics().size(),
-                                    getTopicsResult.getTopicsHash(),
-                                    getTopicsResult.isFiltered());
-                            getTopicsResult.getTopics().forEach(topicName ->
-                                    log.debug("Get topics under namespace {}, topic: {}",
-                                            namespaceName, topicName));
-                        }
+                        log.debug().attr("namespace", namespaceName)
+                                .attr("topicsSize", getTopicsResult.getTopics().size())
+                                .attr("topicsHash", getTopicsResult.getTopicsHash())
+                                .attr("filtered", getTopicsResult.isFiltered())
+                                .log("Pattern consumer get topics under namespace");
+                        getTopicsResult.getTopics().forEach(topicName ->
+                                log.debug().attr("namespace", namespaceName)
+                                        .attr("topic", topicName)
+                                        .log("Get topics under namespace"));
 
                         final List<String> oldTopics = new ArrayList<>(getPartitions());
                         return updateSubscriptions(topicsPattern, getTopicsResult, topicsChangeListener, oldTopics,
@@ -279,10 +281,10 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
         final List<CompletableFuture<?>> listenersCallback = new ArrayList<>(2);
         Set<String> topicsAdded = TopicList.minus(newTopics, oldTopics);
         Set<String> topicsRemoved = TopicList.minus(oldTopics, newTopics);
-        if (log.isDebugEnabled()) {
-            log.debug("Pattern consumer [{}] Recheck pattern consumer's topics. topicsAdded: {}, topicsRemoved: {}",
-                    subscriptionForLog, topicsAdded, topicsRemoved);
-        }
+        LOG.debug().attr("subscription", subscriptionForLog)
+                .attr("topicsAdded", topicsAdded)
+                .attr("topicsRemoved", topicsRemoved)
+                .log("Pattern consumer rechecking topics");
         listenersCallback.add(topicsChangedListener.onTopicsAdded(topicsAdded));
         listenersCallback.add(topicsChangedListener.onTopicsRemoved(topicsRemoved));
         return FutureUtil.waitForAll(Collections.unmodifiableList(listenersCallback));
@@ -330,8 +332,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     CompletableFuture<Void> unsubscribeFuture = new CompletableFuture<>();
                     consumer.closeAsync().whenComplete((__, ex) -> {
                         if (ex != null) {
-                            log.error("Pattern consumer [{}] failed to unsubscribe from topics: {}",
-                                    PatternMultiTopicsConsumerImpl.this.getSubscription(), topicName.toString(), ex);
+                            log.error().attr("topic", topicName.toString())
+                                    .exception(ex)
+                                    .log("Pattern consumer failed to unsubscribe from topic");
                             unsubscribeFuture.completeExceptionally(ex);
                         } else {
                             consumers.remove(topicName.toString(), consumer);
@@ -343,11 +346,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     partialRemovedForLog.add(topicName.toString());
                 }
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Pattern consumer [{}] remove topics. {}",
-                        PatternMultiTopicsConsumerImpl.this.getSubscription(),
-                        partialRemovedForLog);
-            }
+            log.debug().attr("topics", partialRemovedForLog)
+                    .log("Pattern consumer remove topics");
 
             // Remove partitioned topics in memory.
             return FutureUtil.waitForAll(unsubscribeList).handle((__, ex) -> {
@@ -370,11 +370,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                         }
                     }
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("Pattern consumer [{}] remove partitioned topics because all partitions have been"
-                                    + " removed. {}", PatternMultiTopicsConsumerImpl.this.getSubscription(),
-                            removedPartitionedTopicsForLog);
-                }
+                log.debug().attr("removed", removedPartitionedTopicsForLog)
+                        .log("Pattern consumer removed partitioned topics because all partitions have been removed");
                 return null;
             });
         }
@@ -418,9 +415,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                     } else if (topicName.getPartitionIndex() < 0) {
                         // Error-1: Received adding non-partitioned topic event, but has subscribed a partitioned topic
                         // with the same name.
-                        log.error("Pattern consumer [{}] skip to subscribe to the non-partitioned topic {}, because has"
-                                + "subscribed a partitioned topic with the same name",
-                                PatternMultiTopicsConsumerImpl.this.getSubscription(), topicName.toString());
+                        log.error().attr("topic", topicName.toString())
+                                .log("Pattern consumer skip subscribing to"
+                                        + " non-partitioned topic because a"
+                                        + " partitioned topic with the same"
+                                        + " name already exists");
                     } else {
                         if (topicName.getPartitionIndex() + 1
                                 > partitionedTopics.get(topicName.getPartitionedTopicName())) {
@@ -432,8 +431,9 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                 PartitionedTopicMetadata.NON_PARTITIONED);
                         consumerFuture.whenComplete((__, ex) -> {
                             if (ex != null) {
-                                log.warn("Pattern consumer [{}] Failed to subscribe to topics: {}",
-                                        PatternMultiTopicsConsumerImpl.this.getSubscription(), topicName, ex);
+                                log.warn().attr("topic", topicName)
+                                        .exception(ex)
+                                        .log("Pattern consumer failed to subscribe to topic");
                             }
                         });
                         futures.add(consumerFuture);
@@ -446,9 +446,11 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                         && topicName.getPartitionIndex() >= 0) {
                     // Error-2: Received adding partitioned topic event, but has subscribed a non-partitioned topic
                     // with the same name.
-                    log.error("Pattern consumer [{}] skip to subscribe to the partitioned topic {}, because has"
-                                    + "subscribed a non-partitioned topic with the same name",
-                            PatternMultiTopicsConsumerImpl.this.getSubscription(), topicName);
+                    log.error().attr("topic", topicName)
+                            .log("Pattern consumer skip subscribing to"
+                                    + " partitioned topic because a"
+                                    + " non-partitioned topic with the same"
+                                    + " name already exists");
                     groupedTopics.remove(topicName.getPartitionedTopicName());
                 }
             }
@@ -457,16 +459,16 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                 CompletableFuture<Void> consumerFuture = subscribeAsync(partitionedTopic, false);
                 consumerFuture.whenComplete((__, ex) -> {
                     if (ex != null) {
-                        log.warn("Pattern consumer [{}] Failed to subscribe to topics: {}",
-                                PatternMultiTopicsConsumerImpl.this.getSubscription(), partitionedTopic, ex);
+                        log.warn().attr("topic", partitionedTopic)
+                                .exception(ex)
+                                .log("Pattern consumer failed to subscribe to topic");
                     }
                 });
                 futures.add(consumerFuture);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Pattern consumer [{}] add topics. expend partitions {}, new subscribing {}",
-                        PatternMultiTopicsConsumerImpl.this.getSubscription(), expendPartitionsForLog, groupedTopics);
-            }
+            log.debug().attr("partitions", expendPartitionsForLog)
+                    .attr("subscribing", groupedTopics)
+                    .log("Pattern consumer add topics");
             return FutureUtil.waitForAll(futures);
         }
     }
@@ -512,6 +514,4 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                                 CompletableFuture<Void> subscribeFuture) {
         subscribeFuture.completeExceptionally(error);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PatternMultiTopicsConsumerImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
@@ -57,7 +57,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Group the acknowledgements for a certain time and then sends them out in a single protobuf command.
  */
-@Slf4j
+@CustomLog
 public class PersistentAcknowledgmentsGroupingTracker implements AcknowledgmentsGroupingTracker {
 
     /**
@@ -418,9 +418,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         ClientCnx cnx = consumer.getClientCnx();
 
         if (cnx == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cannot flush pending acks since we're not connected to broker", consumer);
-            }
+                log.debug().attr("consumer", consumer)
+                        .log("Cannot flush pending acks since we're not connected to broker");
             return;
         }
 
@@ -507,11 +506,11 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
         }
 
         if (shouldFlush) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Flushing pending acks to broker: last-cumulative-ack: {} -- individual-acks: {}"
-                                + " -- individual-batch-index-acks: {}",
-                        consumer, lastCumulativeAck, pendingIndividualAcks, entriesToAck);
-            }
+                log.debug().attr("consumer", consumer)
+                        .attr("lastCumulativeAck", lastCumulativeAck)
+                        .attr("individualAcks", pendingIndividualAcks)
+                        .attr("individualBatchIndexAcks", entriesToAck)
+                        .log("Flushing pending acks to broker");
             cnx.ctx().flush();
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -31,6 +31,7 @@ import static org.apache.pulsar.common.protocol.Commands.hasChecksum;
 import static org.apache.pulsar.common.protocol.Commands.readChecksum;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -108,10 +109,10 @@ import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, ConnectionHandler.Connection {
+
+    private static final Logger LOG = Logger.get(ProducerImpl.class);
 
     // Producer id, used to identify a producer within a single connection
     protected final long producerId;
@@ -137,6 +138,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     // Globally unique producer name
     protected String producerName;
+    protected final Logger log;
     private final boolean userProvidedProducerName;
 
     private String connectionId;
@@ -218,6 +220,13 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         overrideProducerName.ifPresent(key -> this.producerName = key);
 
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("producerName", () -> producerName)
+                .attr("producerId", () -> producerId)
+                .attr("channel", () -> cnx() != null ? cnx().channel() : null)
+                .build();
+
         this.compressor = CompressionCodecProvider.getCompressionCodec(conf.getCompressionType());
 
         if (conf.getInitialSequenceId() != null) {
@@ -242,7 +251,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 try {
                     msgCryptoBc = new MessageCryptoBc(logCtx, true);
                 } catch (Exception e) {
-                    log.error("MessageCryptoBc may not included in the jar in Producer. e:", e);
+                    log.error().exception(e).log("MessageCryptoBc may not be included in the jar in Producer");
                     msgCryptoBc = null;
                 }
                 this.msgCrypto = msgCryptoBc;
@@ -258,7 +267,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     msgCrypto.addPublicKeyCipher(conf.getEncryptionKeys(), conf.getCryptoKeyReader());
                 } catch (CryptoException e) {
                     if (!producerCreatedFuture.isDone()) {
-                        log.warn("[{}] [{}] [{}] Failed to add public key cipher.", topic, producerName, producerId);
+                        log.warn().log("Failed to add public key cipher");
                         producerCreatedFuture.completeExceptionally(
                                 PulsarClientException.wrap(e,
                                         String.format("The producer %s of the topic %s "
@@ -350,9 +359,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 final int availableReleasePermits =
                         conf.getMaxPendingMessages() - this.semaphore.get().availablePermits();
                 if (availableReleasePermits - releaseCountRequest < 0) {
-                    log.error("Semaphore permit release count request greater then availableReleasePermits"
-                                    + " : availableReleasePermits={}, releaseCountRequest={}",
-                            availableReleasePermits, releaseCountRequest);
+                    log.error().attr("availablereleasepermits", availableReleasePermits)
+                            .attr("releasecountrequest", releaseCountRequest)
+                            .log("Semaphore permit release count request"
+                                    + " greater then availableReleasePermits:"
+                                    + " availableReleasePermits=,"
+                                    + " releaseCountRequest=");
                     errorState = true;
                 }
             }
@@ -410,9 +422,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     public void printWarnLogWhenCanNotDetermineDeduplication(Channel channel, long sequenceId,
                                                              long highestSequenceId) {
-        log.warn("[{}] producer [id:{}, name:{}, channel: {}] message with sequence-id {}-{} published by has been"
-                        + " dropped because Broker can not determine whether is duplicate or not",
-                topic, producerId, producerName, channel, sequenceId, highestSequenceId);
+        log.warn()
+                .attr("sequenceId", sequenceId)
+                .attr("highestSequenceId", highestSequenceId)
+                .log("Message has been dropped"
+                        + " because Broker can not determine whether"
+                        + " is duplicate or not");
     }
 
     private class DefaultSendMessageCallback implements SendCallback {
@@ -465,8 +480,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             pendingBytesUpDownCounter.subtract(msgSize);
             ByteBuf payload = msg.getDataBuffer();
             if (payload == null) {
-                log.error("[{}] [{}] Payload is null when calling onSendComplete, which is not expected.",
-                        topic, producerName);
+                log.error("Payload is null when calling onSendComplete, which is not expected.");
             }
             try {
                 if (e != null) {
@@ -783,10 +797,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 if (sequenceId <= lastSequenceIdPushed) {
                     isLastSequenceIdPotentialDuplicated = true;
                     if (sequenceId <= lastSequenceIdPublished) {
-                        log.warn("Message with sequence id {} is definitely a duplicate", sequenceId);
+                        log.warn().attr("sequenceId", sequenceId).log("Message is definitely a duplicate");
                     } else {
-                        log.info("Message with sequence id {} might be a duplicate but cannot be determined at this"
-                                + " time.", sequenceId);
+                        log.info().attr("sequenceId", sequenceId)
+                                .log("Message might be a duplicate but cannot"
+                                        + " be determined at this time.");
                     }
                     doBatchSendAndAdd(msg, callback, payload);
                 } else {
@@ -916,7 +931,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         getOrCreateSchemaAsync(cnx, schemaInfo).handle((v, ex) -> {
             if (ex != null) {
                 Throwable t = FutureUtil.unwrapCompletionException(ex);
-                log.warn("[{}] [{}] GetOrCreateSchema error", topic, producerName, t);
+                log.warn()
+                        .exception(t)
+                        .log("GetOrCreateSchema error");
                 if (t instanceof PulsarClientException.IncompatibleSchemaException) {
                     // Only the first time of failed schema registration will trigger a "recoverProcessOpSendMsgFrom".
                     if (!Broken.equals(msg.getSchemaState())) {
@@ -929,7 +946,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     return null;
                 }
             } else {
-                log.info("[{}] [{}] GetOrCreateSchema succeed", topic, producerName);
+                log.info("GetOrCreateSchema succeed");
                 // In broker, if schema version is an empty byte array, it means the topic doesn't have schema.
                 // In this case, we cache the schema version to `SchemaVersion.Empty.bytes()`.
                 // When we need to set the schema version of the message metadata,
@@ -961,7 +978,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         long requestId = client.newRequestId();
         ByteBuf request = Commands.newGetOrCreateSchema(requestId, topic, schemaInfo);
-        log.info("[{}] [{}] GetOrCreateSchema request", topic, producerName);
+        log.info("GetOrCreateSchema request");
         return cnx.sendGetOrCreateSchema(request, requestId);
     }
 
@@ -987,8 +1004,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         } catch (PulsarClientException e) {
             // Unless config is set to explicitly publish un-encrypted message upon failure, fail the request
             if (conf.getCryptoFailureAction() == ProducerCryptoFailureAction.SEND) {
-                log.warn("[{}] [{}] Failed to encrypt message {}. Proceeding with publishing unencrypted message",
-                        topic, producerName, e.getMessage());
+                log.warn()
+                        .exceptionMessage(e)
+                        .log("Failed to encrypt message. Proceeding with publishing unencrypted message");
                 return compressedPayload;
             }
             throw e;
@@ -1043,10 +1061,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     private void doBatchSendAndAdd(MessageImpl<?> msg, SendCallback callback, ByteBuf payload) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] Closing out batch to accommodate large message with size {}", topic, producerName,
-                    msg.getUncompressedSize());
-        }
+            log.debug()
+                    .attr("messageSize", msg.getUncompressedSize())
+                    .log("Closing out batch to accommodate large message");
         try {
             batchMessageAndSend(false);
             boolean isBatchFull = batchMessageContainer.add(msg, callback);
@@ -1154,10 +1171,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
         @Override
         public void run() {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Sending message cnx {}, sequenceId {}", producer.topic, producer.producerName, cnx,
-                        sequenceId);
-            }
+                producer.log.debug()
+                        .attr("sequenceId", sequenceId)
+                        .log("Sending message");
 
             try {
                 cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
@@ -1232,7 +1248,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         if (schema != null) {
             closeTasks.add(schema.closeAsync().whenComplete((__, t) -> {
                 if (t != null) {
-                    log.warn("Exception ignored in closing schema of producer", t);
+                    log.warn().exception(t).log("Exception ignored in closing schema of producer");
                 }
             }));
         }
@@ -1247,7 +1263,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
         ClientCnx cnx = cnx();
         if (cnx == null || currentState != State.Ready) {
-            log.info("[{}] [{}] Closed Producer (not connected)", topic, producerName);
+            log.info("Closed Producer (not connected)");
             closeAndClearPendingMessages();
             return CompletableFuture.completedFuture(null);
         }
@@ -1260,7 +1276,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             if (exception == null || !cnx.ctx().channel().isActive()) {
                 // Either we've received the success response for the close producer command from the broker, or the
                 // connection did break in the meantime. In any case, the producer is gone.
-                log.info("[{}] [{}] Closed Producer", topic, producerName);
+                log.info("Closed Producer");
                 closeAndClearPendingMessages();
                 closeFuture.complete(null);
             } else {
@@ -1320,7 +1336,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     public void terminated(ClientCnx cnx) {
         State previousState = getAndUpdateState(state -> (state == State.Closed ? State.Closed : State.Terminated));
         if (previousState != State.Terminated && previousState != State.Closed) {
-            log.info("[{}] [{}] The topic has been terminated", topic, producerName);
+            log.info("The topic has been terminated");
             setClientCnx(null);
             synchronized (this) {
                 failPendingMessages(cnx,
@@ -1336,41 +1352,49 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         synchronized (this) {
             op = pendingMessages.peek();
             if (op == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Got ack for timed out msg {} - {}",
-                            topic, producerName, sequenceId, highestSequenceId);
-                }
+                    log.debug()
+                            .attr("msg", sequenceId)
+                            .attr("highestSequenceId", highestSequenceId)
+                            .log("Got ack for timed out msg");
                 return;
             }
 
             if (sequenceId > op.sequenceId) {
-                log.warn("[{}] [{}] Got ack for msg. expecting: {} - {} - got: {} - {} - queue-size: {}",
-                        topic, producerName, op.sequenceId, op.highestSequenceId, sequenceId, highestSequenceId,
-                        pendingMessages.messagesCount());
+                log.warn()
+                        .attr("expectedSequenceId", op.sequenceId)
+                        .attr("expectedHighestSequenceId", op.highestSequenceId)
+                        .attr("gotSequenceId", sequenceId)
+                        .attr("gotHighestSequenceId", highestSequenceId)
+                        .attr("queueSize", pendingMessages.messagesCount())
+                        .log("Got ack for msg with unexpected sequence id");
                 // Force connection closing so that messages can be re-transmitted in a new connection
                 cnx.channel().close();
                 return;
             } else if (sequenceId < op.sequenceId) {
                 // Ignoring the ack since it's referring to a message that has already timed out.
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Got ack for timed out msg. expecting: {} - {} - got: {} - {}",
-                            topic, producerName, op.sequenceId, op.highestSequenceId, sequenceId, highestSequenceId);
-                }
+                log.debug()
+                        .attr("expectedSequenceId", op.sequenceId)
+                        .attr("expectedHighestSequenceId", op.highestSequenceId)
+                        .attr("gotSequenceId", sequenceId)
+                        .attr("gotHighestSequenceId", highestSequenceId)
+                        .log("Got ack for timed out msg");
                 return;
             } else {
                 // Add check `sequenceId >= highestSequenceId` for backward compatibility.
                 if (sequenceId >= highestSequenceId || highestSequenceId == op.highestSequenceId) {
                     // Message was persisted correctly
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] Received ack for msg {} ", topic, producerName, sequenceId);
-                    }
+                    log.debug()
+                            .attr("sequenceId", sequenceId).log("Received ack for msg");
                     pendingMessages.remove();
                     releaseSemaphoreForSendOp(op);
                 } else {
-                    log.warn("[{}] [{}] Got ack for batch msg error. expecting: {} - {} - got: {} - {} - queue-size: {}"
-                                    + "",
-                            topic, producerName, op.sequenceId, op.highestSequenceId, sequenceId, highestSequenceId,
-                            pendingMessages.messagesCount());
+                    log.warn()
+                            .attr("expectedSequenceId", op.sequenceId)
+                            .attr("expectedHighestSequenceId", op.highestSequenceId)
+                            .attr("gotSequenceId", sequenceId)
+                            .attr("gotHighestSequenceId", highestSequenceId)
+                            .attr("queueSize", pendingMessages.messagesCount())
+                            .log("Got ack for batch msg with unexpected highest sequence id");
                     // Force connection closing so that messages can be re-transmitted in a new connection
                     cnx.channel().close();
                     return;
@@ -1398,8 +1422,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 // application
                 op.sendComplete(null);
             } catch (Throwable t) {
-                log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topic,
-                        producerName, sequenceId, t);
+                log.warn()
+                        .attr("msg", sequenceId)
+                        .exception(t)
+                        .log("Got exception while completing the callback for msg");
             }
         }
         ReferenceCountUtil.safeRelease(op.cmd);
@@ -1439,9 +1465,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     protected synchronized void recoverChecksumError(ClientCnx cnx, long sequenceId) {
         OpSendMsg op = pendingMessages.peek();
         if (op == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Got send failure for timed out msg {}", topic, producerName, sequenceId);
-            }
+                log.debug()
+                        .attr("msg", sequenceId)
+                        .log("Got send failure for timed out msg");
         } else {
             long expectedSequenceId = getHighestSequenceId(op);
             if (sequenceId == expectedSequenceId) {
@@ -1457,23 +1483,24 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                                                 + "topic "
                                                 + "%s is corrupted", producerName, topic)));
                     } catch (Throwable t) {
-                        log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topic,
-                                producerName, sequenceId, t);
+                        log.warn()
+                                .attr("msg", sequenceId)
+                                .exception(t)
+                                .log("Got exception while completing the callback for msg");
                     }
                     ReferenceCountUtil.safeRelease(op.cmd);
                     op.recycle();
                     return;
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] Message is not corrupted, retry send-message with sequenceId {}", topic,
-                                producerName, sequenceId);
-                    }
+                        log.debug()
+                                .attr("sequenceid", sequenceId)
+                                .log("Message is not corrupted, retry send-message with sequenceId");
                 }
 
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Corrupt message is already timed out {}", topic, producerName, sequenceId);
-                }
+                    log.debug()
+                            .attr("out", sequenceId)
+                            .log("Corrupt message is already timed out");
             }
         }
         // as msg is not corrupted : let producer resend pending-messages again including checksum failed message
@@ -1489,8 +1516,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 op.sendComplete(
                         new PulsarClientException.NotAllowedException(errorMsg));
             } catch (Throwable t) {
-                log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topic,
-                        producerName, sequenceId, t);
+                log.warn()
+                        .attr("msg", sequenceId)
+                        .exception(t)
+                        .log("Got exception while completing the callback for msg");
             }
             ReferenceCountUtil.safeRelease(op.cmd);
             op.recycle();
@@ -1524,15 +1553,16 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     long computedChecksum = resumeChecksum(metadataChecksum, msg.getSecond());
                     return checksum == computedChecksum;
                 } else {
-                    log.warn("[{}] [{}] checksum is not present into message with id {}", topic, producerName,
-                            op.sequenceId);
+                    log.warn()
+                            .attr("sequenceId", op.sequenceId)
+                            .log("checksum is not present in message");
                 }
             } finally {
                 headerFrame.resetReaderIndex();
             }
             return true;
         } else {
-            log.warn("[{}] Failed while casting empty ByteBufPair, ", producerName);
+            log.warn("Failed while casting empty ByteBufPair");
             return false;
         }
     }
@@ -1924,7 +1954,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
         cnx.registerProducer(producerId, this);
 
-        log.info("[{}] [{}] Creating producer on cnx {}", topic, producerName, cnx.ctx().channel());
+        log.info("Creating producer");
 
         long requestId = client.newRequestId();
 
@@ -1987,11 +2017,13 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 }
                 resetBackoff();
 
-                log.info("[{}] [{}] Created producer on cnx {}", topic, producerName, cnx.ctx().channel());
+                log.info("Created producer");
                 connectionId = cnx.ctx().channel().toString();
                 connectedSince = DateFormatter.now();
                 if (conf.getAccessMode() != ProducerAccessMode.Shared && !topicEpoch.isPresent()) {
-                    log.info("[{}] [{}] Producer epoch is {}", topic, producerName, response.getTopicEpoch());
+                    log.info()
+                            .attr("topicEpoch", response.getTopicEpoch())
+                            .log("Producer epoch is");
                 }
                 topicEpoch = response.getTopicEpoch();
 
@@ -2050,13 +2082,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
             if (cause instanceof PulsarClientException.ProducerBlockedQuotaExceededException) {
                 synchronized (this) {
-                    log.warn("[{}] [{}] Topic backlog quota exceeded. Throwing Exception on producer.", topic,
-                            producerName);
-
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] Pending messages: {}", topic, producerName,
-                                pendingMessages.messagesCount());
-                    }
+                    log.warn("Topic backlog quota exceeded. Throwing Exception on producer.");
+                        log.debug()
+                                .attr("messages", pendingMessages.messagesCount())
+                                .log("Pending messages");
 
                     PulsarClientException bqe = new PulsarClientException.ProducerBlockedQuotaExceededException(
                             format("The backlog quota of the topic %s that the producer %s produces to is exceeded",
@@ -2064,12 +2093,15 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     failPendingMessages(cnx(), bqe);
                 }
             } else if (cause instanceof PulsarClientException.ProducerBlockedQuotaExceededError) {
-                log.warn("[{}] [{}] Producer is blocked on creation because backlog exceeded on topic.",
-                        producerName, topic);
+                log.warn("Producer is blocked on creation because backlog exceeded on topic.");
             } else if (PulsarClientException.isRetriableError(cause)) {
-                log.info("[{}] [{}] Temporary error in creating producer: {}", topic, producerName, cause.getMessage());
+                log.info()
+                        .exceptionMessage(cause)
+                        .log("Temporary error in creating producer");
             } else {
-                log.error("[{}] [{}] Failed to create producer: {}", topic, producerName, cause.getMessage());
+                log.error()
+                        .exceptionMessage(cause)
+                        .log("Failed to create producer");
             }
 
             if (cause instanceof PulsarClientException.TopicTerminatedException) {
@@ -2124,11 +2156,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     protected void closeWhenReceivedUnrecoverableError(Throwable t, ClientCnx cnx) {
         final String cnxStr = cnx == null ? "null" : String.valueOf(cnx.channel().remoteAddress());
-        log.warn("[{}][{}] {} Closed producer because get an error that does not support to retry: {} {}",
-                topic, producerName, cnxStr, t.getClass().getName(), t.getMessage());
+        log.warn()
+                .attr("cnxStr", cnxStr)
+                .attr("retry", t.getClass().getName())
+                .exceptionMessage(t)
+                .log("Closed producer because get an error that does not support to retry");
         closeAsync().whenComplete((v, ex) -> {
             if (ex != null) {
-                log.error("Failed to close producer on TopicDoesNotExistException.", ex);
+                log.error().exception(ex).log("Failed to close producer on TopicDoesNotExistException.");
             }
             producerCreatedFuture.completeExceptionally(t);
         });
@@ -2142,10 +2177,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             exception.setPreviousExceptionCount(previousExceptionCount);
             if (producerCreatedFuture.completeExceptionally(exception)) {
                 if (nonRetriableError) {
-                    log.info("[{}] Producer creation failed for producer {} with unretriableError = {}",
-                            topic, producerId, exception.getMessage());
+                    log.info()
+                            .exceptionMessage(exception)
+                            .log("Producer creation failed for producer with unretriableError =");
                 } else {
-                    log.info("[{}] Producer creation failed for producer {} after producerTimeout", topic, producerId);
+                    log.info()
+                            .log("Producer creation failed for producer after producerTimeout");
                 }
                 closeProducerTasks();
                 setState(State.Failed);
@@ -2190,9 +2227,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
                 int messagesToResend = pendingMessages.messagesCount();
                 if (pendingMessages.size() == 0) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] No pending messages to resend {}", topic, producerName, messagesToResend);
-                    }
+                        log.debug()
+                                .attr("resend", messagesToResend)
+                                .log("No pending messages to resend");
                     if (changeToReadyState()) {
                         producerCreatedFuture.complete(ProducerImpl.this);
                         scheduleBatchFlushTask(0);
@@ -2206,7 +2243,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
                 }
 
-                log.info("[{}] [{}] Re-Sending {} messages to server", topic, producerName, messagesToResend);
+                log.info()
+                        .attr("reSending", messagesToResend)
+                        .log("Re-Sending messages to server");
                 recoverProcessOpSendMsgFrom(cnx, null, false, expectedEpoch);
             }
         });
@@ -2252,7 +2291,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 headerFrame.resetReaderIndex();
             }
         } else {
-            log.warn("[{}] Failed while casting null into ByteBufPair", producerName);
+            log.warn("Failed while casting null into ByteBufPair");
         }
     }
 
@@ -2309,8 +2348,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 if (diff <= 0) {
                     // The diff is less than or equal to zero, meaning that the message has been timed out.
                     // Set the callback to timeout on every message, then clear the pending queue.
-                    log.info("[{}] [{}] Message send timed out. Failing {} messages", topic, producerName,
-                            getPendingQueueSize());
+                    log.info()
+                            .attr("failing", getPendingQueueSize())
+                            .log("Message send timed out. Failing messages");
                     String msg = format("The producer %s can not send message to the topic %s within given timeout",
                             producerName, topic);
                     if (firstMsg != null) {
@@ -2359,8 +2399,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         op.sendComplete(ex);
                     }
                 } catch (Throwable t) {
-                    log.warn("[{}] [{}] Got exception while completing the callback for msg {}:", topic, producerName,
-                            op.sequenceId, t);
+                    log.warn()
+                            .attr("sequenceId", op.sequenceId)
+                            .exception(t)
+                            .log("Got exception while completing the callback");
                 }
 
                 client.getMemoryLimitController().releaseMemory(op.uncompressedSize);
@@ -2441,10 +2483,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     private synchronized void batchFlushTask() {
-        if (log.isTraceEnabled()) {
-            log.trace("[{}] [{}] Batching the messages from the batch container from flush thread",
-                    topic, producerName);
-        }
+            log.trace("Batching the messages from the batch container from flush thread");
         this.batchFlushTask = null;
         // If we're not ready, don't schedule another flush and don't try to send.
         if (getState() != State.Ready) {
@@ -2466,10 +2505,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     // must acquire semaphore before enqueuing
     private void batchMessageAndSend(boolean shouldScheduleNextBatchFlush) {
-        if (log.isTraceEnabled()) {
-            log.trace("[{}] [{}] Batching the messages from the batch container with {} messages", topic, producerName,
-                    batchMessageContainer.getNumMessagesInBatch());
-        }
+            log.trace()
+                    .attr("numMessagesInBatch", batchMessageContainer.getNumMessagesInBatch())
+                    .log("Batching the messages from the batch container with messages");
         if (!batchMessageContainer.isEmpty()) {
             try {
                 lastBatchSendNanoTime = System.nanoTime();
@@ -2486,8 +2524,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             } catch (Throwable t) {
                 // Since there is a uncompleted payload was built, we should reset it.
                 batchMessageContainer.resetPayloadAfterFailedPublishing();
-                log.warn("[{}] [{}] Failed to create batch message for sending. Batch payloads have been reset and"
-                                + " messages will be retried in subsequent batches.", topic, producerName, t);
+                log.warn()
+                        .exception(t)
+                        .log("Failed to create batch message for sending."
+                                + " Batch payloads have been reset and messages"
+                                + " will be retried in subsequent batches.");
             } finally {
                 if (shouldScheduleNextBatchFlush) {
                     maybeScheduleBatchFlushTask();
@@ -2539,14 +2580,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 cnx.ctx().channel().eventLoop().execute(WriteInEventLoopCallback.create(this, cnx, op));
                 stats.updateNumMsgsSent(op.numMessagesInBatch, op.batchSizeByte);
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Connection is not ready -- sequenceId {}", topic, producerName,
-                            op.sequenceId);
-                }
+                    log.debug()
+                            .attr("sequenceid", op.sequenceId)
+                            .log("Connection is not ready -- sequenceId");
             }
         } catch (Throwable t) {
             releaseSemaphoreForSendOp(op);
-            log.warn("[{}] [{}] error while closing out batch -- {}", topic, producerName, t);
+            log.warn()
+                    .exception(t).log("error while closing out batch");
             op.sendComplete(new PulsarClientException(t, op.sequenceId));
         }
     }
@@ -2581,9 +2622,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         if (expectedEpoch != this.connectionHandler.getEpoch() || cnx() == null) {
             // In this case, the cnx passed to this method is no longer the active connection. This method will get
             // called again once the new connection registers the producer with the broker.
-            log.info("[{}][{}] Producer epoch mismatch or the current connection is null. Skip re-sending the "
-                            + " {} pending messages since they will deliver using another connection.", topic,
-                    producerName, pendingMessages.messagesCount());
+            log.info()
+                    .attr("messagesCount", pendingMessages.messagesCount())
+                    .log("Producer epoch mismatch or the current connection"
+                            + " is null. Skip re-sending the pending messages"
+                            + " since they will deliver using another"
+                            + " connection.");
             return;
         }
         final boolean stripChecksum = cnx.getRemoteEndpointProtocolVersion() < brokerChecksumSupportedVersion();
@@ -2612,9 +2656,12 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         // as it was set to "schemaState -> Broken".
                         SchemaInfo msgSchemaInfo = op.msg.hasReplicateFrom() ? op.msg.getSchemaInfoForReplicator()
                                 : op.msg.getSchemaInfo();
-                        log.error("[{}] [{}] A message attempts to register new schema, but failed. It should be"
-                            + " removed from the pending queue but not, which is not expected. {}",
-                            topic, producerName, SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false));
+                        log.error()
+                                .attr("expected", SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false))
+                                .log("A message attempts to register new"
+                                        + " schema, but failed. It should be"
+                                        + " removed from the pending queue"
+                                        + " but not, which is not expected.");
                         releaseSemaphoreForSendOp(op);
                         msgIterator.remove();
                         op.recycle();
@@ -2630,10 +2677,14 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     // Otherwise, subsequent messages with compatible schemas would be delivered while this message
                     // remains stuck, causing out-of-order delivery or potential message loss with deduplication.
                     if (pauseSendingToPreservePublishOrderOnSchemaRegFailure) {
-                        log.error("[{}] [{}] Publishing paused: message schema incompatible with target cluster."
-                                + " To resume publishing: 1) Adjust schema compatibility strategy on target cluster"
-                                + " 2) Unload topic on target cluster. Schema details: {}",
-                                topic, producerName, SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false));
+                        log.error()
+                                .attr("details", SchemaUtils.jsonifySchemaInfo(msgSchemaInfo, false))
+                                .log("Publishing paused: message schema"
+                                        + " incompatible with target cluster."
+                                        + " To resume publishing: 1) Adjust"
+                                        + " schema compatibility strategy on"
+                                        + " target cluster 2) Unload topic on"
+                                        + " target cluster. Schema details");
                         loopEndDueToSchemaRegisterNeeded = op;
                         pausedSendingToPreservePublishOrderOnSchemaRegFailure = true;
                         break;
@@ -2655,7 +2706,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                         // application
                         op.sendComplete(new IncompatibleSchemaException(failedMsg));
                     } catch (Throwable t) {
-                        log.warn("Got exception while completing the failed publishing: {}", failedMsg, t);
+                        log.warn().attr("publishing", failedMsg)
+                                .exception(t)
+                                .log("Got exception while completing the failed publishing");
                     }
                     releaseSemaphoreForSendOp(op);
                     op.recycle();
@@ -2681,10 +2734,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 stripChecksum(op);
             }
             op.cmd.retain();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Re-Sending message in cnx {}, sequenceId {}", topic, producerName,
-                        cnx.channel(), op.sequenceId);
-            }
+                log.debug()
+                        .attr("sequenceId", op.sequenceId)
+                        .log("Re-Sending message");
             cnx.ctx().write(op.cmd, cnx.ctx().voidPromise());
             op.updateSentTimestamp();
             stats.updateNumMsgsSent(op.numMessagesInBatch, op.batchSizeByte);
@@ -2830,6 +2882,4 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         CompletableFuture<MessageId> lastSendFuture = this.lastSendFuture;
         return lastSendFuture.thenApply(ignore -> null);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ProducerImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
@@ -21,20 +21,18 @@ package org.apache.pulsar.client.impl;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A container that holds the list{@link ProducerInterceptor}
  * and wraps calls to the chain of custom interceptors.
  */
+@CustomLog
 public class ProducerInterceptors implements Closeable {
-
-    private static final Logger log = LoggerFactory.getLogger(ProducerInterceptors.class);
 
     private final List<ProducerInterceptor> interceptors;
 
@@ -67,10 +65,11 @@ public class ProducerInterceptors implements Closeable {
                 interceptorMessage = interceptor.beforeSend(producer, interceptorMessage);
             } catch (Throwable e) {
                 if (producer != null) {
-                    log.warn("Error executing interceptor beforeSend callback for topicName:{} ",
-                            producer.getTopic(), e);
+                    log.warn().attr("topic", producer.getTopic())
+                            .exception(e)
+                            .log("Error executing interceptor beforeSend callback for topicName");
                 } else {
-                    log.warn("Error Error executing interceptor beforeSend callback ", e);
+                    log.warn().exception(e).log("Error Error executing interceptor beforeSend callback ");
                 }
             }
         }
@@ -99,7 +98,7 @@ public class ProducerInterceptors implements Closeable {
                 }
                 interceptor.onSendAcknowledgement(producer, message, msgId, exception);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onSendAcknowledgement callback ", e);
+                log.warn().exception(e).log("Error executing interceptor onSendAcknowledgement callback ");
             }
         }
     }
@@ -109,7 +108,7 @@ public class ProducerInterceptors implements Closeable {
             try {
                 interceptor.onPartitionsChange(topicName, partitions);
             } catch (Throwable e) {
-                log.warn("Error executing interceptor onPartitionsChange callback ", e);
+                log.warn().exception(e).log("Error executing interceptor onPartitionsChange callback ");
             }
         }
     }
@@ -120,7 +119,7 @@ public class ProducerInterceptors implements Closeable {
             try {
                 interceptor.close();
             } catch (Throwable e) {
-                log.error("Fail to close producer interceptor ", e);
+                log.error().exception(e).log("Fail to close producer interceptor ");
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -121,8 +121,8 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
             } catch (Exception e) {
                 log.error().attr("topic", producer.getTopic())
                         .attr("producerName", producer.getProducerName())
-                        .exceptionMessage(e)
-                        .log("operation");
+                        .exception(e)
+                        .log("Failed to update producer stats");
             } finally {
                 // schedule the next stat info
                 statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStatsRecorderImpl.java
@@ -27,13 +27,13 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.ProducerStats;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("deprecation")
+@CustomLog
 public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
 
     private static final long serialVersionUID = 1L;
@@ -103,10 +103,11 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
                 .without(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
         try {
-            log.info("Starting Pulsar producer perf with config: {}", w.writeValueAsString(conf));
-            log.info("Pulsar client config: {}", w.writeValueAsString(pulsarClient.getConfiguration()));
+            log.info().attr("config", w.writeValueAsString(conf)).log("Starting Pulsar producer perf with config");
+            log.info().attr("config", w.writeValueAsString(pulsarClient.getConfiguration()))
+                    .log("Pulsar client config");
         } catch (IOException e) {
-            log.error("Failed to dump config info", e);
+            log.error().exception(e).log("Failed to dump config info");
         }
 
         stat = (timeout) -> {
@@ -118,7 +119,10 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
             try {
                 updateStats();
             } catch (Exception e) {
-                log.error("[{}] [{}]: {}", producer.getTopic(), producer.getProducerName(), e.getMessage());
+                log.error().attr("topic", producer.getTopic())
+                        .attr("producerName", producer.getProducerName())
+                        .exceptionMessage(e)
+                        .log("operation");
             } finally {
                 // schedule the next stat info
                 statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);
@@ -176,27 +180,29 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
                 }
             }
 
-            log.info("[{}] [{}] --- Publish throughput: {} msg/s --- {} Mbit/s --- "
-                            + "Latency: med: {} ms - 95pct: {} ms - 99pct: {} ms - 99.9pct: {} ms - max: {} ms --- "
-                            + "BatchSize: med: {} - 95pct: {} - 99pct: {} - 99.9pct: {} - max: {} --- "
-                            + "MsgSize: med: {} bytes - 95pct: {} bytes - 99pct: {} bytes - 99.9pct: {} bytes "
-                            + "- max: {} bytes --- "
-                            + "Ack received rate: {} ack/s --- Failed messages: {} --- Pending messages: {}",
-                    producer.getTopic(),
-                    producer.getProducerName(),
-                    THROUGHPUT_FORMAT.format(sendMsgsRate),
-                    THROUGHPUT_FORMAT.format(sendBytesRate / 1024 / 1024 * 8),
-                    DEC.format(latencyPctValues[0]), DEC.format(latencyPctValues[2]),
-                    DEC.format(latencyPctValues[3]), DEC.format(latencyPctValues[4]),
-                    DEC.format(latencyPctValues[5]),
-                    DEC.format(batchSizePctValues[0]), DEC.format(batchSizePctValues[2]),
-                    DEC.format(batchSizePctValues[3]), DEC.format(batchSizePctValues[4]),
-                    DEC.format(batchSizePctValues[5]),
-                    DEC.format(msgSizePctValues[0]), DEC.format(msgSizePctValues[2]),
-                    DEC.format(msgSizePctValues[3]), DEC.format(msgSizePctValues[4]),
-                    DEC.format(msgSizePctValues[5]),
-                    THROUGHPUT_FORMAT.format(currentNumAcksReceived / elapsed), currentNumSendFailedMsgs,
-                    getPendingQueueSize());
+            log.info().attr("topic", producer.getTopic())
+                    .attr("producerName", producer.getProducerName())
+                    .attr("sendMsgRate", THROUGHPUT_FORMAT.format(sendMsgsRate))
+                    .attr("sendBytesRateMbps", THROUGHPUT_FORMAT.format(sendBytesRate / 1024 / 1024 * 8))
+                    .attr("latencyMedMs", DEC.format(latencyPctValues[0]))
+                    .attr("latency95pctMs", DEC.format(latencyPctValues[2]))
+                    .attr("latency99pctMs", DEC.format(latencyPctValues[3]))
+                    .attr("latency999pctMs", DEC.format(latencyPctValues[4]))
+                    .attr("latencyMaxMs", DEC.format(latencyPctValues[5]))
+                    .attr("batchSizeMed", DEC.format(batchSizePctValues[0]))
+                    .attr("batchSize95pct", DEC.format(batchSizePctValues[2]))
+                    .attr("batchSize99pct", DEC.format(batchSizePctValues[3]))
+                    .attr("batchSize999pct", DEC.format(batchSizePctValues[4]))
+                    .attr("batchSizeMax", DEC.format(batchSizePctValues[5]))
+                    .attr("msgSizeMedBytes", DEC.format(msgSizePctValues[0]))
+                    .attr("msgSize95pctBytes", DEC.format(msgSizePctValues[2]))
+                    .attr("msgSize99pctBytes", DEC.format(msgSizePctValues[3]))
+                    .attr("msgSize999pctBytes", DEC.format(msgSizePctValues[4]))
+                    .attr("msgSizeMaxBytes", DEC.format(msgSizePctValues[5]))
+                    .attr("ackReceivedRate", THROUGHPUT_FORMAT.format(currentNumAcksReceived / elapsed))
+                    .attr("failedMessages", currentNumSendFailedMsgs)
+                    .attr("pendingMessages", getPendingQueueSize())
+                    .log("Publish stats");
         }
     }
 
@@ -343,6 +349,4 @@ public class ProducerStatsRecorderImpl implements ProducerStatsRecorder {
             statTimeout = null;
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ProducerStatsRecorderImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -32,8 +32,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.protocol.ByteBufPair;
@@ -45,7 +45,7 @@ import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
 
-@Slf4j
+@CustomLog
 public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     public static final String TLS_HANDLER = "tls";
@@ -127,7 +127,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
                         factory.createInternalSslContext();
                         return factory;
                     } catch (Exception e) {
-                        log.error("Unable to initialize and create the ssl context", e);
+                        log.error().exception(e).log("Unable to initialize and create the ssl context");
                         initTlsFuture.completeExceptionally(e);
                         return null;
                     }
@@ -229,13 +229,13 @@ protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData c
                         pulsarSslFactory.getInternalNettySslContext();
                     }
                 } catch (Exception e) {
-                    log.error("SSL Context is not initialized", e);
+                    log.error().exception(e).log("SSL Context is not initialized");
                     PulsarSslConfiguration sslConfiguration = buildSslConfiguration(conf, key);
                     pulsarSslFactory.initialize(sslConfiguration);
                 }
                 pulsarSslFactory.update();
             } catch (Exception e) {
-                log.error("Failed to refresh SSL context", e);
+                log.error().exception(e).log("Failed to refresh SSL context");
             }
         });
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -99,12 +100,9 @@ import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.DnsResolverUtil;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class PulsarClientImpl implements PulsarClient {
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
     private static final int CLOSE_TIMEOUT_SECONDS = 60;
     protected static final double THRESHOLD_FOR_CONSUMER_RECEIVER_QUEUE_SIZE_SHRINKING = 0.95;
 
@@ -283,7 +281,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     tcClient.start();
                 } catch (Throwable e) {
-                    log.error("Start transactionCoordinatorClient error.", e);
+                    log.error().exception(e).log("Start transactionCoordinatorClient error.");
                     throw new PulsarClientException(e);
                 }
             }
@@ -306,7 +304,7 @@ public class PulsarClientImpl implements PulsarClient {
         } catch (Throwable t) {
             // Log the exception first, or it could be missed if there are any subsequent exceptions in the
             // shutdown sequence
-            log.error("Failed to create Pulsar client instance.", t);
+            log.error().exception(t).log("Failed to create Pulsar client instance.");
             shutdown();
             shutdownEventLoopGroup(eventLoopGroupReference);
             closeCnxPool(connectionPoolReference);
@@ -494,9 +492,9 @@ public class PulsarClientImpl implements PulsarClient {
 
 
         checkPartitions(topic, conf.isNonPartitionedTopicExpected(), conf.getProducerName()).thenAccept(partitions -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Received topic metadata. partitions: {}", topic, partitions);
-            }
+                log.debug().attr("topic", topic)
+                        .attr("partitions", partitions)
+                        .log("Received topic metadata. partitions");
 
             ProducerBase<T> producer;
             if (partitions > 0) {
@@ -508,7 +506,7 @@ public class PulsarClientImpl implements PulsarClient {
             }
             producers.add(producer);
         }).exceptionally(ex -> {
-            log.warn("[{}] Failed to get partitioned topic metadata: {}", topic, ex.getMessage());
+            log.warn().attr("topic", topic).exceptionMessage(ex).log("Failed to get partitioned topic metadata");
             producerCreatedFuture.completeExceptionally(ex);
             return null;
         });
@@ -645,9 +643,9 @@ public class PulsarClientImpl implements PulsarClient {
         String topic = conf.getSingleTopic();
 
         getPartitionedTopicMetadata(topic, true, false).thenAccept(metadata -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Received topic metadata. partitions: {}", topic, metadata.partitions);
-            }
+                log.debug().attr("topic", topic)
+                        .attr("partitions", metadata.partitions)
+                        .log("Received topic metadata. partitions");
 
             ConsumerBase<T> consumer;
             if (metadata.partitions > 0) {
@@ -661,7 +659,7 @@ public class PulsarClientImpl implements PulsarClient {
             }
             consumers.add(consumer);
         }).exceptionally(ex -> {
-            log.warn("[{}] Failed to get partitioned topic metadata", topic, ex);
+            log.warn().attr("topic", topic).exception(ex).log("Failed to get partitioned topic metadata");
             consumerSubscribedFuture.completeExceptionally(ex);
             return null;
         });
@@ -698,15 +696,18 @@ public class PulsarClientImpl implements PulsarClient {
         CompletableFuture<Consumer<T>> consumerSubscribedFuture = new CompletableFuture<>();
         lookup.getTopicsUnderNamespace(namespaceName, subscriptionMode, regex, null, conf.getProperties())
             .thenAccept(getTopicsResult -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("Pattern consumer [{}] get topics under namespace {}, topics.size: {},"
-                                    + " topicsHash: {}, changed: {}, filtered: {}", conf.getSubscriptionName(),
-                            namespaceName, getTopicsResult.getTopics().size(), getTopicsResult.getTopicsHash(),
-                            getTopicsResult.isChanged(), getTopicsResult.isFiltered());
-                    getTopicsResult.getTopics().forEach(topicName ->
-                        log.debug("Pattern consumer [{}] get topics under namespace {}, topic: {}",
-                                conf.getSubscriptionName(), namespaceName, topicName));
-                }
+                log.debug().attr("subscriptionName", conf.getSubscriptionName())
+                        .attr("namespace", namespaceName)
+                        .attr("topicsCount", getTopicsResult.getTopics().size())
+                        .attr("topicsHash", getTopicsResult.getTopicsHash())
+                        .attr("changed", getTopicsResult.isChanged())
+                        .attr("filtered", getTopicsResult.isFiltered())
+                        .log("Pattern consumer get topics under namespace");
+                getTopicsResult.getTopics().forEach(topicName ->
+                        log.debug().attr("subscriptionName", conf.getSubscriptionName())
+                                .attr("namespace", namespaceName)
+                                .attr("topic", topicName)
+                                .log("Pattern consumer get topics under namespace"));
 
                 List<String> topicsList;
                 if (!getTopicsResult.isFiltered()) {
@@ -719,10 +720,9 @@ public class PulsarClientImpl implements PulsarClient {
                 }
                 conf.getTopicNames().addAll(topicsList);
 
-                if (log.isDebugEnabled()) {
-                    log.debug("Pattern consumer [{}] initialize topics. {}", conf.getSubscriptionName(),
-                            getTopicsResult.getNonPartitionedOrPartitionTopics());
-                }
+                log.debug().attr("subscriptionName", conf.getSubscriptionName())
+                        .attr("topics", () -> getTopicsResult.getNonPartitionedOrPartitionTopics())
+                        .log("Pattern consumer initialize topics.");
 
                 // Pattern consumer has his unique check mechanism, so do not need the feature "autoUpdatePartitions".
                 conf.setAutoUpdatePartitions(false);
@@ -736,7 +736,7 @@ public class PulsarClientImpl implements PulsarClient {
                 consumers.add(consumer);
             })
             .exceptionally(ex -> {
-                log.warn("[{}] Failed to get topics under namespace", namespaceName);
+                log.warn().attr("namespaceName", namespaceName).log("Failed to get topics under namespace");
                 consumerSubscribedFuture.completeExceptionally(ex);
                 return null;
             });
@@ -791,7 +791,7 @@ public class PulsarClientImpl implements PulsarClient {
         consumers.add(consumer);
         consumerSubscribedFuture.thenRun(() -> readerFuture.complete(reader))
                 .exceptionally(ex -> {
-                    log.warn("Failed to create multiTopicReader", ex);
+                    log.warn().exception(ex).log("Failed to create multiTopicReader");
                     readerFuture.completeExceptionally(ex);
                     return null;
                 });
@@ -805,9 +805,9 @@ public class PulsarClientImpl implements PulsarClient {
         CompletableFuture<Reader<T>> readerFuture = new CompletableFuture<>();
 
         getPartitionedTopicMetadata(topic, true, false).thenAccept(metadata -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Received topic metadata. partitions: {}", topic, metadata.partitions);
-            }
+            log.debug().attr("topic", topic)
+                    .attr("partitions", metadata.partitions)
+                    .log("Received topic metadata. partitions");
             if (metadata.partitions > 0
                     && MultiTopicsConsumerImpl.isIllegalMultiTopicsMessageId(conf.getStartMessageId())) {
                 readerFuture.completeExceptionally(
@@ -830,12 +830,12 @@ public class PulsarClientImpl implements PulsarClient {
             consumers.add(consumer);
 
             consumerSubscribedFuture.thenRun(() -> readerFuture.complete(reader)).exceptionally(ex -> {
-                log.warn("[{}] Failed to get create topic reader", topic, ex);
+                log.warn().attr("topic", topic).exception(ex).log("Failed to get create topic reader");
                 readerFuture.completeExceptionally(ex);
                 return null;
             });
         }).exceptionally(ex -> {
-            log.warn("[{}] Failed to get partitioned topic metadata", topic, ex);
+            log.warn().attr("topic", topic).exception(ex).log("Failed to get partitioned topic metadata");
             readerFuture.completeExceptionally(ex);
             return null;
         });
@@ -884,7 +884,7 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 e.getValue().close();
             } catch (Exception ex) {
-                log.error("Error closing lookup service {}", e.getKey(), ex);
+                log.error().attr("service", e.getKey()).exception(ex).log("Error closing lookup service");
             }
             closedUrlLookupServices.put(e.getKey(), e.getValue());
         });
@@ -895,7 +895,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public CompletableFuture<Void> closeAsync() {
-        log.info("Client closing. URL: {}", lookup.getServiceUrl());
+        log.info().attr("url", lookup.getServiceUrl()).log("Client closing. URL");
         if (!state.compareAndSet(State.Open, State.Closing)) {
             return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Client already closed"));
         }
@@ -907,13 +907,13 @@ public class PulsarClientImpl implements PulsarClient {
 
         producers.forEach(p -> futures.add(p.closeAsync().handle((__, t) -> {
             if (t != null) {
-                log.error("Error closing producer {}", p, t);
+                log.error().attr("producer", p).exception(t).log("Error closing producer");
             }
             return null;
         })));
         consumers.forEach(c -> futures.add(c.closeAsync().handle((__, t) -> {
             if (t != null) {
-                log.error("Error closing consumer {}", c, t);
+                log.error().attr("consumer", c).exception(t).log("Error closing consumer");
             }
             return null;
         })));
@@ -930,7 +930,7 @@ public class PulsarClientImpl implements PulsarClient {
                         PulsarClientImpl.class, "closeAsync"));
         combinedFuture.handle((__, t) -> {
             if (t != null) {
-                log.error("Closing producers and consumers failed. Continuing with shutdown.", t);
+                log.error().exception(t).log("Closing producers and consumers failed. Continuing with shutdown.");
             }
             new Thread(() -> {
                 shutdownExecutor.shutdownNow();
@@ -938,7 +938,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     shutdown();
                 } catch (PulsarClientException e) {
-                    log.error("Shutdown failed. Ignoring the exception.", e);
+                    log.error().exception(e).log("Shutdown failed. Ignoring the exception.");
                 }
                 state.set(State.Closed);
                 closeFuture.complete(null);
@@ -957,7 +957,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     lookup.close();
                 } catch (Throwable t) {
-                    log.warn("Failed to shutdown lookup", t);
+                    log.warn().exception(t).log("Failed to shutdown lookup");
                     throwable = t;
                 }
             }
@@ -988,20 +988,20 @@ public class PulsarClientImpl implements PulsarClient {
                 // eventLoopGroup.
                 shutdownEventLoopGroup(eventLoopGroup);
             } catch (PulsarClientException e) {
-                log.warn("Failed to shutdown eventLoopGroup", e);
+                log.warn().exception(e).log("Failed to shutdown eventLoopGroup");
                 throwable = e;
             }
             try {
                 closeCnxPool(cnxPool);
             } catch (PulsarClientException e) {
-                log.warn("Failed to shutdown cnxPool", e);
+                log.warn().exception(e).log("Failed to shutdown cnxPool");
                 throwable = e;
             }
             if (timer != null && needStopTimer) {
                 try {
                     timer.stop();
                 } catch (Throwable t) {
-                    log.warn("Failed to shutdown timer", t);
+                    log.warn().exception(t).log("Failed to shutdown timer");
                     throwable = t;
                 }
             }
@@ -1015,7 +1015,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     memoryBufferStats.close();
                 } catch (Throwable t) {
-                    log.warn("Failed to close memoryBufferStats", t);
+                    log.warn().exception(t).log("Failed to close memoryBufferStats");
                     throwable = t;
                 }
             }
@@ -1028,7 +1028,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     conf.getAuthentication().close();
                 } catch (Throwable t) {
-                    log.warn("Failed to close authentication", t);
+                    log.warn().exception(t).log("Failed to close authentication");
                     throwable = t;
                 }
             }
@@ -1036,7 +1036,7 @@ public class PulsarClientImpl implements PulsarClient {
                 throw throwable;
             }
         } catch (Throwable t) {
-            log.warn("Failed to shutdown Pulsar client", t);
+            log.warn().exception(t).log("Failed to shutdown Pulsar client");
             throw PulsarClientException.unwrap(t);
         }
     }
@@ -1069,7 +1069,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     externalExecutorProvider.shutdownNow();
                 } catch (Throwable t) {
-                    log.warn("Failed to shutdown externalExecutorProvider", t);
+                    log.warn().exception(t).log("Failed to shutdown externalExecutorProvider");
                     pulsarClientException = PulsarClientException.unwrap(t);
                 }
             }
@@ -1077,7 +1077,7 @@ public class PulsarClientImpl implements PulsarClient {
                 try {
                     internalExecutorProvider.shutdownNow();
                 } catch (Throwable t) {
-                    log.warn("Failed to shutdown internalExecutorService", t);
+                    log.warn().exception(t).log("Failed to shutdown internalExecutorService");
                     pulsarClientException = PulsarClientException.unwrap(t);
                 }
             }
@@ -1086,7 +1086,7 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 scheduledExecutorProvider.shutdownNow();
             } catch (Throwable t) {
-                log.warn("Failed to shutdown scheduledExecutorProvider", t);
+                log.warn().exception(t).log("Failed to shutdown scheduledExecutorProvider");
                 pulsarClientException = PulsarClientException.unwrap(t);
             }
         }
@@ -1095,7 +1095,7 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 lookupExecutorProvider.shutdownNow();
             } catch (Throwable t) {
-                log.warn("Failed to shutdown lookupExecutorProvider", t);
+                log.warn().exception(t).log("Failed to shutdown lookupExecutorProvider");
                 pulsarClientException = PulsarClientException.unwrap(t);
             }
         }
@@ -1113,7 +1113,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public synchronized void updateServiceUrl(String serviceUrl) throws PulsarClientException {
-        log.info("Updating service URL to {}", serviceUrl);
+        log.info().attr("serviceUrl", serviceUrl).log("Updating service URL");
 
         conf.setServiceUrl(serviceUrl);
         lookup.updateServiceUrl(serviceUrl);
@@ -1121,7 +1121,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public void updateAuthentication(Authentication authentication) throws IOException {
-        log.info("Updating authentication to {}", authentication);
+        log.info().attr("authentication", authentication).log("Updating authentication");
         if (conf.getAuthentication() != null) {
             conf.getAuthentication().close();
         }
@@ -1130,12 +1130,13 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public void updateTlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
-        log.info("Updating tlsTrustCertsFilePath to {}", tlsTrustCertsFilePath);
+        log.info().attr("tlsTrustCertsFilePath", tlsTrustCertsFilePath).log("Updating tlsTrustCertsFilePath");
         conf.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
     }
 
     public void updateTlsTrustStorePathAndPassword(String tlsTrustStorePath, String tlsTrustStorePassword) {
-        log.info("Updating tlsTrustStorePath to {}, tlsTrustStorePassword to *****", tlsTrustStorePath);
+        log.info().attr("tlsTrustStorePath", tlsTrustStorePath)
+                .log("Updating tlsTrustStorePath to, tlsTrustStorePassword to *****");
         conf.setTlsTrustStorePath(tlsTrustStorePath);
         conf.setTlsTrustStorePassword(tlsTrustStorePassword);
     }
@@ -1172,7 +1173,7 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 return createLookup(serviceUrl);
             } catch (PulsarClientException e) {
-                log.warn("Failed to update url to lookup service {}, {}", url, e.getMessage());
+                log.warn().attr("service", url).exceptionMessage(e).log("Failed to update url to lookup service");
                 throw new IllegalStateException("Failed to update url " + url);
             }
         });
@@ -1252,7 +1253,7 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 previousLookup.close();
             } catch (Exception e) {
-                log.warn("Failed to close previous lookup service", e);
+                log.warn().exception(e).log("Failed to close previous lookup service");
             }
         }
     }
@@ -1324,8 +1325,9 @@ public class PulsarClientImpl implements PulsarClient {
             previousExceptionCount.getAndIncrement();
 
             ((ScheduledExecutorService) scheduledExecutorProvider.getExecutor()).schedule(() -> {
-                log.warn("[topic: {}] Could not get connection while getPartitionedTopicMetadata -- "
-                        + "Will try again in {} ms", topicName, nextDelay);
+                log.warn().attr("topic", topicName)
+                        .attr("nextDelayMs", nextDelay)
+                        .log("Could not get connection while getting partitioned topic metadata, will retry");
                 remainingTime.addAndGet(-nextDelay);
                 getPartitionedTopicMetadata(topicName, backoff, remainingTime, future, previousExceptionCount,
                         metadataAutoCreationEnabled, useFallbackForNonPIP344Brokers);
@@ -1403,7 +1405,9 @@ public class PulsarClientImpl implements PulsarClient {
             try {
                 schemaInfoProvider = pulsarClientImpl.getSchemaProviderLoadingCache().get(schemaTopicName);
             } catch (ExecutionException e) {
-                log.error("Failed to load schema info provider for topic {}", schemaTopicName, e);
+                log.error().attr("topic", schemaTopicName)
+                        .exception(e)
+                        .log("Failed to load schema info provider for topic");
                 return FutureUtil.failedFuture(e.getCause());
             }
             schema = schema.clone();
@@ -1420,7 +1424,9 @@ public class PulsarClientImpl implements PulsarClient {
                         }
                     }
                     try {
-                        log.info("Configuring schema for topic {} : {}", topicName, schemaInfo);
+                        log.info().attr("topic", topicName)
+                                .attr("schemaInfo", schemaInfo)
+                                .log("Configuring schema for topic");
                         finalSchema.configureSchemaInfo(topicName, "topic", schemaInfo);
                     } catch (RuntimeException re) {
                         return FutureUtil.failedFuture(re);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientSharedResourcesImpl.java
@@ -32,8 +32,8 @@ import io.netty.util.Timer;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
@@ -42,7 +42,7 @@ import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
-@Slf4j
+@CustomLog
 @Getter
 public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResources {
     Set<SharedResource> sharedResources;
@@ -160,7 +160,7 @@ public class PulsarClientSharedResourcesImpl implements PulsarClientSharedResour
             try {
                 memoryBufferStats.close();
             } catch (Throwable t) {
-                log.warn("Failed to close shared memoryBufferStats", t);
+                log.warn().exception(t).log("Failed to close shared memoryBufferStats");
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidServiceURL;
 import org.apache.pulsar.common.net.ServiceURI;
 import org.apache.pulsar.common.util.Backoff;
@@ -40,7 +40,7 @@ import org.apache.pulsar.common.util.Backoff;
 /**
  * The default implementation of {@link ServiceNameResolver}.
  */
-@Slf4j
+@CustomLog
 public class PulsarServiceNameResolver implements ServiceNameResolver {
 
     private volatile ServiceURI serviceUri;
@@ -77,7 +77,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
             // if no available address, use the original address list
             list = allAddressList;
             if (availableAddressList != null) {
-                log.warn("No available hosts found for service url: {}", serviceUrl);
+                log.warn().attr("url", serviceUrl).log("No available hosts found for service url");
             }
         }
         checkState(
@@ -115,7 +115,10 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
         try {
             uri = ServiceURI.create(serviceUrl);
         } catch (IllegalArgumentException iae) {
-            log.error("Invalid service-url {} provided {}", serviceUrl, iae.getMessage(), iae);
+            log.error().attr("serviceUrl", serviceUrl)
+                    .exceptionMessage(iae)
+                    .exception(iae)
+                    .log("Invalid service-url provided");
             throw new InvalidServiceURL(iae);
         }
 
@@ -127,7 +130,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
                 URI hostUri = new URI(hostUrl);
                 addresses.add(InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()));
             } catch (URISyntaxException e) {
-                log.error("Invalid host provided {}", hostUrl, e);
+                log.error().attr("provided", hostUrl).exception(e).log("Invalid host provided");
                 throw new InvalidServiceURL(e);
             }
         }
@@ -168,7 +171,8 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
 
         if (!allAddressSet.contains(address)) {
             // If the address is not part of the original service URL, we ignore it.
-            log.debug("Address {} is not part of the original service URL, ignoring availability update", address);
+            log.debug().attr("address", address)
+                    .log("Address is not part of the original service URL, ignoring availability update");
             return;
         }
 
@@ -201,8 +205,8 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
                     .filter(entry -> entry.getValue().isAvailable() && allAddressSet.contains(entry.getKey()))
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
-            log.info("service name resolver available hosts changed, current available hosts: {}",
-                    availableAddressList);
+            log.info().attr("hosts", availableAddressList)
+                    .log("service name resolver available hosts changed, current available hosts");
         }
     }
 
@@ -255,8 +259,9 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
                 long elapsedTimeMsSinceLast = System.currentTimeMillis() - status.getLastUpdateTimeStampMs();
                 boolean needTryRecover = elapsedTimeMsSinceLast >= status.getNextDelayMsToRecover();
                 if (needTryRecover) {
-                    log.info("service name resolver try to recover host {} after {}", status.getSocketAddress(),
-                            Duration.ofMillis(elapsedTimeMsSinceLast));
+                    log.info().attr("host", status.getSocketAddress())
+                            .attr("afterMs", Duration.ofMillis(elapsedTimeMsSinceLast))
+                            .log("service name resolver try to recover host after");
                     status.setAvailable(true);
                     status.setLastUpdateTimeStampMs(System.currentTimeMillis());
                     status.setNextDelayMsToRecover(status.getQuarantineBackoff().next().toMillis());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pulsar.client.impl;
 
+import io.github.merlimat.slog.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.BatchReceivePolicy;
@@ -48,8 +48,10 @@ import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.CompletableFutureCancellationHandler;
 
-@Slf4j
 public class ReaderImpl<T> implements Reader<T> {
+    private static final Logger LOG = Logger.get(ReaderImpl.class);
+    private final Logger log;
+
     private static final BatchReceivePolicy DISABLED_BATCH_RECEIVE_POLICY = BatchReceivePolicy.builder()
             .timeout(0, TimeUnit.MILLISECONDS)
             .maxNumMessages(1)
@@ -108,8 +110,9 @@ public class ReaderImpl<T> implements Reader<T> {
                     final MessageId messageId = msg.getMessageId();
                     readerListener.received(ReaderImpl.this, msg);
                     consumer.acknowledgeCumulativeAsync(messageId).exceptionally(ex -> {
-                        log.error("[{}][{}] auto acknowledge message {} cumulative fail.", getTopic(),
-                                getConsumer().getSubscription(), messageId, ex);
+                        log.error().attr("messageId", messageId)
+                                .exception(ex)
+                                .log("auto acknowledge message cumulative fail");
                         return null;
                     });
                 }
@@ -131,8 +134,9 @@ public class ReaderImpl<T> implements Reader<T> {
                     final MessageId messageId = msg.getMessageId();
                     readerDecryptFailListener.received(ReaderImpl.this, msg);
                     consumer.acknowledgeCumulativeAsync(messageId).exceptionally(ex -> {
-                        log.error("[{}][{}] auto acknowledge decrypt fail message {} cumulative fail.", getTopic(),
-                                getConsumer().getSubscription(), messageId, ex);
+                        log.error().attr("messageId", messageId)
+                                .exception(ex)
+                                .log("auto acknowledge decrypt fail message cumulative fail");
                         return null;
                     });
                 }
@@ -168,6 +172,10 @@ public class ReaderImpl<T> implements Reader<T> {
                 executorProvider, partitionIdx, false, false, consumerFuture,
                 readerConfiguration.getStartMessageId(), readerConfiguration.getStartMessageFromRollbackDurationInSec(),
                 schema, consumerInterceptors, true /* createTopicIfDoesNotExist */);
+        this.log = LOG.with()
+                .attr("topic", () -> getTopic())
+                .attr("subscription", () -> getConsumer().getSubscription())
+                .build();
     }
 
     @Override
@@ -191,8 +199,9 @@ public class ReaderImpl<T> implements Reader<T> {
         // Acknowledge message immediately because the reader is based on non-durable subscription. When it reconnects,
         // it will specify the subscription position anyway
         consumer.acknowledgeCumulativeAsync(msg).exceptionally(ex -> {
-            log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
-                    getConsumer().getSubscription(), msg.getMessageId(), ex);
+            log.warn().attr("messageId", msg.getMessageId())
+                    .exception(ex)
+                    .log("acknowledge message cumulative fail");
             return null;
         });
         return msg;
@@ -204,8 +213,9 @@ public class ReaderImpl<T> implements Reader<T> {
 
         if (msg != null) {
             consumer.acknowledgeCumulativeAsync(msg).exceptionally(ex -> {
-                log.warn("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
-                        getConsumer().getSubscription(), msg.getMessageId(), ex);
+                log.warn().attr("messageId", msg.getMessageId())
+                        .exception(ex)
+                        .log("acknowledge message cumulative fail");
                 return null;
             });
         }
@@ -218,8 +228,9 @@ public class ReaderImpl<T> implements Reader<T> {
         CompletableFuture<Message<T>> result = originalFuture.thenApply(msg -> {
             consumer.acknowledgeCumulativeAsync(msg)
                     .exceptionally(ex -> {
-                        log.error("[{}][{}] acknowledge message {} cumulative fail.", getTopic(),
-                                getConsumer().getSubscription(), msg.getMessageId(), ex);
+                        log.error().attr("messageId", msg.getMessageId())
+                                .exception(ex)
+                                .log("acknowledge message cumulative fail");
                         return null;
                     });
             return msg;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -24,8 +24,8 @@ import io.netty.util.concurrent.ScheduledFuture;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -37,7 +37,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
-@Slf4j
+@CustomLog
 @SuppressFBWarnings(value = {"EI_EXPOSE_REP2"})
 public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvider {
 
@@ -84,13 +84,11 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
                     int failoverTo = findFailoverTo();
                     if (failoverTo < 0) {
                         // No healthy pulsar service to connect.
-                        log.error(
-                                "Failed to choose a pulsar service to connect, no one pulsar service is healthy."
-                                        + " Current pulsar service: [{}] {}. States: {}, Counters: {}",
-                                currentPulsarServiceIndex,
-                                pulsarServiceUrlArray[currentPulsarServiceIndex],
-                                Arrays.toString(pulsarServiceStateArray),
-                                Arrays.toString(checkCounterArray));
+                        log.error().attr("currentPulsarServiceIndex", currentPulsarServiceIndex)
+                                .attr("currentServiceUrl", pulsarServiceUrlArray[currentPulsarServiceIndex])
+                                .attr("states", Arrays.toString(pulsarServiceStateArray))
+                                .attr("counters", Arrays.toString(checkCounterArray))
+                                .log("Failed to choose a pulsar service to connect, no healthy service available");
                     } else {
                         // Failover to low priority pulsar service.
                         updateServiceUrl(failoverTo);
@@ -100,7 +98,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
                     updateServiceUrl(firstHealthyPulsarService);
                 }
             } catch (Exception ex) {
-                log.error("Failed to re-check cluster status", ex);
+                log.error().exception(ex).log("Failed to re-check cluster status");
             }
         }, checkHealthyIntervalMs, checkHealthyIntervalMs, TimeUnit.MILLISECONDS);
     }
@@ -117,8 +115,9 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
             return;
         }
 
-        log.info("Closing service url provider. Current pulsar service: [{}] {}", currentPulsarServiceIndex,
-                pulsarServiceUrlArray[currentPulsarServiceIndex]);
+        log.info().attr("currentPulsarServiceIndex", currentPulsarServiceIndex)
+                .attr("currentServiceUrl", pulsarServiceUrlArray[currentPulsarServiceIndex])
+                .log("Closing service url provider");
         if (scheduledCheckTask != null) {
             scheduledCheckTask.cancel(false);
         }
@@ -213,11 +212,12 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         try {
             LookupTopicResult res = pulsarClient.getLookup(url).getBroker(TopicName.get(testTopic))
                     .get(3, TimeUnit.SECONDS);
-            if (log.isDebugEnabled()) {
-                log.debug("Success to probe available(lookup res: {}), [{}] {}}. States: {}, Counters: {}",
-                        res.toString(), brokerServiceIndex, url, Arrays.toString(pulsarServiceStateArray),
-                        Arrays.toString(checkCounterArray));
-            }
+                log.debug().attr("res", res.toString())
+                        .attr("brokerServiceIndex", brokerServiceIndex)
+                        .attr("url", url)
+                        .attr("states", Arrays.toString(pulsarServiceStateArray))
+                        .attr("counters", Arrays.toString(checkCounterArray))
+                        .log("Successfully probed service availability");
             return true;
         } catch (Exception e) {
             Throwable actEx = FutureUtil.unwrapCompletionException(e);
@@ -226,21 +226,26 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
                     || actEx instanceof PulsarClientException.TopicDoesNotExistException
                     || actEx instanceof PulsarClientException.LookupException) {
                 if (markTopicNotFoundAsAvailable) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Success to probe available(case tenant/namespace/topic not found), [{}] {}."
-                                + " States: {}, Counters: {}", brokerServiceIndex, url,
-                                Arrays.toString(pulsarServiceStateArray), Arrays.toString(checkCounterArray));
-                    }
+                        log.debug().attr("brokerServiceIndex", brokerServiceIndex)
+                                .attr("url", url)
+                                .attr("states", Arrays.toString(pulsarServiceStateArray))
+                                .attr("counters", Arrays.toString(checkCounterArray))
+                                .log("Successfully probed service availability (topic not found)");
                     return true;
                 } else {
-                    log.warn("Failed to probe available(error tenant/namespace/topic not found), [{}] {}. States: {},"
-                            + " Counters: {}", brokerServiceIndex, url, Arrays.toString(pulsarServiceStateArray),
-                            Arrays.toString(checkCounterArray));
+                    log.warn().attr("brokerServiceIndex", brokerServiceIndex)
+                            .attr("url", url)
+                            .attr("states", Arrays.toString(pulsarServiceStateArray))
+                            .attr("counters", Arrays.toString(checkCounterArray))
+                            .log("Failed to probe service availability (topic not found)");
                     return false;
                 }
             }
-            log.warn("Failed to probe available, [{}] {}. States: {}, Counters: {}", brokerServiceIndex, url,
-                    Arrays.toString(pulsarServiceStateArray), Arrays.toString(checkCounterArray));
+            log.warn().attr("brokerServiceIndex", brokerServiceIndex)
+                    .attr("url", url)
+                    .attr("states", Arrays.toString(pulsarServiceStateArray))
+                    .attr("counters", Arrays.toString(checkCounterArray))
+                    .log("Failed to probe service availability");
             return false;
         }
     }
@@ -264,7 +269,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
             pulsarClient.reloadLookUp();
             currentPulsarServiceIndex = targetIndex;
         } catch (Exception e) {
-            log.error("Failed to {}", logMsg, e);
+            log.error().attr("logMsg", logMsg).exception(e).log("Failed to");
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -389,8 +389,8 @@ public class TableViewImpl<T> implements TableView<T> {
                        long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
                        log.info().attr("topic", reader.getTopic())
                                .attr("replayed", messagesRead)
-                               .attr("0", durationMillis / 1000.0)
-                               .log("Started table view for topic - Replayed messages in seconds");
+                               .attr("durationSeconds", durationMillis / 1000.0)
+                               .log("Started table view for topic - Replayed messages");
                        future.complete(null);
                    }
                 });

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TableViewImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import static org.apache.pulsar.common.topics.TopicCompactionStrategy.TABLE_VIEW_TAG;
+import io.github.merlimat.slog.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -46,9 +46,10 @@ import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 
-@Slf4j
 public class TableViewImpl<T> implements TableView<T> {
 
+    private static final Logger LOG = Logger.get(TableViewImpl.class);
+    private final Logger log;
     private final TableViewConfigurationData conf;
 
     private final ConcurrentMap<String, T> data;
@@ -83,6 +84,7 @@ public class TableViewImpl<T> implements TableView<T> {
 
     TableViewImpl(PulsarClientImpl client, Schema<T> schema, TableViewConfigurationData conf) {
         this.conf = conf;
+        this.log = LOG.with().attr("topic", conf.getTopicName()).build();
         this.isPersistentTopic = conf.getTopicName().startsWith(TopicDomain.persistent.toString());
         this.data = new ConcurrentHashMap<>();
         this.immutableData = Collections.unmodifiableMap(data);
@@ -209,23 +211,19 @@ public class TableViewImpl<T> implements TableView<T> {
             if (msg.hasKey()) {
                 String key = msg.getKey();
                 T cur = msg.size() > 0 ? msg.getValue() : null;
-                if (log.isDebugEnabled()) {
-                    log.debug("Applying message from topic {}. key={} value={}",
-                            conf.getTopicName(),
-                            key,
-                            cur);
-                }
+                    log.debug().attr("key", key)
+                            .attr("value", cur)
+                            .log("Applying message");
 
                 boolean update = true;
                 if (compactionStrategy != null) {
                     T prev = data.get(key);
                     update = !compactionStrategy.shouldKeepLeft(prev, cur);
                     if (!update) {
-                        log.info("Skipped the message from topic {}. key={} value={} prev={}",
-                                conf.getTopicName(),
-                                key,
-                                cur,
-                                prev);
+                        log.info().attr("key", key)
+                                .attr("value", cur)
+                                .attr("prev", prev)
+                                .log("Skipped the message");
                         compactionStrategy.handleSkippedMessage(key, cur);
                     }
                 }
@@ -243,7 +241,7 @@ public class TableViewImpl<T> implements TableView<T> {
                             try {
                                 listener.accept(key, cur);
                             } catch (Throwable t) {
-                                log.error("Table view listener raised an exception", t);
+                                log.error().exception(t).log("Table view listener raised an exception");
                             }
                         }
                     } finally {
@@ -375,11 +373,12 @@ public class TableViewImpl<T> implements TableView<T> {
                                   }
                                }).exceptionally(ex -> {
                                    if (ex.getCause() instanceof PulsarClientException.AlreadyClosedException) {
-                                       log.info("Reader {} was closed while reading existing messages.",
-                                               reader.getTopic());
+                                       log.info().attr("reader", reader.getTopic())
+                                               .log("Reader was closed while reading existing messages.");
                                    } else {
-                                       log.warn("Reader {} was interrupted while reading existing messages. ",
-                                               reader.getTopic(), ex);
+                                       log.warn().attr("reader", reader.getTopic())
+                                               .exception(ex)
+                                               .log("Reader was interrupted while reading existing messages.");
                                    }
                                    future.completeExceptionally(ex);
                                    return null;
@@ -388,10 +387,10 @@ public class TableViewImpl<T> implements TableView<T> {
                        // Reached the end
                        long endTime = System.nanoTime();
                        long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
-                       log.info("Started table view for topic {} - Replayed {} messages in {} seconds",
-                               reader.getTopic(),
-                               messagesRead,
-                               durationMillis / 1000.0);
+                       log.info().attr("topic", reader.getTopic())
+                               .attr("replayed", messagesRead)
+                               .attr("0", durationMillis / 1000.0)
+                               .log("Started table view for topic - Replayed messages in seconds");
                        future.complete(null);
                    }
                 });
@@ -404,7 +403,8 @@ public class TableViewImpl<T> implements TableView<T> {
                     readTailMessages(reader);
                 }).exceptionally(ex -> {
                     if (ex.getCause() instanceof PulsarClientException.AlreadyClosedException) {
-                        log.info("Reader {} was closed while reading tail messages.", reader.getTopic());
+                        log.info().attr("reader", reader.getTopic())
+                                .log("Reader was closed while reading tail messages.");
                         // Fail all refresh request when no more messages can be read.
                         pendingRefreshRequests.keySet().forEach(future -> {
                             pendingRefreshRequests.remove(future);
@@ -417,8 +417,9 @@ public class TableViewImpl<T> implements TableView<T> {
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                         }
-                        log.warn("Reader {} was interrupted while reading tail messages. "
-                                + "Retrying..", reader.getTopic(), ex);
+                        log.warn().attr("reader", reader.getTopic())
+                                .exception(ex)
+                                .log("Reader was interrupted while reading tail messages. " + "Retrying..");
                         readTailMessages(reader);
                     }
                     return null;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicListWatcher.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.channel.ChannelHandlerContext;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -37,17 +38,16 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.topics.TopicsPattern;
 import org.apache.pulsar.common.util.Backoff;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TopicListWatcher extends HandlerState implements ConnectionHandler.Connection {
 
-    private static final Logger log = LoggerFactory.getLogger(TopicListWatcher.class);
+    private static final Logger LOG = Logger.get(TopicListWatcher.class);
 
     private static final AtomicLongFieldUpdater<TopicListWatcher> CREATE_WATCHER_DEADLINE_UPDATER =
             AtomicLongFieldUpdater
                     .newUpdater(TopicListWatcher.class, "createWatcherDeadline");
 
+    private final Logger log;
     private final PatternConsumerUpdateQueue patternConsumerUpdateQueue;
     private final String name;
     private final ConnectionHandler connectionHandler;
@@ -89,6 +89,14 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
         this.localStateTopicsHashSupplier = localStateTopicsHashSupplier;
         this.watcherFuture = watcherFuture;
         this.nextRecheckPatternEpochSupplier = nextRecheckPatternEpochSupplier;
+        this.log = LOG.with()
+                .attr("topic", topic)
+                .attr("handler", () -> getHandlerName())
+                .attr("channel", () -> {
+                    ClientCnx c = cnx();
+                    return c != null ? c.ctx().channel() : null;
+                })
+                .build();
 
         connectionHandler.grabCnx();
     }
@@ -100,8 +108,8 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
             exception.setPreviousExceptionCount(previousExceptionCount);
             if (watcherFuture.completeExceptionally(exception)) {
                 setState(State.Failed);
-                log.info("[{}] Watcher creation failed for {} with non-retriable error {}",
-                        topic, name, exception.getMessage());
+                log.info().exceptionMessage(exception)
+                        .log("Watcher creation failed with non-retriable error");
                 deregisterFromClientCnx();
                 return false;
             }
@@ -131,8 +139,8 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
             return CompletableFuture.completedFuture(null);
         }
 
-        log.info("[{}][{}] Creating topic list watcher on cnx {}, watcherId {}",
-                topic, getHandlerName(), cnx.ctx().channel(), watcherId);
+        log.info().attr("watcherId", watcherId)
+                .log("Creating topic list watcher");
 
         long requestId = client.newRequestId();
 
@@ -155,8 +163,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
                                 // drops the watcher on its side
                                 setState(State.Closed);
                                 deregisterFromClientCnx();
-                                log.warn("[{}] Watcher was closed while reconnecting, closing the connection to {}.",
-                                        topic, cnx.channel().remoteAddress());
+                                log.warn("Watcher was closed while reconnecting, closing the connection");
                                 cnx.channel().close();
                                 future.complete(null);
                                 return;
@@ -175,8 +182,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
                             future.complete(null);
                             return null;
                         }
-                        log.warn("[{}][{}] Failed to create topic list watcher on {}",
-                                topic, getHandlerName(), cnx.channel().remoteAddress());
+                        log.warn("Failed to create topic list watcher");
 
                         if (e.getCause() instanceof PulsarClientException
                                 && PulsarClientException.isRetriableError(e.getCause())
@@ -227,7 +233,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
         }
 
         if (!isConnected()) {
-            log.info("[{}] [{}] Closed watcher (not connected)", topic, getHandlerName());
+            log.info("Closed watcher (not connected)");
             setState(State.Closed);
             deregisterFromClientCnx();
             closeFuture.complete(null);
@@ -248,7 +254,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
                 final ChannelHandlerContext ctx = cnx.ctx();
                 boolean ignoreException = ctx == null || !ctx.channel().isActive();
                 if (ignoreException && exception != null) {
-                    log.debug("Exception ignored in closing watcher", exception);
+                    log.debug().exception(exception).log("Exception ignored in closing watcher");
                 }
                 cleanupAtClose(closeFuture, ignoreException ? null : exception);
                 return null;
@@ -283,7 +289,7 @@ public class TopicListWatcher extends HandlerState implements ConnectionHandler.
     }
 
     private void cleanupAtClose(CompletableFuture<Void> closeFuture, Throwable exception) {
-        log.info("[{}] Closed topic list watcher", getHandlerName());
+        log.info("Closed topic list watcher");
         setState(State.Closed);
         deregisterFromClientCnx();
         if (exception != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -50,16 +51,13 @@ import org.apache.pulsar.common.api.proto.TxnAction;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handler for transaction meta store.
  */
+@CustomLog
 public class TransactionMetaStoreHandler extends HandlerState
         implements ConnectionHandler.Connection, Closeable, TimerTask {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionMetaStoreHandler.class);
 
     private final long transactionCoordinatorId;
     private final ConnectionHandler connectionHandler;
@@ -130,11 +128,15 @@ public class TransactionMetaStoreHandler extends HandlerState
             exception.setPreviousExceptionCount(previousExceptionCount);
             if (connectFuture.completeExceptionally(exception)) {
                 if (nonRetriableError) {
-                    LOG.error("Transaction meta handler with transaction coordinator id {} connection failed.",
-                            transactionCoordinatorId, exception);
+                    log.error().attr("transactionCoordinatorId", transactionCoordinatorId)
+                            .exception(exception)
+                            .log("Transaction meta handler failed.");
                 } else {
-                    LOG.error("Transaction meta handler with transaction coordinator id {} connection failed after "
-                            + "timeout", transactionCoordinatorId, exception);
+                    log.error().attr("transactionCoordinatorId", transactionCoordinatorId)
+                            .exception(exception)
+                            .log("Transaction meta handler with transaction"
+                                    + " coordinator id connection failed"
+                                    + " after timeout");
                 }
                 setState(State.Failed);
                 return false;
@@ -149,8 +151,8 @@ public class TransactionMetaStoreHandler extends HandlerState
     public CompletableFuture<Void> connectionOpened(ClientCnx cnx) {
         final CompletableFuture<Void> future = new CompletableFuture<>();
         internalPinnedExecutor.execute(() -> {
-            LOG.info("Transaction meta handler with transaction coordinator id {} connection opened.",
-                    transactionCoordinatorId);
+            log.info().attr("transactionCoordinatorId", transactionCoordinatorId)
+                    .log("Transaction meta handler with transaction coordinator id connection opened.");
 
             State state = getState();
             if (state == State.Closing || state == State.Closed) {
@@ -167,7 +169,8 @@ public class TransactionMetaStoreHandler extends HandlerState
 
                 cnx.sendRequestWithId(request, requestId).thenRun(() -> {
                     internalPinnedExecutor.execute(() -> {
-                        LOG.info("Transaction coordinator client connect success! tcId : {}", transactionCoordinatorId);
+                        log.info().attr("transactionCoordinatorId", transactionCoordinatorId)
+                                .log("Transaction coordinator client connect success! tcId");
                         if (registerToConnection(cnx)) {
                             this.connectionHandler.resetBackoff();
                             pendingRequests.forEach((requestID, opBase) -> checkStateAndSendRequest(opBase));
@@ -176,8 +179,9 @@ public class TransactionMetaStoreHandler extends HandlerState
                     });
                 }).exceptionally((e) -> {
                     internalPinnedExecutor.execute(() -> {
-                        LOG.error("Transaction coordinator client connect fail! tcId : {}",
-                                transactionCoordinatorId, e.getCause());
+                        log.error().attr("transactionCoordinatorId", transactionCoordinatorId)
+                                .exception(e.getCause())
+                                .log("Transaction coordinator client connect fail! tcId");
                         if (getState() == State.Closing || getState() == State.Closed
                                 || e.getCause() instanceof PulsarClientException.NotAllowedException) {
                             setState(State.Closed);
@@ -190,8 +194,10 @@ public class TransactionMetaStoreHandler extends HandlerState
                     return null;
                 });
             } else {
-                LOG.warn("Can not connect to the transaction coordinator because the protocol version {} is "
-                                + "lower than 19", cnx.getRemoteEndpointProtocolVersion());
+                log.warn().attr("version", cnx.getRemoteEndpointProtocolVersion())
+                        .log("Can not connect to the transaction coordinator"
+                                + " because the protocol version is"
+                                + " lower than 19");
                 registerToConnection(cnx);
                 future.complete(null);
             }
@@ -228,9 +234,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     public CompletableFuture<TxnID> newTransactionAsync(long timeout, TimeUnit unit) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("New transaction with timeout in ms {}", unit.toMillis(timeout));
-        }
+            log.debug().attr("timeoutMs", unit.toMillis(timeout)).log("New transaction with timeout");
         CompletableFuture<TxnID> callback = new CompletableFuture<>();
         if (!canSendRequest(callback)) {
             return callback;
@@ -265,31 +269,27 @@ public class TransactionMetaStoreHandler extends HandlerState
         internalPinnedExecutor.execute(() -> {
             OpForTxnIdCallBack op = (OpForTxnIdCallBack) pendingRequests.remove(requestId);
             if (op == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Got new txn response for transaction {}", txnID);
-                }
+                    log.debug().attr("transaction", txnID).log("Got new txn response for transaction");
                 return;
             }
 
             if (!hasError) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Got new txn response {} for request {}", txnID, requestId);
-                }
+                    log.debug().attr("response", txnID)
+                            .attr("request", requestId)
+                            .log("Got new txn response for request");
                 op.callback.complete(txnID);
             } else {
                 if (checkIfNeedRetryByError(error, message, op)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Get a response for the {}  request {} error "
-                                        + "TransactionCoordinatorNotFound and try it again",
-                                BaseCommand.Type.NEW_TXN.name(), requestId);
-                    }
+                        log.debug().attr("name", BaseCommand.Type.NEW_TXN)
+                                .attr("requestId", requestId)
+                                .log("Get a response for the request error"
+                                        + " TransactionCoordinatorNotFound"
+                                        + " and try it again");
                     pendingRequests.put(requestId, op);
                     timer.newTimeout(timeout -> {
                                 internalPinnedExecutor.execute(() -> {
                                     if (!pendingRequests.containsKey(requestId)) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("The request {} already timeout", requestId);
-                                        }
+                                            log.debug().attr("request", requestId).log("The request already timeout");
                                         return;
                                     }
                                     if (!checkStateAndSendRequest(op)) {
@@ -300,8 +300,10 @@ public class TransactionMetaStoreHandler extends HandlerState
                             , op.backoff.next().toMillis(), TimeUnit.MILLISECONDS);
                     return;
                 }
-                LOG.error("Got {} for request {} error {}", BaseCommand.Type.NEW_TXN.name(),
-                        requestId, error);
+                log.error().attr("name", BaseCommand.Type.NEW_TXN)
+                        .attr("requestId", requestId)
+                        .attr("error", error)
+                        .log("Got for request error");
             }
 
             onResponse(op);
@@ -309,9 +311,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     public CompletableFuture<Void> addPublishPartitionToTxnAsync(TxnID txnID, List<String> partitions) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Add publish partition {} to txn {}", partitions, txnID);
-        }
+            log.debug().attr("partition", partitions).attr("txn", txnID).log("Add publish partition to txn");
         CompletableFuture<Void> callback = new CompletableFuture<>();
         if (!canSendRequest(callback)) {
             return callback;
@@ -350,31 +350,26 @@ public class TransactionMetaStoreHandler extends HandlerState
         internalPinnedExecutor.execute(() -> {
             OpForVoidCallBack op = (OpForVoidCallBack) pendingRequests.remove(requestId);
             if (op == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Got add publish partition to txn response for transaction {}", txnID);
-                }
+                    log.debug().attr("transaction", txnID)
+                            .log("Got add publish partition to txn response for transaction");
                 return;
             }
 
             if (!hasError) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Add publish partition for request {} success.", requestId);
-                }
+                    log.debug().attr("request", requestId).log("Add publish partition for request success.");
                 op.callback.complete(null);
             } else {
                 if (checkIfNeedRetryByError(error, message, op)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Get a response for the {} request {} "
-                                        + " error TransactionCoordinatorNotFound and try it again",
-                                BaseCommand.Type.ADD_PARTITION_TO_TXN.name(), requestId);
-                    }
+                        log.debug().attr("name", BaseCommand.Type.ADD_PARTITION_TO_TXN.name())
+                                .attr("request", requestId)
+                                .log("Get a response for the request"
+                                        + " error TransactionCoordinatorNotFound"
+                                        + " and try it again");
                     pendingRequests.put(requestId, op);
                     timer.newTimeout(timeout -> {
                                 internalPinnedExecutor.execute(() -> {
                                     if (!pendingRequests.containsKey(requestId)) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("The request {} already timeout", requestId);
-                                        }
+                                            log.debug().attr("request", requestId).log("The request already timeout");
                                         return;
                                     }
                                     if (!checkStateAndSendRequest(op)) {
@@ -385,8 +380,11 @@ public class TransactionMetaStoreHandler extends HandlerState
                             , op.backoff.next().toMillis(), TimeUnit.MILLISECONDS);
                     return;
                 }
-                LOG.error("{} for request {}, transaction {}, error: {}",
-                        BaseCommand.Type.ADD_PARTITION_TO_TXN.name(), requestId, txnID, error);
+                log.error().attr("name", BaseCommand.Type.ADD_PARTITION_TO_TXN.name())
+                        .attr("request", requestId)
+                        .attr("transaction", txnID)
+                        .attr("error", error)
+                        .log("for request, transaction, error");
 
             }
 
@@ -395,9 +393,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     public CompletableFuture<Void> addSubscriptionToTxn(TxnID txnID, List<Subscription> subscriptionList) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Add subscription {} to txn {}.", subscriptionList, txnID);
-        }
+            log.debug().attr("subscription", subscriptionList).attr("txn", txnID).log("Add subscription to txn.");
 
         CompletableFuture<Void> callback = new CompletableFuture<>();
         if (!canSendRequest(callback)) {
@@ -446,32 +442,29 @@ public class TransactionMetaStoreHandler extends HandlerState
         internalPinnedExecutor.execute(() -> {
             OpForVoidCallBack op = (OpForVoidCallBack) pendingRequests.remove(requestId);
             if (op == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Add subscription to txn timeout for request {}.", requestId);
-                }
+                    log.debug().attr("request", requestId).log("Add subscription to txn timeout for request.");
                 return;
             }
 
             if (!hasError) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Add subscription to txn success for request {}.", requestId);
-                }
+                    log.debug().attr("request", requestId).log("Add subscription to txn success for request.");
                 op.callback.complete(null);
             } else {
-                LOG.error("Add subscription to txn failed for request {}, transaction {}, error: {}",
-                        requestId, txnID, error);
+                log.error().attr("request", requestId)
+                        .attr("transaction", txnID)
+                        .attr("error", error)
+                        .log("Add subscription to txn failed for request, transaction, error");
                 if (checkIfNeedRetryByError(error, message, op)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Get a response for {} request {} error TransactionCoordinatorNotFound and try it"
-                                        + " again", BaseCommand.Type.ADD_SUBSCRIPTION_TO_TXN.name(), requestId);
-                    }
+                        log.debug().attr("name", BaseCommand.Type.ADD_SUBSCRIPTION_TO_TXN.name())
+                                .attr("request", requestId)
+                                .log("Get a response for request error"
+                                        + " TransactionCoordinatorNotFound"
+                                        + " and try it again");
                     pendingRequests.put(requestId, op);
                     timer.newTimeout(timeout -> {
                                 internalPinnedExecutor.execute(() -> {
                                     if (!pendingRequests.containsKey(requestId)) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("The request {} already timeout", requestId);
-                                        }
+                                            log.debug().attr("request", requestId).log("The request already timeout");
                                         return;
                                     }
                                     if (!checkStateAndSendRequest(op)) {
@@ -482,8 +475,10 @@ public class TransactionMetaStoreHandler extends HandlerState
                             , op.backoff.next().toMillis(), TimeUnit.MILLISECONDS);
                     return;
                 }
-                LOG.error("{} failed for request {} error {}.", BaseCommand.Type.ADD_SUBSCRIPTION_TO_TXN.name(),
-                       requestId, error);
+                log.error().attr("name", BaseCommand.Type.ADD_SUBSCRIPTION_TO_TXN.name())
+                        .attr("request", requestId)
+                        .attr("error", error)
+                        .log("failed for request error.");
 
             }
             onResponse(op);
@@ -491,9 +486,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     public CompletableFuture<Void> endTxnAsync(TxnID txnID, TxnAction action) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("End txn {}, action {}", txnID, action);
-        }
+            log.debug().attr("txn", txnID).attr("action", action).log("End txn, action");
         CompletableFuture<Void> callback = new CompletableFuture<>();
         if (!canSendRequest(callback)) {
             return callback;
@@ -529,31 +522,28 @@ public class TransactionMetaStoreHandler extends HandlerState
         internalPinnedExecutor.execute(() -> {
             OpForVoidCallBack op = (OpForVoidCallBack) pendingRequests.remove(requestId);
             if (op == null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Got end txn response for transaction but no requests pending for txn {}", txnID);
-                }
+                    log.debug().attr("txn", txnID)
+                            .log("Got end txn response for transaction but no requests pending for txn");
                 return;
             }
 
             if (!hasError) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Got end txn response success for request {}, txn {}", requestId, txnID);
-                }
+                    log.debug().attr("request", requestId)
+                            .attr("txn", txnID)
+                            .log("Got end txn response success for request, txn");
                 op.callback.complete(null);
             } else {
                 if (checkIfNeedRetryByError(error, message, op)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Get a response for the {} request {} error "
-                                        + "TransactionCoordinatorNotFound and try it again",
-                                BaseCommand.Type.END_TXN.name(), requestId);
-                    }
+                        log.debug().attr("name", BaseCommand.Type.END_TXN.name())
+                                .attr("request", requestId)
+                                .log("Get a response for the request error"
+                                        + " TransactionCoordinatorNotFound"
+                                        + " and try it again");
                     pendingRequests.put(requestId, op);
                     timer.newTimeout(timeout -> {
                                 internalPinnedExecutor.execute(() -> {
                                     if (!pendingRequests.containsKey(requestId)) {
-                                        if (LOG.isDebugEnabled()) {
-                                            LOG.debug("The request {} already timeout", requestId);
-                                        }
+                                            log.debug().attr("request", requestId).log("The request already timeout");
                                         return;
                                     }
                                     if (!checkStateAndSendRequest(op)) {
@@ -564,8 +554,11 @@ public class TransactionMetaStoreHandler extends HandlerState
                             , op.backoff.next().toMillis(), TimeUnit.MILLISECONDS);
                     return;
                 }
-                LOG.error("Got {} response for request {}, transaction {}, error: {}",
-                        BaseCommand.Type.END_TXN.name(), requestId, txnID, error);
+                log.error().attr("name", BaseCommand.Type.END_TXN.name())
+                        .attr("request", requestId)
+                        .attr("transaction", txnID)
+                        .attr("error", error)
+                        .log("Got response for request, transaction, error");
 
             }
             onResponse(op);
@@ -724,7 +717,8 @@ public class TransactionMetaStoreHandler extends HandlerState
                     op.cmd.retain();
                     cnx.ctx().writeAndFlush(op.cmd, cnx().ctx().voidPromise());
                 } else {
-                    LOG.error("The cnx was null when the TC handler was ready", new NullPointerException());
+                    log.error().exception(new NullPointerException())
+                            .log("The cnx was null when the TC handler was ready");
                 }
                 return true;
             case Connecting:
@@ -776,9 +770,8 @@ public class TransactionMetaStoreHandler extends HandlerState
                         op.callback.completeExceptionally(new PulsarClientException.TimeoutException(
                             String.format("%s failed due to timeout. connection: %s. pending-queue: %s",
                                 op.description, op.clientCnx, pendingRequests.size())));
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Transaction coordinator request {} is timeout.", lastPolled.requestId);
-                        }
+                            log.debug().attr("request", lastPolled.requestId)
+                                    .log("Transaction coordinator request is timeout.");
                         onResponse(op);
                     }
                 } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageRedeliveryTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageRedeliveryTracker.java
@@ -27,15 +27,13 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class UnAckedMessageRedeliveryTracker extends UnAckedMessageTracker {
-
-    private static final Logger log = LoggerFactory.getLogger(UnAckedMessageRedeliveryTracker.class);
 
     protected final HashMap<UnackMessageIdWrapper, HashSet<UnackMessageIdWrapper>> redeliveryMessageIdPartitionMap;
     protected final ArrayDeque<HashSet<UnackMessageIdWrapper>> redeliveryTimePartitions;
@@ -109,7 +107,9 @@ public class UnAckedMessageRedeliveryTracker extends UnAckedMessageTracker {
                 }
             });
             if (!messageIds.isEmpty()) {
-                log.info("[{}] {} messages will be re-delivered", consumerBase, messageIds.size());
+                log.info().attr("consumerBase", consumerBase)
+                        .attr("size", messageIds.size())
+                        .log("messages will be re-delivered");
                 Iterator<MessageId> iterator = messageIds.iterator();
                 while (iterator.hasNext()) {
                     MessageId messageId = iterator.next();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -34,16 +34,15 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.metrics.Counter;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.impl.metrics.Unit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class UnAckedMessageTracker implements Closeable {
-    private static final Logger log = LoggerFactory.getLogger(UnAckedMessageTracker.class);
 
     protected final HashMap<MessageId, HashSet<MessageId>> messageIdPartitionMap;
     protected final ArrayDeque<HashSet<MessageId>> timePartitions;
@@ -152,7 +151,9 @@ public class UnAckedMessageTracker implements Closeable {
                         HashSet<MessageId> headPartition = timePartitions.removeFirst();
                         if (!headPartition.isEmpty()) {
                             consumerAckTimeoutsCounter.add(headPartition.size());
-                            log.info("[{}] {} messages will be re-delivered", consumerBase, headPartition.size());
+                            log.info().attr("consumerBase", consumerBase)
+                                    .attr("count", headPartition.size())
+                                    .log("messages will be re-delivered");
                             headPartition.forEach(messageId -> {
                                 if (messageId instanceof ChunkMessageIdImpl) {
                                     addChunkedMessageIdsAndRemoveFromSequenceMap(messageId, messageIds, consumerBase);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ZeroQueueConsumerImpl.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -38,7 +37,6 @@ import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 
-@Slf4j
 public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
 
     private final Lock zeroQueueLock = new ReentrantLock();
@@ -168,10 +166,8 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
         externalPinnedExecutor.execute(() -> {
             stats.updateNumMsgsReceived(message);
             try {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Calling message listener for unqueued message {}", topic, subscription,
-                            message.getMessageId());
-                }
+                    log.debug().attr("messageId", message.getMessageId())
+                            .log("Calling message listener for unqueued message");
                 waitingOnListenerForZeroQueueSize = true;
                 trackMessage(message);
                 unAckedMessageTracker.add(
@@ -185,8 +181,9 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
                     listener.received(ZeroQueueConsumerImpl.this, beforeConsume(message));
                 }
             } catch (Throwable t) {
-                log.error("[{}][{}] Message listener error in processing unqueued message: {}", topic, subscription,
-                        message.getMessageId(), t);
+                log.error().attr("messageId", message.getMessageId())
+                        .exception(t)
+                        .log("Message listener error in processing unqueued message");
             }
             increaseAvailablePermits(cnx());
             waitingOnListenerForZeroQueueSize = false;
@@ -229,9 +226,8 @@ public class ZeroQueueConsumerImpl<T> extends ConsumerImpl<T> {
     }
 
     private void rejectBatchMessageByClosingConsumer(MessageIdImpl messageId) {
-        log.warn(
-            "Closing consumer [{}]-[{}] due to unsupported received batch-message: {} with zero receiver queue size",
-            subscription, consumerName, messageId);
+        log.warn().attr("messageId", messageId)
+                .log("Closing consumer - due to unsupported received batch-message with zero receiver queue size");
         // close connection
         closeAsync().handle((ok, e) -> {
             // notify callback with failure result

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataKeyStoreTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataKeyStoreTls.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pulsar.client.impl.auth;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.KeyStoreParams;
 
-@Slf4j
+@CustomLog
 public class AuthenticationDataKeyStoreTls implements AuthenticationDataProvider {
 
     private static final long serialVersionUID = 1L;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDataTls.java
@@ -29,12 +29,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.common.util.FileModifiedTimeUpdater;
 import org.apache.pulsar.common.util.SecurityUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class AuthenticationDataTls implements AuthenticationDataProvider {
     private static final long serialVersionUID = 1L;
     protected X509Certificate[] tlsCertificates;
@@ -103,7 +103,9 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
             try {
                 this.tlsCertificates = SecurityUtility.loadCertificatesFromPemFile(certFile.getFileName());
             } catch (KeyManagementException e) {
-                LOG.error("Unable to refresh authData for cert {}: ", certFile.getFileName(), e);
+                log.error().attr("cert", certFile.getFileName())
+                        .exception(e)
+                        .log("Unable to refresh authData for cert");
             }
         } else if (certStreamProvider != null && certStreamProvider.get() != null
                 && !certStreamProvider.get().equals(certStream)) {
@@ -111,7 +113,7 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
                 certStream = certStreamProvider.get();
                 tlsCertificates = SecurityUtility.loadCertificatesFromPemStream(certStream);
             } catch (KeyManagementException e) {
-                LOG.error("Unable to refresh authData from cert stream ", e);
+                log.error().exception(e).log("Unable to refresh authData from cert stream ");
             }
         }
         return this.tlsCertificates;
@@ -123,7 +125,7 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
             try {
                 this.tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemFile(keyFile.getFileName());
             } catch (KeyManagementException e) {
-                LOG.error("Unable to refresh authData for cert {}: ", keyFile.getFileName(), e);
+                log.error().attr("cert", keyFile.getFileName()).exception(e).log("Unable to refresh authData for cert");
             }
         } else if (keyStreamProvider != null && keyStreamProvider.get() != null
                 && !keyStreamProvider.get().equals(keyStream)) {
@@ -131,7 +133,7 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
                 keyStream = keyStreamProvider.get();
                 tlsPrivateKey = SecurityUtility.loadPrivateKeyFromPemStream(keyStream);
             } catch (KeyManagementException e) {
-                LOG.error("Unable to refresh authData from key stream ", e);
+                log.error().exception(e).log("Unable to refresh authData from key stream ");
             }
         }
         return this.tlsPrivateKey;
@@ -151,6 +153,4 @@ public class AuthenticationDataTls implements AuthenticationDataProvider {
     public String getTlsPrivateKeyFilePath() {
         return keyFile != null ? keyFile.getFileName() : null;
     }
-
-    private static final Logger LOG = LoggerFactory.getLogger(AuthenticationDataTls.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationKeyStoreTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationKeyStoreTls.java
@@ -22,7 +22,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
@@ -34,7 +34,7 @@ import org.apache.pulsar.client.impl.AuthenticationUtil;
  * This plugin requires these parameters: keyStoreType, keyStorePath, and  keyStorePassword.
  * This parameter will construct a AuthenticationDataProvider
  */
-@Slf4j
+@CustomLog
 public class AuthenticationKeyStoreTls implements Authentication, EncodedAuthenticationParameterSupport {
     private static final long serialVersionUID = 1L;
 
@@ -89,7 +89,7 @@ public class AuthenticationKeyStoreTls implements Authentication, EncodedAuthent
             params = AuthenticationUtil.configureFromJsonString(paramsString);
         } catch (Exception e) {
             // auth-param is not in json format
-            log.info("parameter not in Json format: {}", paramsString);
+            log.info().attr("format", paramsString).log("parameter not in Json format");
         }
 
         // in ":" "," format.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
@@ -28,8 +28,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
@@ -69,7 +69,7 @@ import org.apache.pulsar.common.util.Backoff;
  *
  * This class is intended to be called from multiple threads, and is therefore designed to be thread-safe.
  */
-@Slf4j
+@CustomLog
 public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticationParameterSupport {
 
     public static final String CONFIG_PARAM_TYPE = "type";
@@ -251,9 +251,7 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
      * Retrieve the token (synchronously), and then schedule refresh runnable.
      */
     private void authenticate() throws PulsarClientException {
-        if (log.isDebugEnabled()) {
             log.debug("Attempting to retrieve OAuth2 token now.");
-        }
         TokenResult tr = this.flow.authenticate();
         this.cachedToken = new CachedToken(tr);
         handleSuccessfulTokenRefresh();
@@ -285,7 +283,9 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
             this.authenticate();
         } catch (PulsarClientException | RuntimeException e) {
             long delayMillis = backoff.next().toMillis();
-            log.error("Error refreshing token. Will retry in {} millis.", delayMillis, e);
+            log.error().attr("delayMillis", delayMillis)
+                    .exception(e)
+                    .log("Error refreshing token. Will retry later");
             scheduleRefresh(delayMillis);
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import lombok.Builder;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
@@ -43,7 +43,7 @@ import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
  *
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">OAuth 2.0 RFC 6749, section 4.4</a>
  */
-@Slf4j
+@CustomLog
 class ClientCredentialsFlow extends FlowBase {
     public static final String CONFIG_PARAM_ISSUER_URL = "issuerUrl";
     public static final String CONFIG_PARAM_AUDIENCE = "audience";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -27,7 +27,7 @@ import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import javax.net.ssl.SSLException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -41,7 +41,7 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 /**
  * An abstract OAuth 2.0 authorization flow.
  */
-@Slf4j
+@CustomLog
 abstract class FlowBase implements Flow {
 
     public static final String CONFIG_PARAM_CONNECT_TIMEOUT = "connectTimeout";
@@ -85,7 +85,7 @@ abstract class FlowBase implements Flow {
                         .trustManager(new File(trustCertsFilePath))
                         .build());
             } catch (SSLException e) {
-                log.error("Could not set " + CONFIG_PARAM_TRUST_CERTS_FILE_PATH, e);
+                log.error().exception(e).log("Could not set " + CONFIG_PARAM_TRUST_CERTS_FILE_PATH);
             }
         }
         return new DefaultAsyncHttpClient(confBuilder.build());
@@ -94,14 +94,12 @@ abstract class FlowBase implements Flow {
     private int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
         Duration duration;
         if (value == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Configuration for [{}] is using the default value: [{}]", name, defaultValue);
-            }
+                log.debug().attr("name", name)
+                        .attr("defaultValue", defaultValue)
+                        .log("Configuration is using the default value");
             duration = defaultValue;
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Configuration for [{}] is: [{}]", name, value);
-            }
+                log.debug().attr("name", name).attr("value", value).log("Configuration");
             duration = value;
         }
 
@@ -112,7 +110,7 @@ abstract class FlowBase implements Flow {
         try {
             this.metadata = createMetadataResolver().resolve();
         } catch (IOException e) {
-            log.error("Unable to retrieve OAuth 2.0 server metadata", e);
+            log.error().exception(e).log("Unable to retrieve OAuth 2.0 server metadata");
             throw new PulsarClientException.AuthenticationException("Unable to retrieve OAuth 2.0 server metadata");
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import lombok.CustomLog;
 import org.apache.avro.util.ByteBufferInputStream;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -36,15 +37,12 @@ import org.apache.pulsar.client.api.schema.SchemaWriter;
 import org.apache.pulsar.client.impl.schema.reader.AbstractMultiVersionReader;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * minimal abstract StructSchema.
  */
+@CustomLog
 public abstract class AbstractStructSchema<T> extends AbstractSchema<T> {
-
-    protected static final Logger LOG = LoggerFactory.getLogger(AbstractStructSchema.class);
 
     protected final SchemaInfo schemaInfo;
     protected SchemaReader<T> reader;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -46,7 +46,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 /**
  * Auto detect schema, returns only GenericRecord instances.
  */
-@Slf4j
+@CustomLog
 public class AutoConsumeSchema implements Schema<GenericRecord> {
 
     private final ConcurrentMap<SchemaVersion, Schema<?>> schemaMap = initSchemaMap();
@@ -168,8 +168,10 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
         if (schemaInfo != null) {
             Schema<?> genericSchema = generateSchema(schemaInfo);
             setSchema(SchemaVersion.Latest, genericSchema);
-            log.info("Configure {} schema for topic {} : {}",
-                    componentName, topicName, schemaInfo.getSchemaDefinition());
+            log.info().attr("configure", componentName)
+                    .attr("topic", topicName)
+                    .attr("schemaDefinition", schemaInfo.getSchemaDefinition())
+                    .log("Configure schema for topic");
         }
     }
 
@@ -350,15 +352,18 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
                     if (e instanceof InterruptedException) {
                         Thread.currentThread().interrupt();
                     }
-                    log.error("Can't get last schema for topic {} using AutoConsumeSchema", topicName);
+                    log.error().attr("topic", topicName).log("Can't get last schema for topic using AutoConsumeSchema");
                     throw new SchemaSerializationException(e.getCause());
                 }
                 // schemaInfo null means that there is no schema attached to the topic.
                 Schema<?> schema = generateSchema(schemaInfo);
                 schema.setSchemaInfoProvider(schemaInfoProvider);
                 setSchema(schemaVersion, schema);
-                log.info("Configure {} schema {} for topic {} : {}",
-                        componentName, schemaVersion, topicName, schemaInfo.getSchemaDefinition());
+                log.info().attr("configure", componentName)
+                        .attr("schema", schemaVersion)
+                        .attr("topic", topicName)
+                        .attr("schemaDefinition", schemaInfo.getSchemaDefinition())
+                        .log("Configure schema for topic");
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AvroSchema.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.client.impl.schema;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabled;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseSchemaInfo;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
@@ -38,15 +38,12 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An AVRO schema implementation.
  */
-@Slf4j
+@CustomLog
 public class AvroSchema<T> extends AvroBaseStructSchema<T> {
-    private static final Logger LOG = LoggerFactory.getLogger(AvroSchema.class);
     private boolean isCustomReaderAndWriter;
     private ClassLoader pojoClassLoader;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.api.schema.SchemaWriter;
@@ -41,7 +41,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 /**
  * A schema implementation to deal with json data.
  */
-@Slf4j
+@CustomLog
 public class JSONSchema<T> extends AvroBaseStructSchema<T> {
     private static final AtomicReference<ObjectMapper> JSON_MAPPER = new AtomicReference<>(createObjectMapper());
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaImpl.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.EncodeData;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -44,7 +44,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 /**
  * [Key, Value] pair schema definition.
  */
-@Slf4j
+@CustomLog
 public class KeyValueSchemaImpl<K, V> extends AbstractSchema<KeyValue<K, V>> implements KeyValueSchema<K, V> {
 
 
@@ -289,8 +289,10 @@ public class KeyValueSchemaImpl<K, V> extends AbstractSchema<KeyValue<K, V>> imp
                                     String componentName,
                                     SchemaInfo schemaInfo) {
         if (schemaInfo == null) {
-            log.info("KeyValueSchema starting from null SchemaInfo. "
-                    + "This means that the topic {} still has not a schema", topicName);
+            log.info().attr("topic", topicName)
+                    .log("KeyValueSchema starting from null SchemaInfo."
+                            + " This means that the topic still has"
+                            + " not a schema");
             return;
         }
         KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo);
@@ -456,11 +458,13 @@ public class KeyValueSchemaImpl<K, V> extends AbstractSchema<KeyValue<K, V>> imp
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
-                log.error("Can't get last schema for topic {} using KeyValueSchemaImpl", topicName);
+                log.error().attr("topic", topicName).log("Can't get last schema for topic using KeyValueSchemaImpl");
                 throw new SchemaSerializationException(e.getCause());
             }
-            log.info("Configure schema {} for topic {} : {}",
-                    schemaVersion, topicName, schemaInfo.getSchemaDefinition());
+            log.info().attr("schema", schemaVersion)
+                    .attr("topic", topicName)
+                    .attr("schemaDefinition", schemaInfo.getSchemaDefinition())
+                    .log("Configure schema for topic");
         }
 
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaUtils.java
@@ -61,7 +61,7 @@ public class ProtobufNativeSchemaUtils {
             log.debug().attr("descriptor", descriptor.getFullName())
                     .attr("bytes", schemaDataBytes).log("descriptor serialized");
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error().exception(e).log("Failed to serialize protobuf schema");
             throw new SchemaSerializationException(e);
         }
         return schemaDataBytes;
@@ -119,7 +119,7 @@ public class ProtobufNativeSchemaUtils {
             log.debug().attr("bytes", schemaDataBytes)
                     .attr("descriptor", descriptor.getFullName()).log("deserialized to descriptor");
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error().exception(e).log("Failed to deserialize protobuf schema");
             throw new SchemaSerializationException(e);
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaUtils.java
@@ -25,18 +25,18 @@ import com.google.protobuf.Descriptors;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.common.protocol.schema.ProtobufNativeSchemaData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Protobuf-Native schema util used for serialize/deserialize
  * between {@link com.google.protobuf.Descriptors.Descriptor} and
  * {@link org.apache.pulsar.common.protocol.schema.ProtobufNativeSchemaData}.
  */
+@CustomLog
 public class ProtobufNativeSchemaUtils {
 
     public static byte[] serialize(Descriptors.Descriptor descriptor) {
@@ -58,7 +58,8 @@ public class ProtobufNativeSchemaUtils {
                     .fileDescriptorSet(fileDescriptorSet)
                     .rootFileDescriptorName(rootFileDescriptorName).rootMessageTypeName(rootMessageTypeName).build();
             schemaDataBytes = ObjectMapperFactory.getMapperWithIncludeAlways().writer().writeValueAsBytes(schemaData);
-            logger.debug("descriptor '{}' serialized to '{}'.", descriptor.getFullName(), schemaDataBytes);
+            log.debug().attr("descriptor", descriptor.getFullName())
+                    .attr("bytes", schemaDataBytes).log("descriptor serialized");
         } catch (Exception e) {
             e.printStackTrace();
             throw new SchemaSerializationException(e);
@@ -115,7 +116,8 @@ public class ProtobufNativeSchemaUtils {
             for (int i = 1; i < paths.length; i++) {
                 descriptor = descriptor.findNestedTypeByName(paths[i]);
             }
-            logger.debug("deserialize '{}' to descriptor: '{}'.", schemaDataBytes, descriptor.getFullName());
+            log.debug().attr("bytes", schemaDataBytes)
+                    .attr("descriptor", descriptor.getFullName()).log("deserialized to descriptor");
         } catch (Exception e) {
             e.printStackTrace();
             throw new SchemaSerializationException(e);
@@ -154,7 +156,5 @@ public class ProtobufNativeSchemaUtils {
             throw new SchemaSerializationException(e);
         }
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(ProtobufNativeSchemaUtils.class);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.BinaryEncoder;
@@ -34,10 +35,9 @@ import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
+@CustomLog
 public class GenericAvroReader implements SchemaReader<GenericRecord> {
 
     private final GenericDatumReader<GenericAvroRecord> reader;
@@ -107,7 +107,7 @@ public class GenericAvroReader implements SchemaReader<GenericRecord> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("GenericAvroReader close inputStream close error", e);
+                log.error().exception(e).log("GenericAvroReader close inputStream close error");
             }
         }
     }
@@ -120,6 +120,4 @@ public class GenericAvroReader implements SchemaReader<GenericRecord> {
     public Optional<Object> getNativeSchema() {
         return Optional.of(schema);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(GenericAvroReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroRecord.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.util.Utf8;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -28,7 +28,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 /**
  * A generic avro record.
  */
-@Slf4j
+@CustomLog
 public class GenericAvroRecord extends VersionedGenericRecord {
 
     private final org.apache.avro.Schema schema;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroSchema.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema.generic;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -26,7 +26,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 /**
  * A generic avro schema.
  */
-@Slf4j
+@CustomLog
 public class GenericAvroSchema extends GenericSchemaImpl {
 
     public static final String OFFSET_PROP = "__AVRO_READ_OFFSET__";

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonReader.java
@@ -25,15 +25,15 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class GenericJsonReader implements SchemaReader<GenericRecord> {
 
     private final ObjectReader objectReader;
@@ -82,10 +82,8 @@ public class GenericJsonReader implements SchemaReader<GenericRecord> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("GenericJsonReader close inputStream close error", e);
+                log.error().exception(e).log("GenericJsonReader close inputStream close error");
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(GenericJsonReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonRecord.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 /**
  * Generic json record.
  */
-@Slf4j
+@CustomLog
 public class GenericJsonRecord extends VersionedGenericRecord {
 
     private final JsonNode jn;
@@ -122,7 +122,7 @@ public class GenericJsonRecord extends VersionedGenericRecord {
                 }
             }
         } catch (Exception e) {
-            log.error("parse schemaInfo failed. ", e);
+            log.error().exception(e).log("parse schemaInfo failed. ");
         }
         return isBinary;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericJsonSchema.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema.generic;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
@@ -27,7 +27,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 /**
  * A generic json schema.
  */
-@Slf4j
+@CustomLog
 public class GenericJsonSchema extends GenericSchemaImpl {
 
     public GenericJsonSchema(SchemaInfo schemaInfo) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
@@ -27,13 +27,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> {
 
     private final Descriptors.Descriptor descriptor;
@@ -53,7 +53,7 @@ public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> 
                     .map(f -> new Field(f.getName(), f.getIndex()))
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            log.error("GenericProtobufNativeReader init error", e);
+            log.error().exception(e).log("GenericProtobufNativeReader init error");
             throw new RuntimeException(e);
         }
     }
@@ -85,6 +85,4 @@ public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> 
     public Optional<Object> getNativeSchema() {
         return Optional.of(descriptor);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(GenericProtobufNativeReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeSchema.java
@@ -22,7 +22,7 @@ import static org.apache.pulsar.client.impl.schema.generic.MultiVersionGenericPr
 import com.google.protobuf.Descriptors;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
 import org.apache.pulsar.client.api.schema.GenericSchema;
@@ -31,7 +31,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 /**
  * Generic ProtobufNative schema.
  */
-@Slf4j
+@CustomLog
 public class GenericProtobufNativeSchema extends AbstractGenericSchema {
 
     Descriptors.Descriptor descriptor;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericAvroReader.java
@@ -19,18 +19,18 @@
 package org.apache.pulsar.client.impl.schema.generic;
 
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseAvroSchema;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A multi version generic avro reader.
  */
+@CustomLog
 public class MultiVersionGenericAvroReader extends AbstractMultiVersionGenericReader {
 
     public MultiVersionGenericAvroReader(boolean useProvidedSchemaAsReaderSchema, Schema readerSchema) {
@@ -41,9 +41,9 @@ public class MultiVersionGenericAvroReader extends AbstractMultiVersionGenericRe
     protected SchemaReader<GenericRecord> loadReader(BytesSchemaVersion schemaVersion) {
         SchemaInfo schemaInfo = getSchemaInfoByVersion(schemaVersion.get());
         if (schemaInfo != null) {
-            LOG.info("Load schema reader for version({}), schema is : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    schemaInfo);
+            log.info().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schemaInfo", schemaInfo)
+                    .log("Load schema reader for version(), schema is");
             Schema writerSchema = parseAvroSchema(schemaInfo.getSchemaDefinition());
             Schema readerSchema = useProvidedSchemaAsReaderSchema ? this.readerSchema : writerSchema;
             readerSchema.addProp(GenericAvroSchema.OFFSET_PROP,
@@ -54,11 +54,10 @@ public class MultiVersionGenericAvroReader extends AbstractMultiVersionGenericRe
                     readerSchema,
                     schemaVersion.get());
         } else {
-            LOG.warn("No schema found for version({}), use latest schema : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    this.readerSchema);
+            log.warn().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", this.readerSchema)
+                    .log("No schema found for version, use latest schema");
             return providerSchemaReader;
         }
     }
-    protected static final Logger LOG = LoggerFactory.getLogger(MultiVersionGenericAvroReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericJsonReader.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseAvroSchema;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.Field;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -28,12 +29,11 @@ import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A multi version generic json reader.
  */
+@CustomLog
 public class MultiVersionGenericJsonReader extends AbstractMultiVersionGenericReader {
 
     public MultiVersionGenericJsonReader(boolean useProvidedSchemaAsReaderSchema, Schema readerSchema,
@@ -45,9 +45,9 @@ public class MultiVersionGenericJsonReader extends AbstractMultiVersionGenericRe
     protected SchemaReader<GenericRecord> loadReader(BytesSchemaVersion schemaVersion) {
         SchemaInfo schemaInfo = getSchemaInfoByVersion(schemaVersion.get());
         if (schemaInfo != null) {
-            LOG.info("Load schema reader for version({}), schema is : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    schemaInfo.getSchemaDefinition());
+            log.info().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", schemaInfo.getSchemaDefinition())
+                    .log("Load schema reader for version");
             Schema readerSchema;
             if (useProvidedSchemaAsReaderSchema) {
                 readerSchema = this.readerSchema;
@@ -60,12 +60,10 @@ public class MultiVersionGenericJsonReader extends AbstractMultiVersionGenericRe
                             .map(f -> new Field(f.name(), f.pos()))
                             .collect(Collectors.toList()), schemaInfo);
         } else {
-            LOG.warn("No schema found for version({}), use latest schema : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    this.readerSchema);
+            log.warn().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", this.readerSchema)
+                    .log("No schema found for version(), use latest schema");
             return providerSchemaReader;
         }
     }
-
-    protected static final Logger LOG = LoggerFactory.getLogger(MultiVersionGenericAvroReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericProtobufNativeReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionGenericProtobufNativeReader.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.client.impl.schema.generic;
 
 import com.google.protobuf.Descriptors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
@@ -31,7 +31,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 /**
  * A multi version generic protobuf-native reader.
  */
-@Slf4j
+@CustomLog
 public class MultiVersionGenericProtobufNativeReader
     extends AbstractMultiVersionReader<GenericRecord>
     implements SchemaReader<GenericRecord> {
@@ -59,9 +59,9 @@ public class MultiVersionGenericProtobufNativeReader
     protected SchemaReader<GenericRecord> loadReader(BytesSchemaVersion schemaVersion) {
         SchemaInfo schemaInfo = getSchemaInfoByVersion(schemaVersion.get());
         if (schemaInfo != null) {
-            log.info("Load schema reader for version({}), schema is : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    schemaInfo);
+            log.info().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", schemaInfo)
+                    .log("Load schema reader");
             Descriptors.Descriptor recordDescriptor = parseProtobufSchema(schemaInfo);
             Descriptors.Descriptor readerSchemaDescriptor =
                 useProvidedSchemaAsReaderSchema ? descriptor : recordDescriptor;
@@ -69,9 +69,9 @@ public class MultiVersionGenericProtobufNativeReader
                     readerSchemaDescriptor,
                     schemaVersion.get());
         } else {
-            log.warn("No schema found for version({}), use latest schema : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    this.schemaInfo);
+            log.warn().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", this.schemaInfo)
+                    .log("No schema found for version, use latest schema");
             return providerSchemaReader;
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
@@ -25,21 +25,19 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Multi version generic schema provider by guava cache.
  */
+@CustomLog
 public class MultiVersionSchemaInfoProvider implements SchemaInfoProvider {
-
-    private static final Logger LOG = LoggerFactory.getLogger(MultiVersionSchemaInfoProvider.class);
 
     private final TopicName topicName;
     private final PulsarClientImpl pulsarClient;
@@ -73,8 +71,10 @@ public class MultiVersionSchemaInfoProvider implements SchemaInfoProvider {
             }
             return cache.get(BytesSchemaVersion.of(schemaVersion));
         } catch (ExecutionException e) {
-            LOG.error("Can't get schema for topic {} schema version {}",
-                    topicName.toString(), new String(schemaVersion, StandardCharsets.UTF_8), e);
+            log.error().attr("topic", topicName.toString())
+                    .attr("version", new String(schemaVersion, StandardCharsets.UTF_8))
+                    .exception(e)
+                    .log("Can't get schema for topic schema version");
             return FutureUtil.failedFuture(e.getCause());
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
@@ -24,6 +24,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.InputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.avro.AvroTypeException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.SerializationException;
@@ -33,12 +34,11 @@ import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The multi version reader abstract class, implement it will handle the multi version schema.
  */
+@CustomLog
 public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
 
     protected final SchemaReader<T> providerSchemaReader;
@@ -72,8 +72,10 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
             return schemaVersion == null ? read(inputStream) :
                     getSchemaReader(schemaVersion).read(inputStream);
         } catch (ExecutionException e) {
-            LOG.error("Can't get generic schema for topic {} schema version {}",
-                    schemaInfoProvider.getTopicName(), Hex.encodeHexString(schemaVersion), e);
+            log.error().attr("topic", schemaInfoProvider.getTopicName())
+                    .attr("version", Hex.encodeHexString(schemaVersion))
+                    .exception(e)
+                    .log("Can't get generic schema");
             throw new RuntimeException("Can't get generic schema for topic " + schemaInfoProvider.getTopicName());
         }
     }
@@ -91,8 +93,10 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
             if (e instanceof AvroTypeException) {
                 throw new SchemaSerializationException(e);
             }
-            LOG.error("Can't get generic schema for topic {} schema version {}",
-                    schemaInfoProvider.getTopicName(), Hex.encodeHexString(schemaVersion), e);
+            log.error().attr("topic", schemaInfoProvider.getTopicName())
+                    .attr("version", Hex.encodeHexString(schemaVersion))
+                    .exception(e)
+                    .log("Can't get generic schema");
             throw new RuntimeException("Can't get generic schema for topic " + schemaInfoProvider.getTopicName());
         }
     }
@@ -129,6 +133,4 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
             );
         }
     }
-
-    protected static final Logger LOG = LoggerFactory.getLogger(AbstractMultiVersionReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.schema.reader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
@@ -29,9 +30,8 @@ import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class AvroReader<T> implements SchemaReader<T> {
 
     private ReflectDatumReader<T> reader;
@@ -96,7 +96,7 @@ public class AvroReader<T> implements SchemaReader<T> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("AvroReader close inputStream close error", e);
+                log.error().exception(e).log("AvroReader close inputStream close error");
             }
         }
     }
@@ -105,7 +105,5 @@ public class AvroReader<T> implements SchemaReader<T> {
     public Optional<Object> getNativeSchema() {
         return Optional.of(schema);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(AvroReader.class);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JacksonJsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JacksonJsonReader.java
@@ -22,16 +22,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Reader implementation for reading objects from JSON.
  *
  * @param <T> object type to read
  */
+@CustomLog
 public class JacksonJsonReader<T> implements SchemaReader<T> {
     private final Class<T> pojo;
     private final ObjectReader objectReader;
@@ -60,10 +60,8 @@ public class JacksonJsonReader<T> implements SchemaReader<T> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("JsonReader close inputStream close error", e);
+                log.error().exception(e).log("JsonReader close inputStream close error");
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(JacksonJsonReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JsonReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/JsonReader.java
@@ -22,10 +22,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
 import java.io.InputStream;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Reader implementation for reading objects from JSON.
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * @deprecated use {@link JacksonJsonReader} instead.
  */
 @Deprecated
+@CustomLog
 public class JsonReader<T> implements SchemaReader<T> {
     private final Class<T> pojo;
     private final ObjectReader objectReader;
@@ -62,10 +62,8 @@ public class JsonReader<T> implements SchemaReader<T> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("JsonReader close inputStream close error", e);
+                log.error().exception(e).log("JsonReader close inputStream close error");
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(JsonReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/MultiVersionAvroReader.java
@@ -20,17 +20,17 @@ package org.apache.pulsar.client.impl.schema.reader;
 
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.getJsr310ConversionEnabled;
 import static org.apache.pulsar.client.impl.schema.util.SchemaUtil.parseAvroSchema;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.api.schema.SchemaReader;
 import org.apache.pulsar.client.impl.schema.SchemaUtils;
 import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A multi version avro reader.
  */
+@CustomLog
 public class MultiVersionAvroReader<T> extends AbstractMultiVersionAvroBaseReader<T> {
 
     private final ClassLoader pojoClassLoader;
@@ -44,21 +44,17 @@ public class MultiVersionAvroReader<T> extends AbstractMultiVersionAvroBaseReade
     protected SchemaReader<T> loadReader(BytesSchemaVersion schemaVersion) {
         SchemaInfo schemaInfo = getSchemaInfoByVersion(schemaVersion.get());
         if (schemaInfo != null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Load schema reader for version({}), schema is : {}, schemaInfo: {}",
-                        SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                        schemaInfo.getSchemaDefinition(), schemaInfo);
-            }
+                log.debug().attr("version", () -> SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                        .attr("schema", schemaInfo.getSchemaDefinition())
+                        .log("Loading schema reader");
             boolean jsr310ConversionEnabled = getJsr310ConversionEnabled(schemaInfo);
             return new AvroReader<>(parseAvroSchema(schemaInfo.getSchemaDefinition()),
                     readerSchema, pojoClassLoader, jsr310ConversionEnabled);
         } else {
-            LOG.warn("No schema found for version({}), use latest schema : {}",
-                    SchemaUtils.getStringSchemaVersion(schemaVersion.get()),
-                    this.readerSchema);
+            log.warn().attr("version", SchemaUtils.getStringSchemaVersion(schemaVersion.get()))
+                    .attr("schema", this.readerSchema)
+                    .log("No schema found for version, use latest schema");
             return providerSchemaReader;
         }
     }
-
-    protected static final Logger LOG = LoggerFactory.getLogger(MultiVersionAvroReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/ProtobufReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/ProtobufReader.java
@@ -23,11 +23,11 @@ import com.google.protobuf.Message;
 import com.google.protobuf.Parser;
 import java.io.IOException;
 import java.io.InputStream;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.SchemaReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ProtobufReader<T extends Message> implements SchemaReader<T> {
     private Parser<T> tParser;
 
@@ -55,10 +55,8 @@ public class ProtobufReader<T extends Message> implements SchemaReader<T> {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                log.error("ProtobufReader close inputStream close error", e);
+                log.error().exception(e).log("ProtobufReader close inputStream close error");
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ProtobufReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryConsumerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryConsumerInterceptor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerInterceptor;
 import org.apache.pulsar.client.api.Message;
@@ -38,8 +39,6 @@ import org.apache.pulsar.client.api.TraceableMessageId;
 import org.apache.pulsar.client.impl.ConsumerBase;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * OpenTelemetry consumer interceptor that creates spans for message consumption.
@@ -62,9 +61,8 @@ import org.slf4j.LoggerFactory;
  * map structure (topic partition → message IDs) and {@link TopicMessageId#getOwnerTopic()} to ensure
  * spans are only ended for messages from the acknowledged topic partition.
  */
+@CustomLog
 public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<T> {
-
-    private static final Logger log = LoggerFactory.getLogger(OpenTelemetryConsumerInterceptor.class);
 
     private Tracer tracer;
     private TextMapPropagator propagator;
@@ -175,10 +173,12 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                     ((TraceableMessageId) messageId).setTracingSpan(span);
                 }
 
-                log.debug("Created consumer span for message {} on topic {}", messageId, topic);
+                log.debug().attr("messageId", messageId)
+                        .attr("topic", topic)
+                        .log("Created consumer span");
             }
         } catch (Exception e) {
-            log.error("Error creating consumer span", e);
+            log.error().exception(e).log("Error creating consumer span");
         }
 
         return message;
@@ -212,7 +212,7 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                     }
                 }
             } catch (Exception e) {
-                log.error("Error ending consumer span on acknowledge", e);
+                log.error().exception(e).log("Error ending consumer span on acknowledge");
             }
         }
     }
@@ -234,7 +234,7 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                         }
                         ((TraceableMessageId) messageId).setTracingSpan(null);
                     } catch (Exception e) {
-                        log.error("Error ending consumer span on cumulative acknowledge", e);
+                        log.error().exception(e).log("Error ending consumer span on cumulative acknowledge");
                     }
                 }
             }
@@ -277,7 +277,9 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                             ((TraceableMessageId) msgId).setTracingSpan(null);
                         }
                     } catch (Exception e) {
-                        log.error("Error ending consumer span on cumulative acknowledge for message {}", msgId, e);
+                        log.error().attr("messageId", msgId)
+                                .exception(e)
+                                .log("Error ending consumer span on cumulative acknowledge");
                     }
                     iterator.remove();
                 } else {
@@ -302,7 +304,7 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                 }
                 ((TraceableMessageId) messageId).setTracingSpan(null);
             } catch (Exception e) {
-                log.error("Error ending consumer span on cumulative acknowledge", e);
+                log.error().exception(e).log("Error ending consumer span on cumulative acknowledge");
             }
         }
     }
@@ -333,7 +335,7 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                         }
                     }
                 } catch (Exception e) {
-                    log.error("Error ending consumer span on negative acknowledge", e);
+                    log.error().exception(e).log("Error ending consumer span on negative acknowledge");
                 }
             }
         }
@@ -365,7 +367,7 @@ public class OpenTelemetryConsumerInterceptor<T> implements ConsumerInterceptor<
                         }
                     }
                 } catch (Exception e) {
-                    log.error("Error ending consumer span on ack timeout", e);
+                    log.error().exception(e).log("Error ending consumer span on ack timeout");
                 }
             }
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryProducerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryProducerInterceptor.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -31,8 +32,6 @@ import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.apache.pulsar.client.impl.ProducerBase;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * OpenTelemetry producer interceptor that creates spans for message publishing.
@@ -43,9 +42,8 @@ import org.slf4j.LoggerFactory;
  * Spans are attached directly to {@link TraceableMessage} instances, eliminating the need
  * for external span tracking via maps.
  */
+@CustomLog
 public class OpenTelemetryProducerInterceptor implements ProducerInterceptor {
-
-    private static final Logger log = LoggerFactory.getLogger(OpenTelemetryProducerInterceptor.class);
 
     private Tracer tracer;
     private TextMapPropagator propagator;
@@ -105,10 +103,10 @@ public class OpenTelemetryProducerInterceptor implements ProducerInterceptor {
             if (TracingContext.isValid(span) && message instanceof TraceableMessage) {
                 // Attach the span directly to the message
                 ((TraceableMessage) message).setTracingSpan(span);
-                log.debug("Created producer span for message on topic {}", topic);
+                log.debug().attr("topic", topic).log("Created producer span");
             }
         } catch (Exception e) {
-            log.error("Error creating producer span", e);
+            log.error().exception(e).log("Error creating producer span");
         }
 
         return message;
@@ -136,7 +134,7 @@ public class OpenTelemetryProducerInterceptor implements ProducerInterceptor {
                 // Clear the span from the message
                 ((TraceableMessage) message).setTracingSpan(null);
             } catch (Exception e) {
-                log.error("Error ending producer span", e);
+                log.error().exception(e).log("Error ending producer span");
             }
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionBuilderImpl.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.impl.transaction;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.transaction.Transaction;
 import org.apache.pulsar.client.api.transaction.TransactionBuilder;
@@ -30,7 +30,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 /**
  * The default implementation of transaction builder to build transactions.
  */
-@Slf4j
+@CustomLog
 public class TransactionBuilderImpl implements TransactionBuilder {
 
     private final PulsarClientImpl client;
@@ -66,13 +66,12 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 .newTransactionAsync(txnTimeout, timeUnit)
                 .whenComplete((txnID, throwable) -> {
                     if (throwable != null) {
-                        log.error("New transaction error.", throwable);
+                        log.error().exception(throwable).log("New transaction error.");
                         future.completeExceptionally(throwable);
                         return;
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("'newTransaction' command completed successfully for transaction: {}", txnID);
-                    }
+                        log.debug().attr("transaction", txnID)
+                                .log("'newTransaction' command completed successfully for transaction");
                     TransactionImpl transaction = new TransactionImpl(client, timeUnit.toMillis(txnTimeout),
                             txnID.getLeastSigBits(), txnID.getMostSigBits());
                     future.complete(transaction);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionCoordinatorClientImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
@@ -40,15 +41,12 @@ import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Transaction coordinator client based topic assigned.
  */
+@CustomLog
 public class TransactionCoordinatorClientImpl implements TransactionCoordinatorClient {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionCoordinatorClientImpl.class);
 
     private final PulsarClientImpl pulsarClient;
     private TransactionMetaStoreHandler[] handlers;
@@ -83,9 +81,8 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
                             SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN.getPartitionedTopicName(), true, false)
                 .thenCompose(partitionMeta -> {
                     List<CompletableFuture<Void>> connectFutureList = new ArrayList<>();
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Transaction meta store assign partition is {}.", partitionMeta.partitions);
-                    }
+                        log.debug().attr("partitions", partitionMeta.partitions)
+                                .log("Transaction meta store assign partition is.");
                     if (partitionMeta.partitions > 0) {
                         handlers = new TransactionMetaStoreHandler[partitionMeta.partitions];
                         for (int i = 0; i < partitionMeta.partitions; i++) {
@@ -131,7 +128,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
     public CompletableFuture<Void> closeAsync() {
         CompletableFuture<Void> result = new CompletableFuture<>();
         if (getState() == State.CLOSING || getState() == State.CLOSED) {
-            LOG.warn("The transaction meta store is closing or closed, doing nothing.");
+            log.warn("The transaction meta store is closing or closed, doing nothing.");
             result.complete(null);
         } else {
             if (handlers != null) {
@@ -139,7 +136,7 @@ public class TransactionCoordinatorClientImpl implements TransactionCoordinatorC
                     try {
                         handler.close();
                     } catch (IOException e) {
-                        LOG.warn("Close transaction meta store handler error", e);
+                        log.warn().exception(e).log("Close transaction meta store handler error");
                     }
                 }
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/transaction/TransactionImpl.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -49,7 +49,7 @@ import org.apache.pulsar.common.util.FutureUtil;
  * failures. This decouples the transactional operations from non-transactional operations as
  * much as possible.
  */
-@Slf4j
+@CustomLog
 @Getter
 public class TransactionImpl implements Transaction , TimerTask {
 
@@ -128,8 +128,10 @@ public class TransactionImpl implements Transaction , TimerTask {
         // and then the opFuture will never be replaced.
         newSendFuture.whenComplete((messageId, e) -> {
             if (e != null) {
-                log.error("The transaction [{}:{}] get an exception when send messages.",
-                        txnIdMostBits, txnIdLeastBits, e);
+                log.error().attr("txnIdMostBits", txnIdMostBits)
+                        .attr("txnIdLeastBits", txnIdLeastBits)
+                        .exception(e)
+                        .log("The transaction got an exception when sending messages");
                 if (!hasOpsFailed) {
                     hasOpsFailed = true;
                 }
@@ -167,8 +169,10 @@ public class TransactionImpl implements Transaction , TimerTask {
         // and then the opFuture will never be replaced.
         newAckFuture.whenComplete((ignore, e) -> {
             if (e != null) {
-                log.error("The transaction [{}:{}] get an exception when ack messages.",
-                        txnIdMostBits, txnIdLeastBits, e);
+                log.error().attr("txnIdMostBits", txnIdMostBits)
+                        .attr("txnIdLeastBits", txnIdLeastBits)
+                        .exception(e)
+                        .log("The transaction got an exception when acking messages");
                 if (!hasOpsFailed) {
                     hasOpsFailed = true;
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ExecutorProvider.java
@@ -29,12 +29,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 
-@Slf4j
+@CustomLog
 public class ExecutorProvider {
     private final int numThreads;
     private final List<Pair<ExecutorService, ExtendedThreadFactory>> executors;
@@ -56,7 +56,7 @@ public class ExecutorProvider {
         public Thread newThread(Runnable r) {
             Thread thread = super.newThread(r);
             thread.setUncaughtExceptionHandler((t, e) ->
-                    log.error("Thread {} got uncaught Exception", t.getName(), e));
+                    log.error().attr("thread", t.getName()).exception(e).log("Thread got uncaught Exception"));
             this.thread = thread;
             return thread;
         }
@@ -115,9 +115,12 @@ public class ExecutorProvider {
             executor.shutdownNow();
             try {
                 if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
-                    log.warn("Failed to terminate executor with pool name {} within timeout. The following are stack"
-                            + " traces of still running threads.\n{}",
-                            poolName, getThreadDump(threadFactory.getThread()));
+                    log.warn().attr("name", poolName)
+                            .attr("threads", getThreadDump(threadFactory.getThread()))
+                            .log("Failed to terminate executor with pool"
+                                    + " name within timeout. The following are"
+                                    + " stack traces of still running"
+                                    + " threads.\n");
                 }
             } catch (InterruptedException e) {
                 log.warn("Shutdown of thread pool was interrupted");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -22,12 +22,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import org.apache.pulsar.common.util.Backoff;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class RetryUtil {
-    private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
 
     public static <T> void retryAsynchronously(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                                ScheduledExecutorService scheduledExecutorService,
@@ -52,7 +51,9 @@ public class RetryUtil {
                 if (isMandatoryStop) {
                     callback.completeExceptionally(e);
                 } else {
-                    log.warn("Execution with retry fail, because of {}, will retry in {} ms", e.getMessage(), next);
+                    log.warn().exceptionMessage(e)
+                            .attr("nextMs", next)
+                            .log("Execution with retry failed, will retry");
                     scheduledExecutorService.schedule(() ->
                                     executeWithRetry(supplier, backoff, scheduledExecutorService, callback),
                             next, TimeUnit.MILLISECONDS);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/ScheduledExecutorProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/ScheduledExecutorProvider.java
@@ -20,9 +20,9 @@ package org.apache.pulsar.client.util;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 
-@Slf4j
+@CustomLog
 public class ScheduledExecutorProvider extends ExecutorProvider {
     public ScheduledExecutorProvider(int numThreads, String poolName, boolean daemon) {
         super(numThreads, poolName, daemon);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
@@ -23,17 +23,15 @@ import static org.testng.Assert.assertFalse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.CustomLog;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 /**
  * Unit test of {@link ConsumerConfiguration}.
  */
+@CustomLog
 public class ConsumerConfigurationTest {
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerConfigurationTest.class);
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
@@ -61,7 +59,7 @@ public class ConsumerConfigurationTest {
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
 
         String confAsString = w.writeValueAsString(conf);
-        log.info("conf : {}", confAsString);
+        log.info().attr("conf", confAsString).log("Consumer configuration");
 
         assertFalse(confAsString.contains("messageListener"));
         assertFalse(confAsString.contains("consumerEventListener"));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AutoClusterFailoverTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ServiceUrlProvider;
@@ -38,7 +38,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker-impl")
-@Slf4j
+@CustomLog
 public class AutoClusterFailoverTest {
     @Test
     public void testBuildAutoClusterFailoverInstance() throws Exception {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConnectionTimeoutTest.java
@@ -29,12 +29,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class ConnectionTimeoutTest {
 
     @Test
@@ -51,7 +51,7 @@ public class ConnectionTimeoutTest {
                 Thread connectThread = new Thread(() -> {
                     try (Socket socket = new Socket()) {
                         socket.connect(serverSocket.getLocalSocketAddress());
-                        log.info("Connected to {}", socket.getRemoteSocketAddress());
+                        log.info().attr("address", socket.getRemoteSocketAddress()).log("Connected");
                         latch.countDown();
                         Thread.sleep(10000L);
                     } catch (IOException e) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchemaTest.java
@@ -19,7 +19,7 @@
 package org.apache.pulsar.client.impl.schema;
 
 import java.nio.ByteBuffer;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 /**
  * AutoConsumeSchema test.
  */
-@Slf4j
+@CustomLog
 public class AutoConsumeSchemaTest {
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -38,9 +38,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
@@ -71,7 +71,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-@Slf4j
+@CustomLog
 public class AvroSchemaTest {
 
     @Data

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/JSONSchemaTest.java
@@ -30,9 +30,9 @@ import io.netty.buffer.ByteBufAllocator;
 import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaValidationException;
 import org.apache.pulsar.client.api.SchemaSerializationException;
@@ -56,7 +56,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class JSONSchemaTest {
 
     public static void assertJSONEqual(String s1, String s2) throws JSONException{

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaInfoTest.java
@@ -27,7 +27,7 @@ import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.SchemaTestUtils.Bar;
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
 /**
  * Unit test {@link KeyValueSchemaInfoTest}.
  */
-@Slf4j
+@CustomLog
 public class KeyValueSchemaInfoTest {
 
     private static final Map<String, String> FOO_PROPERTIES = new HashMap<>() {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/KeyValueSchemaTest.java
@@ -25,7 +25,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import java.util.Map;
 import java.util.TreeMap;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
@@ -38,7 +38,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class KeyValueSchemaTest {
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/PrimitiveSchemaTest.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.DataProvider;
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 /**
  * Unit tests primitive schemas.
  */
-@Slf4j
+@CustomLog
 public class PrimitiveSchemaTest {
 
 
@@ -141,9 +141,9 @@ public class PrimitiveSchemaTest {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void allSchemasShouldRoundtripInput(Map<Schema, List<Object>> testData) {
         for (Map.Entry<Schema, List<Object>> test : testData.entrySet()) {
-            log.info("Test schema {}", test.getKey());
+            log.info().attr("schema", test.getKey()).log("Test schema");
             for (Object value : test.getValue()) {
-                log.info("Encode : {}", value);
+                log.info().attr("value", value).log("Encode");
                 try {
                     assertEquals(value,
                         test.getKey().decode(test.getKey().encode(value)),

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufNativeSchemaTest.java
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -44,7 +44,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class ProtobufNativeSchemaTest {
 
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/ProtobufSchemaTest.java
@@ -34,13 +34,13 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class ProtobufSchemaTest {
 
     private static final String NAME = "foo";

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/AbstractGenericSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/AbstractGenericSchemaTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 /**
  * Unit testing AbstractGenericSchema for non-avroBasedGenericSchema.
  */
-@Slf4j
+@CustomLog
 public class AbstractGenericSchemaTest {
 
     @Test
@@ -76,7 +76,7 @@ public class AbstractGenericSchemaTest {
             org.apache.pulsar.client.schema.proto.Test.TestMessage testMessage = newTestMessage(i);
             byte[] data = encodeSchema.encode(testMessage);
 
-            log.info("Decoding : {}", new String(data, UTF_8));
+            log.info().attr("data", new String(data, UTF_8)).log("Decoding");
 
             GenericRecord record;
             if (decodeSchema instanceof AutoConsumeSchema) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReaderTest.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.client.impl.schema.generic;
 import static org.testng.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
@@ -31,7 +31,7 @@ import org.apache.pulsar.client.impl.schema.SchemaTestUtils.FooV2;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class GenericAvroReaderTest {
 
     private Foo foo;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReaderTest.java
@@ -22,7 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
@@ -31,7 +31,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Slf4j
+@CustomLog
 public class GenericProtobufNativeReaderTest {
 
     private TestMessage message;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImplTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.GenericSchema;
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
 /**
  * Unit testing generic schemas.
  */
-@Slf4j
+@CustomLog
 public class GenericSchemaImplTest {
 
     @Test
@@ -109,7 +109,7 @@ public class GenericSchemaImplTest {
             Foo foo = newFoo(i);
             byte[] data = encodeSchema.encode(foo);
 
-            log.info("Decoding : {}", new String(data, UTF_8));
+            log.info().attr("data", new String(data, UTF_8)).log("Decoding");
 
             GenericRecord record;
             if (decodeSchema instanceof AutoConsumeSchema) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaTest.java
@@ -28,7 +28,7 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  * Unit testing generic schemas.
  * this test is duplicated with GenericSchemaImplTest independent of GenericSchemaImpl
  */
-@Slf4j
+@CustomLog
 public class GenericSchemaTest {
 
     @Test
@@ -138,7 +138,7 @@ public class GenericSchemaTest {
             Foo foo = newFoo(i);
             byte[] data = encodeSchema.encode(foo);
 
-            log.info("Decoding : {}", new String(data, UTF_8));
+            log.info().attr("data", new String(data, UTF_8)).log("Decoding");
 
             GenericRecord record;
             if (decodeSchema instanceof AutoConsumeSchema) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
@@ -23,12 +23,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
-@Slf4j
+@CustomLog
 public class SampleAsyncProducer {
     public static void main(String[] args) throws InterruptedException, IOException {
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://localhost:8080").build();
@@ -44,9 +44,9 @@ public class SampleAsyncProducer {
 
             future.handle((v, ex) -> {
                 if (ex == null) {
-                    log.info("Message persisted: {}", content);
+                    log.info().attr("content", content).log("Message persisted");
                 } else {
-                    log.error("Error persisting message: {}", content, ex);
+                    log.error().attr("content", content).exception(ex).log("Error persisting message");
                 }
                 return null;
             });

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducerWithSchema.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducerWithSchema.java
@@ -23,14 +23,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 
-@Slf4j
+@CustomLog
 public class SampleAsyncProducerWithSchema {
 
     public static void main(String[] args) throws IOException {
@@ -48,9 +48,9 @@ public class SampleAsyncProducerWithSchema {
 
             future.handle((v, ex) -> {
                 if (ex == null) {
-                    log.info("Message persisted: {}", content);
+                    log.info().attr("content", content).log("Message persisted");
                 } else {
-                    log.error("Error persisting message: {}", content, ex);
+                    log.error().attr("content", content).exception(ex).log("Error persisting message");
                 }
                 return null;
             });

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumerListener.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumerListener.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.client.tutorial;
 
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClient;
 
-@Slf4j
+@CustomLog
 public class SampleConsumerListener {
     public static void main(String[] args) throws InterruptedException, IOException {
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://localhost:8080").build();
@@ -31,7 +31,7 @@ public class SampleConsumerListener {
                 .topic("persistent://my-tenant/my-ns/my-topic") //
                 .subscriptionName("my-subscription-name") //
                 .messageListener((consumer, msg) -> {
-                    log.info("Received message: {}", msg);
+                    log.info().attr("message", msg).log("Received message");
                     consumer.acknowledgeAsync(msg);
                 }).subscribe();
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleCryptoConsumer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleCryptoConsumer.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
@@ -30,7 +30,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 
-@Slf4j
+@CustomLog
 public class SampleCryptoConsumer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException {
 
@@ -52,7 +52,7 @@ public class SampleCryptoConsumer {
                 try {
                     keyInfo.setKey(Files.readAllBytes(Paths.get(publicKeyFile)));
                 } catch (IOException e) {
-                    log.error("Failed to read public key from file {}", publicKeyFile, e);
+                    log.error().attr("file", publicKeyFile).exception(e).log("Failed to read public key from file");
                 }
                 return keyInfo;
             }
@@ -65,7 +65,7 @@ public class SampleCryptoConsumer {
                 try {
                     keyInfo.setKey(Files.readAllBytes(Paths.get(privateKeyFile)));
                 } catch (IOException e) {
-                    log.error("Failed to read private key from file {}", privateKeyFile, e);
+                    log.error().attr("file", privateKeyFile).exception(e).log("Failed to read private key from file");
                 }
                 return keyInfo;
             }
@@ -82,7 +82,7 @@ public class SampleCryptoConsumer {
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive();
             // process the messsage
-            log.info("Received: {}", new String(msg.getData()));
+            log.info().attr("message", new String(msg.getData())).log("Received");
         }
 
         // Acknowledge the consumption of all messages at once

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleCryptoProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleCryptoProducer.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 
-@Slf4j
+@CustomLog
 public class SampleCryptoProducer {
 
     public static void main(String[] args) throws InterruptedException, IOException {
@@ -51,7 +51,7 @@ public class SampleCryptoProducer {
                     // Read the public key from the file
                     keyInfo.setKey(Files.readAllBytes(Paths.get(publicKeyFile)));
                 } catch (IOException e) {
-                    log.error("Failed to read public key from file {}", publicKeyFile, e);
+                    log.error().attr("file", publicKeyFile).exception(e).log("Failed to read public key from file");
                 }
                 return keyInfo;
             }
@@ -64,7 +64,7 @@ public class SampleCryptoProducer {
                     // Read the private key from the file
                     keyInfo.setKey(Files.readAllBytes(Paths.get(privateKeyFile)));
                 } catch (IOException e) {
-                    log.error("Failed to read private key from file {}", privateKeyFile, e);
+                    log.error().attr("file", privateKeyFile).exception(e).log("Failed to read private key from file");
                 }
                 return keyInfo;
             }


### PR DESCRIPTION
## Summary
- Convert all 103 source and test files in `pulsar-client` from SLF4J to slog structured logging
- Add derived loggers with context attributes to key classes (ClientCnx, ConsumerImpl, ProducerImpl, TopicListWatcher, TableViewImpl, etc.)
- Standardize attribute names across the codebase (messageId, sequenceId, requestId, etc.)
- Use `.exception(e)` for Throwable objects and lazy attrs for mutable values

## Test plan
- [x] `compileJava` and `compileTestJava` pass
- [x] `checkstyleMain` and `checkstyleTest` pass
- [ ] CI passes

### Motivation

PIP-467

> [!NOTE]
> Please label this PR with `ready-to-test`