### PR TITLE
[improve][broker] Close connection when close consumer write fails

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -3405,14 +3405,25 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         if (getRemoteEndpointProtocolVersion() >= v5.getValue()) {
             assignedBrokerLookupData.ifPresentOrElse(lookup -> {
                         LookupData lookupData = getLookupData(lookup);
-                        writeAndFlush(Commands.newCloseConsumer(consumerId, -1L,
+                        writeCloseConsumerAndCloseConnectionOnFailure(Commands.newCloseConsumer(consumerId, -1L,
                                 lookupData.getBrokerUrl(),
-                                lookupData.getBrokerUrlTls()));
+                                lookupData.getBrokerUrlTls()), consumerId);
                     },
-                    () -> writeAndFlush(Commands.newCloseConsumer(consumerId, -1L, null, null)));
+                    () -> writeCloseConsumerAndCloseConnectionOnFailure(
+                            Commands.newCloseConsumer(consumerId, -1L, null, null), consumerId));
         } else {
             close();
         }
+    }
+
+    private void writeCloseConsumerAndCloseConnectionOnFailure(ByteBuf cmd, long consumerId) {
+        ctx.writeAndFlush(cmd).addListener(future -> {
+            if (!future.isSuccess()) {
+                log.warn("[{}] Forcing connection to close since cannot send close consumer command for consumer {}",
+                        remoteAddress, consumerId, future.cause());
+                close();
+            }
+        });
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -45,10 +45,14 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.vertx.core.impl.ConcurrentHashSet;
 import java.io.Closeable;
 import java.io.IOException;
@@ -2486,6 +2490,35 @@ public class ServerCnxTest {
         assertTrue(channel.isActive());
 
         channel.finish();
+    }
+
+    @Test
+    public void testCloseConsumerClosesConnectionWhenWriteFails() throws Exception {
+        resetChannel();
+        setChannelConnected();
+
+        var ctx = mock(ChannelHandlerContext.class);
+        var writeFuture = mock(ChannelFuture.class);
+        var writeFailure = new RuntimeException("close consumer write failed");
+        when(ctx.writeAndFlush(any())).thenReturn(writeFuture);
+        when(writeFuture.isSuccess()).thenReturn(false);
+        when(writeFuture.cause()).thenReturn(writeFailure);
+        when(writeFuture.addListener(any())).thenAnswer(invocation -> {
+            GenericFutureListener<Future<? super Void>>  listener = invocation.getArgument(0);
+            listener.operationComplete(writeFuture);
+            return writeFuture;
+        });
+        serverCnx.setCtx(ctx);
+
+        var consumer = mock(Consumer.class);
+        when(consumer.consumerId()).thenReturn(1L);
+
+        serverCnx.setRemoteEndpointProtocolVersion(ProtocolVersion.v12.getValue());
+
+        serverCnx.closeConsumer(consumer, Optional.empty());
+
+        verify(ctx).writeAndFlush(any());
+        verify(ctx).close();
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/PulsarHandler.java
@@ -53,7 +53,8 @@ public abstract class PulsarHandler extends PulsarDecoder {
         return remoteEndpointProtocolVersion;
     }
 
-    protected void setRemoteEndpointProtocolVersion(int remoteEndpointProtocolVersion) {
+    @VisibleForTesting
+    public void setRemoteEndpointProtocolVersion(int remoteEndpointProtocolVersion) {
         this.remoteEndpointProtocolVersion = remoteEndpointProtocolVersion;
     }
 


### PR DESCRIPTION
Fix #25146

### Motivation

When the broker asks a client to close a consumer, if the `CloseConsumer` command does not reach the client, the client may keep the consumer alive locally while the broker has already removed it, leading to a silent inconsistent state.

### Modifications

- update broker-side consumer close handling to close the whole connection when sending `CloseConsumer` fails
- keep the existing protocol behavior for older clients that already fall back to closing the connection
- add a broker test covering the failed `CloseConsumer` write path

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added a `ServerCnxTest` case for failed `CloseConsumer` writes to ensure the connection is closed

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
