### PR TITLE
[fix] Fix typo 'seperated' in broker comments

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -344,7 +344,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * 2. Namespace bundle transfer or unloading.
      *   a. The unloading topic triggered by unloading namespace bundles will not wait for clients disconnect. Relate
      *     to {@link CloseFutures#notWaitDisconnectClients}.
-     *   b. The unloading topic triggered by unloading namespace bundles was seperated to two steps when using
+     *   b. The unloading topic triggered by unloading namespace bundles was separated into two steps when using
      *     {@link ExtensibleLoadManagerImpl}.
      *     b-1. step-1: fence the topic on the original Broker, and do not trigger reconnections of clients. Relate
      *       to {@link CloseFutures#transferring}. This step is a half closing.
@@ -3425,7 +3425,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
              *   "replicator.producer" to a null value.
              * Race condition: task 1 will get a NPE when it tries to send messages using the variable
              * "replicator.producer", because task 2 will set this variable to "null".
-             * TODO Create a seperated PR to fix it.
+             * TODO Create a separate PR to fix it.
              */
             closeReplProducersIfNoBacklog().thenRun(() -> {
                 if (hasRemoteProducers()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/GetPartitionMetadataMultiBrokerTest.java
@@ -135,7 +135,7 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
         } catch (Exception ex) {
             // If the namespace bundle has not been loaded yet, it means no non-persistent topic was created. So
             //   this behavior is also correct.
-            // This error is not expected, a seperated PR is needed to fix this issue.
+            // This error is not expected, a separate PR is needed to fix this issue.
             assertTrue(ex.getMessage().contains("Failed to find ownership for"));
         }
     }
@@ -148,7 +148,7 @@ public class GetPartitionMetadataMultiBrokerTest extends GetPartitionMetadataTes
         } catch (Exception ex) {
             // If the namespace bundle has not been loaded yet, it means no non-persistent topic was created. So
             //   this behavior is also correct.
-            // This error is not expected, a seperated PR is needed to fix this issue.
+            // This error is not expected, a separate PR is needed to fix this issue.
             assertTrue(ex.getMessage().contains("Failed to find ownership for"));
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ZkSessionExpireTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ZkSessionExpireTest.java
@@ -256,7 +256,7 @@ public class ZkSessionExpireTest extends NetworkErrorTestBase {
             // Regarding the system topic based load balancer, which does not rely on ZK, the topic may be owned by any
             // broker.
             if (TableViewType.SystemTopic.equals(tableViewType)) {
-                // This implementation will be finished by a seperated PR.
+                // This implementation will be finished by a separate PR.
             }
         });
         Topic broker2Topic3 = pulsar2.getBrokerService().getTopic(topicName, false).join().get();


### PR DESCRIPTION
### Motivation

Four comments in `pulsar-broker` misspell **'separated'** as **'seperated'**. This is a comment-only fix.

### Modifications

- `PersistentTopic.java`: two comment typos (lines 347, 3428)
- `GetPartitionMetadataMultiBrokerTest.java`: two test comments (lines 138, 151)
- `ZkSessionExpireTest.java`: one test comment (line 259)

All changes are in comments; no runtime or behavioral change.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

If the box was checked, please highlight the changes:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [ ] `doc-not-needed`
- [x] `doc-complete`
