### PR TITLE
[fix][broker] Clean up orphan ledger on concurrent initial schema creation in BookkeeperSchemaStorage

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerMetadataUtils.java
@@ -29,28 +29,28 @@ import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
  */
 public final class LedgerMetadataUtils {
 
-    private static final String METADATA_PROPERTY_APPLICATION = "application";
-    private static final byte[] METADATA_PROPERTY_APPLICATION_PULSAR = "pulsar".getBytes(StandardCharsets.UTF_8);
+    public static final String METADATA_PROPERTY_APPLICATION = "application";
+    public static final byte[] METADATA_PROPERTY_APPLICATION_PULSAR = "pulsar".getBytes(StandardCharsets.UTF_8);
 
-    private static final String METADATA_PROPERTY_COMPONENT = "component";
-    private static final byte[] METADATA_PROPERTY_COMPONENT_MANAGED_LEDGER =
+    public static final String METADATA_PROPERTY_COMPONENT = "component";
+    public static final byte[] METADATA_PROPERTY_COMPONENT_MANAGED_LEDGER =
             "managed-ledger".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] METADATA_PROPERTY_COMPONENT_COMPACTED_LEDGER =
+    public static final byte[] METADATA_PROPERTY_COMPONENT_COMPACTED_LEDGER =
             "compacted-ledger".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] METADATA_PROPERTY_COMPONENT_SCHEMA = "schema".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] METADATA_PROPERTY_COMPONENT_SCHEMA = "schema".getBytes(StandardCharsets.UTF_8);
 
-    private static final byte[] METADATA_PROPERTY_COMPONENT_DELAYED_INDEX_BUCKET =
+    public static final byte[] METADATA_PROPERTY_COMPONENT_DELAYED_INDEX_BUCKET =
             "delayed-index-bucket".getBytes(StandardCharsets.UTF_8);
 
-    private static final String METADATA_PROPERTY_MANAGED_LEDGER_NAME = "pulsar/managed-ledger";
-    private static final String METADATA_PROPERTY_CURSOR_NAME = "pulsar/cursor";
-    private static final String METADATA_PROPERTY_COMPACTEDTOPIC = "pulsar/compactedTopic";
-    private static final String METADATA_PROPERTY_COMPACTEDTO = "pulsar/compactedTo";
-    private static final String METADATA_PROPERTY_SCHEMAID = "pulsar/schemaId";
+    public static final String METADATA_PROPERTY_MANAGED_LEDGER_NAME = "pulsar/managed-ledger";
+    public static final String METADATA_PROPERTY_CURSOR_NAME = "pulsar/cursor";
+    public static final String METADATA_PROPERTY_COMPACTEDTOPIC = "pulsar/compactedTopic";
+    public static final String METADATA_PROPERTY_COMPACTEDTO = "pulsar/compactedTo";
+    public static final String METADATA_PROPERTY_SCHEMAID = "pulsar/schemaId";
 
-    private static final String METADATA_PROPERTY_DELAYED_INDEX_BUCKET_KEY = "pulsar/delayedIndexBucketKey";
-    private static final String METADATA_PROPERTY_DELAYED_INDEX_TOPIC = "pulsar/delayedIndexTopic";
-    private static final String METADATA_PROPERTY_DELAYED_INDEX_CURSOR = "pulsar/delayedIndexCursor";
+    public static final String METADATA_PROPERTY_DELAYED_INDEX_BUCKET_KEY = "pulsar/delayedIndexBucketKey";
+    public static final String METADATA_PROPERTY_DELAYED_INDEX_TOPIC = "pulsar/delayedIndexTopic";
+    public static final String METADATA_PROPERTY_DELAYED_INDEX_CURSOR = "pulsar/delayedIndexCursor";
 
     /**
      * Build base metadata for every ManagedLedger.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -376,13 +376,19 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                     return;
                 }
                 Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.warn("[{}] Failed to create schema locator with position {}", schemaId, position, cause);
+                log.warn()
+                        .attr("schemaId", schemaId)
+                        .attr("ledgerId", position.getLedgerId())
+                        .exception(cause)
+                        .log("Failed to create schema locator with position");
                 if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
                     bookKeeper.asyncDeleteLedger(position.getLedgerId(), (rc, ctx) -> {
                         if (rc != BKException.Code.OK) {
-                            log.warn("[{}] Failed to delete orphan ledger {}"
-                                            + " after schema locator creation failed, rc: {}",
-                                    schemaId, position.getLedgerId(), rc);
+                            log.warn()
+                                    .attr("schemaId", schemaId)
+                                    .attr("ledgerId", position.getLedgerId())
+                                    .attr("rc", rc)
+                                    .log("Failed to delete orphan ledger after schema locator creation failed");
                         }
                     }, null);
                 }
@@ -503,7 +509,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 Throwable cause = FutureUtil.unwrapCompletionException(ex);
                 log.warn()
                         .attr("schemaId", schemaId)
-                        .attr("position", position)
+                        .attr("ledgerId", position.getLedgerId())
                         .exception(cause)
                         .log("Failed to update schema locator with position");
                 if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -348,23 +348,45 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     }
 
     private CompletableFuture<Long> createNewSchema(String schemaId, byte[] data, byte[] hash) {
+        // Step 1: Store the schema data into a new BookKeeper ledger
         IndexEntry emptyIndex = new IndexEntry();
         emptyIndex.setVersion(0);
         emptyIndex.setHash(hash);
         emptyIndex.setPosition().setEntryId(-1L).setLedgerId(-1L);
+        CompletableFuture<PositionInfo> stored = addNewSchemaEntryToStore(
+                schemaId, Collections.singletonList(emptyIndex), data
+        );
 
-        return addNewSchemaEntryToStore(schemaId, Collections.singletonList(emptyIndex), data).thenCompose(position -> {
-            // The schema was stored in the ledger, now update the z-node with the pointer to it
+        return stored.thenCompose(position -> {
+            // Step 2: Create the schema locator z-node pointing to the ledger
             IndexEntry info = new IndexEntry();
             info.setVersion(0);
             info.setPosition().copyFrom(position);
             info.setHash(hash);
-
             SchemaLocator locator = new SchemaLocator();
             locator.setInfo().copyFrom(info);
             locator.addIndex().copyFrom(info);
-            return createSchemaLocator(getSchemaPath(schemaId), locator)
-                            .thenApply(ignore -> 0L);
+            CompletableFuture<Long> created = createSchemaLocator(
+                    getSchemaPath(schemaId), locator).thenApply(ignore -> 0L);
+
+            // Step 3: Handle failure by cleaning up the orphan ledger
+            // if concurrent schema creation caused a CAS conflict
+            return created.whenComplete((__, ex) -> {
+                if (ex == null) {
+                    return;
+                }
+                Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                log.warn("[{}] Failed to create schema locator with position {}", schemaId, position, cause);
+                if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
+                    bookKeeper.asyncDeleteLedger(position.getLedgerId(), (rc, ctx) -> {
+                        if (rc != BKException.Code.OK) {
+                            log.warn("[{}] Failed to delete orphan ledger {}"
+                                            + " after schema locator creation failed, rc: {}",
+                                    schemaId, position.getLedgerId(), rc);
+                        }
+                    }, null);
+                }
+            });
         });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -1380,6 +1380,68 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         producers2.clear();
     }
 
+    /**
+     * Test that when multiple producers concurrently create schema for a brand-new topic,
+     * the orphan BookKeeper ledgers created by the losing requests are properly cleaned up.
+     */
+    @Test
+    public void testConcurrentCreateSchemaNoOrphanLedger() throws Exception {
+        final String namespace = "test-namespace-" + randomName(16);
+        String ns = PUBLIC_TENANT + "/" + namespace;
+        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
+
+        final String topic = getTopicName(ns, "testConcurrentCreateSchemaNoOrphanLedger");
+        final String schemaName = TopicName.get(topic).getSchemaName();
+
+        org.apache.bookkeeper.client.PulsarMockBookKeeper mockBk =
+                (org.apache.bookkeeper.client.PulsarMockBookKeeper) pulsar.getBookKeeperClient();
+
+        // Concurrently create producers with the same schema on a brand-new topic
+        int concurrency = 16;
+        @Cleanup("shutdownNow")
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        List<CompletableFuture<Producer<Schemas.PersonOne>>> producers = new ArrayList<>(concurrency);
+        CountDownLatch latch = new CountDownLatch(concurrency);
+        for (int i = 0; i < concurrency; i++) {
+            executor.execute(() -> {
+                producers.add(pulsarClient.newProducer(Schema.AVRO(Schemas.PersonOne.class))
+                        .topic(topic).createAsync());
+                latch.countDown();
+            });
+        }
+        latch.await();
+        FutureUtil.waitForAll(producers).join();
+
+        // Verify only 1 schema version exists
+        assertEquals(admin.schemas().getAllSchemas(topic).size(), 1);
+
+        // Count surviving BK ledgers whose customMetadata "pulsar/schemaId" matches this topic's schemaName.
+        // If orphan ledgers were not cleaned up, there would be more than 1.
+        int schemaLedgerCount = 0;
+        for (org.apache.bookkeeper.client.PulsarMockLedgerHandle lh
+                : mockBk.getLedgerMap().values()) {
+            Map<String, byte[]> metadata = lh.getLedgerMetadata().getCustomMetadata();
+            byte[] schemaIdBytes = metadata.get("pulsar/schemaId");
+            if (schemaIdBytes != null
+                    && schemaName.equals(
+                            new String(schemaIdBytes, java.nio.charset.StandardCharsets.UTF_8))) {
+                schemaLedgerCount++;
+            }
+        }
+        assertEquals(schemaLedgerCount, 1,
+                "Expected exactly 1 schema ledger for the topic, but found "
+                        + schemaLedgerCount + ". Orphan ledgers were not cleaned up.");
+
+        // Cleanup
+        producers.forEach(p -> {
+            try {
+                p.join().close();
+            } catch (Exception ignore) {
+            }
+        });
+        producers.clear();
+    }
+
     @EqualsAndHashCode
     static class User implements Serializable {
         private String name;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -55,6 +55,7 @@ import lombok.EqualsAndHashCode;
 import org.apache.avro.Schema.Parser;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.mledger.impl.LedgerMetadataUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.service.schema.BookkeeperSchemaStorage;
@@ -1400,13 +1401,17 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         int concurrency = 16;
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(concurrency);
-        List<CompletableFuture<Producer<Schemas.PersonOne>>> producers = new ArrayList<>(concurrency);
+        List<CompletableFuture<Producer<Schemas.PersonOne>>> producers =
+                Collections.synchronizedList(new ArrayList<>(concurrency));
         CountDownLatch latch = new CountDownLatch(concurrency);
         for (int i = 0; i < concurrency; i++) {
             executor.execute(() -> {
-                producers.add(pulsarClient.newProducer(Schema.AVRO(Schemas.PersonOne.class))
-                        .topic(topic).createAsync());
-                latch.countDown();
+                try {
+                    producers.add(pulsarClient.newProducer(Schema.AVRO(Schemas.PersonOne.class))
+                            .topic(topic).createAsync());
+                } finally {
+                    latch.countDown();
+                }
             });
         }
         latch.await();
@@ -1418,13 +1423,11 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         // Count surviving BK ledgers whose customMetadata "pulsar/schemaId" matches this topic's schemaName.
         // If orphan ledgers were not cleaned up, there would be more than 1.
         int schemaLedgerCount = 0;
-        for (org.apache.bookkeeper.client.PulsarMockLedgerHandle lh
-                : mockBk.getLedgerMap().values()) {
+        for (org.apache.bookkeeper.client.PulsarMockLedgerHandle lh : mockBk.getLedgerMap().values()) {
             Map<String, byte[]> metadata = lh.getLedgerMetadata().getCustomMetadata();
-            byte[] schemaIdBytes = metadata.get("pulsar/schemaId");
+            byte[] schemaIdBytes = metadata.get(LedgerMetadataUtils.METADATA_PROPERTY_SCHEMAID);
             if (schemaIdBytes != null
-                    && schemaName.equals(
-                            new String(schemaIdBytes, java.nio.charset.StandardCharsets.UTF_8))) {
+                    && schemaName.equals(new String(schemaIdBytes, java.nio.charset.StandardCharsets.UTF_8))) {
                 schemaLedgerCount++;
             }
         }

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -137,7 +137,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
                     long id = sequence.getAndIncrement();
                     log.info().attr("ledgerId", id).log("Creating ledger");
                     PulsarMockLedgerHandle lh =
-                            new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd);
+                            new PulsarMockLedgerHandle(PulsarMockBookKeeper.this, id, digestType, passwd, properties);
                     ledgers.put(id, lh);
                     return FutureUtils.value(lh);
                 } catch (Throwable t) {

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
@@ -69,7 +70,14 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
 
     public PulsarMockLedgerHandle(PulsarMockBookKeeper bk, long id,
                            DigestType digest, byte[] passwd) throws GeneralSecurityException {
-        super(bk.getClientCtx(), id, new Versioned<>(createMetadata(id, digest, passwd), new LongVersion(0L)),
+        this(bk, id, digest, passwd, Collections.emptyMap());
+    }
+
+    public PulsarMockLedgerHandle(PulsarMockBookKeeper bk, long id,
+                           DigestType digest, byte[] passwd,
+                           Map<String, byte[]> customMetadata) throws GeneralSecurityException {
+        super(bk.getClientCtx(), id,
+              new Versioned<>(createMetadata(id, digest, passwd, customMetadata), new LongVersion(0L)),
               digest, passwd, WriteFlag.NONE);
         this.bk = bk;
         this.id = id;
@@ -271,13 +279,17 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
         return readHandle.readLastAddConfirmedAndEntryAsync(entryId, timeOutInMillis, parallel);
     }
 
-    private static LedgerMetadata createMetadata(long id, DigestType digest, byte[] passwd) {
+    private static LedgerMetadata createMetadata(long id, DigestType digest, byte[] passwd,
+                                                   Map<String, byte[]> customMetadata) {
         List<BookieId> ensemble = new ArrayList<>(PulsarMockBookKeeper.getMockEnsemble());
-        return LedgerMetadataBuilder.create()
+        LedgerMetadataBuilder builder = LedgerMetadataBuilder.create()
             .withDigestType(digest.toApiDigestType())
             .withPassword(passwd)
             .withId(id)
-            .newEnsembleEntry(0L, ensemble)
-            .build();
+            .newEnsembleEntry(0L, ensemble);
+        if (customMetadata != null && !customMetadata.isEmpty()) {
+            builder.withCustomMetadata(customMetadata);
+        }
+        return builder.build();
     }
 }


### PR DESCRIPTION
Fixes #18292
Related #18701

### Motivation

When multiple requests concurrently create a schema for a brand-new topic (i.e., the schema locator z-node does not yet exist), each request first creates a BookKeeper ledger via `addNewSchemaEntryToStore`, then attempts to create the schema locator z-node via CAS (`createSchemaLocator` with `expectedVersion = -1L`). 

Only one request succeeds; the others fail with BadVersionException (because ZK MetadataStore translates NODEEXISTS to BadVersionException when expectedVersion == -1). However, the ledgers created by the failed requests were never cleaned up, resulting in orphan ledgers (dirty data) in BookKeeper.

Note that the existing `updateSchemaLocator` method already has cleanup logic for this scenario (deleting the orphan ledger when CAS fails with `BadVersionException`) in #18701, but the `createNewSchema` method — which handles the **initial** schema creation path — was missing this cleanup.

### Modifications

- **`BookkeeperSchemaStorage.createNewSchema`**: Added a `whenComplete` callback after `createSchemaLocator`. When the CAS operation fails due to `AlreadyExistsException` or `BadVersionException`, the orphan BookKeeper ledger is asynchronously deleted, consistent with the existing cleanup logic in `updateSchemaLocator`. The method is also refactored into three clearly commented steps for better readability.

- **`PulsarMockLedgerHandle`**: Added a new constructor that accepts `Map<String, byte[]> customMetadata` and passes it to `LedgerMetadataBuilder.withCustomMetadata()`, so that mock ledgers can retain custom metadata set during creation.

- **`PulsarMockBookKeeper`**: Updated `asyncCreateLedger` to forward the `properties` parameter to the new `PulsarMockLedgerHandle` constructor, enabling tests to inspect ledger custom metadata.

- **`SchemaTest`**: Added `testConcurrentCreateSchemaNoOrphanLedger` test that verifies orphan ledgers are cleaned up when 16 producers concurrently create schema on a brand-new topic. The test inspects surviving BK ledgers via `PulsarMockBookKeeper.getLedgerMap()` and asserts that only 1 ledger with matching `pulsar/schemaId` custom metadata exists.

### Verifying this change

This change added tests and can be verified as follows:

- Added `testConcurrentCreateSchemaNoOrphanLedger` in `SchemaTest` that concurrently creates 16 producers with the same AVRO schema on a brand-new topic, then verifies:
  1. Only 1 schema version exists via `admin.schemas().getAllSchemas()`
  2. Only 1 surviving BK ledger has `customMetadata["pulsar/schemaId"]` matching the topic's schema name (orphan ledgers from failed concurrent creations were deleted)

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [x] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment