### PR TITLE
[branch-4.0][fix][sec] Upgrade log4j to 2.25.4 to address CVE-2026-34477, CVE-2026-34478, CVE-2026-34480, CVE-2026-34481

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
     <surefire.version>3.1.0</surefire.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <slf4j.version>2.0.17</slf4j.version>
     <testng.version>7.7.1</testng.version>
     <commons-lang3.version>3.19.0</commons-lang3.version>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -348,11 +348,11 @@ The Apache Software License, Version 2.0
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
  * Log4J
-    - org.apache.logging.log4j-log4j-api-2.25.3.jar
-    - org.apache.logging.log4j-log4j-core-2.25.3.jar
-    - org.apache.logging.log4j-log4j-slf4j2-impl-2.25.3.jar
-    - org.apache.logging.log4j-log4j-web-2.25.3.jar
-    - org.apache.logging.log4j-log4j-layout-template-json-2.25.3.jar
+    - org.apache.logging.log4j-log4j-api-2.25.4.jar
+    - org.apache.logging.log4j-log4j-core-2.25.4.jar
+    - org.apache.logging.log4j-log4j-slf4j2-impl-2.25.4.jar
+    - org.apache.logging.log4j-log4j-web-2.25.4.jar
+    - org.apache.logging.log4j-log4j-layout-template-json-2.25.4.jar
  * Java Native Access JNA
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -381,10 +381,10 @@ The Apache Software License, Version 2.0
     - simpleclient_tracer_otel-0.16.0.jar
     - simpleclient_tracer_otel_agent-0.16.0.jar
  * Log4J
-    - log4j-api-2.25.3.jar
-    - log4j-core-2.25.3.jar
-    - log4j-slf4j2-impl-2.25.3.jar
-    - log4j-web-2.25.3.jar
+    - log4j-api-2.25.4.jar
+    - log4j-core-2.25.4.jar
+    - log4j-slf4j2-impl-2.25.4.jar
+    - log4j-web-2.25.4.jar
  * OpenTelemetry
     - opentelemetry-api-1.56.0.jar
     - opentelemetry-api-incubator-1.56.0-alpha.jar

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ flexible messaging model and an intuitive client API.</description>
     <rocksdb.version>7.9.2</rocksdb.version>
     <slf4j.version>2.0.17</slf4j.version>
     <commons.collections4.version>4.5.0</commons.collections4.version>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <!-- bouncycastle dependencies aren't necessarily aligned -->
     <bouncycastle.bcprov-jdk18on.version>1.78.1</bouncycastle.bcprov-jdk18on.version>
     <bouncycastle.bcpkix-jdk18on.version>1.81</bouncycastle.bcpkix-jdk18on.version>


### PR DESCRIPTION
### Motivation

Cherry-pick of apache/pulsar#25521 to `branch-4.0`.

log4j 2.25.3 is affected by four CVEs fixed in 2.25.4:

- **CVE-2026-34477** — `verifyHostName` attribute in `<Ssl>` configuration was silently ignored in all versions since 2.12.0. TLS connections from SMTP, Socket, and Syslog appenders configured via the nested `<Ssl>` element were not verifying hostnames, enabling MITM attacks.
- **CVE-2026-34478** — `Rfc5424Layout` silently renamed `newLineEscape` and `useTlsMessageFormat` attributes in 2.21.0, causing CRLF injection for TCP framing users and a silent TLS-to-plain-TCP downgrade for RFC 5425 users.
- **CVE-2026-34480** — `XmlLayout` did not sanitize characters forbidden by XML 1.0, producing invalid XML when log messages or MDC values contained them.
- **CVE-2026-34481** — `JsonTemplateLayout` produced invalid JSON (NaN / Infinity / -Infinity) for `MapMessage` entries containing non-finite floats, which downstream log processors reject per RFC 8259.

None of these affect Pulsar users with the default log4j2.yaml configuration, but shipping library versions with known vulnerabilities trips code scanning and downstream security audits.

### Modifications

`branch-4.0` still uses Maven, so the master commit's `gradle/libs.versions.toml` change does not apply directly. Ported equivalently:

- Bump `log4j2.version` from 2.25.3 to 2.25.4 in `pom.xml` and `buildtools/pom.xml`.
- Update server and shell distribution `LICENSE.bin.txt` to reflect the new jar versions.

### Master PR

- apache/pulsar#25521 — `[fix][sec] Upgrade log4j to 2.25.4 to address CVE-2026-34477, CVE-2026-34478, CVE-2026-34480, CVE-2026-34481`