### PR TITLE
[fix][ci] Ensure discard_max_bytes is set to 0 only for existing block devices

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -53,8 +53,10 @@ runs:
             fi
             # disable discard/trim at device level since remount with nodiscard doesn't seem to be effective
             # https://www.spinics.net/lists/linux-ide/msg52562.html
-            for i in /sys/block/sd*/queue/discard_max_bytes; do
-              echo 0 | sudo tee $i
+            for i in /sys/block/*/queue/discard_max_bytes; do
+              if [ -f "$i" ]; then
+                echo 0 | sudo tee "$i"
+              fi
             done
             # disable unnecessary timers
             sudo systemctl stop fstrim.timer fstrim.service \


### PR DESCRIPTION
### Motivation

In CI environments, the following error was observed when attempting to disable discard:

```
tee: '/sys/block/sd*/queue/discard_max_bytes': No such file or directory
Error: Process completed with exit code 1.
```

This happens because the script assumes block devices follow the `sd*` naming convention, which is not always true (e.g., NVMe or virtual disks). As a result, the glob does not match any files and causes the step to fail.

### Modifications

* Replace `/sys/block/sd*/queue/discard_max_bytes` with `/sys/block/*/queue/discard_max_bytes` to support all block device types
* Add a file existence check (`-f`) before applying `tee` to avoid errors when the file is not present