### PR TITLE
[improve][broker] Use full bundle name for namespace bundle destination affinity in ModularLoadManagerImpl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1395,9 +1395,15 @@ public abstract class NamespacesBase extends AdminResource {
         if (StringUtils.isBlank(destinationBroker)) {
             return CompletableFuture.completedFuture(null);
         }
-        String bundleName = pulsar().getNamespaceService().getNamespaceBundleFactory()
-                .getBundle(namespaceName.toString(), bundleRange)
-                .toString();
+        final String bundleName;
+        try {
+            bundleName = pulsar().getNamespaceService().getNamespaceBundleFactory()
+                    .getBundle(namespaceName.toString(), bundleRange)
+                    .toString();
+        } catch (RuntimeException e) {
+            return FutureUtil.failedFuture(e);
+        }
+
         return pulsar().getLoadManager().get().getAvailableBrokersAsync()
                 .thenCompose(brokers -> {
                     if (!brokers.contains(destinationBroker)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1395,14 +1395,6 @@ public abstract class NamespacesBase extends AdminResource {
         if (StringUtils.isBlank(destinationBroker)) {
             return CompletableFuture.completedFuture(null);
         }
-        final String bundleName;
-        try {
-            bundleName = pulsar().getNamespaceService().getNamespaceBundleFactory()
-                    .getBundle(namespaceName.toString(), bundleRange)
-                    .toString();
-        } catch (RuntimeException e) {
-            return FutureUtil.failedFuture(e);
-        }
 
         return pulsar().getLoadManager().get().getAvailableBrokersAsync()
                 .thenCompose(brokers -> {
@@ -1424,6 +1416,9 @@ public abstract class NamespacesBase extends AdminResource {
                     if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar())) {
                         return;
                     }
+                    final String bundleName = pulsar().getNamespaceService().getNamespaceBundleFactory()
+                            .getBundle(namespaceName.toString(), bundleRange)
+                            .toString();
                     // For ExtensibleLoadManager, this operation will be ignored.
                     pulsar().getLoadManager().get().setNamespaceBundleAffinity(bundleName, destinationBroker);
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1395,6 +1395,9 @@ public abstract class NamespacesBase extends AdminResource {
         if (StringUtils.isBlank(destinationBroker)) {
             return CompletableFuture.completedFuture(null);
         }
+        String bundleName = pulsar().getNamespaceService().getNamespaceBundleFactory()
+                .getBundle(namespaceName.toString(), bundleRange)
+                .toString();
         return pulsar().getLoadManager().get().getAvailableBrokersAsync()
                 .thenCompose(brokers -> {
                     if (!brokers.contains(destinationBroker)) {
@@ -1416,7 +1419,7 @@ public abstract class NamespacesBase extends AdminResource {
                         return;
                     }
                     // For ExtensibleLoadManager, this operation will be ignored.
-                    pulsar().getLoadManager().get().setNamespaceBundleAffinity(bundleRange, destinationBroker);
+                    pulsar().getLoadManager().get().setNamespaceBundleAffinity(bundleName, destinationBroker);
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -64,8 +64,7 @@ public class ModularLoadManagerWrapper implements LoadManager {
 
     @Override
     public Optional<ResourceUnit> getLeastLoaded(final ServiceUnitId serviceUnit) {
-        String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(serviceUnit.toString());
-        String affinityBroker = loadManager.setNamespaceBundleAffinity(bundleRange, null);
+        String affinityBroker = loadManager.setNamespaceBundleAffinity(serviceUnit.toString(), null);
         if (!StringUtils.isBlank(affinityBroker)) {
             return Optional.of(buildBrokerResourceUnit(affinityBroker));
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -413,6 +413,26 @@ public class ModularLoadManagerImplTest {
         Assert.assertEquals(brokerServiceUrl, topicLookupAfterUnload);
     }
 
+    @Test
+    public void testBrokerAffinityLookupUsesFullBundleName() throws Exception {
+        String affinityBroker1 = "affinity-broker-1";
+        String affinityBroker2 = "affinity-broker-2";
+        NamespaceBundle bundle1 = makeBundle("tenant-1", "ns-1");
+        NamespaceBundle bundle2 = makeBundle("tenant-1", "ns-2");
+
+        LoadManager wrapper = pulsar1.getLoadManager().get();
+        wrapper.setNamespaceBundleAffinity(bundle1.toString(), affinityBroker1);
+        wrapper.setNamespaceBundleAffinity(bundle2.toString(), affinityBroker2);
+
+        Optional<ResourceUnit> leastLoadedBroker1 = wrapper.getLeastLoaded(bundle1);
+        Optional<ResourceUnit> leastLoadedBroker2 = wrapper.getLeastLoaded(bundle2);
+
+        Assert.assertTrue(leastLoadedBroker1.isPresent());
+        Assert.assertTrue(leastLoadedBroker2.isPresent());
+        Assert.assertEquals(leastLoadedBroker1.get().getResourceId(), affinityBroker1);
+        Assert.assertEquals(leastLoadedBroker2.get().getResourceId(), affinityBroker2);
+    }
+
     /**
      * It verifies that once broker owns max-number of topics: load-manager doesn't allocates new bundles to that broker
      * unless all the brokers are in same state.


### PR DESCRIPTION
### Motivation

When unloading a namespace bundle with `destinationBroker` under `ModularLoadManagerImpl`, the affinity key was stored by `bundleRange` only.

Different namespaces can share the same bundle range, especially for single-bundle namespaces such as `0x00000000_0xffffffff`. In that case, the destination affinity can collide across namespaces, and the next lookup may
consume the affinity for the wrong bundle.

As a result, `unload --destinationBroker` may appear ineffective or unstable when transferring multiple bundles that share the same range.

### Modifications

- Store namespace bundle destination affinity by full bundle name instead of bare `bundleRange`.
- Consume the destination affinity in `ModularLoadManagerWrapper#getLeastLoaded` by full bundle name as well.
- Add an admin-side test to verify the affinity key passed to the load manager is the full bundle name.
- Add a load manager test to verify affinity lookup is resolved by full bundle name.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment