### PR TITLE
[fix][broker] Avoid Project access in broker test setup

### DIFF
--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -142,27 +142,42 @@ evaluationDependsOn(":pulsar-io")
 evaluationDependsOn(":pulsar-functions")
 
 // NAR/JAR files needed by broker tests (mirrors Maven's maven-dependency-plugin config).
+// Resolve through dependency configurations instead of cross-project task references.
+val testNars by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    attributes {
+        attribute(org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "nar")
+    }
+}
+val testExamplesJar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
+dependencies {
+    testNars(project(":pulsar-functions:pulsar-functions-api-examples-builtin"))
+    testNars(project(":pulsar-io:pulsar-io-data-generator"))
+    testNars(project(":pulsar-io:pulsar-io-batch-data-generator"))
+    testExamplesJar(project(":pulsar-functions:pulsar-functions-api-examples"))
+}
+
 tasks.withType<Test> {
-    dependsOn(
-        ":pulsar-functions:pulsar-functions-api-examples:jar",
-        ":pulsar-functions:pulsar-functions-api-examples-builtin:nar",
-        ":pulsar-io:pulsar-io-data-generator:nar",
-        ":pulsar-io:pulsar-io-batch-data-generator:nar",
-    )
+    val narFiles = testNars.incoming.artifacts.resolvedArtifacts
+    val jarFiles = testExamplesJar.incoming.artifacts.resolvedArtifacts
     doFirst {
-        fun narPath(projectPath: String): String {
-            val p = rootProject.project(projectPath)
-            return p.tasks.named("nar").get().outputs.files.singleFile.absolutePath
+        val narMap = narFiles.get().associate {
+            val id = it.id.componentIdentifier as org.gradle.api.artifacts.component.ProjectComponentIdentifier
+            id.projectPath to it.file.absolutePath
         }
-        fun jarPath(projectPath: String): String {
-            val p = rootProject.project(projectPath)
-            return p.tasks.named<Jar>("jar").get().archiveFile.get().asFile.absolutePath
-        }
-        val examplesJarPath = jarPath(":pulsar-functions:pulsar-functions-api-examples")
+        val examplesJarPath = jarFiles.get().first().file.absolutePath
         systemProperty("pulsar-functions-api-examples.jar.path", examplesJarPath)
-        systemProperty("pulsar-functions-api-examples.nar.path", narPath(":pulsar-functions:pulsar-functions-api-examples-builtin"))
-        systemProperty("pulsar-io-data-generator.nar.path", narPath(":pulsar-io:pulsar-io-data-generator"))
-        systemProperty("pulsar-io-batch-data-generator.nar.path", narPath(":pulsar-io:pulsar-io-batch-data-generator"))
+        systemProperty("pulsar-functions-api-examples.nar.path",
+            narMap[":pulsar-functions:pulsar-functions-api-examples-builtin"]!!)
+        systemProperty("pulsar-io-data-generator.nar.path",
+            narMap[":pulsar-io:pulsar-io-data-generator"]!!)
+        systemProperty("pulsar-io-batch-data-generator.nar.path",
+            narMap[":pulsar-io:pulsar-io-batch-data-generator"]!!)
         // A valid jar that is not a valid nar — used for invalid-nar tests
         systemProperty("pulsar-io-invalid.nar.path", examplesJarPath)
     }

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
 }
 
 tasks.withType<Test> {
+    dependsOn(testNars, testExamplesJar)
     val narFiles = testNars.incoming.artifacts.resolvedArtifacts
     val jarFiles = testExamplesJar.incoming.artifacts.resolvedArtifacts
     doFirst {

--- a/pulsar-functions/worker/build.gradle.kts
+++ b/pulsar-functions/worker/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
 }
 
 tasks.withType<Test> {
+    dependsOn(testNars, testExamplesJar)
     // Map resolved NAR/JAR files to system properties
     val narFiles = testNars.incoming.artifacts.resolvedArtifacts
     val jarFiles = testExamplesJar.incoming.artifacts.resolvedArtifacts


### PR DESCRIPTION
#### Motivation
Broker tests configured NAR and JAR paths through `rootProject.project(...)` inside the test task action. That captures Gradle `Project` objects in the task configuration and breaks configuration cache for `:pulsar-broker:test`.

```
1 problem was found storing the configuration cache.
- Task `:pulsar-broker:test` of type `org.gradle.api.tasks.testing.Test`: cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with the configuration cache.
  See https://docs.gradle.org/9.4.1/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types
```

#### Changes
- replace broker test cross-project task lookups with resolvable dependency configurations
- resolve required broker test NAR and JAR artifacts through `resolvedArtifacts`
- keep the existing test system properties while making the test task compatible with configuration cache