### PR TITLE
[improve] PIP-467: Convert pulsar-broker module logging from SLF4J to slog

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.bookkeeper.common.component.ComponentStarter;
 import org.apache.bookkeeper.common.component.LifecycleComponent;
 import org.apache.bookkeeper.common.util.ReflectionUtils;
@@ -58,8 +59,6 @@ import org.apache.pulsar.docs.tools.CmdGenerateDocs;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.service.WorkerServiceLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -67,6 +66,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.ScopeType;
 
 @Command(description = "broker", showDefaultValues = true, scope = ScopeType.INHERIT)
+@CustomLog
 public class PulsarBrokerStarter {
 
     private static ServiceConfiguration loadConfig(String configFile) throws Exception {
@@ -111,12 +111,12 @@ public class PulsarBrokerStarter {
         try {
             bookieConf.loadConf(new File(bookieConfigFile).toURI().toURL());
             bookieConf.validate();
-            log.info("Using bookie configuration file {}", bookieConfigFile);
+            log.info().attr("file", bookieConfigFile).log("Using bookie configuration file");
         } catch (MalformedURLException e) {
-            log.error("Could not open configuration file: {}", bookieConfigFile, e);
+            log.error().attr("file", bookieConfigFile).exception(e).log("Could not open configuration file");
             throw new IllegalArgumentException("Could not open configuration file");
         } catch (ConfigurationException e) {
-            log.error("Malformed configuration file: {}", bookieConfigFile, e);
+            log.error().attr("file", bookieConfigFile).exception(e).log("Malformed configuration file");
             throw new IllegalArgumentException("Malformed configuration file");
         }
 
@@ -208,8 +208,9 @@ public class PulsarBrokerStarter {
                                               workerConfig,
                                               Optional.ofNullable(functionsWorkerService),
                                               (exitCode) -> {
-                                                  log.info("Halting broker process with code {}",
-                                                           exitCode);
+                                                  log.info()
+                                                          .attr("exitCode", exitCode)
+                                                          .log("Halting broker process");
                                                   ShutdownUtil.triggerImmediateForcefulShutdown(exitCode);
                                               });
 
@@ -327,7 +328,6 @@ public class PulsarBrokerStarter {
         }
     }
 
-
     @SuppressWarnings("deprecation")
     public static void main(String[] args) throws Exception {
         DateFormat dateFormat = new SimpleDateFormat(
@@ -345,7 +345,7 @@ public class PulsarBrokerStarter {
                 try {
                     starter.shutdown();
                 } catch (Throwable t) {
-                    log.error("Error while shutting down Pulsar service", t);
+                    log.error().exception(t).log("Error while shutting down Pulsar service");
                 } finally {
                     LogManager.shutdown();
                 }
@@ -354,9 +354,13 @@ public class PulsarBrokerStarter {
 
         PulsarByteBufAllocator.registerOOMListener(oomException -> {
             if (starter.brokerConfig != null && starter.brokerConfig.isSkipBrokerShutdownOnOOM()) {
-                log.error("-- Received OOM exception: {}", oomException.getMessage(), oomException);
+                log.error()
+                        .exception(oomException)
+                        .log("- Received OOM exception");
             } else {
-                log.error("-- Shutting down - Received OOM exception: {}", oomException.getMessage(), oomException);
+                log.error()
+                        .exception(oomException)
+                        .log("- Shutting down - Received OOM exception");
                 if (starter.pulsarService != null) {
                     starter.pulsarService.shutdownNow();
                 }
@@ -369,12 +373,10 @@ public class PulsarBrokerStarter {
                 System.exit(start);
             }
         } catch (Throwable t) {
-            log.error("Failed to start pulsar service.", t);
+            log.error().exception(t).log("Failed to start pulsar service.");
             ShutdownUtil.triggerImmediateForcefulShutdown();
         } finally {
             starter.join();
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarBrokerStarter.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.common.net.ServiceURI;
 import org.apache.bookkeeper.conf.ServerConfiguration;
@@ -55,8 +56,6 @@ import org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver;
 import org.apache.pulsar.metadata.impl.DualMetadataStore;
 import org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -65,6 +64,7 @@ import picocli.CommandLine.ScopeType;
 /**
  * Setup the metadata for a new Pulsar cluster.
  */
+@CustomLog
 public class PulsarClusterMetadataSetup {
 
     private static final int DEFAULT_BUNDLE_NUMBER = 16;
@@ -287,14 +287,17 @@ public class PulsarClusterMetadataSetup {
         try {
             initializeCluster(arguments, bundleNumberForDefaultNamespace);
         } catch (Exception e) {
-            log.error("Unexpected error during cluster metadata initialization", e);
+            log.error().exception(e).log("Unexpected error during cluster metadata initialization");
             throw e;
         }
     }
 
     private static void initializeCluster(Arguments arguments, int bundleNumberForDefaultNamespace) throws Exception {
-        log.info("Setting up cluster {} with metadata-store={} configuration-metadata-store={}", arguments.cluster,
-                arguments.metadataStoreUrl, arguments.configurationMetadataStore);
+        log.info()
+                .attr("cluster", arguments.cluster)
+                .attr("metadataStoreUrl", arguments.metadataStoreUrl)
+                .attr("configurationMetadataStore", arguments.configurationMetadataStore)
+                .log("Setting up cluster");
 
         MetadataStoreExtended localStore = initLocalMetadataStore(arguments.metadataStoreUrl,
                 arguments.metadataStoreConfigPath,
@@ -397,17 +400,17 @@ public class PulsarClusterMetadataSetup {
         createPartitionedTopic(configStore, SystemTopicNames.TRANSACTION_COORDINATOR_ASSIGN,
                 arguments.numTransactionCoordinators);
 
-        log.info("Cluster metadata for '{}' setup correctly", arguments.cluster);
+        log.info().attr("cluster", arguments.cluster).log("Cluster metadata setup correctly");
         } finally {
             try {
                 localStore.close();
             } catch (Exception e) {
-                log.warn("Failed to close local metadata store", e);
+                log.warn().exception(e).log("Failed to close local metadata store");
             }
             try {
                 configStore.close();
             } catch (Exception e) {
-                log.warn("Failed to close config metadata store", e);
+                log.warn().exception(e).log("Failed to close config metadata store");
             }
         }
     }
@@ -440,7 +443,7 @@ public class PulsarClusterMetadataSetup {
 
             namespaceResources.createPolicies(namespaceName, policies);
         } else {
-            log.info("Namespace {} already exists.", namespaceName);
+            log.info().attr("namespace", namespaceName).log("Namespace already exists.");
             var replicaClusterFound = false;
             var policiesOptional = namespaceResources.getPolicies(namespaceName);
             if (policiesOptional.isPresent() && policiesOptional.get().replication_clusters.contains(cluster)) {
@@ -451,8 +454,10 @@ public class PulsarClusterMetadataSetup {
                     policies.replication_clusters.add(cluster);
                     return policies;
                 });
-                log.info("Updated namespace:{} policies. Added the replication cluster:{}",
-                        namespaceName, cluster);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("cluster", cluster)
+                        .log("Updated namespace policies. Added the replication cluster");
             }
         }
     }
@@ -522,6 +527,4 @@ public class PulsarClusterMetadataSetup {
         }
         return store;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarClusterMetadataSetup.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataTeardown.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -45,8 +46,6 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -55,6 +54,7 @@ import picocli.CommandLine.ScopeType;
 /**
  * Teardown the metadata for a existed Pulsar cluster.
  */
+@CustomLog
 public class PulsarClusterMetadataTeardown {
 
     @Command(name = "delete-cluster-metadata", showDefaultValues = true, scope = ScopeType.INHERIT)
@@ -179,11 +179,11 @@ public class PulsarClusterMetadataTeardown {
                 resources.getClusterResources().deleteCluster(arguments.cluster);
             } catch (MetadataStoreException.NotFoundException ex) {
                 // Ignore if the cluster does not exist
-                log.info("Cluster metadata for '{}' does not exist.", arguments.cluster);
+                log.info().attr("cluster", arguments.cluster).log("Cluster metadata does not exist");
             }
         }
 
-        log.info("Cluster metadata for '{}' teardown.", arguments.cluster);
+        log.info().attr("cluster", arguments.cluster).log("Cluster metadata teardown");
     }
 
     private static void removeCurrentClusterFromAllowedClusters(
@@ -218,20 +218,20 @@ public class PulsarClusterMetadataTeardown {
     private static void deleteLedger(BookKeeper bookKeeper, long ledgerId) {
         try {
             bookKeeper.deleteLedger(ledgerId);
-            if (log.isDebugEnabled()) {
-                log.debug("Delete ledger id: {}", ledgerId);
-            }
-        } catch (InterruptedException | BKException ex) {
+                log.debug().attr("ledgerId", ledgerId).log("Deleted ledger");
+                    } catch (InterruptedException | BKException ex) {
             if (ex instanceof BKException bkException) {
                 switch (bkException.getCode()) {
                     case BKException.Code.NoSuchLedgerExistsException:
                     case BKException.Code.NoSuchLedgerExistsOnMetadataServerException:
-                        log.warn("Failed to delete deleted ledger. ledgerId={} errorCode={}",
-                                ledgerId, bkException.getCode());
+                        log.warn()
+                                .attr("ledgerId", ledgerId)
+                                .attr("errorCode", bkException.getCode())
+                                .log("Failed to delete deleted ledger");
                         return;
                 }
             }
-            log.error("Failed to delete ledger {}: {}", ledgerId, ex);
+            log.error().attr("ledgerId", ledgerId).exceptionMessage(ex).log("Failed to delete ledger");
             throw new RuntimeException(ex);
         }
     }
@@ -247,7 +247,8 @@ public class PulsarClusterMetadataTeardown {
                     try {
                         managedLedgerFactory.delete(topicName.getPersistenceNamingEncoding());
                     } catch (InterruptedException | ManagedLedgerException e) {
-                        log.error("Failed to delete ledgers of {}: {}", topicName, e);
+                        log.error().attr("topic", topicName).exceptionMessage(e)
+                                .log("Failed to delete ledgers for topic");
                         throw new RuntimeException(e);
                     }
                 });
@@ -271,12 +272,11 @@ public class PulsarClusterMetadataTeardown {
                             deleteLedger(bookKeeper, locator.getIndexAt(i).getPosition().getLedgerId());
                         }
                     } catch (Exception e) {
-                        log.warn("Invalid data format from {}: {}", topicRoot, e);
+                        log.warn().attr("topic", topicRoot).exceptionMessage(e)
+                                .log("Invalid data format");
                     }
                 });
             });
         });
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarClusterMetadataTeardown.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.conf.ServerConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
@@ -57,7 +57,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ScopeType;
 
-@Slf4j
+@CustomLog
 @Command(name = "standalone", showDefaultValues = true, scope = ScopeType.INHERIT)
 public class PulsarStandalone implements AutoCloseable {
 
@@ -399,7 +399,12 @@ public class PulsarStandalone implements AutoCloseable {
                 admin.namespaces().createNamespace(ns.toString(), config.getDefaultNumberOfNamespaceBundles());
             }
         } catch (PulsarAdminException e) {
-            log.error("Failed to create namespace {} on cluster {} and tenant {}", ns, cluster, publicTenant, e);
+            log.error()
+                    .attr("namespace", ns)
+                    .attr("cluster", cluster)
+                    .attr("tenant", publicTenant)
+                    .exception(e)
+                    .log("Failed to create namespace on cluster and tenant");
         }
     }
 
@@ -441,7 +446,7 @@ public class PulsarStandalone implements AutoCloseable {
                 bkEnsemble = null;
             }
         } catch (Exception e) {
-            log.error("Shutdown failed: {}", e.getMessage(), e);
+            log.error().exception(e).log("Shutdown failed");
         }
     }
 
@@ -452,11 +457,11 @@ public class PulsarStandalone implements AutoCloseable {
             Path metadataDirPath = Paths.get(metadataDir);
             metadataStoreUrl = "rocksdb://" + metadataDirPath.toAbsolutePath();
             if (wipeData && Files.exists(metadataDirPath)) {
-                log.info("Wiping RocksDb metadata store at {}", metadataStoreUrl);
+                log.info().attr("metadataStoreUrl", metadataStoreUrl).log("Wiping RocksDb metadata store");
                 cleanDirectory(metadataDirPath.toFile());
             }
         } else {
-            log.info("Starting BK with metadata store: {}", metadataStoreUrl);
+            log.info().attr("metadataStoreUrl", metadataStoreUrl).log("Starting BK with metadata store");
         }
 
         ServerConfiguration bkServerConf = new ServerConfiguration();
@@ -504,7 +509,7 @@ public class PulsarStandalone implements AutoCloseable {
     }
 
     protected void processTerminator(int exitCode) {
-        log.info("Halting standalone process with code {}", exitCode);
+        log.info().attr("exitCode", exitCode).log("Halting standalone process");
         ShutdownUtil.triggerImmediateForcefulShutdown(exitCode);
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -24,8 +24,8 @@ import com.google.common.base.Strings;
 import java.io.FileInputStream;
 import java.util.Arrays;
 import lombok.AccessLevel;
+import lombok.CustomLog;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -34,7 +34,7 @@ import org.apache.pulsar.docs.tools.CmdGenerateDocs;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
-@Slf4j
+@CustomLog
 public class PulsarStandaloneStarter extends PulsarStandalone {
 
     private static final String PULSAR_CONFIG_FILE = "pulsar.config.file";
@@ -130,7 +130,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
             try {
                 doClose(false);
             } catch (Exception e) {
-                log.error("Shutdown failed: {}", e.getMessage(), e);
+                log.error().exception(e).log("Shutdown failed");
             } finally {
                 if (!testMode) {
                     LogManager.shutdown();
@@ -172,7 +172,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
     protected void processTerminator(int exitCode) {
         if (testMode) {
             // In test mode, don't halt the JVM — it would kill the test runner
-            log.info("Ignoring process termination in test mode (exit code {})", exitCode);
+            log.info().attr("exitCode", exitCode).log("Ignoring process termination in test mode");
             return;
         }
         super.processTerminator(exitCode);
@@ -188,7 +188,7 @@ public class PulsarStandaloneStarter extends PulsarStandalone {
         try {
             standalone.start();
         } catch (Throwable th) {
-            log.error("Failed to start pulsar service.", th);
+            log.error().exception(th).log("Failed to start pulsar service.");
             LogManager.shutdown();
             Runtime.getRuntime().exit(1);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BookKeeperClientFactoryImpl.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
@@ -50,7 +50,7 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.bookkeeper.AbstractMetadataDriver;
 import org.apache.pulsar.metadata.bookkeeper.PulsarMetadataClientDriver;
 
-@Slf4j
+@CustomLog
 public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
 
     @Override
@@ -164,7 +164,10 @@ public class BookKeeperClientFactoryImpl implements BookKeeperClientFactory {
         bkConf.setNumIOThreads(conf.getBookkeeperClientNumIoThreads());
         PropertiesUtils.filterAndMapProperties(conf.getProperties(), "bookkeeper_")
                 .forEach((key, value) -> {
-                    log.info("Applying BookKeeper client configuration setting {}={}", key, value);
+                    log.info()
+                            .attr("key", key)
+                            .attr("value", value)
+                            .log("Applying BookKeeper client configuration setting");
                     bkConf.setProperty(key, value);
                 });
         return bkConf;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.EnsemblePlacementPolicy;
 import org.apache.bookkeeper.conf.ClientConfiguration;
@@ -48,11 +49,9 @@ import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.stats.CacheMetricsCollector;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
-    private static final Logger log = LoggerFactory.getLogger(ManagedLedgerClientFactory.class);
     private static final String DEFAULT_STORAGE_CLASS_NAME = "bookkeeper";
     private BookkeeperManagedLedgerStorageClass defaultStorageClass;
     @VisibleForTesting
@@ -94,12 +93,15 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         long managedLedgerMaxReadsInFlightSizeBytes = conf.getManagedLedgerMaxReadsInFlightSizeInMB() * 1024L * 1024L;
         if (managedLedgerMaxReadsInFlightSizeBytes > 0 && conf.getDispatcherMaxReadSizeBytes() > 0
                 && managedLedgerMaxReadsInFlightSizeBytes < conf.getDispatcherMaxReadSizeBytes()) {
-            log.warn("Invalid configuration for managedLedgerMaxReadsInFlightSizeInMB: {}, "
-                            + "dispatcherMaxReadSizeBytes: {}. managedLedgerMaxReadsInFlightSizeInMB in bytes should "
-                            + "be greater than dispatcherMaxReadSizeBytes. You should set "
-                            + "managedLedgerMaxReadsInFlightSizeInMB to at least {}",
-                    conf.getManagedLedgerMaxReadsInFlightSizeInMB(), conf.getDispatcherMaxReadSizeBytes(),
-                    (conf.getDispatcherMaxReadSizeBytes() / (1024L * 1024L)) + 1);
+            log.warn()
+                    .attr("managedLedgerMaxReadsInFlightSizeInMB", conf.getManagedLedgerMaxReadsInFlightSizeInMB())
+                    .attr("dispatcherMaxReadSizeBytes", conf.getDispatcherMaxReadSizeBytes())
+                    .attr("minManagedLedgerMaxReadsInFlightSizeInMB",
+                            (conf.getDispatcherMaxReadSizeBytes() / (1024L * 1024L)) + 1)
+                    .log("Invalid configuration:"
+                            + " managedLedgerMaxReadsInFlightSizeInMB in bytes"
+                            + " should be greater than"
+                            + " dispatcherMaxReadSizeBytes");
         }
         managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightSize(managedLedgerMaxReadsInFlightSizeBytes);
         managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis(
@@ -211,7 +213,6 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         return defaultStorageClass;
     }
 
-
     @VisibleForTesting
     public Map<EnsemblePlacementPolicyConfig, BookKeeper> getBkEnsemblePolicyToBookKeeperMap() {
         return bkEnsemblePolicyToBkClientMap.synchronous().asMap();
@@ -240,7 +241,7 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
                 //
                 // an alternative solution is to close bookkeeper client before shutting down managed ledger
                 // factory, however that might be introducing more unknowns.
-                log.warn("Encountered exceptions on closing bookkeeper client", ree);
+                log.warn().attr("client", ree).log("Encountered exceptions on closing bookkeeper client");
             }
             bkEnsemblePolicyToBkClientMap.synchronous().asMap().forEach((policy, bk) -> {
                 try {
@@ -248,12 +249,12 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
                         bk.close();
                     }
                 } catch (Exception e) {
-                    log.warn("Failed to close bookkeeper-client for policy {}", policy, e);
+                    log.warn().attr("policy", policy).exception(e).log("Failed to close bookkeeper-client for policy");
                 }
             });
             log.info("Closed BookKeeper client");
         } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            log.warn().exception(e).log("Failed to close ManagedLedgerClientFactory");
             throw new IOException(e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -68,6 +68,7 @@ import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.ws.rs.core.Response;
 import lombok.AccessLevel;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -202,16 +203,14 @@ import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.zookeeper.DefaultMetadataNodeSizeStats;
 import org.eclipse.jetty.ee8.servlet.ServletHolder;
 import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServlet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Main class for Pulsar broker service.
  */
+@CustomLog
 @Getter(AccessLevel.PUBLIC)
 @Setter(AccessLevel.PROTECTED)
 public class PulsarService implements AutoCloseable, ShutdownService {
-    private static final Logger LOG = LoggerFactory.getLogger(PulsarService.class);
     private static final double GRACEFUL_SHUTDOWN_TIMEOUT_RATIO_OF_TOTAL_TIMEOUT = 0.5d;
     private static final int DEFAULT_MONOTONIC_CLOCK_GRANULARITY_MILLIS = 8;
     private static final Pattern METRICS_LABEL_NAME_PATTERN = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
@@ -328,8 +327,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private volatile HealthChecker healthChecker;
 
     public PulsarService(ServiceConfiguration config) {
-        this(config, Optional.empty(), (exitCode) -> LOG.info("Process termination requested with code {}. "
-                 + "Ignoring, as this constructor is intended for tests. ", exitCode));
+        this(config, Optional.empty(), (exitCode) -> log.info()
+                .attr("exitCode", exitCode)
+                .log("Process termination requested. Ignoring, as this constructor is intended for tests."));
     }
 
     public PulsarService(ServiceConfiguration config, Optional<WorkerService> functionWorkerService,
@@ -477,13 +477,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 throw (PulsarServerException) cause;
             } else if (getConfiguration().getBrokerShutdownTimeoutMs() == 0
                     && (cause instanceof TimeoutException || cause instanceof CancellationException)) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                        "Shutdown timeout ignored when timeout is 0, "
-                            + "which is primarily used in tests to forcefully shutdown the broker",
-                        cause);
-                }
-            } else {
+                    log.debug()
+                            .exception(cause)
+                            .log("Shutdown timeout ignored when timeout is 0, which is primarily used in tests to"
+                                    + " forcefully shutdown the broker");
+                            } else {
                 throw new PulsarServerException(cause);
             }
         } catch (InterruptedException e) {
@@ -520,7 +518,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (closeFuture != null) {
                 return closeFuture;
             }
-            LOG.info("Closing PulsarService");
+            log.info("Closing PulsarService");
             if (topicPoliciesService != null) {
                 topicPoliciesService.close();
             }
@@ -540,7 +538,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 try {
                     this.resourceUsageTransportManager.close();
                 } catch (Exception e) {
-                    LOG.warn("ResourceUsageTransportManager closing failed {}", e.getMessage());
+                    log.warn().exceptionMessage(e).log("ResourceUsageTransportManager closing failed");
                 }
                 this.resourceUsageTransportManager = null;
             }
@@ -548,7 +546,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 try {
                     this.resourceGroupServiceManager.close();
                 } catch (Exception e) {
-                    LOG.warn("ResourceGroupServiceManager closing failed {}", e.getMessage());
+                    log.warn().exceptionMessage(e).log("ResourceGroupServiceManager closing failed");
                 }
                 this.resourceGroupServiceManager = null;
             }
@@ -558,7 +556,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     this.webService.close(waitForWebServiceToStop);
                     this.webService = null;
                 } catch (Exception e) {
-                    LOG.error("Web service closing failed", e);
+                    log.error().exception(e).log("Web service closing failed");
                     // Even if the web service fails to close, the graceful shutdown process continues
                 }
             }
@@ -572,7 +570,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 try {
                     this.compactionServiceFactory.close();
                 } catch (Exception e) {
-                    LOG.warn("CompactionServiceFactory closing failed {}", e.getMessage());
+                    log.warn().exceptionMessage(e).log("CompactionServiceFactory closing failed");
                 }
                 this.compactionServiceFactory = null;
             }
@@ -618,7 +616,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 try {
                     this.managedLedgerStorage.close();
                 } catch (Exception e) {
-                    LOG.warn("ManagedLedgerClientFactory closing failed {}", e.getMessage());
+                    log.warn().exceptionMessage(e).log("ManagedLedgerClientFactory closing failed");
                 }
                 this.managedLedgerStorage = null;
             }
@@ -643,7 +641,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (transactionBufferClient != null) {
                 transactionBufferClient.close();
             }
-
 
             if (client != null) {
                 client.close();
@@ -743,20 +740,19 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
             asyncCloseFutures.add(EventLoopUtil.shutdownGracefully(ioEventLoopGroup));
 
-
             // add timeout handling for closing executors
             asyncCloseFutures.add(executorServicesShutdown.handle());
 
             closeFuture = addTimeoutHandling(FutureUtil.waitForAllAndSupportCancel(asyncCloseFutures));
             closeFuture.handle((v, t) -> {
                 if (t == null) {
-                    LOG.info("Closed");
+                    log.info("Closed");
                 } else if (t instanceof CancellationException) {
-                    LOG.info("Closed (shutdown cancelled)");
+                    log.info("Closed (shutdown cancelled)");
                 } else if (t instanceof TimeoutException) {
-                    LOG.info("Closed (shutdown timeout)");
+                    log.info("Closed (shutdown timeout)");
                 } else {
-                    LOG.warn("Closed with errors", t);
+                    log.warn().exception(t).log("Closed with errors");
                 }
                 state = State.Closed;
                 isClosedCondition.signalAll();
@@ -795,8 +791,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 shutdownExecutor, () -> FutureUtil.createTimeoutException("Timeout in close", getClass(), "close"));
         future.handle((v, t) -> {
             if (t instanceof TimeoutException) {
-                LOG.info("Shutdown timed out after {} ms", brokerShutdownTimeoutMs);
-                LOG.info(ThreadDumpUtil.buildThreadDiagnosticString());
+                log.info().attr("timeoutMs", brokerShutdownTimeoutMs).log("Shutdown timed out");
+                log.info(ThreadDumpUtil.buildThreadDiagnosticString());
             }
             // shutdown the shutdown executor
             shutdownExecutor.shutdownNow();
@@ -835,14 +831,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
      * Start the pulsar service instance.
      */
     public void start() throws PulsarServerException {
-        LOG.info("Starting Pulsar Broker service; version: '{}'",
-                (brokerVersion != null ? brokerVersion : "unknown"));
-        LOG.info("Git Revision {}", PulsarVersion.getGitSha());
-        LOG.info("Git Branch {}", PulsarVersion.getGitBranch());
-        LOG.info("Built by {} on {} at {}",
-                PulsarVersion.getBuildUser(),
-                PulsarVersion.getBuildHost(),
-                PulsarVersion.getBuildTime());
+        log.info()
+                .attr("version", (brokerVersion != null ? brokerVersion : "unknown"))
+                .attr("gitRevision", PulsarVersion.getGitSha())
+                .attr("gitBranch", PulsarVersion.getGitBranch())
+                .attr("buildUser", PulsarVersion.getBuildUser())
+                .attr("buildHost", PulsarVersion.getBuildHost())
+                .attr("buildTime", PulsarVersion.getBuildTime())
+                .log("Starting Pulsar Broker service");
 
         long startTimestamp = System.currentTimeMillis();  // start time mills
 
@@ -1093,12 +1089,16 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     + (config.getWebServicePortTls().isPresent() ? ", tls-port = " + config.getWebServicePortTls() : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrl) ? ", broker url= " + brokerServiceUrl : "")
                     + (StringUtils.isNotEmpty(brokerServiceUrlTls) ? ", broker tls url= " + brokerServiceUrlTls : "");
-            LOG.info("messaging service is ready, bootstrap_seconds={}, {}, cluster={}, configs={}",
-                    bootstrapTimeSeconds, bootstrapMessage, config.getClusterName(), config);
+            log.info()
+                    .attr("bootstrapTimeSeconds", bootstrapTimeSeconds)
+                    .attr("bootstrapMessage", bootstrapMessage)
+                    .attr("cluster", config.getClusterName())
+                    .attr("config", config)
+                    .log("Messaging service is ready");
 
             state = State.Started;
         } catch (Exception e) {
-            LOG.error("Failed to start Pulsar service: {}", e.getMessage(), e);
+            log.error().exception(e).log("Failed to start Pulsar service");
             PulsarServerException startException = PulsarServerException.from(e);
             readyForIncomingRequestsFuture.completeExceptionally(startException);
             throw startException;
@@ -1222,11 +1222,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
         // Add websocket service
         addWebSocketServiceHandler(webService, attributeMap, config);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Attempting to add static directory");
-        }
-        // Add static resources
+            log.debug("Attempting to add static directory");
+                // Add static resources
         webService.addStaticResources("/static", "/static");
 
         // Add broker additional servlets
@@ -1234,11 +1231,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     }
 
     private void handleMetadataSessionEvent(SessionEvent e) {
-        LOG.info("Received metadata service session event: {}", e);
+        log.info().attr("event", e).log("Received metadata service session event");
         if (e == SessionEvent.SessionLost
                 && config.getZookeeperSessionExpiredPolicy() == MetadataSessionExpiredPolicy.shutdown) {
-            LOG.warn("The session with metadata service was lost. Shutting down.\n{}\n",
-                    ThreadDumpUtil.buildThreadDiagnosticString());
+            log.warn()
+                    .attr("threads", ThreadDumpUtil.buildThreadDiagnosticString())
+                    .log("The session with metadata service was lost. Shutting down.\n\n");
             shutdownNow();
         }
     }
@@ -1259,13 +1257,19 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     case JAVAX_SERVLET -> {
                         Object servletInstance = servletWithClassLoader.getServletInstance();
                         if (!(servletInstance instanceof javax.servlet.Servlet)) {
-                            LOG.error("AdditionalServletWithClassLoader {} has invalid servlet instance type {} which "
-                                            + "doesn't match {}. Skipping.", servletWithClassLoader,
-                                    servletInstance.getClass().getName(), servletWithClassLoader.getServletType());
+                            log.error()
+                                    .attr("servlet", servletWithClassLoader)
+                                    .attr("type", servletInstance.getClass().getName())
+                                    .attr("match", servletWithClassLoader.getServletType())
+                                    .log("AdditionalServletWithClassLoader has invalid servlet instance type which"
+                                            + " doesn't match . Skipping.");
                             try {
                                 servletWithClassLoader.close();
                             } catch (Exception e) {
-                                LOG.error("Failed to close servlet {}.", servletWithClassLoader, e);
+                                log.error()
+                                        .attr("servlet", servletWithClassLoader)
+                                        .exception(e)
+                                        .log("Failed to close servlet .");
                             }
                             continue;
                         }
@@ -1273,15 +1277,22 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                                 new ServletHolder((Servlet) servletInstance);
                         webService.addServlet(servletWithClassLoader.getBasePath(), servletHolder,
                                 config.isAuthenticationEnabled(), attributeMap);
-                        LOG.info("Broker add additional servlet basePath {} ", servletWithClassLoader.getBasePath());
+                        log.info()
+                                .attr("basePath", servletWithClassLoader.getBasePath())
+                                .log("Broker add additional servlet basePath");
                     }
                     default -> {
-                        LOG.error("AdditionalServletWithClassLoader {} has unsupported servlet type {}. Skipping.",
-                                servletWithClassLoader, servletWithClassLoader.getServletType());
+                        log.error()
+                                .attr("servlet", servletWithClassLoader)
+                                .attr("type", servletWithClassLoader.getServletType())
+                                .log("AdditionalServletWithClassLoader has unsupported servlet type . Skipping.");
                         try {
                             servletWithClassLoader.close();
                         } catch (Exception e) {
-                            LOG.error("Failed to close servlet {}.", servletWithClassLoader, e);
+                            log.error()
+                                    .attr("servlet", servletWithClassLoader)
+                                    .exception(e)
+                                    .log("Failed to close servlet .");
                         }
                         continue;
                     }
@@ -1362,14 +1373,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     protected void startLeaderElectionService() {
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(this)) {
-            LOG.info("The load manager extension is enabled. Skipping PulsarService LeaderElectionService.");
+            log.info("The load manager extension is enabled. Skipping PulsarService LeaderElectionService.");
             return;
         }
         this.leaderElectionService =
                 new LeaderElectionService(coordinationService, getBrokerId(), getSafeWebServiceAddress(),
                 state -> {
                     if (state == LeaderElectionState.Leading) {
-                        LOG.info("This broker {} was elected leader", getBrokerId());
+                        log.info().attr("broker", getBrokerId()).log("This broker was elected leader");
                         if (getConfiguration().isLoadBalancerEnabled()) {
                             startLoadBalancerTasks();
                         }
@@ -1377,10 +1388,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         if (leaderElectionService != null) {
                             final Optional<LeaderBroker> currentLeader = leaderElectionService.getCurrentLeader();
                             if (currentLeader.isPresent()) {
-                                LOG.info("This broker {} is a follower. Current leader is {}", getBrokerId(),
-                                        currentLeader);
+                                log.info()
+                                        .attr("broker", getBrokerId())
+                                        .attr("currentLeader", currentLeader)
+                                        .log("This broker is a follower");
                             } else {
-                                LOG.info("This broker {} is a follower. No leader has been elected yet", getBrokerId());
+                                log.info()
+                                        .attr("broker", getBrokerId())
+                                        .log("This broker is a follower. No leader has been elected yet");
                             }
 
                         }
@@ -1421,14 +1436,17 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             // Namespace not created hence no need to unload it
             NamespaceName nsName = NamespaceService.getSLAMonitorNamespace(getBrokerId(), config);
             if (!this.pulsarResources.getNamespaceResources().namespaceExists(nsName)) {
-                LOG.info("SLA Namespace = {} doesn't exist.", nsName);
+                log.info().attr("namespace", nsName).log("SLA Namespace doesn't exist.");
                 return;
             }
 
             boolean acquiredSLANamespace;
             try {
                 acquiredSLANamespace = nsService.registerSLANamespace();
-                LOG.info("Register SLA Namespace = {}, returned - {}.", nsName, acquiredSLANamespace);
+                log.info()
+                        .attr("namespace", nsName)
+                        .attr("acquired", acquiredSLANamespace)
+                        .log("Register SLA Namespace");
             } catch (PulsarServerException e) {
                 acquiredSLANamespace = false;
             }
@@ -1437,17 +1455,17 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 this.nsService.unloadSLANamespace();
             }
         } catch (Exception ex) {
-            LOG.warn(
-                    "Exception while trying to unload the SLA namespace,"
-                            + " will try to unload the namespace again after 1 minute. Exception:",
-                    ex);
+            log.warn()
+                    .exception(ex)
+                    .log("Exception while trying to unload the SLA namespace, will try to unload the namespace again"
+                            + " after 1 minute. Exception");
             executor.schedule(this::acquireSLANamespace, 1, TimeUnit.MINUTES);
         } catch (Throwable ex) {
             // To make sure SLA monitor doesn't interfere with the normal broker flow
-            LOG.warn(
-                    "Exception while trying to unload the SLA namespace,"
-                            + " will not try to unload the namespace again. Exception:",
-                    ex);
+            log.warn()
+                    .exception(ex)
+                    .log("Exception while trying to unload the SLA namespace, will not try to unload the namespace"
+                            + " again. Exception");
         }
     }
 
@@ -1468,7 +1486,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     protected void startNamespaceService() throws PulsarServerException {
 
-        LOG.info("Starting name space service, bootstrap namespaces=" + config.getBootstrapNamespaces());
+        log.info()
+                .attr("bootstrapNamespaces", config.getBootstrapNamespaces())
+                .log("Starting name space service, bootstrap namespaces");
 
         this.nsService = getNamespaceServiceProvider().get();
     }
@@ -1478,11 +1498,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     }
 
     protected void startLoadManagementService() throws PulsarServerException {
-        LOG.info("Starting load management service ...");
+        log.info("Starting load management service ...");
         this.loadManager.get().start();
 
         if (config.isLoadBalancerEnabled() && !ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(this)) {
-            LOG.info("Starting load balancer");
+            log.info("Starting load balancer");
             if (this.loadReportTask == null) {
                 long loadReportMinInterval = config.getLoadBalancerReportUpdateMinIntervalMillis();
                 this.loadReportTask = this.loadManagerExecutor.scheduleAtFixedRate(
@@ -1499,7 +1519,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
      */
     public void loadNamespaceTopics(NamespaceBundle bundle) {
         executor.submit(() -> {
-            LOG.info("Loading all topics on bundle: {}", bundle);
+            log.info().attr("bundle", bundle).log("Loading all topics on bundle");
 
             NamespaceName nsName = bundle.getNamespaceObject();
             List<CompletableFuture<Optional<Topic>>> persistentTopics = new ArrayList<>();
@@ -1516,7 +1536,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                         }
                     }
                 } catch (Throwable t) {
-                    LOG.warn("Failed to preload topic {}", topic, t);
+                    log.warn().attr("topic", topic).exception(t).log("Failed to preload topic");
                 }
             }
 
@@ -1527,8 +1547,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     long numTopicsLoaded = persistentTopics.stream()
                             .filter(optionalTopicFuture -> optionalTopicFuture.getNow(Optional.empty()).isPresent())
                             .count();
-                    LOG.info("Loaded {} topics on {} -- time taken: {} seconds", numTopicsLoaded, bundle,
-                            topicLoadTimeSeconds);
+                    log.info()
+                            .attr("numTopicsLoaded", numTopicsLoaded)
+                            .attr("bundle", bundle)
+                            .attr("timeTakenSeconds", topicLoadTimeSeconds)
+                            .log("Loaded topics on bundle");
                 });
             }
             return null;
@@ -1553,7 +1576,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             config.isBookkeeperMetadataStoreSeparated() ? config.getBookkeeperMetadataStoreUrl() : null,
             this.getWorkerConfig().map(WorkerConfig::getStateStorageServiceUrl).orElse(null));
     }
-
 
     /**
      * check the current pulsar service is running, including Started and Init state.
@@ -1584,7 +1606,6 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     public NamespaceService getNamespaceService() {
         return this.nsService;
     }
-
 
     public Optional<WorkerService> getWorkerServiceOpt() {
         return functionWorkerService;
@@ -1634,7 +1655,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     return createManagedLedgerOffloader(offloadPolicies);
                 }
             } catch (PulsarServerException e) {
-                LOG.error("create ledgerOffloader failed for namespace {}", namespaceName.toString(), e);
+                log.error()
+                        .attr("namespace", namespaceName.toString())
+                        .exception(e)
+                        .log("create ledgerOffloader failed for namespace");
                 return new NullLedgerOffloader();
             }
         });
@@ -1672,7 +1696,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     }
                 }
             } else {
-                LOG.debug("No ledger offloader configured, using NULL instance");
+                log.debug("No ledger offloader configured, using NULL instance");
                 return NullLedgerOffloader.INSTANCE;
             }
         } catch (Throwable t) {
@@ -1855,7 +1879,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         if (this.adminClient == null) {
             try {
                 this.adminClient = getCreateAdminClientBuilder().build();
-                LOG.info("created admin with url {} ", adminClient.getServiceUrl());
+                log.info().attr("url", adminClient.getServiceUrl()).log("created admin with url");
             } catch (Exception e) {
                 throw new PulsarServerException(e);
             }
@@ -2019,11 +2043,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 workerConfig.setFunctionWebServiceUrl(webServiceAddress);
             }
 
-            LOG.info("Starting function worker service: serviceUrl = {},"
-                + " webServiceUrl = {}, functionWebServiceUrl = {}",
-                workerConfig.getPulsarServiceUrl(),
-                workerConfig.getPulsarWebServiceUrl(),
-                workerConfig.getFunctionWebServiceUrl());
+            log.info()
+                    .attr("serviceUrl", workerConfig.getPulsarServiceUrl())
+                    .attr("webServiceUrl", workerConfig.getPulsarWebServiceUrl())
+                    .attr("functionWebServiceUrl", workerConfig.getFunctionWebServiceUrl())
+                    .log("Starting function worker service");
 
             functionWorkerService.get().initInBroker(
                 config,
@@ -2037,7 +2061,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 authenticationService,
                 authorizationService,
                 ErrorNotifier.getShutdownServiceImpl(this));
-            LOG.info("Function worker service started");
+            log.info("Function worker service started");
         }
     }
 
@@ -2138,12 +2162,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
      */
     @Override
     public void shutdownNow() {
-        LOG.info("Invoking Pulsar service immediate shutdown");
+        log.info("Invoking Pulsar service immediate shutdown");
         try {
             // Try to close metadata service session to ensure all ephemeral locks get released immediately
             closeMetadataServiceSession();
         } catch (Exception e) {
-            LOG.warn("Failed to close metadata service session: {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to close metadata service session");
         }
 
         processTerminator.accept(-1);
@@ -2184,23 +2208,25 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             final PulsarMetadataEventSynchronizer oldSynchronizer = configMetadataSynchronizer;
             // Skip if not support.
             if (!(configurationMetadataStore instanceof MetadataStoreExtended)) {
-                LOG.info(
-                        "Skip to update Metadata Synchronizer because of the Configuration Metadata Store using[{}]"
-                                + " does not support.", configurationMetadataStore.getClass().getName());
+                log.info()
+                        .attr("configurationMetadataStore", configurationMetadataStore.getClass().getName())
+                        .log("Skip to update Metadata Synchronizer because of the Configuration Metadata Store using"
+                                + " does not support.");
                 return;
             }
             // Skip if no changes.
             //   case-1: both null.
             //   case-2: both topics are the same.
             if ((oldSynchronizer == null && StringUtils.isBlank(newTopic))) {
-                LOG.info("Skip to update Metadata Synchronizer because the topic[null] does not changed.");
+                log.info("Skip to update Metadata Synchronizer because the topic[null] does not changed.");
             }
             if (StringUtils.isNotBlank(newTopic) && oldSynchronizer != null) {
                 TopicName newTopicName = TopicName.get(newTopic);
                 TopicName oldTopicName = TopicName.get(oldSynchronizer.getTopicName());
                 if (newTopicName.equals(oldTopicName)) {
-                    LOG.info("Skip to update Metadata Synchronizer because the topic[{}] does not changed.",
-                            oldTopicName);
+                    log.info()
+                            .attr("topic", oldTopicName)
+                            .log("Skip to update Metadata Synchronizer because the topic does not changed.");
                 }
             }
             // Update(null or not null).
@@ -2224,8 +2250,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     newSynchronizer.start();
                 } catch (Exception e) {
                     // It only occurs when get internal client fails.
-                    LOG.error("Start Metadata Synchronizer with topic {} failed.",
-                            newTopic, e);
+                    log.error()
+                            .attr("topic", newTopic)
+                            .exception(e)
+                            .log("Start Metadata Synchronizer with topic failed.");
                 }
             };
             executor.submit(() -> {
@@ -2252,7 +2280,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             if (config.isSystemTopicEnabled()) {
                 return new SystemTopicBasedTopicPoliciesService(this);
             } else {
-                LOG.warn("System topic is disabled while the topic policies service is {}, disable it", className);
+                log.warn()
+                        .attr("className", className)
+                        .log("System topic is disabled while the topic policies service is set, disabling it");
                 return TopicPoliciesService.DISABLED;
             }
         }
@@ -2287,7 +2317,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     try {
                         healthChecker = new HealthChecker(this);
                     } catch (PulsarServerException e) {
-                        LOG.error("Failed to create health checker", e);
+                        log.error().exception(e).log("Failed to create health checker");
                         throw new RuntimeException(e);
                     }
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TransactionMetadataStoreService.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.broker.transaction.exception.coordinator.TransactionCoordinatorException;
@@ -69,13 +70,9 @@ import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException.TransactionMetadataStoreStateException;
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig;
 import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class TransactionMetadataStoreService {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionMetadataStoreService.class);
-
     private final Map<TransactionCoordinatorID, TransactionMetadataStore> stores;
     private final TransactionMetadataStoreProvider transactionMetadataStoreProvider;
     private final PulsarService pulsarService;
@@ -91,7 +88,6 @@ public class TransactionMetadataStoreService {
     private final ExecutorService internalPinnedExecutor;
 
     private static final long HANDLE_PENDING_CONNECT_TIME_OUT = 30000L;
-
 
     public TransactionMetadataStoreService(TransactionMetadataStoreProvider transactionMetadataStoreProvider,
                                            PulsarService pulsarService, TransactionBufferClient tbClient,
@@ -143,7 +139,7 @@ public class TransactionMetadataStoreService {
                                     // we need to put store into stores map before
                                     // handle committing and aborting transaction.
                                     stores.put(tcId, store);
-                                    LOG.info("Added new transaction meta store {}", tcId);
+                                    log.info().attr("tcId", tcId).log("Added new transaction meta store");
                                     recoverTracker.handleCommittingAndAbortingTransaction();
                                     timeoutTracker.start();
 
@@ -189,7 +185,10 @@ public class TransactionMetadataStoreService {
                                         break;
                                     }
                                 }
-                                LOG.error("Add transaction metadata store with id {} error", tcId.getId(), e);
+                                log.error()
+                                        .attr("tcId", tcId.getId())
+                                        .exception(e)
+                                        .log("Add transaction metadata store error");
                             });
                             return null;
                         });
@@ -198,10 +197,10 @@ public class TransactionMetadataStoreService {
                         // other will be added to the deque, when the op of openTransactionMetadataStore finished
                         // then handle the requests witch in the queue
                         deque.add(completableFuture);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Handle tc client connect added into pending queue! tcId : {}", tcId);
-                        }
-                    }
+                            log.debug()
+                                    .attr("tcId", tcId)
+                                    .log("Handle tc client connect added into pending queue");
+                                            }
                 })).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     completableFuture.completeExceptionally(realCause);
@@ -243,9 +242,9 @@ public class TransactionMetadataStoreService {
             if (metadataStore != null) {
                 metadataStore.closeAsync().whenComplete((v, ex) -> {
                     if (ex != null) {
-                        LOG.error("Close transaction metadata store with id " + tcId, ex);
+                        log.error().attr("tcId", tcId).exception(ex).log("Close transaction metadata store");
                     } else {
-                        LOG.info("Removed and closed transaction meta store {}", tcId);
+                        log.info().attr("tcId", tcId).log("Removed and closed transaction meta store");
                     }
                 });
             }
@@ -333,7 +332,7 @@ public class TransactionMetadataStoreService {
             default:
                 TransactionCoordinatorException.UnsupportedTxnActionException exception =
                         new TransactionCoordinatorException.UnsupportedTxnActionException(txnID, txnAction);
-                LOG.error(exception.getMessage());
+                log.error(exception.getMessage());
                 future.completeExceptionally(exception);
                 return;
         }
@@ -351,16 +350,20 @@ public class TransactionMetadataStoreService {
                         return;
                     }
                     if (!isRetryableException(ex)) {
-                        LOG.error("End transaction fail! TxnId : {}, "
-                                + "TxnAction : {}", txnID, txnAction, ex);
+                        log.error()
+                                .attr("txnId", txnID)
+                                .attr("txnAction", txnAction)
+                                .exception(ex)
+                                .log("End transaction fail! TxnId: , TxnAction");
                         future.completeExceptionally(ex);
                         return;
                     }
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("EndTxnInTransactionBuffer retry! TxnId : {}, "
-                                + "TxnAction : {}", txnID, txnAction, ex);
-                    }
-                    transactionOpRetryTimer.newTimeout(timeout ->
+                        log.debug()
+                                .attr("txnId", txnID)
+                                .attr("txnAction", txnAction)
+                                .exception(ex)
+                                .log("EndTxnInTransactionBuffer retry! TxnId: , TxnAction");
+                                        transactionOpRetryTimer.newTimeout(timeout ->
                                     endTransaction(txnID, txnAction, isTimeout, future),
                             endTransactionRetryIntervalTime, TimeUnit.MILLISECONDS);
                 });
@@ -374,10 +377,11 @@ public class TransactionMetadataStoreService {
             default -> false;
         };
         if (!isLegal) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("EndTxnInTransactionBuffer op retry! TxnId : {}, TxnAction : {}", txnID, txnAction);
-            }
-            return FutureUtil.failedFuture(
+                log.debug()
+                        .attr("txnId", txnID)
+                        .attr("txnAction", txnAction)
+                        .log("EndTxnInTransactionBuffer op retry! TxnId : , TxnAction");
+                        return FutureUtil.failedFuture(
                     new InvalidTxnStatusException(txnID, expectStatus, txnStatus));
         }
        return CompletableFuture.completedFuture(null);
@@ -401,11 +405,11 @@ public class TransactionMetadataStoreService {
             if (isRetryableException(e)) {
                 endTransaction(txnID, TxnAction.ABORT_VALUE, true);
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Transaction have been handle complete, "
-                            + "don't need to handle by transaction timeout! TxnId : {}", txnID);
-                }
-            }
+                    log.debug()
+                            .attr("txnId", txnID)
+                            .log("Transaction have been handle complete, don't need to handle by transaction"
+                                    + " timeout! TxnId");
+                            }
             return null;
         });
     }
@@ -494,15 +498,14 @@ public class TransactionMetadataStoreService {
                 });
     }
 
-
     public void close () {
         this.internalPinnedExecutor.shutdown();
         stores.forEach((tcId, metadataStore) ->
             metadataStore.closeAsync().whenComplete((v, ex) -> {
                 if (ex != null) {
-                    LOG.error("Close transaction metadata store with id " + tcId, ex);
+                    log.error().attr("tcId", tcId).exception(ex).log("Close transaction metadata store");
                 } else {
-                    LOG.info("Removed and closed transaction meta store {}", tcId);
+                    log.info().attr("tcId", tcId).log("Removed and closed transaction meta store");
                 }
         }));
         stores.clear();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -39,7 +39,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.commons.lang3.StringUtils;
@@ -84,7 +83,6 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.BadVersionException;
 
-@Slf4j
 public abstract class AdminResource extends PulsarWebResource {
 
     protected NamespaceName namespaceName;
@@ -146,16 +144,13 @@ public abstract class AdminResource extends PulsarWebResource {
         return pulsar().getPulsarResources().getNamespaceResources().getPoliciesReadOnlyAsync()
                 .thenAccept(arePoliciesReadOnly -> {
                     if (arePoliciesReadOnly) {
-                        if (log.isDebugEnabled()) {
                             log.debug("Policies are read-only. Broker cannot do read-write operations");
-                        }
-                        throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
+                                                throw new RestException(Status.FORBIDDEN,
+                                                        "Broker is forbidden to do read-write operations");
                     } else {
                         // Do nothing, just log the message.
-                        if (log.isDebugEnabled()) {
                             log.debug("Broker is allowed to make read-write operations");
-                        }
-                    }
+                                            }
                 });
     }
 
@@ -178,24 +173,28 @@ public abstract class AdminResource extends PulsarWebResource {
         CompletableFuture<Void> result = new CompletableFuture<>();
         getPulsarResources().getTopicResources().createPersistentTopicAsync(topicName.getPartition(partition))
                 .thenAccept(r -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Topic partition {} created.", clientAppId(), topicName.getPartition(partition));
-                    }
-                    result.complete(null);
+                        log.debug()
+                                .attr("partition", topicName.getPartition(partition))
+                                .log("Topic partition created.");
+                                        result.complete(null);
                 }).exceptionally(ex -> {
                     if (ex.getCause() instanceof AlreadyExistsException) {
-                        log.info("[{}] Topic partition {} is exists, doing nothing.", clientAppId(),
-                                topicName.getPartition(partition));
+                        log.info()
+                                .attr("partition", topicName.getPartition(partition))
+                                .log("Topic partition is exists, doing nothing.");
                         result.complete(null);
                     } else if (ex.getCause() instanceof BadVersionException) {
-                        log.warn("[{}] Partitioned topic {} is already created.", clientAppId(),
-                                topicName.getPartition(partition));
+                        log.warn()
+                                .attr("topic", topicName.getPartition(partition))
+                                .log("Partitioned topic is already created.");
                         // metadata-store api returns BadVersionException if node already exists while creating the
                         // resource
                         result.complete(null);
                     } else {
-                        log.error("[{}] Fail to create topic partition {}", clientAppId(),
-                                topicName.getPartition(partition), ex.getCause());
+                        log.error()
+                                .attr("partition", topicName.getPartition(partition))
+                                .exception(ex.getCause())
+                                .log("Fail to create topic partition");
                         result.completeExceptionally(ex.getCause());
                     }
                     return null;
@@ -209,7 +208,10 @@ public abstract class AdminResource extends PulsarWebResource {
         try {
             this.namespaceName = NamespaceName.get(tenant, namespace);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Invalid namespace name [{}/{}]", clientAppId(), tenant, namespace);
+            log.warn()
+                    .attr("tenant", tenant)
+                    .attr("namespace", namespace)
+                    .log("Invalid namespace name");
             throw new RestException(Status.PRECONDITION_FAILED, "Namespace name is not valid");
         }
     }
@@ -222,7 +224,10 @@ public abstract class AdminResource extends PulsarWebResource {
         } catch (RestException re) {
             throw re;
         } catch (Exception e) {
-            log.warn("Failed to validate global cluster configuration : ns={}  emsg={}", namespaceName, e.getMessage());
+            log.warn()
+                    .attr("namespace", namespaceName)
+                    .exceptionMessage(e)
+                    .log("Failed to validate global cluster configuration");
             throw new RestException(Status.SERVICE_UNAVAILABLE, "Failed to validate global cluster configuration");
         }
     }
@@ -232,7 +237,12 @@ public abstract class AdminResource extends PulsarWebResource {
             this.namespaceName = NamespaceName.get(tenant, namespace);
             this.topicName = TopicName.get(domain(), namespaceName, topic);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Invalid topic name [{}://{}/{}/{}]", clientAppId(), domain(), tenant, namespace, topic);
+            log.warn()
+                    .attr("domain", domain())
+                    .attr("tenant", tenant)
+                    .attr("namespace", namespace)
+                    .attr("topic", topic)
+                    .log("Invalid topic name");
             throw new RestException(Status.PRECONDITION_FAILED, "Topic name is not valid");
         }
     }
@@ -294,7 +304,10 @@ public abstract class AdminResource extends PulsarWebResource {
         } catch (RestException re) {
             throw re;
         } catch (Exception e) {
-            log.error("[{}] Failed to get namespace policies {}", clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to get namespace policies");
             throw new RestException(e);
         }
 
@@ -479,8 +492,10 @@ public abstract class AdminResource extends PulsarWebResource {
                     .listPartitionedTopicsAsync(namespaceName, topicDomain)
                     .join();
         } catch (Exception e) {
-            log.error("[{}] Failed to get partitioned topic list for namespace {}", clientAppId(),
-                    namespaceName.toString(), e);
+            log.error()
+                    .attr("namespace", namespaceName.toString())
+                    .exception(e)
+                    .log("Failed to get partitioned topic list for namespace");
             throw new RestException(e);
         }
     }
@@ -499,8 +514,10 @@ public abstract class AdminResource extends PulsarWebResource {
             return getPulsarResources().getTopicResources().getExistingPartitions(topicName)
                     .get(config().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.error("[{}] Failed to get topic partition list for namespace {}", clientAppId(),
-                    namespaceName.toString(), e);
+            log.error()
+                    .attr("namespace", namespaceName.toString())
+                    .exception(e)
+                    .log("Failed to get topic partition list for namespace");
             throw new RestException(e);
         }
     }
@@ -549,9 +566,10 @@ public abstract class AdminResource extends PulsarWebResource {
                                     .filter(t -> !pulsar().getBrokerService().isSystemTopic(TopicName.get(t)))
                                     .count();
                             if (topicsCount + numPartitions > maxTopicsPerNamespace) {
-                                log.error("[{}] Failed to create partitioned topic {}, "
-                                                + "exceed maximum number of topics in namespace", clientAppId(),
-                                        topicName);
+                                log.error()
+                                        .attr("topic", topicName)
+                                        .log("Failed to create partitioned topic , exceed maximum number of topics"
+                                                + " in namespace");
                                 throw new RestException(Status.PRECONDITION_FAILED,
                                         "Exceed maximum number of topics in namespace.");
                             }
@@ -566,7 +584,9 @@ public abstract class AdminResource extends PulsarWebResource {
                             if (topicExistsInfo.getTopicType().equals(TopicType.NON_PARTITIONED)
                                     || (topicExistsInfo.getTopicType().equals(TopicType.PARTITIONED)
                                     && !createLocalTopicOnly)) {
-                                log.warn("[{}] Failed to create already existing topic {}", clientAppId(), topicName);
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .log("Failed to create already existing topic");
                                 throw new RestException(Status.CONFLICT, "This topic already exists");
                             }
                         }
@@ -599,20 +619,27 @@ public abstract class AdminResource extends PulsarWebResource {
                     if (!createLocalTopicOnly
                             && pulsar().getConfig().isCreateTopicToRemoteClusterForReplication()) {
                         internalCreatePartitionedTopicToReplicatedClustersInBackground(numPartitions);
-                        log.info("[{}] Successfully created partitioned for topic {} for the remote clusters",
-                                clientAppId(), topicName);
+                        log.info()
+                                .attr("topic", topicName)
+                                .log("Successfully created partitioned for topic for the remote clusters");
                     } else {
-                        log.info("[{}] Skip creating partitioned for topic {} for the remote clusters",
-                                clientAppId(), topicName);
+                        log.info()
+                                .attr("topic", topicName)
+                                .log("Skip creating partitioned for topic for the remote clusters");
                     }
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (AdminResource.isConflictException(ex)) {
-                        log.info("[{}] Failed to create partitioned topic {}: {}", clientAppId(), topicName,
-                                ex.getMessage());
+                        log.info()
+                                .attr("topic", topicName)
+                                .exceptionMessage(ex)
+                                .log("Failed to create partitioned topic");
                     } else {
-                        log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to create partitioned topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -661,8 +688,11 @@ public abstract class AdminResource extends PulsarWebResource {
             clusterResources.getClusterAsync(cluster).whenComplete((clusterData, ex1) -> {
                 if (ex1 != null) {
                     // Unexpected error, such as NPE. Catch all error to avoid the "createRemoteTopicFuture" stuck.
-                    log.error("[{}] An un-expected error occurs when trying to create partitioned topic {} in cluster"
-                                    + " {}.", clientAppId(), topicName, cluster, ex1);
+                    log.error()
+                            .attr("topic", topicName)
+                            .attr("cluster", cluster)
+                            .exception(ex1)
+                            .log("An un-expected error occurs when trying to create partitioned topic in cluster .");
                     createRemoteTopicFuture.completeExceptionally(new RestException(ex1));
                     return;
                 }
@@ -670,8 +700,11 @@ public abstract class AdminResource extends PulsarWebResource {
                 try {
                     remotePulsarAdmin = pulsar().getBrokerService().getClusterPulsarAdmin(cluster, clusterData);
                 } catch (Exception ex) {
-                    log.error("[{}] [{}] An un-expected error occurs when trying to create remote pulsar admin for"
-                            + " cluster {}", clientAppId(), topicName, cluster, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("An un-expected error occurs when trying to create remote pulsar admin for cluster");
                     createRemoteTopicFuture.completeExceptionally(new RestException(ex));
                     return;
                 }
@@ -681,8 +714,10 @@ public abstract class AdminResource extends PulsarWebResource {
                         .whenComplete((ignore, ex2) -> {
                     if (ex2 == null) {
                         // Create success.
-                        log.info("[{}] Successfully created partitioned topic {} in cluster {}",
-                                clientAppId(), topicName, cluster);
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("cluster", cluster)
+                                .log("Successfully created partitioned topic in cluster");
                         createRemoteTopicFuture.complete(null);
                         return;
                     }
@@ -694,15 +729,21 @@ public abstract class AdminResource extends PulsarWebResource {
                             if (ex3 != null) {
                                 // Unexpected error, such as NPE. Catch all error to avoid the
                                 // "createRemoteTopicFuture" stuck.
-                                log.error("[{}] Failed to check remote-cluster's topic metadata when creating"
-                                                + " partitioned topic {} in cluster {}.",
-                                        clientAppId(), topicName, cluster, ex3);
+                                log.error()
+                                        .attr("topic", topicName)
+                                        .attr("cluster", cluster)
+                                        .exception(ex3)
+                                        .log("Failed to check remote-cluster's topic metadata when creating"
+                                                + " partitioned topic in cluster .");
                                 createRemoteTopicFuture.completeExceptionally(new RestException(ex3));
                             }
                             // Call get partitioned metadata of remote cluster success.
                             if (topicMeta.partitions == numPartitions) {
-                                log.info("[{}] Skip created partitioned topic {} in cluster {},  because that {}",
-                                        clientAppId(), topicName, cluster, unwrapEx2.getMessage());
+                                log.info()
+                                        .attr("topic", topicName)
+                                        .attr("cluster", cluster)
+                                        .exceptionMessage(unwrapEx2)
+                                        .log("Skip created partitioned topic in cluster , because that");
                                 createRemoteTopicFuture.complete(null);
                             } else {
                                 String errorMsg = String.format("[%s] There is an exists topic %s with different"
@@ -717,8 +758,11 @@ public abstract class AdminResource extends PulsarWebResource {
                         });
                     } else {
                         // An HTTP error was responded from the remote cluster.
-                        log.error("[{}] Failed to create partitioned topic {} in cluster {}.",
-                                clientAppId(), topicName, cluster, ex2);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("cluster", cluster)
+                                .exception(ex2)
+                                .log("Failed to create partitioned topic in cluster .");
                         createRemoteTopicFuture.completeExceptionally(new RestException(unwrapEx2));
                     }
                 });
@@ -755,22 +799,29 @@ public abstract class AdminResource extends PulsarWebResource {
                                 future.complete(null);
                                 return;
                             }
-                            log.warn("[{}] Failed to create already existing partitioned topic {}",
-                                    clientAppId(), topicName);
+                            log.warn()
+                                    .attr("topic", topicName)
+                                    .log("Failed to create already existing partitioned topic");
                             future.completeExceptionally(
                                     new RestException(Status.CONFLICT, "Partitioned topic already exists"));
                         } else if (ex instanceof BadVersionException) {
-                            log.warn("[{}] Failed to create partitioned topic {}: concurrent modification",
-                                    clientAppId(), topicName);
+                            log.warn()
+                                    .attr("topic", topicName)
+                                    .log("Failed to create partitioned topic : concurrent modification");
                             future.completeExceptionally(
                                     new RestException(Status.CONFLICT, "Concurrent modification"));
                         } else {
-                            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to create partitioned topic");
                             future.completeExceptionally(new RestException(ex.getCause()));
                         }
                         return;
                     }
-                    log.info("[{}] Successfully created partitioned topic {}", clientAppId(), topicName);
+                    log.info()
+                            .attr("topic", topicName)
+                            .log("Successfully created partitioned topic");
                     future.complete(null);
                 });
         return future;
@@ -779,8 +830,10 @@ public abstract class AdminResource extends PulsarWebResource {
     protected CompletableFuture<SchemaCompatibilityStrategy> getSchemaCompatibilityStrategyAsync() {
         return getSchemaCompatibilityStrategyAsyncWithoutAuth().whenComplete((__, ex) -> {
                     if (ex != null) {
-                        log.error("[{}] Failed to get schema compatibility strategy of topic {} {}",
-                                clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exceptionMessage(ex)
+                                .log("Failed to get schema compatibility strategy of topic");
                     }
                 });
     }
@@ -967,21 +1020,25 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected void validateOffloadPolicies(OffloadPoliciesImpl offloadPolicies) {
         if (offloadPolicies == null) {
-            log.warn("[{}] Failed to update offload configuration for namespace {}: offloadPolicies is null",
-                    clientAppId(), namespaceName);
+            log.warn()
+                    .attr("namespace", namespaceName)
+                    .log("Failed to update offload configuration for namespace : offloadPolicies is null");
             throw new RestException(Status.PRECONDITION_FAILED,
                     "The offloadPolicies must be specified for namespace offload.");
         }
         if (!offloadPolicies.driverSupported()) {
-            log.warn("[{}] Failed to update offload configuration for namespace {}: "
-                            + "driver is not supported, support value: {}",
-                    clientAppId(), namespaceName, OffloadPoliciesImpl.getSupportedDriverNames());
+            log.warn()
+                    .attr("namespace", namespaceName)
+                    .attr("value", OffloadPoliciesImpl.getSupportedDriverNames())
+                    .log("Failed to update offload configuration for namespace: driver is not supported, support"
+                            + " value");
             throw new RestException(Status.PRECONDITION_FAILED,
                     "The driver is not supported, support value: " + OffloadPoliciesImpl.getSupportedDriverNames());
         }
         if (!offloadPolicies.bucketValid()) {
-            log.warn("[{}] Failed to update offload configuration for namespace {}: bucket must be specified",
-                    clientAppId(), namespaceName);
+            log.warn()
+                    .attr("namespace", namespaceName)
+                    .log("Failed to update offload configuration for namespace : bucket must be specified");
             throw new RestException(Status.PRECONDITION_FAILED,
                     "The bucket must be specified for namespace offload.");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokerStatsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokerStatsBase.java
@@ -44,12 +44,8 @@ import org.apache.pulsar.common.stats.AllocatorStats;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.apache.pulsar.policies.data.loadbalancer.LoadReport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class BrokerStatsBase extends AdminResource {
-    private static final Logger log = LoggerFactory.getLogger(BrokerStatsBase.class);
-
     @GET
     @Path("/metrics")
     @ApiOperation(value = "Gets the metrics for Monitoring",
@@ -63,7 +59,7 @@ public class BrokerStatsBase extends AdminResource {
             Collection<Metrics> metrics = pulsar().getMetricsGenerator().generate();
             return metrics;
         } catch (Exception e) {
-            log.error("[{}] Failed to generate metrics", clientAppId(), e);
+            log.error().exception(e).log("Failed to generate metrics");
             throw new RestException(e);
         }
     }
@@ -80,7 +76,7 @@ public class BrokerStatsBase extends AdminResource {
             Collection<Metrics> metrics = MBeanStatsGenerator.generate(pulsar());
             return metrics;
         } catch (Exception e) {
-            log.error("[{}] Failed to generate mbean stats", clientAppId(), e);
+            log.error().exception(e).log("Failed to generate mbean stats");
             throw new RestException(e);
         }
     }
@@ -117,7 +113,7 @@ public class BrokerStatsBase extends AdminResource {
         } catch (IllegalArgumentException e) {
             throw new RestException(Status.NOT_ACCEPTABLE, e.getMessage());
         } catch (Exception e) {
-            log.error("[{}] Failed to generate allocator stats", clientAppId(), e);
+            log.error().exception(e).log("Failed to generate allocator stats");
             throw new RestException(e);
         }
     }
@@ -139,7 +135,9 @@ public class BrokerStatsBase extends AdminResource {
         try {
             return BookieClientStatsGenerator.generate(pulsar());
         } catch (Exception e) {
-            log.error("[{}] Failed to generate pending bookie ops stats for topics", clientAppId(), e);
+            log.error()
+                    .exception(e)
+                    .log("Failed to generate pending bookie ops stats for topics");
             throw new RestException(e);
         }
     }
@@ -155,7 +153,9 @@ public class BrokerStatsBase extends AdminResource {
         try {
             return (pulsar().getLoadManager().get()).generateLoadReport();
         } catch (Exception e) {
-            log.error("[{}] Failed to generate LoadReport for broker, reason [{}]", clientAppId(), e.getMessage(), e);
+            log.error()
+                    .exception(e)
+                    .log("Failed to generate LoadReport for broker");
             throw new RestException(e);
         }
     }
@@ -170,7 +170,7 @@ public class BrokerStatsBase extends AdminResource {
                 throw new RestException(Status.CONFLICT, lm.getClass().getName() + " does not support this operation");
             }
         } catch (Exception e) {
-            log.error("Unable to get Resource Availability", e);
+            log.error().exception(e).log("Unable to get Resource Availability");
             throw new RestException(e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -56,14 +56,11 @@ import org.apache.pulsar.common.policies.data.BrokerOperation;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ThreadDumpUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Broker admin base.
  */
 public class BrokersBase extends AdminResource {
-    private static final Logger LOG = LoggerFactory.getLogger(BrokersBase.class);
     // log a full thread dump when a deadlock is detected in healthcheck once every 10 minutes
     // to prevent excessive logging
     private static final long LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED = 600000L;
@@ -89,12 +86,17 @@ public class BrokersBase extends AdminResource {
                 .thenCompose(__ -> validateClusterOwnershipAsync(cluster))
                 .thenCompose(__ -> pulsar().getLoadManager().get().getAvailableBrokersAsync())
                 .thenAccept(activeBrokers -> {
-                    LOG.info("[{}] Successfully to get active brokers, cluster={}", clientAppId(), cluster);
+                    log.info()
+                            .attr("cluster", cluster)
+                            .log("Successfully to get active brokers, cluster");
                     asyncResponse.resume(activeBrokers);
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (!isRedirectException(ex)) {
-                        LOG.error("[{}] Fail to get active brokers, cluster={}", clientAppId(), cluster, ex);
+                        log.error()
+                                .attr("cluster", cluster)
+                                .exception(ex)
+                                .log("Fail to get active brokers, cluster");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -134,11 +136,13 @@ public class BrokersBase extends AdminResource {
                     BrokerInfo brokerInfo = BrokerInfo.builder()
                             .serviceUrl(leaderBroker.getServiceUrl())
                             .brokerId(leaderBroker.getBrokerId()).build();
-                    LOG.info("[{}] Successfully to get the information of the leader broker.", clientAppId());
+                    log.info("Successfully got the information of the leader broker");
                     asyncResponse.resume(brokerInfo);
                 })
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to get the information of the leader broker.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get the information of the leader broker.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -164,8 +168,10 @@ public class BrokersBase extends AdminResource {
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (!isRedirectException(ex)) {
-                        LOG.error("[{}] Failed to get the namespace ownership status. cluster={}, broker={}",
-                                clientAppId(), cluster, brokerId);
+                        log.error()
+                                .attr("cluster", cluster)
+                                .attr("broker", brokerId)
+                                .log("Failed to get the namespace ownership status");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -189,10 +195,17 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.UPDATE_DYNAMIC_CONFIGURATION)
                 .thenCompose(__ -> persistDynamicConfigurationAsync(configName, configValue))
                 .thenAccept(__ -> {
-                    LOG.info("[{}] Updated Service configuration {}/{}", clientAppId(), configName, configValue);
+                    log.info()
+                            .attr("configuration", configName)
+                            .attr("configValue", configValue)
+                            .log("Updated Service configuration");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
-                    LOG.error("[{}] Failed to update configuration {}/{}", clientAppId(), configName, configValue, ex);
+                    log.error()
+                            .attr("configuration", configName)
+                            .attr("configValue", configValue)
+                            .exception(ex)
+                            .log("Failed to update configuration");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -214,10 +227,15 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.DELETE_DYNAMIC_CONFIGURATION)
                 .thenCompose(__ -> internalDeleteDynamicConfigurationOnMetadataAsync(configName))
                 .thenAccept(__ -> {
-                    LOG.info("[{}] Successfully to delete dynamic configuration {}", clientAppId(), configName);
+                    log.info()
+                            .attr("configuration", configName)
+                            .log("Successfully to delete dynamic configuration");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
-                    LOG.error("[{}] Failed to delete dynamic configuration {}", clientAppId(), configName, ex);
+                    log.error()
+                            .attr("configuration", configName)
+                            .exception(ex)
+                            .log("Failed to delete dynamic configuration");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -237,7 +255,9 @@ public class BrokersBase extends AdminResource {
                 .thenCompose(__ -> dynamicConfigurationResources().getDynamicConfigurationAsync())
                 .thenAccept(configOpt -> asyncResponse.resume(configOpt.orElseGet(Collections::emptyMap)))
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to get all dynamic configuration.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get all dynamic configuration.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -254,7 +274,9 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.LIST_DYNAMIC_CONFIGURATIONS)
                 .thenAccept(__ -> asyncResponse.resume(pulsar().getBrokerService().getDynamicConfiguration()))
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to get all dynamic configuration names.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get all dynamic configuration names.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -270,7 +292,9 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.LIST_RUNTIME_CONFIGURATIONS)
                 .thenAccept(__ -> asyncResponse.resume(pulsar().getBrokerService().getRuntimeConfiguration()))
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to get runtime configuration.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get runtime configuration.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -312,7 +336,9 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.GET_INTERNAL_CONFIGURATION_DATA)
                 .thenAccept(__ -> asyncResponse.resume(pulsar().getInternalConfigurationData()))
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to get internal configuration data.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get internal configuration data.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -333,7 +359,9 @@ public class BrokersBase extends AdminResource {
                     asyncResponse.resume(Response.noContent().build());
                 } , pulsar().getBrokerService().getBacklogQuotaChecker())
                 .exceptionally(ex -> {
-                    LOG.error("[{}] Failed to trigger backlog quota check.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to trigger backlog quota check.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -376,14 +404,18 @@ public class BrokersBase extends AdminResource {
                 .thenAccept(__ -> checkDeadlockedThreads())
                 .thenCompose(__ -> internalRunHealthCheck())
                 .thenAccept(__ -> {
-                    LOG.info("[{}] Successfully run health check.", clientAppId());
+                    log.info("Successfully ran health check");
                     asyncResponse.resume(Response.ok("ok").build());
                 }).exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
                         if (isNotFoundException(ex)) {
-                            LOG.warn("[{}] Failed to run health check: {}", clientAppId(), ex.getMessage());
+                            log.warn()
+                                    .exceptionMessage(ex)
+                                    .log("Failed to run health check");
                         } else {
-                            LOG.error("[{}] Failed to run health check.", clientAppId(), ex);
+                            log.error()
+                                    .exception(ex)
+                                    .log("Failed to run health check.");
                         }
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
@@ -402,10 +434,12 @@ public class BrokersBase extends AdminResource {
             if (System.currentTimeMillis() - threadDumpLoggedTimestamp
                     > LOG_THREADDUMP_INTERVAL_WHEN_DEADLOCK_DETECTED) {
                 threadDumpLoggedTimestamp = System.currentTimeMillis();
-                LOG.error("Deadlocked threads detected. {}\n{}", threadNames,
-                        ThreadDumpUtil.buildThreadDiagnosticString());
+                log.error()
+                        .attr("detected", threadNames)
+                        .attr("n", ThreadDumpUtil.buildThreadDiagnosticString())
+                        .log("Deadlocked threads detected. \n");
             } else {
-                LOG.error("Deadlocked threads detected. {}", threadNames);
+                log.error().attr("detected", threadNames).log("Deadlocked threads detected.");
             }
             throw new IllegalStateException("Deadlocked threads detected. " + threadNames);
         }
@@ -458,11 +492,11 @@ public class BrokersBase extends AdminResource {
                 BrokerOperation.SHUTDOWN)
                 .thenCompose(__ -> doShutDownBrokerGracefullyAsync(maxConcurrentUnloadPerSec, forcedTerminateTopic))
                 .thenAccept(__ -> {
-                    LOG.info("[{}] Successfully shutdown broker gracefully", clientAppId());
+                    log.info("Successfully shutdown broker gracefully");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-            LOG.error("[{}] Failed to shutdown broker gracefully", clientAppId(), ex);
+            log.error().exception(ex).log("Failed to shutdown broker gracefully");
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
         });
@@ -474,7 +508,6 @@ public class BrokersBase extends AdminResource {
         return pulsar().closeAsync(false);
     }
 
-
     private CompletableFuture<Void> validateBothSuperuserAndBrokerOperation(String cluster, String brokerId,
                                                                             BrokerOperation operation) {
         final var superUserAccessValidation = validateSuperUserAccessAsync();
@@ -485,25 +518,24 @@ public class BrokersBase extends AdminResource {
                         || !brokerOperationValidation.isCompletedExceptionally()) {
                         return null;
                     }
-                    if (LOG.isDebugEnabled()) {
-                        Throwable superUserValidationException = null;
-                        try {
-                            superUserAccessValidation.join();
-                        } catch (Throwable ex) {
-                            superUserValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        Throwable brokerOperationValidationException = null;
-                        try {
-                            brokerOperationValidation.join();
-                        } catch (Throwable ex) {
-                            brokerOperationValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        LOG.debug("validateBothSuperuserAndBrokerOperation failed."
-                                  + " originalPrincipal={} clientAppId={} operation={} broker={} "
-                                  + "superuserValidationError={} brokerOperationValidationError={}",
-                                originalPrincipal(), clientAppId(), operation.toString(), brokerId,
-                                superUserValidationException, brokerOperationValidationException);
+                    Throwable superUserValidationException = null;
+                    try {
+                        superUserAccessValidation.join();
+                    } catch (Throwable ex) {
+                        superUserValidationException = FutureUtil.unwrapCompletionException(ex);
                     }
+                    Throwable brokerOperationValidationException = null;
+                    try {
+                        brokerOperationValidation.join();
+                    } catch (Throwable ex) {
+                        brokerOperationValidationException = FutureUtil.unwrapCompletionException(ex);
+                    }
+                    log.debug().attr("originalPrincipal", originalPrincipal())
+                            .attr("operation", operation.toString())
+                            .attr("broker", brokerId)
+                            .attr("superuserValidationError", superUserValidationException)
+                            .attr("brokerOperationValidationError", brokerOperationValidationException)
+                            .log("validateBothSuperuserAndBrokerOperation failed");
                     throw new RestException(Status.UNAUTHORIZED,
                             String.format("Unauthorized to validateBothSuperuserAndBrokerOperation for"
                                           + " originalPrincipal [%s] and clientAppId [%s] "
@@ -511,7 +543,6 @@ public class BrokersBase extends AdminResource {
                                     originalPrincipal(), clientAppId(), operation.toString(), brokerId));
                 });
     }
-
 
     private CompletableFuture<Void> validateBrokerOperationAsync(String cluster, String brokerId,
                                                                  BrokerOperation operation) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -76,8 +76,6 @@ import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicyImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ClustersBase extends AdminResource {
 
@@ -95,7 +93,7 @@ public class ClustersBase extends AdminResource {
                 .thenApply(HashSet::new)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get clusters {}", clientAppId(), ex);
+                    log.error().exception(ex).log("Failed to get clusters");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -123,7 +121,10 @@ public class ClustersBase extends AdminResource {
                     asyncResponse.resume(clusterData
                             .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Cluster does not exist")));
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -181,10 +182,13 @@ public class ClustersBase extends AdminResource {
                     }
                     return clusterResources().createClusterAsync(cluster, clusterData);
                 }).thenAccept(__ -> {
-                    log.info("[{}] Created cluster {}", clientAppId(), cluster);
+                    log.info().attr("cluster", cluster).log("Created cluster");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to create cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to create cluster");
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof IllegalArgumentException) {
                         asyncResponse.resume(new RestException(PRECONDITION_FAILED,
@@ -237,10 +241,13 @@ public class ClustersBase extends AdminResource {
                     }
                     return clusterResources().updateClusterAsync(cluster, old -> clusterData);
                 }).thenAccept(__ -> {
-                    log.info("[{}] Updated cluster {}", clientAppId(), cluster);
+                    log.info().attr("cluster", cluster).log("Updated cluster");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to update cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to update cluster");
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
@@ -278,7 +285,10 @@ public class ClustersBase extends AdminResource {
                             policies.orElseThrow(() -> new RestException(Status.NOT_FOUND, "Cluster does not exist")));
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get cluster {} migration", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get cluster migration");
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
@@ -336,10 +346,13 @@ public class ClustersBase extends AdminResource {
                     return data;
                 }))
                 .thenAccept(__ -> {
-                    log.info("[{}] Updated cluster {}", clientAppId(), cluster);
+                    log.info().attr("cluster", cluster).log("Updated cluster");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to update cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to update cluster");
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
@@ -380,12 +393,17 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> innerSetPeerClusterNamesAsync(cluster, peerClusterNames))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully added peer-cluster {} for {}",
-                            clientAppId(), peerClusterNames, cluster);
+                    log.info()
+                            .attr("peerClusters", peerClusterNames)
+                            .attr("cluster", cluster)
+                            .log("Successfully added peer-cluster");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to validate peer-cluster list {}, {}", clientAppId(), peerClusterNames, ex);
+                    log.error()
+                            .attr("peerClusters", peerClusterNames)
+                            .exceptionMessage(ex)
+                            .log("Failed to validate peer-cluster list");
                     if (realCause instanceof NotFoundException) {
                         asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
                         return null;
@@ -444,7 +462,10 @@ public class ClustersBase extends AdminResource {
                             clusterOpt.orElseThrow(() -> new RestException(Status.NOT_FOUND, "Cluster does not exist"));
                     asyncResponse.resume(clusterData.getPeerClusterNames());
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -470,16 +491,21 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> internalDeleteClusterAsync(cluster))
                 .thenAccept(__ -> {
-                    log.info("[{}] Deleted cluster {}", clientAppId(), cluster);
+                    log.info().attr("cluster", cluster).log("Deleted cluster");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof NotFoundException) {
-                        log.warn("[{}] Failed to delete cluster {} - Does not exist", clientAppId(), cluster);
+                        log.warn()
+                                .attr("cluster", cluster)
+                                .log("Failed to delete cluster - Does not exist");
                         asyncResponse.resume(new RestException(Status.NOT_FOUND, "Cluster does not exist"));
                         return null;
                     }
-                    log.error("[{}] Failed to delete cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to delete cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -530,7 +556,10 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> internalGetNamespaceIsolationPolicies(cluster))
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get clusters/{}/namespaceIsolationPolicies", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get namespace isolation policies");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -563,7 +592,6 @@ public class ClustersBase extends AdminResource {
                     });
     }
 
-
     @GET
     @Path("/{cluster}/namespaceIsolationPolicies/{policyName}")
     @ApiOperation(
@@ -594,8 +622,10 @@ public class ClustersBase extends AdminResource {
                     }
                     asyncResponse.resume(policies.get(policyName));
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get clusters/{}/namespaceIsolationPolicies/{}",
-                            clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get namespace isolation policies");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -628,12 +658,14 @@ public class ClustersBase extends AdminResource {
                                 .collect(Collectors.toList())))
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get namespace isolation-policies {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get namespace isolation policies");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }
-
 
     private BrokerNamespaceIsolationData internalGetBrokerNsIsolationData(
             String broker,
@@ -682,7 +714,11 @@ public class ClustersBase extends AdminResource {
                 .thenApply(policies -> internalGetBrokerNsIsolationData(broker, policies))
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get namespace isolation-policies {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .attr("broker", broker)
+                            .exception(ex)
+                            .log("Failed to get namespace isolation policies");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -732,8 +768,10 @@ public class ClustersBase extends AdminResource {
                             .thenApply(__ -> oldPolicy);
                 }).thenCompose(oldPolicy -> filterAndUnloadMatchedNamespaceAsync(cluster, policyData, oldPolicy))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successful to update clusters/{}/namespaceIsolationPolicies/{}.",
-                            clientAppId(), cluster, policyName);
+                    log.info()
+                            .attr("cluster", cluster)
+                            .attr("policy", policyName)
+                            .log("Successfully updated namespace isolation policies");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
@@ -748,14 +786,18 @@ public class ClustersBase extends AdminResource {
                                 "Invalid format of input policy data. policy: " + policyName + "; data: " + jsonData));
                         return null;
                     } else if (realCause instanceof NotFoundException) {
-                        log.warn("[{}] Failed to update clusters/{}/namespaceIsolationPolicies: Does not exist",
-                                clientAppId(), cluster);
+                        log.warn()
+                                .attr("cluster", cluster)
+                                .log("Failed to update namespace isolation policies: Does not exist");
                         asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                 "NamespaceIsolationPolicies for cluster " + cluster + " does not exist"));
                         return null;
                     }
-                    log.info("[{}] Failed to update clusters/{}/namespaceIsolationPolicies/{}. Input data is invalid",
-                            clientAppId(), cluster, policyName, realCause);
+                    log.info()
+                            .attr("cluster", cluster)
+                            .attr("policy", policyName)
+                            .exception(realCause)
+                            .log("Failed to update namespace isolation policies: input data is invalid");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -812,7 +854,7 @@ public class ClustersBase extends AdminResource {
             // If unload type is 'changed', we need to figure out a further subset of namespaces whose placement might
             // actually have been changed.
 
-            log.debug("Old policy: {} ; new policy: {}", oldPolicy, policyData);
+            log.debug().attr("oldPolicy", oldPolicy).attr("newPolicy", policyData).log("Old and new policy");
 
             boolean unloadAllNamespaces = false;
             // We also compare that the previous primary broker list is same as current, in case all namespaces need
@@ -828,12 +870,15 @@ public class ClustersBase extends AdminResource {
             Set<String> commonNamespaces = new HashSet<>(policyData.getNamespaces());
             commonNamespaces.retainAll(oldNamespaces);
 
-            log.debug("combined regexes: {}; common regexes:{}", combinedNamespaces, commonNamespaces);
+            log.debug()
+                    .attr("combinedNamespaces", combinedNamespaces)
+                    .attr("commonNamespaces", commonNamespaces)
+                    .log("combined and common regexes");
 
             if (!unloadAllNamespaces) {
                 // Find the changed regexes ((new U old) - (new ∩ old)).
                 combinedNamespaces.removeAll(commonNamespaces);
-                log.debug("changed regexes: {}", commonNamespaces);
+                log.debug().attr("commonNamespaces", commonNamespaces).log("Changed regexes");
             }
 
             // Now we further filter the filtered namespaces based on this combinedNamespaces set
@@ -850,7 +895,9 @@ public class ClustersBase extends AdminResource {
                     // write load info to load manager to make the load happens fast
                     pulsar().getLoadManager().get().writeLoadReportOnZookeeper(true);
                 } catch (Exception e) {
-                    log.warn("[{}] Failed to writeLoadReportOnZookeeper.", clientAppId(), e);
+                    log.warn()
+                            .exception(e)
+                            .log("Failed to writeLoadReportOnZookeeper.");
                 }
             });
         });
@@ -891,14 +938,18 @@ public class ClustersBase extends AdminResource {
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof NotFoundException) {
-                        log.warn("[{}] Failed to update brokers/{}/namespaceIsolationPolicies: Does not exist",
-                                clientAppId(), cluster);
+                        log.warn()
+                                .attr("cluster", cluster)
+                                .log("Failed to delete namespace isolation policies: Does not exist");
                         asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                 "NamespaceIsolationPolicies for cluster " + cluster + " does not exist"));
                         return null;
                     }
-                    log.error("[{}] Failed to update brokers/{}/namespaceIsolationPolicies/{}", clientAppId(), cluster,
-                            policyName, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .attr("policy", policyName)
+                            .exception(ex)
+                            .log("Failed to delete namespace isolation policy");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -932,21 +983,28 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> clusterResources().getFailureDomainResources()
                         .setFailureDomainWithCreateAsync(cluster, domainName, old -> domain))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successful set failure domain {} for cluster {}",
-                            clientAppId(), domainName, cluster);
+                    log.info()
+                            .attr("domain", domainName)
+                            .attr("cluster", cluster)
+                            .log("Successful set failure domain for cluster");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof NotFoundException) {
-                        log.warn("[{}] Failed to update domain {}. clusters {}  Does not exist", clientAppId(), cluster,
-                                domainName);
+                        log.warn()
+                                .attr("cluster", cluster)
+                                .attr("domain", domainName)
+                                .log("Failed to update failure domain: Does not exist");
                         asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                 "Domain " + domainName + " for cluster " + cluster + " does not exist"));
                         return null;
                     }
-                    log.error("[{}] Failed to update clusters/{}/domainName/{}",
-                            clientAppId(), cluster, domainName, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .attr("domain", domainName)
+                            .exception(ex)
+                            .log("Failed to update failure domain");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -979,7 +1037,10 @@ public class ClustersBase extends AdminResource {
                                             .getFailureDomainAsync(cluster, domainName)
                                             .thenApply(failureDomainImpl -> Pair.of(domainName, failureDomainImpl))
                                             .exceptionally(ex -> {
-                                                log.warn("Failed to get domain {}", domainName, ex);
+                                                log.warn()
+                                                        .attr("domain", domainName)
+                                                        .exception(ex)
+                                                        .log("Failed to get domain");
                                                 return null;
                                             })).collect(Collectors.toList());
                             return FutureUtil.waitForAll(futures)
@@ -991,15 +1052,20 @@ public class ClustersBase extends AdminResource {
                         }).exceptionally(ex -> {
                             Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                             if (realCause instanceof NotFoundException) {
-                                log.warn("[{}] Failure-domain is not configured for cluster {}",
-                                        clientAppId(), cluster, ex);
+                                log.warn()
+                                        .attr("cluster", cluster)
+                                        .exception(ex)
+                                        .log("Failure-domain is not configured for cluster");
                                 return Collections.emptyMap();
                             }
                             throw FutureUtil.wrapToCompletionException(ex);
                         })
                 ).thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get failure-domains for cluster {}", clientAppId(), cluster, ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get failure-domains for cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1034,7 +1100,11 @@ public class ClustersBase extends AdminResource {
                             "Domain " + domainName + " for cluster " + cluster + " does not exist"));
                     asyncResponse.resume(failureDomain);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get domain {} for cluster {}", clientAppId(), domainName, cluster, ex);
+                    log.error()
+                            .attr("domain", domainName)
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to get domain for cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1065,17 +1135,27 @@ public class ClustersBase extends AdminResource {
                 .thenCompose(__ -> clusterResources()
                         .getFailureDomainResources().deleteFailureDomainAsync(cluster, domainName))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successful delete domain {} in cluster {}", clientAppId(), domainName, cluster);
+                    log.info()
+                            .attr("domain", domainName)
+                            .attr("cluster", cluster)
+                            .log("Successful delete domain in cluster");
                     asyncResponse.resume(Response.ok().build());
                 }).exceptionally(ex -> {
                     Throwable cause = FutureUtil.unwrapCompletionException(ex);
                     if (cause instanceof NotFoundException) {
-                        log.warn("[{}] Domain {} does not exist in {}", clientAppId(), domainName, cluster);
+                        log.warn()
+                                .attr("domain", domainName)
+                                .attr("cluster", cluster)
+                                .log("Domain does not exist");
                         asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                 "Domain-name " + domainName + " or cluster " + cluster + " does not exist"));
                         return null;
                     }
-                    log.error("[{}] Failed to delete domain {} in cluster {}", clientAppId(), domainName, cluster, ex);
+                    log.error()
+                            .attr("domain", domainName)
+                            .attr("cluster", cluster)
+                            .exception(ex)
+                            .log("Failed to delete domain in cluster");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1112,21 +1192,18 @@ public class ClustersBase extends AdminResource {
                                             throw FutureUtil.wrapToCompletionException(ex);
                                         }
                                         if (realCause instanceof NotFoundException) {
-                                            if (log.isDebugEnabled()) {
-                                                log.debug("[{}] Domain is not configured for cluster",
-                                                        clientAppId(), ex);
-                                            }
-                                            return null;
+                                                log.debug()
+                                                        .exception(ex)
+                                                        .log("Domain is not configured for cluster");
+                                                                                        return null;
                                         }
-                                        log.warn("Failed to get domain {}", domainName, ex);
+                                        log.warn().attr("domain", domainName).exception(ex).log("Failed to get domain");
                                         return null;
                                     })
                             ).collect(Collectors.toList());
                     return FutureUtil.waitForAll(futures);
                 });
     }
-
-
 
     private CompletableFuture<Void> validateBothSuperuserAndClusterOperation(String clusterName,
                                                                              ClusterOperation operation) {
@@ -1138,25 +1215,24 @@ public class ClustersBase extends AdminResource {
                         || !clusterOperationValidation.isCompletedExceptionally()) {
                         return null;
                     }
-                    if (log.isDebugEnabled()) {
-                        Throwable superUserValidationException = null;
-                        try {
-                            superUserAccessValidation.join();
-                        } catch (Throwable ex) {
-                            superUserValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        Throwable clusterOperationValidationException = null;
-                        try {
-                            clusterOperationValidation.join();
-                        } catch (Throwable ex) {
-                            clusterOperationValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        log.debug("validateBothSuperuserAndClusterOperation failed."
-                                  + " originalPrincipal={} clientAppId={} operation={} cluster={} "
-                                  + "superuserValidationError={} clusterOperationValidationError={}",
-                                originalPrincipal(), clientAppId(), operation.toString(), clusterName,
-                                superUserValidationException, clusterOperationValidationException);
+                    Throwable superUserValidationException = null;
+                    try {
+                        superUserAccessValidation.join();
+                    } catch (Throwable ex) {
+                        superUserValidationException = FutureUtil.unwrapCompletionException(ex);
                     }
+                    Throwable clusterOperationValidationException = null;
+                    try {
+                        clusterOperationValidation.join();
+                    } catch (Throwable ex) {
+                        clusterOperationValidationException = FutureUtil.unwrapCompletionException(ex);
+                    }
+                    log.debug().attr("originalPrincipal", originalPrincipal())
+                            .attr("operation", operation.toString())
+                            .attr("cluster", clusterName)
+                            .attr("superuserValidationError", superUserValidationException)
+                            .attr("clusterOperationValidationError", clusterOperationValidationException)
+                            .log("validateBothSuperuserAndClusterOperation failed");
                     throw new RestException(Status.UNAUTHORIZED,
                             String.format("Unauthorized to validateBothSuperuserAndClusterOperation for"
                                           + " originalPrincipal [%s] and clientAppId [%s] "
@@ -1164,7 +1240,6 @@ public class ClustersBase extends AdminResource {
                                     originalPrincipal(), clientAppId(), operation.toString(), clusterName));
                 });
     }
-
 
     private CompletableFuture<Void> validateBothSuperuserAndClusterPolicyOperation(String clusterName, PolicyName name,
                                                                                    PolicyOperation operation) {
@@ -1176,25 +1251,24 @@ public class ClustersBase extends AdminResource {
                         || !clusterOperationValidation.isCompletedExceptionally()) {
                         return null;
                     }
-                    if (log.isDebugEnabled()) {
-                        Throwable superUserValidationException = null;
-                        try {
-                            superUserAccessValidation.join();
-                        } catch (Throwable ex) {
-                            superUserValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        Throwable clusterOperationValidationException = null;
-                        try {
-                            clusterOperationValidation.join();
-                        } catch (Throwable ex) {
-                            clusterOperationValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        log.debug("validateBothSuperuserAndClusterPolicyOperation failed."
-                                  + " originalPrincipal={} clientAppId={} operation={} cluster={} "
-                                  + "superuserValidationError={} clusterOperationValidationError={}",
-                                originalPrincipal(), clientAppId(), operation.toString(), clusterName,
-                                superUserValidationException, clusterOperationValidationException);
+                    Throwable superUserValidationException = null;
+                    try {
+                        superUserAccessValidation.join();
+                    } catch (Throwable ex) {
+                        superUserValidationException = FutureUtil.unwrapCompletionException(ex);
                     }
+                    Throwable clusterOperationValidationException = null;
+                    try {
+                        clusterOperationValidation.join();
+                    } catch (Throwable ex) {
+                        clusterOperationValidationException = FutureUtil.unwrapCompletionException(ex);
+                    }
+                    log.debug().attr("originalPrincipal", originalPrincipal())
+                            .attr("operation", operation.toString())
+                            .attr("cluster", clusterName)
+                            .attr("superuserValidationError", superUserValidationException)
+                            .attr("clusterOperationValidationError", clusterOperationValidationException)
+                            .log("validateBothSuperuserAndClusterPolicyOperation failed");
                     throw new RestException(Status.UNAUTHORIZED,
                             String.format("Unauthorized to validateBothSuperuserAndClusterPolicyOperation for"
                                           + " originalPrincipal [%s] and clientAppId [%s] "
@@ -1202,9 +1276,6 @@ public class ClustersBase extends AdminResource {
                                     originalPrincipal(), clientAppId(), operation.toString(), clusterName));
                 });
     }
-
-
-
 
     private CompletableFuture<Void> validateClusterOperationAsync(String cluster, ClusterOperation operation) {
         final var pulsar = pulsar();
@@ -1246,6 +1317,4 @@ public class ClustersBase extends AdminResource {
         }
         return CompletableFuture.completedFuture(null);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ClustersBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/MetadataMigrationBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/MetadataMigrationBase.java
@@ -27,7 +27,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.migration.MigrationState;
@@ -38,7 +37,6 @@ import org.apache.pulsar.metadata.impl.DualMetadataStore;
 /**
  * Admin resource for metadata store migration operations.
  */
-@Slf4j
 public class MetadataMigrationBase extends AdminResource {
 
     @GET
@@ -59,7 +57,7 @@ public class MetadataMigrationBase extends AdminResource {
                 return MigrationState.NOT_STARTED;
             }
         } catch (Exception e) {
-            log.error("Failed to get migration status", e);
+            log.error().exception(e).log("Failed to get migration status");
             throw new RestException(e);
         }
     }
@@ -96,20 +94,20 @@ public class MetadataMigrationBase extends AdminResource {
             // Start migration in background thread
             pulsar().getExecutor().submit(() -> {
                 try {
-                    log.info("Starting metadata migration to: {}", targetUrl);
+                    log.info().attr("targetUrl", targetUrl).log("Starting metadata migration");
                     coordinator.startMigration();
                     log.info("Metadata migration completed successfully");
                 } catch (Exception e) {
-                    log.error("Metadata migration failed", e);
+                    log.error().exception(e).log("Metadata migration failed");
                 }
             });
 
-            log.info("Migration initiated to target: {}", targetUrl);
+            log.info().attr("targetUrl", targetUrl).log("Migration initiated");
 
         } catch (RestException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Failed to start migration", e);
+            log.error().exception(e).log("Failed to start migration");
             throw new RestException(e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -49,7 +49,6 @@ import javax.ws.rs.container.CompletionCallback;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -125,7 +124,6 @@ import org.apache.pulsar.metadata.api.MetadataStoreException.NotFoundException;
 import org.apache.zookeeper.KeeperException;
 import org.jspecify.annotations.NonNull;
 
-@Slf4j
 public abstract class NamespacesBase extends AdminResource {
 
     protected CompletableFuture<List<String>> internalGetTenantNamespaces(String tenant) {
@@ -135,7 +133,10 @@ public abstract class NamespacesBase extends AdminResource {
         try {
             NamedEntity.checkName(tenant);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Tenant name is invalid {}", clientAppId(), tenant, e);
+            log.warn()
+                    .attr("tenant", tenant)
+                    .exception(e)
+                    .log("Tenant name is invalid");
             return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED, "Tenant name is not valid"));
         }
         return validateTenantOperationAsync(tenant, TenantOperation.LIST_NAMESPACES)
@@ -168,7 +169,9 @@ public abstract class NamespacesBase extends AdminResource {
                     return CompletableFuture.completedFuture(null);
                 })
                 .thenCompose(__ -> namespaceResources().createPoliciesAsync(namespaceName, policies))
-                .thenAccept(__ -> log.info("[{}] Created namespace {}", clientAppId(), namespaceName));
+                .thenAccept(__ -> log.info()
+                        .attr("namespace", namespaceName)
+                        .log("Created namespace"));
     }
 
     protected CompletableFuture<List<String>> internalGetListOfTopics(AsyncResponse response, Policies policies,
@@ -373,18 +376,23 @@ public abstract class NamespacesBase extends AdminResource {
                                         try {
                                             admin = pulsar().getAdminClient();
                                         } catch (PulsarServerException ex) {
-                                            log.error("[{}] Get admin client error when preparing to delete topics.",
-                                                    clientAppId(), ex);
+                                            log.error()
+                                                    .exception(ex)
+                                                    .log("Get admin client error when preparing to delete topics.");
                                             return FutureUtil.failedFuture(ex);
                                         }
-                                        log.info("[{}] Deleting namespace bundle {}/{}", clientAppId(),
-                                                namespaceName, bundle.getBundleRange());
+                                        log.info()
+                                                .attr("namespace", namespaceName)
+                                                .attr("bundleRange", bundle.getBundleRange())
+                                                .log("Deleting namespace bundle");
                                         return admin.namespaces().deleteNamespaceBundleAsync(namespaceName.toString(),
                                                 bundle.getBundleRange(), force);
                                     } else {
-                                        log.warn("[{}] Skipping deleting namespace bundle {}/{} "
-                                                        + "as it's not owned by any broker",
-                                                clientAppId(), namespaceName, bundle.getBundleRange());
+                                        log.warn()
+                                                .attr("namespace", namespaceName)
+                                                .attr("bundleRange", bundle.getBundleRange())
+                                                .log("Skipping deleting namespace bundle as it's not owned by any"
+                                                        + " broker");
                                     }
                                     return CompletableFuture.completedFuture(null);
                                 })
@@ -397,9 +405,10 @@ public abstract class NamespacesBase extends AdminResource {
                             if (rc.getCause() != null && rc.getCause() instanceof KeeperException.NotEmptyException) {
                                 KeeperException.NotEmptyException ne =
                                         (KeeperException.NotEmptyException) rc.getCause();
-                                log.info("[{}] There are in-flight topics created during the namespace deletion, "
-                                        + "retry to delete the namespace again. (path {} is not empty on metadata)",
-                                        namespaceName, ne.getPath());
+                                log.info()
+                                        .attr("namespace", namespaceName)
+                                        .attr("path", ne.getPath())
+                                        .log("In-flight topics during namespace deletion, retrying");
                                 final int next = retryTimes - 1;
                                 if (next > 0) {
                                     // async recursive
@@ -448,7 +457,9 @@ public abstract class NamespacesBase extends AdminResource {
         try {
             admin = pulsar().getAdminClient();
         } catch (Exception ex) {
-            log.error("[{}] Get admin client error when preparing to delete topics.", clientAppId(), ex);
+            log.error()
+                    .exception(ex)
+                    .log("Get admin client error when preparing to delete topics.");
             return FutureUtil.failedFuture(ex);
         }
         List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -506,12 +517,13 @@ public abstract class NamespacesBase extends AdminResource {
                                                     .host(replClusterUrl.getHost())
                                                     .port(replClusterUrl.getPort())
                                                     .replaceQueryParam("authoritative", false).build();
-                                            if (log.isDebugEnabled()) {
-                                                log.debug("[{}] Redirecting the rest call to {}: cluster={}",
-                                                        clientAppId(), redirect, cluster);
-                                            }
-                                            throw new WebApplicationException(
-                                                    Response.temporaryRedirect(redirect).build());
+                                                log.debug()
+                                                        .attr("redirect", redirect)
+                                                        .attr("cluster", cluster)
+                                                        .log("Redirecting the rest call");
+                                                        throw new WebApplicationException(
+                                                                Response.temporaryRedirect(redirect)
+                                                                        .build());
                                         });
                             }
                             return CompletableFuture.completedFuture(policies);
@@ -544,8 +556,12 @@ public abstract class NamespacesBase extends AdminResource {
     @SuppressWarnings("deprecation")
     protected CompletableFuture<Void> internalDeleteNamespaceBundleAsync(String bundleRange, boolean authoritative,
                                                                          boolean force) {
-        log.info("[{}] Deleting namespace bundle {}/{} authoritative:{} force:{}",
-                clientAppId(), namespaceName, bundleRange, authoritative, force);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("bundleRange", bundleRange)
+                .attr("authoritative", authoritative)
+                .attr("force", force)
+                .log("Deleting namespace bundle");
         return validateNamespaceOperationAsync(namespaceName, NamespaceOperation.DELETE_BUNDLE)
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
@@ -586,11 +602,11 @@ public abstract class NamespacesBase extends AdminResource {
                                             UriBuilder.fromUri(uri.getRequestUri()).host(replClusterUrl.getHost())
                                                     .port(replClusterUrl.getPort())
                                                     .replaceQueryParam("authoritative", false).build();
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("[{}] Redirecting the rest call to {}: cluster={}",
-                                                clientAppId(), redirect, cluster);
-                                    }
-                                    throw new WebApplicationException(
+                                        log.debug()
+                                                .attr("redirect", redirect)
+                                                .attr("cluster", cluster)
+                                                .log("Redirecting the rest call");
+                                                                        throw new WebApplicationException(
                                             Response.temporaryRedirect(redirect).build());
                                 });
                     }
@@ -638,25 +654,35 @@ public abstract class NamespacesBase extends AdminResource {
                 }).thenCompose(__ ->
                         getAuthorizationService().grantPermissionAsync(namespaceName, actions, role, null))
                 .thenAccept(unused ->
-                        log.info("[{}] Successfully granted access for role {}: {} - namespaceName {}",
-                                clientAppId(), role, actions, namespaceName))
+                        log.info()
+                                .attr("role", role)
+                                .attr("actions", actions)
+                                .attr("namespace", namespaceName)
+                                .log("Successfully granted access for role : - namespaceName"))
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     //The IllegalArgumentException and the IllegalStateException were historically thrown by the
                     // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
                     if (realCause instanceof MetadataStoreException.NotFoundException
                             || realCause instanceof IllegalArgumentException) {
-                        log.warn("[{}] Failed to set permissions for namespace {}: does not exist", clientAppId(),
-                                namespaceName, ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to set permissions for namespace : does not exist");
                         throw new RestException(Status.NOT_FOUND, "Topic's namespace does not exist");
                     } else if (realCause instanceof MetadataStoreException.BadVersionException
                             || realCause instanceof IllegalStateException) {
-                        log.warn("[{}] Failed to set permissions for namespace {}: {}",
-                                clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exceptionMessage(ex.getCause())
+                                .exception(ex)
+                                .log("Failed to set permissions for namespace");
                         throw new RestException(Status.CONFLICT, "Concurrent modification");
                     } else {
-                        log.error("[{}] Failed to get permissions for namespace {}",
-                                clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to get permissions for namespace");
                         throw new RestException(realCause);
                     }
                 });
@@ -668,24 +694,33 @@ public abstract class NamespacesBase extends AdminResource {
                         TopicName.get(options.get(0).getTopic()).getTenant())
                 ).thenCompose(__ -> internalCheckTopicExists(options.stream().map(o -> TopicName.get(o.getTopic()))))
                 .thenCompose(__ -> getAuthorizationService().grantPermissionAsync(options))
-                .thenAccept(unused -> log.info("[{}] Successfully granted access for {}", clientAppId(), options))
+                .thenAccept(unused -> log.info()
+                        .attr("options", options)
+                        .log("Successfully granted access"))
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     //The IllegalArgumentException and the IllegalStateException were historically thrown by the
                     // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
                     if (realCause instanceof MetadataStoreException.NotFoundException
                             || realCause instanceof IllegalArgumentException) {
-                        log.warn("[{}] Failed to grant permissions for namespace {}: does not exist", clientAppId(),
-                                namespaceName, ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to grant permissions for namespace : does not exist");
                         throw new RestException(Status.NOT_FOUND, "Topic's namespace does not exist");
                     } else if (realCause instanceof MetadataStoreException.BadVersionException
                             || realCause instanceof IllegalStateException) {
-                        log.warn("[{}] Failed to grant permissions for namespace {}: {}",
-                                clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exceptionMessage(ex.getCause())
+                                .exception(ex)
+                                .log("Failed to grant permissions for namespace");
                         throw new RestException(Status.CONFLICT, "Concurrent modification");
                     } else {
-                        log.error("[{}] Failed to grant permissions for namespace {}",
-                                clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to grant permissions for namespace");
                         throw new RestException(realCause);
                     }
                 });
@@ -698,24 +733,33 @@ public abstract class NamespacesBase extends AdminResource {
                         TopicName.get(options.get(0).getTopic()).getTenant()))
                 .thenCompose(__ -> internalCheckTopicExists(options.stream().map(o -> TopicName.get(o.getTopic()))))
                 .thenCompose(__ -> getAuthorizationService().revokePermissionAsync(options))
-                .thenAccept(unused -> log.info("[{}] Successfully revoke access for {}", clientAppId(), options))
+                .thenAccept(unused -> log.info()
+                        .attr("options", options)
+                        .log("Successfully revoked access"))
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     //The IllegalArgumentException and the IllegalStateException were historically thrown by the
                     // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
                     if (realCause instanceof MetadataStoreException.NotFoundException
                             || realCause instanceof IllegalArgumentException) {
-                        log.warn("[{}] Failed to revoke permissions for namespace {}: does not exist", clientAppId(),
-                                namespaceName, ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to revoke permissions for namespace : does not exist");
                         throw new RestException(Status.NOT_FOUND, "Topic's namespace does not exist");
                     } else if (realCause instanceof MetadataStoreException.BadVersionException
                             || realCause instanceof IllegalStateException) {
-                        log.warn("[{}] Failed to revoke permissions for namespace {}: {}",
-                                clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .exceptionMessage(ex.getCause())
+                                .exception(ex)
+                                .log("Failed to revoke permissions for namespace");
                         throw new RestException(Status.CONFLICT, "Concurrent modification");
                     } else {
-                        log.error("[{}] Failed to revoke permissions for namespace {}",
-                                clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to revoke permissions for namespace");
                         throw new RestException(realCause);
                     }
                 });
@@ -746,24 +790,31 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(__ -> getAuthorizationService()
                         .grantSubscriptionPermissionAsync(namespaceName, subscription, roles, null))
                 .thenAccept(unused -> {
-                    log.info("[{}] Successfully granted permission on subscription for role {}:{} - "
-                            + "namespaceName {}", clientAppId(), roles, subscription, namespaceName);
+                    log.info()
+                            .attr("role", roles)
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .log("Successfully granted permission on subscription for role: - namespaceName");
                 })
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     //The IllegalArgumentException and the IllegalStateException were historically thrown by the
                     // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
                     if (realCause.getCause() instanceof IllegalArgumentException) {
-                        log.warn("[{}] Failed to set permissions for namespace {}: does not exist", clientAppId(),
-                                namespaceName);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .log("Failed to set permissions for namespace : does not exist");
                         throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
                     } else if (realCause.getCause() instanceof IllegalStateException) {
-                        log.warn("[{}] Failed to set permissions for namespace {}: concurrent modification",
-                                clientAppId(), namespaceName);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .log("Failed to set permissions for namespace : concurrent modification");
                         throw new RestException(Status.CONFLICT, "Concurrent modification");
                     } else {
-                        log.error("[{}] Failed to get permissions for namespace {}",
-                                clientAppId(), namespaceName, realCause);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exceptionMessage(realCause)
+                                .log("Failed to get permissions for namespace");
                         throw new RestException(realCause);
                     }
                 });
@@ -1044,8 +1095,10 @@ public abstract class NamespacesBase extends AdminResource {
                     future.complete(null);
                     return null;
                 }
-                log.error("Failed to validate remote-side non-partitioned topic metadata for topic '{}'", topic,
-                    ex);
+                log.error()
+                        .attr("topic", topic)
+                        .exception(ex)
+                        .log("Failed to validate remote-side non-partitioned topic metadata for topic ''");
                 future.completeExceptionally(new RestException(Status.CONFLICT,
                     "Failed to validate remote-side non-partitioned topic metadata for topic  " + topic));
                 return null;
@@ -1269,11 +1322,14 @@ public abstract class NamespacesBase extends AdminResource {
                     if (autoSubscriptionCreationOverride != null) {
                         String autoOverride = autoSubscriptionCreationOverride.isAllowAutoSubscriptionCreation()
                                 ? "enabled" : "disabled";
-                        log.info("[{}] Successfully {} autoSubscriptionCreation on namespace {}", clientAppId(),
-                                autoOverride, namespaceName);
+                        log.info()
+                                .attr("autoSubscriptionCreation", autoOverride)
+                                .attr("namespace", namespaceName)
+                                .log("Successfully set autoSubscriptionCreation on namespace");
                     } else {
-                        log.info("[{}] Successfully remove autoSubscriptionCreation on namespace {}",
-                                clientAppId(), namespaceName);
+                        log.info()
+                                .attr("namespace", namespaceName)
+                                .log("Successfully remove autoSubscriptionCreation on namespace");
                     }
                 });
     }
@@ -1298,7 +1354,9 @@ public abstract class NamespacesBase extends AdminResource {
     protected CompletableFuture<Void> internalUnloadNamespaceAsync() {
         return validateSuperUserAccessAsync()
                 .thenCompose(__ -> {
-                    log.info("[{}] Unloading namespace {}", clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Unloading namespace");
                     // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
                     return validateGlobalNamespaceOwnershipAsync(namespaceName);
                 })
@@ -1312,7 +1370,10 @@ public abstract class NamespacesBase extends AdminResource {
                             futures.add(pulsar().getAdminClient().namespaces().unloadNamespaceBundleAsync(
                                     namespaceName.toString(), bundle));
                         } catch (PulsarServerException e) {
-                            log.error("[{}] Failed to unload namespace {}", clientAppId(), namespaceName, e);
+                            log.error()
+                                    .attr("namespace", namespaceName)
+                                    .exception(e)
+                                    .log("Failed to unload namespace");
                             throw new RestException(e);
                         }
                     }
@@ -1322,8 +1383,10 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected CompletableFuture<Void> internalSetBookieAffinityGroupAsync(BookieAffinityGroupData bookieAffinityGroup) {
         return validateSuperUserAccessAsync().thenCompose(__ -> {
-            log.info("[{}] Setting bookie affinity group {} for namespace {}", clientAppId(), bookieAffinityGroup,
-                    this.namespaceName);
+            log.info()
+                    .attr("bookieAffinityGroup", bookieAffinityGroup)
+                    .attr("namespace", this.namespaceName)
+                    .log("Setting bookie affinity group for namespace");
             // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
             return validateGlobalNamespaceOwnershipAsync(namespaceName);
         }).thenCompose(__ -> getDefaultBundleDataAsync().thenCompose(
@@ -1331,9 +1394,10 @@ public abstract class NamespacesBase extends AdminResource {
                         oldPolicies.map(policies -> new LocalPolicies(policies.bundles, bookieAffinityGroup,
                                         policies.namespaceAntiAffinityGroup, policies.migrated))
                                 .orElseGet(() -> new LocalPolicies(defaultBundleData, bookieAffinityGroup, null)))))
-        .thenAccept(__ -> log.info(
-                "[{}] Successfully updated bookie affinity group: namespace={}, bookieAffinityGroup={}", clientAppId(),
-                namespaceName, bookieAffinityGroup));
+        .thenAccept(__ -> log.info()
+                .attr("namespace", namespaceName)
+                .attr("bookieAffinityGroup", bookieAffinityGroup)
+                .log("Successfully updated bookie affinity group"));
     }
 
     protected CompletableFuture<Void> internalDeleteBookieAffinityGroupAsync() {
@@ -1379,13 +1443,11 @@ public abstract class NamespacesBase extends AdminResource {
                                 .replaceQueryParam("authoritative",
                                         false).build();
                         // Redirect
-                        if (log.isDebugEnabled()) {
-                            log.debug("Redirecting the request call to leader - {}", redirect);
-                        }
-                        return FutureUtil.failedFuture((
+                            log.debug().attr("leader", redirect).log("Redirecting the request call to leader -");
+                                                return FutureUtil.failedFuture((
                                 new WebApplicationException(Response.temporaryRedirect(redirect).build())));
                     } catch (MalformedURLException exception) {
-                        log.error("The redirect url is malformed - {}", redirectUrl);
+                        log.error().attr("malformed", redirectUrl).log("The redirect url is malformed -");
                         return FutureUtil.failedFuture(new RestException(exception));
                     }
                 });
@@ -1398,8 +1460,11 @@ public abstract class NamespacesBase extends AdminResource {
         return pulsar().getLoadManager().get().getAvailableBrokersAsync()
                 .thenCompose(brokers -> {
                     if (!brokers.contains(destinationBroker)) {
-                        log.warn("[{}] Failed to unload namespace bundle {}/{} to inactive broker {}.",
-                                clientAppId(), namespaceName, bundleRange, destinationBroker);
+                        log.warn()
+                                .attr("bundle", namespaceName)
+                                .attr("bundleRange", bundleRange)
+                                .attr("broker", destinationBroker)
+                                .log("Failed to unload namespace bundle to inactive broker");
                         return FutureUtil.failedFuture(new BrokerServiceException.NotAllowedException(
                                 "Not allowed unload namespace bundle to inactive destination broker"));
                     }
@@ -1430,7 +1495,10 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(__ -> setNamespaceBundleAffinityAsync(bundleRange, destinationBroker))
                 .thenAccept(__ -> {
                     checkNotNull(bundleRange, "BundleRange should not be null");
-                    log.info("[{}] Unloading namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("bundleRange", bundleRange)
+                            .log("Unloading namespace bundle");
                 })
                 .thenApply(__ ->
                     pulsar().getNamespaceService().getNamespaceBundleFactory()
@@ -1439,11 +1507,12 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(bundle ->
                     pulsar().getNamespaceService().isNamespaceBundleOwned(bundle)
                           .exceptionally(ex -> {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Failed to validate cluster ownership for {}-{}, {}",
-                                        namespaceName.toString(), bundleRange, ex.getMessage(), ex);
-                            }
-                            return false;
+                                log.debug()
+                                        .attr("namespace", namespaceName.toString())
+                                        .attr("bundleRange", bundleRange)
+                                        .exception(ex)
+                                        .log("Failed to validate cluster ownership");
+                                                        return false;
                           })
                 )
                 .thenCompose(isOwnedByLocalCluster -> {
@@ -1460,8 +1529,10 @@ public abstract class NamespacesBase extends AdminResource {
                      isBundleOwnedByAnyBroker(namespaceName, policies.bundles, bundleRange)
                         .thenCompose(flag -> {
                             if (!flag) {
-                                log.info("[{}] Namespace bundle is not owned by any broker {}/{}", clientAppId(),
-                                        namespaceName, bundleRange);
+                                log.info()
+                                        .attr("namespace", namespaceName)
+                                        .attr("bundleRange", bundleRange)
+                                        .log("Namespace bundle is not owned by any broker");
                                 return CompletableFuture.completedFuture(null);
                             }
                             Optional<String> destinationBrokerOpt = Optional.ofNullable(destinationBroker);
@@ -1480,7 +1551,10 @@ public abstract class NamespacesBase extends AdminResource {
         return validateSuperUserAccessAsync()
                 .thenAccept(__ -> {
                     checkNotNull(bundleName, "BundleRange should not be null");
-                    log.info("[{}] Split namespace bundle {}/{}", clientAppId(), namespaceName, bundleName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("bundleName", bundleName)
+                            .log("Split namespace bundle");
                     List<String> supportedNamespaceBundleSplitAlgorithms =
                             pulsar().getConfig().getSupportedNamespaceBundleSplitAlgorithms();
                     if (StringUtils.isNotBlank(splitAlgorithmName)) {
@@ -1518,10 +1592,12 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected CompletableFuture<TopicHashPositions> internalGetTopicHashPositionsAsync(String bundleRange,
                                                                                        List<String> topics) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Getting hash position for topic list {}, bundle {}", clientAppId(), topics, bundleRange);
-        }
-        return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.PERSISTENCE, PolicyOperation.READ)
+            log.debug()
+                    .attr("list", topics)
+                    .attr("bundle", bundleRange)
+                    .log("Getting hash position for topic list , bundle");
+                return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.PERSISTENCE,
+                        PolicyOperation.READ)
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenCompose(policies -> {
                     return validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange,
@@ -1595,29 +1671,40 @@ public abstract class NamespacesBase extends AdminResource {
 
     protected void internalSetPublishRate(PublishRate maxPublishMessageRate) {
         validateSuperUserAccess();
-        log.info("[{}] Set namespace publish-rate {}/{}", clientAppId(), namespaceName, maxPublishMessageRate);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("maxPublishMessageRate", maxPublishMessageRate)
+                .log("Set namespace publish-rate");
         updatePolicies(namespaceName, policies -> {
             policies.publishMaxMessageRate.put(pulsar().getConfiguration().getClusterName(), maxPublishMessageRate);
             return policies;
         });
-        log.info("[{}] Successfully updated the publish_max_message_rate for cluster on namespace {}", clientAppId(),
-                namespaceName);
+        log.info()
+                .attr("namespace", namespaceName)
+                .log("Successfully updated the publish_max_message_rate for cluster on namespace");
     }
 
     protected CompletableFuture<Void> internalSetPublishRateAsync(PublishRate maxPublishMessageRate) {
-        log.info("[{}] Set namespace publish-rate {}/{}", clientAppId(), namespaceName, maxPublishMessageRate);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("maxPublishMessageRate", maxPublishMessageRate)
+                .log("Set namespace publish-rate");
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             policies.publishMaxMessageRate.put(pulsar().getConfiguration().getClusterName(), maxPublishMessageRate);
-            log.info("[{}] Successfully updated the publish_max_message_rate for cluster on namespace {}",
-                    clientAppId(), namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully updated the publish_max_message_rate for cluster on namespace");
             return policies;
         }));
     }
 
     protected void internalRemovePublishRate() {
         validateSuperUserAccess();
-        log.info("[{}] Remove namespace publish-rate {}/{}", clientAppId(), namespaceName, topicName);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("topic", topicName)
+                .log("Remove namespace publish-rate");
         try {
             updatePolicies(namespaceName, policies -> {
                 if (policies.publishMaxMessageRate != null) {
@@ -1625,24 +1712,31 @@ public abstract class NamespacesBase extends AdminResource {
                 }
                 return policies;
             });
-            log.info("[{}] Successfully remove the publish_max_message_rate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully remove the publish_max_message_rate for cluster on namespace");
         } catch (Exception e) {
-            log.error("[{}] Failed to remove the publish_max_message_rate for cluster on namespace {}", clientAppId(),
-                    namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to remove the publish_max_message_rate for cluster on namespace");
             throw new RestException(e);
         }
     }
 
     protected CompletableFuture<Void> internalRemovePublishRateAsync() {
-        log.info("[{}] Remove namespace publish-rate {}/{}", clientAppId(), namespaceName, topicName);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("topic", topicName)
+                .log("Remove namespace publish-rate");
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             if (policies.publishMaxMessageRate != null) {
                 policies.publishMaxMessageRate.remove(pulsar().getConfiguration().getClusterName());
             }
-            log.info("[{}] Successfully remove the publish_max_message_rate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully remove the publish_max_message_rate for cluster on namespace");
             return policies;
         }));
     }
@@ -1656,13 +1750,17 @@ public abstract class NamespacesBase extends AdminResource {
 
     @SuppressWarnings("deprecation")
     protected CompletableFuture<Void> internalSetTopicDispatchRateAsync(DispatchRateImpl dispatchRate) {
-        log.info("[{}] Set namespace dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("dispatchRate", dispatchRate)
+                .log("Set namespace dispatch-rate");
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             policies.topicDispatchRate.put(pulsar().getConfiguration().getClusterName(), dispatchRate);
             policies.clusterDispatchRate.put(pulsar().getConfiguration().getClusterName(), dispatchRate);
-            log.info("[{}] Successfully updated the dispatchRate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully updated the dispatchRate for cluster on namespace");
             return policies;
         }));
     }
@@ -1673,8 +1771,9 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             policies.topicDispatchRate.remove(pulsar().getConfiguration().getClusterName());
             policies.clusterDispatchRate.remove(pulsar().getConfiguration().getClusterName());
-            log.info("[{}] Successfully delete the dispatchRate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully delete the dispatchRate for cluster on namespace");
             return policies;
         }));
     }
@@ -1690,8 +1789,9 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                     policies.subscriptionDispatchRate.put(pulsar().getConfiguration().getClusterName(), dispatchRate);
-                    log.info("[{}] Successfully updated the subscriptionDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully updated the subscriptionDispatchRate for cluster on namespace");
                     return policies;
                 }));
     }
@@ -1700,8 +1800,9 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
                     policies.subscriptionDispatchRate.remove(pulsar().getConfiguration().getClusterName());
-                    log.info("[{}] Successfully delete the subscriptionDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully delete the subscriptionDispatchRate for cluster on namespace");
                     return policies;
                 }));
     }
@@ -1714,12 +1815,16 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     protected CompletableFuture<Void> internalSetSubscribeRateAsync(SubscribeRate subscribeRate) {
-        log.info("[{}] Set namespace subscribe-rate {}/{}", clientAppId(), namespaceName, subscribeRate);
+        log.info()
+                .attr("namespace", namespaceName)
+                .attr("subscribeRate", subscribeRate)
+                .log("Set namespace subscribe-rate");
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             policies.clusterSubscribeRate.put(pulsar().getConfiguration().getClusterName(), subscribeRate);
-            log.info("[{}] Successfully updated the subscribeRate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully updated the subscribeRate for cluster on namespace");
             return policies;
         }));
     }
@@ -1728,12 +1833,12 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.WRITE)
                 .thenCompose(__ -> updatePoliciesAsync(namespaceName, policies -> {
             policies.clusterSubscribeRate.remove(pulsar().getConfiguration().getClusterName());
-            log.info("[{}] Successfully delete the subscribeRate for cluster on namespace {}", clientAppId(),
-                    namespaceName);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .log("Successfully delete the subscribeRate for cluster on namespace");
             return policies;
         }));
     }
-
 
     protected CompletableFuture<SubscribeRate> internalGetSubscribeRateAsync() {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.RATE, PolicyOperation.READ)
@@ -1783,21 +1888,25 @@ public abstract class NamespacesBase extends AdminResource {
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND,
                     "Namespace policies does not exist"));
             if (!checkQuotas(policies, retention)) {
-                log.warn("[{}] Failed to update retention configuration"
-                                + " for namespace {}: conflicts with backlog quota",
-                        clientAppId(), namespaceName);
+                log.warn()
+                        .attr("namespace", namespaceName)
+                        .log("Failed to update retention configuration for namespace: conflicts with backlog quota");
                 throw new RestException(Status.PRECONDITION_FAILED,
                         "Retention Quota must exceed configured backlog quota for namespace.");
             }
             policies.retention_policies = retention;
             namespaceResources().setPolicies(namespaceName, p -> policies);
-            log.info("[{}] Successfully updated retention configuration: namespace={}, map={}", clientAppId(),
-                    namespaceName, objectWriter().writeValueAsString(retention));
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("retention", objectWriter().writeValueAsString(retention))
+                    .log("Successfully updated retention configuration");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update retention configuration for namespace {}", clientAppId(), namespaceName,
-                    e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update retention configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -1819,8 +1928,10 @@ public abstract class NamespacesBase extends AdminResource {
         return updatePoliciesAsync(namespaceName, policies -> {
             policies.persistence = persistence;
             return policies;
-        }).thenAccept(__ -> log.info("[{}] Successfully updated persistence configuration: namespace={}, map={}",
-                clientAppId(), namespaceName, persistence)
+        }).thenAccept(__ -> log.info()
+                .attr("namespace", namespaceName)
+                .attr("persistence", persistence)
+                .log("Successfully updated persistence configuration")
         );
     }
 
@@ -1840,8 +1951,9 @@ public abstract class NamespacesBase extends AdminResource {
                         }
                     }
                     return FutureUtil.waitForAll(futures);
-                }).thenRun(() -> log.info("[{}] Successfully cleared backlog on all the bundles for namespace {}",
-                        clientAppId(), namespaceName));
+                }).thenRun(() -> log.info()
+                        .attr("namespace", namespaceName)
+                        .log("Successfully cleared backlog on all the bundles for namespace"));
     }
 
     @SuppressWarnings("deprecation")
@@ -1863,8 +1975,10 @@ public abstract class NamespacesBase extends AdminResource {
                         validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange,
                                 authoritative, false))
                 .thenCompose(bundle -> clearBacklogAsync(bundle, null))
-                .thenRun(() -> log.info("[{}] Successfully cleared backlog on namespace bundle {}/{}", clientAppId(),
-                        namespaceName, bundleRange));
+                .thenRun(() -> log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("bundleRange", bundleRange)
+                        .log("Successfully cleared backlog on namespace bundle"));
     }
 
     protected CompletableFuture<Void> internalClearNamespaceBacklogForSubscriptionAsync(String subscription,
@@ -1888,9 +2002,10 @@ public abstract class NamespacesBase extends AdminResource {
                         }
                     }
                     return FutureUtil.waitForAll(futures);
-                }).thenRun(() -> log.info(
-                        "[{}] Successfully cleared backlog for subscription {} on all the bundles for namespace {}",
-                        clientAppId(), subscription, namespaceName));
+                }).thenRun(() -> log.info()
+                        .attr("subscription", subscription)
+                        .attr("namespace", namespaceName)
+                        .log("Successfully cleared backlog for subscription on all the bundles for namespace"));
     }
 
     @SuppressWarnings("deprecation")
@@ -1916,9 +2031,11 @@ public abstract class NamespacesBase extends AdminResource {
                         validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange,
                                 authoritative, false))
                 .thenCompose(bundle -> clearBacklogAsync(bundle, subscription))
-                .thenRun(() -> log.info(
-                        "[{}] Successfully cleared backlog for subscription {} on namespace bundle {}/{}",
-                        clientAppId(), subscription, namespaceName, bundleRange));
+                .thenRun(() -> log.info()
+                        .attr("subscription", subscription)
+                        .attr("namespace", namespaceName)
+                        .attr("bundleRange", bundleRange)
+                        .log("Successfully cleared backlog for subscription on namespace bundle"));
     }
 
     protected CompletableFuture<Void> internalUnsubscribeNamespaceAsync(String subscription,
@@ -1941,8 +2058,10 @@ public abstract class NamespacesBase extends AdminResource {
                         }
                     }
                     return FutureUtil.waitForAll(futures);
-                }).thenRun(() -> log.info("[{}] Successfully unsubscribed {} on all the bundles for namespace {}",
-                        clientAppId(), subscription, namespaceName));
+                }).thenRun(() -> log.info()
+                        .attr("subscription", subscription)
+                        .attr("namespace", namespaceName)
+                        .log("Successfully unsubscribed on all the bundles for namespace"));
     }
 
     @SuppressWarnings("deprecation")
@@ -1962,8 +2081,11 @@ public abstract class NamespacesBase extends AdminResource {
                         validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange,
                                 authoritative, false))
                 .thenCompose(bundle -> unsubscribeAsync(bundle, subscription))
-                .thenRun(() -> log.info("[{}] Successfully unsubscribed {} on namespace bundle {}/{}",
-                        clientAppId(), subscription, namespaceName, bundleRange));
+                .thenRun(() -> log.info()
+                        .attr("subscription", subscription)
+                        .attr("namespace", namespaceName)
+                        .attr("bundleRange", bundleRange)
+                        .log("Successfully unsubscribed on namespace bundle"));
     }
 
     protected void internalSetSubscriptionAuthMode(SubscriptionAuthMode subscriptionAuthMode) {
@@ -1976,13 +2098,18 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.subscription_auth_mode = authMode;
                 return policies;
             });
-            log.info("[{}] Successfully updated subscription auth mode: namespace={}, map={}", clientAppId(),
-                    namespaceName, objectWriter().writeValueAsString(authMode));
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("authMode", objectWriter().writeValueAsString(authMode))
+                    .log("Successfully updated subscription auth mode");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update subscription auth mode for namespace {}", clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update subscription auth mode for namespace");
             throw new RestException(e);
         }
     }
@@ -1996,11 +2123,15 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.encryption_required = encryptionRequired;
                 return policies;
             });
-            log.info("[{}] Successfully {} on namespace {}", clientAppId(), encryptionRequired ? "true" : "false",
-                    namespaceName);
+            log.info()
+                    .attr("encryptionRequired", encryptionRequired)
+                    .attr("namespace", namespaceName)
+                    .log("Successfully set encryption required on namespace");
         } catch (Exception e) {
-            log.error("[{}] Failed to modify encryption required status on namespace {}", clientAppId(),
-                    namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to modify encryption required status on namespace");
             throw new RestException(e);
         }
     }
@@ -2027,14 +2158,20 @@ public abstract class NamespacesBase extends AdminResource {
             field.setAccessible(true);
             field.set(policies, value);
             namespaceResources().setPolicies(namespaceName, p -> policies);
-            log.info("[{}] Successfully updated {} configuration: namespace={}, value={}", clientAppId(), fieldName,
-                    namespaceName, objectWriter().writeValueAsString(value));
+            log.info()
+                    .attr("field", fieldName)
+                    .attr("namespace", namespaceName)
+                    .attr("value", objectWriter().writeValueAsString(value))
+                    .log("Successfully updated configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update {} configuration for namespace {}", clientAppId(), fieldName
-                    , namespaceName, e);
+            log.error()
+                    .attr("field", fieldName)
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2063,9 +2200,10 @@ public abstract class NamespacesBase extends AdminResource {
                                                         policies.migrated))
                                                 .orElseGet(() -> new LocalPolicies(defaultBundleData, null,
                                                         antiAffinityGroup)))))
-                .thenAccept(__ -> log.info(
-                        "[{}] Successfully updated namespace anti-affinity group, namespace={}, anti-affinity"
-                                + " group={}", clientAppId(), namespaceName, antiAffinityGroup));
+                .thenAccept(__ -> log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("antiAffinityGroup", antiAffinityGroup)
+                        .log("Successfully updated namespace anti-affinity group"));
     }
 
     protected CompletableFuture<String> internalGetNamespaceAntiAffinityGroupAsync() {
@@ -2079,13 +2217,16 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.ANTI_AFFINITY, PolicyOperation.WRITE)
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> {
-                    log.info("[{}] Removing anti-affinity group for namespace: {}", clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Removing anti-affinity group for namespace");
                     return getLocalPolicies().setLocalPoliciesAsync(namespaceName,
                             (policies) -> new LocalPolicies(policies.bundles, policies.bookieAffinityGroup, null,
                                     policies.migrated));
                 })
-                .thenAccept(__ -> log.info("[{}] Successfully removed anti-affinity group for namespace: {}",
-                        clientAppId(), namespaceName));
+                .thenAccept(__ -> log.info()
+                        .attr("namespace", namespaceName)
+                        .log("Successfully removed anti-affinity group for namespace"));
     }
 
     protected CompletableFuture<List<String>> internalGetAntiAffinityNamespacesAsync(String cluster,
@@ -2109,8 +2250,11 @@ public abstract class NamespacesBase extends AdminResource {
         return validateNamespacePolicyOperationAsync(namespaceName, PolicyName.ANTI_AFFINITY, PolicyOperation.READ)
                 .thenCompose(__ -> validateClusterExistsAsync(cluster))
                 .thenCompose(__ -> {
-                    log.info("[{}]-{} Finding namespaces for {} in {}", clientAppId(), tenant, antiAffinityGroup,
-                            cluster);
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("antiAffinityGroup", antiAffinityGroup)
+                            .attr("cluster", cluster)
+                            .log("Finding namespaces");
                     return tenantResources().getListOfNamespacesAsync(tenant).thenCompose(namespaces -> {
                         List<CompletableFuture<String>> nsFutures = namespaces.stream()
                                 .map(ns -> getLocalPolicies().getLocalPoliciesAsync(NamespaceName.get(ns))
@@ -2176,7 +2320,6 @@ public abstract class NamespacesBase extends AdminResource {
                 });
     }
 
-
     private CompletableFuture<Void> unsubscribeAsync(NamespaceBundle bundle, String subscription) {
         if (subscription.startsWith(pulsar().getConfiguration().getReplicatorPrefix())) {
             return CompletableFuture.failedFuture(
@@ -2225,10 +2368,8 @@ public abstract class NamespacesBase extends AdminResource {
             partitions.add(String.format("0x%08x", partBoundary));
         }
         if (partitions.size() != initialBundles.getBoundaries().size()) {
-            if (log.isDebugEnabled()) {
                 log.debug("Input bundles included repeated partition points. Ignored.");
-            }
-        }
+                    }
         try {
             NamespaceBundleFactory.validateFullRange(partitions);
         } catch (IllegalArgumentException iae) {
@@ -2304,13 +2445,17 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.max_producers_per_topic = maxProducersPerTopic;
                 return policies;
             });
-            log.info("[{}] Successfully updated maxProducersPerTopic configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, maxProducersPerTopic);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("maxProducersPerTopic", maxProducersPerTopic)
+                    .log("Successfully updated maxProducersPerTopic configuration");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update maxProducersPerTopic configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update maxProducersPerTopic configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2333,14 +2478,18 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.max_consumers_per_topic = maxConsumersPerTopic;
                 return policies;
             });
-            log.info("[{}] Successfully updated maxConsumersPerTopic configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, maxConsumersPerTopic);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("maxConsumersPerTopic", maxConsumersPerTopic)
+                    .log("Successfully updated maxConsumersPerTopic configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update maxConsumersPerTopic configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update maxConsumersPerTopic configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2358,13 +2507,17 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.max_consumers_per_subscription = maxConsumersPerSubscription;
                 return policies;
             });
-            log.info("[{}] Successfully updated maxConsumersPerSubscription configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, maxConsumersPerSubscription);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("maxConsumersPerSubscription", maxConsumersPerSubscription)
+                    .log("Successfully updated maxConsumersPerSubscription configuration");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update maxConsumersPerSubscription configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update maxConsumersPerSubscription configuration");
             throw new RestException(e);
         }
     }
@@ -2381,14 +2534,18 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.max_unacked_messages_per_consumer = maxUnackedMessagesPerConsumer;
                 return policies;
             });
-            log.info("[{}] Successfully updated maxUnackedMessagesPerConsumer configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, maxUnackedMessagesPerConsumer);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("maxUnackedMessagesPerConsumer", maxUnackedMessagesPerConsumer)
+                    .log("Successfully updated maxUnackedMessagesPerConsumer configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update maxUnackedMessagesPerConsumer configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update maxUnackedMessagesPerConsumer configuration");
             throw new RestException(e);
         }
     }
@@ -2415,15 +2572,18 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.max_unacked_messages_per_subscription = maxUnackedMessagesPerSubscription;
                 return policies;
             });
-            log.info("[{}] Successfully updated maxUnackedMessagesPerSubscription"
-                            + " configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, maxUnackedMessagesPerSubscription);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("maxUnackedMessagesPerSubscription", maxUnackedMessagesPerSubscription)
+                    .log("Successfully updated maxUnackedMessagesPerSubscription configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update maxUnackedMessagesPerSubscription configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update maxUnackedMessagesPerSubscription configuration");
             throw new RestException(e);
         }
     }
@@ -2441,14 +2601,18 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.compaction_threshold = newThreshold;
                 return policies;
             });
-            log.info("[{}] Successfully updated compactionThreshold configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, newThreshold);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("compactionThreshold", newThreshold)
+                    .log("Successfully updated compactionThreshold configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update compactionThreshold configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update compactionThreshold configuration");
             throw new RestException(e);
         }
     }
@@ -2466,14 +2630,18 @@ public abstract class NamespacesBase extends AdminResource {
                 mergeOffloadThresholdsForCompatibility(policies);
                 return policies;
             });
-            log.info("[{}] Successfully updated offloadThreshold configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, newThreshold);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("offloadThreshold", newThreshold)
+                    .log("Successfully updated offloadThreshold configuration");
 
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update offloadThreshold configuration for namespace {}",
-                    clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update offloadThreshold configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2495,14 +2663,18 @@ public abstract class NamespacesBase extends AdminResource {
                         })
                 )
                 .thenAccept(v -> {
-                    log.info("[{}] Successfully updated offloadThresholdInSeconds configuration:"
-                            + " namespace={}, value={}", clientAppId(), namespaceName, newThreshold);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("offloadThresholdInSeconds", newThreshold)
+                            .log("Successfully updated offloadThresholdInSeconds configuration");
                     f.complete(null);
                 })
                 .exceptionally(t -> {
                     Throwable cause = FutureUtil.unwrapCompletionException(t);
-                    log.error("[{}] Failed to update offloadThresholdInSeconds configuration for namespace {}",
-                            clientAppId(), namespaceName, t);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(t)
+                            .log("Failed to update offloadThresholdInSeconds configuration for namespace");
                     f.completeExceptionally(new RestException(cause));
                     return null;
                 });
@@ -2523,13 +2695,17 @@ public abstract class NamespacesBase extends AdminResource {
                 mergeOffloadThresholdsForCompatibility(policies);
                 return policies;
             });
-            log.info("[{}] Successfully updated offloadDeletionLagMs configuration: namespace={}, value={}",
-                    clientAppId(), namespaceName, newDeletionLagMs);
+            log.info()
+                    .attr("namespace", namespaceName)
+                    .attr("offloadDeletionLagMs", newDeletionLagMs)
+                    .log("Successfully updated offloadDeletionLagMs configuration");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update offloadDeletionLag configuration for namespace {}", clientAppId(),
-                    namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update offloadDeletionLag configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2615,7 +2791,6 @@ public abstract class NamespacesBase extends AdminResource {
             }));
     }
 
-
     @SuppressWarnings({"deprecation", "unchecked"})
     private <T> void mutatePolicy(Function<Policies, Policies> policyTransformation,
                                   Function<Policies, T> getter,
@@ -2635,13 +2810,19 @@ public abstract class NamespacesBase extends AdminResource {
             if (exception.getValue() != null) {
                 throw (Exception) exception.getValue();
             }
-            log.info("[{}] Successfully updated {} configuration: namespace={}, value={}", clientAppId(), policyName,
-                    namespaceName, getter.apply((Policies) policiesObj.getValue()));
+            log.info()
+                    .attr("policy", policyName)
+                    .attr("namespace", namespaceName)
+                    .attr("value", getter.apply((Policies) policiesObj.getValue()))
+                    .log("Successfully updated configuration");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update {} configuration for namespace {}",
-                    clientAppId(), policyName, namespaceName, e);
+            log.error()
+                    .attr("policy", policyName)
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update configuration for namespace");
             throw new RestException(e);
         }
     }
@@ -2701,18 +2882,25 @@ public abstract class NamespacesBase extends AdminResource {
                 mergeOffloadThresholdsForCompatibility(policies);
                 return policies;
             }).thenApply(r -> {
-                log.info("[{}] Successfully updated offload configuration: namespace={}, map={}", clientAppId(),
-                        namespaceName, offloadPolicies);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("offloadPolicies", offloadPolicies)
+                        .log("Successfully updated offload configuration");
                 asyncResponse.resume(Response.noContent().build());
                 return null;
             }).exceptionally(e -> {
-                log.error("[{}] Failed to update offload configuration for namespace {}", clientAppId(), namespaceName,
-                        e);
+                log.error()
+                        .attr("namespace", namespaceName)
+                        .exception(e)
+                        .log("Failed to update offload configuration for namespace");
                 asyncResponse.resume(new RestException(e));
                 return null;
             });
         } catch (Exception e) {
-            log.error("[{}] Failed to update offload configuration for namespace {}", clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to update offload configuration for namespace");
             asyncResponse.resume(e.getCause() instanceof NotFoundException
                     ? new RestException(Status.CONFLICT, "Concurrent modification")
                     : new RestException(e));
@@ -2732,19 +2920,26 @@ public abstract class NamespacesBase extends AdminResource {
                 policies.offload_threshold_in_seconds = -1;
                 return policies;
             }).thenApply(r -> {
-                log.info("[{}] Successfully remove offload configuration: namespace={}", clientAppId(), namespaceName);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .log("Successfully remove offload configuration: namespace");
                 asyncResponse.resume(Response.noContent().build());
                 return null;
             }).exceptionally(e -> {
-                log.error("[{}] Failed to remove offload configuration for namespace {}", clientAppId(), namespaceName,
-                        e);
+                log.error()
+                        .attr("namespace", namespaceName)
+                        .exception(e)
+                        .log("Failed to remove offload configuration for namespace");
                 asyncResponse.resume(e.getCause() instanceof NotFoundException
                         ? new RestException(Status.CONFLICT, "Concurrent modification")
                         : new RestException(e));
                 return null;
             });
         } catch (Exception e) {
-            log.error("[{}] Failed to remove offload configuration for namespace {}", clientAppId(), namespaceName, e);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(e)
+                    .log("Failed to remove offload configuration for namespace");
             asyncResponse.resume(new RestException(e));
         }
     }
@@ -2773,13 +2968,18 @@ public abstract class NamespacesBase extends AdminResource {
                    return policies;
                }))
                .thenAccept(v -> {
-                   log.info("[{}] Successfully set property for key {} on namespace {}", clientAppId(), key,
-                           namespaceName);
+                   log.info()
+                           .attr("key", key)
+                           .attr("namespace", namespaceName)
+                           .log("Successfully set property for key on namespace");
                    asyncResponse.resume(Response.noContent().build());
                }).exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to set property for key {} on namespace {}", clientAppId(), key,
-                           namespaceName, cause);
+                   log.error()
+                           .attr("key", key)
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to set property for key on namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2793,13 +2993,18 @@ public abstract class NamespacesBase extends AdminResource {
                    return policies;
                }))
                .thenAccept(v -> {
-                   log.info("[{}] Successfully set {} properties on namespace {}", clientAppId(), properties.size(),
-                           namespaceName);
+                   log.info()
+                           .attr("set", properties.size())
+                           .attr("namespace", namespaceName)
+                           .log("Successfully set properties on namespace");
                    asyncResponse.resume(Response.noContent().build());
                }).exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to set {} properties on namespace {}", clientAppId(), properties.size(),
-                           namespaceName, cause);
+                   log.error()
+                           .attr("set", properties.size())
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to set properties on namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2811,8 +3016,11 @@ public abstract class NamespacesBase extends AdminResource {
                .thenAccept(policies -> asyncResponse.resume(policies.properties.get(key)))
                .exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to get property for key {} of namespace {}", clientAppId(), key,
-                           namespaceName, cause);
+                   log.error()
+                           .attr("key", key)
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to get property for key of namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2824,7 +3032,10 @@ public abstract class NamespacesBase extends AdminResource {
                .thenAccept(policies -> asyncResponse.resume(policies.properties))
                .exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to get properties of namespace {}", clientAppId(), namespaceName, cause);
+                   log.error()
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to get properties of namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2839,12 +3050,17 @@ public abstract class NamespacesBase extends AdminResource {
                    return policies;
                })).thenAccept(v -> {
                    asyncResponse.resume(oldVal.get());
-                   log.info("[{}] Successfully remove property for key {} on namespace {}", clientAppId(), key,
-                           namespaceName);
+                   log.info()
+                           .attr("key", key)
+                           .attr("namespace", namespaceName)
+                           .log("Successfully remove property for key on namespace");
                }).exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to remove property for key {} on namespace {}", clientAppId(), key,
-                           namespaceName, cause);
+                   log.error()
+                           .attr("key", key)
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to remove property for key on namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2861,12 +3077,17 @@ public abstract class NamespacesBase extends AdminResource {
                }))
                .thenAccept(v -> {
                    asyncResponse.resume(Response.noContent().build());
-                   log.info("[{}] Successfully clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
-                           namespaceName);
+                   log.info()
+                           .attr("clear", clearedCount.get())
+                           .attr("namespace", namespaceName)
+                           .log("Successfully clear properties on namespace");
                }).exceptionally(ex -> {
                    Throwable cause = ex.getCause();
-                   log.error("[{}] Failed to clear {} properties on namespace {}", clientAppId(), clearedCount.get(),
-                           namespaceName, cause);
+                   log.error()
+                           .attr("clear", clearedCount.get())
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to clear properties on namespace");
                    asyncResponse.resume(cause);
                    return null;
                });
@@ -2876,7 +3097,9 @@ public abstract class NamespacesBase extends AdminResource {
        CompletableFuture<Void> result = new CompletableFuture<>();
        namespaceResources().setPoliciesAsync(ns, updateFunction)
            .thenAccept(v -> {
-               log.info("[{}] Successfully updated the policies on namespace {}", clientAppId(), namespaceName);
+               log.info()
+                       .attr("namespace", namespaceName)
+                       .log("Successfully updated the policies on namespace");
                result.complete(null);
            })
            .exceptionally(ex -> {
@@ -2884,11 +3107,15 @@ public abstract class NamespacesBase extends AdminResource {
                if (cause instanceof NotFoundException) {
                    result.completeExceptionally(new RestException(Status.NOT_FOUND, "Namespace does not exist"));
                } else if (cause instanceof BadVersionException) {
-                   log.warn("[{}] Failed to update the replication clusters on"
-                                   + " namespace {} : concurrent modification", clientAppId(), namespaceName);
+                   log.warn()
+                           .attr("namespace", namespaceName)
+                           .log("Failed to update the replication clusters on namespace: concurrent modification");
                    result.completeExceptionally(new RestException(Status.CONFLICT, "Concurrent modification"));
                } else {
-                   log.error("[{}] Failed to update namespace policies {}", clientAppId(), namespaceName, cause);
+                   log.error()
+                           .attr("namespace", namespaceName)
+                           .exception(cause)
+                           .log("Failed to update namespace policies");
                    result.completeExceptionally(new RestException(cause));
                }
                return null;
@@ -2922,7 +3149,10 @@ public abstract class NamespacesBase extends AdminResource {
                     throw new RestException(Status.PRECONDITION_FAILED, "ResourceGroup does not exist");
                 }
             } catch (Exception e) {
-                log.error("[{}] Invalid ResourceGroup {}: {}", clientAppId(), rgName, e);
+                log.error()
+                        .attr("resourceGroup", rgName)
+                        .exceptionMessage(e)
+                        .log("Invalid ResourceGroup");
                 throw new RestException(e);
             }
         }
@@ -2933,7 +3163,7 @@ public abstract class NamespacesBase extends AdminResource {
     @SuppressWarnings("deprecation")
     protected void internalScanOffloadedLedgers(OffloaderObjectsScannerUtils.ScannerResultSink sink)
             throws Exception {
-        log.info("internalScanOffloadedLedgers {}", namespaceName);
+        log.info().attr("namespace", namespaceName).log("internalScanOffloadedLedgers");
         validateNamespacePolicyOperation(namespaceName, PolicyName.OFFLOAD, PolicyOperation.READ);
 
         Policies policies = getNamespacePolicies(namespaceName);
@@ -2957,7 +3187,6 @@ public abstract class NamespacesBase extends AdminResource {
                 }));
     }
 
-
     /**
      * Base method for setReplicatorDispatchRate v1 and v2.
      * Notion: don't re-use this logic.
@@ -2965,20 +3194,25 @@ public abstract class NamespacesBase extends AdminResource {
     protected void internalSetReplicatorDispatchRate(AsyncResponse asyncResponse, DispatchRateImpl dispatchRate) {
         validateNamespacePolicyOperationAsync(namespaceName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE)
                 .thenAccept(__ -> {
-                    log.info("[{}] Set namespace replicator dispatch-rate {}/{}",
-                            clientAppId(), namespaceName, dispatchRate);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("dispatchRate", dispatchRate)
+                            .log("Set namespace replicator dispatch-rate");
                 }).thenCompose(__ -> namespaceResources().setPoliciesAsync(namespaceName, policies -> {
                     String clusterName = pulsar().getConfiguration().getClusterName();
                     policies.replicatorDispatchRate.put(clusterName, dispatchRate);
                     return policies;
                 })).thenAccept(__ -> {
                     asyncResponse.resume(Response.noContent().build());
-                    log.info("[{}] Successfully updated the replicatorDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully updated the replicatorDispatchRate for cluster on namespace");
                 }).exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    log.error("[{}] Failed to update the replicatorDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update the replicatorDispatchRate for cluster on namespace");
                     return null;
                 });
     }
@@ -2998,8 +3232,10 @@ public abstract class NamespacesBase extends AdminResource {
                 }).thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    log.error("[{}] Failed to get replicator dispatch-rate configured for the namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get replicator dispatch-rate configured for the namespace");
                     return null;
                 });
     }
@@ -3015,12 +3251,15 @@ public abstract class NamespacesBase extends AdminResource {
                     return policies;
                 })).thenAccept(__ -> {
                     asyncResponse.resume(Response.noContent().build());
-                    log.info("[{}] Successfully delete the replicatorDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully delete the replicatorDispatchRate for cluster on namespace");
                 }).exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    log.error("[{}] Failed to delete the replicatorDispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete the replicatorDispatchRate for cluster on namespace");
                     return null;
                 });
     }
@@ -3040,7 +3279,10 @@ public abstract class NamespacesBase extends AdminResource {
                 })
                 .exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    log.error("[{}] Failed to get backlog quota map on namespace {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get backlog quota map on namespace");
                     return null;
                 });
     }
@@ -3056,13 +3298,17 @@ public abstract class NamespacesBase extends AdminResource {
                 .thenCompose(__ -> setBacklogQuotaAsync(backlogQuotaType, backlogQuota))
                 .thenAccept(__ -> {
                     asyncResponse.resume(Response.noContent().build());
-                    log.info("[{}] Successfully updated backlog quota map: namespace={}, map={}", clientAppId(),
-                            namespaceName, backlogQuota);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("backlogQuota", backlogQuota)
+                            .log("Successfully updated backlog quota map");
                 }).exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     if (isNot307And404And400Exception(ex)) {
-                        log.error("[{}] Failed to update backlog quota map for namespace {}",
-                                clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to update backlog quota map for namespace");
                     }
                     return null;
                 });
@@ -3082,12 +3328,16 @@ public abstract class NamespacesBase extends AdminResource {
                     return policies;
                 })).thenAccept(__ -> {
                     asyncResponse.resume(Response.noContent().build());
-                    log.info("[{}] Successfully removed backlog namespace={}, quota={}", clientAppId(), namespaceName,
-                            backlogQuotaType);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("quotaType", backlogQuotaType)
+                            .log("Successfully removed backlog quota");
                 }).exceptionally(ex -> {
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
-                    log.error("[{}] Failed to update backlog quota map for namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update backlog quota map for namespace");
                     return null;
                 });
     }
@@ -3100,7 +3350,9 @@ public abstract class NamespacesBase extends AdminResource {
                                                         policies.bookieAffinityGroup,
                                                         policies.namespaceAntiAffinityGroup, migrated))
                                         .orElseGet(() -> new LocalPolicies(defaultBundleData, null, null, migrated)))))
-                .thenAccept(__ -> log.info("Successfully updated migration on namespace {}", namespaceName));
+                .thenAccept(__ -> log.info()
+                        .attr("namespace", namespaceName)
+                        .log("Successfully updated migration on namespace"));
     }
 
     protected Policies getDefaultPolicesIfNull(Policies policies) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/OffloaderObjectsScannerUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/OffloaderObjectsScannerUtils.java
@@ -23,14 +23,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 
-@Slf4j
+@CustomLog
 @UtilityClass
 public class OffloaderObjectsScannerUtils {
 
@@ -54,7 +54,7 @@ public class OffloaderObjectsScannerUtils {
         AtomicInteger totalErrors = new AtomicInteger();
         AtomicInteger totalUnknown = new AtomicInteger();
         managedLedgerOffloader.scanLedgers((md -> {
-            log.info("Found ledger {}", md);
+            log.info().attr("metadata", md).log("Found ledger");
             Map<String, Object> objectInfo = new HashMap<>();
             objectInfo.put("ledger", md.getLedgerId());
             objectInfo.put("name", md.getName());
@@ -82,7 +82,8 @@ public class OffloaderObjectsScannerUtils {
                             Thread.currentThread().interrupt();
                             throw new RuntimeException(err);
                         } catch (ManagedLedgerException err) {
-                            log.error("Error while checking managed ledger {}", managedLedgerName);
+                            log.error().attr("managedLedger", managedLedgerName)
+                                    .log("Error while checking managed ledger");
                             throw new RuntimeException(err);
                         }
                     }
@@ -118,24 +119,36 @@ public class OffloaderObjectsScannerUtils {
             ManagedLedgerInfo.LedgerInfo ledgerInfo = managedLedgerInfo
                     .ledgers.stream().filter(l -> l.ledgerId == ledgerId).findAny().orElse(null);
             if (ledgerInfo == null) {
-                log.info("Managed ledger {} does not contain ledger {}", managedLedgerName, ledgerId);
+                log.info()
+                        .attr("managedLedger", managedLedgerName)
+                        .attr("ledgerId", ledgerId)
+                        .log("Managed ledger does not contain ledger");
                 return STATUS_NOT_FOUND;
             }
             data.put("numEntries", ledgerInfo.entries);
             data.put("offloaded", ledgerInfo.isOffloaded);
             if (!ledgerInfo.isOffloaded) {
-                log.info("Ledger {} is not marked as OFFLOADED in {}", ledgerId, managedLedgerName);
+                log.info()
+                        .attr("ledgerId", ledgerId)
+                        .attr("managedLedger", managedLedgerName)
+                        .log("Ledger is not marked as OFFLOADED");
                 return STATUS_NOT_OFFLOADED;
             }
             String uuidOnMetadata = ledgerInfo.offloadedContextUuid;
             if (!Objects.equals(uuidOnMetadata, uuid)) {
-                log.info("Ledger {} uuid {} does not match name uuid {}", ledgerId, uuidOnMetadata, uuid);
+                log.info()
+                        .attr("ledgerId", ledgerId)
+                        .attr("metadataUuid", uuidOnMetadata)
+                        .attr("uuid", uuid)
+                        .log("Ledger uuid does not match name uuid");
                 return STATUS_BAD_UUID;
             }
             return "OK";
         }  catch (ManagedLedgerException.ManagedLedgerNotFoundException
                 | ManagedLedgerException.MetadataNotFoundException notFound) {
-            log.info("Managed ledger {} does not exist (maybe the topic has been deleted)", managedLedgerName);
+            log.info()
+                    .attr("managedLedger", managedLedgerName)
+                    .log("Managed ledger does not exist (maybe the topic has been deleted)");
             return STATUS_NOT_FOUND;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PackagesBase.java
@@ -26,7 +26,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -37,7 +36,6 @@ import org.apache.pulsar.packages.management.core.common.PackageName;
 import org.apache.pulsar.packages.management.core.common.PackageType;
 import org.apache.pulsar.packages.management.core.exceptions.PackagesManagementException;
 
-@Slf4j
 public class PackagesBase extends AdminResource {
 
     private PackagesManagement getPackagesManagement() {
@@ -68,7 +66,7 @@ public class PackagesBase extends AdminResource {
         } else if (throwable instanceof FileAlreadyExistsException) {
             asyncResponse.resume(new RestException(Response.Status.CONFLICT, throwable.getMessage()));
         } else {
-            log.error("Encountered unexpected error", throwable);
+            log.error().exception(throwable).log("Encountered unexpected error");
             asyncResponse.resume(new RestException(Response.Status.INTERNAL_SERVER_ERROR, throwable.getMessage()));
         }
         return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -153,13 +153,12 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  */
 public class PersistentTopicsBase extends AdminResource {
-    private static final Logger log = LoggerFactory.getLogger(PersistentTopicsBase.class);
+    private static final io.github.merlimat.slog.Logger LOG =
+            io.github.merlimat.slog.Logger.get(PersistentTopicsBase.class);
 
     private static final int OFFLINE_TOPIC_STAT_TTL_MINS = 10;
     private static final String DEPRECATED_CLIENT_VERSION_PREFIX = "Pulsar-CPP-v";
@@ -199,8 +198,9 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(namespaceExists -> {
                     // Validate that namespace exists, throws 404 if it doesn't exist
                     if (!namespaceExists) {
-                        log.warn("[{}] Failed to get partitioned topic list {}: Namespace does not exist",
-                                clientAppId(), namespaceName);
+                        log.warn()
+                                .attr("namespace", namespaceName)
+                                .log("Failed to get partitioned topic list : Namespace does not exist");
                         throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
                     } else {
                         return getPartitionedTopicListAsync(TopicDomain.getEnum(domain()));
@@ -225,7 +225,7 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void validateCreateTopic(TopicName topicName) {
         if (isTransactionInternalName(topicName)) {
-            log.warn("Forbidden to create transaction internal topic: {}", topicName);
+            log.warn().attr("topic", topicName).log("Forbidden to create transaction internal topic");
             throw new RestException(Status.BAD_REQUEST, "Cannot create topic in system topic format!");
         }
     }
@@ -239,25 +239,34 @@ public class PersistentTopicsBase extends AdminResource {
         AuthorizationService authService = pulsar().getBrokerService().getAuthorizationService();
         if (null != authService) {
             return authService.grantPermissionAsync(topicUri, actions, role, null/*additional auth-data json*/)
-                    .thenAccept(__ -> log.info("[{}] Successfully granted access for role {}: {} - topic {}",
-                            clientAppId(), role, actions, topicUri))
+                    .thenAccept(__ -> log.info()
+                            .attr("role", role)
+                            .attr("actions", actions)
+                            .attr("topic", topicUri)
+                            .log("Successfully granted access for role on topic"))
                     .exceptionally(ex -> {
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                         //The IllegalArgumentException and the IllegalStateException were historically thrown by the
                         // grantPermissionAsync method, so we catch them here to ensure backwards compatibility.
                         if (realCause instanceof MetadataStoreException.NotFoundException
                                 || realCause instanceof IllegalArgumentException) {
-                            log.warn("[{}] Failed to set permissions for topic {}: Namespace does not exist",
-                                    clientAppId(), topicUri, realCause);
+                            log.warn()
+                                    .attr("topic", topicUri)
+                                    .exception(realCause)
+                                    .log("Failed to set permissions for topic: Namespace does not exist");
                             throw new RestException(Status.NOT_FOUND, "Topic's namespace does not exist");
                         } else if (realCause instanceof MetadataStoreException.BadVersionException
                                 || realCause instanceof IllegalStateException) {
-                            log.warn("[{}] Failed to set permissions for topic {}: {}", clientAppId(), topicUri,
-                                    realCause.getMessage(), realCause);
+                            log.warn()
+                                    .attr("topic", topicUri)
+                                    .exceptionMessage(realCause)
+                                    .log("Failed to set permissions for topic");
                             throw new RestException(Status.CONFLICT, "Concurrent modification");
                         } else {
-                            log.error("[{}] Failed to get permissions for topic {}", clientAppId(), topicUri,
-                                    realCause);
+                            log.error()
+                                    .attr("topic", topicUri)
+                                    .exceptionMessage(realCause)
+                                    .log("Failed to get permissions for topic");
                             throw new RestException(realCause);
                         }
                     });
@@ -284,7 +293,10 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenAccept(unused -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to get permissions for topic {}", clientAppId(), topicName, realCause);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exceptionMessage(realCause)
+                            .log("Failed to get permissions for topic");
                     resumeAsyncResponseExceptionally(asyncResponse, realCause);
                     return null;
                 });
@@ -320,7 +332,10 @@ public class PersistentTopicsBase extends AdminResource {
                 })
                 ).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to revoke permissions for topic {}", clientAppId(), topicName, realCause);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exceptionMessage(realCause)
+                            .log("Failed to revoke permissions for topic");
                     resumeAsyncResponseExceptionally(asyncResponse, realCause);
                     return null;
                 });
@@ -336,19 +351,23 @@ public class PersistentTopicsBase extends AdminResource {
            .thenCompose(__ -> getPartitionedTopicMetadataAsync(topicName, false, false))
            .thenAccept(partitionMetadata -> {
                if (partitionMetadata.partitions > 0) {
-                   log.warn("[{}] Partitioned topic with the same name already exists {}", clientAppId(), topicName);
+                   log.warn()
+                           .attr("exists", topicName)
+                           .log("Partitioned topic with the same name already exists");
                    throw new RestException(Status.CONFLICT, "This topic already exists");
                }
            })
            .thenCompose(__ -> pulsar().getBrokerService().getTopicIfExists(topicName.toString()))
            .thenCompose(existedTopic -> {
                if (existedTopic.isPresent()) {
-                   log.warn("[{}] Topic {} already exists", clientAppId(), topicName);
+                   log.warn().attr("topic", topicName).log("Topic already exists");
                    throw new RestException(Status.CONFLICT, "This topic already exists");
                }
                return pulsar().getBrokerService().getTopic(topicName.toString(), true, properties);
            })
-           .thenAccept(__ -> log.info("[{}] Successfully created non-partitioned topic {}", clientAppId(), topicName));
+           .thenAccept(__ -> log.info()
+                   .attr("topic", topicName)
+                   .log("Successfully created non-partitioned topic"));
     }
 
     /**
@@ -454,10 +473,10 @@ public class PersistentTopicsBase extends AdminResource {
                                                                             FutureUtil.unwrapCompletionException(ex);
                                                                     if (!(rc instanceof PulsarAdminException
                                                                             .ConflictException)) {
-                                                                        log.warn("[{}] got an error while copying"
-                                                                                        + " the subscription to the"
-                                                                                        + " partition {}.", topicName,
-                                                                                Throwables.getRootCause(rc));
+                                                                        log.warn()
+                                                                                .attr("topic", topicName)
+                                                                                .exception(Throwables.getRootCause(rc))
+                                                                                .log("Error copying subscription");
                                                                         throw FutureUtil.wrapToCompletionException(rc);
                                                                     }
                                                                     // Ignore subscription already exist exception
@@ -482,8 +501,9 @@ public class PersistentTopicsBase extends AdminResource {
                                 boolean containsCurrentCluster =
                                         replicationClusters.contains(pulsar().getConfig().getClusterName());
                                 if (!containsCurrentCluster) {
-                                    log.error("[{}] local cluster is not part of replicated cluster for namespace {}",
-                                            clientAppId(), topicName);
+                                    log.error()
+                                            .attr("namespace", topicName)
+                                            .log("local cluster is not part of replicated cluster for namespace");
                                     throw new RestException(422,
                                             "Local cluster is not part of replicate cluster list");
                                 }
@@ -499,8 +519,11 @@ public class PersistentTopicsBase extends AdminResource {
                                                         .topics().updatePartitionedTopicAsync(topicName.toString(),
                                                             expectPartitions, true, force)
                                                         .exceptionally(ex -> {
-                                                            log.warn("[{}][{}] Update remote cluster partition fail.",
-                                                                        topicName, replicationCluster, ex);
+                                                            log.warn()
+                                                                    .attr("topic", topicName)
+                                                                    .attr("replicationCluster", replicationCluster)
+                                                                    .exception(ex)
+                                                                    .log("Update remote cluster partition fail.");
                                                             throw FutureUtil.wrapToCompletionException(ex);
                                                         })
                                                 )
@@ -534,7 +557,9 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> tryCreatePartitionsAsync(metadata.partitions)).thenAccept(v -> {
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(e -> {
-                    log.error("[{}] Failed to create partitions for topic {}", clientAppId(), topicName);
+                    log.error()
+                            .attr("topic", topicName)
+                            .log("Failed to create partitions for topic");
                     resumeAsyncResponseExceptionally(asyncResponse, e);
                     return null;
                 });
@@ -544,8 +569,9 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (!isRedirectException(ex)) {
-                log.error("[{}] Failed to create partitions for topic {}",
-                        clientAppId(), topicName);
+                log.error()
+                        .attr("topic", topicName)
+                        .log("Failed to create partitions for topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -631,7 +657,9 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalUpdatePropertiesAsync(boolean authoritative,
                                                                     Map<String, String> properties) {
         if (properties == null || properties.isEmpty()) {
-            log.warn("[{}] [{}] properties is empty, ignore update", clientAppId(), topicName);
+            log.warn()
+                    .attr("topic", topicName)
+                    .log("properties is empty, ignore update");
             return CompletableFuture.completedFuture(null);
         }
         return validateTopicOperationAsync(topicName, TopicOperation.UPDATE_METADATA)
@@ -653,8 +681,10 @@ public class PersistentTopicsBase extends AdminResource {
                             });
                     }
                 }).thenAccept(__ ->
-                    log.info("[{}] [{}] update properties success with properties {}", clientAppId(),
-                            topicName, properties));
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("properties", properties)
+                            .log("update properties success with properties"));
     }
 
     private CompletableFuture<Void> internalUpdateNonPartitionedTopicProperties(Map<String, String> properties) {
@@ -715,8 +745,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 });
                     }
                 }).thenAccept(__ ->
-                        log.info("[{}] remove [{}] properties success with key {}",
-                                clientAppId(), topicName, key));
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("key", key)
+                                .log("remove properties success with key"));
     }
 
     private CompletableFuture<Void> internalRemoveNonPartitionedTopicProperties(String key) {
@@ -803,7 +835,9 @@ public class PersistentTopicsBase extends AdminResource {
                         .runWithMarkDeleteAsync(topicName, () -> namespaceResources()
                                 .getPartitionedTopicResources().deletePartitionedTopicAsync(topicName)))
                 .thenAccept(__ -> {
-                    log.info("[{}] Deleted partitioned topic {}", clientAppId(), topicName);
+                    log.info()
+                            .attr("topic", topicName)
+                            .log("Deleted partitioned topic");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
@@ -813,7 +847,8 @@ public class PersistentTopicsBase extends AdminResource {
                     } else if (realCause instanceof WebApplicationException){
                         asyncResponse.resume(realCause);
                     } else if (realCause instanceof MetadataStoreException.NotFoundException) {
-                        log.warn("Namespace policies of {} not found", topicName.getNamespaceObject());
+                        log.warn().attr("namespace", topicName.getNamespaceObject())
+                                .log("Namespace policies not found");
                         asyncResponse.resume(new RestException(
                                 new RestException(Status.NOT_FOUND,
                                         getPartitionedTopicNotFoundErrorMessage(topicName.toString()))));
@@ -825,7 +860,10 @@ public class PersistentTopicsBase extends AdminResource {
                     } else {
                         // If the exception is not redirect exception we need to log it.
                         if (!isRedirectException(ex)) {
-                            log.error("[{}] Fail to Delete partitioned topic {}", clientAppId(), topicName, realCause);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exceptionMessage(realCause)
+                                    .log("Fail to Delete partitioned topic");
                         }
                         asyncResponse.resume(new RestException(realCause));
                     }
@@ -858,14 +896,15 @@ public class PersistentTopicsBase extends AdminResource {
                                             // For all other exception,
                                             // we fail the delete partition method even if a single
                                             // partition is failed to be deleted
-                                            if (log.isDebugEnabled()) {
-                                                log.debug("[{}] Partition not found: {}", clientAppId(),
-                                                        topicNamePartition);
-                                            }
-                                            future.complete(null);
+                                                log.debug()
+                                                        .attr("topic", topicNamePartition)
+                                                        .log("Partition not found");
+                                                                                        future.complete(null);
                                         } else {
-                                            log.error("[{}] Failed to delete partition {}", clientAppId(),
-                                                    topicNamePartition, realCause);
+                                            log.error()
+                                                    .attr("partition", topicNamePartition)
+                                                    .exceptionMessage(realCause)
+                                                    .log("Failed to delete partition");
                                             future.completeExceptionally(realCause);
                                         }
                                     } else {
@@ -874,8 +913,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 });
                         return future;
                     } catch (PulsarServerException ex) {
-                        log.error("[{}] Failed to get admin client while delete partition {}",
-                                clientAppId(), topicNamePartition, ex);
+                        log.error()
+                                .attr("partition", topicNamePartition)
+                                .exception(ex)
+                                .log("Failed to get admin client while delete partition");
                         return FutureUtil.failedFuture(ex);
                     }
                 }).collect(Collectors.toList()));
@@ -888,15 +929,21 @@ public class PersistentTopicsBase extends AdminResource {
                     if (ex != null){
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                         if (realCause instanceof MetadataStoreException.NotFoundException) {
-                            log.warn("Namespace policies of {} not found", topicName.getNamespaceObject());
+                            log.warn()
+                                    .attr("namespace", topicName.getNamespaceObject())
+                                    .log("Namespace policies not found");
                             future.complete(null);
                         } else {
-                            log.error("Failed to delete authentication policies for partitioned topic {}",
-                                    topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to delete authentication policies for partitioned topic");
                             future.completeExceptionally(realCause);
                         }
                     } else {
-                        log.info("Successfully delete authentication policies for partitioned topic {}", topicName);
+                        log.info()
+                                .attr("topic", topicName)
+                                .log("Successfully delete authentication policies for partitioned topic");
                         future.complete(null);
                     }
                 });
@@ -904,7 +951,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalUnloadTopic(AsyncResponse asyncResponse, boolean authoritative) {
-        log.info("[{}] Unloading topic {}", clientAppId(), topicName);
+        log.info().attr("topic", topicName).log("Unloading topic");
         validateTopicOperationAsync(topicName, TopicOperation.UNLOAD)
         .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName))
         .thenAccept(__ -> {
@@ -926,8 +973,10 @@ public class PersistentTopicsBase extends AdminResource {
                                        futures.add(pulsar().getAdminClient().topics().unloadAsync(
                                                topicNamePartition.toString()));
                                    } catch (Exception e) {
-                                       log.error("[{}] Failed to unload topic {}", clientAppId(),
-                                               topicNamePartition, e);
+                                       log.error()
+                                               .attr("topic", topicNamePartition)
+                                               .exception(e)
+                                               .log("Failed to unload topic");
                                        asyncResponse.resume(new RestException(e));
                                        return;
                                    }
@@ -941,8 +990,10 @@ public class PersistentTopicsBase extends AdminResource {
                                        } else if (th instanceof WebApplicationException) {
                                            asyncResponse.resume(th);
                                        } else {
-                                           log.error("[{}] Failed to unload topic {}", clientAppId(), topicName,
-                                                   exception);
+                                           log.error()
+                                                   .attr("topic", topicName)
+                                                   .exception(exception)
+                                                   .log("Failed to unload topic");
                                            asyncResponse.resume(new RestException(exception));
                                        }
                                    } else {
@@ -956,8 +1007,10 @@ public class PersistentTopicsBase extends AdminResource {
                        }).exceptionally(ex -> {
                            // If the exception is not redirect exception we need to log it.
                            if (isNot307And404Exception(ex)) {
-                               log.error("[{}] Failed to get partitioned metadata while unloading topic {}",
-                                       clientAppId(), topicName, ex);
+                               log.error()
+                                       .attr("topic", topicName)
+                                       .exception(ex)
+                                       .log("Failed to get partitioned metadata while unloading topic");
                            }
                            resumeAsyncResponseExceptionally(asyncResponse, ex);
                            return null;
@@ -966,8 +1019,10 @@ public class PersistentTopicsBase extends AdminResource {
        }).exceptionally(ex -> {
            // If the exception is not redirect exception we need to log it.
            if (isNot307And404Exception(ex)) {
-               log.error("[{}] Failed to validate the global namespace ownership while unloading topic {}",
-                       clientAppId(), topicName, ex);
+               log.error()
+                       .attr("topic", topicName)
+                       .exception(ex)
+                       .log("Failed to validate the global namespace ownership while unloading topic");
            }
            resumeAsyncResponseExceptionally(asyncResponse, ex);
            return null;
@@ -1126,13 +1181,18 @@ public class PersistentTopicsBase extends AdminResource {
                         .thenCompose(__ -> getTopicReferenceAsync(topicName))
                         .thenCompose(topic -> topic.close(false))
                         .thenRun(() -> {
-                            log.info("[{}] Successfully unloaded topic {}", clientAppId(), topicName);
+                            log.info()
+                                    .attr("topic", topicName)
+                                    .log("Successfully unloaded topic");
                             asyncResponse.resume(Response.noContent().build());
                         })
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to unload topic {}, {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exceptionMessage(ex)
+                                .log("Failed to unload topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1146,14 +1206,18 @@ public class PersistentTopicsBase extends AdminResource {
                         .removeTransactionMetadataStore(
                                 TransactionCoordinatorID.get(topicName.getPartitionIndex())))
                 .thenRun(() -> {
-                    log.info("[{}] Successfully unloaded tc {}", clientAppId(), topicName.getPartitionIndex());
+                    log.info()
+                            .attr("tc", topicName.getPartitionIndex())
+                            .log("Successfully unloaded tc");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to unload tc {},{}", clientAppId(),
-                                topicName.getPartitionIndex(), ex);
+                        log.error()
+                                .attr("tc", topicName.getPartitionIndex())
+                                .exceptionMessage(ex)
+                                .log("Failed to unload tc");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1211,10 +1275,8 @@ public class PersistentTopicsBase extends AdminResource {
                                                 .map(item -> topicName.getPartition(item.getKey()).toString())
                                                 .collect(Collectors.toList())
                                 ).thenAccept(topics -> {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("activeTopics : {}", topics);
-                                    }
-                                    topics.forEach(topic -> {
+                                        log.debug().attr("activeTopics", topics).log("Active topics");
+                                                                        topics.forEach(topic -> {
                                         try {
                                             CompletableFuture<List<String>> subscriptionsAsync = pulsar()
                                                     .getAdminClient()
@@ -1238,8 +1300,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 resumeAsyncResponse(asyncResponse, subscriptions, subscriptionFutures);
                             }
                         } catch (Exception e) {
-                            log.error("[{}] Failed to get list of subscriptions for {}",
-                                    clientAppId(), topicName, e);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(e)
+                                    .log("Failed to get list of subscriptions");
                             asyncResponse.resume(e);
                         }
                     } else {
@@ -1248,8 +1312,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get partitioned topic metadata while get"
-                                + " subscriptions for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get partitioned topic metadata while get subscriptions for topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1258,8 +1324,11 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to validate the global namespace/topic ownership while get subscriptions"
-                        + " for topic {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to validate the global namespace/topic ownership while get subscriptions for"
+                                + " topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1270,8 +1339,10 @@ public class PersistentTopicsBase extends AdminResource {
                                      List<CompletableFuture<Object>> subscriptionFutures) {
         FutureUtil.waitForAll(subscriptionFutures).whenComplete((r, ex) -> {
             if (ex != null) {
-                log.warn("[{}] Failed to get list of subscriptions for {}: {}", clientAppId(),
-                        topicName, ex.getMessage());
+                log.warn()
+                        .attr("topic", topicName)
+                        .exceptionMessage(ex)
+                        .log("Failed to get list of subscriptions");
                 if (ex instanceof PulsarAdminException) {
                     PulsarAdminException pae = (PulsarAdminException) ex;
                     if (pae.getStatusCode() == Status.NOT_FOUND.getStatusCode()) {
@@ -1298,7 +1369,10 @@ public class PersistentTopicsBase extends AdminResource {
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get list of subscriptions for {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get list of subscriptions");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1358,8 +1432,10 @@ public class PersistentTopicsBase extends AdminResource {
                                             }
                                         }));
                             } catch (PulsarServerException e) {
-                                log.error("[{}] Failed to get admin client while get managed info for {}" ,
-                                        clientAppId(), topicNamePartition, e);
+                                log.error()
+                                        .attr("topic", topicNamePartition)
+                                        .exception(e)
+                                        .log("Failed to get admin client while get managed info");
                                 throw new RestException(e);
                             }
                         }
@@ -1370,7 +1446,10 @@ public class PersistentTopicsBase extends AdminResource {
                                     asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                             getTopicNotFoundErrorMessage(topicName.toString())));
                                 } else {
-                                    log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, t);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .exception(t)
+                                            .log("Failed to get managed info");
                                     asyncResponse.resume(new RestException(t));
                                 }
                             } else {
@@ -1391,8 +1470,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get partitioned metadata while get managed info for {}",
-                                clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get partitioned metadata while getting managed info");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1401,8 +1482,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to validate the global namespace ownership while get managed info for {}",
-                        clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to validate the global namespace ownership while getting managed info");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1435,7 +1518,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 return null;
                             });
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get managed info for {}", clientAppId(), topicName, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to get managed info");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1522,7 +1608,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to get partitioned internal stats for {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to get partitioned internal stats for");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1573,7 +1662,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to get partitioned internal stats for {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to get partitioned internal stats for");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1687,15 +1779,21 @@ public class PersistentTopicsBase extends AdminResource {
                         result.setFilterRejectedMessages(rawResult.getFilterRejectedMessages());
                         result.setFilterRescheduledMessages(rawResult.getFilterRescheduledMessages());
                         result.setAborted(rawResult.getScanOutcome() != ScanOutcome.COMPLETED);
-                        log.info("[{}] analyzeBacklog topic {} subscription {} result {}", clientAppId(), subName,
-                            topicName, result);
+                        log.info()
+                                .attr("topic", subName)
+                                .attr("topic", topicName)
+                                .attr("result", result)
+                                .log("analyzeBacklog topic subscription result");
                         asyncResponse.resume(result);
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to analyze subscription backlog {} {}",
-                                clientAppId(), topicName, subName, cause);
+                        log.error()
+                                .attr("backlog", topicName)
+                                .attr("subscription", subName)
+                                .exception(cause)
+                                .log("Failed to analyze subscription backlog");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, cause);
                     return null;
@@ -1715,13 +1813,20 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                     return sub.updateSubscriptionProperties(subscriptionProperties);
                 }).thenRun(() -> {
-                    log.info("[{}][{}] Updated subscription {}", clientAppId(), topicName, subName);
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("subscription", subName)
+                            .log("Updated subscription");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable cause = ex.getCause();
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to update subscription {} {}", clientAppId(), topicName, subName, cause);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(cause)
+                                .log("Failed to update subscription");
                     }
                     asyncResponse.resume(new RestException(cause));
                     return null;
@@ -1749,7 +1854,11 @@ public class PersistentTopicsBase extends AdminResource {
                     Throwable cause = ex.getCause();
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to update subscription {} {}", clientAppId(), topicName, subName, cause);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(cause)
+                                .log("Failed to update subscription");
                     }
                     asyncResponse.resume(new RestException(cause));
                     return null;
@@ -1779,8 +1888,11 @@ public class PersistentTopicsBase extends AdminResource {
                                     .skipAllMessagesAsync(topicNamePartition.toString(),
                                         subName));
                             } catch (Exception e) {
-                                log.error("[{}] Failed to skip all messages {} {}",
-                                    clientAppId(), topicNamePartition, subName, e);
+                                log.error()
+                                        .attr("messages", topicNamePartition)
+                                        .attr("subscription", subName)
+                                        .exception(e)
+                                        .log("Failed to skip all messages");
                                 asyncResponse.resume(new RestException(e));
                                 return CompletableFuture.completedFuture(null);
                             }
@@ -1794,8 +1906,11 @@ public class PersistentTopicsBase extends AdminResource {
                                         new RestException(Status.NOT_FOUND,
                                                 getSubNotFoundErrorMessage(topicName.toString(), subName)));
                                 } else {
-                                    log.error("[{}] Failed to skip all messages {} {}",
-                                        clientAppId(), topicName, subName, t);
+                                    log.error()
+                                            .attr("messages", topicName)
+                                            .attr("subscription", subName)
+                                            .exception(t)
+                                            .log("Failed to skip all messages");
                                     asyncResponse.resume(new RestException(t));
                                 }
                                 return null;
@@ -1811,8 +1926,11 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to skip all messages for subscription {} on topic {}",
-                        clientAppId(), subName, topicName, ex);
+                log.error()
+                        .attr("subscription", subName)
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to skip all messages for subscription on topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1826,11 +1944,17 @@ public class PersistentTopicsBase extends AdminResource {
                     BiConsumer<Void, Throwable> biConsumer = (v, ex) -> {
                         if (ex != null) {
                             asyncResponse.resume(new RestException(ex));
-                            log.error("[{}] Failed to skip all messages {} {}",
-                                clientAppId(), topicName, subName, ex);
+                            log.error()
+                                    .attr("messages", topicName)
+                                    .attr("subscription", subName)
+                                    .exception(ex)
+                                    .log("Failed to skip all messages");
                         } else {
                             asyncResponse.resume(Response.noContent().build());
-                            log.info("[{}] Cleared backlog on {} {}", clientAppId(), topicName, subName);
+                            log.info()
+                                    .attr("topic", topicName)
+                                    .attr("subscription", subName)
+                                    .log("Cleared backlog");
                         }
                     };
                     if (subName.startsWith(topic.getReplicatorPrefix())) {
@@ -1855,8 +1979,11 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to skip all messages for subscription {} on topic {}",
-                                clientAppId(), subName, topicName, ex);
+                        log.error()
+                                .attr("subscription", subName)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to skip all messages for subscription on topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1872,7 +1999,11 @@ public class PersistentTopicsBase extends AdminResource {
         .thenCompose(partitionMetadata -> {
              if (partitionMetadata.partitions > 0) {
                  String msg = "Skip messages on a partitioned topic is not allowed";
-                 log.warn("[{}] {} {} {}", clientAppId(), msg, topicName, subName);
+                 log.warn()
+                         .attr("msg", msg)
+                         .attr("topic", topicName)
+                         .attr("subscription", subName)
+                         .log("");
                  throw new  RestException(Status.METHOD_NOT_ALLOWED, msg);
              }
              return getTopicReferenceAsync(topicName).thenCompose(t -> {
@@ -1890,8 +2021,11 @@ public class PersistentTopicsBase extends AdminResource {
                                  new RestException(Status.NOT_FOUND, "Replicator not found"));
                      }
                      return repl.skipMessages(numMessages).thenAccept(unused -> {
-                         log.info("[{}] Skipped {} messages on {} {}", clientAppId(), numMessages,
-                                 topicName, subName);
+                         log.info()
+                                 .attr("skipped", numMessages)
+                                 .attr("topic", topicName)
+                                 .attr("subscription", subName)
+                                 .log("Skipped messages");
                          asyncResponse.resume(Response.noContent().build());
                          }
                      );
@@ -1903,8 +2037,11 @@ public class PersistentTopicsBase extends AdminResource {
                                          getSubNotFoundErrorMessage(topicName.toString(), subName)));
                      }
                      return sub.skipMessages(numMessages).thenAccept(unused -> {
-                         log.info("[{}] Skipped {} messages on {} {}", clientAppId(), numMessages,
-                                 topicName, subName);
+                         log.info()
+                                 .attr("skipped", numMessages)
+                                 .attr("topic", topicName)
+                                 .attr("subscription", subName)
+                                 .log("Skipped messages");
                          asyncResponse.resume(Response.noContent().build());
                          }
                      );
@@ -1914,8 +2051,12 @@ public class PersistentTopicsBase extends AdminResource {
         ).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to skip {} messages {} {}", clientAppId(), numMessages, topicName,
-                        subName, ex);
+                log.error()
+                        .attr("skip", numMessages)
+                        .attr("messages", topicName)
+                        .attr("subscription", subName)
+                        .exception(ex)
+                        .log("Failed to skip messages");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -1945,9 +2086,11 @@ public class PersistentTopicsBase extends AdminResource {
                                     .expireMessagesForAllSubscriptionsAsync(
                                             topicNamePartition.toString(), expireTimeInSeconds));
                         } catch (Exception e) {
-                            log.error("[{}] Failed to expire messages up to {} on {}",
-                                    clientAppId(), expireTimeInSeconds,
-                                    topicNamePartition, e);
+                            log.error()
+                                    .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                    .attr("topic", topicNamePartition)
+                                    .exception(e)
+                                    .log("Failed to expire messages");
                             asyncResponse.resume(new RestException(e));
                             return;
                         }
@@ -1957,11 +2100,17 @@ public class PersistentTopicsBase extends AdminResource {
                         if (exception != null) {
                             Throwable t = FutureUtil.unwrapCompletionException(exception);
                             if (t instanceof PulsarAdminException) {
-                                log.warn("[{}] Failed to expire messages up to {} on {}: {}", clientAppId(),
-                                        expireTimeInSeconds, topicName, t.toString());
+                                log.warn()
+                                        .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                        .attr("topic", topicName)
+                                        .exceptionMessage(t)
+                                        .log("Failed to expire messages");
                             } else {
-                                log.error("[{}] Failed to expire messages up to {} on {}", clientAppId(),
-                                        expireTimeInSeconds, topicName, t);
+                                log.error()
+                                        .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                        .attr("topic", topicName)
+                                        .exception(t)
+                                        .log("Failed to expire messages");
                             }
                             resumeAsyncResponseExceptionally(asyncResponse, t);
                             return null;
@@ -1978,8 +2127,10 @@ public class PersistentTopicsBase extends AdminResource {
         ).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to expire messages for all subscription on topic {}", clientAppId(), topicName,
-                        ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to expire messages for all subscription on topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -2017,8 +2168,11 @@ public class PersistentTopicsBase extends AdminResource {
                             futures.add(internalExpireMessagesByTimestampForSinglePartitionAsync(partitionMetadata,
                                     subNames.get(i), expireTimeInSeconds));
                         } catch (Exception e) {
-                            log.error("[{}] Failed to expire messages for all subscription up to {} on {}",
-                                    clientAppId(), expireTimeInSeconds, topicName, e);
+                            log.error()
+                                    .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                    .attr("topic", topicName)
+                                    .exception(e)
+                                    .log("Failed to expire messages for all subscriptions");
                             asyncResponse.resume(new RestException(e));
                             return;
                         }
@@ -2028,11 +2182,17 @@ public class PersistentTopicsBase extends AdminResource {
                         if (exception != null) {
                             Throwable throwable = FutureUtil.unwrapCompletionException(exception);
                             if (throwable instanceof RestException) {
-                                log.warn("[{}] Failed to expire messages for all subscription up to {} on {}: {}",
-                                        clientAppId(), expireTimeInSeconds, topicName, throwable.toString());
+                                log.warn()
+                                        .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                        .attr("topic", topicName)
+                                        .exceptionMessage(throwable)
+                                        .log("Failed to expire messages for all subscriptions");
                             } else {
-                                log.error("[{}] Failed to expire messages for all subscription up to {} on {}",
-                                        clientAppId(), expireTimeInSeconds, topicName, throwable);
+                                log.error()
+                                        .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                        .attr("topic", topicName)
+                                        .exception(throwable)
+                                        .log("Failed to expire messages for all subscriptions");
                             }
                             resumeAsyncResponseExceptionally(asyncResponse, throwable);
                             return null;
@@ -2044,8 +2204,11 @@ public class PersistentTopicsBase extends AdminResource {
                 ).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to expire messages for all subscription up to {} on {}", clientAppId(),
-                        expireTimeInSeconds, topicName, ex);
+                log.error()
+                        .attr("expireTimeInSeconds", expireTimeInSeconds)
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to expire messages for all subscriptions");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -2091,8 +2254,12 @@ public class PersistentTopicsBase extends AdminResource {
                                             failureCount.incrementAndGet();
                                             partitionException.set(ex);
                                         } else {
-                                            log.warn("[{}] [{}] Failed to reset cursor on subscription {} to time {}",
-                                                clientAppId(), topicNamePartition, subName, timestamp, ex);
+                                            log.warn()
+                                                    .attr("topicNamePartition", topicNamePartition)
+                                                    .attr("subscription", subName)
+                                                    .attr("time", timestamp)
+                                                    .exception(ex)
+                                                    .log("Failed to reset cursor on subscription to time");
                                             future.completeExceptionally(ex);
                                             return null;
                                         }
@@ -2105,8 +2272,12 @@ public class PersistentTopicsBase extends AdminResource {
                                     return null;
                                 });
                         } catch (Exception e) {
-                            log.warn("[{}] [{}] Failed to reset cursor on subscription {} to time {}", clientAppId(),
-                                topicNamePartition, subName, timestamp, e);
+                            log.warn()
+                                    .attr("topicNamePartition", topicNamePartition)
+                                    .attr("subscription", subName)
+                                    .attr("time", timestamp)
+                                    .exception(e)
+                                    .log("Failed to reset cursor on subscription to time");
                             future.completeExceptionally(e);
                         }
                     }
@@ -2114,13 +2285,20 @@ public class PersistentTopicsBase extends AdminResource {
                     return future.whenComplete((r, ex) -> {
                         // report an error to user if unable to reset for all partitions
                         if (failureCount.get() == numPartitions) {
-                            log.warn("[{}] [{}] Failed to reset cursor on subscription {} to time {}",
-                                clientAppId(), topicName,
-                                subName, timestamp, partitionException.get());
+                            log.warn()
+                                    .attr("topic", topicName)
+                                    .attr("subscription", subName)
+                                    .attr("time", timestamp)
+                                    .attr("get", partitionException.get())
+                                    .log("Failed to reset cursor on subscription to time");
                             throw new RestException(Status.PRECONDITION_FAILED, partitionException.get().getMessage());
                         } else if (failureCount.get() > 0) {
-                            log.warn("[{}] [{}] Partial errors for reset cursor on subscription {} to time {}",
-                                clientAppId(), topicName, subName, timestamp, partitionException.get());
+                            log.warn()
+                                    .attr("topic", topicName)
+                                    .attr("subscription", subName)
+                                    .attr("time", timestamp)
+                                    .attr("get", partitionException.get())
+                                    .log("Partial errors for reset cursor on subscription to time");
                         }
                     });
                 } else {
@@ -2134,8 +2312,11 @@ public class PersistentTopicsBase extends AdminResource {
         return validateTopicOwnershipAsync(topicName, authoritative)
             .thenCompose(__ -> validateTopicOperationAsync(topicName, TopicOperation.RESET_CURSOR, subName))
             .thenCompose(__ -> {
-                log.info("[{}] [{}] Received reset cursor on subscription {} to time {}",
-                    clientAppId(), topicName, subName, timestamp);
+                log.info()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("time", timestamp)
+                        .log("Received reset cursor on subscription to time");
                 return getTopicReferenceAsync(topicName);
             })
             .thenCompose(topic -> {
@@ -2147,8 +2328,11 @@ public class PersistentTopicsBase extends AdminResource {
                 return sub.resetCursor(timestamp);
             })
             .thenRun(() ->
-                log.info("[{}][{}] Reset cursor on subscription {} to time {}",
-                    clientAppId(), topicName, subName, timestamp));
+                log.info()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("time", timestamp)
+                        .log("Reset cursor on subscription to time"));
     }
 
     protected void internalCreateSubscription(AsyncResponse asyncResponse, String subscriptionName,
@@ -2157,8 +2341,12 @@ public class PersistentTopicsBase extends AdminResource {
         .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName))
         .thenAccept(__ -> {
             final MessageIdImpl targetMessageId = messageId == null ? (MessageIdImpl) MessageId.latest : messageId;
-            log.info("[{}][{}] Creating subscription {} at message id {} with properties {}", clientAppId(),
-                    topicName, subscriptionName, targetMessageId, properties);
+            log.info()
+                    .attr("topic", topicName)
+                    .attr("subscription", subscriptionName)
+                    .attr("messageId", targetMessageId)
+                    .attr("properties", properties)
+                    .log("Creating subscription at message id with properties");
             // If the topic name is a partition name, no need to get partition topic metadata again
             if (topicName.isPartitioned()) {
                 internalCreateSubscriptionForNonPartitionedTopic(asyncResponse,
@@ -2200,8 +2388,12 @@ public class PersistentTopicsBase extends AdminResource {
                                                     return null;
                                                 });
                                     } catch (Exception e) {
-                                        log.warn("[{}] [{}] Failed to create subscription {} at message id {}",
-                                              clientAppId(), topicNamePartition, subscriptionName, targetMessageId, e);
+                                        log.warn()
+                                                .attr("topicNamePartition", topicNamePartition)
+                                                .attr("subscription", subscriptionName)
+                                                .attr("messageId", targetMessageId)
+                                                .exception(e)
+                                                .log("Failed to create subscription at message id");
                                         future.completeExceptionally(e);
                                     }
                                 }
@@ -2218,9 +2410,12 @@ public class PersistentTopicsBase extends AdminResource {
                                     }
 
                                     if (partitionException.get() != null) {
-                                        log.warn("[{}] [{}] Failed to create subscription {} at message id {}",
-                                                clientAppId(), topicName,
-                                                subscriptionName, targetMessageId, partitionException.get());
+                                        log.warn()
+                                                .attr("topic", topicName)
+                                                .attr("subscription", subscriptionName)
+                                                .attr("messageId", targetMessageId)
+                                                .exceptionMessage(partitionException.get())
+                                                .log("Failed to create subscription");
                                         if (partitionException.get() instanceof PulsarAdminException) {
                                             asyncResponse.resume(
                                                     new RestException((PulsarAdminException) partitionException.get()));
@@ -2241,8 +2436,11 @@ public class PersistentTopicsBase extends AdminResource {
                         })).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to create subscription {} on topic {}",
-                                clientAppId(), subscriptionName, topicName, ex);
+                        log.error()
+                                .attr("subscription", subscriptionName)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to create subscription on topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2251,8 +2449,11 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to create subscription {} on topic {}",
-                        clientAppId(), subscriptionName, topicName, ex);
+                log.error()
+                        .attr("subscription", subscriptionName)
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to create subscription on topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -2288,14 +2489,21 @@ public class PersistentTopicsBase extends AdminResource {
             return subscription.resetCursor(
                     PositionFactory.create(targetMessageId.getLedgerId(), targetMessageId.getEntryId()));
         }).thenRun(() -> {
-            log.info("[{}][{}] Successfully created subscription {} at message id {}", clientAppId(),
-                    topicName, subscriptionName, targetMessageId);
+            log.info()
+                    .attr("topic", topicName)
+                    .attr("subscription", subscriptionName)
+                    .attr("messageId", targetMessageId)
+                    .log("Successfully created subscription at message id");
             asyncResponse.resume(Response.noContent().build());
         }).exceptionally(ex -> {
             Throwable t = (ex instanceof CompletionException ? ex.getCause() : ex);
             if (!(t instanceof WebApplicationException)) {
-                log.warn("[{}][{}] Failed to create subscription {} at message id {}", clientAppId(), topicName,
-                        subscriptionName, targetMessageId, t);
+                log.warn()
+                        .attr("topic", topicName)
+                        .attr("subscription", subscriptionName)
+                        .attr("messageId", targetMessageId)
+                        .exception(t)
+                        .log("Failed to create subscription at message id");
             }
 
             if (t instanceof SubscriptionInvalidCursorPosition) {
@@ -2333,9 +2541,11 @@ public class PersistentTopicsBase extends AdminResource {
                                         .updateSubscriptionPropertiesAsync(topicNamePartition.toString(),
                                                 subName, subscriptionProperties));
                             } catch (Exception e) {
-                                log.error("[{}] Failed to update properties for subscription {} {}",
-                                        clientAppId(), topicNamePartition, subName,
-                                        e);
+                                log.error()
+                                        .attr("topic", topicNamePartition)
+                                        .attr("subscription", subName)
+                                        .exception(e)
+                                        .log("Failed to update properties for subscription");
                                 asyncResponse.resume(new RestException(e));
                                 return;
                             }
@@ -2353,8 +2563,11 @@ public class PersistentTopicsBase extends AdminResource {
                                             "Subscription has active connected consumers"));
                                     return null;
                                 } else {
-                                    log.error("[{}] Failed to update properties for subscription {} {}",
-                                            clientAppId(), topicName, subName, t);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .attr("subscription", subName)
+                                            .exception(t)
+                                            .log("Failed to update properties for subscription");
                                     asyncResponse.resume(new RestException(t));
                                     return null;
                                 }
@@ -2368,8 +2581,11 @@ public class PersistentTopicsBase extends AdminResource {
                                 subscriptionProperties, authoritative);
                     }
                 }, pulsar().getExecutor()).exceptionally(ex -> {
-                    log.error("[{}] Failed to update properties for subscription {} from topic {}",
-                            clientAppId(), subName, topicName, ex);
+                    log.error()
+                            .attr("subscription", subName)
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to update properties for subscription from topic");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2377,8 +2593,11 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to update subscription {} from topic {}",
-                        clientAppId(), subName, topicName, ex);
+                log.error()
+                        .attr("subscription", subName)
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to update subscription from topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -2412,8 +2631,11 @@ public class PersistentTopicsBase extends AdminResource {
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to analyze back log of subscription {} from topic {}",
-                                clientAppId(), subName, topicName, ex);
+                        log.error()
+                                .attr("subscription", subName)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to analyze back log of subscription from topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2441,9 +2663,11 @@ public class PersistentTopicsBase extends AdminResource {
                                         .getSubscriptionPropertiesAsync(topicNamePartition.toString(),
                                                 subName));
                             } catch (Exception e) {
-                                log.error("[{}] Failed to update properties for subscription {} {}",
-                                        clientAppId(), topicNamePartition, subName,
-                                        e);
+                                log.error()
+                                        .attr("topic", topicNamePartition)
+                                        .attr("subscription", subName)
+                                        .exception(e)
+                                        .log("Failed to update properties for subscription");
                                 asyncResponse.resume(new RestException(e));
                                 return;
                             }
@@ -2457,8 +2681,11 @@ public class PersistentTopicsBase extends AdminResource {
                                             getSubNotFoundErrorMessage(topicName.toString(), subName)));
                                     return null;
                                 } else {
-                                    log.error("[{}] Failed to get properties for subscription {} {}",
-                                            clientAppId(), topicName, subName, t);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .attr("subscription", subName)
+                                            .exception(t)
+                                            .log("Failed to get properties for subscription");
                                     asyncResponse.resume(new RestException(t));
                                     return null;
                                 }
@@ -2483,8 +2710,11 @@ public class PersistentTopicsBase extends AdminResource {
                                 authoritative);
                     }
                 }, pulsar().getExecutor()).exceptionally(ex -> {
-                    log.error("[{}] Failed to update properties for subscription {} from topic {}",
-                            clientAppId(), subName, topicName, ex);
+                    log.error()
+                            .attr("subscription", subName)
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to update properties for subscription from topic");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2492,8 +2722,11 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to update subscription {} from topic {}",
-                        clientAppId(), subName, topicName, ex);
+                log.error()
+                        .attr("subscription", subName)
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to update subscription from topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -2509,8 +2742,10 @@ public class PersistentTopicsBase extends AdminResource {
                 return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                         .thenCompose(topicMetadata -> {
                             if (topicMetadata.partitions > 0) {
-                                log.warn("[{}] Not supported operation on partitioned-topic {} {}",
-                                        clientAppId(), topicName, subName);
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subName)
+                                        .log("Not supported operation on partitioned-topic");
                                 throw new CompletionException(new RestException(Status.METHOD_NOT_ALLOWED,
                                         "Reset-cursor at position is not allowed for partitioned-topic"));
                             }
@@ -2521,8 +2756,11 @@ public class PersistentTopicsBase extends AdminResource {
             }
         }).thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName))
         .thenCompose(__ -> {
-            log.info("[{}][{}] received reset cursor on subscription {} to position {}", clientAppId(), topicName,
-                    subName, messageId);
+            log.info()
+                    .attr("topic", topicName)
+                    .attr("subscription", subName)
+                    .attr("position", messageId)
+                    .log("received reset cursor on subscription to position");
             return validateTopicOwnershipAsync(topicName, authoritative);
         }).thenCompose(ignore -> getTopicReferenceAsync(topicName))
         .thenAccept(topic -> {
@@ -2543,15 +2781,20 @@ public class PersistentTopicsBase extends AdminResource {
                 Position seekPosition = calculatePositionAckSet(isExcluded, bi, batchIndex,
                         messageId);
                 sub.resetCursor(seekPosition).thenRun(() -> {
-                    log.info("[{}][{}] successfully reset cursor on subscription {}"
-                                    + " to position {}", clientAppId(),
-                            topicName, subName, messageId);
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("subscription", subName)
+                            .attr("position", messageId)
+                            .log("successfully reset cursor on subscription to position");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     Throwable t = (ex instanceof CompletionException ? ex.getCause() : ex);
-                    log.warn("[{}][{}] Failed to reset cursor on subscription {}"
-                                    + " to position {}", clientAppId(),
-                            topicName, subName, messageId, t);
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("subscription", subName)
+                            .attr("position", messageId)
+                            .exception(t)
+                            .log("Failed to reset cursor on subscription to position");
                     if (t instanceof SubscriptionInvalidCursorPosition) {
                         asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
                                 "Unable to find position for position specified: "
@@ -2571,8 +2814,12 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.warn("[{}][{}] Failed to reset cursor on subscription {} to position {}",
-                        clientAppId(), topicName, subName, messageId, ex.getCause());
+                log.warn()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("position", messageId)
+                        .exception(ex.getCause())
+                        .log("Failed to reset cursor on subscription to position");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex.getCause());
             return null;
@@ -2626,8 +2873,12 @@ public class PersistentTopicsBase extends AdminResource {
             } catch (NullPointerException npe) {
                 batchSizeFuture.completeExceptionally(new RestException(Status.NOT_FOUND, "Message not found"));
             } catch (Exception exception) {
-                log.error("[{}] Failed to get message with ledgerId {} entryId {} from {}",
-                        clientAppId(), messageId.getLedgerId(), messageId.getEntryId(), topicName, exception);
+                log.error()
+                        .attr("ledgerId", messageId.getLedgerId())
+                        .attr("entryId", messageId.getEntryId())
+                        .attr("topic", topicName)
+                        .exception(exception)
+                        .log("Failed to get message");
                 batchSizeFuture.completeExceptionally(new RestException(exception));
             }
         } else {
@@ -2680,8 +2931,9 @@ public class PersistentTopicsBase extends AdminResource {
                 return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                         .thenAccept(topicMetadata -> {
                             if (topicMetadata.partitions > 0) {
-                                log.warn("[{}] Not supported getMessageById operation on partitioned-topic {}",
-                                        clientAppId(), topicName);
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .log("Not supported getMessageById operation on partitioned-topic");
                                 throw new RestException(Status.METHOD_NOT_ALLOWED,
                                         "GetMessageById is not allowed on partitioned-topic");
                             }
@@ -2748,7 +3000,9 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(__ -> getTopicReferenceAsync(topicName))
             .thenCompose(topic -> {
                 if (!(topic instanceof PersistentTopic)) {
-                    log.error("[{}] Not supported operation of non-persistent topic {} ", clientAppId(), topicName);
+                    log.error()
+                            .attr("topic", topicName)
+                            .log("Not supported operation of non-persistent topic");
                     throw new RestException(Status.METHOD_NOT_ALLOWED,
                         "Get message ID by timestamp on a non-persistent topic is not allowed");
                 }
@@ -2776,9 +3030,10 @@ public class PersistentTopicsBase extends AdminResource {
                 long entryTimestamp = entry.getEntryTimestamp();
                 return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
             } catch (Exception e) {
-                log.error("[{}] Error deserializing message for message position find",
-                    topicName,
-                    e);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(e)
+                        .log("Error deserializing message for message position find");
             } finally {
                 entry.release();
             }
@@ -2815,8 +3070,10 @@ public class PersistentTopicsBase extends AdminResource {
         .thenCompose(topic -> {
             CompletableFuture<Entry> entry;
             if (!(topic instanceof PersistentTopic)) {
-                log.error("[{}] Not supported operation of non-persistent topic {} {}", clientAppId(),
-                        topicName, subName);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .log("Not supported operation of non-persistent topic");
                 throw new RestException(Status.METHOD_NOT_ALLOWED,
                         "Peek messages on a non-persistent topic is not allowed");
             } else {
@@ -2839,8 +3096,12 @@ public class PersistentTopicsBase extends AdminResource {
             } catch (NullPointerException npe) {
                 throw new RestException(Status.NOT_FOUND, "Message not found");
             } catch (Exception exception) {
-                log.error("[{}] Failed to peek message at position {} from {} {}", clientAppId(),
-                        messagePosition, topicName, subName, exception);
+                log.error()
+                        .attr("position", messagePosition)
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .exception(exception)
+                        .log("Failed to peek message");
                 throw new RestException(exception);
             } finally {
                 if (entry != null) {
@@ -2874,7 +3135,9 @@ public class PersistentTopicsBase extends AdminResource {
         }).thenCompose(__ -> getTopicReferenceAsync(topicName))
         .thenCompose(topic -> {
             if (!(topic instanceof PersistentTopic)) {
-                log.error("[{}] Not supported operation of non-persistent topic {} ", clientAppId(), topicName);
+                log.error()
+                        .attr("topic", topicName)
+                        .log("Not supported operation of non-persistent topic");
                 throw new RestException(Status.METHOD_NOT_ALLOWED,
                         "Examine messages on a non-persistent topic is not allowed");
             }
@@ -2910,9 +3173,11 @@ public class PersistentTopicsBase extends AdminResource {
                 }, null);
                 return future.thenApply(entry -> Pair.of(entry, (PersistentTopic) topic));
             } catch (ManagedLedgerException exception) {
-                log.error("[{}] Failed to examine message at position {} from {} due to {}", clientAppId(),
-                        messagePosition,
-                        topicName, exception);
+                log.error()
+                        .attr("position", messagePosition)
+                        .attr("topic", topicName)
+                        .exceptionMessage(exception)
+                        .log("Failed to examine message");
                 throw new RestException(exception);
             }
         }).thenApply(entryTopicPair -> {
@@ -3158,8 +3423,9 @@ public class PersistentTopicsBase extends AdminResource {
                 return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                         .thenCompose(topicMetadata -> {
                             if (topicMetadata.partitions > 0) {
-                                log.warn("[{}] Not supported calculate backlog size operation on partitioned-topic {}",
-                                        clientAppId(), topicName);
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .log("Not supported calculate backlog size operation on partitioned-topic");
                                 asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
                                         "calculate backlog size is not allowed for partitioned-topic"));
                             }
@@ -3189,8 +3455,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (!isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to validate global namespace ownership "
-                        + "to get backlog size for topic {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to validate global namespace ownership to get backlog size for topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -3219,10 +3487,10 @@ public class PersistentTopicsBase extends AdminResource {
                     return getRetentionPoliciesAsync(topicName, topicPolicies)
                             .thenCompose(retentionPolicies -> {
                                 if (!checkBacklogQuota(backlogQuota, retentionPolicies)) {
-                                    log.warn(
-                                            "[{}] Failed to update backlog configuration for topic {}: conflicts with"
-                                                    + " retention quota",
-                                            clientAppId(), topicName);
+                                    log.warn()
+                                            .attr("topic", topicName)
+                                            .log("Failed to update backlog configuration for topic: conflicts with"
+                                                    + " retention quota");
                                     return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
                                             "Backlog Quota exceeds configured retention quota for topic. "
                                                     + "Please increase retention quota and retry"));
@@ -3239,13 +3507,12 @@ public class PersistentTopicsBase extends AdminResource {
                                             Map<String, BacklogQuotaImpl> backLogQuotaMap =
                                                     policies.getBackLogQuotaMap();
                                             try {
-                                                log.info(
-                                                        "[{}] Successfully updated backlog quota map: namespace={}, "
-                                                                + "topic={}, map={}",
-                                                        clientAppId(),
-                                                        namespaceName,
-                                                        topicName.getLocalName(),
-                                                        objectWriter().writeValueAsString(backLogQuotaMap));
+                                                log.info()
+                                                        .attr("namespace", namespaceName)
+                                                        .attr("topic", topicName.getLocalName())
+                                                        .attr("backlogQuotaMap",
+                                                                objectWriter().writeValueAsString(backLogQuotaMap))
+                                                        .log("Successfully updated backlog quota map");
                                             } catch (JsonProcessingException ignore) {
                                             }
                                         });
@@ -3314,9 +3581,12 @@ public class PersistentTopicsBase extends AdminResource {
                     return FutureUtil.waitForAll(futures);
                 }).thenCompose(__ -> {
                     if (!pulsar().getConfig().isCreateTopicToRemoteClusterForReplication()) {
-                        log.info("[{}] Skip creating partitioned for topic {} for the remote clusters {}",
-                                clientAppId(), topicName, replicationClustersSet.stream().filter(v ->
-                                        !pulsar().getConfig().getClusterName().equals(v)).collect(Collectors.toList()));
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("clusters", replicationClustersSet.stream().filter(v ->
+                                        !pulsar().getConfig().getClusterName().equals(v)).collect(Collectors
+                                                .toList())).log("Skip creating partitioned for topic for the remote"
+                                                        + " clusters");
                         return CompletableFuture.completedFuture(null);
                     }
                     // Sync to create partitioned topic on the remote cluster if needed.
@@ -3336,12 +3606,11 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, isGlobal,
                         false, policies -> {
                     policies.setReplicationClusters(clusterIds);
-                    log.info("[{}] Successfully set replication clusters for namespace={}, "
-                                    + "topic={}, clusters={}",
-                            clientAppId(),
-                            namespaceName,
-                            topicName.getLocalName(),
-                            policies.getReplicationClusters());
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("clusters", policies.getReplicationClusters())
+                            .log("Successfully set replication clusters");
                 })); // Replication clusters are typically local policy
     }
 
@@ -3350,11 +3619,10 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, isGlobal,
                         true, policies -> {
                     policies.setReplicationClusters(null);
-                    log.info("[{}] Successfully removed replication clusters for namespace={}, "
-                                    + "topic={}, clusters set to null",
-                            clientAppId(),
-                            namespaceName,
-                            topicName.getLocalName());
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .log("Successfully removed replication clusters (set to null)");
                 }));
     }
 
@@ -3404,9 +3672,11 @@ public class PersistentTopicsBase extends AdminResource {
         return pulsar().getTopicPoliciesService()
                 .updateTopicPoliciesAsync(topicName, isGlobal, expirationTimeToSet == null, policies -> {
                     policies.setSubscriptionExpirationTimeInMinutes(expirationTimeToSet);
-                    log.info("[{}] Successfully set topic subscription expiration time: namespace={}, "
-                                    + "topic={}, time={}",
-                            clientAppId(), namespaceName, topicName.getLocalName(), expirationTimeToSet);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("expirationTime", expirationTimeToSet)
+                            .log("Successfully set topic subscription expiration time");
                 });
     }
 
@@ -3420,8 +3690,11 @@ public class PersistentTopicsBase extends AdminResource {
         return pulsar().getTopicPoliciesService()
                 .updateTopicPoliciesAsync(topicName, isGlobal, ttlInSecondToSet == null, policies -> {
                     policies.setMessageTTLInSeconds(ttlInSecondToSet);
-                    log.info("[{}] Successfully set topic message ttl: namespace={}, topic={}, ttl={}",
-                            clientAppId(), namespaceName, topicName.getLocalName(), ttlInSecondToSet);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("ttl", ttlInSecondToSet)
+                            .log("Successfully set topic message ttl");
                 });
     }
 
@@ -3466,8 +3739,10 @@ public class PersistentTopicsBase extends AdminResource {
                                     backlogQuota = currentNamespacePolicies.backlog_quota_map.get(backlogQuotaType);
                                 }
                                 if (!checkBacklogQuota(backlogQuota, retentionToSet)) {
-                                    log.warn("[{}] Failed to update retention quota configuration for topic {}: "
-                                            + "conflicts with retention quota", clientAppId(), topicName);
+                                    log.warn()
+                                            .attr("topic", topicName)
+                                            .log("Failed to update retention quota configuration for topic:"
+                                                    + " conflicts with retention quota");
                                     return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
                                             "Retention Quota must exceed configured backlog quota for topic. "
                                                     + "Please increase retention quota and retry"));
@@ -3718,7 +3993,7 @@ public class PersistentTopicsBase extends AdminResource {
         if (topicName.isPartitioned()) {
             String msg = "Termination of a non-partitioned topic is not allowed using partitioned-terminate"
                     + ", please use terminate commands";
-            log.error("[{}] [{}] {}", clientAppId(), topicName, msg);
+            log.error().attr("topic", topicName).attr("msg", msg).log("");
             asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED, msg));
             return;
         }
@@ -3729,7 +4004,7 @@ public class PersistentTopicsBase extends AdminResource {
             if (partitionMetadata.partitions == 0) {
                 String msg = "Termination of a non-partitioned topic is not allowed using partitioned-terminate"
                         + ", please use terminate commands";
-                log.error("[{}] [{}] {}", clientAppId(), topicName, msg);
+                log.error().attr("topic", topicName).attr("msg", msg).log("");
                 asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED, msg));
                 return;
             }
@@ -3746,15 +4021,19 @@ public class PersistentTopicsBase extends AdminResource {
                                 .terminateTopicAsync(topicNamePartition.toString())
                                 .whenComplete((messageId, throwable) -> {
                                     if (throwable != null) {
-                                        log.error("[{}] Failed to terminate topic {}", clientAppId(),
-                                                topicNamePartition, throwable);
+                                        log.error()
+                                                .attr("topic", topicNamePartition)
+                                                .exception(throwable)
+                                                .log("Failed to terminate topic");
                                         asyncResponse.resume(new RestException(throwable));
                                     }
                                     messageIds.put(finalI, messageId);
                                 }));
                     } catch (Exception e) {
-                        log.error("[{}] Failed to terminate topic {}", clientAppId(), topicNamePartition,
-                                e);
+                        log.error()
+                                .attr("topic", topicNamePartition)
+                                .exception(e)
+                                .log("Failed to terminate topic");
                         throw new RestException(e);
                     }
                 }
@@ -3765,7 +4044,10 @@ public class PersistentTopicsBase extends AdminResource {
                             asyncResponse.resume(new RestException(Status.NOT_FOUND,
                                     getTopicNotFoundErrorMessage(topicName.toString())));
                         } else {
-                            log.error("[{}] Failed to terminate topic {}", clientAppId(), topicName, t);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(t)
+                                    .log("Failed to terminate topic");
                             asyncResponse.resume(new RestException(t));
                         }
                     }
@@ -3776,7 +4058,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to terminate topic {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to terminate topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -3812,9 +4097,11 @@ public class PersistentTopicsBase extends AdminResource {
                                                     .expireMessagesAsync(topicNamePartition.toString(),
                                                             subName, expireTimeInSeconds));
                                         } catch (Exception e) {
-                                            log.error("[{}] Failed to expire messages up to {} on {}",
-                                                    clientAppId(),
-                                                    expireTimeInSeconds, topicNamePartition, e);
+                                            log.error()
+                                                    .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                                    .attr("topic", topicNamePartition)
+                                                    .exception(e)
+                                                    .log("Failed to expire messages");
                                             asyncResponse.resume(new RestException(e));
                                             return;
                                         }
@@ -3830,14 +4117,17 @@ public class PersistentTopicsBase extends AdminResource {
                                                 return null;
                                             } else {
                                                 if (t instanceof PulsarAdminException) {
-                                                    log.warn("[{}] Failed to expire messages up "
-                                                            + "to {} on {}: {}", clientAppId(),
-                                                                    expireTimeInSeconds, topicName,
-                                                                            t.toString());
+                                                    log.warn()
+                                                            .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                                            .attr("topic", topicName)
+                                                            .exceptionMessage(t)
+                                                            .log("Failed to expire messages");
                                                 } else {
-                                                    log.error("[{}] Failed to expire messages up "
-                                                            + "to {} on {}", clientAppId(),
-                                                                    expireTimeInSeconds, topicName, t);
+                                                    log.error()
+                                                            .attr("expireTimeInSeconds", expireTimeInSeconds)
+                                                            .attr("topic", topicName)
+                                                            .exception(t)
+                                                            .log("Failed to expire messages");
                                                 }
                                                 resumeAsyncResponseExceptionally(asyncResponse, t);
                                                 return null;
@@ -3860,11 +4150,17 @@ public class PersistentTopicsBase extends AdminResource {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(cause)) {
                 if (cause instanceof RestException) {
-                    log.warn("[{}] Failed to expire messages up to {} on {}: {}", clientAppId(), expireTimeInSeconds,
-                            topicName, cause.toString());
+                    log.warn()
+                            .attr("expireTimeInSeconds", expireTimeInSeconds)
+                            .attr("topic", topicName)
+                            .exceptionMessage(cause)
+                            .log("Failed to expire messages");
                 } else {
-                    log.error("[{}] Failed to expire messages up to {} on {}", clientAppId(), expireTimeInSeconds,
-                            topicName, cause);
+                    log.error()
+                            .attr("expireTimeInSeconds", expireTimeInSeconds)
+                            .attr("topic", topicName)
+                            .exception(cause)
+                            .log("Failed to expire messages");
                 }
             }
             resumeAsyncResponseExceptionally(asyncResponse, cause);
@@ -3906,18 +4202,21 @@ public class PersistentTopicsBase extends AdminResource {
                     return;
                 }
                 if (messageExpirer.expireMessages(expireTimeInSeconds)) {
-                    log.info("[{}] Message expire started up to {} on {} {}", clientAppId(),
-                            expireTimeInSeconds, topicName, subName);
+                    log.info()
+                            .attr("expireTimeInSeconds", expireTimeInSeconds)
+                            .attr("topic", topicName)
+                            .attr("subscription", subName)
+                            .log("Message expire started up to on");
                     resultFuture.complete(null);
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Expire message by timestamp not issued on topic {} for subscription {} "
-                                + "due to ongoing message expiration not finished or subscription almost"
-                                + " catch up. If it's performed on a partitioned topic operation might "
-                                + "succeeded on other partitions, please check stats of individual "
-                                + "partition.", topicName, subName);
-                    }
-                    resultFuture.completeExceptionally(new RestException(Status.CONFLICT, "Expire message "
+                        log.debug()
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .log("Expire message by timestamp not issued:"
+                                        + " ongoing expiration or subscription"
+                                        + " almost caught up");
+                                        resultFuture.completeExceptionally(new RestException(Status.CONFLICT,
+                                                "Expire message "
                             + "by timestamp not issued on topic " + topicName + " for subscription "
                             + subName + " due to ongoing message expiration not finished or subscription "
                             + "almost catch  up. If it's performed on a partitioned topic operation might"
@@ -3938,7 +4237,11 @@ public class PersistentTopicsBase extends AdminResource {
         if (messageId.getPartitionIndex() != topicName.getPartitionIndex()) {
             String msg = "Invalid parameter for expire message by position, partition index of "
                     + "passed in message position doesn't match partition index for the topic";
-            log.warn("[{}] {} {}({}).", clientAppId(), msg, topicName, messageId);
+            log.warn()
+                    .attr("msg", msg)
+                    .attr("topic", topicName)
+                    .attr("messageId", messageId)
+                    .log(".");
             asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED, msg));
             return;
         }
@@ -3950,7 +4253,12 @@ public class PersistentTopicsBase extends AdminResource {
                         .thenCompose(topicMetadata -> {
                             if (topicMetadata.partitions > 0) {
                                 String msg = "Expire message at position is not supported for partitioned-topic";
-                                log.warn("[{}] {} {}({}) {}", clientAppId(), msg, topicName, messageId, subName);
+                                log.warn()
+                                        .attr("msg", msg)
+                                        .attr("topic", topicName)
+                                        .attr("messageId", messageId)
+                                        .attr("subscription", subName)
+                                        .log("");
                                 asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED, msg));
                             }
                             return CompletableFuture.completedFuture(null);
@@ -3961,15 +4269,22 @@ public class PersistentTopicsBase extends AdminResource {
         }).thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName))
         .thenCompose(__ -> validateTopicOwnershipAsync(topicName, authoritative))
         .thenCompose(__ -> {
-            log.info("[{}][{}] Received expire messages on subscription {} to position {}", clientAppId(),
-                    topicName, subName, messageId);
+            log.info()
+                    .attr("topic", topicName)
+                    .attr("subscription", subName)
+                    .attr("position", messageId)
+                    .log("Received expire messages on subscription to position");
             return internalExpireMessagesNonPartitionedTopicByPosition(asyncResponse, subName,
                     messageId, isExcluded, batchIndex);
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to expire messages up to {} on subscription {} to position {}",
-                        clientAppId(), topicName, subName, messageId, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("position", messageId)
+                        .exception(ex)
+                        .log("Failed to expire messages up to on subscription to position");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -4010,15 +4325,20 @@ public class PersistentTopicsBase extends AdminResource {
                     Position position = calculatePositionAckSet(isExcluded, bi, batchIndex, messageId);
                     try {
                         if (messageExpirer.expireMessages(position)) {
-                            log.info("[{}] Message expire started up to {} on {} {}", clientAppId(), position,
-                                    topicName, subName);
+                            log.info()
+                                    .attr("position", position)
+                                    .attr("topic", topicName)
+                                    .attr("subscription", subName)
+                                    .log("Message expire started up to on");
                         } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Expire message by position not issued on topic {} for subscription {} "
-                                        + "due to ongoing message expiration not finished or subscription almost "
-                                        + "catch up.", topicName, subName);
-                            }
-                            throw new RestException(Status.CONFLICT, "Expire message by position not issued on topic "
+                                log.debug()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subName)
+                                        .log("Expire message by position not issued:"
+                                                + " ongoing expiration or subscription"
+                                                + " almost caught up");
+                                throw new RestException(Status.CONFLICT,
+                                                                "Expire message by position not issued on topic "
                                     + topicName + " for subscription " + subName + " due to ongoing"
                                     + " message expiration not finished or invalid message position provided.");
                         }
@@ -4031,28 +4351,49 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(e -> {
                     Throwable throwable = FutureUtil.unwrapCompletionException(e);
                     if (throwable instanceof RestException) {
-                        log.warn("[{}] Failed to expire messages up to {} on {} with subscription {}: {}",
-                                clientAppId(), messageId, topicName, subName, throwable.toString());
+                        log.warn()
+                                .attr("messageId", messageId)
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exceptionMessage(throwable)
+                                .log("Failed to expire messages up to on with subscription");
                     } else {
-                        log.error("[{}] Failed to expire messages up to {} on {} with subscription {}", clientAppId(),
-                                messageId, topicName, subName, throwable);
+                        log.error()
+                                .attr("messageId", messageId)
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(throwable)
+                                .log("Failed to expire messages up to on with subscription");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, throwable);
                     return null;
                 });
             } catch (Exception e) {
-                log.warn("[{}][{}] Failed to expire messages up to {} on subscription {} to position {}",
-                        clientAppId(), topicName, messageId, subName, messageId, e);
+                log.warn()
+                        .attr("topic", topicName)
+                        .attr("messageId", messageId)
+                        .attr("subscription", subName)
+                        .attr("position", messageId)
+                        .exception(e)
+                        .log("Failed to expire messages up to on subscription to position");
                 resumeAsyncResponseExceptionally(asyncResponse, e);
             }
         }).exceptionally(ex -> {
             Throwable cause = FutureUtil.unwrapCompletionException(ex);
             if (cause instanceof RestException) {
-                log.warn("[{}] Failed to expire messages up to {} on subscription {} to position {}: {}", clientAppId(),
-                        topicName, subName, messageId, cause.toString());
+                log.warn()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("position", messageId)
+                        .exceptionMessage(cause)
+                        .log("Failed to expire messages up to on subscription to position");
             } else {
-                log.error("[{}] Failed to expire messages up to {} on subscription {} to position {}", clientAppId(),
-                        topicName, subName, messageId, cause);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .attr("position", messageId)
+                        .exception(cause)
+                        .log("Failed to expire messages up to on subscription to position");
             }
             resumeAsyncResponseExceptionally(asyncResponse, cause);
             return null;
@@ -4060,7 +4401,7 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     protected void internalTriggerCompaction(AsyncResponse asyncResponse, boolean authoritative) {
-        log.info("[{}] Trigger compaction on topic {}", clientAppId(), topicName);
+        log.info().attr("topic", topicName).log("Trigger compaction on topic");
         validateTopicOperationAsync(topicName, TopicOperation.COMPACT)
         .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName))
         .thenAccept(__ -> {
@@ -4082,8 +4423,10 @@ public class PersistentTopicsBase extends AdminResource {
                                         .topics()
                                         .triggerCompactionAsync(topicNamePartition.toString()));
                             } catch (Exception e) {
-                                log.error("[{}] Failed to trigger compaction on topic {}",
-                                        clientAppId(), topicNamePartition, e);
+                                log.error()
+                                        .attr("topic", topicNamePartition)
+                                        .exception(e)
+                                        .log("Failed to trigger compaction on topic");
                                 asyncResponse.resume(new RestException(e));
                                 return;
                             }
@@ -4099,8 +4442,10 @@ public class PersistentTopicsBase extends AdminResource {
                                     asyncResponse.resume(th);
                                     return null;
                                 } else {
-                                    log.error("[{}] Failed to trigger compaction on topic {}",
-                                            clientAppId(), topicName, exception);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .exception(exception)
+                                            .log("Failed to trigger compaction on topic");
                                     asyncResponse.resume(new RestException(exception));
                                     return null;
                                 }
@@ -4114,7 +4459,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to trigger compaction on topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4123,8 +4471,10 @@ public class PersistentTopicsBase extends AdminResource {
         }).exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to validate global namespace ownership to trigger compaction on topic {}",
-                        clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to validate global namespace ownership to trigger compaction on topic");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -4146,14 +4496,19 @@ public class PersistentTopicsBase extends AdminResource {
                         resumeAsyncResponseExceptionally(asyncResponse,
                             new RestException(Status.CONFLICT, ex.getMessage()));
                     } else {
-                        log.error("[{}] Failed to trigger compaction on topic {}", clientAppId(),
-                            topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to trigger compaction on topic");
                         resumeAsyncResponseExceptionally(asyncResponse, new RestException(ex));
                     }
                 })).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to trigger compaction for {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to trigger compaction for");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4181,14 +4536,17 @@ public class PersistentTopicsBase extends AdminResource {
                                 new RestException(Status.CONFLICT, e.getMessage()));
                         return;
                     } catch (Exception e) {
-                        log.warn("Unexpected error triggering offload", e);
+                        log.warn().exception(e).log("Unexpected error triggering offload");
                         resumeAsyncResponseExceptionally(asyncResponse, new RestException(e));
                         return;
                     }
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to trigger offload for {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to trigger offload for");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4205,7 +4563,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to offload status on topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to offload status on topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4231,7 +4592,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 }).exceptionally(ex -> {
                                     Throwable throwable2 = FutureUtil.unwrapCompletionException(ex);
                                     if (throwable2 instanceof RestException) {
-                                        log.warn("Failed to authorize {} on topic {}", clientAppId, topicName);
+                                        log.warn()
+                                                .attr("authorize", clientAppId)
+                                                .attr("topic", topicName)
+                                                .log("Failed to authorize on topic");
                                         authorizationFuture.completeExceptionally(new PulsarClientException(
                                                 String.format("Authorization failed %s on topic %s with error %s",
                                                 clientAppId, topicName, throwable2.getMessage())));
@@ -4243,7 +4607,11 @@ public class PersistentTopicsBase extends AdminResource {
                     } else {
                         // throw without wrapping to PulsarClientException that considers: unknown error marked as
                         // internal server error
-                        log.warn("Failed to authorize {} on topic {}", clientAppId, topicName, throwable);
+                        log.warn()
+                                .attr("authorize", clientAppId)
+                                .attr("topic", topicName)
+                                .exception(throwable)
+                                .log("Failed to authorize on topic");
                         authorizationFuture.completeExceptionally(throwable);
                     }
                     return null;
@@ -4262,11 +4630,11 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(res ->
                         pulsar.getBrokerService().fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName))
                 .thenAccept(metadata -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, topicName,
-                                metadata.partitions);
-                    }
-                    metadataFuture.complete(metadata);
+                        log.debug()
+                                .attr("topic", topicName)
+                                .attr("partitions", metadata.partitions)
+                                .log("Total number of partitions for topic is");
+                                        metadataFuture.complete(metadata);
                 })
                 .exceptionally(e -> {
                     metadataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(e));
@@ -4293,11 +4661,11 @@ public class PersistentTopicsBase extends AdminResource {
             .thenCompose(res -> pulsar.getBrokerService()
                 .fetchPartitionedTopicMetadataCheckAllowAutoCreationAsync(topicName))
             .thenAccept(metadata -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("Total number of partitions for topic {} is {}", topicName,
-                        metadata.partitions);
-                }
-                metadataFuture.complete(metadata);
+                    LOG.debug()
+                            .attr("topic", topicName)
+                            .attr("partitions", metadata.partitions)
+                            .log("Total number of partitions for topic is");
+                                metadataFuture.complete(metadata);
             }).exceptionally(ex -> {
             metadataFuture.completeExceptionally(ex.getCause());
             return null;
@@ -4399,7 +4767,7 @@ public class PersistentTopicsBase extends AdminResource {
                     }
                 }
             } catch (Exception e) {
-                log.warn("[{}] Failed to parse version {} ", clientAppId(), userAgent);
+                log.warn().attr("version", userAgent).log("Failed to parse version");
             }
         }
         return CompletableFuture.completedFuture(null);
@@ -4430,17 +4798,21 @@ public class PersistentTopicsBase extends AdminResource {
                         .thenAccept(metadata -> {
                             // Partition topic index is 0 to (number of partition - 1)
                             if (metadata.partitions > 0 && suffix >= (long) metadata.partitions) {
-                                log.warn("[{}] Can't create topic {} with \"-partition-\" followed by"
-                                                + " a number smaller than number of partition of partitioned topic {}.",
-                                        clientAppId(), topicName, partitionTopicName.getLocalName());
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .attr("partitionedTopic", partitionTopicName.getLocalName())
+                                        .log("Can't create topic with -partition- followed by"
+                                                + " a number smaller than partition count");
                                 throw new RestException(Status.PRECONDITION_FAILED,
                                         "Can't create topic " + topicName + " with \"-partition-\" followed by"
                                                 + " a number smaller than number of partition of partitioned topic "
                                                 + partitionTopicName.getLocalName());
                             } else if (metadata.partitions == 0) {
-                                log.warn("[{}] Can't create topic {} with \"-partition-\" followed by"
-                                                + " numeric value if there isn't a partitioned topic {} created.",
-                                        clientAppId(), topicName, partitionTopicName.getLocalName());
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .attr("partitionedTopic", partitionTopicName.getLocalName())
+                                        .log("Can't create topic with -partition- followed by"
+                                                + " numeric value without a partitioned topic");
                                 throw new RestException(Status.PRECONDITION_FAILED,
                                         "Can't create topic " + topicName + " with \"-partition-\" followed by"
                                                 + " numeric value if there isn't a partitioned topic "
@@ -4469,7 +4841,9 @@ public class PersistentTopicsBase extends AdminResource {
                         return;
                     }
                     if (!(topic instanceof PersistentTopic)) {
-                        log.error("[{}] Not supported operation of non-persistent topic {}", clientAppId(), topicName);
+                        log.error()
+                                .attr("topic", topicName)
+                                .log("Not supported operation of non-persistent topic");
                         asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
                                 "GetLastMessageId on a non-persistent topic is not allowed"));
                         return;
@@ -4484,7 +4858,10 @@ public class PersistentTopicsBase extends AdminResource {
                 }).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get last messageId {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get last messageId");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4492,7 +4869,9 @@ public class PersistentTopicsBase extends AdminResource {
     }
     protected CompletableFuture<Void> internalTrimTopic(AsyncResponse asyncResponse, boolean authoritative) {
         if (!topicName.isPersistent()) {
-            log.info("[{}] Trim on a non-persistent topic {} is not allowed", clientAppId(), topicName);
+            log.info()
+                    .attr("topic", topicName)
+                    .log("Trim on a non-persistent topic is not allowed");
             asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
                     "Trim on a non-persistent topic is not allowed"));
             return null;
@@ -4518,7 +4897,9 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))
                 .thenCompose(topic -> {
                     if (!(topic instanceof PersistentTopic persistentTopic)) {
-                        log.info("[{}] Trim on a non-persistent topic {} is not allowed", clientAppId(), topicName);
+                        log.info()
+                                .attr("topic", topicName)
+                                .log("Trim on a non-persistent topic is not allowed");
                         asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
                                 "Trim on a non-persistent topic is not allowed"));
                         return CompletableFuture.completedFuture(null);
@@ -4548,7 +4929,10 @@ public class PersistentTopicsBase extends AdminResource {
             try {
                 futures.add(pulsar().getAdminClient().topics().trimTopicAsync(topicNamePartition.toString()));
             } catch (Exception e) {
-                log.error("[{}] Failed to trim topic {}", clientAppId(), topicNamePartition, e);
+                log.error()
+                        .attr("topic", topicNamePartition)
+                        .exception(e)
+                        .log("Failed to trim topic");
                 return FutureUtil.failedFuture(new RestException(e));
             }
         }
@@ -4655,7 +5039,6 @@ public class PersistentTopicsBase extends AdminResource {
             }
         });
     }
-
 
     protected CompletableFuture<Optional<Integer>> internalGetMaxConsumersPerSubscription(boolean isGlobal) {
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
@@ -4784,8 +5167,11 @@ public class PersistentTopicsBase extends AdminResource {
     protected void handleTopicPolicyException(String methodName, Throwable thr, AsyncResponse asyncResponse) {
         Throwable cause = thr.getCause();
         if (isNot307And4xxException(cause)) {
-            log.error("[{}] Failed to perform {} on topic {}",
-                    clientAppId(), methodName, topicName, cause);
+            log.error()
+                    .attr("perform", methodName)
+                    .attr("topic", topicName)
+                    .exception(cause)
+                    .log("Failed to perform on topic");
         }
         resumeAsyncResponseExceptionally(asyncResponse, cause);
     }
@@ -4813,7 +5199,10 @@ public class PersistentTopicsBase extends AdminResource {
                                 pulsar().getAdminClient().topics()
                                 .truncateAsync(topicNamePartition.toString()));
                         } catch (Exception e) {
-                            log.error("[{}] Failed to truncate topic {}", clientAppId(), topicNamePartition, e);
+                            log.error()
+                                    .attr("topic", topicNamePartition)
+                                    .exception(e)
+                                    .log("Failed to truncate topic");
                             return FutureUtil.failedFuture(new RestException(e));
                         }
                     }
@@ -4827,8 +5216,11 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected void internalSetReplicatedSubscriptionStatus(AsyncResponse asyncResponse, String subName,
             boolean authoritative, boolean enabled) {
-        log.info("[{}] Attempting to change replicated subscription status to {} - {} {}", clientAppId(), enabled,
-                topicName, subName);
+        log.info()
+                .attr("enabled", enabled)
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .log("Attempting to change replicated subscription status to -");
 
         // Reject the request if the topic is not persistent
         if (!topicName.isPersistent()) {
@@ -4842,7 +5234,6 @@ public class PersistentTopicsBase extends AdminResource {
         CompletableFuture<Void> validateFuture =
                 validateTopicOperationAsync(topicName, TopicOperation.SET_REPLICATED_SUBSCRIPTION_STATUS, subName)
                         .thenCompose(__ -> validateGlobalNamespaceOwnershipAsync(namespaceName));
-
 
         CompletableFuture<Void> resultFuture;
         // If the topic name is a partition name, no need to get partition topic metadata again
@@ -4863,8 +5254,12 @@ public class PersistentTopicsBase extends AdminResource {
                                     futures.add(pulsar().getAdminClient().topics().setReplicatedSubscriptionStatusAsync(
                                             topicNamePartition.toString(), subName, enabled));
                                 } catch (Exception e) {
-                                    log.warn("[{}] Failed to change replicated subscription status to {} - {} {}",
-                                            clientAppId(), enabled, topicNamePartition, subName, e);
+                                    log.warn()
+                                            .attr("enabled", enabled)
+                                            .attr("topicNamePartition", topicNamePartition)
+                                            .attr("subscription", subName)
+                                            .exception(e)
+                                            .log("Failed to change replicated subscription status to -");
                                     resumeAsyncResponseExceptionally(asyncResponse, e);
                                     return;
                                 }
@@ -4883,8 +5278,12 @@ public class PersistentTopicsBase extends AdminResource {
                                                 "Cannot enable/disable replicated subscriptions on non-global topics"));
                                         return null;
                                     } else {
-                                        log.warn("[{}] Failed to change replicated subscription status to {} - {} {}",
-                                                clientAppId(), enabled, topicName, subName, t);
+                                        log.warn()
+                                                .attr("enabled", enabled)
+                                                .attr("topic", topicName)
+                                                .attr("subscription", subName)
+                                                .exception(t)
+                                                .log("Failed to change replicated subscription status to -");
                                         asyncResponse.resume(new RestException(t));
                                         return null;
                                     }
@@ -4903,8 +5302,12 @@ public class PersistentTopicsBase extends AdminResource {
         resultFuture.exceptionally(ex -> {
             // If the exception is not redirect exception we need to log it.
             if (isNot307And404Exception(ex)) {
-                log.warn("[{}] Failed to change replicated subscription status to {} - {} {}", clientAppId(), enabled,
-                        topicName, subName, ex);
+                log.warn()
+                        .attr("enabled", enabled)
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .exception(ex)
+                        .log("Failed to change replicated subscription status to -");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -4939,8 +5342,11 @@ public class PersistentTopicsBase extends AdminResource {
                                 }
 
                                 ((PersistentTopic) topic).checkReplicatedSubscriptionControllerState();
-                                log.info("[{}] Changed replicated subscription status to {} - {} {}", clientAppId(),
-                                        enabled, topicName, subName);
+                                log.info()
+                                        .attr("enabled", enabled)
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subName)
+                                        .log("Changed replicated subscription status to -");
                                 asyncResponse.resume(Response.noContent().build());
                             } else {
                                 asyncResponse.resume(new RestException(Status.METHOD_NOT_ALLOWED,
@@ -4950,8 +5356,11 @@ public class PersistentTopicsBase extends AdminResource {
                 ).exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to set replicated subscription status on {} {}", clientAppId(),
-                                topicName, subName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(ex)
+                                .log("Failed to set replicated subscription status on");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -4961,7 +5370,10 @@ public class PersistentTopicsBase extends AdminResource {
     protected void internalGetReplicatedSubscriptionStatus(AsyncResponse asyncResponse,
                                                            String subName,
                                                            boolean authoritative) {
-        log.info("[{}] Attempting to get replicated subscription status on {} {}", clientAppId(), topicName, subName);
+        log.info()
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .log("Attempting to get replicated subscription status on");
 
         // Reject the request if the topic is not persistent
         if (!topicName.isPersistent()) {
@@ -5001,14 +5413,19 @@ public class PersistentTopicsBase extends AdminResource {
                                                     .getReplicatedSubscriptionStatusAsync(partition.toString(), subName)
                                                     .whenComplete((__, throwable) -> {
                                                         if (throwable != null) {
-                                                            log.error("[{}] Failed to get replicated subscriptions on"
-                                                                    + " {} {}",
-                                                                clientAppId(), partition, subName, throwable);
+                                                            log.error()
+                                                                    .attr("partition", partition)
+                                                                    .attr("subscription", subName)
+                                                                    .exception(throwable)
+                                                                    .log("Failed to get replicated subscriptions on");
                                                         }
                                                     });
                                             } catch (Exception e) {
-                                                log.warn("[{}] Failed to get replicated subscription status on {} {}",
-                                                    clientAppId(), partition, subName, e);
+                                                log.warn()
+                                                        .attr("partition", partition)
+                                                        .attr("subscription", subName)
+                                                        .exception(e)
+                                                        .log("Failed to get replicated subscription status on");
                                                 return FutureUtil.failedFuture(e);
                                             }
                                         }
@@ -5026,8 +5443,11 @@ public class PersistentTopicsBase extends AdminResource {
                                         asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED,
                                                 "Cannot get replicated subscriptions on non-global topics"));
                                     } else {
-                                        log.error("[{}] Failed to get replicated subscription status on {} {}",
-                                                clientAppId(), topicName, subName, t);
+                                        log.error()
+                                                .attr("topic", topicName)
+                                                .attr("subscription", subName)
+                                                .exception(t)
+                                                .log("Failed to get replicated subscription status on");
                                         asyncResponse.resume(new RestException(t));
                                     }
                                     return null;
@@ -5044,8 +5464,11 @@ public class PersistentTopicsBase extends AdminResource {
 
         resultFuture.exceptionally(ex -> {
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to get replicated subscription status on {} {}", clientAppId(),
-                        topicName, subName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("subscription", subName)
+                        .exception(ex)
+                        .log("Failed to get replicated subscription status on");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -5081,8 +5504,11 @@ public class PersistentTopicsBase extends AdminResource {
                 .whenComplete((res, e) -> {
                     if (e != null) {
                         Throwable cause = FutureUtil.unwrapCompletionException(e);
-                        log.error("[{}] Failed to get replicated subscription status on {} {}", clientAppId(),
-                            topicName, subName, cause);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(cause)
+                                .log("Failed to get replicated subscription status on");
                         resumeAsyncResponseExceptionally(asyncResponse, e);
                     } else {
                         asyncResponse.resume(res);
@@ -5269,8 +5695,10 @@ public class PersistentTopicsBase extends AdminResource {
                         return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
                                 .thenAccept(topicMetadata -> {
                                     if (topicMetadata.partitions > 0) {
-                                        log.warn("[{}] Not supported getMessageIdByIndex operation on "
-                                                        + "partitioned-topic {}", clientAppId(), topicName);
+                                        log.warn()
+                                                .attr("topic", topicName)
+                                                .log("Not supported getMessageIdByIndex operation on"
+                                                        + " partitioned-topic");
                                         throw new RestException(Status.METHOD_NOT_ALLOWED,
                                                 "GetMessageIDByIndex is not allowed on partitioned-topic");
                                     }
@@ -5280,8 +5708,9 @@ public class PersistentTopicsBase extends AdminResource {
                 .thenCompose(__ -> getTopicReferenceAsync(topicName))
                 .thenCompose(topic -> {
                     if (!(topic instanceof PersistentTopic persistentTopic)) {
-                        log.error("[{}] Get message id by index on a non-persistent topic {} is not allowed",
-                                clientAppId(), topicName);
+                        log.error()
+                                .attr("topic", topicName)
+                                .log("Get message id by index on a non-persistent topic is not allowed");
                         return FutureUtil.failedFuture(new RestException(Status.METHOD_NOT_ALLOWED,
                                 "Get message id by index on a non-persistent topic is not allowed"));
                     }
@@ -5310,7 +5739,9 @@ public class PersistentTopicsBase extends AdminResource {
                                                 return messageIndex < index;
                                             }
                                         } catch (Throwable e) {
-                                            log.error("Error deserialize message for message position find", e);
+                                            log.error()
+                                                    .exception(e)
+                                                    .log("Error deserialize message for message position find");
                                             return false;
                                         } finally {
                                             entry.release();
@@ -5355,14 +5786,16 @@ public class PersistentTopicsBase extends AdminResource {
 
             @Override
             public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("[{}] Failed to read position {} on topic {}",
-                        clientAppId(), position, topicName, exception);
+                log.error()
+                        .attr("position", position)
+                        .attr("topic", topicName)
+                        .exception(exception)
+                        .log("Failed to read position on topic");
                 indexFuture.completeExceptionally(exception);
             }
         }, null);
         return indexFuture;
     }
-
 
     private static Long getIndexFromEntry(Entry entry) {
         return Commands.peekBrokerEntryMetadataToObject(entry.getDataBuffer(), brokerEntryMetadata -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
@@ -26,8 +26,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class ResourceGroupsBase extends AdminResource {
     protected List<String> internalGetResourceGroups() {
@@ -35,7 +33,7 @@ public abstract class ResourceGroupsBase extends AdminResource {
             validateSuperUserAccess();
             return resourceGroupResources().listResourceGroups();
         } catch (Exception e) {
-            log.error("[{}] Failed to get ResourceGroups list: {}", clientAppId(), e);
+            log.error().exception(e).log("Failed to get ResourceGroups list");
             throw new RestException(e);
         }
     }
@@ -49,7 +47,10 @@ public abstract class ResourceGroupsBase extends AdminResource {
         } catch (RestException re) {
             throw re;
         } catch (Exception e) {
-            log.error("[{}] Failed to get ResourceGroup  {}", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exception(e)
+                    .log("Failed to get ResourceGroup");
             throw new RestException(e);
         }
     }
@@ -78,11 +79,16 @@ public abstract class ResourceGroupsBase extends AdminResource {
 
             // write back the new ResourceGroup config.
             resourceGroupResources().updateResourceGroup(rgName, r -> resourceGroup);
-            log.info("[{}] Successfully updated the ResourceGroup {}", clientAppId(), rgName);
+            log.info()
+                    .attr("resourceGroup", rgName)
+                    .log("Successfully updated the ResourceGroup");
         } catch (RestException pfe) {
             throw pfe;
         } catch (Exception e) {
-            log.error("[{}] Failed to update configuration for ResourceGroup {}", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exception(e)
+                    .log("Failed to update configuration for ResourceGroup");
             throw new RestException(e);
         }
     }
@@ -98,12 +104,17 @@ public abstract class ResourceGroupsBase extends AdminResource {
                 ? -1 : rgConfig.getDispatchRateInBytes());
         try {
             resourceGroupResources().createResourceGroup(rgName, rgConfig);
-            log.info("[{}] Created ResourceGroup {}", clientAppId(), rgName);
+            log.info().attr("resourceGroup", rgName).log("Created ResourceGroup");
         } catch (MetadataStoreException.AlreadyExistsException e) {
-            log.warn("[{}] Failed to create ResourceGroup {} - already exists", clientAppId(), rgName);
+            log.warn()
+                    .attr("resourceGroup", rgName)
+                    .log("Failed to create ResourceGroup - already exists");
             throw new RestException(Response.Status.CONFLICT, "ResourceGroup already exists");
         } catch (Exception e) {
-            log.error("[{}] Failed to create ResourceGroup {}", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exception(e)
+                    .log("Failed to create ResourceGroup");
             throw new RestException(e);
         }
 
@@ -119,7 +130,10 @@ public abstract class ResourceGroupsBase extends AdminResource {
             try {
                 rgExists = resourceGroupResources().resourceGroupExists(rgName);
             } catch (Exception e) {
-                log.error("[{}] Failed to create/update ResourceGroup {}: {}", clientAppId(), rgName, e);
+                log.error()
+                        .attr("resourceGroup", rgName)
+                        .exceptionMessage(e)
+                        .log("Failed to create/update ResourceGroup");
             }
 
             try {
@@ -129,11 +143,17 @@ public abstract class ResourceGroupsBase extends AdminResource {
                     internalCreateResourceGroup(rgName, rgConfig);
                 }
             } catch (Exception e) {
-                log.error("[{}] Failed to create/update ResourceGroup {}: {}", clientAppId(), rgName, e);
+                log.error()
+                        .attr("resourceGroup", rgName)
+                        .exceptionMessage(e)
+                        .log("Failed to create/update ResourceGroup");
                 throw new RestException(e);
             }
         } catch (Exception e) {
-            log.error("[{}] Failed to create/update ResourceGroup {}: {}", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exceptionMessage(e)
+                    .log("Failed to create/update ResourceGroup");
             throw new RestException(e);
         }
     }
@@ -150,7 +170,10 @@ public abstract class ResourceGroupsBase extends AdminResource {
                 }
             }
         } catch (Exception e) {
-            log.error("[{}] Failed to get tenant/namespace list {}: {}", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exceptionMessage(e)
+                    .log("Failed to get tenant/namespace list");
             throw new RestException(e);
         }
         return false;
@@ -169,12 +192,13 @@ public abstract class ResourceGroupsBase extends AdminResource {
                 throw new RestException(Response.Status.PRECONDITION_FAILED, "ResourceGroup is in use");
             }
             resourceGroupResources().deleteResourceGroup(rgName);
-            log.info("[{}] Deleted ResourceGroup {}", clientAppId(), rgName);
+            log.info().attr("resourceGroup", rgName).log("Deleted ResourceGroup");
         } catch (Exception e) {
-            log.error("[{}] Failed to delete ResourceGroup {}.", clientAppId(), rgName, e);
+            log.error()
+                    .attr("resourceGroup", rgName)
+                    .exception(e)
+                    .log("Failed to delete ResourceGroup .");
             throw new RestException(e);
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ResourceGroupsBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceQuotasBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceQuotasBase.java
@@ -19,11 +19,9 @@
 package org.apache.pulsar.broker.admin.impl;
 
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 
-@Slf4j
 public abstract class ResourceQuotasBase extends NamespacesBase {
 
     public ResourceQuota getDefaultResourceQuota() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/SchemasResourceBase.java
@@ -48,8 +48,6 @@ import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.common.schema.SchemaType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SchemasResourceBase extends AdminResource {
 
@@ -245,10 +243,7 @@ public class SchemasResourceBase extends AdminResource {
                 .thenCompose(__ -> validateTopicOperationAsync(topicName, operation));
     }
 
-
     protected boolean shouldPrintErrorLog(Throwable ex) {
         return isNot307And404Exception(ex);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(SchemasResourceBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TenantsBase.java
@@ -49,13 +49,8 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TenantsBase extends PulsarWebResource {
-
-    private static final Logger log = LoggerFactory.getLogger(TenantsBase.class);
-
     @GET
     @ApiOperation(value = "Get the list of existing tenants.", response = String.class, responseContainer = "List")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
@@ -70,7 +65,7 @@ public class TenantsBase extends PulsarWebResource {
                     deepCopy.sort(null);
                     asyncResponse.resume(deepCopy);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get tenants list", clientAppId, ex);
+                    log.error().exception(ex).log("Failed to get tenants list");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -94,7 +89,7 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get tenant admin {}", clientAppId, ex);
+                    log.error().exception(ex).log("Failed to get tenant admin");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -117,7 +112,10 @@ public class TenantsBase extends PulsarWebResource {
         try {
             NamedEntity.checkName(tenant);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Failed to create tenant with invalid name {}", clientAppId, tenant, e);
+            log.warn()
+                    .attr("tenant", tenant)
+                    .exception(e)
+                    .log("Failed to create tenant with invalid name");
             asyncResponse.resume(new RestException(Status.PRECONDITION_FAILED, "Tenant name is not valid"));
             return;
         }
@@ -144,11 +142,14 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenCompose(__ -> tenantResources().createTenantAsync(tenant, tenantInfo))
                 .thenAccept(__ -> {
-                    log.info("[{}] Created tenant {}", clientAppId, tenant);
+                    log.info().attr("tenant", tenant).log("Created tenant");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to create tenant {}", clientAppId, tenant, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .exception(ex)
+                            .log("Failed to create tenant");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -184,10 +185,15 @@ public class TenantsBase extends PulsarWebResource {
                 })
                 .thenCompose(__ -> tenantResources().updateTenantAsync(tenant, old -> newTenantAdmin))
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully updated tenant info {}", clientAppId, tenant);
+                    log.info()
+                            .attr("info", tenant)
+                            .log("Successfully updated tenant info");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
-                    log.warn("[{}] Failed to update tenant {}", clientAppId, tenant, ex);
+                    log.warn()
+                            .attr("tenant", tenant)
+                            .exception(ex)
+                            .log("Failed to update tenant");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -210,12 +216,15 @@ public class TenantsBase extends PulsarWebResource {
                 .thenCompose(__ -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(__ -> internalDeleteTenant(tenant, force))
                 .thenAccept(__ -> {
-                    log.info("[{}] Deleted tenant {}", clientAppId, tenant);
+                    log.info().attr("tenant", tenant).log("Deleted tenant");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                    log.error("[{}] Failed to delete tenant {}", clientAppId, tenant, cause);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .exception(cause)
+                            .log("Failed to delete tenant");
                     if (cause instanceof IllegalStateException) {
                         asyncResponse.resume(new RestException(Status.CONFLICT, cause));
                     } else {
@@ -262,7 +271,10 @@ public class TenantsBase extends PulsarWebResource {
                             futures.add(adminClient.namespaces().deleteNamespaceAsync(namespace, true));
                         }
                     } catch (Exception e) {
-                        log.error("[{}] Failed to force delete namespaces {}", clientAppId(), namespaces, e);
+                        log.error()
+                                .attr("namespaces", namespaces)
+                                .exception(e)
+                                .log("Failed to force delete namespaces");
                         throw new RestException(e);
                     }
                     return futures;
@@ -285,7 +297,7 @@ public class TenantsBase extends PulsarWebResource {
                 .filter(c -> !StringUtils.isBlank(c))
                 .collect(Collectors.toSet());
         if (cleanedClusters.isEmpty() || allowedClusters.stream().anyMatch(StringUtils::isBlank)) {
-            log.warn("[{}] Validation failed: allowed clusters are empty or contain blanks", clientAppId());
+            log.warn("Validation failed: allowed clusters are empty or contain blanks");
             return FutureUtil.failedFuture(
                     new RestException(Status.PRECONDITION_FAILED, "Clusters cannot be empty or blank"));
         }
@@ -295,7 +307,9 @@ public class TenantsBase extends PulsarWebResource {
                     .filter(cluster -> !availableClusters.contains(cluster))
                     .collect(Collectors.toList());
             if (nonexistentClusters.size() > 0) {
-                log.warn("[{}] Failed to validate due to clusters {} do not exist", clientAppId(), nonexistentClusters);
+                log.warn()
+                        .attr("clusters", nonexistentClusters)
+                        .log("Failed to validate due to clusters do not exist");
                 throw new RestException(Status.PRECONDITION_FAILED, "Clusters do not exist");
             }
         });
@@ -305,8 +319,9 @@ public class TenantsBase extends PulsarWebResource {
         if (info.getAdminRoles() != null && !info.getAdminRoles().isEmpty()) {
             for (String adminRole : info.getAdminRoles()) {
                 if (!StringUtils.trim(adminRole).equals(adminRole)) {
-                    log.warn("[{}] Failed to validate due to adminRole {} contains whitespace in the beginning or end.",
-                            clientAppId(), adminRole);
+                    log.warn()
+                            .attr("adminRole", adminRole)
+                            .log("Failed to validate due to adminRole contains whitespace in the beginning or end.");
                     return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
                             "AdminRoles contains whitespace in the beginning or end."));
                 }
@@ -325,25 +340,23 @@ public class TenantsBase extends PulsarWebResource {
                         || !tenantOperationValidationFuture.isCompletedExceptionally()) {
                         return true;
                     }
-                    if (log.isDebugEnabled()) {
-                        Throwable superUserValidationException = null;
-                        try {
-                            superUserValidationFuture.join();
-                        } catch (Throwable ex) {
-                            superUserValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        Throwable brokerOperationValidationException = null;
-                        try {
-                            tenantOperationValidationFuture.join();
-                        } catch (Throwable ex) {
-                            brokerOperationValidationException = FutureUtil.unwrapCompletionException(ex);
-                        }
-                        log.debug("validateBothTenantOperationAndSuperUser failed."
-                                  + " originalPrincipal={} clientAppId={} operation={} "
-                                  + "superuserValidationError={} tenantOperationValidationError={}",
-                                originalPrincipal(), clientAppId(), operation.toString(),
-                                superUserValidationException, brokerOperationValidationException);
+                    Throwable superUserValidationException = null;
+                    try {
+                        superUserValidationFuture.join();
+                    } catch (Throwable ex) {
+                        superUserValidationException = FutureUtil.unwrapCompletionException(ex);
                     }
+                    Throwable tenantOperationValidationException = null;
+                    try {
+                        tenantOperationValidationFuture.join();
+                    } catch (Throwable ex) {
+                        tenantOperationValidationException = FutureUtil.unwrapCompletionException(ex);
+                    }
+                    log.debug().attr("originalPrincipal", originalPrincipal())
+                            .attr("operation", operation.toString())
+                            .attr("superuserValidationError", superUserValidationException)
+                            .attr("tenantOperationValidationError", tenantOperationValidationException)
+                            .log("validateBothTenantOperationAndSuperUser failed");
                     throw new RestException(Status.UNAUTHORIZED,
                             String.format("Unauthorized to validateBothTenantOperationAndSuperUser for"
                                           + " originalPrincipal [%s] and clientAppId [%s] "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/TransactionsBase.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -72,7 +71,6 @@ import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException.TransactionNotFoundException;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 
-@Slf4j
 public abstract class TransactionsBase extends AdminResource {
 
     protected void internalListCoordinators(AsyncResponse asyncResponse) {
@@ -95,8 +93,9 @@ public abstract class TransactionsBase extends AdminResource {
                     asyncResponse.resume(result.values());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to list transaction coordinators: {}",
-                            clientAppId(), ex.getMessage(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to list transaction coordinators");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -154,7 +153,9 @@ public abstract class TransactionsBase extends AdminResource {
                     asyncResponse.resume(stats);
                 });
             }).exceptionally(ex -> {
-                log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
+                log.error()
+                        .exception(ex)
+                        .log("Failed to get transaction coordinator state.");
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
             });
@@ -375,7 +376,9 @@ public abstract class TransactionsBase extends AdminResource {
                         asyncResponse.resume(transactionMetadataMaps);
                     });
                 }).exceptionally(ex -> {
-                    log.error("[{}] Failed to get transaction coordinator state.", clientAppId(), ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get transaction coordinator state.");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -528,8 +531,13 @@ public abstract class TransactionsBase extends AdminResource {
             this.namespaceName = NamespaceName.get(tenant, namespace);
             this.topicName = TopicName.get(TopicDomain.persistent.toString(), namespaceName, topic);
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Failed to validate topic name {}://{}/{}/{}", clientAppId(), domain(), tenant, namespace,
-                    topic, e);
+            log.warn()
+                    .attr("domain", domain())
+                    .attr("tenant", tenant)
+                    .attr("namespace", namespace)
+                    .attr("topic", topic)
+                    .exception(e)
+                    .log("Failed to validate topic name");
             throw new RestException(Response.Status.PRECONDITION_FAILED, "Topic name is not valid");
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Bookies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Bookies.java
@@ -39,7 +39,6 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.discover.RegistrationClient;
 import org.apache.bookkeeper.meta.MetadataClientDriver;
@@ -55,7 +54,6 @@ import org.apache.pulsar.common.policies.data.RawBookieInfo;
 @Path("/bookies")
 @Api(value = "/bookies", description = "Configure bookies rack placement", tags = "bookies")
 @Produces(MediaType.APPLICATION_JSON)
-@Slf4j
 @SuppressWarnings("deprecation")
 public class Bookies extends AdminResource {
     private static final String PATH_SEPARATOR = "/";
@@ -146,7 +144,7 @@ public class Bookies extends AdminResource {
 
                     return brc;
                 }).thenAccept(__ -> {
-            log.info("Removed {} from rack mapping info", bookieAddress);
+            log.info().attr("bookieAddress", bookieAddress).log("Removed from rack mapping info");
             asyncResponse.resume(Response.noContent().build());
         }).exceptionally(ex -> {
             asyncResponse.resume(ex);
@@ -198,7 +196,7 @@ public class Bookies extends AdminResource {
 
                     return brc;
                 }).thenAccept(__ -> {
-            log.info("Updated rack mapping info for {}", bookieAddress);
+            log.info().attr("bookieAddress", bookieAddress).log("Updated rack mapping info");
             asyncResponse.resume(Response.noContent().build());
         }).exceptionally(ex -> {
             asyncResponse.resume(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ExtNonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ExtNonPersistentTopics.java
@@ -37,8 +37,6 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is for preventing docs conflict before we find a good way to fix
@@ -86,10 +84,11 @@ public class ExtNonPersistentTopics extends PersistentTopicsBase {
             internalCreatePartitionedTopic(asyncResponse, metadata.partitions, createLocalTopicOnly,
                     metadata.properties);
         } catch (Exception e) {
-            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to create partitioned topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ExtPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ExtPersistentTopics.java
@@ -39,8 +39,6 @@ import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is for preventing docs conflict before we find a good way to fix
@@ -90,10 +88,11 @@ public class ExtPersistentTopics extends PersistentTopicsBase {
             internalCreatePartitionedTopic(asyncResponse, metadata.partitions, createLocalTopicOnly,
                     metadata.properties);
         } catch (Exception e) {
-            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to create partitioned topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -88,8 +88,6 @@ import org.apache.pulsar.common.policies.data.impl.BundlesDataImpl;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/namespaces")
 @Produces(MediaType.APPLICATION_JSON)
@@ -109,7 +107,10 @@ public class Namespaces extends NamespacesBase {
         internalGetTenantNamespaces(tenant)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get namespaces list for tenant {}: {}", clientAppId(), tenant, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .exceptionMessage(ex)
+                            .log("Failed to get namespaces list for tenant");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -136,7 +137,10 @@ public class Namespaces extends NamespacesBase {
                 .thenApply(topics -> filterSystemTopic(topics, includeSystemTopic))
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("Failed to get topics list for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get topics list for namespace");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -157,9 +161,15 @@ public class Namespaces extends NamespacesBase {
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
                     if (AdminResource.isNotFoundOrConflictException(ex)) {
-                        log.info("Failed to get policies for namespace {}: {}", namespaceName, ex.getMessage());
+                        log.info()
+                                .attr("namespace", namespaceName)
+                                .exceptionMessage(ex)
+                                .log("Failed to get policies for namespace");
                     } else {
-                        log.error("Failed to get policies for namespace {}", namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to get policies for namespace");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -188,7 +198,10 @@ public class Namespaces extends NamespacesBase {
                     if (root instanceof MetadataStoreException.AlreadyExistsException) {
                         response.resume(new RestException(Response.Status.CONFLICT, "Namespace already exists"));
                     } else {
-                        log.error("[{}] Failed to create namespace {}", clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to create namespace");
                         resumeAsyncResponseExceptionally(response, ex);
                     }
                     return null;
@@ -212,12 +225,17 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalDeleteNamespaceAsync(force)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successful delete namespace {}", clientAppId(), namespace);
+                    log.info()
+                            .attr("namespace", namespace)
+                            .log("Successful delete namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to delete namespace {}", clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to delete namespace");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -243,7 +261,10 @@ public class Namespaces extends NamespacesBase {
                 .thenRun(() -> response.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to delete namespace bundle {}", clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to delete namespace bundle");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -267,7 +288,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getAuthorizationService().getPermissionsAsync(namespaceName))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
-                    log.error("Failed to get permissions for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get permissions for namespace");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -290,8 +314,11 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getAuthorizationService().getSubscriptionPermissionsAsync(namespaceName))
                 .thenAccept(permissions -> response.resume(permissions))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get permissions on subscription for namespace {}: {} ", clientAppId(),
-                            namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to get permissions on subscription for namespace");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -315,8 +342,11 @@ public class Namespaces extends NamespacesBase {
         internalGrantPermissionOnNamespaceAsync(role, actions)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set permissions for namespace {}: {}",
-                            clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to set permissions for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -336,8 +366,10 @@ public class Namespaces extends NamespacesBase {
         internalGrantPermissionOnTopicsAsync(options)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to grant permissions {}",
-                            clientAppId(), options, ex);
+                    log.error()
+                            .attr("permissions", options)
+                            .exception(ex)
+                            .log("Failed to grant permissions");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -357,8 +389,10 @@ public class Namespaces extends NamespacesBase {
         internalRevokePermissionOnTopicsAsync(options)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to revoke permissions {}",
-                            clientAppId(), options, ex);
+                    log.error()
+                            .attr("permissions", options)
+                            .exception(ex)
+                            .log("Failed to revoke permissions");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -383,9 +417,12 @@ public class Namespaces extends NamespacesBase {
         internalGrantPermissionOnSubscriptionAsync(subscription, roles)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to grant permission on subscription for role {}:{} - "
-                                    + "namespaceName {}: {}",
-                            clientAppId(), roles, subscription, namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("role", roles)
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to grant permission on subscription");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -405,8 +442,12 @@ public class Namespaces extends NamespacesBase {
         internalRevokePermissionsOnNamespaceAsync(role)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to revoke permission on role {} - namespace {}: {}",
-                            clientAppId(), role, namespace, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("role", role)
+                            .attr("namespace", namespace)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to revoke permission on role - namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -427,8 +468,13 @@ public class Namespaces extends NamespacesBase {
         internalRevokePermissionsOnSubscriptionAsync(subscription, role)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to revoke permission on subscription for role {}:{} - namespace {}: {}",
-                            clientAppId(), role, subscription, namespace, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("role", role)
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespace)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to revoke permission on subscription for role : - namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -448,8 +494,10 @@ public class Namespaces extends NamespacesBase {
         internalGetNamespaceReplicationClustersAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(e -> {
-                    log.error("[{}] Failed to get namespace replication clusters on namespace {}", clientAppId(),
-                            namespace, e);
+                    log.error()
+                            .attr("namespace", namespace)
+                            .exception(e)
+                            .log("Failed to get namespace replication clusters on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, e);
                     return null;
                 });
@@ -476,8 +524,10 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceReplicationClusters(clusterIds, compareTopicPartitions)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(e -> {
-                    log.error("[{}] Failed to set namespace replication clusters on namespace {}",
-                            clientAppId(), namespace, e);
+                    log.error()
+                            .attr("namespace", namespace)
+                            .exception(e)
+                            .log("Failed to set namespace replication clusters on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, e);
                     return null;
                 });
@@ -496,7 +546,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.message_ttl_in_seconds))
                 .exceptionally(ex -> {
-                    log.error("Failed to get namespace message TTL for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get namespace message TTL for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -518,7 +571,10 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceMessageTTLAsync(messageTTL)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("Failed to set namespace message TTL for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set namespace message TTL for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -539,7 +595,10 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceMessageTTLAsync(null)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("Failed to remove namespace message TTL for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove namespace message TTL for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -559,8 +618,11 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.subscription_expiration_time_minutes))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get subscription expiration time for namespace {}: {} ", clientAppId(),
-                            namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to get subscription expiration time for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -584,8 +646,11 @@ public class Namespaces extends NamespacesBase {
         internalSetSubscriptionExpirationTimeAsync(expirationTime)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set subscription expiration time for namespace {}: {} ", clientAppId(),
-                            namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to set subscription expiration time for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -605,8 +670,11 @@ public class Namespaces extends NamespacesBase {
         internalSetSubscriptionExpirationTimeAsync(null)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to remove subscription expiration time for namespace {}: {} ", clientAppId(),
-                            namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to remove subscription expiration time for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -623,7 +691,10 @@ public class Namespaces extends NamespacesBase {
         internalGetDeduplicationAsync()
                 .thenAccept(deduplication -> asyncResponse.resume(deduplication))
                 .exceptionally(ex -> {
-                    log.error("Failed to get broker deduplication config for namespace {}", namespace, ex);
+                    log.error()
+                            .attr("namespace", namespace)
+                            .exception(ex)
+                            .log("Failed to get broker deduplication config for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -645,7 +716,10 @@ public class Namespaces extends NamespacesBase {
         internalModifyDeduplicationAsync(enableDeduplication)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("Failed to modify broker deduplication config for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to modify broker deduplication config for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -665,7 +739,10 @@ public class Namespaces extends NamespacesBase {
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(e -> {
                     Throwable ex = FutureUtil.unwrapCompletionException(e);
-                    log.error("Failed to remove broker deduplication config for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove broker deduplication config for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -683,7 +760,10 @@ public class Namespaces extends NamespacesBase {
         internalGetAutoTopicCreationAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("Failed to get autoTopicCreation info for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get autoTopicCreation info for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -709,15 +789,18 @@ public class Namespaces extends NamespacesBase {
                 .thenAccept(__ -> {
                     String autoOverride = (autoTopicCreationOverride != null
                             && autoTopicCreationOverride.isAllowAutoTopicCreation()) ? "enabled" : "disabled";
-                    log.info("[{}] Successfully {} autoTopicCreation on namespace {}", clientAppId(),
-                            autoOverride, namespaceName);
+                    log.info()
+                            .attr("successfully", autoOverride)
+                            .attr("namespace", namespaceName)
+                            .log("Successfully autoTopicCreation on namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(e -> {
                     Throwable ex = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] Failed to set autoTopicCreation status on namespace {}", clientAppId(),
-                            namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set autoTopicCreation status on namespace");
                     if (ex instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Response.Status.NOT_FOUND, "Namespace does not exist"));
                     } else {
@@ -739,15 +822,17 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSetAutoTopicCreationAsync(null)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully remove autoTopicCreation on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully remove autoTopicCreation on namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(e -> {
                     Throwable ex = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] Failed to remove autoTopicCreation status on namespace {}", clientAppId(),
-                            namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove autoTopicCreation status on namespace");
                     if (ex instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Response.Status.NOT_FOUND, "Namespace does not exist"));
                     } else {
@@ -773,14 +858,17 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSetAutoSubscriptionCreationAsync(autoSubscriptionCreationOverride)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully set autoSubscriptionCreation on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully set autoSubscriptionCreation on namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(e -> {
                     Throwable ex = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] Failed to set autoSubscriptionCreation on namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set autoSubscriptionCreation on namespace");
                     if (ex instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Response.Status.NOT_FOUND, "Namespace does not exist"));
                     } else {
@@ -803,7 +891,10 @@ public class Namespaces extends NamespacesBase {
         internalGetAutoSubscriptionCreationAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("Failed to get autoSubscriptionCreation for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get autoSubscriptionCreation for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -821,14 +912,17 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSetAutoSubscriptionCreationAsync(null)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully set autoSubscriptionCreation on namespace {}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully set autoSubscriptionCreation on namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(e -> {
                     Throwable ex = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] Failed to set autoSubscriptionCreation on namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set autoSubscriptionCreation on namespace");
                     if (ex instanceof MetadataStoreException.NotFoundException) {
                         asyncResponse.resume(new RestException(Response.Status.NOT_FOUND, "Namespace does not exist"));
                     } else {
@@ -854,8 +948,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.bundles))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get bundle data for namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get bundle data for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -888,13 +984,17 @@ public class Namespaces extends NamespacesBase {
         }
         internalUnloadNamespaceAsync()
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully unloaded all the bundles in namespace {}", clientAppId(),
-                            namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully unloaded all the bundles in namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to unload namespace {}", clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to unload namespace");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -917,14 +1017,18 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalUnloadNamespaceBundleAsync(bundleRange, destinationBroker, authoritative)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully unloaded namespace bundle {}",
-                            clientAppId(), bundleRange);
+                    log.info()
+                            .attr("bundle", bundleRange)
+                            .log("Successfully unloaded namespace bundle");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to unload namespace bundle {}/{}",
-                                clientAppId(), namespaceName, bundleRange, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .attr("bundleRange", bundleRange)
+                                .exception(ex)
+                                .log("Failed to unload namespace bundle");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -951,13 +1055,18 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSplitNamespaceBundleAsync(bundleRange, authoritative, unload, splitAlgorithmName, splitBoundaries)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully split namespace bundle {}", clientAppId(), bundleRange);
+                    log.info()
+                            .attr("bundle", bundleRange)
+                            .log("Successfully split namespace bundle");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to split namespace bundle {}/{} due to {}",
-                                clientAppId(), namespaceName, bundleRange, ex.getMessage());
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .attr("bundleRange", bundleRange)
+                                .exceptionMessage(ex)
+                                .log("Failed to split namespace bundle");
                     }
                     Throwable realCause = FutureUtil.unwrapCompletionException(ex);
                     if (realCause instanceof IllegalArgumentException) {
@@ -987,8 +1096,10 @@ public class Namespaces extends NamespacesBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] {} Failed to get topic list for bundle {}.", clientAppId(),
-                                namespaceName, bundleRange);
+                        log.error()
+                                .attr("namespaceName", namespaceName)
+                                .attr("bundle", bundleRange)
+                                .log("Failed to get topic list for bundle .");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1025,8 +1136,10 @@ public class Namespaces extends NamespacesBase {
         internalRemovePublishRateAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to remove the publish_max_message_rate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove the publish_max_message_rate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1047,7 +1160,10 @@ public class Namespaces extends NamespacesBase {
         internalGetPublishRateAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("Failed to get publish rate for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get publish rate for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1067,8 +1183,10 @@ public class Namespaces extends NamespacesBase {
         internalSetTopicDispatchRateAsync(dispatchRate)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to update the dispatchRate for cluster on namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update the dispatchRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1086,8 +1204,10 @@ public class Namespaces extends NamespacesBase {
         internalDeleteTopicDispatchRateAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to delete the dispatchRate for cluster on namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete the dispatchRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1127,8 +1247,10 @@ public class Namespaces extends NamespacesBase {
         internalSetSubscriptionDispatchRateAsync(dispatchRate)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to update the subscription dispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update the subscription dispatchRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1148,8 +1270,10 @@ public class Namespaces extends NamespacesBase {
         internalGetSubscriptionDispatchRateAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get the subscription dispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get the subscription dispatchRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1168,8 +1292,10 @@ public class Namespaces extends NamespacesBase {
         internalDeleteSubscriptionDispatchRateAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to delete the subscription dispatchRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete the subscription dispatchRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1187,8 +1313,10 @@ public class Namespaces extends NamespacesBase {
         internalDeleteSubscribeRateAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to delete the subscribeRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete the subscribeRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1208,8 +1336,10 @@ public class Namespaces extends NamespacesBase {
         internalSetSubscribeRateAsync(subscribeRate)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to update the subscribeRate for cluster on namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update the subscribeRate for cluster on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1226,7 +1356,10 @@ public class Namespaces extends NamespacesBase {
         internalGetSubscribeRateAsync()
                 .thenAccept(subscribeRate -> asyncResponse.resume(subscribeRate))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get subscribe rate for namespace {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get subscribe rate for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1337,8 +1470,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.retention_policies))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get retention config on a namespace {}", clientAppId(), namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get retention config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1391,8 +1526,10 @@ public class Namespaces extends NamespacesBase {
         internalSetPersistenceAsync(persistence)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to update the persistence for a namespace {}", clientAppId(), namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to update the persistence for a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1410,8 +1547,10 @@ public class Namespaces extends NamespacesBase {
         internalDeletePersistenceAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to delete the persistence for a namespace {}", clientAppId(), namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete the persistence for a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1434,8 +1573,10 @@ public class Namespaces extends NamespacesBase {
         internalSetBookieAffinityGroupAsync(bookieAffinityGroup)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set bookie affinity group for namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set bookie affinity group for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1456,8 +1597,10 @@ public class Namespaces extends NamespacesBase {
         internalGetBookieAffinityGroupAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get bookie affinity group for namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get bookie affinity group for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1478,8 +1621,10 @@ public class Namespaces extends NamespacesBase {
         internalDeleteBookieAffinityGroupAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to delete bookie affinity group for namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to delete bookie affinity group for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1500,8 +1645,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.persistence))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get persistence configuration for a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get persistence configuration for a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1521,7 +1668,10 @@ public class Namespaces extends NamespacesBase {
         internalClearNamespaceBacklogAsync(authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to clear backlog on namespace {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to clear backlog on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1543,8 +1693,11 @@ public class Namespaces extends NamespacesBase {
         internalClearNamespaceBundleBacklogAsync(bundleRange, authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to clear backlog on namespace bundle {}/{}", clientAppId(),
-                            namespaceName, bundleRange, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .attr("bundleRange", bundleRange)
+                            .exception(ex)
+                            .log("Failed to clear backlog on namespace bundle");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1565,8 +1718,11 @@ public class Namespaces extends NamespacesBase {
         internalClearNamespaceBacklogForSubscriptionAsync(subscription, authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to clear backlog for subscription {} on namespace {}", clientAppId(),
-                            subscription, namespaceName, ex);
+                    log.error()
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to clear backlog for subscription on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1589,8 +1745,12 @@ public class Namespaces extends NamespacesBase {
         internalClearNamespaceBundleBacklogForSubscriptionAsync(subscription, bundleRange, authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to clear backlog for subscription {} on namespace bundle {}/{}",
-                            clientAppId(), subscription, namespaceName, bundleRange, ex);
+                    log.error()
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .attr("bundleRange", bundleRange)
+                            .exception(ex)
+                            .log("Failed to clear backlog for subscription on namespace bundle");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1611,8 +1771,11 @@ public class Namespaces extends NamespacesBase {
         internalUnsubscribeNamespaceAsync(subscription, authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to unsubscribe {} on namespace {}", clientAppId(),
-                            subscription, namespaceName, ex);
+                    log.error()
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to unsubscribe on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1634,8 +1797,12 @@ public class Namespaces extends NamespacesBase {
         internalUnsubscribeNamespaceBundleAsync(subscription, bundleRange, authoritative)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to unsubscribe {} on namespace bundle {}/{}", clientAppId(),
-                            subscription, namespaceName, bundleRange, ex);
+                    log.error()
+                            .attr("subscription", subscription)
+                            .attr("namespace", namespaceName)
+                            .attr("bundleRange", bundleRange)
+                            .exception(ex)
+                            .log("Failed to unsubscribe on namespace bundle");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1671,8 +1838,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.subscription_auth_mode))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get subscription auth mode in a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get subscription auth mode in a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1708,8 +1877,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.encryption_required))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get message encryption required status in a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get message encryption required status in a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1730,8 +1901,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.delayed_delivery_policies))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get delayed delivery messages config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get delayed delivery messages config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1779,8 +1952,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.inactive_topic_policies))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get inactive topic policies config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get inactive topic policies config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1829,8 +2004,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.max_producers_per_topic))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxProducersPerTopic config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxProducersPerTopic config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1879,8 +2056,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.deduplicationSnapshotIntervalSeconds))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get deduplicationSnapshotInterval config on a namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get deduplicationSnapshotInterval config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1915,8 +2094,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.max_consumers_per_topic))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxConsumersPerTopic config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxConsumersPerTopic config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -1965,8 +2146,11 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(polices -> asyncResponse.resume(polices.max_consumers_per_subscription))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxConsumersPerSubscription config on namespace {}: {} ",
-                            clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to get maxConsumersPerSubscription config on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2018,8 +2202,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.max_unacked_messages_per_consumer))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxUnackedMessagesPerConsumer config on a namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxUnackedMessagesPerConsumer config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2070,8 +2256,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.max_unacked_messages_per_subscription))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxUnackedMessagesPerSubscription config on a namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxUnackedMessagesPerSubscription config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2120,8 +2308,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.max_subscriptions_per_topic))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxSubscriptionsPerTopic config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxSubscriptionsPerTopic config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2176,8 +2366,12 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceAntiAffinityGroupAsync(antiAffinityGroup)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set namespace anti-affinity group, tenant: {}, namespace: {}, "
-                            + "antiAffinityGroup: {}", clientAppId(), tenant, namespace, antiAffinityGroup, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("antiAffinityGroup", antiAffinityGroup)
+                            .exception(ex)
+                            .log("Failed to set namespace anti-affinity group");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2195,8 +2389,11 @@ public class Namespaces extends NamespacesBase {
         internalGetNamespaceAntiAffinityGroupAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get namespace anti-affinity group, tenant: {}, namespace: {}",
-                            clientAppId(), tenant, namespace, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .exception(ex)
+                            .log("Failed to get namespace anti-affinity group");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2217,8 +2414,11 @@ public class Namespaces extends NamespacesBase {
         internalRemoveNamespaceAntiAffinityGroupAsync()
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to remove namespace anti-affinity group, tenant: {}, namespace: {}",
-                            clientAppId(), tenant, namespace, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .exception(ex)
+                            .log("Failed to remove namespace anti-affinity group");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2238,9 +2438,12 @@ public class Namespaces extends NamespacesBase {
         internalGetAntiAffinityNamespacesAsync(cluster, antiAffinityGroup, tenant)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get all namespaces in cluster of given anti-affinity group, cluster: {}, "
-                            + "tenant: {}, antiAffinityGroup: {}", clientAppId(), cluster, tenant, antiAffinityGroup,
-                            ex);
+                    log.error()
+                            .attr("cluster", cluster)
+                            .attr("tenant", tenant)
+                            .attr("antiAffinityGroup", antiAffinityGroup)
+                            .exception(ex)
+                            .log("Failed to get all namespaces in cluster of given anti-affinity group");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2262,8 +2465,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.compaction_threshold))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get compaction threshold on namespace {}", clientAppId(), namespaceName,
-                            ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get compaction threshold on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2328,7 +2533,10 @@ public class Namespaces extends NamespacesBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get offload threshold on namespace {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get offload threshold on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2379,7 +2587,10 @@ public class Namespaces extends NamespacesBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get offload threshold on namespace {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get offload threshold on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2434,8 +2645,10 @@ public class Namespaces extends NamespacesBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get offload deletion lag milliseconds on namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get offload deletion lag milliseconds on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2532,8 +2745,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.schema_compatibility_strategy))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get the strategy of the namespace schema compatibility {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("compatibility", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get the strategy of the namespace schema compatibility");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2578,8 +2793,10 @@ public class Namespaces extends NamespacesBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get the flag of whether allow auto update schema on a namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get the flag of whether allow auto update schema on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2623,8 +2840,10 @@ public class Namespaces extends NamespacesBase {
                     asyncResponse.resume(subscriptionTypes);
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get the set of whether allow subscription types on a namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get the set of whether allow subscription types on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2677,8 +2896,10 @@ public class Namespaces extends NamespacesBase {
             .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
             .thenAccept(policies -> asyncResponse.resume(policies.allowed_topic_property_keys_for_metrics))
             .exceptionally(ex -> {
-                log.error("[{}] Failed to get allowed topic property keys for metrics for namespace {}",
-                    clientAppId(), namespaceName, ex);
+                log.error()
+                        .attr("namespace", namespaceName)
+                        .exception(ex)
+                        .log("Failed to get allowed topic property keys for metrics for namespace");
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
             });
@@ -2702,8 +2923,10 @@ public class Namespaces extends NamespacesBase {
         internalSetAllowedTopicPropertyKeysForMetricsAsync(allowedKeys)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set allowed topic property keys for metrics for namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set allowed topic property keys for metrics for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2724,8 +2947,10 @@ public class Namespaces extends NamespacesBase {
         internalSetAllowedTopicPropertyKeysForMetricsAsync(null)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to remove allowed topic property keys for metrics for namespace {}",
-                            clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove allowed topic property keys for metrics for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2759,8 +2984,10 @@ public class Namespaces extends NamespacesBase {
                     }
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get schema validation enforced flag for namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get schema validation enforced flag for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2849,8 +3076,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.offload_policies))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get offload policies on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get offload policies on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -2873,8 +3102,10 @@ public class Namespaces extends NamespacesBase {
                     asyncResponse.resume(maxTopicsPerNamespace);
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get maxTopicsPerNamespace config on a namespace {}", clientAppId(),
-                            namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get maxTopicsPerNamespace config on a namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3016,7 +3247,10 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(policies -> asyncResponse.resume(policies.resource_group_name))
                 .exceptionally(ex -> {
-                    log.error("Failed to get the resource group attached to the namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get the resource group attached to the namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3094,13 +3328,16 @@ public class Namespaces extends NamespacesBase {
                     out.flush();
                     outputStream.flush();
                 } catch (Exception err) {
-                    log.error("error", err);
+                    log.error().exception(err).log("error");
                     throw new RuntimeException(err);
                 }
             };
             return Response.ok(output).type(MediaType.APPLICATION_JSON_TYPE).build();
         } catch (Throwable err) {
-            log.error("Error while scanning offloaded ledgers for namespace {}", namespaceName, err);
+            log.error()
+                    .attr("namespace", namespaceName)
+                    .exception(err)
+                    .log("Error while scanning offloaded ledgers for namespace");
             throw new RestException(Response.Status.INTERNAL_SERVER_ERROR,
                     "Error while scanning ledgers for " + namespaceName);
         }
@@ -3120,8 +3357,11 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(polices -> asyncResponse.resume(polices.entryFilters))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get entry filters config on namespace {}: {} ",
-                            clientAppId(), namespaceName, ex.getCause().getMessage(), ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exceptionMessage(ex.getCause())
+                            .exception(ex)
+                            .log("Failed to get entry filters config on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3144,7 +3384,10 @@ public class Namespaces extends NamespacesBase {
         internalSetEntryFiltersPerTopicAsync(entryFilters)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("Failed to set entry filters for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to set entry filters for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3165,7 +3408,10 @@ public class Namespaces extends NamespacesBase {
         internalSetEntryFiltersPerTopicAsync(null)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("Failed to remove entry filters for namespace {}", namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to remove entry filters for namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3186,8 +3432,11 @@ public class Namespaces extends NamespacesBase {
         internalEnableMigrationAsync(migrated)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to update migration, tenant: {}, namespace: {}",
-                            clientAppId(), tenant, namespace, ex);
+                    log.error()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .exception(ex)
+                            .log("Failed to update migration");
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -3207,8 +3456,9 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSetDispatcherPauseOnAckStatePersistentAsync(true)
                 .thenRun(() -> {
-                    log.info("[{}] Successfully enabled dispatcherPauseOnAckStatePersistent: namespace={}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully enabled dispatcherPauseOnAckStatePersistent: namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -3231,8 +3481,9 @@ public class Namespaces extends NamespacesBase {
         validateNamespaceName(tenant, namespace);
         internalSetDispatcherPauseOnAckStatePersistentAsync(false)
                 .thenRun(() -> {
-                    log.info("[{}] Successfully remove dispatcherPauseOnAckStatePersistent: namespace={}",
-                            clientAppId(), namespaceName);
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .log("Successfully remove dispatcherPauseOnAckStatePersistent: namespace");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -3259,7 +3510,6 @@ public class Namespaces extends NamespacesBase {
                 });
     }
 
-
     @POST
     @Path("/{tenant}/{namespace}/allowedClusters")
     @ApiOperation(value = "Set the allowed clusters for a namespace.")
@@ -3278,8 +3528,10 @@ public class Namespaces extends NamespacesBase {
         internalSetNamespaceAllowedClusters(clusterIds)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(e -> {
-                    log.error("[{}] Failed to set namespace allowed clusters on namespace {}",
-                            clientAppId(), namespace, e);
+                    log.error()
+                            .attr("namespace", namespace)
+                            .exception(e)
+                            .log("Failed to set namespace allowed clusters on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, e);
                     return null;
                 });
@@ -3299,12 +3551,12 @@ public class Namespaces extends NamespacesBase {
         internalGetNamespaceAllowedClustersAsync()
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(e -> {
-                    log.error("[{}] Failed to get namespace allowed clusters on namespace {}", clientAppId(),
-                            namespace, e);
+                    log.error()
+                            .attr("namespace", namespace)
+                            .exception(e)
+                            .log("Failed to get namespace allowed clusters on namespace");
                     resumeAsyncResponseExceptionally(asyncResponse, e);
                     return null;
                 });
     }
-
-    private static final Logger log = LoggerFactory.getLogger(Namespaces.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/NonPersistentTopics.java
@@ -62,8 +62,6 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentPartitionedTopicStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentTopicStatsImpl;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  */
@@ -72,8 +70,6 @@ import org.slf4j.LoggerFactory;
 @Api(value = "/non-persistent", description = "Non-Persistent topic admin apis", tags = "non-persistent topic")
 @SuppressWarnings("deprecation")
 public class NonPersistentTopics extends PersistentTopics {
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopics.class);
-
     @GET
     @Path("/{tenant}/{namespace}/{topic}/partitions")
     @ApiOperation(value = "Get partitioned topic metadata.", response = PartitionedTopicMetadata.class)
@@ -103,7 +99,10 @@ public class NonPersistentTopics extends PersistentTopics {
             if (ex != null) {
                 Throwable actEx = FutureUtil.unwrapCompletionException(ex);
                 if (isNot307And404Exception(actEx)) {
-                    log.error("[{}] Failed to get internal stats for topic {}", clientAppId(), topicName, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to get internal stats for topic");
                 }
                 resumeAsyncResponseExceptionally(asyncResponse, actEx);
             } else {
@@ -147,7 +146,10 @@ public class NonPersistentTopics extends PersistentTopics {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get internal stats for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get internal stats for topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -190,11 +192,13 @@ public class NonPersistentTopics extends PersistentTopics {
             validateTopicName(tenant, namespace, encodedTopic);
             internalCreatePartitionedTopic(asyncResponse, numPartitions, createLocalTopicOnly);
         } catch (Exception e) {
-            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to create partitioned topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
-
 
     @GET
     @Path("{tenant}/{namespace}/{topic}/partitioned-stats")
@@ -243,7 +247,10 @@ public class NonPersistentTopics extends PersistentTopics {
             try {
                 validateGlobalNamespaceOwnership(namespaceName);
             } catch (Exception e) {
-                log.error("[{}] Failed to get partitioned stats for {}", clientAppId(), topicName, e);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(e)
+                        .log("Failed to get partitioned stats");
                 resumeAsyncResponseExceptionally(asyncResponse, e);
                 return;
             }
@@ -314,7 +321,10 @@ public class NonPersistentTopics extends PersistentTopics {
                     return null;
                 });
             }).exceptionally(ex -> {
-                log.error("[{}] Failed to get partitioned stats for {}", clientAppId(), topicName, ex);
+                log.error()
+                        .attr("topic", topicName)
+                        .exception(ex)
+                        .log("Failed to get partitioned stats");
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
             });
@@ -324,7 +334,6 @@ public class NonPersistentTopics extends PersistentTopics {
             asyncResponse.resume(new RestException(e));
         }
     }
-
 
     @PUT
     @Path("/{tenant}/{namespace}/{topic}/unload")
@@ -386,10 +395,10 @@ public class NonPersistentTopics extends PersistentTopics {
         Policies policies = null;
         try {
             validateNamespaceName(tenant, namespace);
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] list of topics on namespace {}", clientAppId(), namespaceName);
-            }
-            validateNamespaceOperation(namespaceName, NamespaceOperation.GET_TOPICS);
+                log.debug()
+                        .attr("namespace", namespaceName)
+                        .log("list of topics on namespace");
+                        validateNamespaceOperation(namespaceName, NamespaceOperation.GET_TOPICS);
             policies = getNamespacePolicies(namespaceName);
 
             // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
@@ -412,8 +421,11 @@ public class NonPersistentTopics extends PersistentTopics {
             try {
                 futures.add(pulsar().getAdminClient().topics().getListInBundleAsync(namespaceName.toString(), bundle));
             } catch (PulsarServerException e) {
-                log.error("[{}] Failed to get list of topics under namespace {}/{}", clientAppId(), namespaceName,
-                        bundle, e);
+                log.error()
+                        .attr("namespace", namespaceName)
+                        .attr("bundle", bundle)
+                        .exception(e)
+                        .log("Failed to get list of topics under namespace");
                 asyncResponse.resume(new RestException(e));
                 return;
             }
@@ -461,11 +473,11 @@ public class NonPersistentTopics extends PersistentTopics {
             @ApiParam(value = "Bundle range of a topic", required = true)
             @PathParam("bundle") String bundleRange) {
         validateNamespaceName(tenant, namespace);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] list of topics on namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange);
-        }
-
-        validateNamespaceOperation(namespaceName, NamespaceOperation.GET_BUNDLE);
+            log.debug()
+                    .attr("namespace", namespaceName)
+                    .attr("bundleRange", bundleRange)
+                    .log("list of topics on namespace bundle");
+                validateNamespaceOperation(namespaceName, NamespaceOperation.GET_BUNDLE);
         Policies policies = getNamespacePolicies(namespaceName);
 
         // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
@@ -473,8 +485,10 @@ public class NonPersistentTopics extends PersistentTopics {
 
         isBundleOwnedByAnyBroker(namespaceName, policies.bundles, bundleRange).thenAccept(flag -> {
             if (!flag) {
-                log.info("[{}] Namespace bundle is not owned by any broker {}/{}", clientAppId(), namespaceName,
-                        bundleRange);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("bundleRange", bundleRange)
+                        .log("Namespace bundle is not owned by any broker");
                 asyncResponse.resume(Response.noContent().build());
             } else {
                 validateNamespaceBundleOwnershipAsync(namespaceName, policies.bundles, bundleRange, true, true)
@@ -496,8 +510,11 @@ public class NonPersistentTopics extends PersistentTopics {
                             asyncResponse.resume(topicList);
                         }).exceptionally(ex -> {
                             if (isNot307And404Exception(ex)) {
-                                log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
-                                        namespaceName, bundleRange, ex);
+                                log.error()
+                                        .attr("namespace", namespaceName)
+                                        .attr("bundleRange", bundleRange)
+                                        .exception(ex)
+                                        .log("Failed to list topics on namespace bundle");
                             }
                             resumeAsyncResponseExceptionally(asyncResponse, ex);
                             return null;
@@ -505,8 +522,11 @@ public class NonPersistentTopics extends PersistentTopics {
             }
         }).exceptionally(ex -> {
             if (isNot307And404Exception(ex)) {
-                log.error("[{}] Failed to list topics on namespace bundle {}/{}", clientAppId(),
-                        namespaceName, bundleRange, ex);
+                log.error()
+                        .attr("namespace", namespaceName)
+                        .attr("bundleRange", bundleRange)
+                        .exception(ex)
+                        .log("Failed to list topics on namespace bundle");
             }
             resumeAsyncResponseExceptionally(asyncResponse, ex);
             return null;
@@ -619,13 +639,12 @@ public class NonPersistentTopics extends PersistentTopics {
         preValidation(authoritative)
                 .thenCompose(__ -> internalRemoveEntryFilters(isGlobal))
                 .thenRun(() -> {
-                    log.info(
-                            "[{}] Successfully remove entry filters: tenant={}, namespace={}, topic={}, isGlobal={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            isGlobal);
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("isGlobal", isGlobal)
+                            .log("Successfully remove entry filters");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -94,8 +94,6 @@ import org.apache.pulsar.common.policies.data.stats.PartitionedTopicStatsImpl;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  */
@@ -132,7 +130,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenAccept(topicList -> asyncResponse.resume(filterSystemTopic(topicList, includeSystemTopic)))
             .exceptionally(ex -> {
                 if (isNot307And404Exception(ex)) {
-                    log.error("[{}] Failed to get topic list {}", clientAppId(), namespaceName, ex);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(ex)
+                            .log("Failed to get topic list");
                 }
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
@@ -163,7 +164,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                         filterSystemTopic(partitionedTopicList, includeSystemTopic)))
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get partitioned topic list {}", clientAppId(), namespaceName, ex);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(ex)
+                                .log("Failed to get partitioned topic list");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -197,12 +201,18 @@ public class PersistentTopics extends PersistentTopicsBase {
             validateTopicName(tenant, namespace, encodedTopic);
             internalGetPermissionsOnTopic().thenAccept(permissions -> asyncResponse.resume(permissions))
                     .exceptionally(ex -> {
-                        log.error("[{}] Failed to get permissions for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get permissions for topic");
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
                     });
         } catch (Exception e) {
-            log.error("[{}] Failed to validate topic name {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to validate topic name");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -314,7 +324,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             validateCreateTopic(topicName);
             internalCreatePartitionedTopic(asyncResponse, numPartitions, createLocalTopicOnly);
         } catch (Exception e) {
-            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to create partitioned topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -355,7 +368,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex) && !isConflictException(ex)) {
-                        log.error("[{}] Failed to create non-partitioned topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to create non-partitioned topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -725,8 +741,6 @@ public class PersistentTopics extends PersistentTopicsBase {
             });
     }
 
-
-
     @DELETE
     @Path("/{tenant}/{namespace}/{topic}/maxUnackedMessagesOnSubscription")
     @ApiOperation(value = "Delete max unacked messages per subscription config on a topic.")
@@ -806,8 +820,6 @@ public class PersistentTopics extends PersistentTopicsBase {
             });
     }
 
-
-
     @DELETE
     @Path("/{tenant}/{namespace}/{topic}/delayedDelivery")
     @ApiOperation(value = "Set delayed delivery messages config on a topic.")
@@ -878,19 +890,24 @@ public class PersistentTopics extends PersistentTopicsBase {
         validateTopicPolicyOperationAsync(topicName, PolicyName.PARTITION, PolicyOperation.WRITE)
                 .thenCompose(__ -> internalUpdatePartitionedTopicAsync(numPartitions, updateLocalTopic, force))
                 .thenAccept(__ -> {
-                    log.info("[{}][{}] Updated topic partition to {}.", clientAppId(), topicName, numPartitions);
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("numPartitions", numPartitions)
+                            .log("Updated topic partitions");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex) && !isConflictException(ex)) {
-                        log.error("[{}][{}] Failed to update partition to {}",
-                                clientAppId(), topicName, numPartitions, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("numPartitions", numPartitions)
+                                .exception(ex)
+                                .log("Failed to update partitions");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }
-
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/createMissedPartitions")
@@ -954,11 +971,15 @@ public class PersistentTopics extends PersistentTopicsBase {
                     Throwable t = FutureUtil.unwrapCompletionException(ex);
                     if (!isRedirectException(t)) {
                         if (AdminResource.isNotFoundException(t)) {
-                            log.info("[{}] Failed to get partitioned metadata topic {}: {}",
-                                    clientAppId(), topicName, ex.getMessage());
+                            log.info()
+                                    .attr("topic", topicName)
+                                    .exceptionMessage(ex)
+                                    .log("Failed to get partitioned metadata topic");
                         } else {
-                            log.error("[{}] Failed to get partitioned metadata topic {}",
-                                    clientAppId(), topicName, t);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(t)
+                                    .log("Failed to get partitioned metadata topic");
                         }
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
@@ -993,7 +1014,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get topic {} properties", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get topic properties");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1030,7 +1054,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
             .exceptionally(ex -> {
                 if (isNot307And404Exception(ex)) {
-                    log.error("[{}] Failed to update topic {} properties", clientAppId(), topicName, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to update topic properties");
                 }
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
@@ -1065,8 +1092,11 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to remove key {} in properties on topic {}",
-                                clientAppId(), key, topicName, ex);
+                        log.error()
+                                .attr("key", key)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to remove key in properties on topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1199,7 +1229,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                         ex = new RestException(Response.Status.NOT_FOUND,
                                 getTopicNotFoundErrorMessage(topicName.toString()));
                     } else if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to delete topic {}", clientAppId(), topicName, t);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(t)
+                                .log("Failed to delete topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1237,7 +1270,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                     if (t instanceof IllegalStateException){
                         ex = new RestException(422/* Unprocessable entity*/, t.getMessage());
                     } else if (isNot307And4xxException(ex)) {
-                        log.error("[{}] Failed to delete topic {}", clientAppId(), topicName, t);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(t)
+                                .log("Failed to delete topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1321,7 +1357,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get stats for {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get stats");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1355,7 +1394,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get internal stats for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get internal stats for topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -1510,8 +1552,11 @@ public class PersistentTopics extends PersistentTopicsBase {
 
                     // If the exception is not redirect exception we need to log it.
                     if (!isRedirectException(cause)) {
-                        log.error("[{}] Failed to delete subscription {} from topic {}", clientAppId(), subName,
-                                topicName, cause);
+                        log.error()
+                                .attr("subscription", subName)
+                                .attr("topic", topicName)
+                                .exception(cause)
+                                .log("Failed to delete subscription from topic");
                     }
 
                     if (cause instanceof BrokerServiceException.SubscriptionBusyException) {
@@ -1818,8 +1863,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .exceptionally(ex -> {
                 Throwable t = FutureUtil.unwrapCompletionException(ex);
                 if (!isRedirectException(t)) {
-                    log.error("[{}][{}] Failed to reset cursor on subscription {} to time {}",
-                        clientAppId(), topicName, encodedSubName, timestamp, t);
+                    log.error()
+                            .attr("topic", topicName)
+                            .attr("subscription", encodedSubName)
+                            .attr("time", timestamp)
+                            .exception(t)
+                            .log("Failed to reset cursor on subscription to time");
                 }
                 if (t instanceof BrokerServiceException.SubscriptionInvalidCursorPosition) {
                     t = new RestException(Response.Status.PRECONDITION_FAILED,
@@ -2034,8 +2083,11 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get peek nth message for topic {} subscription {}", clientAppId(),
-                                topicName, decode(encodedSubName), ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("subscription", decode(encodedSubName))
+                                .exception(ex)
+                                .log("Failed to get peek nth message for topic subscription");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2083,8 +2135,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenAccept(asyncResponse::resume)
             .exceptionally(ex -> {
                 if (isNot307And404Exception(ex)) {
-                    log.error("[{}] Failed to examine a specific message on the topic {}", clientAppId(), topicName,
-                            ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to examine a specific message on the topic");
                 }
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
@@ -2132,8 +2186,12 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .exceptionally(ex -> {
                     // If the exception is not redirect exception we need to log it.
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get message with ledgerId {} entryId {} from {}",
-                                clientAppId(), ledgerId, entryId, topicName, ex);
+                        log.error()
+                                .attr("ledgerId", ledgerId)
+                                .attr("entryId", entryId)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get message");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2177,8 +2235,11 @@ public class PersistentTopics extends PersistentTopicsBase {
                 })
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get message ID by timestamp {} from {}",
-                            clientAppId(), timestamp, topicName, ex);
+                        log.error()
+                                .attr("timestamp", timestamp)
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get message ID by timestamp");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2209,11 +2270,15 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .exceptionally(ex -> {
                     Throwable t = FutureUtil.unwrapCompletionException(ex);
                     if (t instanceof MetadataStoreException.NotFoundException) {
-                        log.warn("[{}] Failed to get topic backlog {}: Namespace does not exist", clientAppId(),
-                                namespaceName);
+                        log.warn()
+                                .attr("backlog", namespaceName)
+                                .log("Failed to get topic backlog : Namespace does not exist");
                         ex = new RestException(Response.Status.NOT_FOUND, "Namespace does not exist");
                     } else if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get estimated backlog for topic {}", clientAppId(), encodedTopic, ex);
+                        log.error()
+                                .attr("topic", encodedTopic)
+                                .exception(ex)
+                                .log("Failed to get estimated backlog for topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -2772,11 +2837,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetRetention(retention, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully updated retention: namespace={}, topic={}, retention={}",
-                            clientAppId(),
-                            namespaceName,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(retention));
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("retention", objectWriter().writeValueAsString(retention))
+                            .log("Successfully updated retention");
                 } catch (JsonProcessingException ignore) {
                 }
                 asyncResponse.resume(Response.noContent().build());
@@ -2810,10 +2875,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveRetention(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove retention: namespace={}, topic={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove retention");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -2845,8 +2910,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetDispatcherPauseOnAckStatePersistent(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully enabled dispatcherPauseOnAckStatePersistent: namespace={}, topic={}",
-                    clientAppId(), namespaceName, topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully enabled dispatcherPauseOnAckStatePersistent");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -2878,8 +2945,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveDispatcherPauseOnAckStatePersistent(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove dispatcherPauseOnAckStatePersistent: namespace={}, topic={}",
-                        clientAppId(), namespaceName, topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove dispatcherPauseOnAckStatePersistent");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -2969,12 +3038,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetPersistence(persistencePolicies, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully updated persistence policies: "
-                                    + "namespace={}, topic={}, persistencePolicies={}",
-                            clientAppId(),
-                            namespaceName,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(persistencePolicies));
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("persistencePolicies", objectWriter().writeValueAsString(persistencePolicies))
+                            .log("Successfully updated persistence policies");
                 } catch (JsonProcessingException ignore) {
                 }
                 asyncResponse.resume(Response.noContent().build());
@@ -3007,10 +3075,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemovePersistence(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove persistence policies: namespace={}, topic={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove persistence policies");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3070,9 +3138,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxSubscriptionsPerTopic(maxSubscriptionsPerTopic, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully updated maxSubscriptionsPerTopic: namespace={}, topic={}"
-                                + ", maxSubscriptions={}, isGlobal={}"
-                        , clientAppId(), namespaceName, topicName.getLocalName(), maxSubscriptionsPerTopic, isGlobal);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("maxSubscriptions", maxSubscriptionsPerTopic)
+                        .attr("isGlobal", isGlobal)
+                        .log("Successfully updated maxSubscriptionsPerTopic");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3103,8 +3174,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxSubscriptionsPerTopic(null, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove maxSubscriptionsPerTopic: namespace={}, topic={}",
-                        clientAppId(), namespaceName, topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove maxSubscriptionsPerTopic");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3164,9 +3237,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetReplicatorDispatchRate(dispatchRate, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully updated replicatorDispatchRate: namespace={}, topic={}"
-                                + ", replicatorDispatchRate={}, isGlobal={}",
-                        clientAppId(), namespaceName, topicName.getLocalName(), dispatchRate, isGlobal);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("replicatorDispatchRate", dispatchRate)
+                        .attr("isGlobal", isGlobal)
+                        .log("Successfully updated replicatorDispatchRate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3197,8 +3273,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetReplicatorDispatchRate(null, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove replicatorDispatchRate limit: namespace={}, topic={}",
-                        clientAppId(), namespaceName, topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove replicatorDispatchRate limit");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3258,11 +3336,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxProducers(maxProducers, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully updated max producers: namespace={}, topic={}, maxProducers={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName(),
-                        maxProducers);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("maxProducers", maxProducers)
+                        .log("Successfully updated max producers");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3293,10 +3371,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveMaxProducers(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove max producers: namespace={}, topic={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully removed max producers");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3356,11 +3434,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxConsumers(maxConsumers, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully updated max consumers: namespace={}, topic={}, maxConsumers={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName(),
-                        maxConsumers);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("maxConsumers", maxConsumers)
+                        .log("Successfully updated max consumers");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3391,10 +3469,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveMaxConsumers(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove max consumers: namespace={}, topic={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove max consumers");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3455,13 +3533,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxMessageSize(maxMessageSize, isGlobal))
             .thenRun(() -> {
-                log.info(
-                        "[{}] Successfully set max message size: namespace={}, topic={}, maxMessageSiz={}, isGlobal={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName(),
-                        maxMessageSize,
-                        isGlobal);
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("maxMessageSize", maxMessageSize)
+                        .attr("isGlobal", isGlobal)
+                        .log("Successfully set max message size");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3492,10 +3569,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalSetMaxMessageSize(null, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove max message size: namespace={}, topic={}",
-                        clientAppId(),
-                        namespaceName,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("namespace", namespaceName)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove max message size");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3503,7 +3580,6 @@ public class PersistentTopics extends PersistentTopicsBase {
                 return null;
             });
     }
-
 
     @POST
     @Path("/{tenant}/{namespace}/{topic}/terminate")
@@ -3541,7 +3617,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to terminated topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to terminated topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -3640,8 +3719,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (isNot307And404Exception(ex)) {
-                        log.error("[{}] Failed to get the status of a compaction operation for the topic {}",
-                                clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get the status of a compaction operation for the topic");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -3781,7 +3862,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             internalTrimTopic(asyncResponse, authoritative).exceptionally(ex -> {
                 // If the exception is not redirect exception we need to log it.
                 if (isNot307And404Exception(ex)) {
-                    log.error("[{}] Failed to trim topic {}", clientAppId(), topicName, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to trim topic");
                 }
                 resumeAsyncResponseExceptionally(asyncResponse, ex);
                 return null;
@@ -3842,13 +3926,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetDispatchRate(dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic dispatch rate:"
-                                    + " tenant={}, namespace={}, topic={}, dispatchRate={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(dispatchRate));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("dispatchRate", objectWriter().writeValueAsString(dispatchRate))
+                            .log("Successfully set topic dispatch rate");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -3880,11 +3963,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveDispatchRate(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove topic dispatch rate: tenant={}, namespace={}, topic={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove topic dispatch rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -3949,13 +4032,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetSubscriptionDispatchRate(dispatchRate, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic subscription dispatch rate:"
-                                    + " tenant={}, namespace={}, topic={}, dispatchRate={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(dispatchRate));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("dispatchRate", objectWriter().writeValueAsString(dispatchRate))
+                            .log("Successfully set topic subscription dispatch rate");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -3987,11 +4069,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveSubscriptionDispatchRate(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove topic subscription dispatch rate: tenant={}, namespace={}, topic={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove topic subscription dispatch rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4057,14 +4139,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetSubscriptionLevelDispatchRate(
                     Codec.decode(encodedSubscriptionName), dispatchRate, isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully set subscription level dispatch rate:"
-                                + " tenant={}, namespace={}, topic={}, sub={}, dispatchRate={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName(),
-                        encodedSubscriptionName,
-                        dispatchRate);
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("subscription", encodedSubscriptionName)
+                        .attr("dispatchRate", dispatchRate)
+                        .log("Successfully set subscription level dispatch rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4098,9 +4179,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalRemoveSubscriptionLevelDispatchRate(
                     Codec.decode(encodedSubscriptionName), isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove subscription level dispatch rate: "
-                                + "tenant={}, namespace={}, topic={}, sub={}",
-                        clientAppId(), tenant, namespace, topicName.getLocalName(), encodedSubscriptionName);
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("subscription", encodedSubscriptionName)
+                        .log("Successfully remove subscription level dispatch rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4160,13 +4244,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetCompactionThreshold(compactionThreshold, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic compaction threshold:"
-                                    + " tenant={}, namespace={}, topic={}, compactionThreshold={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(compactionThreshold));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("compactionThreshold", objectWriter().writeValueAsString(compactionThreshold))
+                            .log("Successfully set topic compaction threshold");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -4198,11 +4281,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveCompactionThreshold(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove topic compaction threshold: tenant={}, namespace={}, topic={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove topic compaction threshold");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4266,13 +4349,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetMaxConsumersPerSubscription(maxConsumersPerSubscription, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic max consumers per subscription:"
-                                    + " tenant={}, namespace={}, topic={}, maxConsumersPerSubscription={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(maxConsumersPerSubscription));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("maxConsumersPerSubscription",
+                                    objectWriter().writeValueAsString(maxConsumersPerSubscription))
+                            .log("Successfully set topic max consumers per subscription");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -4304,12 +4387,11 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveMaxConsumersPerSubscription(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove topic max consumers per subscription:"
-                                + " tenant={}, namespace={}, topic={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName());
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .log("Successfully remove topic max consumers per subscription");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4369,14 +4451,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetPublishRate(publishRate, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic publish rate:"
-                                    + " tenant={}, namespace={}, topic={}, isGlobal={}, publishRate={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            isGlobal,
-                            objectWriter().writeValueAsString(publishRate));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("isGlobal", isGlobal)
+                            .attr("publishRate", objectWriter().writeValueAsString(publishRate))
+                            .log("Successfully set topic publish rate");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -4408,12 +4489,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemovePublishRate(isGlobal))
             .thenRun(() -> {
-                log.info("[{}] Successfully remove topic publish rate: tenant={}, namespace={}, topic={}, isGlobal={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName(),
-                        isGlobal);
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("isGlobal", isGlobal)
+                        .log("Successfully remove topic publish rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4480,13 +4561,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetSubscriptionTypesEnabled(subscriptionTypesEnabled, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic is enabled sub types :"
-                                    + " tenant={}, namespace={}, topic={}, subscriptionTypesEnabled={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            objectWriter().writeValueAsString(subscriptionTypesEnabled));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("subscriptionTypesEnabled",
+                                    objectWriter().writeValueAsString(subscriptionTypesEnabled))
+                            .log("Successfully set topic is enabled sub types");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -4518,10 +4599,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
                 .thenCompose(__ -> internalRemoveSubscriptionTypesEnabled(isGlobal))
                 .thenRun(() -> {
-                    log.info("[{}] Successfully remove subscription types enabled: namespace={}, topic={}",
-                            clientAppId(),
-                            namespaceName,
-                            topicName.getLocalName());
+                    log.info()
+                            .attr("namespace", namespaceName)
+                            .attr("topic", topicName.getLocalName())
+                            .log("Successfully remove subscription types enabled");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -4581,14 +4662,13 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> internalSetSubscribeRate(subscribeRate, isGlobal))
             .thenRun(() -> {
                 try {
-                    log.info("[{}] Successfully set topic subscribe rate:"
-                                    + " tenant={}, namespace={}, topic={}, isGlobal={} subscribeRate={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            isGlobal,
-                            objectWriter().writeValueAsString(subscribeRate));
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("isGlobal", isGlobal)
+                            .attr("subscribeRate", objectWriter().writeValueAsString(subscribeRate))
+                            .log("Successfully set topic subscribe rate");
                 } catch (JsonProcessingException ignore) {}
                 asyncResponse.resume(Response.noContent().build());
             })
@@ -4621,13 +4701,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             .thenCompose(__ -> preValidation(authoritative))
             .thenCompose(__ -> internalRemoveSubscribeRate(isGlobal))
             .thenRun(() -> {
-                log.info(
-                        "[{}] Successfully remove topic subscribe rate: tenant={}, namespace={}, topic={}, isGlobal={}",
-                        clientAppId(),
-                        tenant,
-                        namespace,
-                        topicName.getLocalName(),
-                        isGlobal);
+                log.info()
+                        .attr("tenant", tenant)
+                        .attr("namespace", namespace)
+                        .attr("topic", topicName.getLocalName())
+                        .attr("isGlobal", isGlobal)
+                        .log("Successfully remove topic subscribe rate");
                 asyncResponse.resume(Response.noContent().build());
             })
             .exceptionally(ex -> {
@@ -4664,7 +4743,10 @@ public class PersistentTopics extends PersistentTopicsBase {
             .exceptionally(ex -> {
                 Throwable t = FutureUtil.unwrapCompletionException(ex);
                 if (!isRedirectException(t)) {
-                    log.error("[{}] Failed to truncate topic {}", clientAppId(), topicName, t);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(t)
+                            .log("Failed to truncate topic");
                 }
                 if (t instanceof PulsarAdminException.NotFoundException) {
                     t = new RestException(Response.Status.NOT_FOUND, t.getMessage());
@@ -4797,14 +4879,12 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
                 .thenCompose(__ -> internalSetSchemaCompatibilityStrategy(strategy))
                 .thenRun(() -> {
-                    log.info(
-                            "[{}] Successfully set topic schema compatibility strategy: tenant={}, namespace={}, "
-                                    + "topic={}, schemaCompatibilityStrategy={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            strategy);
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("schemaCompatibilityStrategy", strategy)
+                            .log("Successfully set topic schema compatibility strategy");
                     asyncResponse.resume(Response.noContent().build());
                 }).exceptionally(ex -> {
                     handleTopicPolicyException("setSchemaCompatibilityStrategy", ex, asyncResponse);
@@ -4838,13 +4918,11 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
                 .thenCompose(__ -> internalSetSchemaCompatibilityStrategy(null))
                 .thenRun(() -> {
-                    log.info(
-                            "[{}] Successfully remove topic schema compatibility strategy: tenant={}, namespace={}, "
-                                    + "topic={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName());
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .log("Successfully remove topic schema compatibility strategy");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -4992,13 +5070,12 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
                 .thenCompose(__ -> internalRemoveEntryFilters(isGlobal))
                 .thenRun(() -> {
-                    log.info(
-                            "[{}] Successfully remove entry filters: tenant={}, namespace={}, topic={}, isGlobal={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            isGlobal);
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("isGlobal", isGlobal)
+                            .log("Successfully remove entry filters");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -5172,14 +5249,12 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenCompose(__ -> preValidation(authoritative))
                 .thenCompose(__ -> internalSetAutoSubscriptionCreation(null, isGlobal))
                 .thenRun(() -> {
-                    log.info(
-                            "[{}] Successfully remove topic removeAutoSubscriptionCreation: "
-                                    + "tenant={}, namespace={}, topic={}, isGlobal={}",
-                            clientAppId(),
-                            tenant,
-                            namespace,
-                            topicName.getLocalName(),
-                            isGlobal);
+                    log.info()
+                            .attr("tenant", tenant)
+                            .attr("namespace", namespace)
+                            .attr("topic", topicName.getLocalName())
+                            .attr("isGlobal", isGlobal)
+                            .log("Successfully remove topic removeAutoSubscriptionCreation");
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
@@ -5213,8 +5288,11 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to get message id by index for topic {}, index {}",
-                                clientAppId(), topicName, index, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("index", index)
+                                .exception(ex)
+                                .log("Failed to get message id by index");
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
@@ -5237,12 +5315,10 @@ public class PersistentTopics extends PersistentTopicsBase {
                         map.put(key, value);
                     }
                 } catch (Exception e) {
-                    log.warn("Failed to decode property: {}", pair, e);
+                    log.warn().attr("property", pair).exception(e).log("Failed to decode property");
                 }
             }
         }
         return map;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceQuotas.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceQuotas.java
@@ -34,11 +34,9 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.impl.ResourceQuotasBase;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
 
-@Slf4j
 @Path("/resource-quotas")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -53,7 +51,7 @@ public class ResourceQuotas extends ResourceQuotasBase {
         getDefaultResourceQuotaAsync()
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get default resource quota", clientAppId());
+                    log.error("Failed to get default resource quota");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -68,7 +66,7 @@ public class ResourceQuotas extends ResourceQuotasBase {
         setDefaultResourceQuotaAsync(quota)
                 .thenAccept(__ -> response.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set default resource quota", clientAppId());
+                    log.error("Failed to set default resource quota");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
         });
@@ -93,8 +91,10 @@ public class ResourceQuotas extends ResourceQuotasBase {
         internalGetNamespaceBundleResourceQuota(bundleRange)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get namespace resource quota for bundle {}",
-                            clientAppId(), bundleRange, ex);
+                    log.error()
+                            .attr("bundle", bundleRange)
+                            .exception(ex)
+                            .log("Failed to get namespace resource quota for bundle");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -120,12 +120,16 @@ public class ResourceQuotas extends ResourceQuotasBase {
         validateNamespaceName(tenant, namespace);
         internalSetNamespaceBundleResourceQuota(bundleRange, quota)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully set namespace bundle resource quota {}", clientAppId(), bundleRange);
+                    log.info()
+                            .attr("quota", bundleRange)
+                            .log("Successfully set namespace bundle resource quota");
                     response.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to set namespace resource quota for bundle {}",
-                            clientAppId(), bundleRange, ex);
+                    log.error()
+                            .attr("bundle", bundleRange)
+                            .exception(ex)
+                            .log("Failed to set namespace resource quota for bundle");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -150,12 +154,16 @@ public class ResourceQuotas extends ResourceQuotasBase {
         validateNamespaceName(tenant, namespace);
         internalRemoveNamespaceBundleResourceQuota(bundleRange)
                 .thenAccept(__ -> {
-                    log.info("[{}] Successfully remove namespace bundle resource quota {}", clientAppId(), bundleRange);
+                    log.info()
+                            .attr("quota", bundleRange)
+                            .log("Successfully remove namespace bundle resource quota");
                     response.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to remove namespace bundle resource quota {}",
-                            clientAppId(), bundleRange, ex);
+                    log.error()
+                            .attr("quota", bundleRange)
+                            .exception(ex)
+                            .log("Failed to remove namespace bundle resource quota");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/SchemasResource.java
@@ -40,7 +40,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.impl.SchemasResourceBase;
 import org.apache.pulsar.broker.service.schema.exceptions.IncompatibleSchemaException;
 import org.apache.pulsar.broker.service.schema.exceptions.InvalidSchemaDataException;
@@ -60,7 +59,6 @@ import org.apache.pulsar.common.util.FutureUtil;
     description = "Schemas related admin APIs",
     tags = "schemas"
 )
-@Slf4j
 @SuppressWarnings("deprecation")
 public class SchemasResource extends SchemasResourceBase {
 
@@ -94,7 +92,10 @@ public class SchemasResource extends SchemasResourceBase {
                 .thenApply(response::resume)
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to get schema for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get schema for topic");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -127,8 +128,11 @@ public class SchemasResource extends SchemasResourceBase {
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to get schema for topic {} with version {}",
-                                clientAppId(), topicName, version, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .attr("version", version)
+                                .exception(ex)
+                                .log("Failed to get schema for topic with version");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -160,7 +164,10 @@ public class SchemasResource extends SchemasResourceBase {
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to get all schemas for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get all schemas for topic");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -191,7 +198,10 @@ public class SchemasResource extends SchemasResourceBase {
         getSchemaMetadataAsync(authoritative)
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to get schema metadata for topic {}", clientAppId(), topicName, ex);
+                    log.error()
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to get schema metadata for topic");
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });
@@ -223,7 +233,10 @@ public class SchemasResource extends SchemasResourceBase {
                 })
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to delete schemas for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to delete schemas for topic");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -270,7 +283,10 @@ public class SchemasResource extends SchemasResourceBase {
                                 root.getMessage()).build());
                     } else {
                         if (shouldPrintErrorLog(ex)) {
-                            log.error("[{}] Failed to post schemas for topic {}", clientAppId(), topicName, root);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .attr("root", root)
+                                    .log("Failed to post schemas for topic");
                         }
                         resumeAsyncResponseExceptionally(response, ex);
                     }
@@ -310,7 +326,10 @@ public class SchemasResource extends SchemasResourceBase {
                         .build()))
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to test compatibility for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to test compatibility for topic");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
@@ -347,7 +366,10 @@ public class SchemasResource extends SchemasResourceBase {
                 .thenAccept(version -> response.resume(LongSchemaVersionResponse.builder().version(version).build()))
                 .exceptionally(ex -> {
                     if (shouldPrintErrorLog(ex)) {
-                        log.error("[{}] Failed to get version by schema for topic {}", clientAppId(), topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to get version by schema for topic");
                     }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Worker.java
@@ -32,7 +32,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.common.functions.WorkerInfo;
@@ -40,7 +39,6 @@ import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.service.api.Workers;
 
-@Slf4j
 @Path("/worker")
 public class Worker extends AdminResource implements Supplier<WorkerService> {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
@@ -28,14 +28,12 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.common.policies.data.WorkerFunctionInstanceStats;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.service.api.Workers;
 
-@Slf4j
 @Path("/worker-stats")
 public class WorkerStats extends AdminResource {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v3/Transactions.java
@@ -38,7 +38,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.admin.impl.TransactionsBase;
@@ -62,7 +61,6 @@ import org.jspecify.annotations.Nullable;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/transactions", description = "Transactions admin apis", tags = "transactions")
-@Slf4j
 @SuppressWarnings("deprecation")
 public class Transactions extends TransactionsBase {
 
@@ -120,8 +118,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get transaction state in transaction buffer {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get transaction state in transaction buffer");
                         }
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
@@ -158,8 +158,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get transaction state in pending ack {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get transaction state in pending ack");
                         }
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
@@ -196,8 +198,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get transaction buffer stats in topic {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get transaction buffer stats in topic");
                         }
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
@@ -232,8 +236,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get transaction pending ack stats in topic {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get transaction pending ack stats in topic");
                         }
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
@@ -330,8 +336,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get pending ack internal stats {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get pending ack internal stats");
                         }
                         return resumeAsyncResponseWithBrokerException(asyncResponse, ex);
                     });
@@ -381,8 +389,10 @@ public class Transactions extends TransactionsBase {
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
                         if (isNot307And404Exception(ex)) {
-                            log.error("[{}] Failed to get transaction buffer internal stats {}",
-                                    clientAppId(), topicName, ex);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to get transaction buffer internal stats");
                         }
                         return resumeAsyncResponseWithBrokerException(asyncResponse, ex);
                     });
@@ -410,7 +420,7 @@ public class Transactions extends TransactionsBase {
                         return null;
                     });
         } catch (Exception e) {
-            log.warn("{} Failed to update the scale of transaction coordinators", clientAppId());
+            log.warn("Failed to update the scale of transaction coordinators");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -444,13 +454,17 @@ public class Transactions extends TransactionsBase {
             internalGetPositionStatsPendingAckStats(authoritative, subName, position, batchIndex)
                     .thenAccept(asyncResponse::resume)
                     .exceptionally(ex -> {
-                        log.warn("{} Failed to check position [{}] stats for topic [{}], subscription [{}]",
-                                clientAppId(), position, topicName, subName, ex);
+                        log.warn()
+                                .attr("position", position)
+                                .attr("topic", topicName)
+                                .attr("subscription", subName)
+                                .exception(ex)
+                                .log("Failed to check position stats");
                         resumeAsyncResponseExceptionally(asyncResponse, ex);
                         return null;
                     });
         } catch (Exception ex) {
-            log.warn("Failed to get position stats in pending ack", ex);
+            log.warn().exception(ex).log("Failed to get position stats in pending ack");
             resumeAsyncResponseExceptionally(asyncResponse, ex);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/AbstractDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/AbstractDelayedDeliveryTracker.java
@@ -18,16 +18,18 @@
  */
 package org.apache.pulsar.broker.delayed;
 
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
 
-@Slf4j
 public abstract class AbstractDelayedDeliveryTracker implements DelayedDeliveryTracker, TimerTask {
+
+    private static final Logger LOG = Logger.get(AbstractDelayedDeliveryTracker.class);
+    protected final Logger log;
 
     protected final DelayedDeliveryContext context;
 
@@ -79,6 +81,7 @@ public abstract class AbstractDelayedDeliveryTracker implements DelayedDeliveryT
         this.tickTimeMillis = tickTimeMillis;
         this.clock = clock;
         this.isDelayedDeliveryDeliverAtTimeStrict = isDelayedDeliveryDeliverAtTimeStrict;
+        this.log = LOG.with().attr("dispatcher", context.getName()).build();
     }
 
     /**
@@ -137,12 +140,9 @@ public abstract class AbstractDelayedDeliveryTracker implements DelayedDeliveryT
         // Compute the earliest time that we schedule the timer to run.
         long remainingTickDelayMillis = lastTickRun + tickTimeMillis - now;
         long calculatedDelayMillis = Math.max(delayMillis, remainingTickDelayMillis);
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Start timer in {} millis", context.getName(), calculatedDelayMillis);
-        }
-
-        // Even though we may delay longer than this timestamp because of the tick delay, we still track the
+            log.debug().attr("delayMillis", calculatedDelayMillis)
+                    .log("Start timer");
+                // Even though we may delay longer than this timestamp because of the tick delay, we still track the
         // current timeout with reference to the next message's timestamp.
         currentTimeoutTarget = timestamp;
         timeout = timer.newTimeout(this, calculatedDelayMillis, TimeUnit.MILLISECONDS);
@@ -150,10 +150,8 @@ public abstract class AbstractDelayedDeliveryTracker implements DelayedDeliveryT
 
     @Override
     public void run(Timeout timeout) throws Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Timer triggered", context.getName());
-        }
-        if (timeout == null || timeout.isCancelled()) {
+            log.debug("Timer triggered");
+                if (timeout == null || timeout.isCancelled()) {
             return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.pulsar.broker.PulsarService;
@@ -38,12 +39,9 @@ import org.apache.pulsar.broker.delayed.bucket.RecoverDelayedDeliveryTrackerExce
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrackerFactory {
-    private static final Logger log = LoggerFactory.getLogger(BucketDelayedDeliveryTrackerFactory.class);
-
     BucketSnapshotStorage bucketSnapshotStorage;
 
     private Timer timer;
@@ -87,8 +85,12 @@ public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrack
         try {
             tracker = newTracker0(dispatcher);
         } catch (RecoverDelayedDeliveryTrackerException ex) {
-            log.warn("Failed to recover BucketDelayedDeliveryTracker, fallback to InMemoryDelayedDeliveryTracker."
-                    + " topic {}, subscription {}", topicName, subscriptionName, ex);
+            log.warn()
+                    .attr("topic", topicName)
+                    .attr("subscription", subscriptionName)
+                    .exception(ex)
+                    .log("Failed to recover BucketDelayedDeliveryTracker, fallback to"
+                            + " InMemoryDelayedDeliveryTracker. topic , subscription");
             // If failed to create BucketDelayedDeliveryTracker, fallback to InMemoryDelayedDeliveryTracker
             brokerService.initializeFallbackDelayedDeliveryTrackerFactory();
             tracker = brokerService.getFallbackDelayedDeliveryTrackerFactory().newTracker(dispatcher);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.delayed;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timer;
 import java.time.Clock;
 import java.util.NavigableSet;
@@ -27,15 +28,16 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.common.util.collections.LongOpenHashSet;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
-@Slf4j
 public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker {
+
+    private static final Logger LOG = Logger.get(InMemoryDelayedDeliveryTracker.class);
+    protected final Logger log;
 
     // timestamp -> ledgerId -> entryId
     // TreeMap -> TreeMap -> RoaringBitmap
@@ -86,6 +88,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                                            boolean isDelayedDeliveryDeliverAtTimeStrict,
                                            long fixedDelayDetectionLookahead) {
         super(context, timer, tickTimeMillis, clock, isDelayedDeliveryDeliverAtTimeStrict);
+        this.log = LOG.with().ctx(super.log).build();
         this.fixedDelayDetectionLookahead = fixedDelayDetectionLookahead;
         this.timestampPrecisionBitCnt = calculateTimestampPrecisionBitCnt(tickTimeMillis);
     }
@@ -124,13 +127,12 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
             messagesHaveFixedDelay = false;
             return false;
         }
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Add message {}:{} -- Delivery in {} ms ", context.getName(), ledgerId, entryId,
-                    deliverAt - clock.millis());
-        }
-
-        long timestamp = trimLowerBit(deliverAt, timestampPrecisionBitCnt);
+            log.debug()
+                    .attr("ledgerId", ledgerId)
+                    .attr("entryId", entryId)
+                    .attr("deliveryInMs", () -> deliverAt - clock.millis())
+                    .log("Add message");
+                long timestamp = trimLowerBit(deliverAt, timestampPrecisionBitCnt);
         delayedMessageMap.computeIfAbsent(timestamp, k -> new TreeMap<>())
                 .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap())
                 .add(entryId);
@@ -216,18 +218,17 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                 delayedMessageMap.remove(timestamp);
             }
         }
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Get scheduled messages - found {}", context.getName(), positions.size());
-        }
-
-        if (delayedMessageMap.isEmpty()) {
+            log.debug()
+                    .attr("messagesCount", positions.size())
+                    .log("Get scheduled messages");
+                if (delayedMessageMap.isEmpty()) {
             // Reset to initial state
             highestDeliveryTimeTracked = 0;
             messagesHaveFixedDelay = true;
             if (delayedMessagesCount.get() != 0) {
-                log.warn("[{}] Delayed message tracker is empty, but delayedMessagesCount is {}",
-                        context.getName(), delayedMessagesCount.get());
+                log.warn()
+                        .attr("delayedMessagesCount", delayedMessagesCount.get())
+                        .log("Delayed message tracker is empty, but delayedMessagesCount is non-zero");
             }
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTrackerFactory.java
@@ -23,15 +23,13 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class InMemoryDelayedDeliveryTrackerFactory implements DelayedDeliveryTrackerFactory {
-    private static final Logger log = LoggerFactory.getLogger(InMemoryDelayedDeliveryTrackerFactory.class);
-
     private Timer timer;
 
     private long tickTimeMillis;
@@ -59,8 +57,11 @@ public class InMemoryDelayedDeliveryTrackerFactory implements DelayedDeliveryTra
             tracker = newTracker0(dispatcher);
         } catch (Exception e) {
             // it should never go here
-            log.warn("Failed to create InMemoryDelayedDeliveryTracker, topic {}, subscription {}",
-                    topicName, subscriptionName, e);
+            log.warn()
+                    .attr("topic", topicName)
+                    .attr("subscription", subscriptionName)
+                    .exception(e)
+                    .log("Failed to create InMemoryDelayedDeliveryTracker");
         }
         return tracker;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BookkeeperBucketSnapshotStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BookkeeperBucketSnapshotStorage.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -41,7 +41,7 @@ import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
 
-@Slf4j
+@CustomLog
 public class BookkeeperBucketSnapshotStorage implements BucketSnapshotStorage {
 
     private static final byte[] LedgerPassword = "".getBytes();
@@ -221,7 +221,7 @@ public class BookkeeperBucketSnapshotStorage implements BucketSnapshotStorage {
         CompletableFuture<Void> future = new CompletableFuture<>();
         ledgerHandle.asyncClose((rc, handle, ctx) -> {
             if (rc != BKException.Code.OK) {
-                log.warn("Failed to close a Ledger Handle: {}", ledgerHandle.getId());
+                log.warn().attr("handle", ledgerHandle.getId()).log("Failed to close a Ledger Handle");
                 future.completeExceptionally(bkException("Close ledger", rc, ledgerHandle.getId()));
             } else {
                 future.complete(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
@@ -36,7 +36,7 @@ import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.roaringbitmap.RoaringBitmap;
 
-@Slf4j
+@CustomLog
 @Data
 @AllArgsConstructor
 abstract class Bucket {
@@ -68,7 +68,6 @@ abstract class Bucket {
     private volatile Long bucketId;
 
     private volatile CompletableFuture<Long> snapshotCreateFuture;
-
 
     Bucket(String dispatcherName, ManagedCursor cursor, FutureUtil.Sequencer<Void> sequencer,
            BucketSnapshotStorage storage, long startLedgerId, long endLedgerId) {
@@ -142,15 +141,22 @@ abstract class Bucket {
                                 topicName, cursorName)
                         .whenComplete((__, ex) -> {
                             if (ex != null) {
-                                log.warn("[{}] Failed to create bucket snapshot, bucketKey: {}",
-                                        dispatcherName, bucketKey, ex);
+                                log.warn()
+                                        .attr("dispatcher", dispatcherName)
+                                        .attr("bucketKey", bucketKey)
+                                        .exception(ex)
+                                        .log("Failed to create bucket snapshot");
                             }
                         }), BucketSnapshotPersistenceException.class, MaxRetryTimes).thenCompose(newBucketId -> {
                     bucket.setBucketId(newBucketId);
 
                     return putBucketKeyId(bucketKey, newBucketId).exceptionally(ex -> {
-                        log.warn("[{}] Failed to record bucketId to cursor property, bucketKey: {}, bucketId: {}",
-                                dispatcherName, bucketKey, newBucketId, ex);
+                        log.warn()
+                                .attr("dispatcher", dispatcherName)
+                                .attr("bucketKey", bucketKey)
+                                .attr("bucketId", newBucketId)
+                                .exception(ex)
+                                .log("Failed to record bucketId to cursor property");
                         return null;
                     }).thenApply(__ -> newBucketId);
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -25,6 +25,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import java.time.Clock;
@@ -46,7 +47,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -65,9 +65,11 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
 import org.roaringbitmap.RoaringBitmap;
 
-@Slf4j
 @ThreadSafe
 public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker {
+
+    private static final Logger LOG = Logger.get(BucketDelayedDeliveryTracker.class);
+    protected final Logger log;
 
     /**
      * Record to represent a snapshot key with ledger ID and entry ID.
@@ -94,7 +96,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     private final int maxNumBuckets;
 
     private final AtomicLong numberDelayedMessages = new AtomicLong(0);
-
 
     @Getter
     @VisibleForTesting
@@ -147,6 +148,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                                         int maxIndexesPerBucketSnapshotSegment, int maxNumBuckets)
             throws RecoverDelayedDeliveryTrackerException {
         super(context, timer, tickTimeMillis, clock, isDelayedDeliveryDeliverAtTimeStrict);
+        this.log = LOG.with().ctx(super.log).build();
         this.minIndexCountPerBucket = minIndexCountPerBucket;
         this.timeStepPerBucketSnapshotSegmentInMillis = timeStepPerBucketSnapshotSegmentInMillis;
         this.maxIndexesPerBucketSnapshotSegment = maxIndexesPerBucketSnapshotSegment;
@@ -173,8 +175,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         ManagedCursor cursor = this.lastMutableBucket.getCursor();
         Map<String, String> cursorProperties = cursor.getCursorProperties();
         if (MapUtils.isEmpty(cursorProperties)) {
-            log.info("[{}] Recover delayed message index bucket snapshot finish, don't find bucket snapshot",
-                    context.getName());
+            log.info("Recover delayed message index bucket snapshot finish, don't find bucket snapshot");
             return 0;
         }
         FutureUtil.Sequencer<Void> sequencer = this.lastMutableBucket.getSequencer();
@@ -194,8 +195,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
         Map<Range<Long>, ImmutableBucket> immutableBucketMap = immutableBuckets.asMapOfRanges();
         if (immutableBucketMap.isEmpty()) {
-            log.info("[{}] Recover delayed message index bucket snapshot finish, don't find bucket snapshot",
-                    context.getName());
+            log.info("Recover delayed message index bucket snapshot finish, don't find bucket snapshot");
             return 0;
         }
 
@@ -209,7 +209,9 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         try {
             FutureUtil.waitForAll(futures.values()).get(AsyncOperationTimeoutSeconds * 5, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            log.error("[{}] Failed to recover delayed message index bucket snapshot.", context.getName(), e);
+            log.error()
+                    .exception(e)
+                    .log("Failed to recover delayed message index bucket snapshot.");
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
@@ -249,8 +251,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             numberDelayedMessages.add(bucket.numberBucketDelayedMessages);
         });
 
-        log.info("[{}] Recover delayed message index bucket snapshot finish, buckets: {}, numberDelayedMessages: {}",
-                context.getName(), immutableBucketMap.size(), numberDelayedMessages.longValue());
+        log.info()
+                .attr("buckets", immutableBucketMap.size())
+                .attr("numberDelayedMessages", numberDelayedMessages.longValue())
+                .log("Recover delayed message index bucket snapshot finish");
 
         return numberDelayedMessages.longValue();
     }
@@ -338,8 +342,9 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     if (ex == null) {
                         immutableBucket.setSnapshotSegments(null);
                         immutableBucket.asyncUpdateSnapshotLength();
-                        log.info("[{}] Create bucket snapshot finish, bucketKey: {}", context.getName(),
-                                immutableBucket.bucketKey());
+                        log.info()
+                                .attr("bucketKey", immutableBucket.bucketKey())
+                                .log("Create bucket snapshot finish, bucketKey");
 
                         stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.create,
                                 System.currentTimeMillis() - startTime);
@@ -347,8 +352,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         return bucketId;
                     }
 
-                    log.error("[{}] Failed to create bucket snapshot, bucketKey: {}", context.getName(),
-                            immutableBucket.bucketKey(), ex);
+                    log.error()
+                            .attr("bucketKey", immutableBucket.bucketKey())
+                            .exception(ex)
+                            .log("Failed to create bucket snapshot");
                     stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
 
                     // Put indexes back into the shared queue and downgrade to memory mode
@@ -417,13 +424,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         }
 
         numberDelayedMessages.incrementAndGet();
-
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Add message {}:{} -- Delivery in {} ms ", context.getName(), ledgerId, entryId,
-                    deliverAt - clock.millis());
-        }
-
-        updateTimer();
+            log.debug()
+                    .attr("ledgerId", ledgerId)
+                    .attr("entryId", entryId)
+                    .attr("deliveryInMs", deliverAt - clock.millis())
+                    .log("Add message");
+                updateTimer();
 
         return true;
     }
@@ -470,17 +476,16 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         List<ImmutableBucket> toBeMergeImmutableBuckets = selectMergedBuckets(immutableBucketList, MAX_MERGE_NUM);
 
         if (toBeMergeImmutableBuckets.isEmpty()) {
-            log.warn("[{}] Can't find able merged buckets", context.getName());
+            log.warn("Can't find able merged buckets");
             return CompletableFuture.completedFuture(null);
         }
 
         final String bucketsStr = toBeMergeImmutableBuckets.stream().map(Bucket::bucketKey).collect(
                 Collectors.joining(",")).replaceAll(DELAYED_BUCKET_KEY_PREFIX + "_", "");
-        if (log.isDebugEnabled()) {
-            log.info("[{}] Merging bucket snapshot, bucketKeys: {}", context.getName(), bucketsStr);
-        }
-
-        for (ImmutableBucket immutableBucket : toBeMergeImmutableBuckets) {
+            log.info()
+                    .attr("bucketKeys", bucketsStr)
+                    .log("Merging bucket snapshot, bucketKeys");
+                for (ImmutableBucket immutableBucket : toBeMergeImmutableBuckets) {
             immutableBucket.merging = true;
         }
 
@@ -493,13 +498,17 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                 }
             }
             if (ex != null) {
-                log.error("[{}] Failed to merge bucket snapshot, bucketKeys: {}",
-                        context.getName(), bucketsStr, ex);
+                log.error()
+                        .attr("bucketKeys", bucketsStr)
+                        .exception(ex)
+                        .log("Failed to merge bucket snapshot, bucketKeys");
 
                 stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.merge);
             } else {
-                log.info("[{}] Merge bucket snapshot finish, bucketKeys: {}, bucketNum: {}",
-                        context.getName(), bucketsStr, immutableBuckets.asMapOfRanges().size());
+                log.info()
+                        .attr("bucketKeys", bucketsStr)
+                        .attr("bucketNum", immutableBuckets.asMapOfRanges().size())
+                        .log("Merge bucket snapshot finish");
 
                 stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.merge,
                         System.currentTimeMillis() - mergeStartTime);
@@ -612,10 +621,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     @Override
     public synchronized NavigableSet<Position> getScheduledMessages(int maxMessages) {
         if (!checkPendingLoadDone()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Skip getScheduledMessages to wait for bucket snapshot load finish.",
-                        context.getName());
-            }
+            log.debug("Skip getScheduledMessages to wait for bucket snapshot load finish");
             return Collections.emptyNavigableSet();
         }
 
@@ -641,20 +647,23 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             if (bucket != null && immutableBuckets.asMapOfRanges().containsValue(bucket)) {
                 // All message of current snapshot segment are scheduled, try load next snapshot segment
                 if (bucket.merging) {
-                    log.info("[{}] Skip load to wait for bucket snapshot merge finish, bucketKey:{}",
-                            context.getName(), bucket.bucketKey());
+                    log.info()
+                            .attr("bucketKey", bucket.bucketKey())
+                            .log("Skip load to wait for bucket snapshot merge finish");
                     break;
                 }
 
                 final int preSegmentEntryId = bucket.currentSegmentEntryId;
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Loading next bucket snapshot segment, bucketKey: {}, nextSegmentEntryId: {}",
-                            context.getName(), bucket.bucketKey(), preSegmentEntryId + 1);
-                }
-                boolean createFutureDone = bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE).isDone();
+                    log.debug()
+                            .attr("bucketKey", bucket.bucketKey())
+                            .attr("nextSegmentEntryId", preSegmentEntryId + 1)
+                            .log("Loading next bucket snapshot segment");
+                                boolean createFutureDone = bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)
+                                        .isDone();
                 if (!createFutureDone) {
-                    log.info("[{}] Skip load to wait for bucket snapshot create finish, bucketKey:{}",
-                            context.getName(), bucket.bucketKey());
+                    log.info()
+                            .attr("bucketKey", bucket.bucketKey())
+                            .log("Skip load to wait for bucket snapshot create finish");
                     break;
                 }
 
@@ -685,14 +694,20 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         // Back bucket state
                         bucket.setCurrentSegmentEntryId(preSegmentEntryId);
 
-                        log.error("[{}] Failed to load bucket snapshot segment, bucketKey: {}, segmentEntryId: {}",
-                                context.getName(), bucket.bucketKey(), preSegmentEntryId + 1, ex);
+                        log.error()
+                                .attr("bucketKey", bucket.bucketKey())
+                                .attr("segmentEntryId", preSegmentEntryId + 1)
+                                .exception(ex)
+                                .log("Failed to load bucket snapshot segment");
 
                         stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.load);
                     } else {
-                        log.info("[{}] Load next bucket snapshot segment finish, bucketKey: {}, segmentEntryId: {}",
-                                context.getName(), bucket.bucketKey(),
-                                (preSegmentEntryId == bucket.lastSegmentEntryId) ? "-1" : preSegmentEntryId + 1);
+                        log.info()
+                                .attr("bucketKey", bucket.bucketKey())
+                                .attr("segmentEntryId",
+                                        (preSegmentEntryId == bucket.lastSegmentEntryId) ? "-1" : preSegmentEntryId
+                                        + 1)
+                                .log("Load next bucket snapshot segment finish");
 
                         stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.load,
                                 System.currentTimeMillis() - loadStartTime);
@@ -757,7 +772,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     .map(bucket -> bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)).toList();
             FutureUtil.waitForAll(completableFutures).get(AsyncOperationTimeoutSeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.warn("[{}] Failed wait to snapshot generate", context.getName(), e);
+            log.warn().exception(e).log("Failed wait to snapshot generate");
         }
     }
 
@@ -790,7 +805,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         return findImmutableBucket(ledgerId).map(bucket -> bucket.containsMessage(ledgerId, entryId))
                 .orElse(false);
     }
-
 
     public Map<String, TopicMetricBean> genTopicMetricMap() {
         stats.recordNumOfBuckets(immutableBuckets.asMapOfRanges().size() + 1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/ImmutableBucket.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.mutable.MutableLong;
@@ -39,7 +39,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.roaringbitmap.InvalidRoaringFormat;
 import org.roaringbitmap.RoaringBitmap;
 
-@Slf4j
+@CustomLog
 class ImmutableBucket extends Bucket {
 
     @Setter
@@ -78,9 +78,12 @@ class ImmutableBucket extends Bucket {
             loadMetaDataFuture = executeWithRetry(() -> bucketSnapshotStorage.getBucketSnapshotMetadata(bucketId)
                     .whenComplete((___, ex) -> {
                         if (ex != null) {
-                            log.warn("[{}] Failed to get bucket snapshot metadata,"
-                                            + " bucketKey: {}, bucketId: {}",
-                                    dispatcherName, bucketKey, bucketId, ex);
+                            log.warn()
+                                    .attr("dispatcher", dispatcherName)
+                                    .attr("bucketKey", bucketKey)
+                                    .attr("bucketId", bucketId)
+                                    .exception(ex)
+                                    .log("Failed to get bucket snapshot metadata");
                         }
                     }), BucketSnapshotPersistenceException.class, MaxRetryTimes)
                     .thenApply(snapshotMetadata -> {
@@ -118,9 +121,13 @@ class ImmutableBucket extends Bucket {
                     () -> bucketSnapshotStorage.getBucketSnapshotSegment(bucketId, nextSegmentEntryId,
                             nextSegmentEntryId).whenComplete((___, ex) -> {
                         if (ex != null) {
-                            log.warn("[{}] Failed to get bucket snapshot segment. bucketKey: {},"
-                                            + " bucketId: {}, segmentEntryId: {}", dispatcherName, bucketKey(),
-                                    bucketId, nextSegmentEntryId, ex);
+                            log.warn()
+                                    .attr("dispatcher", dispatcherName)
+                                    .attr("bucketKey", bucketKey())
+                                    .attr("bucketId", bucketId)
+                                    .attr("segmentEntryId", nextSegmentEntryId)
+                                    .exception(ex)
+                                    .log("Failed to get bucket snapshot segment");
                         }
                     }), BucketSnapshotPersistenceException.class, MaxRetryTimes)
                     .thenApply(bucketSnapshotSegments -> {
@@ -180,10 +187,13 @@ class ImmutableBucket extends Bucket {
             return bucketSnapshotStorage.getBucketSnapshotSegment(getAndUpdateBucketId(), nextSegmentEntryId,
                     lastSegmentEntryId).whenComplete((__, ex) -> {
                 if (ex != null) {
-                    log.warn(
-                            "[{}] Failed to get remain bucket snapshot segment, bucketKey: {},"
-                                    + " nextSegmentEntryId: {}, lastSegmentEntryId: {}",
-                            dispatcherName, bucketKey(), nextSegmentEntryId, lastSegmentEntryId, ex);
+                    log.warn()
+                            .attr("dispatcher", dispatcherName)
+                            .attr("bucketKey", bucketKey())
+                            .attr("nextSegmentEntryId", nextSegmentEntryId)
+                            .attr("lastSegmentEntryId", lastSegmentEntryId)
+                            .exception(ex)
+                            .log("Failed to get remain bucket snapshot segment");
                 }
             });
         }, BucketSnapshotPersistenceException.class, MaxRetryTimes);
@@ -199,13 +209,20 @@ class ImmutableBucket extends Bucket {
                 BucketSnapshotPersistenceException.class, MaxRetryTimes)
                 .whenComplete((__, ex) -> {
                     if (ex != null) {
-                        log.error("[{}] Failed to delete bucket snapshot, bucketId: {}, bucketKey: {}",
-                                dispatcherName, bucketId, bucketKey, ex);
+                        log.error()
+                                .attr("dispatcher", dispatcherName)
+                                .attr("bucketId", bucketId)
+                                .attr("bucketKey", bucketKey)
+                                .exception(ex)
+                                .log("Failed to delete bucket snapshot");
 
                         stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.delete);
                     } else {
-                        log.info("[{}] Delete bucket snapshot finish, bucketId: {}, bucketKey: {}",
-                                dispatcherName, bucketId, bucketKey);
+                        log.info()
+                                .attr("dispatcher", dispatcherName)
+                                .attr("bucketId", bucketId)
+                                .attr("bucketKey", bucketKey)
+                                .log("Delete bucket snapshot finish");
 
                         stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.delete,
                                 System.currentTimeMillis() - deleteStartTime);
@@ -224,8 +241,12 @@ class ImmutableBucket extends Bucket {
         long bucketId = getAndUpdateBucketId();
         return bucketSnapshotStorage.getBucketSnapshotLength(bucketId).whenComplete((length, ex) -> {
             if (ex != null) {
-                log.error("[{}] Failed to get snapshot length, bucketId: {}, bucketKey: {}",
-                        dispatcherName, bucketId, bucketKey(), ex);
+                log.error()
+                        .attr("dispatcher", dispatcherName)
+                        .attr("bucketId", bucketId)
+                        .attr("bucketKey", bucketKey())
+                        .exception(ex)
+                        .log("Failed to get snapshot length");
             } else {
                 setSnapshotLength(length);
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/MutableBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/MutableBucket.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.delayed.proto.DelayedIndex;
@@ -37,7 +37,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
 import org.roaringbitmap.RoaringBitmap;
 
-@Slf4j
+@CustomLog
 class MutableBucket extends Bucket implements AutoCloseable {
 
     private final TripleLongPriorityQueue priorityQueue;
@@ -61,12 +61,12 @@ class MutableBucket extends Bucket implements AutoCloseable {
             final long timeStepPerBucketSnapshotSegment, final int maxIndexesPerBucketSnapshotSegment,
             TripleLongPriorityQueue sharedQueue, DelayedIndexQueue delayedIndexQueue, final long startLedgerId,
             final long endLedgerId) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Creating bucket snapshot, startLedgerId: {}, endLedgerId: {}", dispatcherName,
-                    startLedgerId, endLedgerId);
-        }
-
-        if (delayedIndexQueue.isEmpty()) {
+            log.debug()
+                    .attr("dispatcher", dispatcherName)
+                    .attr("startLedgerId", startLedgerId)
+                    .attr("endLedgerId", endLedgerId)
+                    .log("Creating bucket snapshot");
+                if (delayedIndexQueue.isEmpty()) {
             return null;
         }
         long numMessages = 0;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorUtils.java
@@ -25,8 +25,8 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.nar.NarClassLoaderBuilder;
@@ -36,7 +36,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
  * Util class to search and load {@link BrokerInterceptor}s.
  */
 @UtilityClass
-@Slf4j
+@CustomLog
 public class BrokerInterceptorUtils {
 
     static final String BROKER_INTERCEPTOR_DEFINITION_FILE = "broker_interceptor.yml";
@@ -76,7 +76,7 @@ public class BrokerInterceptorUtils {
     public BrokerInterceptorDefinitions searchForInterceptors(String interceptorsDirectory,
                                                               String narExtractionDirectory) throws IOException {
         Path path = Paths.get(interceptorsDirectory).toAbsolutePath().normalize();
-        log.info("Searching for broker interceptors in {}", path);
+        log.info().attr("path", path).log("Searching for broker interceptors");
 
         BrokerInterceptorDefinitions interceptors = new BrokerInterceptorDefinitions();
         if (!path.toFile().exists()) {
@@ -90,7 +90,7 @@ public class BrokerInterceptorUtils {
                     BrokerInterceptorDefinition def =
                             BrokerInterceptorUtils.getBrokerInterceptorDefinition(archive.toString(),
                                     narExtractionDirectory);
-                    log.info("Found broker interceptors from {} : {}", archive, def);
+                    log.info().attr("archive", archive).attr("def", def).log("Found broker interceptors");
 
                     checkArgument(StringUtils.isNotBlank(def.getName()));
                     checkArgument(StringUtils.isNotBlank(def.getInterceptorClass()));
@@ -101,10 +101,10 @@ public class BrokerInterceptorUtils {
 
                     interceptors.interceptors().put(def.getName(), metadata);
                 } catch (Throwable t) {
-                    log.warn("Failed to load broker interceptor from {}."
-                            + " It is OK however if you want to use this broker interceptor,"
-                            + " please make sure you put the correct broker interceptor NAR"
-                            + " package in the broker interceptors directory.", archive, t);
+                    log.warn()
+                            .attr("archive", archive)
+                            .exception(t)
+                            .log("Failed to load broker interceptor");
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptorWithClassLoader.java
@@ -26,9 +26,9 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Consumer;
@@ -45,7 +45,7 @@ import org.apache.pulsar.common.nar.NarClassLoader;
 /**
  * A broker interceptor with it's classloader.
  */
-@Slf4j
+@CustomLog
 @Data
 @RequiredArgsConstructor
 public class BrokerInterceptorWithClassLoader implements BrokerInterceptor {
@@ -148,7 +148,6 @@ public class BrokerInterceptorWithClassLoader implements BrokerInterceptor {
             Thread.currentThread().setContextClassLoader(previousContext);
         }
     }
-
 
     @Override
     public void messageProduced(ServerCnx cnx, Producer producer, long startTimeNs, long ledgerId,
@@ -300,7 +299,7 @@ public class BrokerInterceptorWithClassLoader implements BrokerInterceptor {
         try {
             narClassLoader.close();
         } catch (IOException e) {
-            log.warn("Failed to close the broker interceptor class loader", e);
+            log.warn().exception(e).log("Failed to close the broker interceptor class loader");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/BrokerInterceptors.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -43,7 +43,7 @@ import org.apache.pulsar.common.intercept.InterceptException;
 /**
  * A collection of broker interceptor.
  */
-@Slf4j
+@CustomLog
 public class BrokerInterceptors implements BrokerInterceptor {
 
     private final Map<String, BrokerInterceptorWithClassLoader> interceptors;
@@ -83,9 +83,12 @@ public class BrokerInterceptors implements BrokerInterceptor {
                 if (interceptor != null) {
                     orderedInterceptorMap.put(interceptorName, interceptor);
                 }
-                log.info("Successfully loaded broker interceptor for name `{}`", interceptorName);
+                log.info().attr("interceptorName", interceptorName).log("Successfully loaded broker interceptor");
             } catch (IOException e) {
-                log.error("Failed to load the broker interceptor for name `" + interceptorName + "`", e);
+                log.error()
+                        .attr("interceptorName", interceptorName)
+                        .exception(e)
+                        .log("Failed to load the broker interceptor");
                 throw new RuntimeException("Failed to load the broker interceptor for name `" + interceptorName + "`");
             }
         });
@@ -227,7 +230,6 @@ public class BrokerInterceptors implements BrokerInterceptor {
             }
         }
     }
-
 
     @Override
     public void onConnectionCreated(ServerCnx cnx) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImpl.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.intercept.ManagedLedgerInterceptor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -30,11 +31,9 @@ import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.ManagedLedgerPayloadProcessor;
 import org.apache.pulsar.common.protocol.Commands;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ManagedLedgerInterceptorImpl implements ManagedLedgerInterceptor {
-    private static final Logger log = LoggerFactory.getLogger(ManagedLedgerInterceptorImpl.class);
     private static final String INDEX = "index";
     private final Set<BrokerEntryMetadataInterceptor> brokerEntryMetadataInterceptors;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LinuxInfoUtils.java
@@ -35,13 +35,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.BitRateUnit;
 
-@Slf4j
+@CustomLog
 public class LinuxInfoUtils {
 
     // CGROUP
@@ -78,7 +78,7 @@ public class LinuxInfoUtils {
                 getCpuUsageMethod.setAccessible(true);
             }
         } catch (Throwable e) {
-            log.warn("Failed to get runtime metrics", e);
+            log.warn().exception(e).log("Failed to get runtime metrics");
         }
     }
 
@@ -99,10 +99,10 @@ public class LinuxInfoUtils {
                 return Files.exists(Paths.get(CGROUPS_CPU_USAGE_PATH));
             }
             String provider = (String) getMetricsProviderMethod.invoke(metrics);
-            log.info("[LinuxInfo] The system metrics provider is: {}", provider);
+            log.info().attr("provider", provider).log("The system metrics provider");
             return provider.contains("cgroup");
         } catch (Exception e) {
-            log.warn("[LinuxInfo] Failed to check cgroup CPU: {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to check cgroup CPU");
             return false;
         }
     }
@@ -129,7 +129,7 @@ public class LinuxInfoUtils {
                     return 100.0 * quota / period;
                 }
             } catch (Exception e) {
-                log.warn("[LinuxInfo] Failed to read CPU quotas from cgroup", e);
+                log.warn().exception(e).log("Failed to read CPU quotas from cgroup");
                 // Fallback to availableProcessors
             }
         }
@@ -148,7 +148,7 @@ public class LinuxInfoUtils {
             }
             return readLongFromFile(Paths.get(CGROUPS_CPU_USAGE_PATH));
         } catch (Exception e) {
-            log.error("[LinuxInfo] Failed to read CPU usage from cgroup", e);
+            log.error().exception(e).log("Failed to read CPU usage from cgroup");
             return -1;
         }
     }
@@ -170,7 +170,7 @@ public class LinuxInfoUtils {
         try (Stream<String> stream = Files.lines(Paths.get(PROC_STAT_PATH))) {
             Optional<String> first = stream.findFirst();
             if (!first.isPresent()) {
-                log.error("[LinuxInfo] Failed to read CPU usage from /proc/stat, because of empty values.");
+                log.error("Failed to read CPU usage from /proc/stat, empty values");
                 return ResourceUsage.empty();
             }
             String[] words = first.get().split("\\s+");
@@ -184,7 +184,7 @@ public class LinuxInfoUtils {
                     .idle(idle)
                     .total(total).build();
         } catch (IOException e) {
-            log.error("[LinuxInfo] Failed to read CPU usage from /proc/stat", e);
+            log.error().exception(e).log("Failed to read CPU usage from /proc/stat");
             return ResourceUsage.empty();
         }
     }
@@ -202,18 +202,14 @@ public class LinuxInfoUtils {
             // Check the type to make sure it's ethernet (type "1")
             final Path nicTypePath = nicPath.resolve("type");
             if (!Files.exists(nicTypePath)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to read NIC type, the expected linux type file does not exist."
-                              + " nic_type_path={}", nicTypePath);
-                }
+                log.debug().attr("nicTypePath", nicTypePath)
+                        .log("Failed to read NIC type, the expected linux type file does not exist");
                return false;
             }
             // wireless NICs don't report speed, ignore them.
             return Integer.parseInt(readTrimStringFromFile(nicTypePath)) == ARPHRD_ETHER;
         } catch (Exception ex) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to read NIC type. nic_path={}", nicPath, ex);
-            }
+            log.debug().attr("nicPath", nicPath).exception(ex).log("Failed to read NIC type");
             return false;
         }
     }
@@ -236,7 +232,8 @@ public class LinuxInfoUtils {
                     return false;
             }
         } catch (Exception e) {
-            log.warn("[LinuxInfo] Failed to read {} NIC operstate, the detail is: {}", nicPath, e.getMessage());
+            log.warn().attr("nicPath", nicPath).exceptionMessage(e)
+                    .log("Failed to read NIC operstate");
             // Read operstate got error.
             return false;
         }
@@ -256,11 +253,9 @@ public class LinuxInfoUtils {
                 // ERROR-level logs about NIC rate limiting reading failures are periodically printed but not
                 // continuously printed
                 if (failedCounterInReadingNicLimits.getAndIncrement() % errLogPrintedFrequencyInReadingNicLimits == 0) {
-                    log.error("[LinuxInfo] Failed to get the nic limit of {}.", nicPath, e);
+                    log.error().attr("nicPath", nicPath).exception(e).log("Failed to get the nic limit");
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[LinuxInfo] Failed to get the nic limit of {}.", nicPath, e);
-                    }
+                    log.debug().attr("nicPath", nicPath).exception(e).log("Failed to get the nic limit");
                 }
                 return 0d;
             }
@@ -279,7 +274,7 @@ public class LinuxInfoUtils {
             try {
                 return readDoubleFromFile(getReplacedNICPath(type.template, nic));
             } catch (IOException e) {
-                log.error("[LinuxInfo] Failed to read {} bytes for NIC {} ", type, nic, e);
+                log.error().attr("type", type).attr("nic", nic).exception(e).log("Failed to read bytes for NIC");
                 return 0d;
             }
         }).sum(), BitRateUnit.Byte);
@@ -296,7 +291,7 @@ public class LinuxInfoUtils {
                     .map(path -> path.getFileName().toString())
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            log.error("[LinuxInfo] Failed to find NICs", e);
+            log.error().exception(e).log("Failed to find NICs");
             return Collections.emptyList();
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import io.github.merlimat.slog.Logger;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -37,8 +38,6 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * LoadManager runs through set of load reports collected from different brokers and generates a recommendation of
@@ -48,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * Concrete Load Manager is also return the least loaded broker that should own the new namespace.
  */
 public interface LoadManager {
-    Logger LOG = LoggerFactory.getLogger(LoadManager.class);
+    Logger LOG = Logger.get(LoadManager.class);
 
     String LOADBALANCE_BROKERS_ROOT = "/loadbalance/brokers";
 
@@ -176,7 +175,7 @@ public interface LoadManager {
                 return casted;
             }
         } catch (Exception e) {
-            LOG.warn("Error when trying to create load manager: ", e);
+            LOG.warn().exception(e).log("Error when trying to create load manager");
         }
         // If we failed to create a load manager, default to SimpleLoadManagerImpl.
         return new SimpleLoadManagerImpl(pulsar);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadReportUpdaterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadReportUpdaterTask.java
@@ -19,14 +19,13 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 
 /**
  * Represents a task which reads load report from zookeeper for all the brokers and updates the ranking.
  */
+@CustomLog
 public class LoadReportUpdaterTask implements Runnable {
-    private static final Logger LOG = LoggerFactory.getLogger(LoadReportUpdaterTask.class);
     private final AtomicReference<LoadManager> loadManager;
 
     public LoadReportUpdaterTask(AtomicReference<LoadManager> manager) {
@@ -38,7 +37,7 @@ public class LoadReportUpdaterTask implements Runnable {
         try {
             loadManager.get().writeLoadReportOnZookeeper();
         } catch (Exception e) {
-            LOG.warn("Unable to write load report on Zookeeper", e);
+            log.warn().exception(e).log("Unable to write load report on Zookeeper");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadResourceQuotaUpdaterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadResourceQuotaUpdaterTask.java
@@ -19,14 +19,13 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 
 /**
  * LoadManager namespace bundle quota update task.
  */
+@CustomLog
 public class LoadResourceQuotaUpdaterTask implements Runnable {
-    private static final Logger LOG = LoggerFactory.getLogger(LoadResourceQuotaUpdaterTask.class);
     private final AtomicReference<LoadManager> loadManager;
 
     public LoadResourceQuotaUpdaterTask(AtomicReference<LoadManager> loadManager) {
@@ -38,7 +37,7 @@ public class LoadResourceQuotaUpdaterTask implements Runnable {
         try {
             this.loadManager.get().writeResourceQuotasToZooKeeper();
         } catch (Exception e) {
-            LOG.warn("Error write resource quota", e);
+            log.warn().exception(e).log("Error write resource quota");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadSheddingTask.java
@@ -22,17 +22,16 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * LoadManager load shedding task.
  */
+@CustomLog
 public class LoadSheddingTask implements Runnable {
-    private static final Logger LOG = LoggerFactory.getLogger(LoadSheddingTask.class);
     private final AtomicReference<LoadManager> loadManager;
     private final ScheduledExecutorService loadManagerExecutor;
 
@@ -66,7 +65,7 @@ public class LoadSheddingTask implements Runnable {
             }
             loadManager.get().doLoadShedding();
         } catch (Exception e) {
-            LOG.warn("Error during the load shedding", e);
+            log.warn().exception(e).log("Error during the load shedding");
         } finally {
             start();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -39,7 +39,7 @@ import org.apache.pulsar.metadata.api.coordination.LockManager;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 
-@Slf4j
+@CustomLog
 public class NoopLoadManager implements LoadManager {
 
     private PulsarService pulsar;
@@ -68,9 +68,9 @@ public class NoopLoadManager implements LoadManager {
         String brokerReportPath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + brokerId;
 
         try {
-            log.info("Acquiring broker resource lock on {}", brokerReportPath);
+            log.info().attr("broker", brokerReportPath).log("Acquiring broker resource lock");
             lockManager.acquireLock(brokerReportPath, localData).join();
-            log.info("Acquired broker resource lock on {}", brokerReportPath);
+            log.info().attr("broker", brokerReportPath).log("Acquired broker resource lock");
         } catch (CompletionException ce) {
             throw new PulsarServerException(MetadataStoreException.unwrap(ce));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -50,7 +50,7 @@ import org.apache.pulsar.metadata.api.extended.SessionEvent;
 /**
  * The broker registry impl, base on the LockManager.
  */
-@Slf4j
+@CustomLog
 public class BrokerRegistryImpl implements BrokerRegistry {
 
     private static final int MAX_REGISTER_RETRY_DELAY_IN_MILLIS = 1000;
@@ -137,18 +137,20 @@ public class BrokerRegistryImpl implements BrokerRegistry {
     public CompletableFuture<Void> registerAsync() {
         final var state = this.state.get();
         if (state != State.Started && state != State.Registered) {
-            log.info("[{}] Skip registering self because the state is {}", getBrokerId(), state);
+            log.info().attr("broker", getBrokerId()).attr("state", state)
+                    .log("Skip registering self because the state is invalid");
             return CompletableFuture.completedFuture(null);
         }
-        log.info("[{}] Started registering self to {} (state: {})", getBrokerId(), brokerIdKeyPath, state);
+        log.info().attr("broker", getBrokerId()).attr("brokerIdKeyPath", brokerIdKeyPath).attr("state", state)
+                .log("Started registering self");
         return brokerLookupDataMetadataCache.put(brokerIdKeyPath, brokerLookupData, EnumSet.of(CreateOption.Ephemeral))
                 .orTimeout(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)
                 .whenComplete((__, ex) -> {
                     if (ex == null) {
                         this.state.set(State.Registered);
-                        log.info("[{}] Finished registering self", getBrokerId());
+                        log.info().attr("broker", getBrokerId()).log("Finished registering self");
                     } else {
-                        log.error("[{}] Failed registering self", getBrokerId(), ex);
+                        log.error().attr("broker", getBrokerId()).exception(ex).log("Failed registering self");
                     }
                 });
     }
@@ -179,7 +181,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
                         .get(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof MetadataStoreException.NotFoundException) {
-                    log.warn("{} has already been unregistered", brokerIdKeyPath);
+                    log.warn().attr("broker", brokerIdKeyPath).log("has already been unregistered");
                 } else {
                     throw MetadataStoreException.unwrap(e);
                 }
@@ -219,7 +221,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
                     if (lookupDataOpt.isPresent()) {
                         map.put(brokerId, lookupDataOpt.get());
                     } else {
-                        log.warn("Got an empty lookup data, brokerId: {}", brokerId);
+                        log.warn().attr("broker", brokerId).log("Got an empty lookup data, brokerId");
                     }
                 }));
             }
@@ -242,7 +244,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
             this.listeners.clear();
             this.unregister();
         } catch (Exception ex) {
-            log.error("Unexpected error when unregistering the broker registry", ex);
+            log.error().exception(ex).log("Unexpected error when unregistering the broker registry");
         } finally {
             this.state.set(State.Closed);
         }
@@ -253,9 +255,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
             return;
         }
         try {
-            if (log.isDebugEnabled()) {
-                log.debug("Handle notification: [{}]", t);
-            }
+            log.debug().attr("notification", t).log("Handle notification");
             // The registered node is an ephemeral node that could be deleted when the metadata store client's session
             // is expired. In this case, we should register again.
             final var brokerId = t.getPath().substring(LOADBALANCE_BROKERS_ROOT.length() + 1);
@@ -288,9 +288,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
         if (!this.isStarted()) {
             return;
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Handle metadata session event: [{}]", event);
-        }
+        log.debug().attr("event", event).log("Handle metadata session event");
         if (event == SessionEvent.SessionReestablished || event == SessionEvent.Reconnected) {
             this.registerAsyncWithRetries();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -100,9 +100,8 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
-import org.slf4j.Logger;
 
-@Slf4j
+@CustomLog
 public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerSelectionStrategyFactory {
 
     public static final String BROKER_LOAD_DATA_STORE_TOPIC = TopicName.get(
@@ -280,17 +279,17 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         return get(pulsar.getLoadManager().get());
     }
 
-    public static boolean debug(ServiceConfiguration config, Logger log) {
-        return config.isLoadBalancerDebugModeEnabled() || log.isDebugEnabled();
+    public static boolean debug(ServiceConfiguration config, io.github.merlimat.slog.Logger log) {
+        return config.isLoadBalancerDebugModeEnabled();
     }
 
     public static void createSystemTopic(PulsarService pulsar, String topic) throws PulsarServerException {
         try {
             pulsar.getAdminClient().topics().createNonPartitionedTopic(topic);
-            log.info("Created topic {}.", topic);
+            log.info().attr("topic", topic).log("Created topic");
         } catch (PulsarAdminException.ConflictException ex) {
             if (debug(pulsar.getConfiguration(), log)) {
-                log.info("Topic {} already exists.", topic);
+                log.info().attr("topic", topic).log("Topic already exists");
             }
         } catch (PulsarAdminException e) {
             throw new PulsarServerException(e);
@@ -309,15 +308,17 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 Long threshold = pulsar.getAdminClient().topicPolicies().getCompactionThreshold(TOPIC);
                 if (threshold == null || target != threshold.longValue()) {
                     pulsar.getAdminClient().topicPolicies().setCompactionThreshold(TOPIC, target);
-                    log.info("Set compaction threshold: {} bytes for system topic {}.", target, TOPIC);
+                    log.info().attr("threshold", target).attr("topic", TOPIC)
+                            .log("Set compaction threshold: bytes for system topic");
                 }
             } else {
-                log.warn("System topic or topic level policies is disabled. "
-                        + "{} compaction threshold follows the broker or namespace policies.", TOPIC);
+                log.warnf("System topic or topic level policies is disabled. "
+                        + "%s compaction threshold follows the broker or namespace policies.",
+                        TOPIC);
             }
             return true;
         } catch (Exception e) {
-            log.error("Failed to set compaction threshold for system topic:{}", TOPIC, e);
+            log.error().attr("topic", TOPIC).exception(e).log("Failed to set compaction threshold for system topic");
         }
         return false;
     }
@@ -349,7 +350,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                                 }
                         );
             } catch (Throwable e) {
-                log.error("Failed to lookup destination broker for topic:{}", topic, e);
+                log.error().attr("topic", topic).exception(e).log("Failed to lookup destination broker for topic");
                 return CompletableFuture.completedFuture(Optional.empty());
             }
         }
@@ -430,7 +431,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                                             brokerLoadDataReporter.reportAsync(false);
                                             // TODO: update broker load metrics using getLocalData
                                         } catch (Throwable e) {
-                                            log.error("Failed to run the broker load manager executor job.", e);
+                                            log.error()
+                                                    .exception(e)
+                                                    .log("Failed to run the broker load manager executor job");
                                         }
                                     },
                                     interval,
@@ -442,7 +445,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                                             // TODO: consider excluding the bundles that are in the process of split.
                                             topBundleLoadDataReporter.reportAsync(false);
                                         } catch (Throwable e) {
-                                            log.error("Failed to run the top bundles load manager executor job.", e);
+                                            log.error()
+                                                    .exception(e)
+                                                    .log("Failed to run the top bundles load manager executor job");
                                         }
                                     },
                                     interval,
@@ -477,7 +482,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
             } catch (PulsarServerException e) {
                 // If close failed, this broker might still exist in the metadata store. Then it could be found by other
                 // brokers as an available broker. Hence, print a warning log for it.
-                log.warn("Failed to close the broker registry: {}", e.getMessage());
+                log.warn().exceptionMessage(e).log("Failed to close the broker registry");
             }
         }
         initWaiter.complete(false); // exit the background thread gracefully
@@ -529,7 +534,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 return this.selectAsync(serviceUnit, Collections.emptySet(), options).thenCompose(brokerOpt -> {
                     if (brokerOpt.isPresent()) {
                         assignCounter.incrementSuccess();
-                        log.info("Selected new owner broker: {} for bundle: {}.", brokerOpt.get(), bundle);
+                        log.info().attr("broker", brokerOpt.get()).attr("bundle", bundle)
+                                .log("Selected new owner broker: for bundle");
                         return serviceUnitStateChannel.publishAssignEventAsync(bundle, brokerOpt.get());
                     }
                     return CompletableFuture.completedFuture(null);
@@ -569,7 +575,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
      * @return The ephemeral node data showing the current ownership info in <code>ServiceUnitStateChannel</code>
      */
     public CompletableFuture<NamespaceEphemeralData> tryAcquiringOwnership(NamespaceBundle namespaceBundle) {
-        log.info("Try acquiring ownership for bundle: {} - {}.", namespaceBundle, brokerRegistry.getBrokerId());
+        log.info().attr("bundle", namespaceBundle).attr("broker", brokerRegistry.getBrokerId())
+                .log("Try acquiring ownership for bundle: -");
         final String bundle = namespaceBundle.toString();
         return assign(Optional.empty(), namespaceBundle, LookupOptions.builder().readOnly(false).build())
                 .thenApply(brokerLookupData -> {
@@ -633,7 +640,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                     }
                     return FutureUtil.waitForAll(futures).exceptionally(e -> {
                         // TODO: We may need to revisit this error case.
-                        log.error("Failed to filter out brokers when select bundle: {}", bundle, e);
+                        log.error().attr("bundle", bundle).exception(e)
+                                .log("Failed to filter out brokers when select bundle");
                         return null;
                     }).thenApply(__ -> {
                         if (availableBrokerCandidates.isEmpty()) {
@@ -660,7 +668,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         var namespace = NamespaceBundle.getBundleNamespace(bundle.toString());
         if (sheddingExcludedNamespaces.contains(namespace)) {
             if (debug(conf, log)) {
-                log.info("Use round robin broker selector for {}", bundle);
+                log.info().attr("bundle", bundle).log("Use round robin broker selector for bundle");
             }
             return sheddingExcludedNamespaceSelectionStrategy;
         }
@@ -705,7 +713,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
             return CompletableFuture.completedFuture(null);
         }
         if (NamespaceService.isSLAOrHeartbeatNamespace(bundle.getNamespaceObject().toString())) {
-            log.info("Skip unloading namespace bundle: {}.", bundle);
+            log.info().attr("bundle", bundle).log("Skip unloading namespace bundle");
             return CompletableFuture.completedFuture(null);
         }
         return getOwnershipAsync(Optional.empty(), bundle)
@@ -743,7 +751,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                                                              NamespaceBundleSplitAlgorithm splitAlgorithm,
                                                              List<Long> boundaries) {
         if (NamespaceService.isSLAOrHeartbeatNamespace(bundle.getNamespaceObject().toString())) {
-            log.info("Skip split namespace bundle: {}.", bundle);
+            log.info().attr("bundle", bundle).log("Skip split namespace bundle");
             return CompletableFuture.completedFuture(null);
         }
         final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle.toString());
@@ -836,12 +844,12 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         try {
             brokerLoadDataStore.shutdown();
         } catch (IOException e) {
-            log.warn("Failed to shutdown brokerLoadDataStore", e);
+            log.warn().exception(e).log("Failed to shutdown brokerLoadDataStore");
         }
         try {
             topBundlesLoadDataStore.shutdown();
         } catch (IOException e) {
-            log.warn("Failed to shutdown topBundlesLoadDataStore", e);
+            log.warn().exception(e).log("Failed to shutdown topBundlesLoadDataStore");
         }
     }
 
@@ -862,7 +870,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 log.error("Still no Leader is found even after LeaderElectionService restarted.");
                 return false;
             }
-            log.info("Successfully started LeaderElectionService. The new channel owner is {}", channelOwner);
+            log.info().attr("channelOwner", channelOwner)
+                    .log("Successfully started LeaderElectionService");
             return true;
         }
         return false;
@@ -870,8 +879,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
     @VisibleForTesting
     synchronized void playLeader() {
-        log.info("This broker:{} is setting the role from {} to {}",
-                pulsar.getBrokerId(), role, Leader);
+        log.info().attr("broker", pulsar.getBrokerId()).attr("from", role).attr("to", Leader)
+                .log("Broker is setting the role");
         int retry = 0;
         boolean becameFollower = false;
         while (!Thread.currentThread().isInterrupted()) {
@@ -910,12 +919,12 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 break;
             } catch (Throwable e) {
                 if (disabled()) {
-                    log.warn("The broker:{} failed to set the role but exit because it's disabled",
-                            pulsar.getBrokerId(), e);
+                    log.warn().attr("broker", pulsar.getBrokerId()).exception(e)
+                            .log("The broker: failed to set the role but exit because it's disabled");
                     return;
                 }
-                log.warn("The broker:{} failed to set the role. Retrying {} th ...",
-                        pulsar.getBrokerId(), ++retry, e);
+                log.warn().attr("broker", pulsar.getBrokerId()).attr("retrying", ++retry).exception(e)
+                        .log("The broker: failed to set the role. Retrying th");
                 try {
                     Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
                 } catch (InterruptedException ex) {
@@ -930,13 +939,14 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         }
 
         if (becameFollower) {
-            log.warn("The broker:{} became follower while initializing leader role.", pulsar.getBrokerId());
+            log.warn().attr("broker", pulsar.getBrokerId())
+                    .log("The broker: became follower while initializing leader role");
             playFollower();
             return;
         }
 
         role = Leader;
-        log.info("This broker:{} plays the leader now.", pulsar.getBrokerId());
+        log.info().attr("broker", pulsar.getBrokerId()).log("This broker: plays the leader now");
 
         // flush the load data when the leader is elected.
         brokerLoadDataReporter.reportAsync(true);
@@ -945,8 +955,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
     @VisibleForTesting
     synchronized void playFollower() {
-        log.info("This broker:{} is setting the role from {} to {}",
-                pulsar.getBrokerId(), role, Follower);
+        log.info().attr("broker", pulsar.getBrokerId()).attr("from", role).attr("to", Follower)
+                .log("Broker is setting the role");
         int retry = 0;
         boolean becameLeader = false;
         while (!Thread.currentThread().isInterrupted()) {
@@ -980,12 +990,12 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                 break;
             } catch (Throwable e) {
                 if (disabled()) {
-                    log.warn("The broker:{} failed to set the role but exit because it's disabled",
-                            pulsar.getBrokerId(), e);
+                    log.warn().attr("broker", pulsar.getBrokerId()).exception(e)
+                            .log("The broker: failed to set the role but exit because it's disabled");
                     return;
                 }
-                log.warn("The broker:{} failed to set the role. Retrying {} th ...",
-                        pulsar.getBrokerId(), ++retry, e);
+                log.warn().attr("broker", pulsar.getBrokerId()).attr("retrying", ++retry).exception(e)
+                        .log("The broker: failed to set the role. Retrying th");
                 try {
                     Thread.sleep(Math.min(retry * 10, MAX_ROLE_CHANGE_RETRY_DELAY_IN_MILLIS));
                 } catch (InterruptedException ex) {
@@ -1000,13 +1010,14 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         }
 
         if (becameLeader) {
-            log.warn("This broker:{} became leader while initializing follower role.", pulsar.getBrokerId());
+            log.warn().attr("broker", pulsar.getBrokerId())
+                    .log("This broker: became leader while initializing follower role");
             playLeader();
             return;
         }
 
         role = Follower;
-        log.info("This broker:{} plays a follower now.", pulsar.getBrokerId());
+        log.info().attr("broker", pulsar.getBrokerId()).log("This broker: plays a follower now");
 
         // flush the load data when the leader is elected.
         brokerLoadDataReporter.reportAsync(true);
@@ -1073,8 +1084,9 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                     configuredSystemTopics = configureSystemTopics(pulsar, COMPACTION_THRESHOLD);
                 }
                 if (role != Leader) {
-                    log.warn("Current role:{} does not match with the channel ownership:{}. "
-                            + "Playing the leader role.", role, isChannelOwner);
+                    log.warn().attr("role", role).attr("ownership", isChannelOwner)
+                            .log("Current role does not match with the channel ownership. "
+                                    + "Playing the leader role");
                     playLeader();
                 }
 
@@ -1086,14 +1098,15 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
 
             } else {
                 if (role != Follower) {
-                    log.warn("Current role:{} does not match with the channel ownership:{}. "
-                            + "Playing the follower role.", role, isChannelOwner);
+                    log.warn().attr("role", role).attr("ownership", isChannelOwner)
+                            .log("Current role does not match with the channel ownership. "
+                                    + "Playing the follower role");
                     playFollower();
                 }
                 serviceUnitStateTableViewSyncer.close();
             }
         } catch (Throwable e) {
-            log.error("Failed to monitor load manager state", e);
+            log.error().exception(e).log("Failed to monitor load manager state");
         }
     }
 
@@ -1124,7 +1137,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
                     .getTopicReference(name)
                     .ifPresent(topic -> futures.add(topic.close(true)
                             .exceptionally(__ -> {
-                                log.warn("Failed to close internal topic:{}", name);
+                                log.warn().attr("topic", name).log("Failed to close internal topic");
                                 return null;
                             })));
         }
@@ -1132,7 +1145,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
             FutureUtil.waitForAll(futures)
                     .get(pulsar.getConfiguration().getNamespaceBundleUnloadingTimeoutMs(), TimeUnit.MILLISECONDS);
         } catch (Throwable e) {
-            log.warn("Failed to wait for closing internal topics", e);
+            log.warn().exception(e).log("Failed to wait for closing internal topics");
         }
     }
 
@@ -1168,8 +1181,8 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         var timeout = pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds();
         var lookup = brokerRegistry.lookupAsync(brokerRegistry.getBrokerId()).get(timeout, TimeUnit.SECONDS);
         if (lookup.isEmpty()) {
-            log.warn("Found this broker:{} has not registered yet. Trying to register it",
-                    brokerRegistry.getBrokerId());
+            log.warn().attr("broker", brokerRegistry.getBrokerId())
+                    .log("Found this broker: has not registered yet. Trying to register it");
             brokerRegistry.registerAsync().get(timeout, TimeUnit.SECONDS);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -65,8 +65,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -101,7 +101,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
 
-@Slf4j
+@CustomLog
 public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
     private static final int OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS = 5000;
@@ -241,12 +241,11 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                                     monitorOwnerships(brokerRegistry.getAvailableBrokersAsync()
                                             .get(inFlightStateWaitingTimeInMillis, MILLISECONDS));
                                 } catch (Exception e) {
-                                    log.info("Failed to monitor the ownerships. will retry..", e);
+                                    log.info().exception(e).log("Failed to monitor the ownerships. will retry");
                                 }
                             },
                             0, ownershipMonitorDelayTimeInSecs, SECONDS);
-            log.info("This leader broker:{} started the ownership monitor.",
-                    brokerId);
+            log.info().attr("broker", brokerId).log("This leader broker: started the ownership monitor");
         }
     }
 
@@ -255,8 +254,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         if (monitorTask != null) {
             monitorTask.cancel(false);
             monitorTask = null;
-            log.info("This previous leader broker:{} stopped the ownership monitor.",
-                    brokerId);
+            log.info().attr("broker", brokerId).log("This previous leader broker: stopped the ownership monitor");
         }
     }
 
@@ -277,11 +275,13 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             ServiceUnitStateTableView tableview =
                     Reflections.createInstance(conf.getLoadManagerServiceUnitStateTableViewClassName(),
                             ServiceUnitStateTableView.class, Thread.currentThread().getContextClassLoader());
-            log.info("Created service unit state tableview: {}", tableview.getClass().getCanonicalName());
+            log.info().attr("tableView", tableview.getClass().getCanonicalName())
+                    .log("Created service unit state tableview");
             return tableview;
         } catch (Throwable e) {
-            log.error("Error when trying to create service unit state tableview: {}.",
-                    conf.getLoadManagerServiceUnitStateTableViewClassName(), e);
+            log.error().attr("tableView", conf.getLoadManagerServiceUnitStateTableViewClassName())
+                    .exception(e)
+                    .log("Error when trying to create service unit state tableview");
             throw e;
         }
     }
@@ -300,7 +300,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             var leader = leaderElectionService.readCurrentLeader().get(
                     MAX_CHANNEL_OWNER_ELECTION_WAITING_TIME_IN_SECS, TimeUnit.SECONDS);
             if (leader.isPresent()) {
-                log.info("Successfully found the channel leader:{}.", leader.get());
+                log.info().attr("leader", leader.get()).log("Successfully found the channel leader");
             } else {
                 log.warn("Failed to find the channel leader.");
             }
@@ -329,7 +329,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             log.info("Successfully started the channel.");
         } catch (Exception e) {
             String msg = "Failed to start the channel.";
-            log.error(msg, e);
+            log.error().exception(e).log(msg);
             throw new PulsarServerException(msg, e);
         }
     }
@@ -391,7 +391,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
         } catch (Exception e) {
             String msg = "Failed to close the channel.";
-            log.error(msg, e);
+            log.error().exception(e).log(msg);
             throw new PulsarServerException(msg, e);
         }
     }
@@ -515,8 +515,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                             });
                 }).whenComplete((__, e) -> {
                     if (e != null) {
-                        log.error("{} failed to get active owner broker. serviceUnit:{}, state:{}, owner:{}",
-                                brokerId, serviceUnit, state, owner, e);
+                        log.error().attr("broker", brokerId).attr("serviceUnit", serviceUnit)
+                                .attr("state", state).attr("owner", owner).exception(e)
+                                .log("failed to get active owner broker");
                         ownerLookUpCounters.get(state).getFailure().incrementAndGet();
                     }
                 }).thenApply(Optional::ofNullable);
@@ -624,12 +625,13 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 return Optional.empty();
             }
             case Deleted -> {
-                log.warn("Trying to get the assigned broker from the deleted serviceUnit:{}", serviceUnit);
+                log.warn().attr("serviceUnit", serviceUnit)
+                        .log("Trying to get the assigned broker from the deleted serviceUnit");
                 return Optional.empty();
             }
             default -> {
-                log.warn("Trying to get the assigned broker from unknown state:{} serviceUnit:{}", state,
-                        serviceUnit);
+                log.warn().attr("state", state).attr("serviceUnit", serviceUnit)
+                        .log("Trying to get the assigned broker from unknown state: serviceUnit");
                 return Optional.empty();
             }
         }
@@ -724,8 +726,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
         long totalHandledRequests = getHandlerTotalCounter(data).incrementAndGet();
         if (debug()) {
-            log.info("{} received a handle request for serviceUnit:{}, data:{}. totalHandledRequests:{}",
-                    brokerId, serviceUnit, data, totalHandledRequests);
+            log.info().attr("broker", brokerId).attr("serviceUnit", serviceUnit).attr("data", data)
+                    .attr("totalHandledRequests", totalHandledRequests)
+                    .log("received a handle request");
         }
 
         ServiceUnitState state = state(data);
@@ -749,15 +752,18 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 default -> throw new IllegalStateException("Failed to handle channel data:" + data);
             }
         } catch (Throwable e) {
-            log.error("Failed to handle the event. serviceUnit:{}, data:{}, handlerFailureCount:{}",
-                    serviceUnit, data, getHandlerFailureCounter(data).incrementAndGet(), e);
+            log.error().attr("serviceUnit", serviceUnit).attr("data", data)
+                    .attr("handlerFailureCount", getHandlerFailureCounter(data).incrementAndGet())
+                    .exception(e)
+                    .log("Failed to handle the event");
             throw e;
         }
     }
 
     private void handleExisting(String serviceUnit, ServiceUnitStateData data) {
         if (debug()) {
-            log.info("Loaded the service unit state data. serviceUnit: {}, data: {}", serviceUnit, data);
+            log.info().attr("serviceUnit", serviceUnit).attr("data", data)
+                    .log("Loaded the service unit state data");
         }
         ServiceUnitState state = state(data);
         if (state.equals(Owned) && isTargetBroker(data.dstBroker())) {
@@ -778,10 +784,12 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private void handleInvalidate(String serviceUnit, ServiceUnitStateData data) {
         closeServiceUnit(serviceUnit, true).whenComplete((__, ex) -> {
             if (ex == null) {
-                log.info("Unloaded serviceUnit:{} because the ownership is invalidate", serviceUnit);
+                log.info().attr("serviceUnit", serviceUnit)
+                        .log("Unloaded serviceUnit: because the ownership is invalidate");
                 return;
             }
-            log.error("Failed to unload serviceUnit:{} after the ownership is invalidate", serviceUnit, ex);
+            log.error().attr("serviceUnit", serviceUnit).exception(ex)
+                    .log("Failed to unload serviceUnit: after the ownership is invalidate");
         });
     }
 
@@ -825,24 +833,24 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             if (debug() || isTransferCommand(data)) {
                 long handlerTotalCount = getHandlerTotalCounter(data).get();
                 long handlerFailureCount = getHandlerFailureCounter(data).get();
-                log.info("{} handled {} event for serviceUnit:{}, cur:{}, next:{}, "
-                                + "totalHandledRequests:{}, totalFailedRequests:{}",
-                        brokerId, getLogEventTag(data), serviceUnit,
-                        data == null ? "" : data,
-                        next == null ? "" : next,
-                        handlerTotalCount, handlerFailureCount
-                );
+                log.info()
+                        .attr("broker", brokerId)
+                        .attr("event", getLogEventTag(data))
+                        .attr("serviceUnit", serviceUnit)
+                        .attr("cur", data == null ? "" : data)
+                        .attr("next", next == null ? "" : next)
+                        .attr("handlerTotalCount", handlerTotalCount)
+                        .attr("totalFailedRequests", handlerFailureCount)
+                        .log("Handled event for serviceUnit");
             }
         } else {
             long handlerTotalCount = getHandlerTotalCounter(data).get();
             long handlerFailureCount = getHandlerFailureCounter(data).incrementAndGet();
-            log.error("{} failed to handle {} event for serviceUnit:{}, cur:{}, next:{}, "
-                            + "totalHandledRequests:{}, totalFailedRequests:{}",
-                    brokerId, getLogEventTag(data), serviceUnit,
-                    data == null ? "" : data,
-                    next == null ? "" : next,
-                    handlerTotalCount, handlerFailureCount,
-                    e);
+            log.error().attr("broker", brokerId).attr("event", getLogEventTag(data))
+                    .attr("serviceUnit", serviceUnit).attr("cur", data == null ? "" : data)
+                    .attr("next", next == null ? "" : next).attr("handlerTotalCount", handlerTotalCount)
+                    .attr("totalFailedRequests", handlerFailureCount).exception(e)
+                    .log("Failed to handle event for serviceUnit");
         }
     }
 
@@ -862,7 +870,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         var getOwnerRequest = getOwnerRequests.remove(serviceUnit);
         if (getOwnerRequest != null) {
             if (debug()) {
-                log.info("Returned owner request for serviceUnit:{}", serviceUnit);
+                log.info().attr("serviceUnit", serviceUnit).log("Returned owner request for serviceUnit");
             }
             getOwnerRequest.complete(data.dstBroker());
         }
@@ -972,8 +980,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return tableview.put(serviceUnit, data)
                 .whenComplete((__, e) -> {
                     if (e != null) {
-                        log.error("Failed to publish the message: serviceUnit:{}, data:{}",
-                                serviceUnit, data, e);
+                        log.error().attr("serviceUnit", serviceUnit).attr("data", data).exception(e)
+                                .log("Failed to publish the message: serviceUnit: , data");
                     }
                 });
     }
@@ -982,8 +990,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return tableview.delete(serviceUnit)
                 .whenComplete((__, e) -> {
                     if (e != null) {
-                        log.error("Failed to tombstone the serviceUnit:{}}",
-                                serviceUnit, e);
+                        log.error().attr("serviceUnit", serviceUnit).exception(e)
+                                .log("Failed to tombstone the serviceUnit: }");
                     }
                 });
     }
@@ -1001,16 +1009,17 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                         TimeUnit.MILLISECONDS)
                 .exceptionally(e -> {
                     var ownerAfter = getOwnerNow(serviceUnit);
-                    log.warn("{} failed to wait for owner for serviceUnit:{}; Trying to "
-                                    + "return the current owner:{}",
-                            brokerId, serviceUnit, ownerAfter, e);
+                    log.warn().attr("broker", brokerId).attr("serviceUnit", serviceUnit)
+                            .attr("owner", ownerAfter).exception(e)
+                            .log("failed to wait for owner for serviceUnit: ; Trying to " + "return the current owner");
                     if (ownerAfter == null) {
                         throw new IllegalStateException(e);
                     }
                     return ownerAfter.orElse(null);
                 });
         if (debug()) {
-            log.info("{} is waiting for owner for serviceUnit:{}", brokerId, serviceUnit);
+            log.info().attr("broker", brokerId).attr("serviceUnit", serviceUnit)
+                    .log("is waiting for owner for serviceUnit");
         }
         return future;
     }
@@ -1050,7 +1059,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 future.whenComplete((__, e) -> {
                     getOwnerRequests.remove(serviceUnit);
                     if (e != null) {
-                        log.warn("{} failed to getOwner for serviceUnit:{}", brokerId, serviceUnit, e);
+                        log.warn().attr("broker", brokerId).attr("serviceUnit", serviceUnit).exception(e)
+                                .log("failed to getOwner for serviceUnit");
                     }
                 });
             }
@@ -1080,14 +1090,16 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                     double unloadBundleTime = TimeUnit.NANOSECONDS
                             .toMillis((System.nanoTime() - startTime));
                     if (ex != null) {
-                        log.error("Failed to close topics under bundle:{} in {} ms",
-                                bundle.toString(), unloadBundleTime, ex);
+                        log.error().attr("bundle", bundle.toString()).attr("unloadTimeMs", unloadBundleTime)
+                                .exception(ex)
+                                .log("Failed to close topics under bundle");
                         if (!disconnectClients) {
                             pulsar.getBrokerService().cleanUnloadedTopicFromCache(bundle);
                         }
                     } else {
-                        log.info("Unloading bundle:{} with {} topics completed in {} ms",
-                                bundle, unloadedTopics, unloadBundleTime);
+                        log.info().attr("bundle", bundle).attr("topicCount", unloadedTopics)
+                                .attr("unloadTimeMs", unloadBundleTime)
+                                .log("Unloaded bundle topics");
                     }
                 });
     }
@@ -1148,8 +1160,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                         Deleted, null, parentData.sourceBroker(), getNextVersionId(parentData))))
                 .thenAccept(__ -> {
                     double splitBundleTime = TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - startTime));
-                    log.info("Successfully split {} parent namespace-bundle to {} in {} ms",
-                            parentBundle, childBundles, splitBundleTime);
+                    log.info().attr("parentBundle", parentBundle).attr("childBundles", childBundles)
+                            .attr("splitTimeMs", splitBundleTime)
+                            .log("Successfully split parent namespace-bundle");
                     namespaceService.onNamespaceBundleSplit(parentBundle);
                     completionFuture.complete(null);
                 })
@@ -1158,8 +1171,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                     Throwable throwable = FutureUtil.unwrapCompletionException(ex);
                     if ((throwable instanceof MetadataStoreException.BadVersionException)
                             && (counter.incrementAndGet() < NamespaceService.BUNDLE_SPLIT_RETRY_LIMIT)) {
-                        log.warn("Failed to update bundle range in metadata store. Retrying {} th / {} limit",
-                                counter.get(), NamespaceService.BUNDLE_SPLIT_RETRY_LIMIT, ex);
+                        log.warn().attr("retry", counter.get())
+                                .attr("retryLimit", NamespaceService.BUNDLE_SPLIT_RETRY_LIMIT).exception(ex)
+                                .log("Failed to update bundle range in metadata store. Retrying");
                         pulsar.getExecutor().schedule(() -> splitServiceUnitOnceAndRetry(
                                         namespaceService, bundleFactory, algorithm, parentBundle, childBundles,
                                         boundaries, parentData, counter, startTime, completionFuture),
@@ -1169,7 +1183,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                         String msg = format("Failed to split bundle %s, Retried %d th / %d limit, reason %s",
                                 parentBundle.toString(), counter.get(),
                                 NamespaceService.BUNDLE_SPLIT_RETRY_LIMIT, throwable.getMessage());
-                        log.warn(msg, throwable);
+                        log.warn().exception(throwable).log(msg);
                         completionFuture.completeExceptionally(
                                 new BrokerServiceException.ServiceUnitNotReadyException(msg));
                     }
@@ -1186,7 +1200,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             var childData = tableview.get(childBundleStr);
             if (childData != null) {
                 if (debug) {
-                    log.info("Already owned child bundle:{}", childBundleStr);
+                    log.info().attr("bundle", childBundleStr).log("Already owned child bundle");
                 }
             } else {
                 childData = new ServiceUnitStateData(Owned, parentData.sourceBroker(),
@@ -1216,15 +1230,15 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                         targetNsBundle.validateBundle(parentBundle);
                     } catch (IllegalArgumentException e) {
                         if (debug) {
-                            log.info("Namespace bundles do not contain the parent bundle:{}",
-                                    parentBundle);
+                            log.info().attr("bundle", parentBundle)
+                                    .log("Namespace bundles do not contain the parent bundle");
                         }
                         for (var childBundle : childBundles) {
                             try {
                                 targetNsBundle.validateBundle(childBundle);
                                 if (debug) {
-                                    log.info("Namespace bundles contain the child bundle:{}",
-                                            childBundle);
+                                    log.info().attr("bundle", childBundle)
+                                            .log("Namespace bundles contain the child bundle");
                                 }
                             } catch (Exception ex) {
                                 throw FutureUtil.wrapToCompletionException(
@@ -1274,8 +1288,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         if (e == SessionReestablished || e == SessionLost) {
             lastMetadataSessionEvent = e;
             lastMetadataSessionEventTimestamp = System.currentTimeMillis();
-            log.info("Received metadata session event:{} at timestamp:{}",
-                    lastMetadataSessionEvent, lastMetadataSessionEventTimestamp);
+            log.info().attr("event", lastMetadataSessionEvent)
+                    .attr("timestamp", lastMetadataSessionEventTimestamp)
+                    .log("Received metadata session event: at timestamp");
         }
     }
 
@@ -1304,10 +1319,10 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     @VisibleForTesting
     protected void handleBrokerRegistrationEvent(String broker, NotificationType type) {
         if (type == NotificationType.Created) {
-            log.info("BrokerRegistry detected the broker:{} registry has been created.", broker);
+            log.info().attr("broker", broker).log("BrokerRegistry detected the broker: registry has been created");
             handleBrokerCreationEvent(broker);
         } else if (type == NotificationType.Deleted) {
-            log.info("BrokerRegistry detected the broker:{} registry has been deleted.", broker);
+            log.info().attr("broker", broker).log("BrokerRegistry detected the broker: registry has been deleted");
             handleBrokerDeletionEvent(broker);
         }
     }
@@ -1334,22 +1349,23 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                         if (future != null) {
                             future.cancel(false);
                             totalInactiveBrokerCleanupCancelledCnt++;
-                            log.info("Successfully cancelled the ownership cleanup for broker:{}."
-                                            + " Active cleanup job count:{}",
-                                    broker, cleanupJobs.size());
+                            log.info().attr("broker", broker).attr("count", cleanupJobs.size())
+                                    .log("Successfully cancelled the ownership cleanup for broker: ."
+                                            + " Active cleanup job count");
                         } else {
                             if (debug()) {
-                                log.info("No needs to cancel the ownership cleanup for broker:{}."
-                                                + " There was no scheduled cleanup job. Active cleanup job count:{}",
-                                        broker, cleanupJobs.size());
+                                log.info().attr("broker", broker).attr("count", cleanupJobs.size())
+                                        .log("No needs to cancel the ownership cleanup for broker: ."
+                                                + " There was no scheduled cleanup job. Active cleanup job count");
                             }
                         }
                     })
                     .exceptionally(e -> {
                         if (FutureUtil.unwrapCompletionException(e) instanceof PulsarAdminException.NotFoundException) {
-                            log.warn("{} Failed to run health check: {}", broker, e.getMessage());
+                            log.warn().attr("broker", broker).exceptionMessage(e)
+                                    .log("Failed to run health check");
                         } else {
-                            log.error("{} Failed to run health check", broker, e);
+                            log.error().attr("broker", broker).exception(e).log("Failed to run health check");
                         }
                         return null;
                     });
@@ -1359,27 +1375,30 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private void handleBrokerDeletionEvent(String broker) {
         try {
             if (!isChannelOwner()) {
-                log.warn("This broker is not the leader now. Ignoring BrokerDeletionEvent for broker {}.", broker);
+                log.warn().attr("broker", broker)
+                        .log("This broker is not the leader now. Ignoring BrokerDeletionEvent for broker");
                 return;
             }
         } catch (Exception e) {
             if (e instanceof ExecutionException && e.getCause() instanceof IllegalStateException) {
-                log.warn("Failed to handle broker deletion event due to {}", e.getMessage());
+                log.warn().exceptionMessage(e).log("Failed to handle broker deletion event");
             } else {
-                log.error("Failed to handle broker deletion event.", e);
+                log.error().exception(e).log("Failed to handle broker deletion event");
             }
             return;
         }
         MetadataState state = getMetadataState();
-        log.info("Handling broker:{} ownership cleanup based on metadata connection state:{}, event:{}, event_ts:{}:",
-                broker, state, lastMetadataSessionEvent, lastMetadataSessionEventTimestamp);
+        log.info().attr("broker", broker).attr("state", state).attr("event", lastMetadataSessionEvent)
+                .attr("eventTs", lastMetadataSessionEventTimestamp)
+                .log("Handling broker ownership cleanup based on metadata connection state");
         switch (state) {
             case Stable -> scheduleCleanup(broker, minCleanupDelayTimeInSecs);
             case Jittery -> scheduleCleanup(broker, maxCleanupDelayTimeInSecs);
             case Unstable -> {
                 totalInactiveBrokerCleanupIgnoredCnt++;
-                log.error("MetadataState state is unstable. "
-                        + "Ignoring the ownership cleanup request for the reported broker :{}", broker);
+                log.errorf("MetadataState state is unstable. "
+                        + "Ignoring the ownership cleanup request for the reported broker :%s",
+                        broker);
             }
         }
     }
@@ -1387,7 +1406,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private boolean channelDisabled() {
         final var channelState = this.channelState;
         if (channelState == Disabled || channelState == Closed) {
-            log.warn("[{}] Skip scheduleCleanup because the state is {} now", brokerId, channelState);
+            log.warn().attr("broker", brokerId).attr("channelState", channelState)
+                    .log("Skip scheduleCleanup because the state is disabled");
             return true;
         }
         return false;
@@ -1408,9 +1428,11 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                                     try {
                                         doCleanup(broker, false);
                                     } catch (Throwable e) {
-                                        log.error("Failed to run the cleanup job for the broker {}, "
-                                                        + "totalCleanupErrorCnt:{}.",
-                                                broker, totalCleanupErrorCnt.incrementAndGet(), e);
+                                        log.error().attr("broker", broker)
+                                                .attr("value", totalCleanupErrorCnt.incrementAndGet())
+                                                .exception(e)
+                                                .log("Failed to run the cleanup job for the broker , "
+                                                        + "totalCleanupErrorCnt");
                                     }
                                 }
                                 , delayed);
@@ -1426,8 +1448,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             }
         }
 
-        log.info("Scheduled ownership cleanup for broker:{} with delay:{} secs. Pending clean jobs:{}.",
-                broker, delayInSecs, cleanupJobs.size());
+        log.info().attr("broker", broker).attr("delay", delayInSecs).attr("jobs", cleanupJobs.size())
+                .log("Scheduled ownership cleanup for broker: with delay: secs. Pending clean jobs");
     }
 
 
@@ -1472,9 +1494,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                                 true,
                                 version)))
                 .thenCompose(override -> {
-                    log.info(
-                            "Overriding inactiveBroker:{}, ownership serviceUnit:{} from orphanData:{} to "
-                                    + "overrideData:{}",
+                    log.infof(
+                            "Overriding inactiveBroker:%s, ownership serviceUnit:%s from orphanData:%s to "
+                                    + "overrideData:%s",
                             inactiveBroker, serviceUnit, orphanData, override);
                     return publishOverrideEventAsync(serviceUnit, override);
                 });
@@ -1494,7 +1516,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
                 if (data.state() == Owned && broker.equals(data.dstBroker())) {
                     cleaned = false;
-                    log.info("[{}] bundle {} is still owned by this, data: {}", broker, serviceUnit, data);
+                    log.info().attr("broker", broker).attr("bundle", serviceUnit).attr("data", data)
+                            .log("Bundle is still owned by this broker");
                     break;
                 }
             }
@@ -1505,17 +1528,18 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                     tableview.flush(OWNERSHIP_CLEAN_UP_WAIT_RETRY_DELAY_IN_MILLIS / 2);
                     Thread.sleep(OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS / 2);
                 } catch (InterruptedException e) {
-                    log.warn("Interrupted while delaying the next service unit clean-up. Cleaning broker:{}",
-                            brokerId);
+                    log.warn().attr("broker", brokerId)
+                            .log("Interrupted while delaying the next service unit clean-up. Cleaning broker");
                 } catch (ExecutionException e) {
-                    log.error("Failed to flush table view", e.getCause());
+                    log.error().exception(e.getCause()).log("Failed to flush table view");
                 } catch (TimeoutException e) {
-                    log.warn("Failed to flush the table view in {} ms", OWNERSHIP_CLEAN_UP_WAIT_RETRY_DELAY_IN_MILLIS);
+                    log.warn().attr("timeoutMs", OWNERSHIP_CLEAN_UP_WAIT_RETRY_DELAY_IN_MILLIS)
+                            .log("Failed to flush the table view");
                 }
             }
         }
-        log.info("Finished cleanup waiting for orphan broker:{}. Elapsed {} ms", brokerId,
-                System.currentTimeMillis() - started);
+        log.info().attr("broker", brokerId).attr("elapsed", System.currentTimeMillis() - started)
+                .log("Finished cleanup waiting for orphan broker: . Elapsed ms");
     }
 
     private CompletableFuture<Void> healthCheckBrokerAsync(String brokerId) {
@@ -1534,7 +1558,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             admin.brokers().healthcheckAsync(Optional.of(brokerId))
                     .whenComplete((__, e) -> {
                         if (e == null) {
-                            log.info("Completed health-check broker :{}", brokerId, e);
+                            log.info().attr("broker", brokerId).exception(e).log("Completed health-check broker");
                             future.complete(null);
                             return;
                         }
@@ -1558,8 +1582,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 FutureUtil.waitForAll(overrideFutures)
                         .get(config.getMetadataStoreOperationTimeoutSeconds(), SECONDS);
             } catch (Throwable e) {
-                log.error("Failed to override ownership: totalCleanupErrorCnt:{}",
-                        totalCleanupErrorCnt.incrementAndGet(), e);
+                log.error().attr("totalCleanupErrorCnt", totalCleanupErrorCnt.incrementAndGet()).exception(e)
+                        .log("Failed to override ownership: totalCleanupErrorCnt");
             } finally {
                 overrideFutures.clear();
             }
@@ -1570,12 +1594,13 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         try {
             if (getChannelOwnerAsync().get(MAX_CHANNEL_OWNER_ELECTION_WAITING_TIME_IN_SECS, TimeUnit.SECONDS)
                     .isEmpty()) {
-                log.error("Found the channel owner is empty. Skip the inactive broker:{}'s orphan bundle cleanup",
-                        broker);
+                log.error().attr("broker", broker)
+                        .log("Found the channel owner is empty. Skip the inactive broker: 's orphan bundle cleanup");
                 return;
             }
         } catch (Exception e) {
-            log.error("Failed to find the channel owner. Skip the inactive broker:{}'s orphan bundle cleanup", broker);
+            log.error().attr("broker", broker)
+                    .log("Failed to find the channel owner. Skip the inactive broker: 's orphan bundle cleanup");
             return;
         }
 
@@ -1586,31 +1611,31 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 healthCheckBrokerAsync(broker).get(
                         MAX_BROKER_HEALTH_CHECK_DELAY_IN_MILLIS * (MAX_BROKER_HEALTH_CHECK_RETRY + 1)
                         , MILLISECONDS);
-                log.warn("Found that the broker to clean is healthy. Skip the broker:{}'s orphan bundle cleanup",
-                        broker);
+                log.warn().attr("broker", broker)
+                        .log("Found that the broker to clean is healthy. Skip the broker: 's orphan bundle cleanup");
                 return;
             } catch (Exception e) {
                 if (debug()) {
                     if (e instanceof ExecutionException
                             && e.getCause() instanceof PulsarAdminException.NotFoundException) {
-                        log.info("The broker {} is not healthy because it's not found", broker);
+                        log.info().attr("broker", broker).log("The broker is not healthy because it's not found");
                     } else {
-                        log.info("Failed to check broker:{} health", broker, e);
+                        log.info().attr("broker", broker).exception(e).log("Failed to check broker: health");
                     }
                 }
-                log.info("Checked the broker:{} health. Continue the orphan bundle cleanup", broker);
+                log.info().attr("broker", broker).log("Checked the broker: health. Continue the orphan bundle cleanup");
             }
         }
 
 
         long startTime = System.nanoTime();
-        log.info("Started ownership cleanup for the inactive broker:{}", broker);
+        log.info().attr("broker", broker).log("Started ownership cleanup for the inactive broker");
         int orphanServiceUnitCleanupCnt = 0;
         long totalCleanupErrorCntStart = totalCleanupErrorCnt.get();
         try {
             tableview.flush(OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS);
         } catch (Exception e) {
-            log.error("Failed to flush", e);
+            log.error().exception(e).log("Failed to flush");
         }
         List<CompletableFuture<Void>> overrideFutures = new ArrayList<>();
         Map<String, ServiceUnitStateData> orphanSystemServiceUnits = new HashMap<>();
@@ -1635,7 +1660,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         try {
             tableview.flush(OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS);
         } catch (Exception e) {
-            log.error("Failed to flush the in-flight non-system bundle override messages.", e);
+            log.error().exception(e).log("Failed to flush the in-flight non-system bundle override messages");
         }
 
 
@@ -1654,7 +1679,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         var orphanSystemServiceUnitIter = orphanSystemServiceUnits.entrySet().iterator();
         while (orphanSystemServiceUnitIter.hasNext()) {
             var orphanSystemServiceUnit = orphanSystemServiceUnitIter.next();
-            log.info("Overriding orphan system service unit:{}", orphanSystemServiceUnit.getKey());
+            log.info().attr("unit", orphanSystemServiceUnit.getKey()).log("Overriding orphan system service unit");
             overrideFutures.add(
                     overrideOwnership(orphanSystemServiceUnit.getKey(), orphanSystemServiceUnit.getValue(), broker,
                             gracefully));
@@ -1664,7 +1689,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         try {
             tableview.flush(OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS);
         } catch (Exception e) {
-            log.error("Failed to flush the in-flight system bundle override messages.", e);
+            log.error().exception(e).log("Failed to flush the in-flight system bundle override messages");
         }
 
         double cleanupTime = TimeUnit.NANOSECONDS
@@ -1674,14 +1699,11 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         getContext().topBundleLoadDataStore().removeAsync(broker);
         getContext().brokerLoadDataStore().removeAsync(broker);
 
-        log.info("Completed a cleanup for the inactive broker:{} in {} ms. "
-                        + "Cleaned up orphan service units: orphanServiceUnitCleanupCnt:{}, "
-                        + "approximate cleanupErrorCnt:{}, metrics:{} ",
-                broker,
-                cleanupTime,
-                orphanServiceUnitCleanupCnt,
-                totalCleanupErrorCnt.get() - totalCleanupErrorCntStart,
-                printCleanupMetrics());
+        log.info().attr("broker", broker).attr("cleanupTimeMs", cleanupTime)
+                .attr("orphanServiceUnitCleanupCnt", orphanServiceUnitCleanupCnt)
+                .attr("cleanupErrorCnt", totalCleanupErrorCnt.get() - totalCleanupErrorCntStart)
+                .attr("metrics", printCleanupMetrics())
+                .log("Completed a cleanup for the inactive broker");
 
     }
 
@@ -1701,7 +1723,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                 return;
             }
         } catch (Exception e) {
-            log.error("Failed to monitor ownerships", e);
+            log.error().exception(e).log("Failed to monitor ownerships");
             return;
         }
 
@@ -1712,15 +1734,15 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
         var metadataState = getMetadataState();
         if (metadataState != Stable) {
-            log.warn("metadata state:{} is not Stable. Skipping ownership monitor. lastMetadataSessionEvent:{},"
-                            + " lastMetadataSessionEventTimestamp:{}",
-                    metadataState, lastMetadataSessionEvent, lastMetadataSessionEventTimestamp);
+            log.warn().attr("state", metadataState).attr("lastMetadataSessionEvent", lastMetadataSessionEvent)
+                    .attr("lastMetadataSessionEventTimestamp", lastMetadataSessionEventTimestamp)
+                    .log("metadata state is not Stable. Skipping ownership monitor");
             return;
         }
 
         var debug = debug();
         if (debug) {
-            log.info("Started the ownership monitor run for activeBrokerCount:{}", brokers.size());
+            log.info().attr("broker", brokers.size()).log("Started the ownership monitor run for activeBrokerCount");
         }
 
         long startTime = System.nanoTime();
@@ -1760,14 +1782,16 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
 
             if (!isActiveState(state) && now - stateData.timestamp() > stateTombstoneDelayTimeInMillis) {
-                log.info("Found semi-terminal states to tombstone"
-                        + " serviceUnit:{}, stateData:{}", serviceUnit, stateData);
+                log.infof("Found semi-terminal states to tombstone"
+                        + " serviceUnit:%s, stateData:%s",
+                        serviceUnit, stateData);
                 tombstoneAsync(serviceUnit).whenComplete((__, e) -> {
                     if (e != null) {
-                        log.error("Failed cleaning the ownership serviceUnit:{}, stateData:{}, "
-                                        + "cleanupErrorCnt:{}.",
-                                serviceUnit, stateData,
-                                totalCleanupErrorCnt.incrementAndGet() - totalCleanupErrorCntStart, e);
+                        log.error().attr("serviceUnit", serviceUnit).attr("stateData", stateData)
+                                .attr("cleanupErrorCnt",
+                                        totalCleanupErrorCnt.incrementAndGet() - totalCleanupErrorCntStart)
+                                .exception(e)
+                                .log("Failed cleaning the ownership");
                     }
                 });
                 serviceUnitTombstoneCleanupCnt++;
@@ -1799,7 +1823,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         try {
             tableview.flush(OWNERSHIP_CLEAN_UP_MAX_WAIT_TIME_IN_MILLIS);
         } catch (Exception e) {
-            log.error("Failed to flush the in-flight messages.", e);
+            log.error().exception(e).log("Failed to flush the in-flight messages");
         }
 
         boolean cleaned = false;
@@ -1816,17 +1840,17 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         if (debug || cleaned) {
             double monitorTime = TimeUnit.NANOSECONDS
                     .toMillis((System.nanoTime() - startTime));
-            log.info("Completed the ownership monitor run in {} ms. "
-                            + "Scheduled cleanups for inactive brokers:{}. inactiveBrokerCount:{}. "
-                            + "Published cleanups for orphan service units, orphanServiceUnitCleanupCnt:{}. "
-                            + "Tombstoned semi-terminal state service units, serviceUnitTombstoneCleanupCnt:{}. "
-                            + "Approximate cleanupErrorCnt:{}, metrics:{}. ",
-                    monitorTime,
-                    inactiveBrokers, inactiveBrokers.size(),
-                    orphanServiceUnitCleanupCnt,
-                    serviceUnitTombstoneCleanupCnt,
-                    totalCleanupErrorCnt.get() - totalCleanupErrorCntStart,
-                    printCleanupMetrics());
+            log.info().attr("monitorTimeMs", monitorTime).attr("inactiveBrokers", inactiveBrokers)
+                    .attr("inactiveBrokerCount", inactiveBrokers.size())
+                    .attr("orphanServiceUnitCleanupCnt", orphanServiceUnitCleanupCnt)
+                    .attr("serviceUnitTombstoneCleanupCnt", serviceUnitTombstoneCleanupCnt)
+                    .attr("cleanupErrorCnt", totalCleanupErrorCnt.get() - totalCleanupErrorCntStart)
+                    .attr("metrics", printCleanupMetrics())
+                    .log("Completed the ownership monitor run. "
+                            + "Scheduled cleanups for inactive brokers. "
+                            + "Published cleanups for orphan service units, orphanServiceUnitCleanupCnt: . "
+                                    + "Tombstoned semi-terminal state service units, serviceUnitTombstoneCleanupCnt: . "
+                                            + "Approximate cleanupErrorCnt: , metrics: .");
         }
 
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateMetadataStoreTableViewImpl.java
@@ -29,8 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import lombok.CustomLog;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.MetadataSessionExpiredPolicy;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -39,7 +39,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreTableView;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.tableview.impl.MetadataStoreTableViewImpl;
 
-@Slf4j
+@CustomLog
 public class ServiceUnitStateMetadataStoreTableViewImpl extends ServiceUnitStateTableViewBase {
     public static final String PATH_PREFIX = "/service_unit_state";
     private static final String VALID_PATH_REG_EX = "^\\/service_unit_state\\/.*\\/0x[0-9a-fA-F]{8}_0x[0-9a-fA-F]{8}$";
@@ -49,7 +49,7 @@ public class ServiceUnitStateMetadataStoreTableViewImpl extends ServiceUnitState
         try {
             VALID_PATH_PATTERN = Pattern.compile(VALID_PATH_REG_EX);
         } catch (PatternSyntaxException error) {
-            log.error("Invalid regular expression {}", VALID_PATH_REG_EX, error);
+            log.error().attr("expression", VALID_PATH_REG_EX).exception(error).log("Invalid regular expression");
             throw new IllegalArgumentException(error);
         }
     }
@@ -92,7 +92,7 @@ public class ServiceUnitStateMetadataStoreTableViewImpl extends ServiceUnitState
 
     protected void handleTableViewShutDownEvent(Throwable throwable) {
         log.error("The component of load-balance, which named metadata store table view has shutdown. This Broker can"
-                    + " not work anymore, start tp shutdow,");
+                + " not work anymore, start tp shutdow,");
         pulsar.shutdownNow();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewBase.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -37,7 +36,6 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 /**
  * ServiceUnitStateTableView base class.
  */
-@Slf4j
 abstract class ServiceUnitStateTableViewBase implements ServiceUnitStateTableView {
     protected static final String INVALID_STATE_ERROR_MSG = "The tableview has not been started.";
     private final Map<NamespaceBundle, Boolean> ownedServiceUnitsMap = new ConcurrentHashMap<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewImpl.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.client.api.CompressionType;
@@ -39,7 +39,7 @@ import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 
-@Slf4j
+@CustomLog
 public class ServiceUnitStateTableViewImpl extends ServiceUnitStateTableViewBase {
 
     public static final String TOPIC = TopicName.get(
@@ -149,11 +149,13 @@ public class ServiceUnitStateTableViewImpl extends ServiceUnitStateTableViewBase
                 .whenComplete((messageId, e) -> {
                     if (e != null) {
                         if (e instanceof PulsarClientException.AlreadyClosedException) {
-                            log.info("Skip publishing the message since the producer is closed, serviceUnit: {}, data: "
-                                    + "{}", key, value);
+                            log.info()
+                                    .attr("serviceUnit", key)
+                                    .attr("value", value)
+                                    .log("Skip publishing: producer closed");
                         } else {
-                            log.error("Failed to publish the message: serviceUnit:{}, data:{}",
-                                    key, value, e);
+                            log.error().attr("serviceUnit", key).attr("data", value).exception(e)
+                                    .log("Failed to publish the message");
                         }
                         future.completeExceptionally(e);
                     } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateTableViewSyncer.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -43,7 +43,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
  * It syncs service unit(bundle) states between metadata store and system topic table views.
  * One could enable this syncer before migration from one to the other and disable it after the migration finishes.
  */
-@Slf4j
+@CustomLog
 public class ServiceUnitStateTableViewSyncer implements Closeable {
     private static final int MAX_CONCURRENT_SYNC_COUNT = 100;
     private static final int SYNC_WAIT_TIME_IN_SECS = 300;
@@ -76,7 +76,7 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
             isActive = true;
 
         } catch (Throwable e) {
-            log.error("Failed to start ServiceUnitStateTableViewSyncer", e);
+            log.error().exception(e).log("Failed to start ServiceUnitStateTableViewSyncer");
             throw e;
         }
     }
@@ -131,10 +131,10 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
                             + SYNC_WAIT_TIME_IN_SECS + " secs");
         }
 
-        log.info("Synced existing items MetadataStoreTableView.size:{} , "
-                        + "SystemTopicTableView.size: {} in {} secs",
-                metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
-                TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
+        log.info().attr("metadataStoreTableViewSize", metadataStoreTableView.entrySet().size())
+                .attr("systemTopicTableViewSize", systemTopicTableView.entrySet().size())
+                .attr("elapsedSecs", TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started))
+                .log("Synced existing items");
     }
 
     private void syncTailItems() throws InterruptedException, IOException, TimeoutException {
@@ -178,10 +178,10 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
         }
 
 
-        log.info("Successfully started ServiceUnitStateTableViewSyncer MetadataStoreTableView.size:{} , "
-                        + "SystemTopicTableView.size: {} in {} secs",
-                metadataStoreTableView.entrySet().size(), systemTopicTableView.entrySet().size(),
-                TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started));
+        log.info().attr("metadataStoreTableViewSize", metadataStoreTableView.entrySet().size())
+                .attr("systemTopicTableViewSize", systemTopicTableView.entrySet().size())
+                .attr("elapsedSecs", TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - started))
+                .log("Successfully started ServiceUnitStateTableViewSyncer");
     }
 
     private void syncExistingItemsToMetadataStore(ServiceUnitStateTableView src)
@@ -260,7 +260,7 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
                 log.info("Closed SystemTopicTableView");
             }
         } catch (Exception e) {
-            log.error("Failed to close SystemTopicTableView", e);
+            log.error().exception(e).log("Failed to close SystemTopicTableView");
             throw e;
         }
 
@@ -271,7 +271,7 @@ public class ServiceUnitStateTableViewSyncer implements Closeable {
                 log.info("Closed MetadataStoreTableView");
             }
         } catch (Exception e) {
-            log.error("Failed to close MetadataStoreTableView", e);
+            log.error().exception(e).log("Failed to close MetadataStoreTableView");
             throw e;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/StateChangeListeners.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/StateChangeListeners.java
@@ -22,10 +22,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.extensions.manager.StateChangeListener;
 
-@Slf4j
+@CustomLog
 public class StateChangeListeners {
 
     private final List<StateChangeListener> stateChangeListeners;
@@ -61,8 +61,9 @@ public class StateChangeListeners {
             try {
                 listener.beforeEvent(serviceUnit, data);
             } catch (Throwable ex) {
-                log.error("StateChangeListener: {} exception while notifying arrival event {} for service unit {}",
-                        listener, data, serviceUnit, ex);
+                log.error().attr("stateChangeListener", listener).attr("event", data)
+                        .attr("unit", serviceUnit).exception(ex)
+                        .log("StateChangeListener: exception while notifying arrival event for service unit");
             }
         });
         return CompletableFuture.completedFuture(null);
@@ -73,8 +74,9 @@ public class StateChangeListeners {
             try {
                 listener.handleEvent(serviceUnit, data, t);
             } catch (Throwable ex) {
-                log.error("StateChangeListener: {} exception while handling {} for service unit {}",
-                        listener, data, serviceUnit, ex);
+                log.error().attr("stateChangeListener", listener).attr("handling", data)
+                        .attr("unit", serviceUnit).exception(ex)
+                        .log("StateChangeListener: exception while handling for service unit");
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilter.java
@@ -20,14 +20,14 @@ package org.apache.pulsar.broker.loadbalance.extensions.filter;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPoliciesHelper;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 
 
-@Slf4j
+@CustomLog
 public class BrokerIsolationPoliciesFilter implements BrokerFilter {
 
     public static final String FILTER_NAME = "broker_isolation_policies_filter";

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerVersionFilter.java
@@ -22,7 +22,7 @@ import com.github.zafarkhaja.semver.Version;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 /**
  * Filter by broker version.
  */
-@Slf4j
+@CustomLog
 public class BrokerVersionFilter implements BrokerFilter {
 
     public static final String FILTER_NAME = "broker_version_filter";
@@ -58,11 +58,9 @@ public class BrokerVersionFilter implements BrokerFilter {
         Version latestVersion;
         try {
             latestVersion = getLatestVersionNumber(brokers);
-            if (log.isDebugEnabled()) {
-                log.debug("Latest broker version found was [{}]", latestVersion);
-            }
+            log.debug().attr("version", latestVersion).log("Latest broker version found");
         } catch (Exception ex) {
-            log.warn("Disabling PreferLaterVersions feature; reason: " + ex.getMessage());
+            log.warn().exceptionMessage(ex).log("Disabling PreferLaterVersions feature");
             return FutureUtil.failedFuture(
                     new BrokerFilterBadVersionException("Cannot determine newest broker version: " + ex.getMessage()));
         }
@@ -77,17 +75,20 @@ public class BrokerVersionFilter implements BrokerFilter {
             String version = next.getValue().brokerVersion();
             Version brokerVersionVersion = Version.valueOf(version);
             if (brokerVersionVersion.equals(latestVersion)) {
-                log.debug("Broker [{}] is running the latest version ([{}])", brokerId, version);
+                log.debug().attr("broker", brokerId).attr("version", version)
+                        .log("Broker is running the latest version");
                 numBrokersLatestVersion++;
             } else {
-                log.info("Broker [{}] is running an older version ([{}]); latest version is [{}]",
-                        brokerId, version, latestVersion);
+                log.info().attr("broker", brokerId).attr("brokerVersion", version)
+                        .attr("latestVersion", latestVersion)
+                        .log("Broker is running an older version");
                 numBrokersOlderVersion++;
                 brokerIterator.remove();
             }
         }
         if (numBrokersOlderVersion == 0) {
-            log.info("All {} brokers are running the latest version [{}]", numBrokersLatestVersion, latestVersion);
+            log.info().attr("brokerCount", numBrokersLatestVersion).attr("version", latestVersion)
+                    .log("All brokers are running the latest version");
         }
         return CompletableFuture.completedFuture(brokers);
     }
@@ -116,8 +117,8 @@ public class BrokerVersionFilter implements BrokerFilter {
             String brokerId = entry.getKey();
             String version = entry.getValue().brokerVersion();
             if (null == version || version.length() == 0) {
-                log.warn("No version string in lookup data for broker [{}]; disabling PreferLaterVersions feature",
-                        brokerId);
+                log.warn().attr("broker", brokerId)
+                        .log("No version string in lookup data for broker; disabling PreferLaterVersions feature");
                 // Trigger the load manager to reset all the brokers to the original set
                 throw new BrokerFilterBadVersionException("No version string in lookup data for broker \""
                         + brokerId + "\"");
@@ -126,9 +127,9 @@ public class BrokerVersionFilter implements BrokerFilter {
             try {
                 brokerVersionVersion = Version.valueOf(version);
             } catch (Exception x) {
-                log.warn("Invalid version string in lookup data for broker [{}]: [{}];"
-                                + " disabling PreferLaterVersions feature",
-                        brokerId, version);
+                log.warn().attr("broker", brokerId).attr("version", version)
+                        .log("Invalid version string in lookup data for broker;"
+                                + " disabling PreferLaterVersions feature");
                 // Trigger the load manager to reset all the brokers to the original set
                 throw new BrokerFilterBadVersionException("Invalid version string in lookup data for broker \""
                         + brokerId + "\": \"" + version + "\")");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManager.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -38,7 +38,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 
-@Slf4j
+@CustomLog
 public class RedirectManager {
     private final PulsarService pulsar;
 
@@ -66,7 +66,7 @@ public class RedirectManager {
                     if (lookupDataOpt.isPresent()) {
                         map.put(brokerId, lookupDataOpt.get());
                     } else {
-                        log.warn("Got an empty lookup data, brokerId: {}", brokerId);
+                        log.warn().attr("broker", brokerId).log("Got an empty lookup data, brokerId");
                     }
                 }));
             }
@@ -100,8 +100,8 @@ public class RedirectManager {
 
             if (Objects.equals(latestServiceLookupData.get().getLoadManagerClassName(), currentLMClassName)) {
                 if (debug) {
-                    log.info("No need to redirect, current load manager class name: {}",
-                            currentLMClassName);
+                    log.info().attr("name", currentLMClassName)
+                            .log("No need to redirect, current load manager class name");
                 }
                 return Optional.empty();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/SplitManager.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.broker.loadbalance.extensions.models.SplitCounter;
@@ -33,7 +33,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.models.SplitDecision;
 /**
  * Split manager.
  */
-@Slf4j
+@CustomLog
 public class SplitManager implements StateChangeListener {
 
 
@@ -66,24 +66,27 @@ public class SplitManager implements StateChangeListener {
                                              TimeUnit timeoutUnit) {
         return eventPubFuture
                 .thenCompose(__ -> inFlightSplitRequests.computeIfAbsent(bundle, ignore -> {
-                    log.info("Published the bundle split event for bundle:{}. "
-                                    + "Waiting the split event to complete. Timeout: {} {}",
-                            bundle, timeout, timeoutUnit);
+                    log.info().attr("bundle", bundle).attr("timeout", timeout)
+                            .attr("timeoutUnit", timeoutUnit)
+                            .log("Published the bundle split event for bundle: . "
+                                    + "Waiting the split event to complete. Timeout");
                     CompletableFuture<Void> future = new CompletableFuture<>();
                     future.orTimeout(timeout, timeoutUnit).whenComplete((v, ex) -> {
                         if (ex != null) {
                             inFlightSplitRequests.remove(bundle);
-                            log.warn("Timed out while waiting for the bundle split event: {}", bundle, ex);
+                            log.warn().attr("bundle", bundle).exception(ex)
+                                    .log("Timed out while waiting for the bundle split event");
                         }
                     });
                     return future;
                 }))
                 .whenComplete((__, ex) -> {
                     if (ex != null) {
-                        log.error("Failed the bundle split event for bundle:{}", bundle, ex);
+                        log.error().attr("bundle", bundle).exception(ex)
+                                .log("Failed the bundle split event for bundle");
                         counter.update(Failure, Unknown);
                     } else {
-                        log.info("Completed the bundle split event for bundle:{}", bundle);
+                        log.info().attr("bundle", bundle).log("Completed the bundle split event for bundle");
                         counter.update(decision);
                     }
                 });
@@ -99,9 +102,7 @@ public class SplitManager implements StateChangeListener {
         switch (state) {
             case Init -> this.complete(serviceUnit, t);
             default -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("Handling {} for service unit {}", data, serviceUnit);
-                }
+                log.debug().attr("handling", data).attr("unit", serviceUnit).log("Handling for service unit");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/UnloadManager.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
@@ -40,7 +40,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.models.UnloadDecision;
 /**
  * Unload manager.
  */
-@Slf4j
+@CustomLog
 public class UnloadManager implements StateChangeListener {
 
     private final UnloadCounter counter;
@@ -86,7 +86,8 @@ public class UnloadManager implements StateChangeListener {
                     future.completeOnTimeout(null, OP_TIMEOUT_NS, TimeUnit.NANOSECONDS).
                             thenAccept(__ -> {
                                 var durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs);
-                                log.info("Operation {} for service unit {} took {} ms", this, serviceUnit, durationMs);
+                                log.info().attr("operation", this).attr("unit", serviceUnit)
+                                        .attr("took", durationMs).log("Operation for service unit took ms");
                                 histogram.labels(brokerId, "bundleUnloading").observe(durationMs);
                             }).whenComplete((__, throwable) -> futures.remove(serviceUnit, future));
                     return future;
@@ -134,33 +135,30 @@ public class UnloadManager implements StateChangeListener {
                                              long timeout,
                                              TimeUnit timeoutUnit) {
         return eventPubFuture.thenCompose(__ -> inFlightUnloadRequest.computeIfAbsent(bundle, ignore -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Handle unload bundle: {}, timeout: {} {}", bundle, timeout, timeoutUnit);
-            }
+            log.debug().attr("bundle", bundle).attr("timeout", timeout).attr("timeoutUnit", timeoutUnit)
+                    .log("Handle unload bundle: , timeout");
             CompletableFuture<Void> future = new CompletableFuture<>();
             future.orTimeout(timeout, timeoutUnit).whenComplete((v, ex) -> {
                 if (ex != null) {
                     inFlightUnloadRequest.remove(bundle);
-                    log.warn("Failed to wait unload for serviceUnit: {}", bundle, ex);
+                    log.warn().attr("bundle", bundle).exception(ex).log("Failed to wait unload for serviceUnit");
                 }
             });
             return future;
         })).whenComplete((__, ex) -> {
             if (ex != null) {
                 counter.update(Failure, Unknown);
-                log.warn("Failed to unload bundle: {}", bundle, ex);
+                log.warn().attr("bundle", bundle).exception(ex).log("Failed to unload bundle");
                 return;
             }
-            log.info("Complete unload bundle: {}", bundle);
+            log.info().attr("bundle", bundle).log("Complete unload bundle");
             counter.update(decision);
         });
     }
 
     @Override
     public void beforeEvent(String serviceUnit, ServiceUnitStateData data) {
-        if (log.isDebugEnabled()) {
-            log.debug("Handling arrival of {} for service unit {}", data, serviceUnit);
-        }
+        log.debug().attr("data", data).attr("serviceUnit", serviceUnit).log("Handling arrival for service unit");
         ServiceUnitState state = ServiceUnitStateData.state(data);
         switch (state) {
             case Free, Owned -> LatencyMetric.DISCONNECT.beginMeasurement(serviceUnit, brokerId, data);
@@ -177,23 +175,19 @@ public class UnloadManager implements StateChangeListener {
         ServiceUnitState state = ServiceUnitStateData.state(data);
 
         if ((state == Owned || state == Assigning) && StringUtils.isBlank(data.sourceBroker())) {
-            if (log.isDebugEnabled()) {
-                log.debug("Skipping {} for service unit {} from the assignment command.", data, serviceUnit);
-            }
+            log.debug().attr("data", data).attr("serviceUnit", serviceUnit)
+                    .log("Skipping service unit from the assignment command");
             return;
         }
 
         if (t != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Handling {} for service unit {} with exception.", data, serviceUnit, t);
-            }
+            log.debug().attr("data", data).attr("serviceUnit", serviceUnit).exception(t)
+                    .log("Handling service unit with exception");
             complete(serviceUnit, t);
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Handling {} for service unit {}", data, serviceUnit);
-        }
+        log.debug().attr("data", data).attr("serviceUnit", serviceUnit).log("Handling service unit");
 
         switch (state) {
             case Free -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/models/TopKBundles.java
@@ -23,10 +23,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.data.TopBundlesLoadData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
@@ -43,7 +43,7 @@ import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 @Getter
 @ToString
 @EqualsAndHashCode
-@Slf4j
+@CustomLog
 public class TopKBundles {
 
     // temp array for sorting
@@ -162,7 +162,7 @@ public class TopKBundles {
                 return true;
             }
         } catch (MetadataStoreException e) {
-            log.error("Failed to get localPolicies for bundle:{}.", bundle, e);
+            log.error().attr("bundle", bundle).exception(e).log("Failed to get localPolicies for bundle");
             throw new RuntimeException(e);
         }
         return false;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/AntiAffinityGroupPolicyHelper.java
@@ -21,14 +21,14 @@ package org.apache.pulsar.broker.loadbalance.extensions.policies;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannel;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 
-@Slf4j
+@CustomLog
 public class AntiAffinityGroupPolicyHelper {
     PulsarService pulsar;
     Map<String, String> brokerToFailureDomainMap;
@@ -54,7 +54,8 @@ public class AntiAffinityGroupPolicyHelper {
             return LoadManagerShared.getNamespaceAntiAffinityGroup(
                     pulsar, LoadManagerShared.getNamespaceNameFromBundleName(bundle)).isPresent();
         } catch (MetadataStoreException e) {
-            log.error("Failed to check unload candidates. Assumes that bundle:{} cannot unload ", bundle, e);
+            log.error().attr("bundle", bundle).exception(e)
+                    .log("Failed to check unload candidates. Assumes that bundle cannot unload");
             return false;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/IsolationPoliciesHelper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/policies/IsolationPoliciesHelper.java
@@ -21,14 +21,14 @@ package org.apache.pulsar.broker.loadbalance.extensions.policies;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 
-@Slf4j
+@CustomLog
 public class IsolationPoliciesHelper {
 
     private final SimpleResourceAllocationPolicies policies;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/BrokerLoadDataReporter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/BrokerLoadDataReporter.java
@@ -22,8 +22,8 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -42,7 +42,7 @@ import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 /**
  * The broker load data reporter.
  */
-@Slf4j
+@CustomLog
 public class BrokerLoadDataReporter implements LoadDataReporter<BrokerLoadData>, StateChangeListener {
 
     private static final long TOMBSTONE_DELAY_IN_MILLIS = 1000 * 10;
@@ -108,7 +108,7 @@ public class BrokerLoadDataReporter implements LoadDataReporter<BrokerLoadData>,
         boolean debug = ExtensibleLoadManagerImpl.debug(conf, log);
         if (force || needBrokerDataUpdate()) {
             if (debug) {
-                log.info("publishing load report:{}", localData.toString(conf));
+                log.info().attr("report", localData.toString(conf)).log("publishing load report");
             }
             CompletableFuture<Void> future =
                     this.brokerLoadDataStore.pushAsync(this.brokerId, newLoadData);
@@ -117,13 +117,13 @@ public class BrokerLoadDataReporter implements LoadDataReporter<BrokerLoadData>,
                     localData.setReportedAt(System.currentTimeMillis());
                     lastData.update(localData);
                 } else {
-                    log.error("Failed to report the broker load data.", ex);
+                    log.error().exception(ex).log("Failed to report the broker load data");
                 }
             });
             return future;
         } else {
             if (debug) {
-                log.info("skipping load report:{}", localData.toString(conf));
+                log.info().attr("report", localData.toString(conf)).log("skipping load report");
             }
         }
         return CompletableFuture.completedFuture(null);
@@ -138,8 +138,8 @@ public class BrokerLoadDataReporter implements LoadDataReporter<BrokerLoadData>,
         boolean debug = ExtensibleLoadManagerImpl.debug(conf, log);
         if (timeSinceLastReportWrittenToStore > updateMaxIntervalMillis) {
             if (debug) {
-                log.info("Writing local data to metadata store because time since last"
-                                + " update exceeded threshold of {} minutes",
+                log.infof("Writing local data to metadata store because time since last"
+                                + " update exceeded threshold of %s minutes",
                         loadBalancerReportUpdateMaxIntervalMinutes);
             }
             // Always update after surpassing the maximum interval.
@@ -188,7 +188,7 @@ public class BrokerLoadDataReporter implements LoadDataReporter<BrokerLoadData>,
         brokerLoadDataStore.removeAsync(brokerId)
                 .whenComplete((__, e) -> {
                             if (e != null) {
-                                log.error("Failed to clean broker load data.", e);
+                                log.error().exception(e).log("Failed to clean broker load data");
                                 lastTombstonedAt = lastSuccessfulTombstonedAt;
                             } else {
                                 boolean debug = ExtensibleLoadManagerImpl.debug(conf, log);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/TopBundleLoadDataReporter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/reporter/TopBundleLoadDataReporter.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.broker.loadbalance.extensions.reporter;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitState;
@@ -34,7 +34,7 @@ import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStore;
 /**
  * The top k highest-loaded bundles' load data reporter.
  */
-@Slf4j
+@CustomLog
 public class TopBundleLoadDataReporter implements LoadDataReporter<TopBundlesLoadData>, StateChangeListener {
 
     private static final long TOMBSTONE_DELAY_IN_MILLIS = 1000 * 10;
@@ -86,11 +86,11 @@ public class TopBundleLoadDataReporter implements LoadDataReporter<TopBundlesLoa
         var topBundlesLoadData = generateLoadData();
         if (topBundlesLoadData != null || force) {
             if (ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log)) {
-                log.info("Reporting TopBundlesLoadData:{}", topKBundles.getLoadData());
+                log.info().attr("bundle", topKBundles.getLoadData()).log("Reporting TopBundlesLoadData");
             }
             return this.bundleLoadDataStore.pushAsync(brokerId, topKBundles.getLoadData())
                     .exceptionally(e -> {
-                        log.error("Failed to report top-bundles load data.", e);
+                        log.error().exception(e).log("Failed to report top-bundles load data");
                         return null;
                     });
         } else {
@@ -109,7 +109,7 @@ public class TopBundleLoadDataReporter implements LoadDataReporter<TopBundlesLoa
         bundleLoadDataStore.removeAsync(brokerId)
                 .whenComplete((__, e) -> {
                             if (e != null) {
-                                log.error("Failed to clean broker load data.", e);
+                                log.error().exception(e).log("Failed to clean broker load data");
                                 lastTombstonedAt = lastSuccessfulTombstonedAt;
                             } else {
                                 boolean debug = ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/SplitScheduler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/SplitScheduler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
@@ -45,7 +45,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 /**
  * Service Unit(e.g. bundles) Split scheduler.
  */
-@Slf4j
+@CustomLog
 public class SplitScheduler implements LoadManagerScheduler {
 
     private final PulsarService pulsar;
@@ -102,8 +102,9 @@ public class SplitScheduler implements LoadManagerScheduler {
     public void execute() {
         boolean debugMode = ExtensibleLoadManagerImpl.debug(conf, log);
         if (debugMode) {
-            log.info("Load balancer enabled: {}, Split enabled: {}.",
-                    conf.isLoadBalancerEnabled(), conf.isLoadBalancerAutoBundleSplitEnabled());
+            log.info().attr("loadBalancerEnabled", conf.isLoadBalancerEnabled())
+                    .attr("splitEnabled", conf.isLoadBalancerAutoBundleSplitEnabled())
+                    .log("Load balancer and split enablement");
         }
 
         if (!isLoadBalancerAutoBundleSplitEnabled()) {
@@ -116,7 +117,7 @@ public class SplitScheduler implements LoadManagerScheduler {
         synchronized (bundleSplitStrategy) {
             final Set<SplitDecision> decisions = bundleSplitStrategy.findBundlesToSplit(context, pulsar);
             if (debugMode) {
-                log.info("Split Decisions: {}", decisions);
+                log.info().attr("decisions", decisions).log("Split Decisions");
             }
             if (!decisions.isEmpty()) {
                 // currently following the unloading timeout
@@ -138,7 +139,7 @@ public class SplitScheduler implements LoadManagerScheduler {
                     FutureUtil.waitForAll(futures)
                             .get(asyncOpTimeoutMs, TimeUnit.MILLISECONDS);
                 } catch (Throwable e) {
-                    log.error("Failed to wait for split events to persist.", e);
+                    log.error().exception(e).log("Failed to wait for split events to persist");
                 }
             } else {
                 if (debugMode) {
@@ -169,7 +170,7 @@ public class SplitScheduler implements LoadManagerScheduler {
                     log.info(joiner.toString());
                 }
             } catch (Throwable e) {
-                log.error("Failed to run the split job.", e);
+                log.error().exception(e).log("Failed to run the split job");
             }
         }, interval, interval, TimeUnit.MILLISECONDS);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedder.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -63,8 +64,6 @@ import org.apache.pulsar.broker.loadbalance.extensions.policies.IsolationPolicie
 import org.apache.pulsar.broker.loadbalance.extensions.store.LoadDataStore;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.common.naming.NamespaceBundle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Load shedding strategy that unloads bundles from the highest loaded brokers.
@@ -89,8 +88,8 @@ import org.slf4j.LoggerFactory;
  * 9. Print more logs with a debug option(loadBalancerDebugModeEnabled=true).
  */
 @NoArgsConstructor
+@CustomLog
 public class TransferShedder implements NamespaceUnloadStrategy {
-    private static final Logger log = LoggerFactory.getLogger(TransferShedder.class);
     private static final double KB = 1024;
     private static final String CANNOT_CONTINUE_UNLOAD_MSG = "Can't continue the unload cycle.";
     private static final String CANNOT_UNLOAD_BROKER_MSG = "Can't unload broker:%s.";
@@ -220,8 +219,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                 // We don't want to use the outdated load data.
                 if (now - localBrokerData.getUpdatedAt()
                         > conf.getLoadBalancerBrokerLoadDataTTLInSeconds() * 1000) {
-                    log.warn(
-                            "Ignoring broker:{} load update because the load data timestamp:{} is too old.",
+                    log.warnf(
+                            "Ignoring broker:%s load update because the load data timestamp:%s is too old.",
                             broker, localBrokerData.getUpdatedAt());
                     decisionReason = OutDatedData;
                     continue;
@@ -232,9 +231,9 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     var elapsed = localBrokerData.getUpdatedAt() - recentlyUnloadedBrokers.get(broker);
                     if (elapsed < conf.getLoadBalanceSheddingDelayInSeconds() * 1000) {
                         if (debug) {
-                            log.warn(
-                                    "Broker:{} load data is too early since "
-                                            + "the last transfer. elapsed {} secs < threshold {} secs",
+                            log.warnf(
+                                    "Broker:%s load data is too early since "
+                                            + "the last transfer. elapsed %s secs < threshold %s secs",
                                     broker,
                                     TimeUnit.MILLISECONDS.toSeconds(elapsed),
                                     conf.getLoadBalanceSheddingDelayInSeconds());
@@ -268,7 +267,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                 decisionReason = NoLoadData;
                 update(0.0, 0.0, 0);
                 if (debug) {
-                    log.info("There is missing load data from brokers:{}", missingLoadDataBrokers);
+                    log.info().attr("broker", missingLoadDataBrokers).log("There is missing load data from brokers");
                 }
                 return Optional.of(decisionReason);
             }
@@ -327,7 +326,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     .get(context.brokerConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
             counter.update(Failure, Unknown);
-            log.warn("Failed to fetch available brokers. Stop unloading.", e);
+            log.warn().exception(e).log("Failed to fetch available brokers. Stop unloading");
             return decisionCache;
         }
 
@@ -340,8 +339,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     context.brokerLoadDataStore(), availableBrokers, recentlyUnloadedBrokers, conf);
             if (skipReason.isPresent()) {
                 if (debugMode) {
-                    log.warn(CANNOT_CONTINUE_UNLOAD_MSG
-                                    + " Skipped the load stat update. Reason:{}.",
+                    log.warnf(CANNOT_CONTINUE_UNLOAD_MSG
+                                    + " Skipped the load stat update. Reason:%s.",
                             skipReason.get());
                 }
                 counter.update(Skip, skipReason.get());
@@ -352,7 +351,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
 
 
             if (debugMode) {
-                log.info("brokers' load stats:{}", stats);
+                log.info().attr("stats", stats).log("brokers' load stats");
             }
 
             // skip metrics
@@ -371,8 +370,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
 
             if (unloadConditionHitCount <= conf.getLoadBalancerSheddingConditionHitCountThreshold()) {
                 if (debugMode) {
-                    log.info(CANNOT_CONTINUE_UNLOAD_MSG
-                                    + " Shedding condition hit count:{} is less than or equal to the threshold:{}.",
+                    log.infof(CANNOT_CONTINUE_UNLOAD_MSG
+                                    + " Shedding condition hit count:%s is less than or equal to the threshold:%s.",
                             unloadConditionHitCount, conf.getLoadBalancerSheddingConditionHitCountThreshold());
                 }
                 counter.update(Skip, HitCount);
@@ -412,9 +411,9 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     }
                 } else {
                     if (debugMode) {
-                        log.info(CANNOT_CONTINUE_UNLOAD_MSG
-                                        + "The overall cluster load meets the target, std:{} <= targetStd:{}."
-                                        + "minBroker:{} is not underloaded. maxBroker:{} is not overloaded.",
+                        log.infof(CANNOT_CONTINUE_UNLOAD_MSG
+                                        + "The overall cluster load meets the target, std:%s <= targetStd:%s."
+                                        + "minBroker:%s is not underloaded. maxBroker:%s is not overloaded.",
                                 stats.std(), targetStd, stats.peekMinBroker(), stats.peekMaxBroker());
                     }
                     break;
@@ -431,7 +430,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                     continue;
                 }
                 if (minBrokerLoadData.isEmpty()) {
-                    log.error("Can't transfer load to broker:{}. MinBrokerLoadData is empty.", minBroker);
+                    log.error().attr("broker", minBroker)
+                            .log("Can't transfer load. MinBrokerLoadData is empty");
                     numOfBrokersWithEmptyLoadData++;
                     continue;
                 }
@@ -606,8 +606,9 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                         if (swap) {
                             minToMaxUnloads.forEach(minToMaxUnload -> {
                                 if (debugMode) {
-                                    log.info("Decided to gain bundle:{} from min broker:{}",
-                                            minToMaxUnload.serviceUnit(), minToMaxUnload.sourceBroker());
+                                    log.info().attr("bundle", minToMaxUnload.serviceUnit())
+                                            .attr("broker", minToMaxUnload.sourceBroker())
+                                            .log("Decided to gain bundle from min broker");
                                 }
                                 var decision = new UnloadDecision();
                                 decision.setUnload(minToMaxUnload);
@@ -665,7 +666,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
             } // while end
 
             if (debugMode) {
-                log.info("decisionCache:{}", decisionCache);
+                log.info().attr("decisionCache", decisionCache).log("decisionCache");
             }
 
             if (decisionCache.isEmpty()) {
@@ -683,7 +684,7 @@ public class TransferShedder implements NamespaceUnloadStrategy {
             }
 
         } catch (Throwable e) {
-            log.error("Failed to process unloading. ", e);
+            log.error().exception(e).log("Failed to process unloading. ");
             this.counter.update(Failure, Unknown);
         }
         return decisionCache;
@@ -752,7 +753,8 @@ public class TransferShedder implements NamespaceUnloadStrategy {
                         .get(context.brokerConfiguration().getMetadataStoreOperationTimeoutSeconds(),
                                 TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.error("Failed to filter brokers with filter: {}", filter.getClass().getName(), e);
+                log.error().attr("filter", filter.getClass().getName()).exception(e)
+                        .log("Failed to filter brokers with filter");
                 return false;
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/UnloadScheduler.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
@@ -44,7 +44,7 @@ import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Reflections;
 
-@Slf4j
+@CustomLog
 public class UnloadScheduler implements LoadManagerScheduler {
 
     private final NamespaceUnloadStrategy namespaceUnloadStrategy;
@@ -111,10 +111,11 @@ public class UnloadScheduler implements LoadManagerScheduler {
 
     @Override
     public synchronized void execute() {
-        boolean debugMode = conf.isLoadBalancerDebugModeEnabled() || log.isDebugEnabled();
+        boolean debugMode = conf.isLoadBalancerDebugModeEnabled();
         if (debugMode) {
-            log.info("Load balancer enabled: {}, Shedding enabled: {}.",
-                    conf.isLoadBalancerEnabled(), conf.isLoadBalancerSheddingEnabled());
+            log.info().attr("loadBalancerEnabled", conf.isLoadBalancerEnabled())
+                    .attr("sheddingEnabled", conf.isLoadBalancerSheddingEnabled())
+                    .log("Load balancer status");
         }
         if (!isLoadBalancerSheddingEnabled()) {
             if (debugMode) {
@@ -140,7 +141,7 @@ public class UnloadScheduler implements LoadManagerScheduler {
                 List<String> availableBrokers = context.brokerRegistry().getAvailableBrokersAsync()
                         .get(asyncOpTimeoutMs, TimeUnit.MILLISECONDS);
                 if (debugMode) {
-                    log.info("Available brokers: {}", availableBrokers);
+                    log.info().attr("broker", availableBrokers).log("Available brokers");
                 }
                 if (availableBrokers.size() <= 1) {
                     log.info("Only 1 broker available: no load shedding will be performed. Skipping.");
@@ -149,13 +150,13 @@ public class UnloadScheduler implements LoadManagerScheduler {
                 final Set<UnloadDecision> decisions = namespaceUnloadStrategy
                         .findBundlesForUnloading(context, recentlyUnloadedBundles, recentlyUnloadedBrokers);
                 if (debugMode) {
-                    log.info("[{}] Unload decision result: {}",
-                            namespaceUnloadStrategy.getClass().getSimpleName(), decisions);
+                    log.info().attr("strategy", namespaceUnloadStrategy.getClass().getSimpleName())
+                            .attr("result", decisions).log("Unload decision result");
                 }
                 if (decisions.isEmpty()) {
                     if (debugMode) {
-                        log.info("[{}] Unload decision unloads is empty. Skipping.",
-                                namespaceUnloadStrategy.getClass().getSimpleName());
+                        log.info().attr("strategy", namespaceUnloadStrategy.getClass().getSimpleName())
+                                .log("Unload decision unloads is empty. Skipping");
                     }
                     return;
                 }
@@ -164,8 +165,8 @@ public class UnloadScheduler implements LoadManagerScheduler {
                 decisions.forEach(decision -> {
                     if (decision.getLabel() == Success) {
                         Unload unload = decision.getUnload();
-                        log.info("[{}] Unloading bundle: {}",
-                                namespaceUnloadStrategy.getClass().getSimpleName(), unload);
+                        log.info().attr("strategy", namespaceUnloadStrategy.getClass().getSimpleName())
+                                .attr("bundle", unload).log("Unloading bundle");
                         futures.add(unloadManager.waitAsync(channel.publishUnloadEventAsync(unload),
                                         unload.serviceUnit(), decision, asyncOpTimeoutMs, TimeUnit.MILLISECONDS)
                                 .thenAccept(__ -> {
@@ -179,8 +180,8 @@ public class UnloadScheduler implements LoadManagerScheduler {
                         .whenComplete((__, ex) -> counter.updateUnloadBrokerCount(unloadBrokers.size()))
                         .get(asyncOpTimeoutMs, TimeUnit.MILLISECONDS);
             } catch (Exception ex) {
-                log.error("[{}] Namespace unload has exception.",
-                        namespaceUnloadStrategy.getClass().getSimpleName(), ex);
+                log.error().attr("strategy", namespaceUnloadStrategy.getClass().getSimpleName())
+                        .exception(ex).log("Namespace unload has exception");
             } finally {
                 if (counter.updatedAt() > counterLastUpdatedAt) {
                     unloadMetrics.set(counter.toMetrics(pulsar.getAdvertisedAddress()));
@@ -217,10 +218,12 @@ public class UnloadScheduler implements LoadManagerScheduler {
             unloadStrategy = Reflections.createInstance(conf.getLoadBalancerLoadSheddingStrategy(),
                     NamespaceUnloadStrategy.class,
                     Thread.currentThread().getContextClassLoader());
-            log.info("Created namespace unload strategy:{}", unloadStrategy.getClass().getCanonicalName());
+            log.info().attr("strategy", unloadStrategy.getClass().getCanonicalName())
+                    .log("Created namespace unload strategy");
         } catch (Exception e) {
-            log.error("Error when trying to create namespace unload strategy: {}. Using {} instead.",
-                    conf.getLoadBalancerLoadSheddingStrategy(), TransferShedder.class.getCanonicalName(), e);
+            log.error().attr("strategy", conf.getLoadBalancerLoadSheddingStrategy())
+                    .attr("fallback", TransferShedder.class.getCanonicalName()).exception(e)
+                    .log("Error when trying to create namespace unload strategy");
             unloadStrategy = new TransferShedder();
         }
         unloadStrategy.initialize(pulsar);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -39,7 +39,7 @@ import org.apache.pulsar.client.api.TableView;
  *
  * @param <T> Load data type.
  */
-@Slf4j
+@CustomLog
 public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
 
     private static final long LOAD_DATA_REPORT_UPDATE_MAX_INTERVAL_MULTIPLIER_BEFORE_RESTART = 2;
@@ -220,10 +220,10 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
             try {
                 closeProducer();
                 startProducer();
-                log.info("Restarted producer on {}, {}", topic, restartReason);
+                log.info().attr("topic", topic).attr("restartReason", restartReason).log("Restarted producer on ,");
             } catch (Exception e) {
                 String msg = "Failed to restart producer on " + topic + ", restart reason: " + restartReason;
-                log.error(msg, e);
+                log.error().exception(e).log(msg);
                 return msg;
             }
         }
@@ -239,10 +239,10 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
             try {
                 closeTableView();
                 startTableView();
-                log.info("Restarted tableview on {}, {}", topic, restartReason);
+                log.info().attr("topic", topic).attr("restartReason", restartReason).log("Restarted tableview on ,");
             } catch (Exception e) {
                 String msg = "Failed to tableview on " + topic + ", restart reason: " + restartReason;
-                log.error(msg, e);
+                log.error().exception(e).log(msg);
                 return msg;
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/DefaultNamespaceBundleSplitStrategyImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/DefaultNamespaceBundleSplitStrategyImpl.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
@@ -51,7 +51,7 @@ import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
  *
  * Migrate from {@link org.apache.pulsar.broker.loadbalance.impl.BundleSplitterTask}
  */
-@Slf4j
+@CustomLog
 public class DefaultNamespaceBundleSplitStrategyImpl implements NamespaceBundleSplitStrategy {
     private static final String CANNOT_CONTINUE_SPLIT_MSG = "Can't continue the split cycle.";
     private static final String CANNOT_SPLIT_BUNDLE_MSG = "Can't split broker:%s.";
@@ -83,7 +83,7 @@ public class DefaultNamespaceBundleSplitStrategyImpl implements NamespaceBundleS
         long maxBundleBandwidth = conf.getLoadBalancerNamespaceBundleMaxBandwidthMbytes() * LoadManagerShared.MIBI;
         long maxSplitCount = conf.getLoadBalancerMaxNumberOfBundlesToSplitPerCycle();
         long splitConditionHitCountThreshold = conf.getLoadBalancerNamespaceBundleSplitConditionHitCountThreshold();
-        boolean debug = log.isDebugEnabled() || conf.isLoadBalancerDebugModeEnabled();
+        boolean debug = conf.isLoadBalancerDebugModeEnabled();
         var channel = ServiceUnitStateChannelImpl.get(pulsar);
 
         for (var etr : channel.getOwnershipEntrySet()) {
@@ -190,7 +190,7 @@ public class DefaultNamespaceBundleSplitStrategyImpl implements NamespaceBundleS
                 }
             } catch (Exception e) {
                 counter.update(Failure, Unknown);
-                log.warn("Failed to get bundle count in namespace:{}", namespace, e);
+                log.warn().attr("namespace", namespace).exception(e).log("Failed to get bundle count in namespace");
                 continue;
             }
 
@@ -244,7 +244,7 @@ public class DefaultNamespaceBundleSplitStrategyImpl implements NamespaceBundleS
                         .get(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             } catch (Throwable e) {
                 counter.update(Failure, Unknown);
-                log.warn(String.format(CANNOT_SPLIT_BUNDLE_MSG + " Failed to get split boundaries.", bundle), e);
+                log.warn().exception(e).logf(CANNOT_SPLIT_BUNDLE_MSG + " Failed to get split boundaries.", bundle);
                 continue;
             }
             if (splitBoundary == null) {
@@ -277,8 +277,8 @@ public class DefaultNamespaceBundleSplitStrategyImpl implements NamespaceBundleS
             namespaceBundleFactory.invalidateBundleCache(NamespaceName.get(namespaceName));
             if (decisionCache.size() == maxSplitCount) {
                 if (debug) {
-                    log.info(CANNOT_CONTINUE_SPLIT_MSG
-                                    + "Too many bundles split in this cycle {} / {}.",
+                    log.infof(CANNOT_CONTINUE_SPLIT_MSG
+                                    + "Too many bundles split in this cycle %s / %s.",
                             decisionCache.size(), maxSplitCount);
                 }
                 break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.concurrent.ThreadSafe;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.LoadManagerContext;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLoadData;
@@ -35,8 +35,8 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
  * This strategy takes into account the historical load percentage and short-term load percentage, and thus will not
  * cause cluster fluctuations due to short-term load jitter.
  */
-@Slf4j
 @ThreadSafe
+@CustomLog
 public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
     // Maintain this list to reduce object creation.
     private final ThreadLocal<ArrayList<String>> bestBrokers;
@@ -55,14 +55,14 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
 
 
         if (maxUsageWithWeight > overloadThreshold) {
-            log.warn(
-                    "Broker {} is overloaded, brokerLoad({}%) > overloadThreshold({}%). load data:{{}}",
+            log.warnf(
+                    "Broker %s is overloaded, brokerLoad(%s%) > overloadThreshold(%s%). load data:{%s}",
                     broker,
                     maxUsageWithWeight * 100,
                     overloadThreshold * 100,
                     brokerLoadData.toString(conf));
         } else if (debugMode) {
-            log.info("Broker {} load data:{{}}", broker, brokerLoadData.toString(conf));
+            log.info().attr("broker", broker).attr("loadData", brokerLoadData.toString(conf)).log("Broker load data");
         }
 
 
@@ -83,7 +83,8 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
             Set<String> candidates, ServiceUnitId bundleToAssign, LoadManagerContext context) {
         var conf = context.brokerConfiguration();
         if (candidates.isEmpty()) {
-            log.warn("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
+            log.warn().attr("bundle", bundleToAssign)
+                    .log("There are no available brokers as candidates at this point for bundle");
             return Optional.empty();
         }
 
@@ -96,11 +97,12 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         // select one of them at the end.
         double totalUsage = 0.0d;
 
-        boolean debugMode = log.isDebugEnabled() || conf.isLoadBalancerDebugModeEnabled();
+        boolean debugMode = conf.isLoadBalancerDebugModeEnabled();
         for (String broker : candidates) {
             var brokerLoadDataOptional = context.brokerLoadDataStore().get(broker);
             if (brokerLoadDataOptional.isEmpty()) {
-                log.warn("There is no broker load data for broker:{}. Skipping this broker. Phase one", broker);
+                log.warn().attr("broker", broker)
+                        .log("There is no broker load data for broker. Skipping this broker. Phase one");
                 noLoadDataBrokers.add(broker);
                 continue;
             }
@@ -117,12 +119,14 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
             final double diffThreshold =
                     conf.getLoadBalancerAverageResourceUsageDifferenceThresholdPercentage() / 100.0;
             if (debugMode) {
-                log.info("Computed avgUsage:{}, diffThreshold:{}", avgUsage, diffThreshold);
+                log.info().attr("avgUsage", avgUsage).attr("diffThreshold", diffThreshold)
+                        .log("Computed avgUsage and diffThreshold");
             }
             for (String broker : candidates) {
                 var brokerLoadDataOptional = context.brokerLoadDataStore().get(broker);
                 if (brokerLoadDataOptional.isEmpty()) {
-                    log.warn("There is no broker load data for broker:{}. Skipping this broker. Phase two", broker);
+                    log.warn().attr("broker", broker)
+                            .log("There is no broker load data for broker. Skipping this broker. Phase two");
                     continue;
                 }
                 double avgResUsage = brokerLoadDataOptional.get().getWeightedMaxEMA();
@@ -135,17 +139,20 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
         if (bestBrokers.isEmpty()) {
             // Assign randomly as all brokers are overloaded.
             if (debugMode) {
-                log.info("Assign randomly as none of the brokers are underloaded. candidatesSize:{}, "
-                        + "noLoadDataBrokersSize:{}", candidates.size(), noLoadDataBrokers.size());
+                log.info().attr("candidatesSize", candidates.size())
+                        .attr("noLoadDataBrokersSize", noLoadDataBrokers.size())
+                        .log("Assign randomly as none of the brokers are underloaded");
             }
             bestBrokers.addAll(candidates);
         }
 
         if (debugMode) {
-            log.info("Selected {} best brokers: {} from candidate brokers: {}, noLoadDataBrokers:{}",
-                    bestBrokers.size(), bestBrokers,
-                    candidates,
-                    noLoadDataBrokers);
+            log.info()
+                    .attr("bestBrokersSize", bestBrokers.size())
+                    .attr("bestBrokers", bestBrokers)
+                    .attr("candidates", candidates)
+                    .attr("noLoadDataBrokers", noLoadDataBrokers)
+                    .log("Selected best brokers from candidates");
         }
         return Optional.of(bestBrokers.get(ThreadLocalRandom.current().nextInt(bestBrokers.size())));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/strategy/LeastResourceUsageWithWeight.java
@@ -56,7 +56,7 @@ public class LeastResourceUsageWithWeight implements BrokerSelectionStrategy {
 
         if (maxUsageWithWeight > overloadThreshold) {
             log.warnf(
-                    "Broker %s is overloaded, brokerLoad(%s%) > overloadThreshold(%s%). load data:{%s}",
+                    "Broker %s is overloaded, brokerLoad(%s%%) > overloadThreshold(%s%%). load data:{%s}",
                     broker,
                     maxUsageWithWeight * 100,
                     overloadThreshold * 100,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/AvgShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/AvgShedder.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.Pair;
@@ -46,7 +46,7 @@ import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
 
-@Slf4j
+@CustomLog
 public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrategy {
     // map bundle to broker.
     private final Map<BundleData, String> bundleBrokerMap = new HashMap<>();
@@ -70,23 +70,22 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
         final double highThreshold = conf.getLoadBalancerAvgShedderHighThreshold();
         final int hitCountHighThreshold = conf.getLoadBalancerAvgShedderHitCountHighThreshold();
         final int hitCountLowThreshold = conf.getLoadBalancerAvgShedderHitCountLowThreshold();
-        if (log.isDebugEnabled()) {
-            log.debug("highThreshold:{}, lowThreshold:{}, hitCountHighThreshold:{}, hitCountLowThreshold:{}, "
-                            + "minMsgThreshold:{}, minThroughputThreshold:{}",
-                    highThreshold, lowThreshold, hitCountHighThreshold, hitCountLowThreshold,
-                    minMsgThreshold, minThroughputThreshold);
-        }
+        log.debug().attr("highThreshold", highThreshold).attr("lowThreshold", lowThreshold)
+                .attr("hitCountHighThreshold", hitCountHighThreshold)
+                .attr("hitCountLowThreshold", hitCountLowThreshold).attr("minMsgThreshold", minMsgThreshold)
+                .attr("minThroughputThreshold", minThroughputThreshold)
+                .log("Shedding configuration");
 
         List<String> brokers = calculateScoresAndSort(loadData, conf);
-        log.info("sorted broker list:{}", brokers);
+        log.info().attr("brokers", brokers).log("sorted broker list");
 
         // find broker pairs for shedding.
         List<Pair<String, String>> pairs = findBrokerPairs(brokers, lowThreshold, highThreshold);
-        log.info("brokerHitCountForHigh:{}, brokerHitCountForLow:{}", brokerHitCountForHigh, brokerHitCountForLow);
+        log.info().attr("brokerHitCountForHigh", brokerHitCountForHigh)
+                .attr("brokerHitCountForLow", brokerHitCountForLow)
+                .log("Broker hit counts");
         if (pairs.isEmpty()) {
-            if (log.isDebugEnabled()) {
-                log.debug("there is no any overload broker, no need to shedding bundles.");
-            }
+            log.debug("there is no any overload broker, no need to shedding bundles.");
             brokerHitCountForHigh.clear();
             brokerHitCountForLow.clear();
             return selectedBundlesCache;
@@ -148,29 +147,30 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
             isMsgRateToOffload = false;
             trafficMarkedToOffload.setValue(throughputRequiredFromUnloadedBundles);
         } else {
-            log.info(
-                    "broker:[{}] is planning to shed bundles to broker:[{}],but the throughput {} MByte/s is "
-                            + "less than minimumThroughputThreshold {} MByte/s, and the msgRate {} rate/s"
-                            + " is also less than minimumMsgRateThreshold {} rate/s, skipping bundle unload.",
+            log.infof(
+                    "broker:[%s] is planning to shed bundles to broker:[%s],but the throughput %s MByte/s is "
+                            + "less than minimumThroughputThreshold %s MByte/s, and the msgRate %s rate/s"
+                            + " is also less than minimumMsgRateThreshold %s rate/s, skipping bundle unload.",
                     overloadedBroker, underloadedBroker, throughputRequiredFromUnloadedBundles / MB,
                     minThroughputThreshold / MB, msgRequiredFromUnloadedBundles, minMsgThreshold);
             return;
         }
 
         if (maxLocalBrokerData.getBundles().size() == 1) {
-            log.warn("HIGH USAGE WARNING : Sole namespace bundle {} is overloading broker {}. "
-                            + "No Load Shedding will be done on this broker",
-                    maxLocalBrokerData.getBundles().iterator().next(), overloadedBroker);
+            log.warn().attr("bundle", maxLocalBrokerData.getBundles().iterator().next())
+                    .attr("broker", overloadedBroker)
+                    .log("HIGH USAGE WARNING: Sole namespace bundle is overloading broker. "
+                            + "No Load Shedding will be done on this broker");
         } else if (maxLocalBrokerData.getBundles().isEmpty()) {
-            log.warn("Broker {} is overloaded despite having no bundles", overloadedBroker);
+            log.warn().attr("broker", overloadedBroker).log("Broker is overloaded despite having no bundles");
         }
 
         // do shedding
-        log.info(
-                "broker:[{}] is planning to shed bundles to broker:[{}]. "
-                        + "maxBroker stat:scores:{}, throughput:{}, msgRate:{}. "
-                        + "minBroker stat:scores:{}, throughput:{}, msgRate:{}. "
-                        + "isMsgRateToOffload:{},  trafficMarkedToOffload:{}",
+        log.infof(
+                "broker:[%s] is planning to shed bundles to broker:[%s]. "
+                        + "maxBroker stat:scores:%s, throughput:%s, msgRate:%s. "
+                        + "minBroker stat:scores:%s, throughput:%s, msgRate:%s. "
+                        + "isMsgRateToOffload:%s,  trafficMarkedToOffload:%s",
                 overloadedBroker, underloadedBroker, brokerScoreMap.get(overloadedBroker), maxThroughput,
                 maxMsgRate, brokerScoreMap.get(underloadedBroker), minThroughput, minMsgRate,
                 isMsgRateToOffload, trafficMarkedToOffload);
@@ -195,10 +195,9 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
                 selectedBundlesCache.put(overloadedBroker, bundle.getKey());
                 bundleBrokerMap.put(bundle.getValue(), underloadedBroker);
                 trafficMarkedToOffload.add(-traffic);
-                if (log.isDebugEnabled()) {
-                    log.debug("Found bundle to unload:{}, isMsgRateToOffload:{}, traffic:{}",
-                            bundle, isMsgRateToOffload, traffic);
-                }
+                log.debug().attr("bundle", bundle).attr("isMsgRateToOffload", isMsgRateToOffload)
+                        .attr("traffic", traffic)
+                        .log("Found bundle to unload");
             }
         });
     }
@@ -217,11 +216,10 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
             String broker = entry.getKey();
             Double score = calculateScores(localBrokerData, conf);
             brokerScoreMap.put(broker, score);
-            if (log.isDebugEnabled()) {
-                log.info("broker:{}, scores:{}, throughput:{}, messageRate:{}", broker, score,
-                        localBrokerData.getMsgThroughputIn() + localBrokerData.getMsgThroughputOut(),
-                        localBrokerData.getMsgRateIn() + localBrokerData.getMsgRateOut());
-            }
+            log.info().attr("broker", broker).attr("score", score)
+                    .attr("throughput", localBrokerData.getMsgThroughputIn() + localBrokerData.getMsgThroughputOut())
+                    .attr("messageRate", localBrokerData.getMsgRateIn() + localBrokerData.getMsgRateOut())
+                    .log("Broker score");
         }
 
         // sort brokers by scores.
@@ -278,13 +276,11 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
         final var brokerToUnload = bundleBrokerMap.getOrDefault(bundleToAssign, null);
         if (brokerToUnload == null || !candidates.contains(bundleBrokerMap.get(bundleToAssign))) {
             // cluster initializing or broker is shutdown
-            if (log.isDebugEnabled()) {
-                if (!bundleBrokerMap.containsKey(bundleToAssign)) {
-                    log.debug("cluster is initializing");
-                } else {
-                    log.debug("expected broker:{} is shutdown, candidates:{}", bundleBrokerMap.get(bundleToAssign),
-                            candidates);
-                }
+            if (!bundleBrokerMap.containsKey(bundleToAssign)) {
+                log.debug("cluster is initializing");
+            } else {
+                log.debug().attr("broker", bundleBrokerMap.get(bundleToAssign)).attr("candidates", candidates)
+                        .log("expected broker is shutdown");
             }
             String broker = getExpectedBroker(candidates, bundleToAssign);
             bundleBrokerMap.put(bundleToAssign, broker);
@@ -305,14 +301,13 @@ public class AvgShedder implements LoadSheddingStrategy, ModularLoadManagerStrat
             final long hashcode = Hashing.crc32().hashString(String.valueOf(new Random().nextInt()),
                     StandardCharsets.UTF_8).padToLong();
             final int index = (int) (Math.abs(hashcode) % sortedBrokers.size());
-            if (log.isDebugEnabled()) {
-                log.debug("Assignment details: brokers={}, bundle={}, hashcode={}, index={}",
-                        sortedBrokers, bundle, hashcode, index);
-            }
+            log.debug().attr("brokers", sortedBrokers).attr("bundle", bundle).attr("hashCode", hashcode)
+                    .attr("index", index)
+                    .log("Assignment details");
             return sortedBrokers.get(index);
         } catch (Throwable e) {
             // theoretically this logic branch should not be executed
-            log.error("Bundle format of {} is invalid", bundle, e);
+            log.error().attr("bundle", bundle).exception(e).log("Bundle format is invalid");
             return sortedBrokers.get(Math.abs(bundle.hashCode()) % sortedBrokers.size());
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BrokerVersionFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BrokerVersionFilter.java
@@ -21,19 +21,16 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.github.zafarkhaja.semver.Version;
 import java.util.Iterator;
 import java.util.Set;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerFilter;
 import org.apache.pulsar.broker.loadbalance.BrokerFilterBadVersionException;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class BrokerVersionFilter implements BrokerFilter {
-
-    private static final Logger LOG = LoggerFactory.getLogger(BrokerVersionFilter.class);
-
     /**
      * Get the most recent broker version number from the load reports of all the running brokers. The version
      * number is from the build artifact in the pom and got added to the package when it was built by Maven
@@ -64,15 +61,16 @@ public class BrokerVersionFilter implements BrokerFilter {
         for (String broker : brokers) {
             BrokerData data = loadData.getBrokerData().get(broker);
             if (null == data) {
-                LOG.warn("No broker data for broker [{}]; disabling PreferLaterVersions feature", broker);
+                log.warn().attr("broker", broker)
+                        .log("No broker data for broker; disabling PreferLaterVersions feature");
                 // trigger the ModularLoadManager to reset all the brokers to the original set
                 throw new BrokerFilterBadVersionException("No broker data for broker \"" + broker + "\"");
             }
 
             String brokerVersion = data.getLocalData().getBrokerVersionString();
             if (null == brokerVersion || brokerVersion.length() == 0) {
-                LOG.warn("No version string in load report for broker [{}]; disabling PreferLaterVersions feature",
-                        broker);
+                log.warn().attr("broker", broker)
+                        .log("No version string in load report for broker; disabling PreferLaterVersions feature");
                 // trigger the ModularLoadManager to reset all the brokers to the original set
                 throw new BrokerFilterBadVersionException("No version string in load report for broker \""
                         + broker + "\"");
@@ -82,9 +80,9 @@ public class BrokerVersionFilter implements BrokerFilter {
             try {
                 brokerVersionVersion = Version.valueOf(brokerVersion);
             } catch (Exception x) {
-                LOG.warn("Invalid version string in load report for broker [{}]: [{}];"
-                                + " disabling PreferLaterVersions feature",
-                        broker, brokerVersion);
+                log.warn().attr("broker", broker).attr("version", brokerVersion)
+                        .log("Invalid version string in load report for broker;"
+                                + " disabling PreferLaterVersions feature");
                 // trigger the ModularLoadManager to reset all the brokers to the original set
                 throw new BrokerFilterBadVersionException("Invalid version string in load report for broker \""
                         + broker + "\": \"" + brokerVersion + "\")");
@@ -126,9 +124,9 @@ public class BrokerVersionFilter implements BrokerFilter {
         com.github.zafarkhaja.semver.Version latestVersion = null;
         try {
             latestVersion = getLatestVersionNumber(brokers, loadData);
-            LOG.info("Latest broker version found was [{}]", latestVersion);
+            log.info().attr("version", latestVersion).log("Latest broker version found");
         } catch (Exception x) {
-            LOG.warn("Disabling PreferLaterVersions feature; reason: " + x.getMessage());
+            log.warn().exceptionMessage(x).log("Disabling PreferLaterVersions feature");
             throw new BrokerFilterBadVersionException("Cannot determine newest broker version: " + x.getMessage());
         }
 
@@ -142,17 +140,20 @@ public class BrokerVersionFilter implements BrokerFilter {
             com.github.zafarkhaja.semver.Version brokerVersionVersion = Version.valueOf(brokerVersion);
 
             if (brokerVersionVersion.equals(latestVersion)) {
-                LOG.debug("Broker [{}] is running the latest version ([{}])", broker, brokerVersion);
+                log.debug().attr("broker", broker).attr("version", brokerVersion)
+                        .log("Broker is running the latest version");
                 ++numBrokersLatestVersion;
             } else {
-                LOG.info("Broker [{}] is running an older version ([{}]); latest version is [{}]",
-                        broker, brokerVersion, latestVersion);
+                log.info().attr("broker", broker).attr("brokerVersion", brokerVersion)
+                        .attr("latestVersion", latestVersion)
+                        .log("Broker is running an older version");
                 ++numBrokersOlderVersion;
                 brokerIterator.remove();
             }
         }
         if (numBrokersOlderVersion == 0) {
-            LOG.info("All {} brokers are running the latest version [{}]", numBrokersLatestVersion, latestVersion);
+            log.info().attr("brokerCount", numBrokersLatestVersion).attr("version", latestVersion)
+                    .log("All brokers are running the latest version");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BundleSplitStrategy;
@@ -28,14 +29,12 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Determines which bundles should be split based on various thresholds.
  */
+@CustomLog
 public class BundleSplitterTask implements BundleSplitStrategy {
-    private static final Logger log = LoggerFactory.getLogger(BundleSplitStrategy.class);
     private final Map<String, String> bundleCache;
 
     private final Map<String, Integer> namespaceBundleCount;
@@ -78,9 +77,8 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                 final String bundle = entry.getKey();
                 final NamespaceBundleStats stats = entry.getValue();
                 if (stats.topics < 2) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("The count of topics on the bundle {} is less than 2, skip split!", bundle);
-                    }
+                    log.debug().attr("bundle", bundle)
+                            .log("The count of topics on the bundle is less than 2, skip split!");
                     continue;
                 }
                 double totalMessageRate = 0;
@@ -100,24 +98,27 @@ public class BundleSplitterTask implements BundleSplitStrategy {
                                 .getBundleCount(NamespaceName.get(namespace));
                         if ((bundleCount + namespaceBundleCount.getOrDefault(namespace, 0))
                                 < maxBundleCount) {
-                            log.info("The bundle {} is considered to be unload. Topics: {}/{}, Sessions: ({}+{})/{}, "
-                                            + "Message Rate: {}/{} (msgs/s), Message Throughput: {}/{} (MB/s)",
-                                    bundle, stats.topics, maxBundleTopics, stats.producerCount, stats.consumerCount,
-                                    maxBundleSessions, totalMessageRate, maxBundleMsgRate,
-                                    totalMessageThroughput / LoadManagerShared.MIBI,
-                                    maxBundleBandwidth / LoadManagerShared.MIBI);
+                            log.info().attr("bundle", bundle)
+                                    .attr("topics", stats.topics).attr("maxBundleTopics", maxBundleTopics)
+                                    .attr("producerCount", stats.producerCount)
+                                    .attr("consumerCount", stats.consumerCount)
+                                    .attr("maxBundleSessions", maxBundleSessions)
+                                    .attr("messageRate", totalMessageRate)
+                                    .attr("maxBundleMsgRate", maxBundleMsgRate)
+                                    .attr("messageThroughputMiB", totalMessageThroughput / LoadManagerShared.MIBI)
+                                    .attr("maxBundleBandwidthMiB", maxBundleBandwidth / LoadManagerShared.MIBI)
+                                    .log("The bundle is considered to be unloaded");
                             bundleCache.put(bundle, broker);
                             int bundleNum = namespaceBundleCount.getOrDefault(namespace, 0);
                             namespaceBundleCount.put(namespace, bundleNum + 1);
                         } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug(
-                                        "Could not split namespace bundle {} because namespace {} has too many bundles:"
-                                                + "{}", bundle, namespace, bundleCount);
-                            }
+                            log.debugf(
+                                    "Could not split namespace bundle %s because namespace %s has too many bundles:"
+                                            + "%s", bundle, namespace, bundleCount);
                         }
                     } catch (Exception e) {
-                        log.warn("Error while getting bundle count for namespace {}", namespace, e);
+                        log.warn().attr("namespace", namespace).exception(e)
+                                .log("Error while getting bundle count for namespace");
                     }
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
@@ -30,15 +31,12 @@ import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Placement strategy which selects a broker based on which one has the least long term message rate.
  */
+@CustomLog
 public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
-    private static Logger log = LoggerFactory.getLogger(LeastLongTermMessageRate.class);
-
     // Maintain this list to reduce object creation.
     private ArrayList<String> bestBrokers;
 
@@ -58,7 +56,8 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
                 conf.getLoadBalancerBandwidthInResourceWeight(),
                 conf.getLoadBalancerBandwidthOutResourceWeight());
         if (maxUsage > overloadThreshold) {
-            log.warn("Broker {} is overloaded: max usage={}", brokerData.getLocalData().getWebServiceUrl(), maxUsage);
+            log.warn().attr("broker", brokerData.getLocalData().getWebServiceUrl()).attr("maxUsage", maxUsage)
+                    .log("Broker is overloaded");
             return Double.POSITIVE_INFINITY;
         }
 
@@ -74,10 +73,9 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
                 + timeAverageData.getLongTermMsgRateOut();
         final double totalMessageRateEstimate = totalMessageRate + timeAverageLongTermMessageRate;
 
-        if (log.isDebugEnabled()) {
-            log.debug("Broker {} has long term message rate {}",
-                    brokerData.getLocalData().getWebServiceUrl(), totalMessageRateEstimate);
-        }
+        log.debug().attr("broker", brokerData.getLocalData().getWebServiceUrl())
+                .attr("rate", totalMessageRateEstimate)
+                .log("Broker has long term message rate");
         return totalMessageRateEstimate;
     }
 
@@ -107,13 +105,14 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
             final double score = getScore(brokerData, conf);
             if (score == Double.POSITIVE_INFINITY) {
                 final LocalBrokerData localData = brokerData.getLocalData();
-                log.warn(
-                        "Broker {} is overloaded: CPU: {}%, MEMORY: {}%, DIRECT MEMORY: {}%, BANDWIDTH IN: {}%, "
-                                + "BANDWIDTH OUT: {}%",
-                        broker, localData.getCpu().percentUsage(), localData.getMemory().percentUsage(),
-                        localData.getDirectMemory().percentUsage(), localData.getBandwidthIn().percentUsage(),
-                        localData.getBandwidthOut().percentUsage());
-
+                log.warn()
+                        .attr("broker", broker)
+                        .attr("cpuPercentage", localData.getCpu().percentUsage())
+                        .attr("memoryPercentage", localData.getMemory().percentUsage())
+                        .attr("directMemoryPercentage", localData.getDirectMemory().percentUsage())
+                        .attr("bandwidthInPercentage", localData.getBandwidthIn().percentUsage())
+                        .attr("bandwidthOutPercentage", localData.getBandwidthOut().percentUsage())
+                        .log("Broker is overloaded");
             }
             if (score < minScore) {
                 // Clear best brokers since this score beats the other brokers.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastResourceUsageWithWeight.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
@@ -37,7 +37,7 @@ import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
  * This strategy takes into account the historical load percentage and short-term load percentage, and thus will not
  * cause cluster fluctuations due to short-term load jitter.
  */
-@Slf4j
+@CustomLog
 public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy {
     private static final double MAX_RESOURCE_USAGE = 1.0d;
     // Maintain this list to reduce object creation.
@@ -59,24 +59,25 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
 
         if (maxUsageWithWeight > overloadThreshold) {
             final LocalBrokerData localData = brokerData.getLocalData();
-            log.warn(
-                    "Broker {} is overloaded, max resource usage with weight percentage: {}%, "
-                            + "CPU: {}%, MEMORY: {}%, DIRECT MEMORY: {}%, BANDWIDTH IN: {}%, "
-                            + "BANDWIDTH OUT: {}%, CPU weight: {}, MEMORY weight: {}, DIRECT MEMORY weight: {}, "
-                            + "BANDWIDTH IN weight: {}, BANDWIDTH OUT weight: {}",
-                    broker, maxUsageWithWeight * 100,
-                    localData.getCpu().percentUsage(), localData.getMemory().percentUsage(),
-                    localData.getDirectMemory().percentUsage(), localData.getBandwidthIn().percentUsage(),
-                    localData.getBandwidthOut().percentUsage(), conf.getLoadBalancerCPUResourceWeight(),
-                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
-                    conf.getLoadBalancerBandwidthInResourceWeight(),
-                    conf.getLoadBalancerBandwidthOutResourceWeight());
+            log.warn()
+                    .attr("broker", broker)
+                    .attr("maxUsageWithWeightPercentage", maxUsageWithWeight * 100)
+                    .attr("cpuPercentage", localData.getCpu().percentUsage())
+                    .attr("memoryPercentage", localData.getMemory().percentUsage())
+                    .attr("directMemoryPercentage", localData.getDirectMemory().percentUsage())
+                    .attr("bandwidthInPercentage", localData.getBandwidthIn().percentUsage())
+                    .attr("bandwidthOutPercentage", localData.getBandwidthOut().percentUsage())
+                    .attr("cpuWeight", conf.getLoadBalancerCPUResourceWeight())
+                    .attr("memoryWeight", conf.getLoadBalancerMemoryResourceWeight())
+                    .attr("directMemoryWeight", conf.getLoadBalancerDirectMemoryResourceWeight())
+                    .attr("bandwidthInWeight", conf.getLoadBalancerBandwidthInResourceWeight())
+                    .attr("bandwidthOutWeight", conf.getLoadBalancerBandwidthOutResourceWeight())
+                    .log("Broker is overloaded");
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Broker {} has max resource usage with weight percentage: {}%",
-                    brokerData.getLocalData().getWebServiceUrl(), maxUsageWithWeight * 100);
-        }
+        log.debug().attr("broker", () -> brokerData.getLocalData().getWebServiceUrl())
+                .attr("percentage", maxUsageWithWeight * 100)
+                .log("Broker has max resource usage with weight percentage");
         return maxUsageWithWeight;
     }
 
@@ -105,16 +106,16 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
                 conf.getLoadBalancerBandwidthOutResourceWeight());
         historyUsage = historyUsage == null
                 ? resourceUsage : historyUsage * historyPercentage + (1 - historyPercentage) * resourceUsage;
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "Broker {} get max resource usage with weight: {}, history resource percentage: {}%, CPU weight: "
-                            + "{}, MEMORY weight: {}, DIRECT MEMORY weight: {}, BANDWIDTH IN weight: {}, BANDWIDTH "
-                            + "OUT weight: {} ",
-                    broker, historyUsage, historyPercentage, conf.getLoadBalancerCPUResourceWeight(),
-                    conf.getLoadBalancerMemoryResourceWeight(), conf.getLoadBalancerDirectMemoryResourceWeight(),
-                    conf.getLoadBalancerBandwidthInResourceWeight(),
-                    conf.getLoadBalancerBandwidthOutResourceWeight());
-        }
+        log.debug()
+                .attr("broker", broker)
+                .attr("historyUsage", historyUsage)
+                .attr("historyPercentage", historyPercentage)
+                .attr("cpuWeight", conf.getLoadBalancerCPUResourceWeight())
+                .attr("memoryWeight", conf.getLoadBalancerMemoryResourceWeight())
+                .attr("directMemoryWeight", conf.getLoadBalancerDirectMemoryResourceWeight())
+                .attr("bandwidthInWeight", conf.getLoadBalancerBandwidthInResourceWeight())
+                .attr("bandwidthOutWeight", conf.getLoadBalancerBandwidthOutResourceWeight())
+                .log("Broker get max resource usage with weight");
         brokerAvgResourceUsageWithWeight.put(broker, historyUsage);
         return historyUsage;
     }
@@ -134,7 +135,8 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
                                                       LoadData loadData,
                                                       ServiceConfiguration conf) {
         if (candidates.isEmpty()) {
-            log.info("There are no available brokers as candidates at this point for bundle: {}", bundleToAssign);
+            log.info().attr("bundle", bundleToAssign)
+                    .log("There are no available brokers as candidates at this point for bundle");
             return Optional.empty();
         }
 
@@ -160,14 +162,13 @@ public class LeastResourceUsageWithWeight implements ModularLoadManagerStrategy 
 
         if (bestBrokers.isEmpty()) {
             // Assign randomly as all brokers are overloaded.
-            log.warn("Assign randomly as all {} brokers are overloaded.", candidates.size());
+            log.warn().attr("candidatesSize", candidates.size()).log("Assign randomly as all brokers are overloaded");
             bestBrokers.addAll(candidates);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Selected {} best brokers: {} from candidate brokers: {}", bestBrokers.size(), bestBrokers,
-                    candidates);
-        }
+        log.debug().attr("bestBrokersSize", bestBrokers.size()).attr("bestBrokers", bestBrokers)
+                .attr("candidates", candidates)
+                .log("Selected best brokers from candidates");
         return Optional.of(bestBrokers.get(ThreadLocalRandom.current().nextInt(bestBrokers.size())));
     }
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.BitRateUnit;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
@@ -46,7 +46,7 @@ import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 /**
  * Class that will return the broker host usage.
  */
-@Slf4j
+@CustomLog
 public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     private long lastCollection;
     private double lastTotalNicUsageTx;
@@ -100,7 +100,8 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
         long now = System.currentTimeMillis();
         double elapsedSeconds = (now - lastCollection) / 1000d;
         if (elapsedSeconds <= 0) {
-            log.warn("elapsedSeconds {} is not expected, skip this round of calculateBrokerHostUsage", elapsedSeconds);
+            log.warn().attr("elapsedSeconds", elapsedSeconds)
+                    .log("elapsedSeconds is not expected, skip this round of calculateBrokerHostUsage");
             return;
         }
         SystemResourceUsage usage = new SystemResourceUsage();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
@@ -50,15 +51,12 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class contains code which in shared between the two load manager implementations.
  */
+@CustomLog
 public class LoadManagerShared {
-    public static final Logger LOG = LoggerFactory.getLogger(LoadManagerShared.class);
-
     // Value of prefix "mibi" (e.g., number of bytes in a mibibyte).
     public static final int MIBI = 1024 * 1024;
 
@@ -100,14 +98,14 @@ public class LoadManagerShared {
         boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
                 ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
         if (isIsolationPoliciesPresent) {
-            LOG.debug("Isolation Policies Present for namespace - [{}]", namespace.toString());
+            log.debug().attr("namespace", namespace.toString()).log("Isolation Policies Present for namespace");
         }
         for (final String brokerId : availableBrokers) {
             String brokerHost;
             try {
                 brokerHost = parseBrokerHost(brokerId);
             } catch (IllegalArgumentException e) {
-                LOG.error("Unable to parse host from {}", brokerId, e);
+                log.error().attr("broker", brokerId).exception(e).log("Unable to parse host from broker ID");
                 continue;
             }
             // todo: in future check if the resource unit has resources to take the namespace
@@ -115,60 +113,48 @@ public class LoadManagerShared {
                 // note: serviceUnitID is namespace name and ResourceID is brokerName
                 if (policies.isPrimaryBroker(namespace, brokerHost)) {
                     primariesCache.add(brokerId);
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Added Primary Broker - [{}] as possible Candidates for"
-                                + " namespace - [{}] with policies", brokerHost, namespace.toString());
-                    }
+                    log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                            .log("Added Primary Broker as possible Candidates for namespace with policies");
                 } else if (policies.isSecondaryBroker(namespace, brokerHost)) {
                     secondaryCache.add(brokerId);
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Added Shared Broker - [{}] as possible "
-                                        + "Candidates for namespace - [{}] with policies",
-                                brokerHost, namespace.toString());
-                    }
+                    log.debugf(
+                            "Added Shared Broker - [%s] as possible "
+                                    + "Candidates for namespace - [%s] with policies",
+                            brokerHost, namespace.toString());
                 } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Skipping Broker - [{}] not primary broker and not shared" + " for namespace - [{}] ",
-                                brokerHost, namespace.toString());
-                    }
+                    log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                            .log("Skipping Broker; not primary broker and not shared for namespace");
 
                 }
             } else {
                 // non-persistent topic can be assigned to only those brokers that enabled for non-persistent topic
                 if (isNonPersistentTopic && !brokerTopicLoadingPredicate.isEnableNonPersistentTopics(brokerId)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Filter broker- [{}] because it doesn't support non-persistent namespace - [{}]",
-                                brokerHost, namespace.toString());
-                    }
+                    log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                            .log("Filter broker because it doesn't support non-persistent namespace");
                 } else if (!isNonPersistentTopic && !brokerTopicLoadingPredicate.isEnablePersistentTopics(brokerId)) {
                     // persistent topic can be assigned to only brokers that enabled for persistent-topic
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Filter broker- [{}] because broker only supports non-persistent namespace - [{}]",
-                                brokerHost, namespace.toString());
-                    }
+                    log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                            .log("Filter broker because broker only supports non-persistent namespace");
                 } else if (policies.isSharedBroker(brokerHost)) {
                     secondaryCache.add(brokerId);
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Added Shared Broker - [{}] as possible Candidates for namespace - [{}]",
-                                brokerHost, namespace.toString());
-                    }
+                    log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                            .log("Added Shared Broker as possible Candidates for namespace");
                 }
             }
         }
         if (isIsolationPoliciesPresent) {
             brokerCandidateCache.addAll(primariesCache);
             if (policies.shouldFailoverToSecondaries(namespace, primariesCache.size())) {
-                LOG.debug(
-                        "Not enough of primaries [{}] available for namespace - [{}], "
-                                + "adding shared [{}] as possible candidate owners",
+                log.debugf(
+                        "Not enough of primaries [%s] available for namespace - [%s], "
+                                + "adding shared [%s] as possible candidate owners",
                         primariesCache.size(), namespace.toString(), secondaryCache.size());
                 brokerCandidateCache.addAll(secondaryCache);
             }
         } else {
-            LOG.debug(
-                    "Policies not present for namespace - [{}] so only "
-                            + "considering shared [{}] brokers for possible owner",
+            log.debugf(
+                    "Policies not present for namespace - [%s] so only "
+                            + "considering shared [%s] brokers for possible owner",
                     namespace.toString(), secondaryCache.size());
             brokerCandidateCache.addAll(secondaryCache);
         }
@@ -198,16 +184,15 @@ public class LoadManagerShared {
             boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
                     ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
             if (isIsolationPoliciesPresent) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Isolation Policies Present for namespace - [{}]", namespace.toString());
-                }
+                log.debug().attr("namespace", namespace.toString())
+                        .log("Isolation Policies Present for namespace");
             }
             for (final String brokerId : availableBrokers) {
                 String brokerHost;
                 try {
                     brokerHost = parseBrokerHost(brokerId);
                 } catch (IllegalArgumentException e) {
-                    LOG.error("Unable to parse host from {}", brokerId, e);
+                    log.error().attr("broker", brokerId).exception(e).log("Unable to parse host from broker ID");
                     continue;
                 }
                 // todo: in future check if the resource unit has resources to take the namespace
@@ -215,66 +200,50 @@ public class LoadManagerShared {
                     // note: serviceUnitID is namespace name and ResourceID is brokerName
                     if (policies.isPrimaryBroker(namespace, brokerHost)) {
                         primariesCache.add(brokerId);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Added Primary Broker - [{}] as possible Candidates for"
-                                    + " namespace - [{}] with policies", brokerHost, namespace.toString());
-                        }
+                        log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                                .log("Added Primary Broker as possible Candidates for namespace with policies");
                     } else if (policies.isSecondaryBroker(namespace, brokerHost)) {
                         secondaryCache.add(brokerId);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(
-                                    "Added Shared Broker - [{}] as possible "
-                                            + "Candidates for namespace - [{}] with policies",
-                                    brokerHost, namespace.toString());
-                        }
+                        log.debugf(
+                                "Added Shared Broker - [%s] as possible "
+                                        + "Candidates for namespace - [%s] with policies",
+                                brokerHost, namespace.toString());
                     } else {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Skipping Broker - [{}] not primary broker and not shared"
-                                            + " for namespace - [{}] ", brokerHost, namespace.toString());
-                        }
+                        log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                                .log("Skipping Broker; not primary broker and not shared for namespace");
 
                     }
                 } else {
                     // non-persistent topic can be assigned to only those brokers that enabled for non-persistent topic
                     if (isNonPersistentTopic && !brokerTopicLoadingPredicate.isEnableNonPersistentTopics(brokerId)) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Filter broker- [{}] because it doesn't support non-persistent namespace - [{}]",
-                                    brokerId, namespace.toString());
-                        }
+                        log.debug().attr("broker", brokerId).attr("namespace", namespace.toString())
+                                .log("Filter broker because it doesn't support non-persistent namespace");
                     } else if (!isNonPersistentTopic && !brokerTopicLoadingPredicate
                             .isEnablePersistentTopics(brokerId)) {
                         // persistent topic can be assigned to only brokers that enabled for persistent-topic
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Filter broker- [{}] because broker only supports non-persistent "
-                                            + "namespace - [{}]", brokerId, namespace.toString());
-                        }
+                        log.debug().attr("broker", brokerId).attr("namespace", namespace.toString())
+                                .log("Filter broker because broker only supports non-persistent namespace");
                     } else if (policies.isSharedBroker(brokerHost)) {
                         secondaryCache.add(brokerId);
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Added Shared Broker - [{}] as possible Candidates for namespace - [{}]",
-                                    brokerHost, namespace.toString());
-                        }
+                        log.debug().attr("broker", brokerHost).attr("namespace", namespace.toString())
+                                .log("Added Shared Broker as possible Candidates for namespace");
                     }
                 }
             }
             if (isIsolationPoliciesPresent) {
                 brokerCandidateCache.addAll(primariesCache);
                 if (policies.shouldFailoverToSecondaries(namespace, primariesCache.size())) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Not enough of primaries [{}] available for namespace - [{}], "
-                                        + "adding shared [{}] as possible candidate owners",
-                                primariesCache.size(), namespace.toString(), secondaryCache.size());
-                    }
+                    log.debugf(
+                            "Not enough of primaries [%s] available for namespace - [%s], "
+                                    + "adding shared [%s] as possible candidate owners",
+                            primariesCache.size(), namespace.toString(), secondaryCache.size());
                     brokerCandidateCache.addAll(secondaryCache);
                 }
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Policies not present for namespace - [{}] so only "
-                                    + "considering shared [{}] brokers for possible owner",
-                            namespace.toString(), secondaryCache.size());
-                }
+                log.debugf(
+                        "Policies not present for namespace - [%s] so only "
+                                + "considering shared [%s] brokers for possible owner",
+                        namespace.toString(), secondaryCache.size());
                 brokerCandidateCache.addAll(secondaryCache);
             }
             return brokerCandidateCache;
@@ -406,7 +375,7 @@ public class LoadManagerShared {
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {
-            LOG.error("Failed to filter anti-affinity group namespace {}", e.getMessage());
+            log.error().exceptionMessage(e).log("Failed to filter anti-affinity group namespace");
         }
     }
 
@@ -472,7 +441,7 @@ public class LoadManagerShared {
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {
-            LOG.error("Failed to filter anti-affinity group namespace {}", e.getMessage());
+            log.error().exceptionMessage(e).log("Failed to filter anti-affinity group namespace");
         }
     }
 
@@ -776,15 +745,15 @@ public class LoadManagerShared {
                             }
                         }
                     } catch (Exception e) {
-                        LOG.warn("Failed to get domain {}", domainName, e);
+                        log.warn().attr("domain", domainName).exception(e).log("Failed to get domain");
                     }
                 }
                 brokerToFailureDomainMap.clear();
                 brokerToFailureDomainMap.putAll(tempBrokerToFailureDomainMap);
             }
-            LOG.info("Cluster domain refreshed {}", brokerToFailureDomainMap);
+            log.info().attr("broker", brokerToFailureDomainMap).log("Cluster domain refreshed");
         } catch (Exception e) {
-            LOG.warn("Failed to get domain-list for cluster {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to get domain-list for cluster");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -44,6 +44,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -87,12 +88,9 @@ import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ModularLoadManagerImpl implements ModularLoadManager {
-    private static final Logger log = LoggerFactory.getLogger(ModularLoadManagerImpl.class);
-
     // Default message rate to assume for unseen bundles.
     public static final double DEFAULT_MESSAGE_RATE = 50;
 
@@ -323,19 +321,16 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
     private void reapDeadBrokerPreallocations(List<String> aliveBrokers) {
         for (String broker : loadData.getBrokerData().keySet()) {
             if (!aliveBrokers.contains(broker)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Broker {} appears to have stopped; now reclaiming any preallocations", broker);
-                }
+                log.debug().attr("broker", broker)
+                        .log("Broker appears to have stopped; now reclaiming any preallocations");
                 final Iterator<Map.Entry<String, String>> iterator = preallocatedBundleToBroker.entrySet().iterator();
                 while (iterator.hasNext()) {
                     Map.Entry<String, String> entry = iterator.next();
                     final String preallocatedBundle = entry.getKey();
                     final String preallocatedBroker = entry.getValue();
                     if (broker.equals(preallocatedBroker)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Removing old preallocation on dead broker {} for bundle {}",
-                                    preallocatedBroker, preallocatedBundle);
-                        }
+                        log.debug().attr("broker", preallocatedBroker).attr("bundle", preallocatedBundle)
+                                .log("Removing old preallocation on dead broker for bundle");
                         iterator.remove();
                     }
                 }
@@ -348,7 +343,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         try {
             return getAvailableBrokersAsync().get(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.warn("Error when trying to get active brokers", e);
+            log.warn().exception(e).log("Error when trying to get active brokers");
             return loadData.getBrokerData().keySet();
         }
     }
@@ -360,7 +355,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 .whenComplete((listLocks, ex) -> {
                     if (ex != null){
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                        log.warn("Error when trying to get active brokers", realCause);
+                        log.warn().exception(realCause).log("Error when trying to get active brokers");
                         future.complete(loadData.getBrokerData().keySet());
                     } else {
                         future.complete(Sets.newHashSet(listLocks));
@@ -415,7 +410,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 longTermData.setNumSamples(NUM_LONG_SAMPLES);
             }
         } catch (Exception e) {
-            log.warn("Error when trying to find bundle {} on metadata store: {}", bundle, e);
+            log.warn().attr("bundle", bundle).exceptionMessage(e)
+                    .log("Error when trying to find bundle on metadata store");
         }
         if (bundleData == null) {
             bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES, defaultStats);
@@ -453,8 +449,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 .toMillis(conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
         long timeSinceLastReportWrittenToStore = System.currentTimeMillis() - localData.getLastUpdate();
         if (timeSinceLastReportWrittenToStore > updateMaxIntervalMillis) {
-            log.info("Writing local data to metadata store because time since last"
-                            + " update exceeded threshold of {} minutes",
+            log.infof("Writing local data to metadata store because time since last"
+                            + " update exceeded threshold of %s minutes",
                     conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
             // Always update after surpassing the maximum interval.
             return true;
@@ -469,10 +465,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                         - getMaxResourceUsageWithWeight(localData, conf))
         );
         if (maxChange > conf.getLoadBalancerReportUpdateThresholdPercentage()) {
-            log.info("Writing local data to metadata store because maximum change {}% exceeded threshold {}%; "
-                            + "time since last report written is {} seconds", maxChange,
-                    conf.getLoadBalancerReportUpdateThresholdPercentage(),
-                    timeSinceLastReportWrittenToStore / 1000.0);
+            log.info().attr("change", maxChange)
+                    .attr("threshold", conf.getLoadBalancerReportUpdateThresholdPercentage())
+                    .attr("timeSinceLastReportSeconds", timeSinceLastReportWrittenToStore / 1000.0)
+                    .log("Writing local data to metadata store because maximum change % exceeded threshold");
             return true;
         }
         return false;
@@ -480,9 +476,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
     // Update both the broker data and the bundle data.
     public void updateAll() {
-        if (log.isDebugEnabled()) {
-            log.debug("Updating broker and bundle data for loadreport");
-        }
+        log.debug("Updating broker and bundle data for loadreport");
         cleanupDeadBrokersData();
         updateAllBrokerData();
         updateBundleData();
@@ -514,7 +508,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 Optional<LocalBrokerData> localData = brokersData.readLock(key).get();
                 if (!localData.isPresent()) {
                     brokerDataMap.remove(broker);
-                    log.info("[{}] Broker load report is not present", broker);
+                    log.info().attr("broker", broker).log("Broker load report is not present");
                     continue;
                 }
 
@@ -527,7 +521,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     brokerDataMap.put(broker, new BrokerData(localData.get()));
                 }
             } catch (Exception e) {
-                log.warn("Error reading broker data from cache for broker - [{}], [{}]", broker, e.getMessage());
+                log.warn().attr("broker", broker).exceptionMessage(e)
+                        .log("Error reading broker data from cache");
             }
         }
         // Remove obsolete brokers.
@@ -653,10 +648,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
                 final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
                 if (sheddingExcludedNamespaces.contains(namespaceName)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Skipping load shedding for namespace {}",
-                                loadSheddingStrategy.getClass().getSimpleName(), namespaceName);
-                    }
+                    log.debug().attr("class", loadSheddingStrategy.getClass().getSimpleName())
+                            .attr("namespace", namespaceName)
+                            .log("Skipping load shedding for namespace");
                     return;
                 }
                 if (!shouldNamespacePoliciesUnload(namespaceName, bundleRange, broker)) {
@@ -669,18 +663,21 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 NamespaceBundle bundleToUnload = LoadManagerShared.getNamespaceBundle(pulsar, bundle);
                 Optional<String> destBroker = this.selectBroker(bundleToUnload);
                 if (!destBroker.isPresent()) {
-                    log.info("[{}] No broker available to unload bundle {} from broker {}",
-                            loadSheddingStrategy.getClass().getSimpleName(), bundle, broker);
+                    log.info().attr("class", loadSheddingStrategy.getClass().getSimpleName())
+                            .attr("bundle", bundle).attr("broker", broker)
+                            .log("No broker available to unload bundle from broker");
                     return;
                 }
                 if (destBroker.get().equals(broker)) {
-                    log.warn("[{}] The destination broker {} is the same as the current owner broker for Bundle {}",
-                            loadSheddingStrategy.getClass().getSimpleName(), destBroker.get(), bundle);
+                    log.warn().attr("class", loadSheddingStrategy.getClass().getSimpleName())
+                            .attr("broker", destBroker.get()).attr("bundle", bundle)
+                            .log("The destination broker is the same as the current owner broker for bundle");
                     return;
                 }
 
-                log.info("[{}] Unloading bundle: {} from broker {} to dest broker {}",
-                        loadSheddingStrategy.getClass().getSimpleName(), bundle, broker, destBroker.get());
+                log.info().attr("class", loadSheddingStrategy.getClass().getSimpleName())
+                        .attr("bundle", bundle).attr("sourceBroker", broker).attr("destBroker", destBroker.get())
+                        .log("Unloading bundle from source broker to dest broker");
                 try {
                     pulsar.getAdminClient().namespaces()
                             .unloadNamespaceBundle(namespaceName, bundleRange, destBroker.get());
@@ -688,7 +685,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     unloadBundleCount++;
                     unloadBundleForBroker.set(true);
                 } catch (PulsarServerException | PulsarAdminException e) {
-                    log.warn("Error when trying to perform load shedding on {} for broker {}", bundle, broker, e);
+                    log.warn().attr("bundle", bundle).attr("broker", broker).exception(e)
+                            .log("Error when trying to perform load shedding on for broker");
                 }
             });
             if (unloadBundleForBroker.get()) {
@@ -747,8 +745,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             }
 
         } catch (Exception e) {
-            log.warn("Failed to check anti-affinity namespace ownership for {}/{}/{}, {}", namespace, bundle,
-                    currentBroker, e.getMessage());
+            log.warn().attr("namespace", namespace).attr("bundle", bundle).attr("broker", currentBroker)
+                    .exceptionMessage(e)
+                    .log("Failed to check anti-affinity namespace ownership");
 
         }
         return true;
@@ -780,7 +779,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
                     NamespaceBundles bundles = namespaceBundleFactory.getBundles(NamespaceName.get(namespaceName));
                     if (!checkBundleDataExistInNamespaceBundles(bundles, bundle)) {
-                        log.warn("Bundle {} has been removed, skip split this bundle ", bundleName);
+                        log.warn().attr("bundle", bundleName).log("Bundle has been removed, skip split this bundle");
                         continue;
                     }
 
@@ -800,14 +799,15 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                             && shouldAntiAffinityNamespaceUnload(namespaceName, bundleRange, broker)) {
                         isUnload = true;
                     }
-                    log.info("Load-manager splitting bundle {} and unloading {}", bundleName, isUnload);
+                    log.info().attr("bundle", bundleName).attr("unloading", isUnload)
+                            .log("Load-manager splitting bundle and unloading");
                     pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
                             isUnload, null);
 
                     splitCount++;
-                    log.info("Successfully split namespace bundle {}", bundleName);
+                    log.info().attr("bundle", bundleName).log("Successfully split namespace bundle");
                 } catch (Exception e) {
-                    log.error("Failed to split namespace bundle {}", bundleName, e);
+                    log.error().attr("bundle", bundleName).exception(e).log("Failed to split namespace bundle");
                 }
             }
 
@@ -915,13 +915,12 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 LoadManagerShared.removeMostServicingBrokersForNamespace(bundle,
                         brokerCandidateCache,
                         brokerToNamespaceToBundleRange);
-                if (log.isDebugEnabled()) {
-                    log.debug("enable distribute bundles evenly to candidate-brokers, broker candidate count={}",
-                            brokerCandidateCache.size());
-                }
+                log.debug().attr("candidateCount", brokerCandidateCache.size())
+                        .log("Enable distribute bundles evenly to candidate-brokers");
             }
 
-            log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);
+            log.info().attr("brokerCount", brokerCandidateCache.size()).attr("bundle", bundle)
+                    .log("Brokers being considered for assignment");
 
             // Use the filter pipeline to finalize broker candidates.
             try {
@@ -949,18 +948,15 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             Set<String> sheddingExcludedNamespaces = conf.getLoadBalancerSheddingExcludedNamespaces();
             String namespaceNameFromBundleName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
             if (sheddingExcludedNamespaces.contains(namespaceNameFromBundleName)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Use round robin broker selector for {}", bundle);
-                }
+                log.debug().attr("bundle", bundle).log("Use round robin broker selector for bundle");
                 broker = sheddingExcludedNamespaceSelectionStrategy
                         .selectBroker(brokerCandidateCache, data, loadData, conf);
             } else {
                 // Choose a broker among the potentially smaller filtered list, when possible
                 broker = placementStrategy.selectBroker(brokerCandidateCache, data, loadData, conf);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Selected broker {} from candidate brokers {}", broker, brokerCandidateCache);
-            }
+            log.debug().attr("selectedBroker", broker).attr("candidates", brokerCandidateCache)
+                    .log("Selected broker from candidate brokers");
 
             if (!broker.isPresent()) {
                 // No brokers available
@@ -1024,7 +1020,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                     .join();
             updateAll();
         } catch (Exception e) {
-            log.error("Unable to acquire lock for broker: [{}]", brokerZnodePath, e);
+            log.error().attr("broker", brokerZnodePath).exception(e).log("Unable to acquire lock for broker");
             throw new PulsarServerException(e);
         }
     }
@@ -1042,7 +1038,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         try {
             brokersData.close();
         } catch (Exception e) {
-            log.warn("Failed to release broker lock: {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to release broker lock");
         }
     }
 
@@ -1061,7 +1057,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 updateLoadBalancingBundlesMetrics(getBundleStats());
             }
         } catch (Exception e) {
-            log.warn("Error when attempting to update local broker data", e);
+            log.warn().exception(e).log("Error when attempting to update local broker data");
             if (e instanceof ConcurrentModificationException) {
                 throw (ConcurrentModificationException) e;
             }
@@ -1149,7 +1145,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 lastData.update(localData);
             }
         } catch (Exception e) {
-            log.warn("Error writing broker data on metadata store", e);
+            log.warn().exception(e).log("Error writing broker data on metadata store");
             if (e instanceof ConcurrentModificationException) {
                 throw (ConcurrentModificationException) e;
             }
@@ -1220,7 +1216,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         try {
             FutureUtil.waitForAll(futures).join();
         } catch (Exception e) {
-            log.warn("Error when writing metadata data to store", e);
+            log.warn().exception(e).log("Error when writing metadata data to store");
         }
     }
 
@@ -1229,7 +1225,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             pulsarResources.getLoadBalanceResources().getBundleDataResources().deleteBundleData(bundle).join();
         } catch (Exception e) {
             if (!(e.getCause() instanceof NotFoundException)) {
-                log.warn("Failed to delete bundle-data {} from metadata store", bundle, e);
+                log.warn().attr("bundle", bundle).exception(e).log("Failed to delete bundle-data from metadata store");
             }
         }
     }
@@ -1238,8 +1234,8 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         pulsarResources.getLoadBalanceResources()
                 .getBrokerTimeAverageDataResources().deleteTimeAverageBrokerData(broker).whenComplete((__, ex) -> {
                     if (ex != null && !(ex.getCause() instanceof MetadataStoreException.NotFoundException)) {
-                        log.warn("Failed to delete dead broker {} time "
-                                + "average data from metadata store", broker, ex);
+                        log.warn().attr("broker", broker).exception(ex)
+                                .log("Failed to delete dead broker time " + "average data from metadata store");
                     }
                 });
     }
@@ -1250,7 +1246,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         try {
             return brokersData.readLock(key).join().orElse(null);
         } catch (Exception e) {
-            log.warn("Failed to get local-broker data for {}", broker, e);
+            log.warn().attr("broker", broker).exception(e).log("Failed to get local-broker data");
             return null;
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -88,7 +88,7 @@ public class OverloadShedder implements LoadSheddingStrategy {
             double minimumThroughputToOffload = brokerCurrentThroughput * percentOfTrafficToOffload;
 
             log.infof(
-                    "Attempting to shed load on %s, which has resource usage %s% above threshold %s%"
+                    "Attempting to shed load on %s, which has resource usage %s%% above threshold %s%%"
                             + " -- Offloading at least %s MByte/s of traffic (%s)",
                     broker, 100 * currentUsage, 100 * overloadThreshold, minimumThroughputToOffload / 1024 / 1024,
                     localData.printResourceUsage());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/OverloadShedder.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.tuple.Pair;
@@ -30,8 +31,6 @@ import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Load shedding strategy which will attempt to shed exactly one bundle on brokers which are overloaded, that is, whose
@@ -45,10 +44,8 @@ import org.slf4j.LoggerFactory;
  * when determining which bundles to unload. If you are looking for a strategy that spreads load evenly across
  * all brokers, see {@link ThresholdShedder}.
  */
+@CustomLog
 public class OverloadShedder implements LoadSheddingStrategy {
-
-    private static final Logger log = LoggerFactory.getLogger(OverloadShedder.class);
-
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
 
     private static final double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
@@ -78,10 +75,8 @@ public class OverloadShedder implements LoadSheddingStrategy {
                     conf.getLoadBalancerBandwidthInResourceWeight(),
                     conf.getLoadBalancerBandwidthOutResourceWeight());
             if (currentUsage < overloadThreshold) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Broker is not overloaded, ignoring at this point ({})", broker,
-                            localData.printResourceUsage());
-                }
+                log.debug().attr("broker", broker).attr("resourceUsage", localData.printResourceUsage())
+                        .log("Broker is not overloaded, ignoring at this point");
                 return;
             }
 
@@ -92,9 +87,9 @@ public class OverloadShedder implements LoadSheddingStrategy {
 
             double minimumThroughputToOffload = brokerCurrentThroughput * percentOfTrafficToOffload;
 
-            log.info(
-                    "Attempting to shed load on {}, which has resource usage {}% above threshold {}%"
-                            + " -- Offloading at least {} MByte/s of traffic ({})",
+            log.infof(
+                    "Attempting to shed load on %s, which has resource usage %s% above threshold %s%"
+                            + " -- Offloading at least %s MByte/s of traffic (%s)",
                     broker, 100 * currentUsage, 100 * overloadThreshold, minimumThroughputToOffload / 1024 / 1024,
                     localData.printResourceUsage());
 
@@ -131,12 +126,12 @@ public class OverloadShedder implements LoadSheddingStrategy {
                    }
                 });
             } else if (localData.getBundles().size() == 1) {
-                log.warn(
-                        "HIGH USAGE WARNING : Sole namespace bundle {} is overloading broker {}. "
+                log.warnf(
+                        "HIGH USAGE WARNING : Sole namespace bundle %s is overloading broker %s. "
                                 + "No Load Shedding will be done on this broker",
                         localData.getBundles().iterator().next(), broker);
             } else {
-                log.warn("Broker {} is overloaded despite having no bundles", broker);
+                log.warn().attr("broker", broker).log("Broker is overloaded despite having no bundles");
             }
 
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PulsarLoadReportImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PulsarLoadReportImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.LoadReport;
 import org.apache.pulsar.broker.loadbalance.ResourceDescription;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
@@ -28,12 +29,9 @@ import org.apache.pulsar.broker.loadbalance.ServiceRequest;
 import org.apache.pulsar.broker.loadbalance.ServiceUnit;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class PulsarLoadReportImpl implements LoadReport {
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarLoadReportImpl.class);
     public Map<ServiceUnit, ServiceRequest> requestPerServiceUnit;
     private SimpleResourceUnit resourceUnit = null;
     private PulsarResourceDescription resourceDescription = null;
@@ -73,7 +71,7 @@ public class PulsarLoadReportImpl implements LoadReport {
                     pulsarLoadReport.resourceDescription);
 
         } catch (Exception e) {
-            log.warn("Failed Parsing Load Report from JSON string", e);
+            log.warn().exception(e).log("Failed Parsing Load Report from JSON string");
         }
         return pulsarLoadReport;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ResourceAvailabilityRanker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ResourceAvailabilityRanker.java
@@ -20,17 +20,15 @@ package org.apache.pulsar.broker.loadbalance.impl;
 
 import java.util.Comparator;
 import java.util.Map;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.LoadRanker;
 import org.apache.pulsar.broker.loadbalance.ResourceDescription;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  */
+@CustomLog
 public class ResourceAvailabilityRanker implements LoadRanker, Comparator<ResourceDescription> {
-    private static final Logger log = LoggerFactory.getLogger(ResourceAvailabilityRanker.class);
-
     /*
      * Every resource's percentage availability is calculated and then added up to denote the total availability of a
      * Resource Unit, if any available resource on a Resource unit is less than 5% we take it out, if only 20% of total
@@ -56,8 +54,9 @@ public class ResourceAvailabilityRanker implements LoadRanker, Comparator<Resour
                 Double temp = ((entry.getValue().limit - entry.getValue().usage) / entry.getValue().limit) * 100;
                 percentAvailable = temp.intValue();
             }
-            log.debug("Resource [{}] in Percentage Available - [{}], Actual Usage is - [{}], Actual Limit is [{}]",
-                    entry.getKey(), percentAvailable, entry.getValue().usage, entry.getValue().limit);
+            log.debug().attr("resource", entry.getKey()).attr("percentAvailable", percentAvailable)
+                    .attr("usage", entry.getValue().usage).attr("limit", entry.getValue().limit)
+                    .log("Resource percentage available");
             // give equal weight to each resource
             int resourceWeight = weight * percentAvailable;
             if (percentAvailable < minAvailableRequired) {
@@ -70,7 +69,8 @@ public class ResourceAvailabilityRanker implements LoadRanker, Comparator<Resour
         }
         if (resourcesWithLowAvailability > 0) {
             availabilityRank = availabilityRank / (resourcesWithLowAvailability * 2);
-            log.debug("Total Resource with Low availability - [{}]", resourcesWithLowAvailability);
+            log.debug().attr("resourcesWithLowAvailability", resourcesWithLowAvailability)
+                    .log("Total resource with low availability");
         }
         if (makeNonFunctional) {
             // this will rarely be selected

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -75,12 +76,9 @@ import org.apache.pulsar.policies.data.loadbalancer.ResourceUnitRanking;
 import org.apache.pulsar.policies.data.loadbalancer.ResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
 import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage.ResourceType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification> {
-
-    private static final Logger log = LoggerFactory.getLogger(SimpleLoadManagerImpl.class);
     private SimpleResourceAllocationPolicies policies;
     private PulsarService pulsar;
 
@@ -268,14 +266,14 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 loadReport = generateLoadReport();
                 this.lastResourceUsageTimestamp = loadReport.getTimestamp();
             } catch (Exception e) {
-                log.warn("Unable to get load report to write it on metadata store", e);
+                log.warn().exception(e).log("Unable to get load report to write it on metadata store");
             }
 
             brokerLock = loadReports.acquireLock(brokerLockPath, loadReport).join();
 
             // first time, populate the broker ranking
             updateRanking();
-            log.info("Created broker ephemeral node on {}", brokerLockPath);
+            log.info().attr("broker", brokerLockPath).log("Created broker ephemeral node");
 
             // load default resource quota
             this.realtimeAvgResourceQuota = pulsar.getBrokerService().getBundlesQuotas()
@@ -288,7 +286,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     LOADBALANCER_DYNAMIC_SETTING_LOAD_FACTOR_MEM_ZPATH, SETTING_NAME_LOAD_FACTOR_MEM,
                     this.realtimeMemoryLoadFactor);
         } catch (Exception e) {
-            log.error("Unable to create node - [{}] for load balance on metadata store", brokerLockPath, e);
+            log.error().attr("broker", brokerLockPath).exception(e)
+                    .log("Unable to create node for load balance on metadata store");
             throw new PulsarServerException(e);
         }
     }
@@ -312,7 +311,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 .whenComplete((listLocks, ex) -> {
                     if (ex != null){
                         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
-                        log.warn("Error when trying to get active brokers", realCause);
+                        log.warn().exception(realCause).log("Error when trying to get active brokers");
                         getAvailableBrokersAsync.completeExceptionally(realCause);
                     } else {
                         getAvailableBrokersAsync.complete(Sets.newHashSet(listLocks));
@@ -325,7 +324,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         try {
             dynamicConfigurationCache.readModifyUpdateOrCreate(path, __ -> settings).join();
         } catch (CompletionException e) {
-            log.warn("Got exception when writing to metadata store [{}]:", path, MetadataStoreException.unwrap(e));
+            log.warn().attr("path", path).exception(MetadataStoreException.unwrap(e))
+                    .log("Got exception when writing to metadata store");
         }
     }
 
@@ -333,7 +333,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         try {
             return dynamicConfigurationCache.get(path).join().map(c -> c.get(settingName)).orElse(defaultValue);
         } catch (Exception e) {
-            log.warn("Got exception when reading path from metadata store [{}]:", path, e);
+            log.warn().attr("path", path).exception(e).log("Got exception when reading path from metadata store");
             return defaultValue;
         }
     }
@@ -343,7 +343,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             return Double.parseDouble(getDynamicConfigurationFromStore(path, settingName,
                     String.valueOf(defaultValue)));
         } catch (Exception e) {
-            log.warn("Got exception when parsing configuration from path [{}]:", path, e);
+            log.warn().attr("path", path).exception(e).log("Got exception when parsing configuration from path");
         }
         return defaultValue;
     }
@@ -353,7 +353,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             return Boolean.parseBoolean(getDynamicConfigurationFromStore(path, settingName,
                     String.valueOf(defaultValue)));
         } catch (Exception e) {
-            log.warn("Got exception when parsing configuration from path [{}]:", path, e);
+            log.warn().attr("path", path).exception(e).log("Got exception when parsing configuration from path");
         }
         return defaultValue;
     }
@@ -650,7 +650,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     private synchronized void doLoadRanking() {
         ResourceUnitRanking.setCpuUsageByMsgRate(this.realtimeCpuLoadFactor);
         String strategy = this.getLoadBalancerPlacementStrategy();
-        log.info("doLoadRanking - load balancing strategy: {}", strategy);
+        log.info().attr("strategy", strategy).log("doLoadRanking - load balancing strategy");
         if (!currentLoadReports.isEmpty()) {
 
             Map<Long, Set<ResourceUnit>> newSortedRankings = new TreeMap<>();
@@ -692,9 +692,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
 
                 newSortedRankings.computeIfAbsent(finalRank, k -> new HashSet<>())
                         .add(entry.getKey());
-                if (log.isDebugEnabled()) {
-                    log.debug("Added Resource Unit [{}] with Rank [{}]", entry.getKey().getResourceId(), finalRank);
-                }
+                log.debug().attr("resourceId", entry.getKey().getResourceId()).attr("finalRank", finalRank)
+                        .log("Added Resource Unit with Rank");
 
                 // update metrics
                 if (resourceUnit.getResourceId().equals(pulsar.getBrokerId())) {
@@ -705,8 +704,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             this.sortedRankings.set(newSortedRankings);
             this.resourceUnitRankings = newResourceUnitRankings;
         } else {
-            log.info("Leader broker[{}] No ResourceUnits to rank this run, Using Old Ranking",
-                    pulsar.getBrokerId());
+            log.info().attr("broker", pulsar.getBrokerId())
+                    .log("Leader broker has no ResourceUnits to rank this run, Using Old Ranking");
         }
     }
 
@@ -842,7 +841,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             this.brokerRotationCursor = (this.brokerRotationCursor + 1) % 1000000;
             ResourceUnitRanking ranking = resourceUnitRankings.get(selectedRU);
             String loadPercentageDesc = ranking.getEstimatedLoadPercentageString();
-            log.info("Assign {} to {} with ({}).", serviceUnitId, selectedRU.getResourceId(), loadPercentageDesc);
+            log.info().attr("serviceUnit", serviceUnitId).attr("broker", selectedRU.getResourceId())
+                    .attr("loadPercentageDesc", loadPercentageDesc).log("Assign service unit to broker");
             if (!ranking.isServiceUnitPreAllocated(serviceUnitId)) {
                 final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(serviceUnitId);
                 final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(serviceUnitId);
@@ -872,7 +872,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache,
                         availableBrokersCache, brokerTopicLoadingPredicate);
             } catch (Exception e) {
-                log.warn("Error when trying to apply policies", e);
+                log.warn().exception(e).log("Error when trying to apply policies");
                 for (final Map.Entry<Long, Set<ResourceUnit>> entry : availableBrokers.entrySet()) {
                     result.putAll(entry.getKey(), entry.getValue());
                 }
@@ -919,7 +919,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 ResourceUnit resourceUnit = new SimpleResourceUnit(broker, new PulsarResourceDescription());
                 availableBrokers.computeIfAbsent(0L, key -> new TreeSet<>()).add(resourceUnit);
             }
-            log.info("Choosing at random from broker list: [{}]", availableBrokers.values());
+            log.info().attr("brokers", availableBrokers.values()).log("Choosing at random from broker list");
         }
         return availableBrokers;
     }
@@ -949,7 +949,9 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 }
             }
         } catch (Exception e) {
-            log.warn("Error during attempt to remove inactive brokers while searching for least active broker", e);
+            log.warn()
+                    .exception(e)
+                    .log("Error during attempt to remove inactive brokers while searching for least active broker");
         }
 
         if (finalCandidates.size() > 0) {
@@ -959,11 +961,12 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             } else {
                 selectedBroker = placementStrategy.findBrokerForPlacement(finalCandidates);
             }
-            log.info("Selected : [{}] for ServiceUnit : [{}]", selectedBroker.getResourceId(), serviceUnit.toString());
+            log.info().attr("broker", selectedBroker.getResourceId()).attr("serviceUnit", serviceUnit.toString())
+                    .log("Selected broker for ServiceUnit");
             return selectedBroker;
         } else {
             // No available broker found
-            log.warn("No broker available to acquire service unit: [{}]", serviceUnit);
+            log.warn().attr("serviceUnit", serviceUnit).log("No broker available to acquire service unit");
             return null;
         }
     }
@@ -971,10 +974,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     @Override
     public void accept(Notification n) {
         if (n.getPath().startsWith(LOADBALANCE_BROKERS_ROOT)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Received updated load report from broker node - [{}], scheduling re-ranking of brokers.",
-                        n.getPath());
-            }
+            log.debug().attr("path", n.getPath())
+                    .log("Received updated load report from broker node, scheduling re-ranking of brokers");
             updateRankingHandle = scheduler.submit(this::updateRanking);
         }
     }
@@ -995,14 +996,17 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                         ResourceUnit ru = new SimpleResourceUnit(lr.getName(), fromLoadReport(lr));
                         this.currentLoadReports.put(ru, lr);
                     } catch (Exception e) {
-                        log.warn("Error reading load report from Cache for broker - [{}], [{}]", broker, e);
+                        log.warn().attr("broker", broker).exceptionMessage(e)
+                                .log("Error reading load report from cache");
                     }
                 }
                 updateRealtimeResourceQuota();
                 doLoadRanking();
             }
         } catch (Exception e) {
-            log.warn("Error reading active brokers list from zookeeper while re-ranking load reports", e);
+            log.warn()
+                    .exception(e)
+                    .log("Error reading active brokers list from zookeeper while re-ranking load reports");
         }
     }
 
@@ -1128,7 +1132,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 loadReport.setPreAllocatedMsgRateOut(preAllocatedQuota.getMsgRateOut());
                 return loadReport;
             } catch (Exception e) {
-                log.error("[{}] Failed to generate LoadReport for broker, reason [{}]", e.getMessage(), e);
+                log.error().exceptionMessage(e)
+                        .log("Failed to generate LoadReport for broker");
                 throw e;
             }
         }
@@ -1209,10 +1214,13 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
 
                     if (resourceChange > pulsar.getConfiguration().getLoadBalancerReportUpdateThresholdPercentage()) {
                         needUpdate = true;
-                        log.info("LoadReport update triggered by change on resource usage, detal ({}).", String.format(
-                                "cpu: %.1f%%, mem: %.1f%%, directMemory: %.1f%%,"
-                                        + " bandwidthIn: %.1f%%, bandwidthOut: %.1f%%)",
-                                cpuChange, memChange, directMemChange, bandwidthInChange, bandwidthOutChange));
+                        log.info()
+                                .attr("value", String.format(
+                                        "cpu: %.1f%%, mem: %.1f%%, directMemory: %.1f%%,"
+                                                + " bandwidthIn: %.1f%%, bandwidthOut: %.1f%%)",
+                                        cpuChange, memChange, directMemChange,
+                                        bandwidthInChange, bandwidthOutChange))
+                                .log("LoadReport update triggered by change on resource usage");
                     }
                 }
             }
@@ -1273,23 +1281,28 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
             try {
                 if (unloadedHotNamespaceCache.getIfPresent(bundleName) == null) {
                     if (LoadManagerShared.isLoadSheddingEnabled(pulsar)) {
-                        log.info("Unloading namespace {} from overloaded broker {}", bundleName, brokerName);
+                        log.info().attr("bundle", bundleName).attr("broker", brokerName)
+                                .log("Unloading namespace from overloaded broker");
                         pulsar.getAdminClient().namespaces().unloadNamespaceBundle(
                                 LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
                                 LoadManagerShared.getBundleRangeFromBundleName(bundleName));
-                        log.info("Successfully unloaded namespace {} from broker {}", bundleName, brokerName);
+                        log.info().attr("bundle", bundleName).attr("broker", brokerName)
+                                .log("Successfully unloaded namespace from broker");
                     } else {
-                        log.info("DRY RUN: Unload in Load Shedding is disabled. Namespace {} would have been "
-                                + "unloaded from overloaded broker {} otherwise.", bundleName, brokerName);
+                        log.info().attr("bundle", bundleName).attr("broker", brokerName)
+                                .log("DRY RUN: Unload in Load Shedding is disabled. Namespace would have been "
+                                        + "unloaded from overloaded broker otherwise");
                     }
                     unloadedHotNamespaceCache.put(bundleName, System.currentTimeMillis());
                 } else {
                     // we can't unload this namespace so move to next one
-                    log.info("Can't unload Namespace {} because it was unloaded last at {} and unload interval has "
-                            + "not exceeded.", bundleName, LocalDateTime.now());
+                    log.info().attr("bundle", bundleName).attr("now", LocalDateTime.now())
+                            .log("Can't unload Namespace because it was unloaded recently and unload interval has "
+                                    + "not exceeded");
                 }
             } catch (Exception e) {
-                log.warn("ERROR failed to unload the bundle {} from overloaded broker {}", bundleName, brokerName, e);
+                log.warn().attr("bundle", bundleName).attr("broker", brokerName).exception(e)
+                        .log("ERROR failed to unload the bundle from overloaded broker");
             }
         }
     }
@@ -1298,8 +1311,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
     public void doLoadShedding() {
         long overloadThreshold = this.getLoadBalancerBrokerOverloadedThresholdPercentage();
         long comfortLoadLevel = this.getLoadBalancerBrokerComfortLoadThresholdPercentage();
-        log.info("Running load shedding task as leader broker, overload threshold {}, comfort loadlevel {}",
-                overloadThreshold, comfortLoadLevel);
+        log.info().attr("threshold", overloadThreshold).attr("loadLevel", comfortLoadLevel)
+                .log("Running load shedding task as leader broker");
         // overloadedRU --> bundleName
         Map<ResourceUnit, String> namespaceBundlesToBeUnloaded = new HashMap<>();
         synchronized (currentLoadReports) {
@@ -1310,7 +1323,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     ResourceType bottleneckResourceType = lr.getBottleneckResourceType();
                     Map<String, NamespaceBundleStats> bundleStats = lr.getSortedBundleStats(bottleneckResourceType);
                     if (bundleStats == null) {
-                        log.warn("Null bundle stats for bundle {}", lr.getName());
+                        log.warn().attr("bundle", lr.getName()).log("Null bundle stats for bundle");
                         continue;
 
                     }
@@ -1318,8 +1331,8 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     if (bundleStats.size() == 1) {
                         // can't unload one namespace, just issue a warning message
                         String bundleName = lr.getBundleStats().keySet().iterator().next();
-                        log.warn(
-                                "HIGH USAGE WARNING : Sole namespace bundle {} is overloading broker {}. "
+                        log.warnf(
+                                "HIGH USAGE WARNING : Sole namespace bundle %s is overloading broker %s. "
                                         + "No Load Shedding will be done on this broker",
                                 bundleName, overloadedRU.getResourceId());
                         continue;
@@ -1329,16 +1342,17 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                         NamespaceBundleStats stats = bundleStat.getValue();
                         // We need at least one underloaded RU from list of candidates that can host this bundle
                         if (isBrokerAvailableForRebalancing(bundleStat.getKey(), comfortLoadLevel)) {
-                            log.info(
-                                    "Namespace bundle {} will be unloaded from overloaded broker {},"
-                                            + " bundle stats (topics: {}, producers {}, "
-                                            + "consumers {}, bandwidthIn {}, bandwidthOut {})",
+                            log.infof(
+                                    "Namespace bundle %s will be unloaded from overloaded broker %s,"
+                                            + " bundle stats (topics: %s, producers %s, "
+                                            + "consumers %s, bandwidthIn %s, bandwidthOut %s)",
                                     bundleName, overloadedRU.getResourceId(), stats.topics, stats.producerCount,
                                     stats.consumerCount, stats.msgThroughputIn, stats.msgThroughputOut);
                             namespaceBundlesToBeUnloaded.put(overloadedRU, bundleName);
                         } else {
-                            log.info("Unable to shed load from broker {}, no brokers with enough capacity available "
-                                    + "for re-balancing {}", overloadedRU.getResourceId(), bundleName);
+                            log.info().attr("broker", overloadedRU.getResourceId()).attr("bundle", bundleName)
+                                    .log("Unable to shed load from broker , no brokers with enough capacity available "
+                                            + "for re-balancing");
                         }
                         break;
                     }
@@ -1360,9 +1374,9 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
         long maxBundleBandwidth =
                 pulsar.getConfiguration().getLoadBalancerNamespaceBundleMaxBandwidthMbytes() * MBytes;
 
-        log.info(
-                "Running namespace bundle split with thresholds: topics {}, sessions {},"
-                        + " msgRate {}, bandwidth {}, maxBundles {}",
+        log.infof(
+                "Running namespace bundle split with thresholds: topics %s, sessions %s,"
+                        + " msgRate %s, bandwidth %s, maxBundles %s",
                 maxBundleTopics, maxBundleSessions, maxBundleMsgRate, maxBundleBandwidth, maxBundleCount);
         if (this.lastLoadReport == null || this.lastLoadReport.getBundleStats() == null) {
             return;
@@ -1383,14 +1397,15 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                     && totalSessions > maxBundleSessions) || totalMsgRate > maxBundleMsgRate
                     || totalBandwidth > maxBundleBandwidth) {
                 if (stats.topics <= 1) {
-                    log.info("Unable to split hot namespace bundle {} since there is only one topic.", bundleName);
+                    log.info().attr("bundle", bundleName)
+                            .log("Unable to split hot namespace bundle since there is only one topic");
                 } else {
                     NamespaceName namespaceName = NamespaceName
                             .get(LoadManagerShared.getNamespaceNameFromBundleName(bundleName));
                     int numBundles = pulsar.getNamespaceService().getBundleCount(namespaceName);
                     if (numBundles >= maxBundleCount) {
-                        log.info("Unable to split hot namespace bundle {} since the namespace has too many bundles.",
-                                bundleName);
+                        log.info().attr("bundle", bundleName)
+                                .log("Unable to split hot namespace bundle since the namespace has too many bundles");
                     } else {
                         needSplit = true;
                     }
@@ -1399,15 +1414,15 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
 
             if (needSplit) {
                 if (this.getLoadBalancerAutoBundleSplitEnabled()) {
-                    log.info(
-                            "Will split hot namespace bundle {}, topics {}, producers+consumers {},"
-                                    + " msgRate in+out {}, bandwidth in+out {}",
+                    log.infof(
+                            "Will split hot namespace bundle %s, topics %s, producers+consumers %s,"
+                                    + " msgRate in+out %s, bandwidth in+out %s",
                             bundleName, stats.topics, totalSessions, totalMsgRate, totalBandwidth);
                     bundlesToBeSplit.add(bundleName);
                 } else {
-                    log.info(
-                            "DRY RUN - split hot namespace bundle {}, topics {}, producers+consumers {},"
-                                    + " msgRate in+out {}, bandwidth in+out {}",
+                    log.infof(
+                            "DRY RUN - split hot namespace bundle %s, topics %s, producers+consumers %s,"
+                                    + " msgRate in+out %s, bandwidth in+out %s",
                             bundleName, stats.topics, totalSessions, totalMsgRate, totalBandwidth);
                 }
             }
@@ -1420,9 +1435,9 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                         LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
                         LoadManagerShared.getBundleRangeFromBundleName(bundleName),
                         pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled(), null);
-                    log.info("Successfully split namespace bundle {}", bundleName);
+                    log.info().attr("bundle", bundleName).log("Successfully split namespace bundle");
                 } catch (Exception e) {
-                    log.error("Failed to split namespace bundle {}", bundleName, e);
+                    log.error().attr("bundle", bundleName).exception(e).log("Failed to split namespace bundle");
                 }
             }
             this.setLoadReportForceUpdateFlag();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.LoadReport;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
@@ -28,11 +29,9 @@ import org.apache.pulsar.broker.loadbalance.ServiceUnit;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.NamespaceIsolationPolicy;
 import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicies;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class SimpleResourceAllocationPolicies {
-    private static final Logger LOG = LoggerFactory.getLogger(SimpleResourceAllocationPolicies.class);
     private final PulsarService pulsar;
 
     public SimpleResourceAllocationPolicies(PulsarService pulsar) {
@@ -49,7 +48,7 @@ public class SimpleResourceAllocationPolicies {
             return pulsar.getPulsarResources().getNamespaceResources().getIsolationPolicies()
                     .getIsolationDataPolicies(clusterName);
         } catch (Exception e) {
-            LOG.warn("GetIsolationPolicies: Unable to get the namespaceIsolationPolicies", e);
+            log.warn().exception(e).log("GetIsolationPolicies: Unable to get the namespaceIsolationPolicies");
             return Optional.empty();
         }
     }
@@ -75,7 +74,7 @@ public class SimpleResourceAllocationPolicies {
             return policies.filter(isolationPolicies -> isolationPolicies.getPolicyByNamespace(namespace) != null)
                     .isPresent();
         } catch (Exception e) {
-            LOG.warn("IsIsolationPoliciesPresent: Unable to get the namespaceIsolationPolicies", e);
+            log.warn().exception(e).log("IsIsolationPoliciesPresent: Unable to get the namespaceIsolationPolicies");
             return false;
         }
     }
@@ -87,7 +86,7 @@ public class SimpleResourceAllocationPolicies {
             return policies.map(isolationPolicies -> isolationPolicies.getPolicyByNamespace(namespace));
 
         } catch (Exception e) {
-            LOG.warn("Unable to get the namespaceIsolationPolicies", e);
+            log.warn().exception(e).log("Unable to get the namespaceIsolationPolicies");
             return Optional.empty();
         }
     }
@@ -109,7 +108,7 @@ public class SimpleResourceAllocationPolicies {
             return policies.map(isolationPolicies -> isolationPolicies.isSharedBroker(broker)).orElse(true);
 
         } catch (Exception e) {
-            LOG.warn("isPrimaryForAnyNamespace", e);
+            log.warn().exception(e).log("isPrimaryForAnyNamespace");
         }
         return false;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Multimap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import lombok.CustomLog;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,8 +34,6 @@ import org.apache.pulsar.policies.data.loadbalancer.BrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Load shedding strategy that unloads any broker that exceeds the average resource utilization of all brokers by a
@@ -49,8 +48,8 @@ import org.slf4j.LoggerFactory;
  * enough bundles to bring the unloaded broker 5% below the current average broker usage. Note that recently
  * unloaded bundles are not unloaded again.
  */
+@CustomLog
 public class ThresholdShedder implements LoadSheddingStrategy {
-    private static final Logger log = LoggerFactory.getLogger(ThresholdShedder.class);
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
     private static final double ADDITIONAL_THRESHOLD_PERCENT_MARGIN = 0.05;
 
@@ -78,10 +77,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             final LocalBrokerData localData = brokerData.getLocalData();
             final double currentUsage = brokerAvgResourceUsage.getOrDefault(broker, 0.0);
             if (currentUsage < avgUsage + threshold) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] broker is not overloaded, ignoring at this point ({})", broker,
-                            localData.printResourceUsage());
-                }
+                log.debug().attr("broker", broker).attr("resourceUsage", localData.printResourceUsage())
+                        .log("Broker is not overloaded, ignoring at this point");
                 return;
             }
 
@@ -91,31 +88,32 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             double minimumThroughputToOffload = brokerCurrentThroughput * percentOfTrafficToOffload;
 
             if (minimumThroughputToOffload < minThroughputThreshold) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] broker is planning to shed throughput {} MByte/s less than "
-                                    + "minimumThroughputThreshold {} MByte/s, skipping bundle unload ({})",
-                            broker, minimumThroughputToOffload / MB, minThroughputThreshold / MB,
-                            localData.printResourceUsage());
-                }
+                log.debug().attr("broker", broker)
+                        .attr("throughputMiB", minimumThroughputToOffload / MB)
+                        .attr("minThroughputThresholdMiB", minThroughputThreshold / MB)
+                        .attr("resourceUsage", localData.printResourceUsage())
+                        .log("Broker is planning to shed less than minimumThroughputThreshold, "
+                                + "skipping bundle unload");
                 return;
             }
 
-            log.info(
-                    "Attempting to shed load on {}, which has max resource usage above avgUsage and threshold {}%"
-                            + " > {}% + {}% -- Offloading at least {} MByte/s of traffic,"
-                                    + " left throughput {} MByte/s ({})",
+            log.infof(
+                    "Attempting to shed load on %s, which has max resource usage above avgUsage and threshold %s%"
+                            + " > %s% + %s% -- Offloading at least %s MByte/s of traffic,"
+                                    + " left throughput %s MByte/s (%s)",
                     broker, 100 * currentUsage, 100 * avgUsage, 100 * threshold, minimumThroughputToOffload / MB,
                     (brokerCurrentThroughput - minimumThroughputToOffload) / MB, localData.printResourceUsage());
 
             if (localData.getBundles().size() > 1) {
                 filterAndSelectBundle(loadData, recentlyUnloadedBundles, broker, localData, minimumThroughputToOffload);
             } else if (localData.getBundles().size() == 1) {
-                log.warn(
-                        "HIGH USAGE WARNING : Sole namespace bundle {} is overloading broker {}. "
-                                + "No Load Shedding will be done on this broker",
-                        localData.getBundles().iterator().next(), broker);
+                log.warn()
+                        .attr("bundle", localData.getBundles().iterator().next())
+                        .attr("broker", broker)
+                        .log("HIGH USAGE WARNING: Sole namespace bundle is overloading broker. "
+                                + "No Load Shedding will be done on this broker");
             } else {
-                log.warn("Broker {} is overloaded despite having no bundles", broker);
+                log.warn().attr("broker", broker).log("Broker is overloaded despite having no bundles");
             }
         });
         if (selectedBundlesCache.isEmpty() && conf.isLowerBoundarySheddingEnabled()) {
@@ -189,10 +187,10 @@ public class ThresholdShedder implements LoadSheddingStrategy {
         boolean hasBrokerBelowLowerBound = result.getLeft();
         String maxUsageBroker = result.getRight();
         if (!hasBrokerBelowLowerBound) {
-            log.info("No broker is below the lower bound, threshold is {}, "
-                            + "avgUsage usage is {}, max usage of Broker {} is {}",
-                    threshold, avgUsage, maxUsageBroker,
-                    brokerAvgResourceUsage.getOrDefault(maxUsageBroker, 0.0));
+            log.info().attr("threshold", threshold).attr("avgUsage", avgUsage)
+                    .attr("maxUsageBroker", maxUsageBroker)
+                    .attr("maxUsage", brokerAvgResourceUsage.getOrDefault(maxUsageBroker, 0.0))
+                    .log("No broker is below the lower bound");
             return;
         }
         BrokerData brokerData = loadData.getBrokerData().get(maxUsageBroker);
@@ -205,9 +203,10 @@ public class ThresholdShedder implements LoadSheddingStrategy {
         double minimumThroughputToOffload = brokerCurrentThroughput * threshold * LOWER_BOUNDARY_THRESHOLD_MARGIN;
         double minThroughputThreshold = conf.getLoadBalancerBundleUnloadMinThroughputThreshold() * MB;
         if (minThroughputThreshold > minimumThroughputToOffload) {
-            log.info("broker {} in lower boundary shedding is planning to shed throughput {} MByte/s less than "
-                            + "minimumThroughputThreshold {} MByte/s, skipping bundle unload.",
-                    maxUsageBroker, minimumThroughputToOffload / MB, minThroughputThreshold / MB);
+            log.info().attr("broker", maxUsageBroker).attr("throughput", minimumThroughputToOffload / MB)
+                    .attr("value", minThroughputThreshold / MB)
+                    .log("broker in lower boundary shedding is planning to shed throughput MByte/s less than "
+                            + "minimumThroughputThreshold MByte/s, skipping bundle unload");
             return;
         }
         filterAndSelectBundle(loadData, loadData.getRecentlyUnloadedBundles(), maxUsageBroker, localData,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ThresholdShedder.java
@@ -98,8 +98,8 @@ public class ThresholdShedder implements LoadSheddingStrategy {
             }
 
             log.infof(
-                    "Attempting to shed load on %s, which has max resource usage above avgUsage and threshold %s%"
-                            + " > %s% + %s% -- Offloading at least %s MByte/s of traffic,"
+                    "Attempting to shed load on %s, which has max resource usage above avgUsage and threshold %s%%"
+                            + " > %s%% + %s%% -- Offloading at least %s MByte/s of traffic,"
                                     + " left throughput %s MByte/s (%s)",
                     broker, 100 * currentUsage, 100 * avgUsage, 100 * threshold, minimumThroughputToOffload / MB,
                     (brokerCurrentThroughput - minimumThroughputToOffload) / MB, localData.printResourceUsage());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/UniformLoadShedder.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.mutable.MutableDouble;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -42,7 +42,7 @@ import org.apache.pulsar.policies.data.loadbalancer.TimeAverageMessageData;
  * bundles which can be unloaded to distribute traffic evenly across all brokers.
  *
  */
-@Slf4j
+@CustomLog
 public class UniformLoadShedder implements LoadSheddingStrategy {
     private final Multimap<String, String> selectedBundlesCache = ArrayListMultimap.create();
     private static final double EPS = 1e-6;
@@ -126,13 +126,11 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                     (int) ((maxThroughput.doubleValue() - minThroughput.doubleValue())
                             * conf.getMaxUnloadPercentage()));
             if (isMsgRateThresholdExceeded) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Found bundles for uniform load balancing. "
-                                    + "msgRate overloaded broker: {} with msgRate: {}, "
-                                    + "msgRate underloaded broker: {} with msgRate: {}",
-                            msgRateOverloadedBroker.get(), maxMsgRate.doubleValue(),
-                            msgRateUnderloadedBroker.get(), minMsgRate.doubleValue());
-                }
+                log.debugf("Found bundles for uniform load balancing. "
+                                + "msgRate overloaded broker: %s with msgRate: %s, "
+                                + "msgRate underloaded broker: %s with msgRate: %s",
+                        msgRateOverloadedBroker.get(), maxMsgRate.doubleValue(),
+                        msgRateUnderloadedBroker.get(), minMsgRate.doubleValue());
                 LocalBrokerData overloadedBrokerData =
                         brokersData.get(msgRateOverloadedBroker.get()).getLocalData();
                 if (overloadedBrokerData.getBundles().size() > 1
@@ -155,20 +153,18 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                                 String bundle = e.getLeft();
                                 double bundleMsgRate = e.getRight();
                                 if (bundleMsgRate <= msgRateRequiredFromUnloadedBundles.intValue()) {
-                                    log.info("Found bundle to unload with msgRate {}", bundleMsgRate);
+                                    log.info().attr("bundle", bundleMsgRate).log("Found bundle to unload with msgRate");
                                     msgRateRequiredFromUnloadedBundles.add(-bundleMsgRate);
                                     selectedBundlesCache.put(msgRateOverloadedBroker.get(), bundle);
                                 }
                             });
                 }
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Found bundles for uniform load balancing. "
-                                    + "msgThroughput overloaded broker: {} with msgThroughput {}, "
-                                    + "msgThroughput underloaded broker: {} with msgThroughput: {}",
-                            msgThroughputOverloadedBroker.get(), maxThroughput.doubleValue(),
-                            msgThroughputUnderloadedBroker.get(), minThroughput.doubleValue());
-                }
+                log.debugf("Found bundles for uniform load balancing. "
+                                + "msgThroughput overloaded broker: %s with msgThroughput %s, "
+                                + "msgThroughput underloaded broker: %s with msgThroughput: %s",
+                        msgThroughputOverloadedBroker.get(), maxThroughput.doubleValue(),
+                        msgThroughputUnderloadedBroker.get(), minThroughput.doubleValue());
                 LocalBrokerData overloadedBrokerData =
                         brokersData.get(msgThroughputOverloadedBroker.get()).getLocalData();
                 if (overloadedBrokerData.getBundles().size() > 1
@@ -193,7 +189,8 @@ public class UniformLoadShedder implements LoadSheddingStrategy {
                                 String bundle = e.getLeft();
                                 double msgThroughput = e.getRight();
                                 if (msgThroughput <= msgThroughputRequiredFromUnloadedBundles.intValue()) {
-                                    log.info("Found bundle to unload with msgThroughput {}", msgThroughput);
+                                    log.info().attr("msgThroughput", msgThroughput)
+                                            .log("Found bundle to unload with msgThroughput");
                                     msgThroughputRequiredFromUnloadedBundles.add(-msgThroughput);
                                     selectedBundlesCache.put(msgThroughputOverloadedBroker.get(), bundle);
                                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/WRRPlacementStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/WRRPlacementStrategy.java
@@ -21,17 +21,16 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import com.google.common.collect.Multimap;
 import java.util.Map;
 import java.util.Random;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.loadbalance.PlacementStrategy;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  * This class implements PlacementStrategy based on Weighted Round Robin Algorithm.
  */
+@CustomLog
 public class WRRPlacementStrategy implements PlacementStrategy {
-    private static final Logger log = LoggerFactory.getLogger(WRRPlacementStrategy.class);
     private final Random rand = new Random();
 
     /**
@@ -59,7 +58,7 @@ public class WRRPlacementStrategy implements PlacementStrategy {
         if (finalCandidates.isEmpty()) {
             return null;
         }
-        log.debug("Total Final Candidates selected - [{}]", finalCandidates.size());
+        log.debug().attr("count", finalCandidates.size()).log("Total final candidates selected");
         int totalAvailability = 0;
         for (Map.Entry<Long, ResourceUnit> candidateOwner : finalCandidates.entries()) {
             totalAvailability += candidateOwner.getKey().intValue();
@@ -75,13 +74,14 @@ public class WRRPlacementStrategy implements PlacementStrategy {
                     .orElse(null);
         }
         int weightedSelector = rand.nextInt(totalAvailability);
-        log.debug("Generated Weighted Selector Number - [{}] ", weightedSelector);
+        log.debug().attr("weightedSelector", weightedSelector).log("Generated weighted selector number");
         long weightRangeSoFar = 0;
         for (Map.Entry<Long, ResourceUnit> candidateOwner : finalCandidates.entries()) {
             weightRangeSoFar += candidateOwner.getKey();
             if (weightedSelector < weightRangeSoFar) {
                 selectedRU = candidateOwner.getValue();
-                log.debug(" Weighted Round Robin Selected RU - [{}]", candidateOwner.getValue().getResourceId());
+                log.debug().attr("resourceId", candidateOwner.getValue().getResourceId())
+                        .log("Weighted round robin selected RU");
                 break;
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -50,17 +50,18 @@ import org.apache.pulsar.common.policies.data.TopicOperation;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TopicLookupBase extends PulsarWebResource {
+
+    private static final io.github.merlimat.slog.Logger LOG =
+            io.github.merlimat.slog.Logger.get(TopicLookupBase.class);
 
     private static final String LOOKUP_PATH = "/lookup/v2/topic/";
 
     protected CompletableFuture<LookupData> internalLookupTopicAsync(final TopicName topicName, boolean authoritative,
                                                                      String listenerName) {
         if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
-            log.warn("No broker was found available for topic {}", topicName);
+            log.warn().attr("topic", topicName).log("No broker was found available for topic");
             return FutureUtil.failedFuture(new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
         }
         return validateGlobalNamespaceOwnershipAsync(topicName.getNamespaceObject())
@@ -98,7 +99,7 @@ public class TopicLookupBase extends PulsarWebResource {
 
                     return lookupFuture.thenApply(optionalResult -> {
                         if (optionalResult == null || !optionalResult.isPresent()) {
-                            log.warn("No broker was found available for topic {}", topicName);
+                            log.warn().attr("topic", topicName).log("No broker was found available for topic");
                             throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
                         }
 
@@ -122,20 +123,26 @@ public class TopicLookupBase extends PulsarWebResource {
                                 path = listenerName == null ? path : path + "&listenerName=" + listenerName;
                                 redirect = new URI(path);
                             } catch (URISyntaxException e) {
-                                log.error("Error in preparing redirect url for {}: {}", topicName, e.getMessage(), e);
+                                log.error()
+                                        .attr("topic", topicName)
+                                        .exception(e)
+                                        .log("Error in preparing redirect url");
                                 throw new RestException(Response.Status.PRECONDITION_FAILED, e.getMessage());
                             }
-                            if (log.isDebugEnabled()) {
-                                log.debug("Redirect lookup for topic {} to {}", topicName, redirect);
-                            }
-                            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                                log.debug()
+                                        .attr("topic", topicName)
+                                        .attr("redirect", redirect)
+                                        .log("Redirect lookup for topic");
+                                throw new WebApplicationException(
+                                        Response.temporaryRedirect(redirect).build());
                         } else {
                             // Found broker owning the topic
-                            if (log.isDebugEnabled()) {
-                                log.debug("Lookup succeeded for topic {} -- broker: {}", topicName,
-                                        result.getLookupData());
-                            }
-                            pulsar().getBrokerService().getLookupRequestSemaphore().release();
+                                log.debug()
+                                        .attr("topic", topicName)
+                                        .attr("broker", result.getLookupData())
+                                        .log("Lookup succeeded for topic - broker");
+                                                        pulsar().getBrokerService().getLookupRequestSemaphore()
+                                                                .release();
                             return result.getLookupData();
                         }
                     });
@@ -151,7 +158,10 @@ public class TopicLookupBase extends PulsarWebResource {
             NamespaceBundle bundle = pulsar().getNamespaceService().getBundle(topicName);
             return bundle.getBundleRange();
         } catch (Exception e) {
-            log.error("[{}] Failed to get namespace bundle for {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to get namespace bundle");
             throw new RestException(e);
         }
     }
@@ -238,11 +248,17 @@ public class TopicLookupBase extends PulsarWebResource {
                 .exceptionally(e -> {
                     Throwable throwable = FutureUtil.unwrapCompletionException(e);
                     if (throwable instanceof RestException) {
-                        log.warn("Failed to authorized {} on topic {}", clientAppId, topicName);
+                        LOG.warn()
+                                .attr("authorized", clientAppId)
+                                .attr("topic", topicName)
+                                .log("Failed to authorized on topic");
                         validationFuture.complete(newLookupErrorResponse(ServerError.AuthorizationError,
                                 throwable.getMessage(), requestId));
                     } else {
-                        log.warn("Unknown error while authorizing {} on topic {}", clientAppId, topicName);
+                        LOG.warn()
+                                .attr("authorizing", clientAppId)
+                                .attr("topic", topicName)
+                                .log("Unknown error while authorizing on topic");
                         validationFuture.completeExceptionally(throwable);
                     }
                     return null;
@@ -261,12 +277,11 @@ public class TopicLookupBase extends PulsarWebResource {
                         .build();
                 pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topicName, options)
                         .thenAccept(lookupResult -> {
-
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Lookup result {}", topicName.toString(), lookupResult);
-                            }
-
-                            if (!lookupResult.isPresent()) {
+                                LOG.debug()
+                                        .attr("toString", topicName.toString())
+                                        .attr("result", lookupResult)
+                                        .log("Lookup result");
+                                                        if (!lookupResult.isPresent()) {
                                 lookupfuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady,
                                         "No broker was available to own " + topicName, requestId));
                                 return;
@@ -312,11 +327,17 @@ public class TopicLookupBase extends PulsarWebResource {
         }
         boolean tlsEnabled = pulsar.getConfig().isBrokerClientTlsEnabled();
         if (!tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrl())) {
-            log.warn("[{}] Unexpected lookup result: brokerUrl is required when TLS isn't enabled. options: {},"
-                + " result {}", topic, options, lookupData);
+            LOG.warn()
+                    .attr("topic", topic)
+                    .attr("options", options)
+                    .attr("result", lookupData)
+                    .log("Unexpected lookup result: brokerUrl is required when TLS isn't enabled");
         } else if (tlsEnabled && StringUtils.isBlank(lookupData.getBrokerUrlTls())) {
-            log.warn("[{}] Unexpected lookup result: brokerUrlTls is required when TLS is enabled. options: {},"
-                    + " result {}", topic, options, lookupData);
+            LOG.warn()
+                    .attr("topic", topic)
+                    .attr("options", options)
+                    .attr("result", lookupData)
+                    .log("Unexpected lookup result: brokerUrlTls is required when TLS is enabled");
         }
     }
 
@@ -329,15 +350,24 @@ public class TopicLookupBase extends PulsarWebResource {
         }
         if (unwrapEx instanceof IllegalStateException) {
             // Current broker still hold the bundle's lock, but the bundle is being unloading.
-            log.info("Failed to lookup {} for topic {} with error {}", clientAppId, topicName, errorMsg);
+            LOG.info()
+                    .attr("topic", topicName)
+                    .attr("errorMessage", errorMsg)
+                    .log("Failed to lookup topic");
             lookupFuture.complete(newLookupErrorResponse(ServerError.MetadataError, errorMsg, requestId));
         } else if (unwrapEx instanceof MetadataStoreException) {
             // Load bundle ownership or acquire lock failed.
-            // Differ with "IllegalStateException", print warning log.
-            log.warn("Failed to lookup {} for topic {} with error {}", clientAppId, topicName, errorMsg);
+            // Differ with "IllegalStateException", print warning LOG.
+            LOG.warn()
+                    .attr("topic", topicName)
+                    .attr("errorMessage", errorMsg)
+                    .log("Failed to lookup topic");
             lookupFuture.complete(newLookupErrorResponse(ServerError.MetadataError, errorMsg, requestId));
         } else {
-            log.warn("Failed to lookup {} for topic {} with error {}", clientAppId, topicName, errorMsg);
+            LOG.warn()
+                    .attr("topic", topicName)
+                    .attr("errorMessage", errorMsg)
+                    .log("Failed to lookup topic");
             lookupFuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady, errorMsg, requestId));
         }
     }
@@ -359,7 +389,10 @@ public class TopicLookupBase extends PulsarWebResource {
                 URI host = URI.create(lookupData.getBrokerUrl());
                 return InetAddress.getByName(host.getHost()).isLoopbackAddress();
             } catch (Exception e) {
-                log.info("Failed to resolve advertised address {}: {}", lookupData.getBrokerUrl(), e.getMessage());
+                LOG.info()
+                        .attr("address", lookupData.getBrokerUrl())
+                        .exceptionMessage(e)
+                        .log("Failed to resolve advertised address");
                 return false;
             }
         }
@@ -368,12 +401,13 @@ public class TopicLookupBase extends PulsarWebResource {
                 URI host = URI.create(lookupData.getBrokerUrlTls());
                 return InetAddress.getByName(host.getHost()).isLoopbackAddress();
             } catch (Exception e) {
-                log.info("Failed to resolve advertised address {}: {}", lookupData.getBrokerUrlTls(), e.getMessage());
+                LOG.info()
+                        .attr("address", lookupData.getBrokerUrlTls())
+                        .exceptionMessage(e)
+                        .log("Failed to resolve advertised address");
                 return false;
             }
         }
         return false;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(TopicLookupBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -33,7 +33,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.lookup.TopicLookupBase;
 import org.apache.pulsar.common.lookup.data.LookupData;
@@ -41,7 +40,6 @@ import org.apache.pulsar.common.naming.TopicName;
 
 @Path("/v2/topic")
 @Api(value = "lookup", tags = "lookup")
-@Slf4j
 public class TopicLookup extends TopicLookupBase {
 
     static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
@@ -69,10 +67,11 @@ public class TopicLookup extends TopicLookupBase {
         internalLookupTopicAsync(topicName, authoritative, listenerName)
                 .thenAccept(lookupData -> asyncResponse.resume(lookupData))
                 .exceptionally(ex -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Failed to check exist for topic {} when lookup", topicName, ex);
-                    }
-                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                        log.debug()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("Failed to check exist for topic when lookup");
+                                        resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -52,7 +52,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -114,8 +114,6 @@ import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The <code>NamespaceService</code> provides resource ownership lookup as well as resource ownership claiming services
@@ -128,10 +126,8 @@ import org.slf4j.LoggerFactory;
  *
  * @see org.apache.pulsar.broker.PulsarService
  */
-@Slf4j
+@CustomLog
 public class NamespaceService implements AutoCloseable {
-    private static final Logger LOG = LoggerFactory.getLogger(NamespaceService.class);
-
     private final ServiceConfiguration config;
     private final AtomicReference<LoadManager> loadManager;
     private final PulsarService pulsar;
@@ -152,7 +148,6 @@ public class NamespaceService implements AutoCloseable {
     private final List<NamespaceBundleOwnershipListener> bundleOwnershipListeners;
 
     private final List<NamespaceBundleSplitListener> bundleSplitListeners;
-
 
     private final RedirectManager redirectManager;
 
@@ -227,8 +222,11 @@ public class NamespaceService implements AutoCloseable {
                     // Do redirection if the cluster is in rollback or deploying.
                     return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
                         if (optResult.isPresent()) {
-                            LOG.info("[{}] Redirect lookup request to {} for topic {}",
-                                    pulsar.getBrokerId(), optResult.get(), topic);
+                            log.info()
+                                    .attr("brokerId", pulsar.getBrokerId())
+                                    .attr("redirect", optResult.get())
+                                    .attr("topic", topic)
+                                    .log("Redirect lookup request");
                             return CompletableFuture.completedFuture(optResult);
                         }
                         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
@@ -307,10 +305,11 @@ public class NamespaceService implements AutoCloseable {
      */
     public CompletableFuture<Optional<URL>> getWebServiceUrlAsync(ServiceUnitId suName, LookupOptions options) {
         if (suName instanceof TopicName name) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Getting web service URL of topic: {} - options: {}", name, options);
-            }
-            return getBundleAsync(name)
+                log.debug()
+                        .attr("topic", name)
+                        .attr("options", options)
+                        .log("Getting web service URL of topic: - options");
+                        return getBundleAsync(name)
                     .thenCompose(namespaceBundle ->
                             internalGetWebServiceUrl(name, namespaceBundle, options));
         }
@@ -343,8 +342,11 @@ public class NamespaceService implements AutoCloseable {
                                                                       LookupOptions options) {
         return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
             if (optResult.isPresent()) {
-                LOG.info("[{}] Redirect lookup request to {} for topic {}",
-                        pulsar.getBrokerId(), optResult.get(), topic);
+                log.info()
+                        .attr("brokerId", pulsar.getBrokerId())
+                        .attr("redirect", optResult.get())
+                        .attr("topic", topic)
+                        .log("Redirect lookup request");
                 try {
                     LookupData lookupData = optResult.get().getLookupData();
                     final String redirectUrl = options.isRequestHttps()
@@ -352,7 +354,9 @@ public class NamespaceService implements AutoCloseable {
                     return CompletableFuture.completedFuture(Optional.of(new URL(redirectUrl)));
                 } catch (Exception e) {
                     // just log the exception, nothing else to do
-                    LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
+                    log.warn()
+                            .exception(e)
+                            .log("internalGetWebServiceUrl");
                 }
                 return CompletableFuture.completedFuture(Optional.empty());
             }
@@ -370,7 +374,9 @@ public class NamespaceService implements AutoCloseable {
                         return Optional.of(new URL(redirectUrl));
                     } catch (Exception e) {
                         // just log the exception, nothing else to do
-                        LOG.warn("internalGetWebServiceUrl [{}]", e.getMessage(), e);
+                        log.warn()
+                                .exception(e)
+                                .log("internalGetWebServiceUrl");
                     }
                 }
                 return Optional.empty();
@@ -387,14 +393,15 @@ public class NamespaceService implements AutoCloseable {
         String brokerId = pulsar.getBrokerId();
         // ensure that we own the heartbeat namespace
         if (registerNamespace(getHeartbeatNamespace(brokerId, config), true)) {
-            LOG.info("added heartbeat namespace name in local cache: ns={}",
-                    getHeartbeatNamespace(brokerId, config));
+            log.info()
+                    .attr("namespace", getHeartbeatNamespace(brokerId, config))
+                    .log("added heartbeat namespace name in local cache");
         }
 
         // we may not need strict ownership checking for bootstrap names for now
         for (String namespace : config.getBootstrapNamespaces()) {
             if (registerNamespace(NamespaceName.get(namespace), false)) {
-                LOG.info("added bootstrap namespace name in local cache: ns={}", namespace);
+                log.info().attr("namespace", namespace).log("added bootstrap namespace name in local cache");
             }
         }
     }
@@ -439,14 +446,14 @@ public class NamespaceService implements AutoCloseable {
 
             // ignore if not be owned for now
             if (!ensureOwned) {
-                LOG.info(msg);
+                log.info(msg);
                 return false;
             }
 
             // should not happen
             throw new IllegalStateException(msg);
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            log.error().exception(e).log("Failed to register namespace bundle ownership");
             throw new PulsarServerException(e);
         }
     }
@@ -465,11 +472,11 @@ public class NamespaceService implements AutoCloseable {
      */
     private CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
             NamespaceBundle bundle, LookupOptions options) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("findBrokerServiceUrl: {} - options: {}", bundle, options);
-        }
-
-        Map<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
+            log.debug()
+                    .attr("bundle", bundle)
+                    .attr("options", options)
+                    .log("findBrokerServiceUrl");
+                Map<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
         if (options.isAuthoritative()) {
             targetMap = findingBundlesAuthoritative;
         } else {
@@ -495,10 +502,9 @@ public class NamespaceService implements AutoCloseable {
                     future.completeExceptionally(
                             new IllegalStateException(String.format("Namespace bundle %s is being unloaded", bundle)));
                 } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Namespace bundle {} already owned by {} ", bundle, nsData);
-                    }
-                    // find the target
+                        log.debug().attr("bundle", bundle).attr("owner", nsData)
+                                .log("Namespace bundle already owned");
+                                        // find the target
                     if (options.hasAdvertisedListenerName()) {
                         AdvertisedListener listener =
                                 nsData.get().getAdvertisedListeners().get(options.getAdvertisedListenerName());
@@ -518,7 +524,11 @@ public class NamespaceService implements AutoCloseable {
                     }
                 }
             }).exceptionally(exception -> {
-                LOG.warn("Failed to check owner for bundle {}: {}", bundle, exception.getMessage(), exception);
+                log.warn()
+                        .attr("bundle", bundle)
+
+                        .exception(exception)
+                        .log("Failed to check owner for bundle");
                 future.completeExceptionally(exception);
                 return null;
             });
@@ -565,7 +575,9 @@ public class NamespaceService implements AutoCloseable {
         String candidateBroker;
         LeaderElectionService les = pulsar.getLeaderElectionService();
         if (les == null) {
-            LOG.warn("The leader election has not yet been completed! NamespaceBundle[{}]", bundle);
+            log.warn()
+                    .attr("namespaceBundle", bundle)
+                    .log("The leader election has not yet been completed! NamespaceBundle");
             lookupFuture.completeExceptionally(
                     new IllegalStateException("The leader election has not yet been completed!"));
             return;
@@ -595,26 +607,27 @@ public class NamespaceService implements AutoCloseable {
                         if (!leaderBrokerActive) {
                             makeLoadManagerDecisionOnThisBroker = true;
                             if (currentLeader.isEmpty()) {
-                                LOG.warn(
-                                        "The information about the current leader broker wasn't available. "
-                                                + "Handling load manager decisions in a decentralized way. "
-                                                + "NamespaceBundle[{}]",
-                                        bundle);
+                                log.warn()
+                                        .attr("namespaceBundle", bundle)
+                                        .log("Leader broker info unavailable."
+                                                + " Using decentralized load"
+                                                + " manager decisions");
                             } else {
-                                LOG.warn(
-                                        "The current leader broker {} isn't active. "
-                                                + "Handling load manager decisions in a decentralized way. "
-                                                + "NamespaceBundle[{}]",
-                                        currentLeader.get(), bundle);
+                                log.warn()
+                                        .attr("broker", currentLeader.get())
+                                        .attr("namespaceBundle", bundle)
+                                        .log("The current leader broker isn't active. Handling load manager"
+                                                + " decisions in a decentralized way. NamespaceBundle");
                             }
                         }
                     }
                     if (makeLoadManagerDecisionOnThisBroker) {
                         Optional<String> availableBroker = getLeastLoadedFromLoadManager(bundle);
                         if (availableBroker.isEmpty()) {
-                            LOG.warn("Load manager didn't return any available broker. "
-                                            + "Returning empty result to lookup. NamespaceBundle[{}]",
-                                    bundle);
+                            log.warn()
+                                    .attr("namespaceBundle", bundle)
+                                    .log("Load manager didn't return any available broker. Returning empty result to"
+                                            + " lookup. NamespaceBundle");
                             lookupFuture.complete(Optional.empty());
                             return;
                         }
@@ -627,7 +640,11 @@ public class NamespaceService implements AutoCloseable {
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Error when searching for candidate broker to acquire {}: {}", bundle, e.getMessage(), e);
+            log.warn()
+                    .attr("acquire", bundle)
+
+                    .exception(e)
+                    .log("Error when searching for candidate broker to acquire");
             lookupFuture.completeExceptionally(e);
             return;
         }
@@ -639,10 +656,8 @@ public class NamespaceService implements AutoCloseable {
                 // Load manager decided that the local broker should try to become the owner
                 ownershipCache.tryAcquiringOwnership(bundle).thenAccept(ownerInfo -> {
                     if (ownerInfo.isDisabled()) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Namespace bundle {} is currently being unloaded", bundle);
-                        }
-                        lookupFuture.completeExceptionally(new IllegalStateException(
+                            log.debug().attr("bundle", bundle).log("Namespace bundle is currently being unloaded");
+                                                lookupFuture.completeExceptionally(new IllegalStateException(
                                 String.format("Namespace bundle %s is currently being unloaded", bundle)));
                     } else {
                         // Found owner for the namespace bundle
@@ -672,7 +687,10 @@ public class NamespaceService implements AutoCloseable {
                         }
                     }
                 }).exceptionally(exception -> {
-                    LOG.warn("Failed to acquire ownership for namespace bundle {}: {}", bundle, exception);
+                    log.warn()
+                            .attr("bundle", bundle)
+                            .exceptionMessage(exception)
+                            .log("Failed to acquire ownership for namespace bundle");
                     lookupFuture.completeExceptionally(new PulsarServerException(
                             "Failed to acquire ownership for namespace bundle " + bundle, exception));
                     return null;
@@ -680,12 +698,11 @@ public class NamespaceService implements AutoCloseable {
 
             } else {
                 // Load managed decider some other broker should try to acquire ownership
-
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Redirecting to broker {} to acquire ownership of bundle {}", candidateBroker, bundle);
-                }
-
-                // Now setting the redirect url
+                    log.debug()
+                            .attr("broker", candidateBroker)
+                            .attr("bundle", bundle)
+                            .log("Redirecting to broker to acquire ownership of bundle");
+                                // Now setting the redirect url
                 createLookupResult(candidateBroker, authoritativeRedirect, options.getAdvertisedListenerName())
                         .thenAccept(lookupResult -> lookupFuture.complete(Optional.of(lookupResult)))
                         .exceptionally(ex -> {
@@ -695,7 +712,10 @@ public class NamespaceService implements AutoCloseable {
 
             }
         } catch (Exception e) {
-            LOG.warn("Error in trying to acquire namespace bundle ownership for {}: {}", bundle, e.getMessage(), e);
+            log.warn()
+                    .attr("bundle", bundle)
+                    .exception(e)
+                    .log("Error in trying to acquire namespace bundle ownership");
             lookupFuture.completeExceptionally(e);
         }
     }
@@ -745,13 +765,13 @@ public class NamespaceService implements AutoCloseable {
     public boolean isBrokerActive(String candidateBroker) {
         Set<String> availableBrokers = getAvailableBrokers();
         if (availableBrokers.contains(candidateBroker)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Broker {} is available for.", candidateBroker);
-            }
+            log.debug().attr("broker", candidateBroker).log("Broker is available");
             return true;
         } else {
-            LOG.warn("Broker {} couldn't be found in available brokers {}",
-                    candidateBroker, String.join(",", availableBrokers));
+            log.warn()
+                    .attr("broker", candidateBroker)
+                    .attr("availableBrokers", String.join(",", availableBrokers))
+                    .log("Broker couldn't be found in available brokers");
             return false;
         }
     }
@@ -774,18 +794,16 @@ public class NamespaceService implements AutoCloseable {
     private Optional<String> getLeastLoadedFromLoadManager(ServiceUnitId serviceUnit) throws Exception {
         Optional<ResourceUnit> leastLoadedBroker = loadManager.get().getLeastLoaded(serviceUnit);
         if (leastLoadedBroker.isEmpty()) {
-            LOG.warn("No broker is available for {}", serviceUnit);
+            log.warn().attr("serviceUnit", serviceUnit).log("No broker is available");
             return Optional.empty();
         }
 
         String lookupAddress = leastLoadedBroker.get().getResourceId();
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("{} : redirecting to the least loaded broker, lookup address={}",
-                    pulsar.getBrokerId(),
-                    lookupAddress);
-        }
-        return Optional.of(lookupAddress);
+            log.debug()
+                    .attr("brokerId", pulsar.getBrokerId())
+                    .attr("address", lookupAddress)
+                    .log("redirecting to the least loaded broker, lookup address");
+                return Optional.of(lookupAddress);
     }
 
     public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle) {
@@ -912,7 +930,11 @@ public class NamespaceService implements AutoCloseable {
                 return false;
             }
         } catch (Exception e) {
-            LOG.warn("Exception in getting ownership info for service unit {}: {}", bundle, e.getMessage(), e);
+            log.warn()
+                    .attr("unit", bundle)
+
+                    .exception(e)
+                    .log("Exception in getting ownership info for service unit");
         }
 
         return false;
@@ -956,8 +978,11 @@ public class NamespaceService implements AutoCloseable {
             CompletableFuture<List<NamespaceBundle>> updateFuture = new CompletableFuture<>();
             if (ex == null) {
                 if (splitBoundaries == null || splitBoundaries.size() == 0) {
-                    LOG.info("[{}] No valid boundary found in {} to split bundle {}",
-                            bundle.getNamespaceObject().toString(), boundaries, bundle.getBundleRange());
+                    log.info()
+                            .attr("namespaceObject", bundle.getNamespaceObject().toString())
+                            .attr("boundaries", boundaries)
+                            .attr("bundle", bundle.getBundleRange())
+                            .log("No valid boundary found to split bundle");
                     completionFuture.complete(null);
                     return;
                 }
@@ -968,7 +993,7 @@ public class NamespaceService implements AutoCloseable {
                                 // Zookeeper.
                                 if (splitBundles == null) {
                                     String msg = format("bundle %s not found under namespace", bundle.toString());
-                                    LOG.warn(msg);
+                                    log.warn(msg);
                                     updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
                                     return;
                                 }
@@ -978,12 +1003,13 @@ public class NamespaceService implements AutoCloseable {
                                 checkArgument(splitBundles.getRight().size() == splitBoundaries.size() + 1,
                                         "bundle has to be split in " + (splitBoundaries.size() + 1) + " bundles");
                                 NamespaceName nsname = bundle.getNamespaceObject();
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.debug("[{}] splitAndOwnBundleOnce: {}, counter: {}, bundles: {}",
-                                            nsname.toString(), bundle.getBundleRange(), counter.get(),
-                                            splitBundles.getRight());
-                                }
-                                try {
+                                    log.debug()
+                                            .attr("namespace", nsname.toString())
+                                            .attr("bundleRange", bundle.getBundleRange())
+                                            .attr("counter", counter.get())
+                                            .attr("bundles", splitBundles.getRight())
+                                            .log("splitAndOwnBundleOnce");
+                                                                try {
                                     // take ownership of newly split bundles
                                     for (NamespaceBundle sBundle : splitBundles.getRight()) {
                                         Objects.requireNonNull(ownershipCache.tryAcquiringOwnership(sBundle));
@@ -997,7 +1023,7 @@ public class NamespaceService implements AutoCloseable {
                                         String msg = format("failed to update namespace policies [%s], "
                                                         + "NamespaceBundle: %s due to %s",
                                                 nsname.toString(), bundle.getBundleRange(), ex1.getMessage());
-                                        LOG.warn(msg);
+                                        log.warn(msg);
                                         updateFuture.completeExceptionally(
                                                 new ServiceUnitNotReadyException(msg, ex1.getCause()));
                                         return null;
@@ -1006,7 +1032,7 @@ public class NamespaceService implements AutoCloseable {
                                     String msg = format(
                                             "failed to acquire ownership of split bundle for namespace [%s], %s",
                                             nsname.toString(), e.getMessage());
-                                    LOG.warn(msg, e);
+                                    log.warn().exception(e).log(msg);
                                     updateFuture.completeExceptionally(new ServiceUnitNotReadyException(msg, e));
                                 }
                             });
@@ -1034,7 +1060,7 @@ public class NamespaceService implements AutoCloseable {
                         // Retry enough, or meet other exception
                         String msg2 = format(" %s not success update nsBundles, counter %d, reason %s",
                             bundle.toString(), counter.get(), t.getMessage());
-                        LOG.warn(msg2);
+                        log.warn(msg2);
                         completionFuture.completeExceptionally(new ServiceUnitNotReadyException(msg2));
                     }
                     return;
@@ -1061,7 +1087,7 @@ public class NamespaceService implements AutoCloseable {
                             String msg1 = format(
                                     "failed to disable bundle %s under namespace [%s] with error %s",
                                     bundle.getNamespaceObject().toString(), bundle, ex.getMessage());
-                            LOG.warn(msg1, e);
+                            log.warn().exception(e).log(msg1);
                             completionFuture.completeExceptionally(new ServiceUnitNotReadyException(msg1));
                             return null;
                         });
@@ -1082,8 +1108,11 @@ public class NamespaceService implements AutoCloseable {
         CompletableFuture<List<Long>> splitBoundary = getSplitBoundary(bundle, boundaries, nsBundleSplitAlgorithm);
         return splitBoundary.thenCompose(splitBoundaries -> {
                     if (splitBoundaries == null || splitBoundaries.size() == 0) {
-                        LOG.info("[{}] No valid boundary found in {} to split bundle {}",
-                                bundle.getNamespaceObject().toString(), boundaries, bundle.getBundleRange());
+                        log.info()
+                                .attr("namespaceObject", bundle.getNamespaceObject().toString())
+                                .attr("boundaries", boundaries)
+                                .attr("bundle", bundle.getBundleRange())
+                                .log("No valid boundary found to split bundle");
                         return CompletableFuture.completedFuture(null);
                     }
                     return pulsar.getNamespaceService().getNamespaceBundleFactory()
@@ -1149,14 +1178,13 @@ public class NamespaceService implements AutoCloseable {
                     return oldPolicies;
                 });
             } else {
-                LOG.error("Policies of namespace {} is not exist!", nsname);
+                log.error().attr("namespace", nsname).log("Policies of namespace is not exist!");
                 Policies newPolicies = new Policies();
                 newPolicies.bundles = nsBundles.getBundlesData();
                 return pulsar.getPulsarResources().getNamespaceResources().createPoliciesAsync(nsname, newPolicies);
             }
         });
     }
-
 
     /**
      * Update new bundle-range to LocalZk (create a new node if not present).
@@ -1282,7 +1310,7 @@ public class NamespaceService implements AutoCloseable {
                     bundleOwnedListener.unLoad(bundle);
                 }
             } catch (Throwable t) {
-                LOG.error("Call bundle {} ownership listener error", bundle, t);
+                log.error().attr("bundle", bundle).exception(t).log("Call bundle ownership listener error");
             }
         }
     }
@@ -1294,7 +1322,11 @@ public class NamespaceService implements AutoCloseable {
                     bundleSplitListener.onSplit(bundle);
                 }
             } catch (Throwable t) {
-                LOG.error("Call bundle {} split listener {} error", bundle, bundleSplitListener, t);
+                log.error()
+                        .attr("bundle", bundle)
+                        .attr("listener", bundleSplitListener)
+                        .exception(t)
+                        .log("Call bundle split listener error");
             }
         }
     }
@@ -1310,7 +1342,7 @@ public class NamespaceService implements AutoCloseable {
             try {
                 getOwnedServiceUnits().forEach(bundle -> notifyNamespaceBundleOwnershipListener(bundle, listeners));
             } catch (Exception e) {
-                LOG.error("Failed to notify namespace bundle ownership listener", e);
+                log.error().exception(e).log("Failed to notify namespace bundle ownership listener");
             }
         });
     }
@@ -1333,7 +1365,7 @@ public class NamespaceService implements AutoCloseable {
                         listener.onLoad(bundle);
                     }
                 } catch (Throwable t) {
-                    LOG.error("Call bundle {} ownership listener error", bundle, t);
+                    log.error().attr("bundle", bundle).exception(t).log("Call bundle ownership listener error");
                 }
             }
         }
@@ -1484,14 +1516,19 @@ public class NamespaceService implements AutoCloseable {
                 pulsarClient = (PulsarClientImpl) pulsar.getClient();
             } catch (Exception ex) {
                 // This error will never occur.
-                log.error("{} Failed to get partition metadata due to create internal admin client fails", topic, ex);
+                log.error()
+                        .attr("topic", topic)
+                        .exception(ex)
+                        .log("Failed to get partition metadata due to create internal admin client fails");
                 return FutureUtil.failedFuture(ex);
             }
             LookupOptions lookupOptions = LookupOptions.builder().readOnly(false).authoritative(true).build();
             return getBrokerServiceUrlAsync(TopicName.get(topic), lookupOptions)
                 .thenCompose(lookupResult -> {
                     if (!lookupResult.isPresent()) {
-                        log.error("{} Failed to get partition metadata due can not find the owner broker", topic);
+                        log.error()
+                                .attr("topic", topic)
+                                .log("Failed to get partition metadata due can not find the owner broker");
                         return FutureUtil.failedFuture(new ServiceUnitNotReadyException(
                                 "No broker was available to own " + topicName));
                     }
@@ -1516,18 +1553,23 @@ public class NamespaceService implements AutoCloseable {
                                 if (fe.getFailedFeatureCheck() == SupportsGetPartitionedMetadataWithoutAutoCreation) {
                                     // Since the feature PIP-344 isn't supported, restore the behavior to previous
                                     // behavior before https://github.com/apache/pulsar/pull/22838 changes.
-                                    log.info("{} Checking the existence of a non-persistent non-partitioned topic "
-                                                    + "was performed using the behavior prior to PIP-344 changes, "
-                                                    + "because the broker does not support the PIP-344 feature "
-                                                    + "'supports_get_partitioned_metadata_without_auto_creation'.",
-                                            topic);
+                                    log.info()
+                                            .attr("topic", topic)
+                                            .log("Topic existence check used"
+                                                    + " pre-PIP-344 behavior:"
+                                                    + " broker lacks support for"
+                                                    + " get_partitioned_metadata"
+                                                    + "_without_auto_creation");
                                     return CompletableFuture.completedFuture(false);
                                 } else {
-                                    log.error("{} Failed to get partition metadata", topic, ex);
+                                    log.error()
+                                            .attr("topic", topic)
+                                            .exception(ex)
+                                            .log("Failed to get partition metadata");
                                     return CompletableFuture.failedFuture(ex);
                                 }
                             } else {
-                                log.error("{} Failed to get partition metadata", topic, ex);
+                                log.error().attr("topic", topic).exception(ex).log("Failed to get partition metadata");
                                 return CompletableFuture.failedFuture(ex);
                             }
                         });
@@ -1598,13 +1640,12 @@ public class NamespaceService implements AutoCloseable {
                         ListUtils::union);
     }
 
-
     public CompletableFuture<List<String>> getPartitions(NamespaceName namespaceName, TopicDomain topicDomain) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Getting children from partitioned-topics now: {} - {}", namespaceName, topicDomain);
-        }
-
-        return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
+            log.debug()
+                    .attr("now", namespaceName)
+                    .attr("topicDomain", topicDomain)
+                    .log("Getting children from partitioned-topics now: -");
+                return pulsar.getPulsarResources().getNamespaceResources().getPartitionedTopicResources()
                 .listPartitionedTopicsAsync(namespaceName, topicDomain)
                 .thenCompose(topics -> {
             CompletableFuture<List<String>> result = new CompletableFuture<>();
@@ -1765,7 +1806,7 @@ public class NamespaceService implements AutoCloseable {
     public void unloadSLANamespace() throws Exception {
         NamespaceName namespaceName = getSLAMonitorNamespace(pulsar.getBrokerId(), config);
 
-        LOG.info("Checking owner for SLA namespace {}", namespaceName);
+        log.info().attr("namespace", namespaceName).log("Checking owner for SLA namespace");
 
         NamespaceBundle nsFullBundle = getFullBundle(namespaceName);
         if (!checkOwnershipPresent(nsFullBundle)) {
@@ -1774,10 +1815,10 @@ public class NamespaceService implements AutoCloseable {
             return;
         }
 
-        LOG.info("Trying to unload SLA namespace {}", namespaceName);
+        log.info().attr("namespace", namespaceName).log("Trying to unload SLA namespace");
         PulsarAdmin adminClient = pulsar.getAdminClient();
         adminClient.namespaces().unload(namespaceName.toString());
-        LOG.info("Namespace {} unloaded successfully", namespaceName);
+        log.info().attr("namespace", namespaceName).log("Namespace unloaded successfully");
     }
 
     public static NamespaceName getHeartbeatNamespace(String lookupBroker, ServiceConfiguration config) {
@@ -1791,7 +1832,9 @@ public class NamespaceService implements AutoCloseable {
     public static String checkHeartbeatNamespace(ServiceUnitId ns) {
         Matcher m = HEARTBEAT_NAMESPACE_PATTERN.matcher(ns.getNamespaceObject().toString());
         if (m.matches()) {
-            LOG.debug("Heartbeat namespace matched the lookup namespace {}", ns.getNamespaceObject().toString());
+            log.debug()
+                    .attr("namespace", ns.getNamespaceObject().toString())
+                    .log("Heartbeat namespace matched the lookup namespace");
             return m.group(1);
         } else {
             return null;
@@ -1832,13 +1875,13 @@ public class NamespaceService implements AutoCloseable {
         String brokerId = pulsar.getBrokerId();
         boolean isNameSpaceRegistered = registerNamespace(getSLAMonitorNamespace(brokerId, config), false);
         if (isNameSpaceRegistered) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Added SLA Monitoring namespace name in local cache: ns={}",
-                        getSLAMonitorNamespace(brokerId, config));
-            }
-        } else if (LOG.isDebugEnabled()) {
-            LOG.debug("SLA Monitoring not owned by the broker: ns={}",
-                    getSLAMonitorNamespace(brokerId, config));
+            log.debug()
+                    .attr("namespace", getSLAMonitorNamespace(brokerId, config))
+                    .log("Added SLA Monitoring namespace name in local cache");
+        } else {
+            log.debug()
+                    .attr("namespace", getSLAMonitorNamespace(brokerId, config))
+                    .log("SLA Monitoring not owned by the broker");
         }
         return isNameSpaceRegistered;
     }
@@ -1849,7 +1892,10 @@ public class NamespaceService implements AutoCloseable {
             try {
                 client.shutdown();
             } catch (PulsarClientException e) {
-                LOG.warn("Error shutting down namespace client for cluster {}", cluster, e);
+                log.warn()
+                        .attr("cluster", cluster)
+                        .exception(e)
+                        .log("Error shutting down namespace client for cluster");
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
@@ -23,19 +23,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @EqualsAndHashCode
 @ToString
+@CustomLog
 public class OwnedBundle {
-    private static final Logger LOG = LoggerFactory.getLogger(OwnedBundle.class);
-
     private final NamespaceBundle bundle;
 
     /**
@@ -110,7 +108,7 @@ public class OwnedBundle {
             while (!this.nsLock.writeLock().tryLock(1, TimeUnit.SECONDS)) {
                 // Using tryLock to avoid deadlocks caused by 2 threads trying to acquire 2 readlocks (eg: replicators)
                 // while a handleUnloadRequest happens in the middle
-                LOG.warn("Contention on OwnedBundle rw lock. Retrying to acquire lock write lock");
+                log.warn("Contention on OwnedBundle rw lock. Retrying to acquire lock write lock");
             }
 
             try {
@@ -130,7 +128,7 @@ public class OwnedBundle {
         }
 
         AtomicInteger unloadedTopics = new AtomicInteger();
-        LOG.info("Disabling ownership: {}", this.bundle);
+        log.info().attr("ownership", this.bundle).log("Disabling ownership");
 
         // close topics forcefully
         return pulsar.getNamespaceService().getOwnershipCache()
@@ -140,7 +138,10 @@ public class OwnedBundle {
                 .handle((numUnloadedTopics, ex) -> {
                     if (ex != null) {
                         // ignore topic-close failure to unload bundle
-                        LOG.error("Failed to close topics under namespace {}", bundle.toString(), ex);
+                        log.error()
+                                .attr("namespace", bundle.toString())
+                                .exception(ex)
+                                .log("Failed to close topics under namespace");
                     } else {
                         unloadedTopics.set(numUnloadedTopics);
                     }
@@ -154,8 +155,12 @@ public class OwnedBundle {
                 }).whenComplete((ignored, ex) -> {
                     double unloadBundleTime = TimeUnit.NANOSECONDS
                             .toMillis((System.nanoTime() - unloadBundleStartTime));
-                    LOG.info("Unloading {} namespace-bundle with {} topics completed in {} ms", this.bundle,
-                            unloadedTopics, unloadBundleTime, ex);
+                    log.info()
+                            .attr("bundle", this.bundle)
+                            .attr("unloadedTopics", unloadedTopics)
+                            .attr("unloadBundleTimeMs", unloadBundleTime)
+                            .exception(ex)
+                            .log("Unloading namespace-bundle completed");
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundles;
@@ -41,19 +41,14 @@ import org.apache.pulsar.common.stats.CacheMetricsCollector;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
 import org.apache.pulsar.metadata.api.coordination.ResourceLock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class provides a cache service for all the service unit ownership among the brokers. It provide a cache service
  * as well as MetadataStore read/write functions for a) lookup of a service unit ownership to a broker; b) take
  * ownership of a service unit by the local broker
  */
-@Slf4j
+@CustomLog
 public class OwnershipCache {
-
-    private static final Logger LOG = LoggerFactory.getLogger(OwnershipCache.class);
-
     /**
      * The local broker URL that this <code>OwnershipCache</code> will set as owner.
      */
@@ -99,7 +94,7 @@ public class OwnershipCache {
                         locallyAcquiredLocks.put(namespaceBundle, rl);
                         rl.getLockExpiredFuture()
                                 .thenRun(() -> {
-                                    log.info("Resource lock for {} has expired", rl.getPath());
+                                    log.info().attr("path", rl.getPath()).log("Resource lock has expired");
                                     namespaceService.unloadNamespaceBundle(namespaceBundle);
                                     invalidateLocalOwnerCache(namespaceBundle);
                                     namespaceService.onNamespaceBundleUnload(namespaceBundle);
@@ -176,14 +171,19 @@ public class OwnershipCache {
         return lockManager.readLock(path).thenCompose(owner -> {
             // If the current broker is the owner, attempt to reacquire ownership to avoid cache loss.
             if (owner.isPresent() && owner.get().equals(selfOwnerInfo)) {
-                log.warn("Detected ownership loss for broker [{}] on namespace bundle [{}]. "
-                                + "Attempting to reacquire ownership to maintain cache consistency.",
-                        selfOwnerInfo, suName);
+                log.warn()
+                        .attr("broker", selfOwnerInfo)
+                        .attr("bundle", suName)
+                        .log("Detected ownership loss for broker on namespace bundle . Attempting to reacquire"
+                                + " ownership to maintain cache consistency.");
                 try {
                     return tryAcquiringOwnership(suName).thenApply(Optional::ofNullable);
                 } catch (Exception e) {
-                    log.error("Failed to reacquire ownership for namespace bundle [{}] on broker [{}]: {}",
-                            suName, selfOwnerInfo, e.getMessage(), e);
+                    log.error()
+                            .attr("bundle", suName)
+                            .attr("broker", selfOwnerInfo)
+                            .exception(e)
+                            .log("Failed to reacquire ownership for namespace bundle on broker");
                     return CompletableFuture.failedFuture(e);
                 }
             }
@@ -206,13 +206,13 @@ public class OwnershipCache {
                     new RuntimeException("Namespace service is not ready for acquiring ownership"));
         }
 
-        LOG.info("Trying to acquire ownership of {}", bundle);
+        log.info().attr("bundle", bundle).log("Trying to acquire ownership");
 
         // Doing a get() on the ownedBundlesCache will trigger an async metadata write to acquire the lock over the
         // service unit
         return ownedBundlesCache.get(bundle)
                 .thenApply(namespaceBundle -> {
-            LOG.info("Successfully acquired ownership of {}", namespaceBundle);
+            log.info().attr("bundle", namespaceBundle).log("Successfully acquired ownership");
             namespaceService.onNamespaceBundleOwned(bundle);
             return selfOwnerInfo;
         });
@@ -249,7 +249,6 @@ public class OwnershipCache {
         }
         return FutureUtil.waitForAll(allFutures);
     }
-
 
     /**
      * Method to access the map of all <code>ServiceUnit</code> objects owned by the local broker.
@@ -348,7 +347,6 @@ public class OwnershipCache {
     public Map<NamespaceBundle, ResourceLock<NamespaceEphemeralData>> getLocallyAcquiredLocks() {
         return locallyAcquiredLocks;
     }
-
 
     public synchronized boolean refreshSelfOwnerInfo() {
         this.selfOwnerInfo = new NamespaceEphemeralData(pulsar.getBrokerServiceUrl(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerUtils.java
@@ -25,8 +25,8 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.nar.NarClassLoaderBuilder;
@@ -36,7 +36,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
  * Util class to search and load {@link ProtocolHandler}s.
  */
 @UtilityClass
-@Slf4j
+@CustomLog
 class ProtocolHandlerUtils {
 
     static final String PULSAR_PROTOCOL_HANDLER_DEFINITION_FILE = "pulsar-protocol-handler.yml";
@@ -76,7 +76,7 @@ class ProtocolHandlerUtils {
     public static ProtocolHandlerDefinitions searchForHandlers(String handlersDirectory,
                                                                String narExtractionDirectory) throws IOException {
         Path path = Paths.get(handlersDirectory).toAbsolutePath().normalize();
-        log.info("Searching for protocol handlers in {}", path);
+        log.info().attr("path", path).log("Searching for protocol handlers");
 
         ProtocolHandlerDefinitions handlers = new ProtocolHandlerDefinitions();
         if (!path.toFile().exists()) {
@@ -89,7 +89,7 @@ class ProtocolHandlerUtils {
                 try {
                     ProtocolHandlerDefinition phDef =
                         ProtocolHandlerUtils.getProtocolHandlerDefinition(archive.toString(), narExtractionDirectory);
-                    log.info("Found protocol handler from {} : {}", archive, phDef);
+                    log.info().attr("archive", archive).attr("phDef", phDef).log("Found protocol handler");
 
                     checkArgument(StringUtils.isNotBlank(phDef.getName()));
                     checkArgument(StringUtils.isNotBlank(phDef.getHandlerClass()));
@@ -100,10 +100,10 @@ class ProtocolHandlerUtils {
 
                     handlers.handlers().put(phDef.getName(), metadata);
                 } catch (Throwable t) {
-                    log.warn("Failed to load connector from {}."
-                        + " It is OK however if you want to use this protocol handler,"
-                        + " please make sure you put the correct protocol handler NAR"
-                        + " package in the handlers directory.", archive, t);
+                    log.warn()
+                            .attr("archive", archive)
+                            .exception(t)
+                            .log("Failed to load protocol handler");
                 }
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerWithClassLoader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlerWithClassLoader.java
@@ -23,9 +23,9 @@ import io.netty.channel.socket.SocketChannel;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.nar.NarClassLoader;
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.nar.NarClassLoader;
 /**
  * A protocol handler with its classloader.
  */
-@Slf4j
+@CustomLog
 @Data
 @RequiredArgsConstructor
 class ProtocolHandlerWithClassLoader implements ProtocolHandler {
@@ -119,7 +119,7 @@ class ProtocolHandlerWithClassLoader implements ProtocolHandler {
         try {
             classLoader.close();
         } catch (IOException e) {
-            log.warn("Failed to close the protocol handler class loader", e);
+            log.warn().exception(e).log("Failed to close the protocol handler class loader");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/protocol/ProtocolHandlers.java
@@ -31,15 +31,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
 
 /**
  * A collection of loaded handlers.
  */
-@Slf4j
+@CustomLog
 public class ProtocolHandlers implements AutoCloseable {
 
     @Getter
@@ -73,18 +73,21 @@ public class ProtocolHandlers implements AutoCloseable {
             try {
                 handler = ProtocolHandlerUtils.load(definition, conf.getNarExtractionDirectory());
             } catch (IOException e) {
-                log.error("Failed to load the protocol handler for protocol `" + protocol + "`", e);
+                log.error()
+                        .attr("protocol", protocol)
+                        .exception(e)
+                        .log("Failed to load the protocol handler for protocol ` `");
                 throw new RuntimeException("Failed to load the protocol handler for protocol `" + protocol + "`");
             }
 
             if (!handler.accept(protocol)) {
                 handler.close();
-                log.error("Malformed protocol handler found for protocol `" + protocol + "`");
+                log.error().attr("protocol", protocol).log("Malformed protocol handler found for protocol ` `");
                 throw new RuntimeException("Malformed protocol handler found for protocol `" + protocol + "`");
             }
 
             handlersBuilder.put(protocol, handler);
-            log.info("Successfully loaded protocol handler for protocol `{}`", protocol);
+            log.info().attr("protocol", protocol).log("Successfully loaded protocol handler for protocol ``");
         });
 
         return new ProtocolHandlers(handlersBuilder.build());
@@ -134,9 +137,11 @@ public class ProtocolHandlers implements AutoCloseable {
                 handler.getValue().newChannelInitializers();
             initializers.forEach((address, initializer) -> {
                 if (!addresses.add(address)) {
-                    log.error("Protocol handler for `{}` attempts to use {} for its listening port."
-                        + " But it is already occupied by other message protocols.",
-                        handler.getKey(), address);
+                    log.error()
+                            .attr("handler", handler.getKey())
+                            .attr("address", address)
+                            .log("Protocol handler attempts to use listening port already occupied by other"
+                                    + " messaging protocols");
                     throw new RuntimeException("Protocol handler for `" + handler.getKey()
                         + "` attempts to use " + address + " for its listening port. But it is"
                         + " already occupied by other messaging protocols");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
@@ -25,14 +25,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.val;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupService.ResourceGroupOpStatus;
 import org.apache.pulsar.broker.service.resource.usage.NetworkUsage;
 import org.apache.pulsar.broker.service.resource.usage.ResourceUsage;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The resource group (RG) data structure. One of these is created internally for every resource group configured.
@@ -44,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * same RG across all of the monitoring classes it uses (Publish/Dispatch/...), instead of referencing one RG for
  * publish, another one for dispatch, etc.
  */
+@CustomLog
 public class ResourceGroup {
 
     /**
@@ -84,8 +84,11 @@ public class ResourceGroup {
         this.setDefaultResourceUsageTransportHandlers();
         this.resourceGroupPublishLimiter = new ResourceGroupPublishLimiter(rgConfig, rgs.getPulsar()
                 .getMonotonicClock());
-        log.info("attaching publish rate limiter {} to {} get {}", this.resourceGroupPublishLimiter, name,
-          this.getResourceGroupPublishLimiter());
+        log.info()
+                .attr("limiter", this.resourceGroupPublishLimiter)
+                .attr("resourceGroup", name)
+                .attr("publishLimiter", this.getResourceGroupPublishLimiter())
+                .log("attaching publish rate limiter");
     }
 
     // ctor for overriding the transport-manager fill/set buffer.
@@ -182,10 +185,10 @@ public class ResourceGroup {
 
             // If this is the first ref, register with the transport manager.
             if (this.resourceGroupTenantRefs.size() + this.resourceGroupNamespaceRefs.size() == 1) {
-                if (log.isDebugEnabled()) {
-                    log.debug("registerUsage for RG={}: registering with transport-mgr", this.resourceGroupName);
-                }
-                transportManager.registerResourceUsagePublisher(this.ruPublisher);
+                    log.debug()
+                            .attr("resourceGroup", this.resourceGroupName)
+                            .log("registerUsage for RG=: registering with transport-mgr");
+                                transportManager.registerResourceUsagePublisher(this.ruPublisher);
                 transportManager.registerResourceUsageConsumer(this.ruConsumer);
             }
         } else {
@@ -197,10 +200,10 @@ public class ResourceGroup {
 
             // If this was the last ref, unregister from the transport manager.
             if (this.resourceGroupTenantRefs.size() + this.resourceGroupNamespaceRefs.size() == 0) {
-                if (log.isDebugEnabled()) {
-                    log.debug("unRegisterUsage for RG={}: un-registering from transport-mgr", this.resourceGroupName);
-                }
-                transportManager.unregisterResourceUsageConsumer(this.ruConsumer);
+                    log.debug()
+                            .attr("resourceGroup", this.resourceGroupName)
+                            .log("unRegisterUsage for RG=: un-registering from transport-mgr");
+                                transportManager.unregisterResourceUsageConsumer(this.ruConsumer);
                 transportManager.unregisterResourceUsagePublisher(this.ruPublisher);
             }
         }
@@ -330,11 +333,11 @@ public class ResourceGroup {
             retval.bytes = pbus.usedValues.bytes;
             retval.messages = pbus.usedValues.messages;
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("getLocalUsageStatsFromBrokerReports: no usage report found for broker={} and monClass={}",
-                        myBrokerId, monClass);
-            }
-        }
+                log.debug()
+                        .attr("broker", myBrokerId)
+                        .attr("monClass", monClass)
+                        .log("getLocalUsageStatsFromBrokerReports: no usage report found");
+                    }
 
         return retval;
     }
@@ -362,10 +365,8 @@ public class ResourceGroup {
                                                      BytesAndMessagesCount newQuota) throws PulsarAdminException {
         // Only the Publish side is functional now; add the Dispatch side code when the consume side is ready.
         if (!ResourceGroupMonitoringClass.Publish.equals(monClass)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Doing nothing for monClass={}; only Publish is functional", monClass);
-            }
-            return null;
+                log.debug().attr("monClass", monClass).log("Doing nothing; only Publish is functional");
+                        return null;
         }
 
         this.checkMonitoringClass(monClass);
@@ -380,12 +381,13 @@ public class ResourceGroup {
         } finally {
             monEntity.localUsageStatsLock.unlock();
         }
-        if (log.isDebugEnabled()) {
-            log.debug("updateLocalQuota for RG={}: set local {} quota to bytes={}, messages={}",
-                    this.resourceGroupName, monClass, newQuota.bytes, newQuota.messages);
-        }
-
-        return oldBMCount;
+            log.debug()
+                    .attr("resourceGroup", this.resourceGroupName)
+                    .attr("monClass", monClass)
+                    .attr("bytes", newQuota.bytes)
+                    .attr("messages", newQuota.messages)
+                    .log("updateLocalQuota for RG: set local quota");
+                return oldBMCount;
     }
 
     protected BytesAndMessagesCount getRgPublishRateLimiterValues() {
@@ -480,17 +482,19 @@ public class ResourceGroup {
         double sentCount = sendReport ? 1 : 0;
         rgLocalUsageReportCount.labels(rgName, monClass.name()).inc(sentCount);
         if (sendReport) {
-            if (log.isDebugEnabled()) {
-                log.debug("fillResourceUsage for RG={}: filled a {} update; bytes={}, messages={}",
-                        rgName, monClass, bytesUsed, messagesUsed);
-            }
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("fillResourceUsage for RG={}: report for {} suppressed "
-                    + "(suppressions={} since last sent report)",
-                        rgName, monClass, numSuppressions);
-            }
-        }
+                log.debug()
+                        .attr("resourceGroup", rgName)
+                        .attr("monClass", monClass)
+                        .attr("bytes", bytesUsed)
+                        .attr("messages", messagesUsed)
+                        .log("fillResourceUsage for RG: filled an update");
+                    } else {
+                log.debug()
+                        .attr("resourceGroup", rgName)
+                        .attr("monClass", monClass)
+                        .attr("suppressions", numSuppressions)
+                        .log("fillResourceUsage for RG: report suppressed since last sent report");
+                    }
 
         return sendReport;
     }
@@ -529,15 +533,16 @@ public class ResourceGroup {
             oldByteCount = oldUsageStats.usedValues.bytes;
             oldMessageCount = oldUsageStats.usedValues.messages;
         }
-
-        if (log.isDebugEnabled()) {
-            log.debug("resourceUsageListener for RG={}: updated {} stats for broker={} "
-                            + "with bytes={} (old ={}), messages={} (old={})",
-                    this.resourceGroupName, monClass, broker,
-                    newByteCount, oldByteCount,
-                    newMessageCount, oldMessageCount);
-        }
-    }
+            log.debug()
+                    .attr("resourceGroup", this.resourceGroupName)
+                    .attr("monClass", monClass)
+                    .attr("broker", broker)
+                    .attr("newBytes", newByteCount)
+                    .attr("oldBytes", oldByteCount)
+                    .attr("newMessages", newMessageCount)
+                    .attr("oldMessages", oldMessageCount)
+                    .log("resourceUsageListener: updated stats for broker");
+            }
 
     private void setResourceGroupMonitoringClassFields() {
         PerMonitoringClassFields monClassFields;
@@ -609,9 +614,6 @@ public class ResourceGroup {
 
     public PerMonitoringClassFields[] monitoringClassFields =
             new PerMonitoringClassFields[ResourceGroupMonitoringClass.values().length];
-
-    private static final Logger log = LoggerFactory.getLogger(ResourceGroupService.class);
-
     // Tenants and namespaces that are directly referencing this resource-group.
     // These are not kept on a per-monitoring class basis, since a given NS (for example) references the same RG
     // across all of its usage classes (publish/dispatch/...).

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListener.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupConfigListener.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.ResourceGroupResources;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -36,8 +37,6 @@ import org.apache.pulsar.common.policies.data.ResourceGroup;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Resource Group Config Listener
@@ -48,9 +47,8 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://github.com/apache/pulsar/wiki/PIP-82%3A-Tenant-and-namespace-level-rate-limiting">Global-quotas</a>
  *
  */
+@CustomLog
 public class ResourceGroupConfigListener implements Consumer<Notification> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ResourceGroupConfigListener.class);
     private final ResourceGroupService rgService;
     private final PulsarService pulsarService;
     private final ResourceGroupResources rgResources;
@@ -72,7 +70,10 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
         }).exceptionally(e -> {
             long nextRetry = retry + 1;
             long delay = 500 * nextRetry;
-            LOG.error("Failed to load all resource groups during initialization, retrying after {}ms: ", delay, e);
+            log.error()
+                    .attr("afterMs", delay)
+                    .exception(e)
+                    .log("Failed to load all resource groups during initialization, retrying later");
             schedule(() -> loadAllResourceGroupsWithRetryAsync(nextRetry), delay);
             return null;
         });
@@ -113,21 +114,22 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
     public synchronized void deleteResourceGroup(String rgName) {
         try {
             if (rgService.resourceGroupGet(rgName) != null) {
-                LOG.info("Deleting resource group {}", rgName);
+                log.info().attr("resourceGroup", rgName).log("Deleting resource group");
                 rgService.resourceGroupDelete(rgName);
             }
         } catch (PulsarAdminException e) {
-            LOG.error("Got exception while deleting resource group {}, {}", rgName, e);
+            log.error().attr("resourceGroup", rgName).exceptionMessage(e)
+                    .log("Got exception while deleting resource group");
         }
     }
 
     public synchronized void createResourceGroup(String rgName, ResourceGroup rg) {
         if (rgService.resourceGroupGet(rgName) == null) {
-            LOG.info("Creating resource group {}, {}", rgName, rg.toString());
+            log.info().attr("resourceGroup", rgName).attr("value", rg).log("Creating resource group");
             try {
                 rgService.resourceGroupCreate(rgName, rg);
             } catch (PulsarAdminException ex1) {
-                LOG.error("Got an exception while creating RG {}", rgName, ex1);
+                log.error().attr("resourceGroup", rgName).exception(ex1).log("Got an exception while creating RG");
             }
         }
     }
@@ -135,15 +137,16 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
     private void updateResourceGroup(String rgName) {
         rgResources.getResourceGroupAsync(rgName).whenComplete((optionalRg, ex) -> {
             if (ex != null) {
-                LOG.error("Exception when getting resource group {}", rgName, ex);
+                log.error().attr("resourceGroup", rgName).exception(ex).log("Exception when getting resource group");
                 return;
             }
             ResourceGroup rg = optionalRg.get();
             try {
-                LOG.info("Updating resource group {}, {}", rgName, rg);
+                log.info().attr("resourceGroup", rgName).attr("value", rg).log("Updating resource group");
                 rgService.resourceGroupUpdate(rgName, rg);
             } catch (PulsarAdminException ex1) {
-                LOG.error("Got an exception while creating resource group {}", rgName, ex1);
+                log.error().attr("resourceGroup", rgName).exception(ex1)
+                        .log("Got an exception while creating resource group");
             }
         });
     }
@@ -155,13 +158,16 @@ public class ResourceGroupConfigListener implements Consumer<Notification> {
         if (!ResourceGroupResources.isResourceGroupPath(notifyPath)) {
             return;
         }
-        LOG.info("Metadata store notification: Path {}, Type {}", notifyPath, notification.getType());
+        log.info()
+                .attr("path", notifyPath)
+                .attr("type", notification.getType())
+                .log("Metadata store notification: Path , Type");
 
         Optional<String> rgName = ResourceGroupResources.resourceGroupNameFromPath(notifyPath);
         if ((notification.getType() == NotificationType.ChildrenChanged)
             || (notification.getType() == NotificationType.Created)) {
             loadAllResourceGroupsAsync().exceptionally((ex) -> {
-                LOG.error("Exception when fetching resource groups", ex);
+                log.error().exception(ex).log("Exception when fetching resource groups");
                 return null;
             });
         } else if (rgName.isPresent()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupNamespaceConfigListener.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupNamespaceConfigListener.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.resourcegroup;
 
 import java.util.function.Consumer;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.TenantResources;
@@ -27,8 +28,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Resource Group Namespace Config Listener
@@ -39,9 +38,8 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://github.com/apache/pulsar/wiki/PIP-82%3A-Tenant-and-namespace-level-rate-limiting">Global-quotas</a>
  *
  */
+@CustomLog
 public class ResourceGroupNamespaceConfigListener implements Consumer<Notification> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ResourceGroupNamespaceConfigListener.class);
     private final ResourceGroupService rgService;
     private final PulsarService pulsarService;
     private final NamespaceResources namespaceResources;
@@ -62,7 +60,7 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
     private void updateNamespaceResourceGroup(NamespaceName nsName) {
         namespaceResources.getPoliciesAsync(nsName).whenCompleteAsync((optionalPolicies, ex) -> {
             if (ex != null) {
-                LOG.error("Exception when getting namespace {}", nsName, ex);
+                log.error().attr("namespace", nsName).exception(ex).log("Exception when getting namespace");
                 return;
             }
             Policies policy = optionalPolicies.get();
@@ -73,13 +71,13 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
     private void loadAllNamespaceResourceGroups() {
         tenantResources.listTenantsAsync().whenComplete((tenantList, ex) -> {
             if (ex != null) {
-                LOG.error("Exception when fetching tenants", ex);
+                log.error().exception(ex).log("Exception when fetching tenants");
                 return;
             }
             for (String ts: tenantList) {
                 namespaceResources.listNamespacesAsync(ts).whenComplete((nsList, ex1) -> {
                     if (ex1 != null) {
-                        LOG.error("Exception when fetching namespaces", ex1);
+                        log.error().exception(ex1).log("Exception when fetching namespaces");
                     } else {
                         for (String ns : nsList) {
                             NamespaceName nsn = NamespaceName.get(ts, ns);
@@ -119,16 +117,26 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
         }
         try {
             if (delete) {
-                LOG.info("Unregistering namespace {} from resource group {}", ns, current.resourceGroupName);
+                log.info()
+                        .attr("namespace", ns)
+                        .attr("resourceGroup", current.resourceGroupName)
+                        .log("Unregistering namespace from resource group");
                 rgService.unRegisterNameSpace(current.resourceGroupName, ns);
             }
             if (add) {
-                LOG.info("Registering namespace {} with resource group {}", ns, policy.resource_group_name);
+                log.info()
+                        .attr("namespace", ns)
+                        .attr("resourceGroup", policy.resource_group_name)
+                        .log("Registering namespace with resource group");
                 rgService.registerNameSpace(policy.resource_group_name, ns);
             }
         } catch (PulsarAdminException e) {
-            LOG.error("Failed to {} namespace {} with resource group {}",
-                    delete ? "unregister" : "register", ns, policy.resource_group_name, e);
+            log.error()
+                    .attr("operation", delete ? "unregister" : "register")
+                    .attr("namespace", ns)
+                    .attr("resourceGroup", policy.resource_group_name)
+                    .exception(e)
+                    .log("Failed to update namespace with resource group");
         }
     }
 
@@ -144,7 +152,10 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
             // We are only interested in the tenant and namespace level notifications
             return;
         }
-        LOG.info("Metadata store notification: Path {}, Type {}", notifyPath, notification.getType());
+        log.info()
+                .attr("path", notifyPath)
+                .attr("type", notification.getType())
+                .log("Metadata store notification: Path , Type");
 
         if (parts.length == 4 && notification.getType() == NotificationType.ChildrenChanged) {
             // Namespace add/delete
@@ -164,7 +175,7 @@ public class ResourceGroupNamespaceConfigListener implements Consumer<Notificati
                         try {
                             rgService.unRegisterNameSpace(rg.resourceGroupName, nsName);
                         } catch (PulsarAdminException e) {
-                            LOG.error("Failed to unregister namespace", e);
+                            log.error().exception(e).log("Failed to unregister namespace");
                         }
                     }
                     break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupService.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.val;
 import org.apache.pulsar.broker.PulsarService;
@@ -40,8 +41,6 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The <code>ResourceGroupService</code> contains APIs to manipulate resource groups. It is assumed that there is a
@@ -53,6 +52,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see PulsarService
  */
+@CustomLog
 public class ResourceGroupService implements AutoCloseable{
     /**
      * Default constructor.
@@ -443,7 +443,7 @@ public class ResourceGroupService implements AutoCloseable{
         ConcurrentHashMap<String, BytesAndMessagesCount> hm;
         switch (monClass) {
             default:
-                log.error("updateStatsWithDiff: Unknown monitoring class={}; ignoring", monClass);
+                log.error().attr("monClass", monClass).log("updateStatsWithDiff: Unknown monitoring class; ignoring");
                 return;
 
             case Publish:
@@ -477,16 +477,21 @@ public class ResourceGroupService implements AutoCloseable{
 
         try {
             boolean statsUpdated = this.incrementUsage(tenantString, nsString, monClass, bmDiff);
-            if (log.isDebugEnabled()) {
-                log.debug("updateStatsWithDiff for topic={}: monclass={} statsUpdated={} for tenant={}, namespace={}; "
-                                + "by {} bytes, {} mesgs",
-                        topicName, monClass, statsUpdated, tenantString, nsString,
-                        bmDiff.bytes, bmDiff.messages);
-            }
-            hm.put(topicName, bmNewCount);
+                log.debug()
+                        .attr("topic", topicName)
+                        .attr("monClass", monClass)
+                        .attr("statsUpdated", statsUpdated)
+                        .attr("tenant", tenantString)
+                        .attr("namespace", nsString)
+                        .attr("bytes", bmDiff.bytes)
+                        .attr("messages", bmDiff.messages)
+                        .log("updateStatsWithDiff");
+                        hm.put(topicName, bmNewCount);
         } catch (Throwable t) {
-            log.error("updateStatsWithDiff: got ex={} while aggregating for {} side",
-                    t.getMessage(), monClass);
+            log.error()
+                    .exceptionMessage(t)
+                    .attr("monClass", monClass)
+                    .log("updateStatsWithDiff: got exception while aggregating");
         }
     }
 
@@ -590,25 +595,29 @@ public class ResourceGroupService implements AutoCloseable{
                     ResourceGroupMonitoringClass.Dispatch);
         }
         double diffTimeSeconds = aggrUsageTimer.observeDuration();
-        if (log.isDebugEnabled()) {
-            log.debug("aggregateResourceGroupLocalUsages took {} milliseconds", diffTimeSeconds * 1000);
-        }
-
-        // Check any re-scheduling requirements for next time.
+            log.debug().attr("took", diffTimeSeconds * 1000).log("aggregateResourceGroupLocalUsages took milliseconds");
+                // Check any re-scheduling requirements for next time.
         // Use the same period as getResourceUsagePublishIntervalInSecs;
         // cancel and re-schedule this task if the period of execution has changed.
         ServiceConfiguration config = pulsar.getConfiguration();
         long newPeriodInSeconds = config.getResourceUsageTransportPublishIntervalInSecs();
         if (schedulersRunning.get() && newPeriodInSeconds != this.aggregateLocalUsagePeriodInSeconds) {
             if (this.aggregateLocalUsagePeriodicTask == null) {
-                log.error("aggregateResourceGroupLocalUsages: Unable to find running task to cancel when "
-                                + "publish period changed from {} to {} {}",
-                        this.aggregateLocalUsagePeriodInSeconds, newPeriodInSeconds, timeUnitScale);
+                log.error()
+                        .attr("from", this.aggregateLocalUsagePeriodInSeconds)
+                        .attr("to", newPeriodInSeconds)
+                        .attr("timeUnitScale", timeUnitScale)
+                        .log("aggregateResourceGroupLocalUsages: Unable to find running task to cancel when publish"
+                                + " period changed");
             } else {
                 boolean cancelStatus = this.aggregateLocalUsagePeriodicTask.cancel(true);
-                log.info("aggregateResourceGroupLocalUsages: Got status={} in cancel of periodic "
-                                + "when publish period changed from {} to {} {}",
-                        cancelStatus, this.aggregateLocalUsagePeriodInSeconds, newPeriodInSeconds, timeUnitScale);
+                log.info()
+                        .attr("cancelStatus", cancelStatus)
+                        .attr("from", this.aggregateLocalUsagePeriodInSeconds)
+                        .attr("to", newPeriodInSeconds)
+                        .attr("timeUnitScale", timeUnitScale)
+                        .log("aggregateResourceGroupLocalUsages: Got status in cancel of periodic when publish"
+                                + " period changed");
             }
             this.aggregateLocalUsagePeriodicTask = pulsar.getExecutor().scheduleAtFixedRate(
                     catchingAndLoggingThrowables(this::aggregateResourceGroupLocalUsages),
@@ -662,46 +671,57 @@ public class ResourceGroupService implements AutoCloseable{
                     if (oldBMCount != null) {
                         long messagesIncrement = updatedQuota.messages - oldBMCount.messages;
                         long bytesIncrement = updatedQuota.bytes - oldBMCount.bytes;
-                        if (log.isDebugEnabled()) {
-                            log.debug("calculateQuota for RG={} [class {}]: "
-                                            + "updatedlocalBytes={}, updatedlocalMesgs={}; "
-                                            + "old bytes={}, old mesgs={};  incremented bytes by {}, messages by {}",
-                                    rgName, monClass, updatedQuota.bytes, updatedQuota.messages,
-                                    oldBMCount.bytes, oldBMCount.messages,
-                                    bytesIncrement, messagesIncrement);
-                        }
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("calculateQuota for RG={} [class {}]: got back null from updateLocalQuota",
-                                    rgName, monClass);
-                        }
-                    }
+                            log.debug()
+                                    .attr("resourceGroup", rgName)
+                                    .attr("monClass", monClass)
+                                    .attr("updatedLocalBytes", updatedQuota.bytes)
+                                    .attr("updatedLocalMessages", updatedQuota.messages)
+                                    .attr("oldBytes", oldBMCount.bytes)
+                                    .attr("oldMessages", oldBMCount.messages)
+                                    .attr("bytesIncrement", bytesIncrement)
+                                    .attr("messagesIncrement", messagesIncrement)
+                                    .log("calculateQuota for RG");
+                                            } else {
+                            log.debug()
+                                    .attr("resourceGroup", rgName)
+                                    .attr("monClass", monClass)
+                                    .log("calculateQuota: got back null from updateLocalQuota");
+                                            }
                 } catch (Throwable t) {
-                    log.error("Got exception={} while calculating new quota for monitoring-class={} of RG={}",
-                            t.getMessage(), monClass, rgName);
+                    log.error()
+                            .exceptionMessage(t)
+                            .attr("class", monClass)
+                            .attr("resourceGroup", rgName)
+                            .log("Got exception while calculating new quota for monitoring-class of RG");
                 }
             }
         });
         double diffTimeSeconds = quotaCalcTimer.observeDuration();
-        if (log.isDebugEnabled()) {
-            log.debug("calculateQuotaForAllResourceGroups took {} milliseconds", diffTimeSeconds * 1000);
-        }
-
-        // Check any re-scheduling requirements for next time.
+            log.debug()
+                    .attr("took", diffTimeSeconds * 1000)
+                    .log("calculateQuotaForAllResourceGroups took milliseconds");
+                // Check any re-scheduling requirements for next time.
         // Use the same period as getResourceUsagePublishIntervalInSecs;
         // cancel and re-schedule this task if the period of execution has changed.
         ServiceConfiguration config = pulsar.getConfiguration();
         long newPeriodInSeconds = config.getResourceUsageTransportPublishIntervalInSecs();
         if (schedulersRunning.get() && newPeriodInSeconds != this.resourceUsagePublishPeriodInSeconds) {
             if (this.calculateQuotaPeriodicTask == null) {
-                log.error("calculateQuotaForAllResourceGroups: Unable to find running task to cancel when "
-                                + "publish period changed from {} to {} {}",
-                        this.resourceUsagePublishPeriodInSeconds, newPeriodInSeconds, timeUnitScale);
+                log.error()
+                        .attr("from", this.resourceUsagePublishPeriodInSeconds)
+                        .attr("to", newPeriodInSeconds)
+                        .attr("timeUnitScale", timeUnitScale)
+                        .log("calculateQuotaForAllResourceGroups: Unable to find running task to cancel when publish"
+                                + " period changed");
             } else {
                 boolean cancelStatus = this.calculateQuotaPeriodicTask.cancel(true);
-                log.info("calculateQuotaForAllResourceGroups: Got status={} in cancel of periodic "
-                        + " when publish period changed from {} to {} {}",
-                        cancelStatus, this.resourceUsagePublishPeriodInSeconds, newPeriodInSeconds, timeUnitScale);
+                log.info()
+                        .attr("cancelStatus", cancelStatus)
+                        .attr("from", this.resourceUsagePublishPeriodInSeconds)
+                        .attr("to", newPeriodInSeconds)
+                        .attr("timeUnitScale", timeUnitScale)
+                        .log("calculateQuotaForAllResourceGroups: Got status in cancel of periodic when publish"
+                                + " period changed");
             }
             this.calculateQuotaPeriodicTask = pulsar.getExecutor().scheduleAtFixedRate(
                         catchingAndLoggingThrowables(this::calculateQuotaForAllResourceGroups),
@@ -748,9 +768,10 @@ public class ResourceGroupService implements AutoCloseable{
                     periodInSecs, periodInSecs, timeUnitScale);
             maxIntervalForSuppressingReportsMSecs =
                     TimeUnit.SECONDS.toMillis(this.resourceUsagePublishPeriodInSeconds) * MaxUsageReportSuppressRounds;
-            if (log.isInfoEnabled()) {
-                log.info("Started ResourceGroupService periodic tasks with period={} {}", periodInSecs, timeUnitScale);
-            }
+            log.info()
+                    .attr("period", periodInSecs)
+                    .attr("timeUnitScale", timeUnitScale)
+                    .log("Started ResourceGroupService periodic tasks with period");
         }
     }
     // Stop schedulers when no tenant or namespace registrations remain.
@@ -767,9 +788,7 @@ public class ResourceGroupService implements AutoCloseable{
                 calculateQuotaPeriodicTask.cancel(true);
                 calculateQuotaPeriodicTask = null;
             }
-            if (log.isInfoEnabled()) {
-                log.info("Stopped ResourceGroupService periodic tasks because no registrations remain");
-            }
+            log.info("Stopped ResourceGroupService periodic tasks because no registrations remain");
         }
     }
 
@@ -797,9 +816,6 @@ public class ResourceGroupService implements AutoCloseable{
             throw new PulsarAdminException("Resource group already exists:" + rgName);
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ResourceGroupService.class);
-
     @Getter
     private final PulsarService pulsar;
 
@@ -821,7 +837,6 @@ public class ResourceGroupService implements AutoCloseable{
     // Maps to maintain the usage per topic, in produce/consume directions.
     private ConcurrentHashMap<String, BytesAndMessagesCount> topicProduceStats = new ConcurrentHashMap<>();
     private ConcurrentHashMap<String, BytesAndMessagesCount> topicConsumeStats = new ConcurrentHashMap<>();
-
 
     // The task that periodically re-calculates the quota budget for local usage.
     private ScheduledFuture<?> aggregateLocalUsagePeriodicTask;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceQuotaCalculatorImpl.java
@@ -20,11 +20,11 @@ package org.apache.pulsar.broker.resourcegroup;
 
 import static java.lang.Float.max;
 import static java.lang.Math.abs;
+import lombok.CustomLog;
 import lombok.val;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
     @Override
     public long computeLocalQuota(long confUsage, long myUsage, long[] allUsages) throws PulsarAdminException {
@@ -34,11 +34,11 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
         if (confUsage < 0) {
             // This can happen if the RG is not configured with this particular limit (message or byte count) yet.
             val retVal = -1;
-            if (log.isDebugEnabled()) {
-                log.debug("Configured usage ({}) is not set; returning a special value ({}) for calculated quota",
-                        confUsage, retVal);
-            }
-            return retVal;
+                log.debug()
+                        .attr("usage", confUsage)
+                        .attr("value", retVal)
+                        .log("Configured usage is not set; returning a special value for calculated quota");
+                        return retVal;
         }
 
         long totalUsage = 0;
@@ -57,12 +57,11 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
         // The caller is expected to check the value returned, or not call here with a zero global usage.
         // [This avoids a division by zero when calculating the local share.]
         if (totalUsage == 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("computeLocalQuota: totalUsage is zero; "
-                        + "returning the configured usage ({}) as new local quota",
-                        confUsage);
-            }
-            return confUsage;
+                log.debug()
+                        .attr("usage", confUsage)
+                        .log("computeLocalQuota: totalUsage is zero; returning the configured usage as new local"
+                                + " quota");
+                        return confUsage;
         }
 
         if (myUsage > totalUsage) {
@@ -84,12 +83,14 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
         float calculatedQuota = max(myUsage + residual * myUsageFraction, 1);
 
         val longCalculatedQuota = (long) calculatedQuota;
-        if (log.isDebugEnabled()) {
-            log.debug("computeLocalQuota: myUsage={}, totalUsage={}, myFraction={}; newQuota returned={} [long: {}]",
-                    myUsage, totalUsage, myUsageFraction, calculatedQuota, longCalculatedQuota);
-        }
-
-        return longCalculatedQuota;
+            log.debug()
+                    .attr("myUsage", myUsage)
+                    .attr("totalUsage", totalUsage)
+                    .attr("myFraction", myUsageFraction)
+                    .attr("newQuota", calculatedQuota)
+                    .attr("longQuota", longCalculatedQuota)
+                    .log("computeLocalQuota");
+                return longCalculatedQuota;
     }
 
     @Override
@@ -125,6 +126,4 @@ public class ResourceQuotaCalculatorImpl implements ResourceQuotaCalculator {
 
         return false;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ResourceQuotaCalculatorImpl.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTopicTransportManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceUsageTopicTransportManager.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -47,8 +48,6 @@ import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Resource Usage Transport Manager
@@ -59,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://github.com/apache/pulsar/wiki/PIP-82%3A-Tenant-and-namespace-level-rate-limiting">Global-quotas</a>
  *
  */
+@CustomLog
 public class ResourceUsageTopicTransportManager implements ResourceUsageTransportManager {
 
     private class ResourceUsageWriterTask implements Runnable, AutoCloseable {
@@ -103,7 +103,10 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
 
                 producer.sendAsync(buf.nioBuffer()).whenComplete((id, ex) -> {
                     if (null != ex) {
-                        LOG.error("Resource usage publisher: error sending message ID {}", id, ex);
+                        log.error()
+                                .attr("messageId", id)
+                                .exception(ex)
+                                .log("Resource usage publisher: error sending message");
                     }
                     buf.release();
                 });
@@ -144,8 +147,11 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
             recdUsageInfo.parseFrom(Unpooled.wrappedBuffer(msg.getData()), msg.getData().length);
             if (timeDelta > TimeUnit.SECONDS.toMillis(
             2 * pulsarService.getConfig().getResourceUsageTransportPublishIntervalInSecs())) {
-                LOG.error("Stale resource usage msg from broker {} publish time {} current time{}",
-                recdUsageInfo.getBroker(), publishTime, currentTime);
+                log.error()
+                        .attr("broker", recdUsageInfo.getBroker())
+                        .attr("publishTime", publishTime)
+                        .attr("currentTime", currentTime)
+                        .log("Stale resource usage msg from broker");
                 return;
             }
             try {
@@ -157,15 +163,13 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
                 });
 
             } catch (IllegalStateException exception) {
-                LOG.error("Resource usage reader: Error parsing incoming message", exception);
+                log.error().exception(exception).log("Resource usage reader: Error parsing incoming message");
             } catch (Exception exception) {
-                LOG.error("Resource usage reader: Unknown exception while parsing message", exception);
+                log.error().exception(exception).log("Resource usage reader: Unknown exception while parsing message");
             }
         }
 
     }
-
-    private static final Logger LOG = LoggerFactory.getLogger(ResourceUsageTopicTransportManager.class);
     private final PulsarService pulsarService;
     private final PulsarClient pulsarClient;
     private final ResourceUsageWriterTask pTask;
@@ -193,7 +197,10 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
                   new TenantInfoImpl(Sets.newHashSet(config.getSuperUserRoles()), Sets.newHashSet(cluster)));
             } catch (PulsarAdminException ex1) {
                 if (!(ex1 instanceof PulsarAdminException.ConflictException)) {
-                    LOG.error("Unexpected exception {} when creating tenant {}", ex1, tenant);
+                    log.error()
+                            .exceptionMessage(ex1)
+                            .attr("tenant", tenant)
+                            .log("Unexpected exception when creating tenant");
                     throw ex1;
                 }
             }
@@ -204,7 +211,10 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
                 admin.namespaces().createNamespace(namespace);
             } catch (PulsarAdminException ex1) {
                 if (!(ex1 instanceof PulsarAdminException.ConflictException)) {
-                    LOG.error("Unexpected exception {} when creating namespace {}", ex1, namespace);
+                    log.error()
+                            .exceptionMessage(ex1)
+                            .attr("namespace", namespace)
+                            .log("Unexpected exception when creating namespace");
                     throw ex1;
                 }
             }
@@ -221,7 +231,7 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
             consumer = new ResourceUsageReader();
             pTask = new ResourceUsageWriterTask();
         } catch (Exception ex) {
-            LOG.error("Error initializing resource usage transport manager", ex);
+            log.error().exception(ex).log("Error initializing resource usage transport manager");
             throw ex;
         }
     }
@@ -268,7 +278,7 @@ public class ResourceUsageTopicTransportManager implements ResourceUsageTranspor
             pTask.close();
             consumer.close();
         } catch (Exception ex1) {
-            LOG.error("Error closing producer/consumer for resource-usage topic", ex1);
+            log.error().exception(ex1).log("Error closing producer/consumer for resource-usage topic");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/RestMessagePublishContext.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/RestMessagePublishContext.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.broker.rest;
 import io.netty.util.Recycler;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.service.Topic;
@@ -29,7 +29,7 @@ import org.apache.pulsar.broker.service.Topic;
 /**
  * PublishContext implementation for REST message publishing.
  */
-@Slf4j
+@CustomLog
 public class RestMessagePublishContext implements Topic.PublishContext {
 
     private Topic topic;
@@ -43,17 +43,11 @@ public class RestMessagePublishContext implements Topic.PublishContext {
     public void completed(Exception exception, long ledgerId, long entryId) {
         if (exception != null) {
             positionFuture.completeExceptionally(exception);
-            if (log.isInfoEnabled()) {
-                log.info("Failed to write entry for rest produce request: ledgerId: {}, entryId: {}. "
-                                + "triggered send callback.",
-                        ledgerId, entryId);
-            }
+            log.info().attr("ledgerId", ledgerId).attr("entryId", entryId)
+                    .log("Failed to write entry for rest produce request. Triggered send callback");
         } else {
-            if (log.isInfoEnabled()) {
-                log.info("Success write topic for rest produce request: {}, ledgerId: {}, entryId: {}. "
-                                + "triggered send callback.",
-                        topic.getName(), ledgerId, entryId);
-            }
+            log.info().attr("topic", topic.getName()).attr("ledgerId", ledgerId).attr("entryId", entryId)
+                    .log("Success write topic for rest produce request. Triggered send callback");
             topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.NANOSECONDS);
             positionFuture.complete(PositionFactory.create(ledgerId, entryId));
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/Topics.java
@@ -35,8 +35,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.websocket.data.ProducerMessages;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -44,8 +42,6 @@ import org.slf4j.LoggerFactory;
 @Api(value = "/persistent", description = "Apis for produce,consume and ack message on topics.", tags = "topics")
 @SuppressWarnings("deprecation")
 public class Topics extends TopicsBase {
-    private static final Logger log = LoggerFactory.getLogger(Topics.class);
-
     @POST
     @Path("/persistent/{tenant}/{namespace}/{topic}")
     @ApiOperation(value = "Produce message to a persistent topic.", response = String.class, responseContainer = "List")
@@ -68,7 +64,10 @@ public class Topics extends TopicsBase {
             validateProducePermission();
             publishMessages(asyncResponse, producerMessages, authoritative);
         } catch (Exception e) {
-            log.error("[{}] Failed to produce on topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to produce on topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -98,7 +97,10 @@ public class Topics extends TopicsBase {
             validateProducePermission();
             publishMessagesToPartition(asyncResponse, producerMessages, authoritative, partition);
         } catch (Exception e) {
-            log.error("[{}] Failed to produce on topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to produce on topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -127,7 +129,10 @@ public class Topics extends TopicsBase {
             validateProducePermission();
             publishMessages(asyncResponse, producerMessages, authoritative);
         } catch (Exception e) {
-            log.error("[{}] Failed to produce on topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to produce on topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }
@@ -158,7 +163,10 @@ public class Topics extends TopicsBase {
             validateProducePermission();
             publishMessagesToPartition(asyncResponse, producerMessages, authoritative, partition);
         } catch (Exception e) {
-            log.error("[{}] Failed to produce on topic {}", clientAppId(), topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Failed to produce on topic");
             resumeAsyncResponseExceptionally(asyncResponse, e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -47,7 +47,6 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
@@ -106,7 +105,6 @@ import org.apache.pulsar.websocket.data.ProducerMessages;
 /**
  * Contains methods used by REST api to producer/consumer/read messages to/from pulsar topics.
  */
-@Slf4j
 public class TopicsBase extends PersistentTopicsBase {
 
     private static String defaultProducerName = "RestProducer";
@@ -134,10 +132,9 @@ public class TopicsBase extends PersistentTopicsBase {
                                         "Fail to add or retrieve schema."));
                             }
                         }).exceptionally(e -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Fail to publish message: " + e.getMessage());
-                    }
-                    asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Fail to publish message:"
+                        log.debug().exceptionMessage(e).log("Fail to publish message");
+                                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
+                                                "Fail to publish message:"
                             + e.getMessage()));
                     return null;
                 });
@@ -175,10 +172,11 @@ public class TopicsBase extends PersistentTopicsBase {
                                         "Fail to add or retrieve schema."));
                             }
                         }).exceptionally(e -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Fail to publish message to single partition: " + e.getLocalizedMessage());
-                    }
-                    asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Fail to publish message"
+                        log.debug()
+                                .attr("localizedMessage", e.getLocalizedMessage())
+                                .log("Fail to publish message to single partition");
+                                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
+                                                "Fail to publish message"
                             + "to single partition: "
                             + e.getMessage()));
                     return null;
@@ -218,11 +216,11 @@ public class TopicsBase extends PersistentTopicsBase {
                 return null;
             });
         } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail publish messages to single partition with rest produce message "
-                                + "request for topic  {}: {} ", topicName, e.getCause());
-            }
-            asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage()));
+                log.debug()
+                        .attr("topic", topicName)
+                        .exception(e.getCause())
+                        .log("Fail publish messages to single partition with rest produce message request for topic");
+                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage()));
         }
     }
 
@@ -261,11 +259,11 @@ public class TopicsBase extends PersistentTopicsBase {
                 return null;
             });
         } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail to publish messages with rest produce message request for topic  {}: {} ",
-                        topicName, e.getCause());
-            }
-            asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage()));
+                log.debug()
+                        .attr("topic", topicName)
+                        .exceptionMessage(e)
+                        .log("Fail to publish messages with rest produce message request");
+                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, e.getMessage()));
         }
     }
 
@@ -292,11 +290,11 @@ public class TopicsBase extends PersistentTopicsBase {
                         headersAndPayload.release();
                     }
                 } catch (Exception e) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Fail to publish single messages to topic  {}: {} ",
-                                topicName, e.getCause());
-                    }
-                    publishResult.completeExceptionally(e);
+                        log.debug()
+                                .attr("topic", topicName)
+                                .exceptionMessage(e)
+                                .log("Fail to publish single messages to topic");
+                                        publishResult.completeExceptionally(e);
                 }
             }
         });
@@ -315,11 +313,11 @@ public class TopicsBase extends PersistentTopicsBase {
                         Integer.parseInt(produceMessageResults.get(index).getMessageId()));
                 produceMessageResults.get(index).setMessageId(messageId.toString());
             } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Fail publish [{}] message with rest produce message request for topic  {}",
-                            index, topicName);
-                }
-                if (e instanceof BrokerServiceException.TopicNotFoundException) {
+                    log.debug()
+                            .attr("publish", index)
+                            .attr("topic", topicName)
+                            .log("Fail publish message with rest produce message request for topic");
+                                if (e instanceof BrokerServiceException.TopicNotFoundException) {
                     // Topic ownership might changed, force to look up again.
                     pulsar().getBrokerService().getOwningTopics().remove(topicName.getPartitionedTopicName());
                 }
@@ -366,10 +364,10 @@ public class TopicsBase extends PersistentTopicsBase {
         try {
             return future.get();
         } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail to lookup topic for rest produce message request for topic {}.", topicName.toString());
-            }
-            if (!asyncResponse.isDone()) {
+                log.debug()
+                        .attr("topic", topicName.toString())
+                        .log("Fail to lookup topic for rest produce message request for topic .");
+                        if (!asyncResponse.isDone()) {
                 asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Internal error: "
                         + e.getMessage()));
             }
@@ -390,11 +388,12 @@ public class TopicsBase extends PersistentTopicsBase {
             } else {
                 // Redirect client to other broker owns the topic or know which broker own the topic.
                 try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Redirect rest produce request for topic {} from {} to {}.",
-                                topicName, pulsar().getWebServiceAddress(), redirectAddresses.get(0));
-                    }
-                    URL redirectAddress = new URL(redirectAddresses.get(0));
+                        log.debug()
+                                .attr("topic", topicName)
+                                .attr("from", pulsar().getWebServiceAddress())
+                                .attr("to", redirectAddresses.get(0))
+                                .log("Redirect rest produce request");
+                                        URL redirectAddress = new URL(redirectAddresses.get(0));
                     URI redirectURI = UriBuilder.fromUri(uri.getRequestUri())
                             .host(redirectAddress.getHost())
                             .port(redirectAddress.getPort())
@@ -402,11 +401,12 @@ public class TopicsBase extends PersistentTopicsBase {
                     asyncResponse.resume(Response.temporaryRedirect(redirectURI).build());
                     future.complete(true);
                 } catch (Exception e) {
-                    if (log.isDebugEnabled()) {
-                        log.error("Error in preparing redirect url with rest produce message request for topic  {}: {}",
-                                topicName, e.getMessage(), e);
-                    }
-                    asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
+                        log.error()
+                                .attr("topic", topicName)
+
+                                .exception(e)
+                                .log("Error in preparing redirect url with rest produce message request for topic");
+                                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
                             "Fail to redirect client request."));
                     future.complete(true);
                 }
@@ -421,10 +421,8 @@ public class TopicsBase extends PersistentTopicsBase {
                                                          boolean authoritative, List<String> redirectAddresses) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
-            if (log.isDebugEnabled()) {
                 log.debug("Too many concurrent lookup request.");
-            }
-            future.completeExceptionally(new BrokerServiceException.TooManyRequestsException("Too many "
+                        future.completeExceptionally(new BrokerServiceException.TooManyRequestsException("Too many "
                     + "concurrent lookup request"));
             return future;
         }
@@ -434,11 +432,10 @@ public class TopicsBase extends PersistentTopicsBase {
 
         lookupFuture.thenAccept(optionalResult -> {
             if (optionalResult == null || !optionalResult.isPresent()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Fail to lookup topic for rest produce message request for topic {}.",
-                            partitionedTopicName);
-                }
-                completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
+                    log.debug()
+                            .attr("topic", partitionedTopicName)
+                            .log("Fail to lookup topic for rest produce message request for topic .");
+                                completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
                 return;
             }
 
@@ -448,24 +445,24 @@ public class TopicsBase extends PersistentTopicsBase {
             if ((StringUtils.isNotBlank(httpUrl) && httpUrl.equals(pulsar().getWebServiceAddress()))
                     || (StringUtils.isNotBlank(httpUrlTls) && httpUrlTls.equals(pulsar().getWebServiceAddressTls()))) {
                 // Current broker owns the topic, add to owning topic.
-                if (log.isDebugEnabled()) {
-                    log.debug("Complete topic look up for rest produce message request for topic {}, "
-                                    + "current broker is owner broker: {}",
-                            partitionedTopicName, result.getLookupData());
-                }
-                pulsar().getBrokerService().getOwningTopics().computeIfAbsent(partitionedTopicName
+                    log.debug()
+                            .attr("topic", partitionedTopicName)
+                            .attr("broker", result.getLookupData())
+                            .log("Complete topic look up for rest produce message request for topic , current broker"
+                                    + " is owner broker");
+                                pulsar().getBrokerService().getOwningTopics().computeIfAbsent(partitionedTopicName
                                 .getPartitionedTopicName(),
                         __ -> ConcurrentHashMap.newKeySet())
                         .add(partitionedTopicName.getPartitionIndex());
                 completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
             } else {
                 // Current broker doesn't own the topic or doesn't know who own the topic.
-                if (log.isDebugEnabled()) {
-                    log.debug("Complete topic look up for rest produce message request for topic {}, "
-                                    + "current broker is not owner broker: {}",
-                            partitionedTopicName, result.getLookupData());
-                }
-                if (result.isRedirect()) {
+                    log.debug()
+                            .attr("topic", partitionedTopicName)
+                            .attr("broker", result.getLookupData())
+                            .log("Complete topic look up for rest produce message request for topic , current broker"
+                                    + " is not owner broker");
+                                if (result.isRedirect()) {
                     // Redirect lookup.
                     completeLookup(Pair.of(Arrays.asList(httpUrl, httpUrlTls), false), redirectAddresses, future);
                 } else {
@@ -474,11 +471,11 @@ public class TopicsBase extends PersistentTopicsBase {
                 }
             }
         }).exceptionally(exception -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail to lookup broker with rest produce message request for topic {}: {}",
-                        partitionedTopicName, exception.getMessage());
-            }
-            completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
+                log.debug()
+                        .attr("topic", partitionedTopicName)
+                        .exceptionMessage(exception)
+                        .log("Fail to lookup broker with rest produce message request for topic");
+                        completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
             return null;
         });
         return future;
@@ -495,11 +492,12 @@ public class TopicsBase extends PersistentTopicsBase {
                 schemaAndMetadata = pulsar().getSchemaRegistryService().getSchema(id, schemaVersion).get();
                 future.complete(Pair.of(schemaAndMetadata.schema, schemaAndMetadata.version));
             } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Fail to retrieve schema of version {} for topic {}: {}",
-                            schemaVersion.getVersion(), topicName, e.getMessage());
-                }
-                future.completeExceptionally(e);
+                    log.debug()
+                            .attr("version", schemaVersion.getVersion())
+                            .attr("topic", topicName)
+                            .exceptionMessage(e)
+                            .log("Fail to retrieve schema of version for topic");
+                                future.completeExceptionally(e);
             }
         } else if (null != schemaData) {
             // Else try to add schema to topic.
@@ -508,11 +506,12 @@ public class TopicsBase extends PersistentTopicsBase {
                 sv = addSchema(schemaData).get();
                 future.complete(Pair.of(schemaData, sv));
             } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Fail to add schema {} for topic {}: {}",
-                            new String(schemaData.toSchemaInfo().getSchema()), topicName, e.getMessage());
-                }
-                future.completeExceptionally(e);
+                    log.debug()
+                            .attr("schema", new String(schemaData.toSchemaInfo().getSchema()))
+                            .attr("topic", topicName)
+                            .exceptionMessage(e)
+                            .log("Fail to add schema for topic");
+                                future.completeExceptionally(e);
             }
         } else {
             // Indicating exception.
@@ -548,11 +547,11 @@ public class TopicsBase extends PersistentTopicsBase {
                 result.complete(future.get());
                 break;
             } catch (Exception e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Fail to add schema to topic " + topicName.getPartitionedTopicName()
-                            + " for partition " + partitions.get(index) + " for REST produce request.");
-                }
-            }
+                    log.debug()
+                            .attr("partitionedTopicName", topicName.getPartitionedTopicName())
+                            .attr("value", partitions.get(index))
+                            .log("Fail to add schema to topic for partition for REST produce request.");
+                            }
         }
         // Not able to add schema to any partition
         if (!result.isDone()) {
@@ -604,10 +603,11 @@ public class TopicsBase extends PersistentTopicsBase {
                         .build();
             }
         } catch (IOException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail to parse schema info for rest produce request with key schema {} and value schema {}"
-                        , keySchema, valueSchema);
-            }
+            log.debug()
+                    .attr("keySchema", keySchema)
+                    .attr("valueSchema", valueSchema)
+                    .exception(e)
+                    .log("Failed to parse schema info for rest produce request");
             return null;
         }
     }
@@ -747,11 +747,11 @@ public class TopicsBase extends PersistentTopicsBase {
                     throw new PulsarClientException.InvalidMessageException("");
             }
         } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Fail to encode value {} with schema {} for rest produce request", input,
-                        new String(schema.getSchemaInfo().getSchema()));
-            }
-            return new byte[0];
+                log.debug()
+                        .attr("value", input)
+                        .attr("schema", new String(schema.getSchemaInfo().getSchema()))
+                        .log("Fail to encode value with schema for rest produce request");
+                        return new byte[0];
         }
     }
 
@@ -787,12 +787,18 @@ public class TopicsBase extends PersistentTopicsBase {
                         .allowTopicOperationAsync(topicName, TopicOperation.PRODUCE, authParams)
                         .get(config().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
             } catch (TimeoutException e) {
-                log.warn("Time-out {} sec while checking authorization on {} ",
-                        config().getMetadataStoreOperationTimeoutSeconds(), topicName);
+                log.warn()
+                        .attr("timeoutSec", config().getMetadataStoreOperationTimeoutSeconds())
+                        .attr("topic", topicName)
+                        .log("Timeout while checking authorization");
                 throw new RestException(Status.INTERNAL_SERVER_ERROR, "Time-out while checking authorization");
             } catch (Exception e) {
-                log.warn("Producer-client  with Role - {} {} failed to get permissions for topic - {}. {}",
-                        authParams.getClientRole(), authParams.getOriginalPrincipal(), topicName, e.getMessage());
+                log.warn()
+                        .attr("role", authParams.getClientRole())
+                        .attr("originalPrincipal", authParams.getOriginalPrincipal())
+                        .attr("topic", topicName)
+                        .exceptionMessage(e)
+                        .log("Producer-client with Role - failed to get permissions for topic - .");
                 throw new RestException(Status.INTERNAL_SERVER_ERROR, "Failed to get permissions");
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.Position;
@@ -55,7 +55,7 @@ import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.compaction.Compactor;
 import org.jspecify.annotations.Nullable;
 
-@Slf4j
+@CustomLog
 public abstract class AbstractBaseDispatcher extends EntryFilterSupport implements Dispatcher {
 
     private static final Gauge PENDING_BYTES_TO_DISPATCH = Gauge
@@ -369,7 +369,11 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
             ReplicatedSubscriptionsSnapshot snapshot = Markers.parseReplicatedSubscriptionsSnapshot(headersAndPayload);
             subscription.processReplicatedSubscriptionSnapshot(snapshot);
         } catch (Throwable t) {
-            log.warn("Failed to process replicated subscription snapshot at {} -- {}", pos, t.getMessage(), t);
+            log.warn()
+                    .attr("pos", pos)
+
+                    .exception(t)
+                    .log("Failed to process replicated subscription snapshot at");
             return;
         }
     }
@@ -443,12 +447,13 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
             }
         }
         if (readLimits.getLeft() == 0 || readLimits.getRight() == 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] message-read exceeded {} message-rate {}/{}, schedule after {}ms", getName(),
-                        limiterType.name().toLowerCase(),
-                        rateLimiter.getDispatchRateOnMsg(), rateLimiter.getDispatchRateOnByte(),
-                        MESSAGE_RATE_BACKOFF_MS);
-            }
+            log.debug()
+                    .attr("name", getName())
+                    .attr("limiterType", limiterType.name().toLowerCase())
+                    .attr("dispatchRateOnMsg", rateLimiter.getDispatchRateOnMsg())
+                    .attr("dispatchRateOnByte", rateLimiter.getDispatchRateOnByte())
+                    .attr("backoffMs", MESSAGE_RATE_BACKOFF_MS)
+                    .log("message-read exceeded message-rate, scheduling after backoff");
             reScheduleRead();
             readLimits.setLeft(-1);
             readLimits.setRight(-1L);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
@@ -41,9 +42,8 @@ import org.apache.pulsar.client.impl.Murmur3Hash32;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBaseDispatcher {
 
     private static final int MAX_RETRY_COUNT_FOR_ADD_CONSUMER_RACE = 5;
@@ -169,7 +169,10 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
 
     private synchronized CompletableFuture<Void> internalAddConsumer(Consumer consumer, int retryCount) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", this.topicName, consumer);
+            log.warn()
+                    .attr("topic", this.topicName)
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -183,8 +186,12 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                         return FutureUtil.failedFuture(new ConsumerBusyException("Exclusive consumer is already"
                                 + " connected"));
                     } else if (retryCount >= MAX_RETRY_COUNT_FOR_ADD_CONSUMER_RACE) {
-                        log.warn("[{}] The active consumer's connection is still inactive after all retries {}, skip "
-                                        + "adding new consumer {}", getName(), actConsumer, consumer);
+                        log.warn()
+                                .attr("arg0", getName())
+                                .attr("actConsumer", actConsumer)
+                                .attr("consumer", consumer)
+                                .log("The active consumer's connection is still inactive after all retries, skip "
+                                        + "adding new consumer");
                         return FutureUtil.failedFuture(new ConsumerBusyException("Exclusive consumer is already"
                                 + " connected after " + MAX_RETRY_COUNT_FOR_ADD_CONSUMER_RACE + " attempts"));
                     } else {
@@ -193,8 +200,11 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
                             // 1. `isActive` was set to false
                             // 2. `consumer.close()` is called
                             // We should wait until the consumer is closed, retry for some times
-                            log.warn("[{}] race condition happened that cnx of the active consumer ({}) is inactive "
-                                    + "but it's not removed, retrying", getName(), actConsumer);
+                            log.warn()
+                                    .attr("arg0", getName())
+                                    .attr("actConsumer", actConsumer)
+                                    .log("race condition happened that cnx of the active consumer () is inactive "
+                                            + "but it's not removed, retrying");
                             final var future = new CompletableFuture<Void>();
                             CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS)
                                     .execute(() -> future.complete(null));
@@ -213,8 +223,9 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
         }
 
         if (subscriptionType == SubType.Failover && isConsumersExceededOnSubscription()) {
-            log.warn("[{}] Attempting to add consumer to subscription which reached max consumers limit",
-                    this.topicName);
+            log.warn()
+                    .attr("topic", this.topicName)
+                    .log("Attempting to add consumer to subscription which reached max consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Subscription reached max consumers limit"));
         }
 
@@ -239,9 +250,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
             // the active consumer is not changed
             Consumer currentActiveConsumer = getActiveConsumer();
             if (null == currentActiveConsumer) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Current active consumer disappears while adding consumer {}", consumer);
-                }
+                log.debug().attr("consumer", consumer).log("Current active consumer disappears while adding consumer");
             } else {
                 consumer.notifyActiveConsumerChange(currentActiveConsumer);
             }
@@ -251,7 +260,7 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     }
 
     public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
-        log.info("Removing consumer {}", consumer);
+        log.info().attr("consumer", consumer).log("Removing consumer");
         if (!consumers.remove(consumer)) {
             throw new ServerMetadataException("Consumer was not connected");
         }
@@ -360,7 +369,4 @@ public abstract class AbstractDispatcherSingleActiveConsumer extends AbstractBas
     public boolean isConsumerConnected() {
         return activeConsumer != null;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(AbstractDispatcherSingleActiveConsumer.class);
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractReplicator.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.opentelemetry.api.common.Attributes;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,10 +47,11 @@ import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.StringInterner;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractReplicator implements Replicator {
+
+    private static final Logger LOG = Logger.get(AbstractReplicator.class);
+    protected final Logger log;
 
     protected final BrokerService brokerService;
     protected final String localTopicName;
@@ -130,6 +132,19 @@ public abstract class AbstractReplicator implements Replicator {
                         localTopicName + "-->" + remoteTopicName,
                 Objects.equals(localCluster, remoteCluster) ? localCluster : localCluster + "-->" + remoteCluster
         );
+        var logBuilder = LOG.with()
+                .attr("topic", localTopicName)
+                .attr("state", () -> state);
+        if (!Objects.equals(localTopicName, remoteTopicName)) {
+            logBuilder.attr("remoteTopic", remoteTopicName);
+        }
+        if (!Objects.equals(localCluster, remoteCluster)) {
+            logBuilder.attr("localCluster", localCluster);
+            logBuilder.attr("remoteCluster", remoteCluster);
+        } else {
+            logBuilder.attr("cluster", localCluster);
+        }
+        this.log = logBuilder.build();
         this.producerBuilder = replicationClient.newProducer(Schema.AUTO_PRODUCE_BYTES()) //
                 .topic(remoteTopicName)
                 .messageRoutingMode(MessageRoutingMode.SinglePartition)
@@ -174,27 +189,21 @@ public abstract class AbstractReplicator implements Replicator {
         Pair<Boolean, State> setStartingRes = compareSetAndGetState(State.Disconnected, State.Starting);
         if (!setStartingRes.getLeft()) {
             if (setStartingRes.getRight() == State.Starting) {
-                log.info("[{}] Skip the producer creation since other thread is doing starting, state : {}",
-                        replicatorId, state);
+                log.info("Skip the producer creation since other thread is starting");
             } else if (setStartingRes.getRight() == State.Started) {
                 // Since the method "startProducer" will be called even if it is started, only print debug-level log.
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Replicator was already running. state: {}", replicatorId, state);
-                }
+                log.debug("Replicator was already running");
             } else if (setStartingRes.getRight() == State.Disconnecting) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Rep.producer is closing, delay to retry(wait the producer close success)."
-                            + " state: {}", replicatorId, state);
-                }
+                log.debug("Rep.producer is closing, delay to retry (wait the producer close success)");
                 delayStartProducerAfterDisconnected();
             } else {
                 /** {@link State.Terminating}, {@link State.Terminated}. **/
-                log.info("[{}] Skip the producer creation since the replicator state is : {}", replicatorId, state);
+                log.info("Skip the producer creation since the replicator is terminating");
             }
             return;
         }
 
-        log.info("[{}] Starting replicator", replicatorId);
+        log.info("Starting replicator");
 
         // Force only replicate messages to a non-partitioned topic, to avoid auto-create a partitioned topic on
         // the remote cluster.
@@ -209,22 +218,21 @@ public abstract class AbstractReplicator implements Replicator {
             Pair<Boolean, State> setDisconnectedRes = compareSetAndGetState(State.Starting, State.Disconnected);
             if (setDisconnectedRes.getLeft()) {
                 long waitTimeMs = backOff.next().toMillis();
-                log.warn("[{}] Failed to create remote producer ({}), retrying in {} s",
-                        replicatorId, ex.getMessage(), waitTimeMs / 1000.0);
+                log.warn()
+                        .exceptionMessage(ex)
+                        .attr("waitTimeSec", waitTimeMs / 1000.0)
+                        .log("Failed to create remote producer, retrying");
                 // BackOff before retrying
                 scheduleCheckTopicActiveAndStartProducer(waitTimeMs);
             } else {
                 if (setDisconnectedRes.getRight() == State.Terminating
                         || setDisconnectedRes.getRight() == State.Terminated) {
-                    log.info("[{}] Skip to create producer, because it has been terminated, state is : {}",
-                            replicatorId, state);
+                    log.info("Skip to create producer, because it has been terminated");
                 } else {
                     /** {@link  State.Disconnected}, {@link  State.Starting}, {@link  State.Started} **/
                     // Since only one task can call "producerBuilder.createAsync()", this scenario is not expected.
                     // So print a warn log.
-                    log.warn("[{}] Other thread will try to create the producer again. so skipped current one task."
-                                    + " State is : {}",
-                            replicatorId, state);
+                    log.warn("Other thread will try to create the producer again, skipping current task");
                 }
             }
             return null;
@@ -238,57 +246,51 @@ public abstract class AbstractReplicator implements Replicator {
      */
     protected void delayStartProducerAfterDisconnected() {
         long waitTimeMs = backOff.next().toMillis();
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "[{}] waiting for producer to close before attempting to reconnect, retrying in {} s",
-                    replicatorId, waitTimeMs / 1000.0);
-        }
+        log.debug()
+                .attr("waitTimeSec", waitTimeMs / 1000.0)
+                .log("Waiting for producer to close before attempting to reconnect");
         scheduleCheckTopicActiveAndStartProducer(waitTimeMs);
     }
 
     protected void scheduleCheckTopicActiveAndStartProducer(final long waitTimeMs) {
         brokerService.executor().schedule(() -> {
             if (state == State.Terminating || state == State.Terminated) {
-                log.info("[{}] Skip scheduled to start the producer since the replicator state is : {}",
-                        replicatorId, state);
+                log.info("Skip scheduled to start the producer since the replicator is terminating");
                 return;
             }
             CompletableFuture<Optional<Topic>> topicFuture = brokerService.getTopics().get(localTopicName);
             if (topicFuture == null) {
                 // Topic closed.
-                log.info("[{}] Skip scheduled to start the producer since the topic was closed successfully."
-                        + " And trigger a terminate.", replicatorId);
+                log.info("Skip scheduled to start the producer since the topic was closed, triggering terminate");
                 terminate();
                 return;
             }
             topicFuture.thenAccept(optional -> {
                 if (optional.isEmpty()) {
                     // Topic closed.
-                    log.info("[{}] Skip scheduled to start the producer since the topic was closed. And trigger a"
-                            + " terminate.", replicatorId);
+                    log.info("Skip scheduled to start the producer since the topic was closed, triggering terminate");
                     terminate();
                     return;
                 }
                 if (optional.get() != localTopic) {
                     // Topic closed and created a new one, current replicator is outdated.
-                    log.info("[{}] Skip scheduled to start the producer since the topic was closed. And trigger a"
-                            + " terminate.", replicatorId);
+                    log.info("Skip scheduled to start the producer since the topic was closed, triggering terminate");
                     terminate();
                     return;
                 }
                 Replicator replicator = localTopic.getReplicators().get(remoteCluster);
                 if (replicator != AbstractReplicator.this) {
                     // Current replicator has been closed, and created a new one.
-                    log.info("[{}] Skip scheduled to start the producer since a new replicator has instead current"
-                            + " one. And trigger a terminate.", replicatorId);
+                    log.info("Skip scheduled to start the producer since a new replicator replaced the current one, "
+                            + "triggering terminate");
                     terminate();
                     return;
                 }
                 startProducer();
             }).exceptionally(ex -> {
-                log.error("[{}] [{}] Stop retry to create producer due to unknown error(topic create failed), and"
-                                + " trigger a terminate. Replicator state: {}",
-                        localTopicName, replicatorId, STATE_UPDATER.get(this), ex);
+                log.error()
+                        .exception(ex)
+                        .log("Stop retry to create producer due to unknown error, triggering terminate");
                 terminate();
                 return null;
             });
@@ -317,13 +319,13 @@ public abstract class AbstractReplicator implements Replicator {
         if (backlog > 0) {
             CompletableFuture<Void> disconnectFuture = new CompletableFuture<>();
             disconnectFuture.completeExceptionally(new TopicBusyException("Cannot close a replicator with backlog"));
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Replicator disconnect failed since topic has backlog", replicatorId);
-            }
+            log.debug("Replicator disconnect failed since topic has backlog");
             return disconnectFuture;
         }
-        log.info("[{}] Disconnect replicator at position {} with backlog {}", replicatorId,
-                getReplicatorReadPosition(), backlog);
+        log.info()
+                .attr("readPosition", getReplicatorReadPosition())
+                .attr("backlog", backlog)
+                .log("Disconnect replicator at position with backlog");
         return beforeDisconnect()
             .thenCompose(__ -> closeProducerAsync(true))
             .thenApply(__ -> {
@@ -368,21 +370,17 @@ public abstract class AbstractReplicator implements Replicator {
                     brokerService.executor().schedule(() -> closeProducerAsync(true),
                             waitTimeMs, TimeUnit.MILLISECONDS);
                 } else {
-                    log.info("[{}] Skip current producer closing since the previous producer has been closed,"
-                                    + " and trying start a new one, state : {}",
-                            replicatorId, setDisconnectingRes.getRight());
+                    log.info("Skip current producer closing since the previous producer has been closed "
+                            + "and a new one is starting");
                 }
             } else if (setDisconnectingRes.getRight() == State.Disconnected
                     || setDisconnectingRes.getRight() == State.Disconnecting) {
-                log.info("[{}] Skip current producer closing since other thread did closing, state : {}",
-                        replicatorId, setDisconnectingRes.getRight());
+                log.info("Skip current producer closing since other thread did closing");
             } else if (setDisconnectingRes.getRight() == State.Terminating
                     || setDisconnectingRes.getRight() == State.Terminated) {
-                log.info("[{}] Skip current producer closing since other thread is doing termination, state : {}",
-                        replicatorId, state);
+                log.info("Skip current producer closing since other thread is doing termination");
             }
-            log.info("[{}] Skip current termination since other thread is doing close producer or termination,"
-                            + " state : {}", replicatorId, state);
+            log.info("Skip current termination since other thread is doing close producer or termination");
             return CompletableFuture.completedFuture(null);
         }
 
@@ -397,14 +395,11 @@ public abstract class AbstractReplicator implements Replicator {
             }
             if (setDisconnectedRes.getRight() == State.Terminating
                     || setDisconnectingRes.getRight() == State.Terminated) {
-                log.info("[{}] Skip setting state to terminated because it was terminated, state : {}",
-                        replicatorId, state);
+                log.info("Skip setting state to terminated because it was already terminated");
             } else {
                 // Since only one task can call "doCloseProducerAsync(producer, action)", this scenario is not expected.
                 // So print a warn log.
-                log.warn("[{}] Other task has change the state to terminated. so skipped current one task."
-                                + " State is : {}",
-                        replicatorId, state);
+                log.warn("Other task has changed the state to terminated, skipping current task");
             }
         });
     }
@@ -416,10 +411,10 @@ public abstract class AbstractReplicator implements Replicator {
             actionAfterClosed.run();
         }).exceptionally(ex -> {
             long waitTimeMs = backOff.next().toMillis();
-            log.warn(
-                    "[{}] Exception: '{}' occurred while trying to close the producer. Replicator state: {}."
-                            + " Retrying again in {} s.",
-                    replicatorId, ex.getMessage(), state, waitTimeMs / 1000.0);
+            log.warn()
+                    .exceptionMessage(ex)
+                    .attr("waitTimeSec", waitTimeMs / 1000.0)
+                    .log("Exception occurred while trying to close the producer, retrying");
             // BackOff before retrying
             brokerService.executor().schedule(() -> doCloseProducerAsync(producer, actionAfterClosed),
                     waitTimeMs, TimeUnit.MILLISECONDS);
@@ -432,8 +427,7 @@ public abstract class AbstractReplicator implements Replicator {
     @SuppressWarnings("unchecked")
     public CompletableFuture<Void> terminate() {
         if (!tryChangeStatusToTerminating()) {
-            log.info("[{}] Skip current termination since other thread is doing termination, state : {}", replicatorId,
-                    state);
+            log.info("Skip current termination since other thread is doing termination");
             return CompletableFuture.completedFuture(null);
         }
         beforeTerminate();
@@ -511,15 +505,12 @@ public abstract class AbstractReplicator implements Replicator {
                 if (isPartitionedTopic) {
                     String s = topicName
                             + " is a partitioned-topic and replication can't be started for partitioned-producer ";
-                    log.error(s);
+                    LOG.error(s);
                     return FutureUtil.failedFuture(new NamingException(s));
                 }
                 return CompletableFuture.completedFuture(null);
             });
     }
-
-    private static final Logger log = LoggerFactory.getLogger(AbstractReplicator.class);
-
     public State getState() {
         return state;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -25,6 +25,7 @@ import static org.apache.pulsar.broker.service.ServerCnxThrottleTracker.Throttle
 import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import io.github.merlimat.slog.Logger;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -93,10 +94,11 @@ import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class AbstractTopic implements Topic, TopicPolicyListener {
+
+    private static final Logger LOG = Logger.get(AbstractTopic.class);
+    protected final Logger log;
 
     protected static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
 
@@ -188,6 +190,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
 
     public AbstractTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
+        this.log = LOG.with().attr("topic", topic).build();
         this.namespace = TopicName.get(topic).getNamespaceObject();
         this.clock = brokerService.getClock();
         this.brokerService = brokerService;
@@ -313,9 +316,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     }
 
     protected void updateTopicPolicyByNamespacePolicy(Policies namespacePolicies) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}]updateTopicPolicyByNamespacePolicy,data={}", topic, namespacePolicies);
-        }
+        log.debug()
+                .attr("namespacePolicies", namespacePolicies)
+                .log("updateTopicPolicyByNamespacePolicy,data");
         if (!isSystemTopic()) {
             updateNamespacePublishRate(namespacePolicies, brokerService.getPulsar().getConfig().getClusterName());
             updateNamespaceDispatchRate(namespacePolicies, brokerService.getPulsar().getConfig().getClusterName());
@@ -640,12 +643,12 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
 
     protected CompletableFuture<Void> addConsumerToSubscription(Subscription subscription, Consumer consumer) {
         if (isConsumersExceededOnTopic()) {
-            log.warn("[{}] Attempting to add consumer to topic which reached max consumers limit", topic);
+            log.warn("Attempting to add consumer to topic which reached max consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Topic reached max consumers limit"));
         }
 
         if (isSameAddressConsumersExceededOnTopic(consumer)) {
-            log.warn("[{}] Attempting to add consumer to topic which reached max same address consumers limit", topic);
+            log.warn("Attempting to add consumer to topic which reached max same address consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Topic reached max same address consumers limit"));
         }
 
@@ -789,18 +792,18 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                     try {
                         checkTopicFenced();
                         if (isMigrated()) {
-                            log.warn("[{}] Attempting to add producer to a migrated topic", topic);
+                            log.warn("Attempting to add producer to a migrated topic");
                             throw new TopicMigratedException("Topic was already migrated");
                         } else if (isTerminated()) {
-                            log.warn("[{}] Attempting to add producer to a terminated topic", topic);
+                            log.warn("Attempting to add producer to a terminated topic");
                             throw new TopicTerminatedException("Topic was already terminated");
                         }
                         return internalAddProducer(producer).thenApply(ignore -> {
                             USAGE_COUNT_UPDATER.incrementAndGet(this);
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(),
-                                        USAGE_COUNT_UPDATER.get(this));
-                            }
+                            log.debug()
+                                    .attr("producerName", producer.getProducerName())
+                                    .attr("usageCount", USAGE_COUNT_UPDATER.get(this))
+                                    .log("Added producer");
                             return producerEpoch;
                         });
                     } catch (BrokerServiceException e) {
@@ -845,12 +848,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                     waitingExclusiveProducers.clear();
                     waitingExclusiveProducersCopy.forEach((Pair<Producer,
                                                            CompletableFuture<Optional<Long>>> handle) -> {
-                        log.info("[{}] Failing waiting producer {}", topic, handle.getKey());
+                        log.info().attr("key", handle.getKey()).log("Failing waiting producer");
                         handle.getValue().completeExceptionally(new ProducerFencedException("Fenced out"));
                         handle.getKey().close(true);
                     });
                     producers.forEach((k, currentProducer) -> {
-                        log.info("[{}] Fencing out producer {}", topic, currentProducer);
+                        log.info()
+                                .attr("currentProducer", currentProducer)
+                                .log("Fencing out producer");
                         currentProducer.close(true);
                     });
                 }
@@ -858,7 +863,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
             case WaitForExclusive: {
                 if (hasExclusiveProducer || !producers.isEmpty()) {
                     CompletableFuture<Optional<Long>> future = new CompletableFuture<>();
-                    log.info("[{}] Queuing producer {} since there's already a producer", topic, producer);
+                    log.info()
+                            .attr("producer", producer)
+                            .log("Queuing producer since there's already a producer");
                     waitingExclusiveProducers.add(Pair.of(producer, future));
                     producerQueuedFuture.complete(null);
                     return future;
@@ -872,7 +879,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
             }
 
         } catch (Exception e) {
-            log.error("[{}] Encountered unexpected error during exclusive producer creation", topic, e);
+            log.error()
+                    .exception(e)
+                    .log("Encountered unexpected error during exclusive producer creation");
             return FutureUtil.failedFuture(new BrokerServiceException(e));
         } finally {
             lock.writeLock().unlock();
@@ -973,21 +982,21 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
 
     protected void checkTopicFenced() throws BrokerServiceException {
         if (isFenced) {
-            log.warn("[{}] Attempting to add producer to a fenced topic", topic);
+            log.warn("Attempting to add producer to a fenced topic");
             throw new BrokerServiceException.TopicFencedException("Topic is temporarily unavailable");
         }
     }
 
     protected CompletableFuture<Void> internalAddProducer(Producer producer) {
         if (isSameAddressProducersExceeded(producer)) {
-            log.warn("[{}] Attempting to add producer to topic which reached max same address producers limit", topic);
+            log.warn("Attempting to add producer to topic which reached max same address producers limit");
             return CompletableFuture.failedFuture(new BrokerServiceException.ProducerBusyException(
                     "Topic '" + topic + "' reached max same address producers limit"));
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] {} Got request to create producer ", topic, producer.getProducerName());
-        }
+        log.debug()
+                .attr("producerName", producer.getProducerName())
+                .log("Got request to create producer");
 
         Producer existProducer = producers.putIfAbsent(producer.getProducerName(), producer);
         if (existProducer != null) {
@@ -1094,19 +1103,20 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                 lock.writeLock().unlock();
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] Removed producer -- count: {}", topic, producer.getProducerName(),
-                    USAGE_COUNT_UPDATER.get(this));
-        }
+        log.debug()
+                .attr("producerName", producer.getProducerName())
+                .attr("usageCount", USAGE_COUNT_UPDATER.get(this))
+                .log("Removed producer");
         lastActive = System.nanoTime();
     }
 
     public void handleConsumerAdded(String subscriptionName, String consumerName) {
         USAGE_COUNT_UPDATER.incrementAndGet(this);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] [{}] Added consumer -- count: {}", topic, subscriptionName,
-                    consumerName, USAGE_COUNT_UPDATER.get(this));
-        }
+        log.debug()
+                .attr("subscriptionName", subscriptionName)
+                .attr("consumerName", consumerName)
+                .attr("usageCount", USAGE_COUNT_UPDATER.get(this))
+                .log("Added consumer");
     }
 
     public void decrementUsageCount() {
@@ -1142,7 +1152,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                     .getPoliciesIfCached(TopicName.get(topic).getNamespaceObject())
                     .orElseGet(Policies::new));
         } catch (Exception e) {
-            log.warn("[{}] Error getting policies {} and publish throttling will be disabled", topic, e.getMessage());
+            log.warn()
+                    .exceptionMessage(e)
+                    .log("Error getting policies and publish throttling will be disabled");
             policies = new Policies();
         }
         updateResourceGroupLimiter(policies);
@@ -1158,7 +1170,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
             if (resourceGroup != null) {
                 this.resourceGroupRateLimitingEnabled = true;
                 this.resourceGroupPublishLimiter = resourceGroup.getResourceGroupPublishLimiter();
-                log.info("Using resource group {} rate limiter for topic {}", rgName, topic);
+                log.info()
+                        .attr("resourceGroup", rgName)
+                        .log("Using resource group rate limiter for topic");
             }
         } else {
             if (this.resourceGroupRateLimitingEnabled) {
@@ -1188,7 +1202,9 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
                     brokerService.getEntryFilterProvider().loadEntryFiltersForPolicy(entryFiltersPolicy);
             entryFilters = Pair.of(entryFilterNames, filters);
         } catch (Throwable e) {
-            log.error("Failed to load entry filters on topic {}: {}", topic, e.getMessage());
+            log.error()
+                    .exceptionMessage(e)
+                    .log("Failed to load entry filters on topic");
             throw new RuntimeException(e);
         }
     }
@@ -1241,9 +1257,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     public boolean isTransferring() {
         return transferring;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(AbstractTopic.class);
-
     public InactiveTopicPolicies getInactiveTopicPolicies() {
         return topicPolicies.getInactiveTopicPolicies().get();
     }
@@ -1282,11 +1295,11 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     public void updatePublishRateLimiter() {
         PublishRate publishRate = topicPolicies.getPublishRate().get();
         if (publishRate.publishThrottlingRateInByte > 0 || publishRate.publishThrottlingRateInMsg > 0) {
-            log.info("Enabling publish rate limiting {} on topic {}", publishRate, getName());
+            log.info()
+                    .attr("publishRate", publishRate)
+                    .log("Enabling publish rate limiting on topic");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Disabling publish throttling for {}", this.topic);
-            }
+            log.debug("Disabling publish throttling");
         }
         this.topicPublishRateLimiter.update(publishRate);
     }
@@ -1386,7 +1399,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
             return getMigratedClusterUrlAsync(pulsar, topic)
                     .get(pulsar.getPulsarResources().getClusterResources().getOperationTimeoutSec(), TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.warn("[{}] Failed to get migration cluster URL", topic, e);
+            LOG.warn().exception(e).log("Failed to get migration cluster URL");
         }
         return Optional.empty();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -42,7 +42,7 @@ import org.apache.pulsar.common.policies.data.impl.BacklogQuotaImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 
-@Slf4j
+@CustomLog
 public class BacklogQuotaManager {
     @Getter
     private final BacklogQuotaImpl defaultQuota;
@@ -63,8 +63,10 @@ public class BacklogQuotaManager {
     public BacklogQuotaImpl getBacklogQuota(NamespaceName namespace, BacklogQuotaType backlogQuotaType) {
         try {
             if (namespaceResources == null) {
-                log.warn("Failed to read policies data from metadata store because namespaceResources is null."
-                        + "default backlog quota will be applied: namespace={}", namespace);
+                log.warn()
+                        .attr("namespace", namespace)
+                        .log("Failed to read policies data from metadata store because namespaceResources is null."
+                                + "default backlog quota will be applied: namespace");
                 return this.defaultQuota;
             } else {
                 return namespaceResources.getPolicies(namespace)
@@ -73,8 +75,11 @@ public class BacklogQuotaManager {
                         .orElse(defaultQuota);
             }
         } catch (MetadataStoreException e) {
-            log.warn("Failed to read policies data from metadata store,"
-                    + " will apply the default backlog quota: namespace={}", namespace, e);
+            log.warn()
+                    .attr("namespace", namespace)
+                    .exception(e)
+                    .log("Failed to read policies data from metadata store,"
+                            + "will apply the default backlog quota: namespace");
             return this.defaultQuota;
         }
     }
@@ -89,8 +94,11 @@ public class BacklogQuotaManager {
         BacklogQuota quota = persistentTopic.getBacklogQuota(backlogQuotaType);
         BacklogQuotaMetrics topicBacklogQuotaMetrics =
                 persistentTopic.getPersistentTopicMetrics().getBacklogQuotaMetrics();
-        log.info("Backlog quota type {} exceeded for topic [{}]. Applying [{}] policy", backlogQuotaType,
-                persistentTopic.getName(), quota.getPolicy());
+        log.info()
+                .attr("backlogQuotaType", backlogQuotaType)
+                .attr("topic", persistentTopic.getName())
+                .attr("policy", quota.getPolicy())
+                .log("Backlog quota type exceeded for topic. Applying policy");
         switch (quota.getPolicy()) {
             case consumer_backlog_eviction:
                 switch (backlogQuotaType) {
@@ -136,26 +144,30 @@ public class BacklogQuotaManager {
         ManagedLedger mLedger = persistentTopic.getManagedLedger();
         long backlogSize = mLedger.getEstimatedBacklogSize();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] target size is [{}] for quota limit [{}], backlog size is [{}]", persistentTopic.getName(),
-                    targetSize, targetSize / reductionFactor, backlogSize);
-        }
+        log.debug()
+                .attr("topic", persistentTopic.getName())
+                .attr("targetSize", targetSize)
+                .attr("quotaLimit", targetSize / reductionFactor)
+                .attr("backlogSize", backlogSize)
+                .log("Target size for quota limit");
         ManagedCursor previousSlowestConsumer = null;
         while (backlogSize > targetSize) {
             // Get the slowest consumer for this managed ledger and save the ledger id of the marked delete position of
             // slowest consumer. Calculate the factor which is used in calculating number of messages to be skipped.
             ManagedCursor slowestConsumer = mLedger.getSlowestConsumer();
             if (slowestConsumer == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] slowest consumer null.", persistentTopic.getName());
-                }
+                log.debug().attr("topic", persistentTopic.getName()).log("Slowest consumer is null");
                 break;
             }
             double messageSkipFactor = ((backlogSize - targetSize) / backlogSize);
 
             if (slowestConsumer == previousSlowestConsumer) {
-                log.info("[{}] Cursors not progressing, target size is [{}] for quota limit [{}], backlog size is [{}]",
-                        persistentTopic.getName(), targetSize, targetSize / reductionFactor, backlogSize);
+                log.info()
+                        .attr("topic", persistentTopic.getName())
+                        .attr("targetSize", targetSize)
+                        .attr("quotaLimit", targetSize / reductionFactor)
+                        .attr("backlogSize", backlogSize)
+                        .log("Cursors not progressing");
                 break;
             }
 
@@ -165,29 +177,34 @@ public class BacklogQuotaManager {
             try {
                 // If there are no messages to skip, break out of the loop
                 if (messagesToSkip == 0) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("no messages to skip for [{}]", slowestConsumer);
-                    }
+                    log.debug().attr("slowestConsumer", slowestConsumer).log("no messages to skip for");
                     break;
                 }
                 // Skip messages on the slowest consumer
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Skipping [{}] messages on slowest consumer [{}] having backlog entries : [{}]",
-                            persistentTopic.getName(), messagesToSkip, slowestConsumer.getName(), entriesInBacklog);
-                }
+                log.debug()
+                        .attr("topic", persistentTopic.getName())
+                        .attr("messagesToSkip", messagesToSkip)
+                        .attr("consumer", slowestConsumer.getName())
+                        .attr("entriesInBacklog", entriesInBacklog)
+                        .log("Skipping messages on slowest consumer having backlog entries");
                 slowestConsumer.skipEntries(messagesToSkip, IndividualDeletedEntries.Include);
             } catch (Exception e) {
-                log.error("[{}] Error skipping [{}] messages from slowest consumer [{}]", persistentTopic.getName(),
-                        messagesToSkip, slowestConsumer.getName(), e);
+                log.error()
+                        .attr("topic", persistentTopic.getName())
+                        .attr("messagesToSkip", messagesToSkip)
+                        .attr("consumer", slowestConsumer.getName())
+                        .exception(e)
+                        .log("Error skipping messages from slowest consumer");
             }
 
             // Make sure that unconsumed size is updated every time when we skip the messages.
             backlogSize = mLedger.getEstimatedBacklogSize();
             previousSlowestConsumer = slowestConsumer;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Updated unconsumed size = [{}]. skipFactor: [{}]", persistentTopic.getName(),
-                        backlogSize, messageSkipFactor);
-            }
+            log.debug()
+                    .attr("topic", persistentTopic.getName())
+                    .attr("backlogSize", backlogSize)
+                    .attr("messageSkipFactor", messageSkipFactor)
+                    .log("Updated unconsumed size =. skipFactor");
         }
     }
 
@@ -206,9 +223,10 @@ public class BacklogQuotaManager {
             // Set the reduction factor to 90%. The aim is to drop down the backlog to 90% of the quota limit.
             double reductionFactor = 0.9;
             int target = (int) (reductionFactor * quota.getLimitTime());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] target backlog expire time is [{}]", persistentTopic.getName(), target);
-            }
+            log.debug()
+                    .attr("topic", persistentTopic.getName())
+                    .attr("target", target)
+                    .log("target backlog expire time is");
 
             persistentTopic.getSubscriptions().forEach((__, subscription) ->
                     subscription.getExpiryMonitor().expireMessages(target)
@@ -224,10 +242,11 @@ public class BacklogQuotaManager {
                         break;
                     }
                     Position oldestPosition = slowestConsumer.getMarkDeletedPosition();
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] slowest consumer mark delete position is [{}], read position is [{}]",
-                            slowestConsumer.getName(), oldestPosition, slowestConsumer.getReadPosition());
-                    }
+                    log.debug()
+                            .attr("name", slowestConsumer.getName())
+                            .attr("oldestPosition", oldestPosition)
+                            .attr("readPosition", slowestConsumer.getReadPosition())
+                            .log("slowest consumer mark delete position is, read position is");
                     ManagedLedgerInfo.LedgerInfo ledgerInfo =
                         mLedger.getLedgerInfo(oldestPosition.getLedgerId()).get();
                     if (ledgerInfo == null) {
@@ -250,8 +269,11 @@ public class BacklogQuotaManager {
                     break;
                 }
             } catch (Exception e) {
-                log.error("[{}] Error resetting cursor for slowest consumer [{}]", persistentTopic.getName(),
-                    mLedger.getSlowestConsumer().getName(), e);
+                log.error()
+                        .attr("topic", persistentTopic.getName())
+                        .attr("consumer", mLedger.getSlowestConsumer().getName())
+                        .exception(e)
+                        .log("Error resetting cursor for slowest consumer");
             }
         }
     }
@@ -267,17 +289,23 @@ public class BacklogQuotaManager {
         Map<String, Producer> producers = persistentTopic.getProducers();
 
         producers.values().forEach(producer -> {
-            log.info("Producer [{}] has exceeded backlog quota on topic [{}]. Disconnecting producer",
-                    producer.getProducerName(), persistentTopic.getName());
+            log.info()
+                    .attr("producerName", producer.getProducerName())
+                    .attr("topic", persistentTopic.getName())
+                    .log("Producer has exceeded backlog quota on topic. Disconnecting producer");
             futures.add(producer.disconnect());
         });
 
         FutureUtil.waitForAll(futures)
                 .thenRun(() ->
-                        log.info("All producers on topic [{}] are disconnected", persistentTopic.getName()))
+                        log.info()
+                                .attr("topic", persistentTopic.getName())
+                                .log("All producers on topic are disconnected"))
                 .exceptionally(exception -> {
-                    log.error("Error in disconnecting producers on topic [{}] [{}]", persistentTopic.getName(),
-                            exception);
+                    log.error()
+                            .attr("topic", persistentTopic.getName())
+                            .exceptionMessage(exception)
+                            .log("Error in disconnecting producers on topic");
                     return null;
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -80,6 +80,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import lombok.AccessLevel;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
@@ -202,13 +203,11 @@ import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.transaction.coordinator.TransactionMetadataStore;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Getter(AccessLevel.PUBLIC)
 @Setter(AccessLevel.PROTECTED)
+@CustomLog
 public class BrokerService implements Closeable {
-    private static final Logger log = LoggerFactory.getLogger(BrokerService.class);
     private static final TimeoutException FAILED_TO_LOAD_TOPIC_TIMEOUT_EXCEPTION =
             FutureUtil.createTimeoutException("Failed to load topic within timeout", BrokerService.class,
                     "futureWithDeadline(...)");
@@ -411,18 +410,21 @@ public class BrokerService implements Closeable {
             this.maxUnackedMessages = pulsar.getConfiguration().getMaxUnackedMessagesPerBroker();
             this.maxUnackedMsgsPerDispatcher = (int) (maxUnackedMessages
                     * pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked());
-            log.info("Enabling per-broker unack-message limit {} and dispatcher-limit {} on blocked-broker",
-                    maxUnackedMessages, maxUnackedMsgsPerDispatcher);
+            log.info()
+                    .attr("maxUnackedMessages", maxUnackedMessages)
+                    .attr("maxUnackedMsgsPerDispatcher", maxUnackedMsgsPerDispatcher)
+                    .log("Enabling per-broker unack-message limit and dispatcher-limit on blocked-broker");
             // block misbehaving dispatcher by checking periodically
             pulsar.getExecutor().scheduleAtFixedRate(this::checkUnAckMessageDispatching,
                     600, 30, TimeUnit.SECONDS);
         } else {
             this.maxUnackedMessages = 0;
             this.maxUnackedMsgsPerDispatcher = 0;
-            log.info(
-                    "Disabling per broker unack-msg blocking due invalid"
-                            + " unAckMsgSubscriptionPercentageLimitOnBrokerBlocked {} ",
-                    pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked());
+            log.info()
+                    .attr("maxUnackedMessagesPerSubscriptionOnBrokerBlocked",
+                            pulsar.getConfiguration().getMaxUnackedMessagesPerSubscriptionOnBrokerBlocked())
+                    .log("Disabling per broker unack-msg blocking due invalid"
+                            + "unAckMsgSubscriptionPercentageLimitOnBrokerBlocked");
         }
 
         this.delayedDeliveryTrackerFactory = DelayedDeliveryTrackerLoader
@@ -482,8 +484,10 @@ public class BrokerService implements Closeable {
 
         this.bundlesQuotas = new BundlesQuotas(pulsar);
         if (pulsar.getConfiguration().getManagedLedgerDeleteMaxConcurrentRequests() > 0) {
-            log.info("Setting managed ledger deletion max concurrent requests to {}",
-                    pulsar.getConfiguration().getManagedLedgerDeleteMaxConcurrentRequests());
+            log.info()
+                    .attr("managedLedgerDeleteMaxConcurrentRequests",
+                            pulsar.getConfiguration().getManagedLedgerDeleteMaxConcurrentRequests())
+                    .log("Setting managed ledger deletion max concurrent requests to");
             this.ledgerDeletionSemaphore = new Semaphore(
                     pulsar.getConfiguration().getManagedLedgerDeleteMaxConcurrentRequests());
             this.ledgerDeletionExecutorProvider = new ExecutorProvider(1, "pulsar-ledger-deletion");
@@ -501,8 +505,10 @@ public class BrokerService implements Closeable {
                 return (DispatchRateLimiterFactory) Class.forName(dispatchRateLimiterFactoryClassName)
                         .getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-                log.warn("Failed to initialize dispatch rate limiter factory class {}",
-                        dispatchRateLimiterFactoryClassName, e);
+                log.warn()
+                        .attr("dispatchRateLimiterFactoryClassName", dispatchRateLimiterFactoryClassName)
+                        .exception(e)
+                        .log("Failed to initialize dispatch rate limiter factory class");
                 throw e;
             }
         } else {
@@ -538,7 +544,7 @@ public class BrokerService implements Closeable {
                 try {
                     startProtocolHandler(protocol, address, initializer);
                 } catch (IOException e) {
-                    log.error("{}", e.getMessage(), e.getCause());
+                    log.error().exceptionMessage(e).log("");
                     throw new RuntimeException(e.getMessage(), e.getCause());
                 }
             });
@@ -576,7 +582,7 @@ public class BrokerService implements Closeable {
         } catch (Exception e) {
             throw new IOException("Failed to bind protocol `" + protocol + "` on " + address, e);
         }
-        log.info("Successfully bind protocol `{}` on {}", protocol, address);
+        log.info().attr("protocol", protocol).attr("address", address).log("Successfully bind protocol `` on");
     }
 
     private ServerBootstrap defaultServerBootstrap() {
@@ -643,10 +649,11 @@ public class BrokerService implements Closeable {
                     }
                 }
 
-                log.info("Started Pulsar Broker service on {}, TLS: {}, listener: {}",
-                        ch.localAddress(),
-                        isTls ? SslContext.defaultServerProvider().toString() : "(none)",
-                        StringUtils.defaultString(a.getListenerName(), "(none)"));
+                log.info()
+                        .attr("localAddress", ch.localAddress())
+                        .attr("tls", isTls ? SslContext.defaultServerProvider().toString() : "(none)")
+                        .attr("listener", StringUtils.defaultString(a.getListenerName(), "(none)"))
+                        .log("Started Pulsar Broker service");
             } catch (Exception e) {
                 throw new IOException("Failed to bind Pulsar broker on " + addr, e);
             }
@@ -785,7 +792,9 @@ public class BrokerService implements Closeable {
     protected void startBacklogQuotaChecker() {
         if (pulsar().getConfiguration().isBacklogQuotaCheckEnabled()) {
             final int interval = pulsar().getConfiguration().getBacklogQuotaCheckIntervalInSeconds();
-            log.info("Scheduling a thread to check backlog quota after [{}] seconds in background", interval);
+            log.info()
+                    .attr("intervalSeconds", interval)
+                    .log("Scheduling a thread to check backlog quota in background");
             backlogQuotaChecker.scheduleAtFixedRateNonConcurrently(this::monitorBacklogQuota, interval, interval,
                     TimeUnit.SECONDS);
         } else {
@@ -862,7 +871,7 @@ public class BrokerService implements Closeable {
                 try {
                     client.shutdown();
                 } catch (Exception e) {
-                    log.warn("Error shutting down repl client for cluster {}", cluster, e);
+                    log.warn().attr("cluster", cluster).exception(e).log("Error shutting down repl client for cluster");
                 }
             });
 
@@ -871,7 +880,7 @@ public class BrokerService implements Closeable {
                 try {
                     admin.close();
                 } catch (Exception e) {
-                    log.warn("Error shutting down repl admin for cluster {}", cluster, e);
+                    log.warn().attr("cluster", cluster).exception(e).log("Error shutting down repl admin for cluster");
                 }
             });
 
@@ -893,7 +902,7 @@ public class BrokerService implements Closeable {
                     CompletableFuture.allOf(shutdownEventLoops.toArray(new CompletableFuture[0]))
                             .handle((v, t) -> {
                                 if (t != null) {
-                                    log.warn("Error shutting down event loops gracefully", t);
+                                    log.warn().exception(t).log("Error shutting down event loops gracefully");
                                 } else {
                                     log.info("Event loops shutdown completed.");
                                 }
@@ -919,7 +928,7 @@ public class BrokerService implements Closeable {
                                 try {
                                     authenticationService.close();
                                 } catch (IOException e) {
-                                    log.warn("Error in closing authenticationService", e);
+                                    log.warn().exception(e).log("Error in closing authenticationService");
                                 }
                                 pulsarStats.close();
                                 pendingTopicLoadOperationsCounter.close();
@@ -930,7 +939,7 @@ public class BrokerService implements Closeable {
                                         fallbackDelayedDeliveryTrackerFactory.close();
                                     }
                                 } catch (Exception e) {
-                                    log.warn("Error in closing delayedDeliveryTrackerFactory", e);
+                                    log.warn().exception(e).log("Error in closing delayedDeliveryTrackerFactory");
                                 }
 
                                 asyncCloseFutures.add(GracefulExecutorServicesShutdown
@@ -962,7 +971,9 @@ public class BrokerService implements Closeable {
                                             log.warn("Broker service didn't complete gracefully. "
                                                     + "Terminating Broker service.");
                                         } else {
-                                            log.warn("Broker service shut down completed with exception", t);
+                                            log.warn()
+                                                    .exception(t)
+                                                    .log("Broker service shut down completed with exception");
                                         }
                                     }
                                     return null;
@@ -993,9 +1004,13 @@ public class BrokerService implements Closeable {
         ).whenComplete((__, e) -> {
             final var elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
             if (e == null) {
-                log.info("Event loop {} shut down after {} ms", name, elapsedMs);
+                log.info().attr("name", name).attr("elapsedMs", elapsedMs).log("Event loop shut down");
             } else {
-                log.warn("Failed to shut down event loop {} after {} ms: {}", name, elapsedMs, e.getMessage());
+                log.warn()
+                        .attr("name", name)
+                        .attr("elapsedMs", elapsedMs)
+                        .exceptionMessage(e)
+                        .log("Failed to shut down event loop");
             }
         });
     }
@@ -1006,7 +1021,7 @@ public class BrokerService implements Closeable {
                     // log problem if closing of channel fails
                     // ignore RejectedExecutionException
                     if (t != null && !(t instanceof RejectedExecutionException)) {
-                        log.warn("Cannot close channel {}", channel, t);
+                        log.warn().attr("channel", channel).exception(t).log("Cannot close channel");
                     }
                     return null;
                 });
@@ -1037,14 +1052,16 @@ public class BrokerService implements Closeable {
                 try {
                     pulsar.getLoadManager().get().disableBroker();
                 } catch (PulsarServerException.NotFoundException ne) {
-                    log.warn("Broker load-manager znode doesn't exist ", ne);
+                    log.warn("Broker load-manager znode doesn't exist");
                     // still continue and release bundle ownership as broker's registration node doesn't exist.
                 }
             }
             double disableBrokerTimeSeconds =
                     TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - disableBrokerStartTime))
                             / 1000.0;
-            log.info("Disable broker in load manager completed in {} seconds", disableBrokerTimeSeconds);
+            log.info()
+                    .attr("disableBrokerTimeSeconds", disableBrokerTimeSeconds)
+                    .log("Disable broker in load manager completed in seconds");
 
             // unload all namespace-bundles gracefully
             long closeTopicsStartTime = System.nanoTime();
@@ -1064,9 +1081,12 @@ public class BrokerService implements Closeable {
                         } catch (Exception e) {
                             if (e instanceof ExecutionException
                                     && e.getCause() instanceof ServiceUnitNotReadyException) {
-                                log.warn("Failed to unload namespace bundle {}: {}", su, e.getMessage());
+                                log.warn()
+                                        .attr("su", su)
+                                        .exceptionMessage(e)
+                                        .log("Failed to unload namespace bundle");
                             } else {
-                                log.warn("Failed to unload namespace bundle {}", su, e);
+                                log.warn().attr("su", su).exception(e).log("Failed to unload namespace bundle");
                             }
                         }
                     }
@@ -1074,11 +1094,16 @@ public class BrokerService implements Closeable {
                 double closeTopicsTimeSeconds =
                         TimeUnit.NANOSECONDS.toMillis((System.nanoTime() - closeTopicsStartTime))
                                 / 1000.0;
-                log.info("Unloading {} namespace-bundles completed in {} seconds", serviceUnits.size(),
-                        closeTopicsTimeSeconds);
+                log.info()
+                        .attr("size", serviceUnits.size())
+                        .attr("closeTopicsTimeSeconds", closeTopicsTimeSeconds)
+                        .log("Unloading namespace-bundles completed in seconds");
             }
         } catch (Exception e) {
-            log.error("Failed to disable broker from loadbalancer list {}", e.getMessage(), e);
+            log.error()
+
+                    .exception(e)
+                    .log("Failed to disable broker from loadbalancer list");
         } finally {
             unloaded = true;
         }
@@ -1193,9 +1218,7 @@ public class BrokerService implements Closeable {
             final boolean isPersistentTopic = topicName.getDomain().equals(TopicDomain.persistent);
             if (isPersistentTopic) {
                 if (!pulsar.getConfiguration().isEnablePersistentTopics()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Broker is unable to load persistent topic {}", topicName);
-                    }
+                    log.debug().attr("topic", topicName).log("Broker is unable to load persistent topic");
                     return FutureUtil.failedFuture(new NotAllowedException(
                             "Broker is unable to load persistent topic"));
                 }
@@ -1209,9 +1232,16 @@ public class BrokerService implements Closeable {
                 topicFuture.exceptionally(t -> {
                     final var now = System.nanoTime();
                     if (FutureUtil.unwrapCompletionException(t) instanceof TimeoutException) {
-                        log.warn("Failed to load {} after {} ms", topicName, context.latencyMs(now));
+                        log.warn()
+                                .attr("topic", topicName)
+                                .attr("latencyMs", context.latencyMs(now))
+                                .log("Failed to load topic");
                     } else {
-                        log.warn("Failed to load {} after {} ms", topicName, context.latencyString(now), t);
+                        log.warn()
+                                .attr("topic", topicName)
+                                .attr("latencyMs", context.latencyString(now))
+                                .exception(t)
+                                .log("Failed to load topic");
                     }
                     pulsarStats.recordTopicLoadFailed();
                     return Optional.empty();
@@ -1234,8 +1264,10 @@ public class BrokerService implements Closeable {
                             // This case should happen rarely when the same topic is loaded concurrently because we
                             // checked if the `topics` cache includes this topic before, so the latency is not the
                             // actual loading latency that should not be recorded in metrics.
-                            log.info("[{}] Finished loading from other concurrent loading task (latency: {})",
-                                    topicName, context.latencyString(System.nanoTime()));
+                            log.info()
+                                    .attr("topic", topicName)
+                                    .attr("latencyMs", context.latencyString(System.nanoTime()))
+                                    .log("Finished loading from other concurrent loading task");
                             cachedFuture.whenComplete((optTopic, e) -> {
                                 if (e == null) {
                                     topicFuture.complete(optTopic);
@@ -1247,10 +1279,10 @@ public class BrokerService implements Closeable {
                     }).exceptionally(e -> {
                         pulsar.getExecutor().execute(() -> topics.remove(topicName.toString(), topicFuture));
                         final Throwable rc = FutureUtil.unwrapCompletionException(e);
-                        final String errorInfo = String.format("Topic creation encountered an exception by initialize"
-                                        + " topic policies service. topic_name=%s error_message=%s", topicName,
-                                rc.getMessage());
-                        log.error(errorInfo, rc);
+                        log.error().attr("topic", topicName)
+                                .exceptionMessage(rc)
+                                .log("Topic creation encountered an exception"
+                                        + " by initialize topic policies service");
                         topicFuture.completeExceptionally(rc);
                         return null;
                     });
@@ -1258,9 +1290,7 @@ public class BrokerService implements Closeable {
                 return topicFuture;
             } else {
                 if (!pulsar.getConfiguration().isEnableNonPersistentTopics()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Broker is unable to load non-persistent topic {}", topicName);
-                    }
+                    log.debug().attr("topic", topicName).log("Broker is unable to load non-persistent topic");
                     return FutureUtil.failedFuture(new NotAllowedException(
                             "Broker is unable to load persistent topic"));
                 }
@@ -1289,14 +1319,18 @@ public class BrokerService implements Closeable {
                 return topicFuture;
             }
         } catch (IllegalArgumentException e) {
-            log.warn("[{}] Illegalargument exception when loading topic", topicName, e);
+            log.warn().attr("topic", topicName).exception(e).log("Illegalargument exception when loading topic");
             return FutureUtil.failedFuture(e);
         } catch (RuntimeException e) {
             Throwable cause = e.getCause();
             if (cause instanceof ServiceUnitNotReadyException) {
-                log.warn("[{}] Service unit is not ready when loading the topic", topicName);
+                log.warn().attr("topic", topicName).log("Service unit is not ready when loading the topic");
             } else {
-                log.warn("[{}] Unexpected exception when loading topic: {}", topicName, e.getMessage(), e);
+                log.warn()
+                        .attr("topic", topicName)
+
+                        .exception(e)
+                        .log("Unexpected exception when loading topic");
             }
 
             return FutureUtil.failedFuture(cause);
@@ -1332,7 +1366,10 @@ public class BrokerService implements Closeable {
             if (t.isReplicated()) {
                 // Delete is disallowed on global topic
                 final var clusters = t.getReplicators().keySet();
-                log.error("Delete forbidden topic {} is replicated on clusters {}", topic, clusters);
+                log.error()
+                        .attr("topic", topic)
+                        .attr("clusters", clusters)
+                        .log("Delete forbidden, topic is replicated on clusters");
                 return FutureUtil.failedFuture(
                         new IllegalStateException("Delete forbidden topic is replicated on clusters " + clusters));
             }
@@ -1340,7 +1377,10 @@ public class BrokerService implements Closeable {
             // shadow topic should be deleted first.
             if (t.isShadowReplicated()) {
                 final var shadowTopics = t.getShadowReplicators().keySet();
-                log.error("Delete forbidden. Topic {} is replicated to shadow topics: {}", topic, shadowTopics);
+                log.error()
+                        .attr("topic", topic)
+                        .attr("shadowTopics", shadowTopics)
+                        .log("Delete forbidden. Topic is replicated to shadow topics");
                 return FutureUtil.failedFuture(new IllegalStateException(
                         "Delete forbidden. Topic " + topic + " is replicated to shadow topics."));
             }
@@ -1348,7 +1388,7 @@ public class BrokerService implements Closeable {
             return t.delete();
         }
 
-        log.info("Topic {} is not loaded, try to delete from metadata", topic);
+        log.info().attr("topic", topic).log("Topic is not loaded, try to delete from metadata");
 
         // Topic is not loaded, though we still might be able to delete from metadata
         TopicName tn = TopicName.get(topic);
@@ -1390,7 +1430,7 @@ public class BrokerService implements Closeable {
                                     }
                                 }, null);
             }).exceptionally(ex1 -> {
-                log.error("Failed to get managed ledger config for topic {}", topic, ex1);
+                log.error().attr("topic", topic).log("Failed to get managed ledger config for topic");
                 future.completeExceptionally(ex1);
                 return null;
             });
@@ -1421,24 +1461,24 @@ public class BrokerService implements Closeable {
 
     public void deleteTopicAuthenticationWithRetry(String topic, CompletableFuture<Void> future, int count) {
         if (count == 0) {
-            log.error("The number of retries has exhausted for topic {}", topic);
+            log.error().attr("topic", topic).log("The number of retries has exhausted for topic");
             future.completeExceptionally(new MetadataStoreException("The number of retries has exhausted"));
             return;
         }
         // Check whether there are auth policies for the topic
         authorizationService.removePermissionsAsync(TopicName.get(topic))
                     .thenAccept(v -> {
-                        log.info("Successfully delete authentication policies for topic {}", topic);
+                        log.info().attr("topic", topic).log("Successfully delete authentication policies for topic");
                         future.complete(null);
                     }).exceptionally(ex1 -> {
                         if (ex1.getCause() instanceof MetadataStoreException.BadVersionException) {
-                            log.warn(
-                                    "Failed to delete authentication policies because of bad version. "
-                                            + "Retry to delete authentication policies for topic {}",
-                                    topic);
+                            log.warn()
+                                    .attr("topic", topic)
+                                    .log("Failed to delete authentication policies because of bad version. "
+                                            + "Retry to delete authentication policies for topic");
                             deleteTopicAuthenticationWithRetry(topic, future, count - 1);
                         } else {
-                            log.error("Failed to delete authentication policies for topic {}", topic, ex1);
+                            log.error().attr("topic", topic).log("Failed to delete authentication policies for topic");
                             future.completeExceptionally(ex1);
                         }
                         return null;
@@ -1462,7 +1502,7 @@ public class BrokerService implements Closeable {
             }
             nonPersistentTopic.setCreateFuture(topicFuture);
         } catch (Throwable e) {
-            log.warn("Failed to create topic {}", topic, e);
+            log.warn().attr("topic", topic).exception(e).log("Failed to create topic");
             topicFuture.completeExceptionally(e);
             return topicFuture;
         }
@@ -1472,13 +1512,16 @@ public class BrokerService implements Closeable {
             nonPersistentTopic.initialize()
                     .thenCompose(__ -> nonPersistentTopic.checkReplication())
                     .thenRun(() -> {
-                        log.info("Created topic {}", nonPersistentTopic);
+                        log.info().attr("nonPersistentTopic", nonPersistentTopic).log("Created topic");
                         long topicLoadLatencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - topicCreateTimeMs;
                         pulsarStats.recordTopicLoadTimeValue(topic, topicLoadLatencyMs);
                         addTopicToStatsMaps(TopicName.get(topic), nonPersistentTopic);
                         topicFuture.complete(Optional.of(nonPersistentTopic));
                     }).exceptionally(ex -> {
-                log.warn("Replication check failed. Removing topic from topics list {}, {}", topic, ex.getCause());
+                log.warn()
+                        .attr("topic", topic)
+                        .exceptionMessage(ex.getCause())
+                        .log("Replication check failed. Removing topic from topics list");
                 nonPersistentTopic.stopReplProducers().whenComplete((v, exception) -> {
                     topicFuture.completeExceptionally(ex);
                 });
@@ -1568,12 +1611,14 @@ public class BrokerService implements Closeable {
                 }
                 if (data.getProxyProtocol() != null && StringUtils.isNotBlank(data.getProxyServiceUrl())) {
                     clientBuilder.proxyServiceUrl(data.getProxyServiceUrl(), data.getProxyProtocol());
-                    log.info("Configuring proxy-url {} with protocol {}", data.getProxyServiceUrl(),
-                            data.getProxyProtocol());
+                    log.info()
+                            .attr("proxyServiceUrl", data.getProxyServiceUrl())
+                            .attr("proxyProtocol", data.getProxyProtocol())
+                            .log("Configuring proxy-url with protocol");
                 }
                 if (StringUtils.isNotBlank(data.getListenerName())) {
                     clientBuilder.listenerName(data.getListenerName());
-                    log.info("Configuring listenerName {}", data.getListenerName());
+                    log.info().attr("listenerName", data.getListenerName()).log("Configuring listenerName");
                 }
                 // Share all the IO threads across broker and client connections
                 ClientConfigurationData conf = ((ClientBuilderImpl) clientBuilder).getClientConfigurationData();
@@ -1716,7 +1761,7 @@ public class BrokerService implements Closeable {
                 builder.readTimeout(conf.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
 
                 PulsarAdmin adminClient = builder.build();
-                log.info("created admin with url {} ", adminApiUrl);
+                log.info().attr("adminApiUrl", adminApiUrl).log("Created client admin instance");
                 return adminClient;
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -1752,9 +1797,7 @@ public class BrokerService implements Closeable {
                         });
                     } else {
                         pendingTopicLoadingQueue.add(context);
-                        if (log.isDebugEnabled()) {
-                            log.debug("topic-loading for {} added into pending queue", topic);
-                        }
+                        log.debug().attr("topic", topic).log("topic-loading for added into pending queue");
                     }
                 }).exceptionally(ex -> {
                     pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
@@ -1811,7 +1854,7 @@ public class BrokerService implements Closeable {
                 //TODO add topicName in properties?
                 createPersistentTopic0(context);
             }).exceptionally(throwable -> {
-                log.warn("[{}] Read topic property failed", topic, throwable);
+                log.warn().attr("topic", topic).exception(throwable).log("Read topic property failed");
                 pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
                 topicFuture.completeExceptionally(throwable);
                 return null;
@@ -1917,26 +1960,36 @@ public class BrokerService implements Closeable {
                                         .thenRun(() -> {
                                             long nowInNanos = System.nanoTime();
                                             long topicLoadLatencyMs = context.latencyMs(nowInNanos);
-                                            log.info("Created topic {} - dedup is {} (latency: {})", topic,
-                                                    persistentTopic.isDeduplicationEnabled() ? "enabled" : "disabled",
-                                                    context.latencyString(nowInNanos));
+                                            log.info()
+                                                    .attr("topic", topic)
+                                                    .attr("dedupEnabled", persistentTopic.isDeduplicationEnabled())
+                                                    .attr("latencyMs", context.latencyString(nowInNanos))
+                                                    .log("Loaded topic");
                                             pulsarStats.recordTopicLoadTimeValue(topic, topicLoadLatencyMs);
                                             if (!topicFuture.complete(Optional.of(persistentTopic))) {
                                                 // Check create persistent topic timeout.
                                                 if (topicFuture.isCompletedExceptionally()) {
-                                                    log.warn("{} future is already completed with failure {}, closing"
-                                                        + " the topic", topic, FutureUtil.getException(topicFuture));
+                                                    log.warn()
+                                                            .attr("topic", topic)
+                                                            .attr("error",
+                                                                    FutureUtil.getException(topicFuture).orElse(null))
+                                                            .log("The future is already completed with failure, "
+                                                                    + "closing the topic");
                                                 } else {
                                                     // It should not happen.
-                                                    log.error("{} future is already completed by another thread, "
-                                                            + "which is not expected. Closing the current one", topic);
+                                                    log.error()
+                                                            .attr("topic", topic)
+                                                            .log("future is already completed by another thread, "
+                                                                    + "which is not expected. Closing the current one");
                                                 }
                                                 executor().submit(() -> {
                                                     persistentTopic.close().whenComplete((ignore, ex) -> {
                                                         topics.remove(topic, topicFuture);
                                                         if (ex != null) {
-                                                            log.warn("[{}] Get an error when closing topic.",
-                                                                    topic, ex);
+                                                            log.warn()
+                                                                    .attr("topic", topic)
+                                                                    .exception(ex)
+                                                                    .log("Get an error when closing topic.");
                                                         }
                                                     });
                                                 });
@@ -1945,14 +1998,18 @@ public class BrokerService implements Closeable {
                                             }
                                         })
                                         .exceptionally((ex) -> {
-                                            log.warn("Replication or dedup check failed."
-                                                    + " Removing topic from topics list {}, {}", topic, ex);
+                                            log.warn()
+                                                    .attr("topic", topic)
+                                                    .exceptionMessage(ex)
+                                                    .log("Replication or dedup check failed."
+                                                            + "Removing topic from topics list");
                                             executor().submit(() -> {
                                                 persistentTopic.close().whenComplete((ignore, closeEx) -> {
                                                     topics.remove(topic, topicFuture);
                                                     if (closeEx != null) {
-                                                        log.warn("[{}] Get an error when closing topic.",
-                                                                topic, closeEx);
+                                                        log.warn()
+                                                                .attr("topic", topic)
+                                                                .log("Get an error when closing topic.");
                                                     }
                                                     topicFuture.completeExceptionally(ex);
                                                 });
@@ -1960,7 +2017,10 @@ public class BrokerService implements Closeable {
                                             return null;
                                         });
                             } catch (Exception e) {
-                                log.warn("Failed to create topic {}: {}", topic, e.getMessage());
+                                log.warn()
+                                        .attr("topic", topic)
+                                        .exceptionMessage(e)
+                                        .log("Failed to create topic");
                                 pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
                                 topicFuture.completeExceptionally(e);
                             }
@@ -1974,7 +2034,7 @@ public class BrokerService implements Closeable {
                                 loadFuture.completeExceptionally(exception);
                                 topicFuture.complete(Optional.empty());
                             } else {
-                                log.warn("Failed to create topic {}", topic, exception);
+                                log.warn().attr("topic", topic).exception(exception).log("Failed to create topic");
                                 pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
                                 topicFuture.completeExceptionally(new PersistenceException(exception));
                             }
@@ -1984,8 +2044,11 @@ public class BrokerService implements Closeable {
         }).exceptionally((exception) -> {
             boolean migrationFailure = exception.getCause() instanceof TopicMigratedException;
             String msg = migrationFailure ? "Topic is already migrated" :
-                "Failed to get topic configuration:";
-            log.warn("[{}] {} {}", topic, msg, exception.getMessage(), exception);
+                "Failed to get topic configuration";
+            log.warn()
+                    .attr("topic", topic)
+                    .exception(exception)
+                    .log(msg);
             // remove topic from topics-map in different thread to avoid possible deadlock if
             // createPersistentTopic-thread only tries to handle this future-result
             pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
@@ -2066,9 +2129,7 @@ public class BrokerService implements Closeable {
 
             if (retentionPolicies == null) {
                 if (SystemTopicNames.isSystemTopic(topicName)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("{} Disable data retention policy for system topic.", topicName);
-                    }
+                    log.debug().attr("topic", topicName).log("Disable data retention policy for system topic.");
                     retentionPolicies = new RetentionPolicies(0, 0);
                 } else {
                     retentionPolicies = policies.map(p -> p.retention_policies).orElseGet(
@@ -2224,11 +2285,17 @@ public class BrokerService implements Closeable {
             return managedLedgerConfig;
         }).exceptionally(ex -> {
             final Throwable rc = FutureUtil.unwrapCompletionException(ex);
-            final String errorInfo = String.format("Topic creation encountered an exception by initialize"
-                            + " topic policies service. topic_name=%s error_message=%s", topicName,
-                    rc.getMessage());
-            log.error(errorInfo, rc);
-            throw FutureUtil.wrapToCompletionException(new ServiceUnitNotReadyException(errorInfo));
+            log.error().attr("topic", topicName)
+                    .exceptionMessage(rc)
+                    .log("Topic creation encountered an exception"
+                            + " by initialize topic policies service");
+            final String errorInfo = String.format(
+                    "Topic creation encountered an exception by initialize"
+                            + " topic policies service. topic_name=%s"
+                            + " error_message=%s",
+                    topicName, rc.getMessage());
+            throw FutureUtil.wrapToCompletionException(
+                    new ServiceUnitNotReadyException(errorInfo));
         });
     }
 
@@ -2247,7 +2314,9 @@ public class BrokerService implements Closeable {
                     invalidateOfflineTopicStatCache(topicName);
                 })
                 .exceptionally(ex -> {
-                    log.warn("Got exception when retrieving bundle name during create persistent topic", ex);
+                    log.warn()
+                            .exception(ex)
+                            .log("Got exception when retrieving bundle name during create persistent topic");
                     return null;
                 });
     }
@@ -2270,7 +2339,7 @@ public class BrokerService implements Closeable {
                 }
             }
         } catch (Exception e) {
-            log.warn("Got exception while refreshing topicStats map", e);
+            log.warn().exception(e).log("Got exception while refreshing topicStats map");
         }
     }
 
@@ -2285,7 +2354,9 @@ public class BrokerService implements Closeable {
     public void invalidateOfflineTopicStatCache(TopicName topicName) {
         PersistentOfflineTopicStats removed = offlineTopicStatCache.remove(topicName);
         if (removed != null) {
-            log.info("Removed cached offline topic stat for {} ", topicName.getPersistenceNamingEncoding());
+            log.info()
+                    .attr("persistenceNamingEncoding", topicName.getPersistenceNamingEncoding())
+                    .log("Removed cached offline topic stat for");
         }
     }
 
@@ -2406,16 +2477,16 @@ public class BrokerService implements Closeable {
                                     BacklogQuota.BacklogQuotaType.message_age,
                                     pulsar.getConfiguration().isPreciseTimeBasedBacklogQuotaCheck());
                         } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug("quota not exceeded for [{}]", topic.getName());
-                            }
+                            log.debug().attr("topic", topic.getName()).log("Quota not exceeded");
                         }
                     });
                 }
             }).whenComplete((unused, throwable) -> {
                 if (throwable != null) {
-                    log.error("Error when checkBacklogQuota({}) in monitorBacklogQuota",
-                            topic.getName(), throwable);
+                    log.error()
+                            .attr("topic", topic.getName())
+                            .exception(throwable)
+                            .log("Error when checkBacklogQuota() in monitorBacklogQuota");
                 }
                 backlogQuotaCheckDuration.observe(
                         MILLISECONDS.toSeconds(System.currentTimeMillis() - startTimeMillis));
@@ -2429,7 +2500,10 @@ public class BrokerService implements Closeable {
                     if (t == null) {
                         return hasOwnership;
                     } else {
-                        log.warn("Failed to check the ownership of the topic: {}, {}", topicName, t.getMessage());
+                        log.warn()
+                                .attr("topic", topicName)
+                                .exceptionMessage(t)
+                                .log("Failed to check the ownership of the topic");
                         return false;
                     }
                 });
@@ -2459,7 +2533,7 @@ public class BrokerService implements Closeable {
                 serviceUnit, disconnectClients, closeWithoutWaitingClientDisconnect);
         ScheduledFuture<?> taskTimeout = executor().schedule(() -> {
             if (!future.isDone()) {
-                log.warn("Unloading of {} has timed out", serviceUnit);
+                log.warn().attr("serviceUnit", serviceUnit).log("Unloading of has timed out");
                 // Complete the future with no error
                 future.complete(0);
             }
@@ -2488,26 +2562,26 @@ public class BrokerService implements Closeable {
                 if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)
                         && ExtensibleLoadManagerImpl.isInternalTopic(topicName.toString())) {
                     if (ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log)) {
-                        log.info("[{}] Skip unloading ExtensibleLoadManager internal topics. Such internal topic "
-                                + "should be closed when shutting down the broker.", topicName);
+                        log.info()
+                                .attr("topic", topicName)
+                                .log("Skip unloading ExtensibleLoadManager internal topics. Such internal topic "
+                                        + "should be closed when shutting down the broker.");
                     }
                     return;
                 }
 
                 // Topic needs to be unloaded
-                log.info("[{}] Unloading topic", topicName);
+                log.info().attr("topic", topicName).log("Unloading topic");
                 if (topicFuture.isCompletedExceptionally()) {
                     try {
                         topicFuture.get();
                     } catch (InterruptedException | ExecutionException ex) {
                         if (ex.getCause() instanceof ServiceUnitNotReadyException) {
                             // Topic was already unloaded
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Topic was already unloaded", topicName);
-                            }
+                            log.debug().attr("topic", topicName).log("Topic was already unloaded");
                             return;
                         } else {
-                            log.warn("[{}] Got exception when closing topic", topicName, ex);
+                            log.warn().attr("topic", topicName).exception(ex).log("Got exception when closing topic");
                         }
                     }
                 }
@@ -2518,7 +2592,7 @@ public class BrokerService implements Closeable {
                         .exceptionally(e -> {
                             if (e.getCause() instanceof BrokerServiceException.ServiceUnitNotReadyException
                                     && e.getMessage().contains("Please redo the lookup")) {
-                                log.warn("[{}] Topic ownership check failed. Skipping it", topicName);
+                                log.warn().attr("topic", topicName).log("Topic ownership check failed. Skipping it");
                                 return null;
                             }
                             throw FutureUtil.wrapToCompletionException(e);
@@ -2545,7 +2619,10 @@ public class BrokerService implements Closeable {
         for (String topic : topics.keySet()) {
             TopicName topicName = TopicName.get(topic);
             if (serviceUnit.includes(topicName) && getTopicReference(topic).isPresent()) {
-                log.info("[{}][{}] Clean unloaded topic from cache.", serviceUnit.toString(), topic);
+                log.info()
+                        .attr("value", serviceUnit.toString())
+                        .attr("topic", topic)
+                        .log("Clean unloaded topic from cache.");
                 pulsar.getBrokerService().removeTopicFromCache(topicName.toString(), serviceUnit, null);
             }
         }
@@ -2628,15 +2705,16 @@ public class BrokerService implements Closeable {
             try {
                 brokerId = pulsar.getBrokerId();
             } catch (Exception ex) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to get brokerId", ex);
-                }
+                log.debug().exception(ex).log("Failed to get brokerId");
                 // If broker is not running, we cannot get brokerId.
                 brokerId = "unknown";
             }
             // Ignore metadata changes when broker is not running
-            log.info("Ignoring metadata change since broker is not running (id={}, state={}) {}", brokerId,
-                    pulsar.getState(), n);
+            log.info()
+                    .attr("brokerId", brokerId)
+                    .attr("state", pulsar.getState())
+                    .attr("notification", n)
+                    .log("Ignoring metadata change since broker is not running");
             return;
         }
         if (n.getType() == NotificationType.Modified && NamespaceResources.pathIsFromNamespace(n.getPath())) {
@@ -2659,15 +2737,13 @@ public class BrokerService implements Closeable {
                         return;
                     }
                     LocalPolicies localPolicies = optLocalPolicies.get();
-                    log.info("[{}] updating with {}", namespace, localPolicies);
+                    log.info().attr("namespace", namespace).attr("localPolicies", localPolicies).log("updating with");
                     topics.forEach((name, topicFuture) -> {
                         if (namespace.includes(TopicName.get(name))) {
                             // If the topic is already created, immediately apply the updated policies, otherwise
                             // once the topic is created it'll apply the policies update
                             topicFuture.thenAccept(topic -> {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("Notifying topic that local policies have changed: {}", name);
-                                }
+                                log.debug().attr("name", name).log("Notifying topic that local policies have changed");
                                 topic.ifPresent(t -> {
                                     if (t instanceof PersistentTopic) {
                                         PersistentTopic topic1 = (PersistentTopic) t;
@@ -2688,16 +2764,15 @@ public class BrokerService implements Closeable {
                     }
 
                     Policies policies = optPolicies.get();
-                    log.info("[{}] updating with {}", namespace, policies);
+                    log.info().attr("namespace", namespace).attr("policies", policies)
+                            .log("Updating namespace with policies");
 
                     topics.forEach((name, topicFuture) -> {
                         if (namespace.includes(TopicName.get(name))) {
                             // If the topic is already created, immediately apply the updated policies, otherwise
                             // once the topic is created it'll apply the policies update
                             topicFuture.thenAccept(topic -> {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("Notifying topic that policies have changed: {}", name);
-                                }
+                                log.debug().attr("topic", name).log("Notifying topic that policies have changed");
 
                                 topic.ifPresent(t -> t.onPoliciesUpdate(policies));
                             });
@@ -2717,7 +2792,7 @@ public class BrokerService implements Closeable {
                     .getPulsarResources()
                     .getDynamicConfigResources();
         } catch (Exception e) {
-            log.warn("Failed to read dynamic broker configuration", e);
+            log.warn().exception(e).log("Failed to read dynamic broker configuration");
         }
 
         if (dynamicConfigResources != null) {
@@ -2746,7 +2821,7 @@ public class BrokerService implements Closeable {
     private void configValueChanged(String configKey, String newValueStr) {
         ConfigField configFieldWrapper = dynamicConfigurationMap.get(configKey);
         if (configFieldWrapper == null) {
-            log.warn("{} does not exist in dynamicConfigurationMap, skip this config.", configKey);
+            log.warn().attr("configKey", configKey).log("does not exist in dynamicConfigurationMap, skip this config.");
             return;
         }
         Consumer listener = configRegisteredListeners.get(configKey);
@@ -2765,8 +2840,11 @@ public class BrokerService implements Closeable {
             } else {
                 // This case only occurs when it is a customized item.
                 // See: https://github.com/apache/pulsar/blob/master/pip/pip-300.md.
-                log.info("Skip update customized dynamic configuration {}/{} in memory, only trigger an event"
-                        + " listeners.", configKey, newValueStr);
+                log.info()
+                        .attr("configKey", configKey)
+                        .attr("newValueStr", newValueStr)
+                        .log("Skip update customized dynamic configuration in memory, only trigger an event "
+                                + "to listeners.");
                 existingValue = configFieldWrapper.lastDynamicValue;
                 newValue = newValueStr == null ? configFieldWrapper.defaultValue : newValueStr;
             }
@@ -2774,10 +2852,14 @@ public class BrokerService implements Closeable {
             configFieldWrapper.lastDynamicValue = newValueStr;
 
             if (newValueStr == null) {
-                log.info("Successfully remove the dynamic configuration {}, and revert to the default value",
-                        configKey);
+                log.info()
+                        .attr("configKey", configKey)
+                        .log("Successfully remove the dynamic configuration, and revert to the default value");
             } else {
-                log.info("Successfully updated configuration {}/{}", configKey, newValueStr);
+                log.info()
+                        .attr("configKey", configKey)
+                        .attr("newValueStr", newValueStr)
+                        .log("Successfully updated configuration");
             }
 
             if (listener != null && !Objects.equals(existingValue, newValue)) {
@@ -2787,7 +2869,7 @@ public class BrokerService implements Closeable {
                 listener.accept(newValue);
             }
         } catch (Exception e) {
-            log.error("Failed to update config {}", configKey, e);
+            log.error().attr("configKey", configKey).exception(e).log("Failed to update config");
         }
     }
 
@@ -2812,8 +2894,11 @@ public class BrokerService implements Closeable {
                                 pulsar().getAdminClient().namespaces().unloadNamespaceBundle(namespace.toString(),
                                         bundle.getBundleRange());
                             } catch (Exception e) {
-                                log.error("Failed to unload namespace-bundle {} that not owned by {}, {}",
-                                        bundle.toString(), localCluster, e.getMessage());
+                                log.error()
+                                        .attr("value", bundle.toString())
+                                        .attr("localCluster", localCluster)
+                                        .exceptionMessage(e)
+                                        .log("Failed to unload namespace-bundle that not owned by");
                             }
                         });
                     }
@@ -2883,7 +2968,10 @@ public class BrokerService implements Closeable {
             try {
                 Class.forName(className);
             } catch (ClassNotFoundException | NoClassDefFoundError e) {
-                log.warn("Configured load-manager class {} not found {}", className, e.getMessage());
+                log.warn()
+                        .attr("className", className)
+                        .exceptionMessage(e)
+                        .log("Configured load-manager class not found");
                 return false;
             }
             return true;
@@ -2903,18 +2991,18 @@ public class BrokerService implements Closeable {
                 LoadManager newLoadManager = null;
                 try {
                     newLoadManager = LoadManager.create(pulsar);
-                    log.info("Created load manager: {}", className);
+                    log.info().attr("className", className).log("Created load manager");
                     pulsar.getLoadManager().get().stop();
                     newLoadManager.start();
                 } catch (Exception ex) {
-                    log.warn("Failed to change load manager", ex);
+                    log.warn().exception(ex).log("Failed to change load manager");
                     try {
                         if (newLoadManager != null) {
                             newLoadManager.stop();
                             newLoadManager = null;
                         }
                     } catch (PulsarServerException e) {
-                        log.warn("Failed to close created load manager", e);
+                        log.warn().exception(e).log("Failed to close created load manager");
                     }
                 }
                 if (newLoadManager != null) {
@@ -3112,7 +3200,7 @@ public class BrokerService implements Closeable {
 
         final PublishRate publishRate = new PublishRate(currentMaxMessageRate, currentMaxByteRate);
 
-        log.info("Update broker publish rate limiting {}", publishRate);
+        log.info().attr("publishRate", publishRate).log("Update broker publish rate limiting");
         brokerPublishRateLimiter.update(publishRate);
     }
 
@@ -3197,7 +3285,8 @@ public class BrokerService implements Closeable {
                                 pulsar.getConfiguration().isAutoSkipNonRecoverableData());
                     }
                 } catch (Exception e) {
-                    log.warn("[{}] failed to update managed-ledger config", topic.getName(), e);
+                    log.warn().attr("topic", topic.getName()).exception(e)
+                            .log("failed to update managed-ledger config");
                 }
             });
         });
@@ -3259,7 +3348,7 @@ public class BrokerService implements Closeable {
                         .setDynamicConfigurationWithCreate(n -> new HashMap<>());
             }
         } catch (Exception e) {
-            log.warn("Failed to read dynamic broker configuration", e);
+            log.warn().exception(e).log("Failed to read dynamic broker configuration");
         }
     }
 
@@ -3305,7 +3394,7 @@ public class BrokerService implements Closeable {
             }
         } catch (IllegalArgumentException | IllegalAccessException ex) {
             // This error never occurs.
-            log.error("Failed to initialize dynamic configuration map", ex);
+            log.error().exception(ex).log("Failed to initialize dynamic configuration map");
             throw new RuntimeException(ex);
         }
         return dynamicConfigurationMap;
@@ -3320,7 +3409,10 @@ public class BrokerService implements Closeable {
                     Object configValue = field.get(pulsar.getConfiguration());
                     runtimeConfigurationMap.put(field.getName(), configValue == null ? "" : configValue);
                 } catch (Exception e) {
-                    log.error("Failed to get value of field {}, {}", field.getName(), e.getMessage());
+                    log.error()
+                            .attr("name", field.getName())
+                            .exceptionMessage(e)
+                            .log("Failed to get value of field");
                 }
             }
         }
@@ -3355,7 +3447,7 @@ public class BrokerService implements Closeable {
                 return null;
             });
         }).exceptionally(e -> {
-            log.error("Failed to create pending topic {}", topic, e);
+            log.error().attr("topic", topic).exception(e).log("Failed to create pending topic");
             pendingTopic.getTopicFuture()
                     .completeExceptionally((e instanceof RuntimeException && e.getCause() != null) ? e.getCause() : e);
             // schedule to process next pending topic
@@ -3417,26 +3509,35 @@ public class BrokerService implements Closeable {
                             }).exceptionallyCompose(ex -> {
                                 // The partitioned topic might be created concurrently.
                                 if (ex.getCause() instanceof MetadataStoreException.AlreadyExistsException) {
-                                    log.info("[{}] The partitioned topic is already created, try to refresh "
-                                            + "the cache and read again.", topicName);
+                                    log.info()
+                                            .attr("topic", topicName)
+                                            .log("The partitioned topic is already created, try to refresh "
+                                                    + "the cache and read again.");
                                     CompletableFuture<PartitionedTopicMetadata> recheckFuture =
                                             fetchPartitionedTopicMetadataAsync(topicName, true);
                                     recheckFuture.exceptionally(ex2 -> {
                                         // Just for printing a log if error occurs.
-                                        log.error("[{}] Fetch partitioned topic metadata failed", topicName, ex);
+                                        log.error()
+                                                .attr("topic", topicName)
+                                                .exception(ex)
+                                                .log("Fetch partitioned topic metadata failed");
                                         return null;
                                     });
                                     return recheckFuture;
                                 } else {
-                                    log.error("[{}] operation of creating partitioned topic metadata failed",
-                                            topicName, ex);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .exception(ex)
+                                            .log("operation of creating partitioned topic metadata failed");
                                     return CompletableFuture.failedFuture(ex);
                                 }
                             });
                     }, pulsar.getExecutor()).exceptionallyCompose(ex -> {
-                        log.error("[{}] operation of get partitioned metadata failed due to calling"
-                                        + " isAllowAutoTopicCreationAsync failed",
-                                topicName, ex);
+                        log.error()
+                                .attr("topic", topicName)
+                                .exception(ex)
+                                .log("operation of get partitioned metadata failed due to calling"
+                                        + "isAllowAutoTopicCreationAsync failed");
                         return CompletableFuture.failedFuture(ex);
                     });
             }, pulsar.getExecutor());
@@ -3471,7 +3572,9 @@ public class BrokerService implements Closeable {
                             .getPartitionedTopicResources();
                     return partitionResources.createPartitionedTopicAsync(topicName, configMetadata)
                             .thenApply(v -> {
-                                log.info("partitioned metadata successfully created for {}", topicName);
+                                log.info()
+                                        .attr("topic", topicName)
+                                        .log("partitioned metadata successfully created for");
                                 return configMetadata;
                             });
                 });
@@ -3504,9 +3607,11 @@ public class BrokerService implements Closeable {
             TopicName topicName, List<String> remoteClusters, int index, Throwable errOccurred) {
         if (index >= remoteClusters.size()) {
             if (errOccurred != null) {
-                log.error("[{}] Failed to check remote topic partitioned metadata on cluster {}. Fallback to "
-                    + "default auto topic creation policy.",
-                    topicName, remoteClusters, errOccurred);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("remoteClusters", remoteClusters)
+                        .log("Failed to check remote topic partitioned metadata on cluster. Fallback to "
+                                + "default auto topic creation policy.");
             }
             return CompletableFuture.completedFuture(TopicExistsInfo.newTopicNotExists());
         }
@@ -3514,8 +3619,10 @@ public class BrokerService implements Closeable {
         return pulsar.getPulsarResources().getClusterResources().getClusterAsync(remoteCluster)
             .thenCompose(clusterData -> {
                 if (clusterData.isEmpty()) {
-                    log.warn("[{}] Skip checking remote cluster {} because cluster data is missing",
-                            topicName, remoteCluster);
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("remoteCluster", remoteCluster)
+                            .log("Skip checking remote cluster because cluster data is missing");
                     return findRemoteTopicMetadataForAutoCreation(topicName, remoteClusters, index + 1, null);
                 }
                 PulsarClient client = getReplicationClient(remoteCluster, clusterData);
@@ -3591,8 +3698,10 @@ public class BrokerService implements Closeable {
                     && dispatcher.getTotalUnackedMessages() > maxUnackedMsgsPerDispatcher) {
                 lock.readLock().lock();
                 try {
-                    log.info("[{}] dispatcher reached to max unack msg limit on blocked-broker {}",
-                            dispatcher.getName(), dispatcher.getTotalUnackedMessages());
+                    log.info()
+                            .attr("name", dispatcher.getName())
+                            .attr("totalUnackedMessages", dispatcher.getTotalUnackedMessages())
+                            .log("dispatcher reached to max unack msg limit on blocked-broker");
                     dispatcher.blockDispatcherOnUnackedMsgs();
                     blockedDispatchers.add(dispatcher);
                 } finally {
@@ -3618,8 +3727,10 @@ public class BrokerService implements Closeable {
         long unAckedMessages = totalUnackedMessages.sum();
         if (unAckedMessages >= maxUnackedMessages && blockedDispatcherOnHighUnackedMsgs.compareAndSet(false, true)) {
             // block dispatcher with higher unack-msg when it reaches broker-unack msg limit
-            log.info("Starting blocking dispatchers with unacked msgs {} due to reached max broker limit {}",
-                    maxUnackedMessages, maxUnackedMsgsPerDispatcher);
+            log.info()
+                    .attr("maxUnackedMessages", maxUnackedMessages)
+                    .attr("maxUnackedMsgsPerDispatcher", maxUnackedMsgsPerDispatcher)
+                    .log("Starting blocking dispatchers with unacked msgs due to reached max broker limit");
             executor().execute(() -> blockDispatchersWithLargeUnAckMessages());
         } else if (blockedDispatcherOnHighUnackedMsgs.get() && unAckedMessages < maxUnackedMessages / 2) {
             // unblock broker-dispatching if received enough acked messages back
@@ -3645,8 +3756,10 @@ public class BrokerService implements Closeable {
                                 (AbstractPersistentDispatcherMultipleConsumers) persistentSubscription.getDispatcher();
                         int dispatcherUnAckMsgs = dispatcher.getTotalUnackedMessages();
                         if (dispatcherUnAckMsgs > maxUnackedMsgsPerDispatcher) {
-                            log.info("[{}] Blocking dispatcher due to reached max broker limit {}",
-                                    dispatcher.getName(), dispatcher.getTotalUnackedMessages());
+                            log.info()
+                                    .attr("name", dispatcher.getName())
+                                    .attr("totalUnackedMessages", dispatcher.getTotalUnackedMessages())
+                                    .log("Blocking dispatcher due to reached max broker limit");
                             dispatcher.blockDispatcherOnUnackedMsgs();
                             blockedDispatchers.add(dispatcher);
                         }
@@ -3669,7 +3782,7 @@ public class BrokerService implements Closeable {
             dispatcherList.forEach(dispatcher -> {
                 dispatcher.unBlockDispatcherOnUnackedMsgs();
                 dispatcher.readMoreEntriesAsync();
-                log.info("[{}] Dispatcher is unblocked", dispatcher.getName());
+                log.info().attr("name", dispatcher.getName()).log("Dispatcher is unblocked");
                 blockedDispatchers.remove(dispatcher);
             });
         } finally {
@@ -3692,7 +3805,7 @@ public class BrokerService implements Closeable {
             this.fallbackDelayedDeliveryTrackerFactory = factory;
         } catch (Exception e) {
             // it should never go here
-            log.error("Failed to initialize InMemoryDelayedDeliveryTrackerFactory", e);
+            log.error().exception(e).log("Failed to initialize InMemoryDelayedDeliveryTrackerFactory");
         }
     }
 
@@ -3764,8 +3877,9 @@ public class BrokerService implements Closeable {
     private CompletableFuture<Boolean> isAllowAutoTopicCreationAsync(final TopicName topicName,
                                                                      final Optional<Policies> policies) {
         if (policies.isPresent() && policies.get().deleted) {
-            log.info("Preventing AutoTopicCreation on a namespace that is being deleted {}",
-                    topicName.getNamespaceObject());
+            log.info()
+                    .attr("namespaceObject", topicName.getNamespaceObject())
+                    .log("Preventing AutoTopicCreation on a namespace that is being deleted");
             return CompletableFuture.completedFuture(false);
         }
 
@@ -3837,7 +3951,7 @@ public class BrokerService implements Closeable {
         if (policies.isPresent() && policies.get().autoTopicCreationOverride != null) {
             return policies.get().autoTopicCreationOverride;
         }
-        log.debug("No autoTopicCreateOverride policy found for {}", topicName);
+        log.debug().attr("topic", topicName).log("No autoTopicCreateOverride policy found for");
         return null;
     }
 
@@ -3890,7 +4004,7 @@ public class BrokerService implements Closeable {
                 // because when we delete a topic, the schema
                 // history is meaningless. But when we delete a schema of a topic, a new schema could be
                 // registered in the future.
-                log.info("Deleted schema storage of id: {}", id);
+                log.info().attr("schemaId", id).log("Deleted schema storage");
             }
         });
     }
@@ -3930,8 +4044,10 @@ public class BrokerService implements Closeable {
                                             .filter(t -> !isSystemTopic(TopicName.get(t)))
                                             .count();
                                     if (topicsCount + numPartitions > maxTopicsPerNamespace) {
-                                        log.error("Failed to create persistent topic {}, "
-                                                + "exceed maximum number of topics in namespace", topicName);
+                                        log.error()
+                                                .attr("topic", topicName)
+                                                .log("Failed to create persistent topic, "
+                                                        + "exceed maximum number of topics in namespace");
                                         return FutureUtil.failedFuture(
                                                 new NotAllowedException(
                                                         "Exceed maximum number of topics in namespace."));
@@ -3990,7 +4106,7 @@ public class BrokerService implements Closeable {
                     return (T) newTopic;
                 }
             } catch (Throwable e) {
-                log.warn("Failed to create persistent topic using factory {}", topic, e);
+                log.warn().attr("topic", topic).exception(e).log("Failed to create persistent topic using factory");
                 throw new PulsarServerException("Topic factory failed to create topic ", e);
             }
         }
@@ -4005,7 +4121,10 @@ public class BrokerService implements Closeable {
                 return (TopicFactory) Class.forName(topicFactoryClassName)
                         .getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-                log.warn("Failed to initialize topic factory class {}", topicFactoryClassName, e);
+                log.warn()
+                        .attr("topicFactoryClassName", topicFactoryClassName)
+                        .exception(e)
+                        .log("Failed to initialize topic factory class");
                 throw e;
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsistentHashingStickyKeyConsumerSelector.java
@@ -28,15 +28,15 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.CustomLog;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Range;
 
 /**
  * This is a consumer selector using consistent hashing to evenly split
  * the number of keys assigned to each consumer.
  */
-@Slf4j
+@CustomLog
 public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyConsumerSelector {
     // use NUL character as field separator for hash key calculation
     private static final String KEY_SEPARATOR = "\0";
@@ -159,16 +159,20 @@ public class ConsistentHashingStickyKeyConsumerSelector implements StickyKeyCons
                 }
             }
             if (hashPointsAdded == 0) {
-                log.error("Failed to add consumer '{}' to the hash ring. There were {} collisions. Consider increasing "
-                                + "the number of points ({}) per consumer by setting "
-                                + "subscriptionKeySharedConsistentHashingReplicaPoints={}",
-                        consumer, hashPointCollisions, numberOfPoints,
-                        Math.max((int) (numberOfPoints * 1.5d), numberOfPoints + 1));
+                log.error()
+                        .attr("consumer", consumer)
+                        .attr("hashPointCollisions", hashPointCollisions)
+                        .attr("numberOfPoints", numberOfPoints)
+                        .attr("suggestedReplicaPoints",
+                                Math.max((int) (numberOfPoints * 1.5d), numberOfPoints + 1))
+                        .log("Failed to add consumer to the hash ring due to collisions. Consider increasing "
+                                + "subscriptionKeySharedConsistentHashingReplicaPoints");
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Added consumer '{}' with {} points, {} collisions", consumer, hashPointsAdded,
-                        hashPointCollisions);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .attr("hashPointsAdded", hashPointsAdded)
+                    .attr("hashPointCollisions", hashPointCollisions)
+                    .log("Added consumer");
             if (!addOrRemoveReturnsImpactedConsumersResult) {
                 return CompletableFuture.completedFuture(Optional.empty());
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AtomicDouble;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.opentelemetry.api.common.Attributes;
@@ -75,13 +76,15 @@ import org.apache.pulsar.common.util.collections.IntIntPair;
 import org.apache.pulsar.common.util.collections.ObjectIntPair;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.apache.pulsar.transaction.common.exception.TransactionConflictException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A Consumer is a consumer currently connected and associated with a Subscription.
  */
 public class Consumer {
+
+    private static final Logger LOG = Logger.get(Consumer.class);
+    private final Logger log;
+
     private final Subscription subscription;
     private final SubType subType;
     private final TransportCnx cnx;
@@ -207,6 +210,13 @@ public class Consumer {
         this.isPersistentTopic = subscription.getTopic() instanceof PersistentTopic;
         this.keySharedMeta = keySharedMeta;
         this.cnx = cnx;
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subscription.getName())
+                .attr("consumerId", consumerId)
+                .attr("consumerName", consumerName)
+                .attr("cnx", cnx)
+                .build();
         this.msgOut = new Rate();
         this.chunkedMessageRate = new Rate();
         this.msgRedeliver = new Rate();
@@ -282,6 +292,7 @@ public class Consumer {
         this.startMessageId = null;
         this.isAcknowledgmentAtBatchIndexLevelEnabled = false;
         this.schemaType = null;
+        this.log = LOG.with().attr("consumerName", consumerName).build();
         MESSAGE_PERMITS_UPDATER.set(this, availablePermits);
         OPEN_TELEMETRY_ATTRIBUTES_FIELD_UPDATER.set(this, null);
     }
@@ -299,10 +310,9 @@ public class Consumer {
     }
 
     void notifyActiveConsumerChange(Consumer activeConsumer) {
-        if (log.isDebugEnabled()) {
-            log.debug("notify consumer {} - that [{}] for subscription {} has new active consumer : {}",
-                consumerId, topicName, subscription.getName(), activeConsumer);
-        }
+        log.debug()
+                .attr("activeConsumer", activeConsumer)
+                .log("Notifying new active consumer for subscription");
         cnx.getCommandSender().sendActiveConsumerChange(consumerId, this == activeConsumer);
     }
 
@@ -344,10 +354,7 @@ public class Consumer {
         this.lastConsumedTimestamp = System.currentTimeMillis();
 
         if (entries.isEmpty() || totalMessages == 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] List of messages is empty, triggering write future immediately for consumerId {}",
-                        topicName, subscription, consumerId);
-            }
+            log.debug("List of messages is empty, triggering write future immediately");
             batchSizes.recyle();
             if (batchIndexesAcks != null) {
                 batchIndexesAcks.recycle();
@@ -388,23 +395,21 @@ public class Consumer {
                         totalEntries--;
                         entries.set(i, null);
                         entry.release();
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}-{}] Skipping sending of {}:{} ledger entry with batchSize of {} since adding"
-                                            + " to pending acks failed in broker.service.Consumer for consumerId: {}",
-                                    topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
-                                    consumerId);
-                        }
+                        log.debug()
+                                .attr("ledgerId", entry.getLedgerId())
+                                .attr("entryId", entry.getEntryId())
+                                .attr("batchSize", batchSize)
+                                .log("Skipping sending of entry since adding to pending acks failed");
                     } else {
                         long[] ackSet = batchIndexesAcks == null ? null : batchIndexesAcks.getAckSet(i);
                         if (ackSet != null) {
                             unackedMessages -= (batchSize - BitSet.valueOf(ackSet).cardinality());
                         }
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}-{}] Added {}:{} ledger entry with batchSize of {} to pendingAcks in"
-                                            + " broker.service.Consumer for consumerId: {}",
-                                    topicName, subscription, entry.getLedgerId(), entry.getEntryId(), batchSize,
-                                    consumerId);
-                        }
+                        log.debug()
+                                .attr("ledgerId", entry.getLedgerId())
+                                .attr("entryId", entry.getEntryId())
+                                .attr("batchSize", batchSize)
+                                .log("Added entry to pendingAcks");
                     }
                 }
             }
@@ -422,11 +427,11 @@ public class Consumer {
         // reduce permit and increment unackedMsg count with total number of messages in batch-msgs
         int ackedCount = batchIndexesAcks == null ? 0 : batchIndexesAcks.getTotalAckedIndexCount();
         MESSAGE_PERMITS_UPDATER.addAndGet(this, ackedCount - totalMessages);
-        if (log.isDebugEnabled()){
-            log.debug("[{}-{}] Added {} minus {} messages to MESSAGE_PERMITS_UPDATER in broker.service.Consumer"
-                            + " for consumerId: {}; avgMessagesPerEntry is {}",
-                   topicName, subscription, ackedCount, totalMessages, consumerId, avgMessagesPerEntry.get());
-        }
+        log.debug()
+                .attr("ackedCount", ackedCount)
+                .attr("totalMessages", totalMessages)
+                .attr("avgMessagesPerEntry", avgMessagesPerEntry.get())
+                .log("Added minus messages to MESSAGE_PERMITS_UPDATER");
         incrementUnackedMessages(unackedMessages);
         Future<Void> writeAndFlushPromise =
                 cnx.getCommandSender().sendMessagesToConsumer(consumerId, topicName, subscription, partitionIdx,
@@ -442,11 +447,9 @@ public class Consumer {
                 bytesOutCounter.add(totalBytes);
                 chunkedMessageRate.recordMultipleEvents(totalChunkedMessages, 0);
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}-{}] Sent messages to client fail by IO exception[{}], close the connection"
-                                    + " immediately. Consumer: {}",  topicName, subscription,
-                            status.cause() == null ? "" : status.cause().getMessage(), this.toString());
-                }
+                log.debug()
+                        .exceptionMessage(status.cause())
+                        .log("Sent messages to client failed by IO exception, closing the connection");
             }
         });
         return writeAndFlushPromise;
@@ -486,22 +489,22 @@ public class Consumer {
     }
 
     public void disconnect(boolean isResetCursor, Optional<BrokerLookupData> assignedBrokerLookupData) {
-        log.info("Disconnecting consumer: {}", this);
+        log.info("Disconnecting consumer");
         cnx.closeConsumer(this, assignedBrokerLookupData);
         try {
             close(isResetCursor);
         } catch (BrokerServiceException e) {
-            log.warn("Consumer {} was already closed: {}", this, e.getMessage(), e);
+            log.warn().exception(e).log("Consumer was already closed");
         }
     }
 
     public void doUnsubscribe(final long requestId, boolean force) {
         subscription.doUnsubscribe(this, force).thenAccept(v -> {
-            log.info("Unsubscribed successfully from {}", subscription);
+            log.info("Unsubscribed successfully");
             cnx.removedConsumer(this);
             cnx.getCommandSender().sendSuccessResponse(requestId);
         }).exceptionally(exception -> {
-            log.warn("Unsubscribe failed for {}", subscription, exception);
+            log.warn().exception(exception).log("Unsubscribe failed");
             cnx.getCommandSender().sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(exception),
                     exception.getCause().getMessage());
             return null;
@@ -520,13 +523,12 @@ public class Consumer {
 
         if (ack.getAckType() == AckType.Cumulative) {
             if (ack.getMessageIdsCount() != 1) {
-                log.warn("[{}] [{}] Received multi-message ack", subscription, consumerId);
+                log.warn("Received multi-message ack");
                 return CompletableFuture.completedFuture(null);
             }
 
             if (Subscription.isIndividualAckMode(subType)) {
-                log.warn("[{}] [{}] Received cumulative ack on shared subscription, ignoring",
-                        subscription, consumerId);
+                log.warn("Received cumulative ack on shared subscription, ignoring");
                 return CompletableFuture.completedFuture(null);
             }
 
@@ -649,8 +651,9 @@ public class Consumer {
             ObjectIntPair<Consumer> ackOwnerConsumerAndBatchSize = getAckOwnerConsumerAndBatchSize(msgId.getLedgerId(),
                     msgId.getEntryId());
             if (ackOwnerConsumerAndBatchSize == null) {
-                log.warn("[{}] [{}] Acknowledging message at {} that was already deleted", subscription,
-                        consumerId, position);
+                log.warn()
+                        .attr("position", position)
+                        .log("Acknowledging message that was already deleted");
                 continue;
             }
             Consumer ackOwnerConsumer = ackOwnerConsumerAndBatchSize.left();
@@ -759,8 +762,10 @@ public class Consumer {
 
     private void checkAckValidationError(CommandAck ack, Position position) {
         if (ack.hasValidationError()) {
-            log.warn("[{}] [{}] Received ack for corrupted message at {} - Reason: {}", subscription,
-                    consumerId, position, ack.getValidationError());
+            log.warn()
+                    .attr("position", position)
+                    .attr("validationError", ack.getValidationError())
+                    .log("Received ack for corrupted message");
         }
     }
 
@@ -857,19 +862,19 @@ public class Consumer {
         int oldPermits;
         if (!blockedConsumerOnUnackedMsgs) {
             oldPermits = MESSAGE_PERMITS_UPDATER.getAndAdd(this, additionalNumberOfMessages);
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Added {} message permits in broker.service.Consumer before updating dispatcher "
-                        + "for consumer {}", topicName, subscription, additionalNumberOfMessages, consumerId);
-            }
+            log.debug()
+                    .attr("additionalNumberOfMessages", additionalNumberOfMessages)
+                    .log("Added message permits before updating dispatcher");
             subscription.consumerFlow(this, additionalNumberOfMessages);
         } else {
             oldPermits = PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.getAndAdd(this, additionalNumberOfMessages);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Added more flow control message permits {} (old was: {}), blocked = {} ", topicName,
-                    subscription, additionalNumberOfMessages, oldPermits, blockedConsumerOnUnackedMsgs);
-        }
+        log.debug()
+                .attr("additionalNumberOfMessages", additionalNumberOfMessages)
+                .attr("oldPermits", oldPermits)
+                .attr("blockedConsumerOnUnackedMsgs", blockedConsumerOnUnackedMsgs)
+                .log("Added more flow control message permits");
 
     }
 
@@ -884,10 +889,9 @@ public class Consumer {
         int additionalNumberOfPermits = PERMITS_RECEIVED_WHILE_CONSUMER_BLOCKED_UPDATER.getAndSet(consumer, 0);
         // add newly flow permits to actual consumer.messagePermits
         MESSAGE_PERMITS_UPDATER.getAndAdd(consumer, additionalNumberOfPermits);
-        if (log.isDebugEnabled()){
-            log.debug("[{}-{}] Added {} blocked permits to broker.service.Consumer for consumer {}", topicName,
-                    subscription, additionalNumberOfPermits, consumerId);
-        }
+        log.debug()
+                .attr("additionalNumberOfPermits", additionalNumberOfPermits)
+                .log("Added blocked permits");
         // dispatch pending permits to flow more messages: it will add more permits to dispatcher and consumer
         subscription.consumerFlow(consumer, additionalNumberOfPermits);
     }
@@ -969,10 +973,9 @@ public class Consumer {
         lastConsumedTimestamp = consumerStats.lastConsumedTimestamp;
         lastConsumedFlowTimestamp = consumerStats.lastConsumedFlowTimestamp;
         MESSAGE_PERMITS_UPDATER.set(this, consumerStats.availablePermits);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Setting broker.service.Consumer's messagePermits to {} for consumer {}", topicName,
-                    subscription, consumerStats.availablePermits, consumerId);
-        }
+        log.debug()
+                .attr("availablePermits", consumerStats.availablePermits)
+                .log("Setting consumer's messagePermits");
         unackedMessages = consumerStats.unackedMessages;
         blockedConsumerOnUnackedMsgs = consumerStats.blockedConsumerOnUnackedMsgs;
         avgMessagesPerEntry.set(consumerStats.avgMessagesPerEntry);
@@ -1045,13 +1048,16 @@ public class Consumer {
                     .allowTopicOperationAsync(topicName, TopicOperation.CONSUME, appId, authData)
                     .handle((ok, e) -> {
                         if (e != null) {
-                            log.warn("[{}] Get unexpected error while authorizing [{}]  {}", appId,
-                                    subscription.getTopicName(), e.getMessage(), e);
+                            log.warn()
+                                    .attr("appId", appId)
+                                    .exception(e)
+                                    .log("Got unexpected error while authorizing");
                         }
 
                         if (ok == null || !ok) {
-                            log.info("[{}] is not allowed to consume from topic [{}] anymore", appId,
-                                    subscription.getTopicName());
+                            log.info()
+                                    .attr("appId", appId)
+                                    .log("Not allowed to consume from topic anymore");
                             disconnect();
                         }
                         return null;
@@ -1092,9 +1098,9 @@ public class Consumer {
             // Message was already removed by the other consumer
             return false;
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] consumer {} received ack {}", topicName, subscription, consumerId, position);
-        }
+        log.debug()
+                .attr("position", position)
+                .log("Consumer received ack");
         updateBlockedConsumerOnUnackedMsgs(ackOwnedConsumer);
         return true;
     }
@@ -1123,9 +1129,7 @@ public class Consumer {
         // cleanup unackedMessage bucket and redeliver those unack-msgs again
         clearUnAckedMsgs();
         blockedConsumerOnUnackedMsgs = false;
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] consumer {} received redelivery", topicName, subscription, consumerId);
-        }
+        log.debug("Consumer received redelivery");
 
         if (pendingAcks != null) {
             List<Position> pendingPositions = new ArrayList<>((int) pendingAcks.size());
@@ -1170,10 +1174,10 @@ public class Consumer {
         addAndGetUnAckedMsgs(this, -totalRedeliveryMessages);
         blockedConsumerOnUnackedMsgs = false;
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] consumer {} received {} msg-redelivery {}", topicName, subscription, consumerId,
-                    totalRedeliveryMessages, pendingPositions.size());
-        }
+        log.debug()
+                .attr("totalRedeliveryMessages", totalRedeliveryMessages)
+                .attr("size", pendingPositions.size())
+                .log("Consumer received msg-redelivery");
 
         subscription.redeliverUnacknowledgedMessages(this, pendingPositions);
         msgRedeliver.recordMultipleEvents(totalRedeliveryMessages, totalRedeliveryMessages);
@@ -1184,10 +1188,9 @@ public class Consumer {
         // if permitsReceivedWhileConsumerBlocked has been accumulated then pass it to Dispatcher to flow messages
         if (numberOfBlockedPermits > 0) {
             MESSAGE_PERMITS_UPDATER.getAndAdd(this, numberOfBlockedPermits);
-            if (log.isDebugEnabled()) {
-               log.debug("[{}-{}] Added {} blockedPermits to broker.service.Consumer's messagePermits for consumer {}",
-                       topicName, subscription, numberOfBlockedPermits, consumerId);
-            }
+            log.debug()
+                    .attr("numberOfBlockedPermits", numberOfBlockedPermits)
+                    .log("Added blockedPermits to consumer's messagePermits");
             subscription.consumerFlow(this, numberOfBlockedPermits);
         }
     }
@@ -1204,7 +1207,10 @@ public class Consumer {
         }
         if (unackedMsgs < 0 && System.currentTimeMillis() - negativeUnackedMsgsTimestamp >= 10_000) {
             negativeUnackedMsgsTimestamp = System.currentTimeMillis();
-            log.warn("unackedMsgs is : {}, ackedMessages : {}, consumer : {}", unackedMsgs, ackedMessages, consumer);
+            log.warn()
+                    .attr("unackedMsgs", unackedMsgs)
+                    .attr("ackedMessages", ackedMessages)
+                    .log("Negative unackedMsgs count");
         }
         return unackedMsgs;
     }
@@ -1255,9 +1261,6 @@ public class Consumer {
     public Map<String, String> getMetadata() {
         return metadata;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(Consumer.class);
-
     public Attributes getOpenTelemetryAttributes() {
         if (openTelemetryAttributes != null) {
             return openTelemetryAttributes;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DistributedIdGenerator.java
@@ -19,9 +19,8 @@
 package org.apache.pulsar.broker.service;
 
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Generate unique ids across multiple nodes.
@@ -32,6 +31,7 @@ import org.slf4j.LoggerFactory;
  * After that, each node can just use a local counter and combine, the application prefix, its own instance id and with
  * the counter incremental value to obtain a globally unique id.
  */
+@CustomLog
 public class DistributedIdGenerator {
 
     private final String prefix;
@@ -52,12 +52,13 @@ public class DistributedIdGenerator {
         this.prefix = prefix;
         this.counter = new AtomicLong(0);
         this.generatorInstanceId = cs.getNextCounterValue(path).get();
-        log.info("Broker distributed id generator started with instance id {}-{}", prefix, generatorInstanceId);
+        log.info()
+                .attr("prefix", prefix)
+                .attr("generatorInstanceId", generatorInstanceId)
+                .log("Broker distributed id generator started");
     }
 
     public String getNextId() {
         return String.format("%s-%d-%d", prefix, generatorInstanceId, counter.getAndIncrement());
     }
-
-    private static final Logger log = LoggerFactory.getLogger(DistributedIdGenerator.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -27,8 +27,8 @@ import java.util.PrimitiveIterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.CustomLog;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.policies.data.DrainingHash;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.DrainingHashImpl;
@@ -43,7 +43,7 @@ import org.roaringbitmap.RoaringBitmap;
  * a consumer operations happened at the same time as another thread requested topic stats which include
  * the draining hashes state. This problem is avoided with the current implementation.
  */
-@Slf4j
+@CustomLog
 public class DrainingHashesTracker {
     private final String dispatcherName;
     private final UnblockingHandler unblockingHandler;
@@ -161,10 +161,13 @@ public class DrainingHashesTracker {
                 drainingHashes.remove(hash);
                 drainingHashesClearedTotal++;
                 boolean empty = drainingHashes.isEmpty();
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Cleared hash {} in stats. empty={} totalCleared={} hashes={}",
-                            dispatcherName, hash, empty, drainingHashesClearedTotal, drainingHashes.getCardinality());
-                }
+                log.debug()
+                        .attr("dispatcher", dispatcherName)
+                        .attr("hash", hash)
+                        .attr("empty", empty)
+                        .attr("drainingHashesClearedTotal", drainingHashesClearedTotal)
+                        .attr("cardinality", () -> drainingHashes.getCardinality())
+                        .log("Cleared hash in stats");
                 if (empty) {
                     // reduce memory usage by trimming the bitmap when the RoaringBitmap instance is empty
                     drainingHashes.trim();
@@ -185,8 +188,11 @@ public class DrainingHashesTracker {
                     int hash = hashIterator.nextInt();
                     DrainingHashEntry entry = getEntry(hash);
                     if (entry == null) {
-                        log.warn("[{}] Draining hash {} not found in the tracker for consumer {}", dispatcherName, hash,
-                                consumer);
+                        log.warn()
+                                .attr("dispatcher", dispatcherName)
+                                .attr("hash", hash)
+                                .attr("consumer", consumer)
+                                .log("Draining hash not found in the tracker for consumer");
                         continue;
                     }
                     int unackedMessages = entry.getRefCount();
@@ -241,10 +247,12 @@ public class DrainingHashesTracker {
         try {
             entry = drainingHashes.get(stickyHash);
             if (entry == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Adding and incrementing draining hash {} for consumer id:{} name:{}",
-                            dispatcherName, stickyHash, consumer.consumerId(), consumer.consumerName());
-                }
+                log.debug()
+                        .attr("dispatcher", dispatcherName)
+                        .attr("hash", stickyHash)
+                        .attr("consumerId", consumer.consumerId())
+                        .attr("consumerName", consumer.consumerName())
+                        .log("Adding and incrementing draining hash for consumer id: name");
                 entry = new DrainingHashEntry(consumer);
                 drainingHashes.put(stickyHash, entry);
                 // add the consumer specific stats
@@ -256,10 +264,13 @@ public class DrainingHashesTracker {
                                 + " in dispatcher " + dispatcherName + ". Same hash being used for consumer " + consumer
                                 + ".");
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Draining hash {} incrementing {} consumer id:{} name:{}", dispatcherName,
-                            stickyHash, entry.getRefCount() + 1, consumer.consumerId(), consumer.consumerName());
-                }
+                log.debug()
+                        .attr("dispatcher", dispatcherName)
+                        .attr("hash", stickyHash)
+                        .attr("arg2", entry.getRefCount() + 1)
+                        .attr("consumerId", consumer.consumerId())
+                        .attr("consumerName", consumer.consumerName())
+                        .log("Draining hash incrementing consumer id: name");
             }
         } finally {
             lock.writeLock().unlock();
@@ -330,10 +341,12 @@ public class DrainingHashesTracker {
                             + ".");
         }
         if (entry.decrementRefCount()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Draining hash {} removing consumer id:{} name:{}", dispatcherName, stickyHash,
-                        consumer.consumerId(), consumer.consumerName());
-            }
+            log.debug()
+                    .attr("dispatcher", dispatcherName)
+                    .attr("hash", stickyHash)
+                    .attr("consumerId", consumer.consumerId())
+                    .attr("consumerName", consumer.consumerName())
+                    .log("Draining hash removing consumer id: name");
 
             DrainingHashEntry removed;
             boolean notifyUnblocking = false;
@@ -365,10 +378,13 @@ public class DrainingHashesTracker {
                 unblockingHandler.stickyKeyHashUnblocked(stickyHash);
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Draining hash {} decrementing {} consumer id:{} name:{}", dispatcherName,
-                        stickyHash, entry.getRefCount(), consumer.consumerId(), consumer.consumerName());
-            }
+            log.debug()
+                    .attr("dispatcher", dispatcherName)
+                    .attr("hash", stickyHash)
+                    .attr("refCount", entry.getRefCount())
+                    .attr("consumerId", consumer.consumerId())
+                    .attr("consumerName", consumer.consumerName())
+                    .log("Draining hash decrementing consumer id: name");
         }
     }
 
@@ -381,7 +397,7 @@ public class DrainingHashesTracker {
      */
     public boolean shouldBlockStickyKeyHash(Consumer consumer, int stickyKeyHash) {
         if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
-            log.warn("[{}] Sticky key hash is not set. Allowing dispatching", dispatcherName);
+            log.warn().attr("dispatcher", dispatcherName).log("Sticky key hash is not set. Allowing dispatching");
             return false;
         }
         DrainingHashEntry entry = getEntry(stickyKeyHash);
@@ -392,8 +408,12 @@ public class DrainingHashesTracker {
         // hash has been reassigned to the original consumer, remove the entry
         // and don't block the hash
         if (entry.getConsumer() == consumer) {
-            log.info("[{}] Hash {} has been reassigned consumer {}. The draining hash entry with refCount={} will "
-                    + "be removed.", dispatcherName, stickyKeyHash, entry.getConsumer(), entry.getRefCount());
+            log.info()
+                    .attr("dispatcher", dispatcherName)
+                    .attr("stickyKeyHash", stickyKeyHash)
+                    .attr("consumer", entry.getConsumer())
+                    .attr("refCount", entry.getRefCount())
+                    .log("Hash has been reassigned to consumer. The draining hash entry will be removed.");
             lock.writeLock().lock();
             try {
                 drainingHashes.remove(stickyKeyHash, entry);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HealthChecker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/HealthChecker.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -56,7 +56,7 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
  * This class implements AutoCloseable to ensure proper cleanup of resources when the broker is shut down.
  * Tests are in AdminApiHealthCheckTest class.
  */
-@Slf4j
+@CustomLog
 public class HealthChecker implements AutoCloseable{
     /**
      * Suffix used for health check topic names.
@@ -145,7 +145,7 @@ public class HealthChecker implements AutoCloseable{
      */
     public CompletableFuture<Void> checkHealth(String clientAppId) {
         final String topicName = heartbeatTopic;
-        log.info("[{}] Running healthCheck with topic={}", clientAppId, topicName);
+        log.info().attr("topic", topicName).log("Running healthCheck with topic");
         final String messageStr = UUID.randomUUID().toString();
         final String subscriptionName = "healthCheck-" + messageStr;
 
@@ -165,8 +165,9 @@ public class HealthChecker implements AutoCloseable{
             pulsar.getBrokerService().getTopic(topicName, true)
                     .thenComposeAsync(topicOptional -> {
                         if (!topicOptional.isPresent()) {
-                            log.error("[{}] Fail to run health check while get topic {}. because get null value.",
-                                    clientAppId, topicName);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .log("Fail to run health check while get topic. because get null value.");
                             return CompletableFuture.failedFuture(new BrokerServiceException.TopicNotFoundException(
                                     String.format("Topic [%s] not found after create.", topicName)));
                         }
@@ -181,8 +182,10 @@ public class HealthChecker implements AutoCloseable{
                         }
                     });
         } catch (Exception e) {
-            log.error("[{}] Fail to run health check while get topic {}. because get exception.",
-                    clientAppId, topicName, e);
+            log.error()
+                    .attr("topic", topicName)
+                    .exception(e)
+                    .log("Fail to run health check while get topic. because get exception.");
             resultFuture.completeExceptionally(e);
         }
     }
@@ -209,7 +212,7 @@ public class HealthChecker implements AutoCloseable{
                         .createAsync()
                         .exceptionally(createException -> {
                             producer.closeAsync().exceptionally(ex -> {
-                                log.error("[{}] Close producer fail while heath check.", clientAppId);
+                                log.error("Close producer fail while health check");
                                 return null;
                             });
                             throw FutureUtil.wrapToCompletionException(createException);
@@ -258,29 +261,29 @@ public class HealthChecker implements AutoCloseable{
         return FutureUtil.waitForAll(futures)
                 .exceptionallyAsync(closeException -> {
                     if (readerCloseFuture.isCompletedExceptionally()) {
-                        log.error("[{}] Close reader fail while health check.", clientAppId);
+                        log.error("Close reader fail while health check");
                         Optional<Topic> topic = pulsar.getBrokerService().getTopicReference(topicName);
                         if (topic.isPresent()) {
                             Subscription subscription =
                                     topic.get().getSubscription(subscriptionName);
                             // re-check subscription after reader close
                             if (subscription != null) {
-                                log.warn("[{}] Force delete subscription {} "
-                                                + "when it still exists after the"
-                                                + " reader is closed.",
-                                        clientAppId, subscription);
+                                log.warn()
+                                        .attr("subscription", subscription)
+                                        .log("Force delete subscription when it still exists after "
+                                                + "the reader is closed");
                                 subscription.deleteForcefully()
                                         .exceptionally(ex -> {
-                                            log.error("[{}] Force delete subscription fail"
-                                                            + " while health check",
-                                                    clientAppId, ex);
+                                            log.error()
+                                                    .exception(ex)
+                                                    .log("Force delete subscription fail while health check");
                                             return null;
                                         });
                             }
                         }
                     } else {
                         // producer future fail.
-                        log.error("[{}] Close producer fail while heath check.", clientAppId);
+                        log.error("Close producer fail while health check");
                     }
                     return null;
                 }, healthCheckExecutor);
@@ -310,7 +313,7 @@ public class HealthChecker implements AutoCloseable{
             Throwable realCause = e.getCause();
             if (!(realCause instanceof ManagedLedgerException.MetadataNotFoundException
                     || realCause instanceof MetadataStoreException.NotFoundException)) {
-                log.error("Errors in deleting heartbeat topic [{}]", topicName, e);
+                log.error().attr("topic", topicName).exception(e).log("Errors in deleting heartbeat topic");
             }
         }
     }
@@ -320,17 +323,17 @@ public class HealthChecker implements AutoCloseable{
         try {
             scheduledExecutorProvider.shutdownNow();
         } catch (Exception e) {
-            log.warn("Failed to shutdown scheduled executor", e);
+            log.warn().exception(e).log("Failed to shutdown scheduled executor");
         }
         try {
             lookupExecutor.shutdownNow();
         } catch (Exception e) {
-            log.warn("Failed to shutdown lookup executor", e);
+            log.warn().exception(e).log("Failed to shutdown lookup executor");
         }
         try {
             client.close();
         } catch (PulsarClientException e) {
-            log.warn("Failed to close pulsar client", e);
+            log.warn().exception(e).log("Failed to close pulsar client");
         }
         for (CompletableFuture<Void> pendingFuture : new ArrayList<>(pendingFutures)) {
             if (!pendingFuture.isDone()) {
@@ -339,7 +342,7 @@ public class HealthChecker implements AutoCloseable{
                         pendingFuture.completeExceptionally(
                                 new PulsarClientException.AlreadyClosedException("HealthChecker is closed"));
                     } catch (Exception e) {
-                        log.warn("Failed to complete pending future", e);
+                        log.warn().exception(e).log("Failed to complete pending future");
                     }
                 });
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -27,6 +27,7 @@ import static org.apache.pulsar.common.protocol.Commands.readChecksum;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.MoreObjects;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
@@ -64,13 +65,15 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents a currently connected producer.
  */
 public class Producer {
+
+    private static final Logger LOG = Logger.get(Producer.class);
+    private final Logger log;
+
     private final Topic topic;
     private final TransportCnx cnx;
     private final String producerName;
@@ -124,6 +127,12 @@ public class Producer {
         this.epoch = epoch;
         this.closeFuture = new CompletableFuture<>();
         this.appId = appId;
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("producerName", producerName)
+                .attr("producerId", producerId)
+                .attr("cnx", cnx)
+                .build();
         this.isNonPersistentTopic = topic instanceof NonPersistentTopic;
         this.isShadowTopic =
                 topic instanceof PersistentTopic && ((PersistentTopic) topic).getShadowSourceTopic().isPresent();
@@ -264,7 +273,7 @@ public class Producer {
             int encryptionKeysCount = msgMetadata.getEncryptionKeysCount();
             // Check whether the message is encrypted or not
             if (encryptionKeysCount < 1) {
-                log.warn("[{}] Messages must be encrypted", getTopic().getName());
+                log.warn("Messages must be encrypted");
                 cnx.execute(() -> {
                     cnx.getCommandSender().sendSendError(producerId, sequenceId, ServerError.MetadataError,
                             "Messages must be encrypted");
@@ -317,7 +326,7 @@ public class Producer {
                 if (checksum == computedChecksum) {
                     return true;
                 } else {
-                    log.error("[{}] [{}] Failed to verify checksum", topic, producerName);
+                    log.error("Failed to verify checksum");
                     return false;
                 }
             } finally {
@@ -325,9 +334,7 @@ public class Producer {
             }
         } else {
             // ignore if checksum is not available
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Payload does not have checksum to verify", topic, producerName);
-            }
+            log.debug("Payload does not have checksum to verify");
             return true;
         }
     }
@@ -506,10 +513,9 @@ public class Producer {
                 producer.cnx.execute(() -> {
                     // if the topic is transferring, we don't send error code to the clients.
                     if (producer.getTopic().isTransferring()) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Received producer exception: {} while transferring.",
-                                    producer.getTopic().getName(), exception.getMessage(), exception);
-                        }
+                        producer.log.debug()
+                                .exception(exception)
+                                .log("Received producer exception while transferring");
                     } else if (!(exception instanceof TopicClosedException)) {
                         // For TopicClosed exception there's no need to send explicit error, since the client was
                         // already notified
@@ -523,10 +529,9 @@ public class Producer {
                     recycle();
                 });
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] [{}] triggered send callback. cnx {}, sequenceId {}", producer.topic,
-                            producer.producerName, producer.producerId, producer.cnx.clientAddress(), sequenceId);
-                }
+                producer.log.debug()
+                        .attr("sequenceId", sequenceId)
+                        .log("Triggered send callback");
 
                 this.ledgerId = ledgerId;
                 this.entryId = entryId;
@@ -551,10 +556,9 @@ public class Producer {
          */
         @Override
         public void run() {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] [{}] Persisted message. cnx {}, sequenceId {}", producer.topic,
-                        producer.producerName, producer.producerId, producer.cnx, sequenceId);
-            }
+            producer.log.debug()
+                    .attr("sequenceId", sequenceId)
+                    .log("Persisted message");
 
             // stats
             producer.stats.recordMsgIn(batchSize, msgSize);
@@ -590,12 +594,12 @@ public class Producer {
             Object positionPairObj = getProperty(MSG_PROP_REPL_SOURCE_POSITION);
             if (positionPairObj == null || !(positionPairObj instanceof long[])
                     || ((long[]) positionPairObj).length < 2) {
-                log.error("[{}] Message can not determine whether the message is duplicated due to the acquired"
-                                + " messages props were are invalid. producer={}. supportsReplDedupByLidAndEid: {},"
-                                + " sequence-id {}, prop-{}: not in expected format",
-                        producer.topic.getName(), producer.producerName,
-                        supportsReplDedupByLidAndEid(), getSequenceId(),
-                        MSG_PROP_REPL_SOURCE_POSITION);
+                producer.log.error()
+                        .attr("supportsReplDedupByLidAndEid", supportsReplDedupByLidAndEid())
+                        .attr("sequenceId", getSequenceId())
+                        .attr("propKey", MSG_PROP_REPL_SOURCE_POSITION)
+                        .log("Message cannot determine whether the message is duplicated due to the acquired "
+                                + "message props being invalid, prop not in expected format");
                 producer.cnx.getCommandSender().sendSendError(producer.producerId,
                         Math.max(highestSequenceId, sequenceId),
                         ServerError.PersistenceError, "Message can not determine whether the message is"
@@ -735,16 +739,14 @@ public class Producer {
      * @return completable future indicate completion of close
      */
     public synchronized CompletableFuture<Void> close(boolean removeFromTopic) {
-        if (log.isDebugEnabled()) {
-            log.debug("Closing producer {} -- isClosed={}", this, isClosed);
-        }
+        log.debug().attr("isClosed", isClosed).log("Closing producer");
 
         if (!isClosed) {
             isClosed = true;
-            if (log.isDebugEnabled()) {
-                log.debug("Trying to close producer {} -- cnxIsActive: {} -- pendingPublishAcks: {}", this,
-                        cnx.isActive(), pendingPublishAcks);
-            }
+            log.debug()
+                    .attr("isActive", cnx.isActive())
+                    .attr("pendingPublishAcks", pendingPublishAcks)
+                    .log("Trying to close producer");
             if (!cnx.isActive() || pendingPublishAcks == 0) {
                 closeNow(removeFromTopic);
             }
@@ -758,9 +760,7 @@ public class Producer {
         }
         cnx.removedProducer(this);
 
-        if (log.isDebugEnabled()) {
-            log.debug("Removed producer: {}", this);
-        }
+        log.debug("Removed producer");
         closeFuture.complete(null);
         isDisconnecting.set(false);
     }
@@ -777,7 +777,9 @@ public class Producer {
      */
     public CompletableFuture<Void> disconnect(Optional<BrokerLookupData> assignedBrokerLookupData) {
         if (!closeFuture.isDone() && isDisconnecting.compareAndSet(false, true)) {
-            log.info("Disconnecting producer: {}, assignedBrokerLookupData: {}", this, assignedBrokerLookupData);
+            log.info()
+                    .attr("assignedBrokerLookupData", assignedBrokerLookupData)
+                    .log("Disconnecting producer");
             cnx.execute(() -> {
                 cnx.closeProducer(this, assignedBrokerLookupData);
                 closeNow(true);
@@ -838,12 +840,16 @@ public class Producer {
                     .allowTopicOperationAsync(topicName, TopicOperation.PRODUCE, appId, cnx.getAuthenticationData())
                     .handle((ok, ex) -> {
                         if (ex != null) {
-                            log.warn("[{}] Get unexpected error while authorizing [{}]  {}", appId, topic.getName(),
-                                    ex.getMessage(), ex);
+                            log.warn()
+                                    .attr("appId", appId)
+                                    .exception(ex)
+                                    .log("Got unexpected error while authorizing");
                         }
 
                         if (ok == null || !ok) {
-                            log.info("[{}] is not allowed to produce on topic [{}] anymore", appId, topic.getName());
+                            log.info()
+                                    .attr("appId", appId)
+                                    .log("Not allowed to produce on topic anymore");
                             disconnect();
                         }
 
@@ -855,8 +861,7 @@ public class Producer {
 
     public void checkEncryption() {
         if (topic.isEncryptionRequired() && !isEncrypted) {
-            log.info("[{}] [{}] Unencrypted producer is not allowed to produce on topic [{}] anymore",
-                    producerId, producerName, topic.getName());
+            log.info("Unencrypted producer is not allowed to produce on topic anymore");
             disconnect();
         }
     }
@@ -896,9 +901,6 @@ public class Producer {
     public boolean isDisconnecting() {
         return isDisconnecting.get();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(Producer.class);
-
     public Attributes getOpenTelemetryAttributes() {
         if (attributes != null) {
             return attributes;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.qos.MonotonicClock;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.policies.data.PublishRate;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 
-@Slf4j
+@CustomLog
 public class PublishRateLimiterImpl implements PublishRateLimiter {
     private volatile AsyncTokenBucket tokenBucketOnMessage;
     private volatile AsyncTokenBucket tokenBucketOnByte;
@@ -152,7 +152,7 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
                     final Producer producerFinal = producer;
                     producer.getCnx().execute(() -> unthrottleAction.accept(producerFinal));
                 } catch (Exception e) {
-                    log.error("Failed to unthrottle producer {}", producer, e);
+                    log.error().attr("producer", producer).exception(e).log("Failed to unthrottle producer");
                 }
                 throttledProducersCount.decrementAndGet();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -27,8 +27,8 @@ import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
 import java.util.concurrent.TimeUnit;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.protocol.ByteBufPair;
@@ -37,7 +37,7 @@ import org.apache.pulsar.common.protocol.OptionalProxyProtocolDecoder;
 import org.apache.pulsar.common.util.PulsarSslConfiguration;
 import org.apache.pulsar.common.util.PulsarSslFactory;
 
-@Slf4j
+@CustomLog
 public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     public static final String TLS_HANDLER = "tls";
@@ -156,7 +156,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
         try {
             this.sslFactory.update();
         } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
+            log.error().exception(e).log("Failed to refresh SSL context");
         }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.client.api.transaction.TxnID;
@@ -44,7 +44,7 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.semaphore.AsyncDualMemoryLimiter;
 import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 
-@Slf4j
+@CustomLog
 public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     private final BrokerInterceptor interceptor;
@@ -214,7 +214,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     public void sendReachedEndOfTopic(long consumerId) {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v9.getValue()) {
-            log.info("[{}] Notifying consumer that end of topic has been reached", this);
+            log.info().attr("this", this).log("Notifying consumer that end of topic has been reached");
             writeAndFlush(Commands.newReachedEndOfTopic(consumerId));
         }
     }
@@ -223,7 +223,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     public boolean sendTopicMigrated(ResourceType type, long resourceId, String brokerUrl, String brokerUrlTls) {
         // Only send notification if the client understand the command
         if (cnx.getRemoteEndpointProtocolVersion() >= ProtocolVersion.v20.getValue()) {
-            log.info("[{}] Notifying {} that topic is migrated", type.name(), resourceId);
+            log.info().attr("name", type.name()).attr("resourceId", resourceId).log("Notifying that topic is migrated");
             writeAndFlush(Commands.newTopicMigrated(type, resourceId, brokerUrl, brokerUrlTls));
             return true;
         }
@@ -252,9 +252,13 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                 int batchSize = batchSizes.getBatchSize(i);
 
                 if (batchSize > 1 && !cnx.isBatchMessageCompatibleVersion()) {
-                    log.warn("[{}-{}] Consumer doesn't support batch messages -  consumerId {}, msg id {}-{}",
-                            topicName, subscription,
-                            consumerId, entry.getLedgerId(), entry.getEntryId());
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("subscription", subscription)
+                            .attr("consumerId", consumerId)
+                            .attr("ledgerId", entry.getLedgerId())
+                            .attr("entryId", entry.getEntryId())
+                            .log("- Consumer doesn't support batch messages - consumerId, msg id");
                     ctx.close();
                     entry.release();
                     continue;
@@ -277,10 +281,14 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
                     Commands.skipChecksumIfPresent(metadataAndPayload);
                 }
 
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}-{}] Sending message to consumerId {}, msg id {}-{} with batchSize {}",
-                            topicName, subscription,  consumerId, entry.getLedgerId(), entry.getEntryId(), batchSize);
-                }
+                log.debug()
+                        .attr("topic", topicName)
+                        .attr("subscription", subscription)
+                        .attr("consumerId", consumerId)
+                        .attr("ledgerId", entry.getLedgerId())
+                        .attr("entryId", entry.getEntryId())
+                        .attr("batchSize", batchSize)
+                        .log("- Sending message to consumerId, msg id- with batchSize");
 
                 int redeliveryCount = redeliveryTracker
                         .getRedeliveryCount(entry.getLedgerId(), entry.getEntryId());
@@ -406,7 +414,10 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
             try {
                 this.interceptor.onPulsarCommand(command, cnx);
             } catch (Exception e) {
-                log.error("Failed to execute command {} on broker interceptor.", command.getType(), e);
+                log.error()
+                        .attr("type", command.getType())
+                        .exception(e)
+                        .log("Failed to execute command on broker interceptor.");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -43,12 +44,9 @@ import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataEvent;
 import org.apache.pulsar.metadata.api.MetadataEventSynchronizer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronizer {
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarMetadataEventSynchronizer.class);
     protected PulsarService pulsar;
     protected BrokerService brokerService;
     @Getter
@@ -92,7 +90,7 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
             log.info("metadata topic doesn't exist.. skipping metadata synchronizer init..");
             return;
         }
-        log.info("Metadata event synchronizer is starting on topic {}", topicName);
+        log.info().attr("topic", topicName).log("Metadata event synchronizer is starting on topic");
         this.client = (PulsarClientImpl) pulsar.getClient();
         if (STATE_UPDATER.compareAndSet(this, State.Init, State.Starting_Producer)) {
             startProducer();
@@ -118,15 +116,22 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
 
     private void publishAsync(MetadataEvent event, CompletableFuture<Void> future) {
         if (!isProducerStarted()) {
-            log.info("Producer is not started on {}, failed to publish {}", topicName, event);
+            log.info()
+                    .attr("topic", topicName)
+                    .attr("event", event)
+                    .log("Producer is not started on, failed to publish");
             future.completeExceptionally(new IllegalStateException("producer is not started yet"));
             return;
         }
         producer.newMessage().value(event).sendAsync().thenAccept(__ -> {
-            log.info("successfully published metadata change event {}", event);
+            log.info().attr("event", event).log("successfully published metadata change event");
             future.complete(null);
         }).exceptionally(ex -> {
-            log.warn("failed to publish metadata update {}, will retry in {}", topicName, MESSAGE_RATE_BACKOFF_MS, ex);
+            log.warn()
+                    .attr("topic", topicName)
+                    .attr("backoffMs", MESSAGE_RATE_BACKOFF_MS)
+                    .exception(ex)
+                    .log("failed to publish metadata update, will retry later");
             pulsar.getBrokerService().executor().schedule(() -> publishAsync(event, future), MESSAGE_RATE_BACKOFF_MS,
                     TimeUnit.MILLISECONDS);
             return null;
@@ -136,15 +141,17 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
     @SuppressWarnings("unchecked")
     protected void startProducer() {
         if (isClosingOrClosed()) {
-            log.info("[{}] Skip to start new producer because the synchronizer is closed", topicName);
+            log.info().attr("topic", topicName).log("Skip to start new producer because the synchronizer is closed");
             return;
         }
         if (producer != null) {
-            log.error("[{}] Failed to start the producer because the producer has been set, state: {}",
-                    topicName, state);
+            log.error()
+                    .attr("topic", topicName)
+                    .attr("state", state)
+                    .log("Failed to start the producer because the producer has been set, state");
             return;
         }
-        log.info("[{}] Starting producer", topicName);
+        log.info().attr("topic", topicName).log("Starting producer");
         client.newProducer(Schema.AVRO(MetadataEvent.class)).topic(topicName)
             .messageRoutingMode(MessageRoutingMode.SinglePartition).enableBatching(false).enableBatching(false)
             .sendTimeout(0, TimeUnit.SECONDS) //
@@ -152,23 +159,30 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                 backOff.reset();
                 if (STATE_UPDATER.compareAndSet(this, State.Starting_Producer, State.Starting_Consumer)) {
                     producer = prod;
-                    log.info("producer is created successfully {}", topicName);
+                    log.info().attr("topic", topicName).log("producer is created successfully");
                     PulsarMetadataEventSynchronizer.this.startConsumer();
                 } else {
                     State stateTransient = state;
-                    log.info("[{}] Closing the new producer because the synchronizer state is {}", prod,
-                            stateTransient);
+                    log.info()
+                            .attr("prod", prod)
+                            .attr("stateTransient", stateTransient)
+                            .log("Closing the new producer because the synchronizer state is");
                     CompletableFuture closeProducer = new CompletableFuture<>();
                     closeResource(() -> prod.closeAsync(), closeProducer);
                     closeProducer.thenRun(() -> {
-                        log.info("[{}] Closed the new producer because the synchronizer state is {}", prod,
-                                stateTransient);
+                        log.info()
+                                .attr("prod", prod)
+                                .attr("stateTransient", stateTransient)
+                                .log("Closed the new producer because the synchronizer state is");
                     });
                 }
             }).exceptionally(ex -> {
                 long waitTimeMs = backOff.next().toMillis();
-                log.warn("[{}] Failed to create producer ({}), retrying in {} s", topicName, ex.getMessage(),
-                        waitTimeMs / 1000.0);
+                log.warn()
+                        .attr("topic", topicName)
+                        .exceptionMessage(ex)
+                        .attr("waitTimeSeconds", waitTimeMs / 1000.0)
+                        .log("Failed to create producer, retrying");
                 // BackOff before retrying
                 pulsar.getExecutor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
                 return null;
@@ -183,19 +197,23 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
     @SuppressWarnings("unchecked")
     private void startConsumer() {
         if (isClosingOrClosed()) {
-            log.info("[{}] Skip to start new consumer because the synchronizer is closed", topicName);
+            log.info().attr("topic", topicName).log("Skip to start new consumer because the synchronizer is closed");
         }
         if (consumer != null) {
-            log.error("[{}] Failed to start the consumer because the consumer has been set, state: {}",
-                    topicName, state);
+            log.error()
+                    .attr("topic", topicName)
+                    .attr("state", state)
+                    .log("Failed to start the consumer because the consumer has been set, state");
             return;
         }
-        log.info("[{}] Starting consumer", topicName);
+        log.info().attr("topic", topicName).log("Starting consumer");
         ConsumerBuilder<MetadataEvent> consumerBuilder = client.newConsumer(Schema.AVRO(MetadataEvent.class))
             .topic(topicName).subscriptionName(SUBSCRIPTION_NAME).ackTimeout(60, TimeUnit.SECONDS)
             .subscriptionType(SubscriptionType.Failover).messageListener((c, msg) -> {
-                log.info("Processing metadata event for {} with listeners {}", msg.getValue().getPath(),
-                        listeners.size());
+                log.info()
+                        .attr("path", msg.getValue().getPath())
+                        .attr("size", listeners.size())
+                        .log("Processing metadata event for with listeners");
                 try {
                     if (listeners.size() == 0) {
                         c.acknowledgeAsync(msg);
@@ -205,8 +223,10 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                     if (listeners.size() == 1) {
                         listeners.get(0).apply(msg.getValue()).thenApply(__ -> c.acknowledgeAsync(msg))
                                 .exceptionally(ex -> {
-                                    log.warn("Failed to synchronize {} for {}", msg.getMessageId(), topicName,
-                                            ex.getCause());
+                                    log.warn()
+                                            .attr("messageId", msg.getMessageId())
+                                            .attr("topic", topicName)
+                                            .log("Failed to synchronize for");
                                     return null;
                                 });
                     } else {
@@ -214,34 +234,47 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                                 .waitForAll(listeners.stream().map(listener -> listener.apply(msg.getValue()))
                                         .collect(Collectors.toList()))
                                 .thenApply(__ -> c.acknowledgeAsync(msg)).exceptionally(ex -> {
-                                    log.warn("Failed to synchronize {} for {}", msg.getMessageId(), topicName);
+                                    log.warn()
+                                            .attr("messageId", msg.getMessageId())
+                                            .attr("topic", topicName)
+                                            .log("Failed to synchronize for");
                                     return null;
                                 });
                     }
                 } catch (Exception e) {
-                    log.warn("Failed to synchronize {} for {}", msg.getMessageId(), topicName);
+                    log.warn()
+                            .attr("messageId", msg.getMessageId())
+                            .attr("topic", topicName)
+                            .log("Failed to synchronize for");
                 }
             });
         consumerBuilder.subscribeAsync().thenAccept(consumer -> {
             backOff.reset();
             if (STATE_UPDATER.compareAndSet(this, State.Starting_Consumer, State.Started)) {
                 this.consumer = consumer;
-                log.info("successfully created consumer {}", topicName);
+                log.info().attr("topic", topicName).log("successfully created consumer");
             } else {
                 State stateTransient = state;
-                log.info("[{}] Closing the new consumer because the synchronizer state is {}", topicName,
-                        stateTransient);
+                log.info()
+                        .attr("topic", topicName)
+                        .attr("stateTransient", stateTransient)
+                        .log("Closing the new consumer because the synchronizer state is");
                 CompletableFuture closeConsumer = new CompletableFuture<>();
                 closeResource(() -> consumer.closeAsync(), closeConsumer);
                 closeConsumer.thenRun(() -> {
-                    log.info("[{}] Closed the new consumer because the synchronizer state is {}", topicName,
-                            stateTransient);
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("stateTransient", stateTransient)
+                            .log("Closed the new consumer because the synchronizer state is");
                 });
             }
         }).exceptionally(ex -> {
             long waitTimeMs = backOff.next().toMillis();
-            log.warn("[{}] Failed to create consumer ({}), retrying in {} s", topicName, ex.getMessage(),
-                    waitTimeMs / 1000.0);
+            log.warn()
+                    .attr("topic", topicName)
+                    .exceptionMessage(ex)
+                    .attr("waitTimeSeconds", waitTimeMs / 1000.0)
+                    .log("Failed to create consumer, retrying");
             // BackOff before retrying
             brokerService.executor().schedule(this::startConsumer, waitTimeMs, TimeUnit.MILLISECONDS);
             return null;
@@ -276,7 +309,10 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
             }
             // Just for avoid spinning loop which would cause 100% CPU consumption here.
             if (++tryChangeStateCounter > 100) {
-                log.error("Unexpected error: the state can not be changed to closing {}, state: {}", topicName, state);
+                log.error()
+                        .attr("topic", topicName)
+                        .attr("state", state)
+                        .log("Unexpected error: the state can not be changed to closing");
                 return CompletableFuture.failedFuture(new RuntimeException("Unexpected error,"
                         + " the state can not be changed to closing"));
             }
@@ -295,13 +331,13 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
         }
 
         // Add logs.
-        closeProducer.thenRun(() -> log.info("Successfully close producer {}", topicName));
-        closeConsumer.thenRun(() -> log.info("Successfully close consumer {}", topicName));
+        closeProducer.thenRun(() -> log.info().attr("topic", topicName).log("Successfully close producer"));
+        closeConsumer.thenRun(() -> log.info().attr("topic", topicName).log("Successfully close consumer"));
 
         closeFuture = FutureUtil.waitForAll(Arrays.asList(closeProducer, closeConsumer));
         closeFuture.thenRun(() -> {
             this.state = State.Closed;
-            log.info("Successfully close metadata store synchronizer {}", topicName);
+            log.info().attr("topic", topicName).log("Successfully close metadata store synchronizer");
         });
         return closeFuture;
     }
@@ -320,8 +356,12 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
             }
             // Retry.
             long waitTimeMs = backOff.next().toMillis();
-            log.warn("[{}] Exception: '{}' occurred while trying to close the {}. Retrying again in {} s.",
-                    topicName, ex.getMessage(), asyncCloseable.getClass().getSimpleName(), waitTimeMs / 1000.0, ex);
+            log.warn()
+                    .attr("topic", topicName)
+                    .attr("className", asyncCloseable.getClass().getSimpleName())
+                    .attr("retryAfterSeconds", waitTimeMs / 1000.0)
+                    .exception(ex)
+                    .log("Exception occurred while trying to close the resource. Retrying");
             brokerService.executor().schedule(() -> closeResource(asyncCloseable, future), waitTimeMs,
                     TimeUnit.MILLISECONDS);
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
@@ -41,12 +42,9 @@ import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.utils.StatsOutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class PulsarStats implements Closeable {
-    private static final Logger log = LoggerFactory.getLogger(PulsarStats.class);
-
     private volatile ByteBuf topicStatsBuf;
     private volatile ByteBuf tempTopicStatsBuf;
 
@@ -142,8 +140,10 @@ public class PulsarStats implements Closeable {
                                     topic.updateRates(nsStats, currentBundleStats, topicStatsStream,
                                             clusterReplicationMetrics, namespaceName, exposePublisherStats);
                                 } catch (Exception e) {
-                                    log.error("Failed to generate topic stats for topic {}: {}",
-                                            name, e.getMessage(), e);
+                                    log.error()
+                                            .attr("topic", name)
+                                            .exception(e)
+                                            .log("Failed to generate topic stats");
                                 }
                                 // this task: helps to activate inactive-backlog-cursors which have caught up and
                                 // connected, also deactivate active-backlog-cursors which has backlog
@@ -154,7 +154,7 @@ public class PulsarStats implements Closeable {
                             } else if (topic instanceof NonPersistentTopic) {
                                 tempNonPersistentTopics.add((NonPersistentTopic) topic);
                             } else {
-                                log.warn("Unsupported type of topic {}", topic.getClass().getName());
+                                log.warn().attr("type", topic.getClass().getName()).log("Unsupported type of topic");
                             }
                         });
                         // end persistent topics section
@@ -168,8 +168,10 @@ public class PulsarStats implements Closeable {
                                     topic.updateRates(nsStats, currentBundleStats, topicStatsStream,
                                             clusterReplicationMetrics, namespaceName, exposePublisherStats);
                                 } catch (Exception e) {
-                                    log.error("Failed to generate topic stats for topic {}: {}",
-                                            topic.getName(), e.getMessage(), e);
+                                    log.error()
+                                            .attr("topic", topic.getName())
+                                            .exception(e)
+                                            .log("Failed to generate topic stats");
                                 }
                             });
                             // end non-persistent topics section
@@ -196,8 +198,10 @@ public class PulsarStats implements Closeable {
                     // Update metricsCollection with namespace stats
                     tempMetricsCollection.add(nsStats.add(namespaceName));
                 } catch (Exception e) {
-                    log.error("Failed to generate namespace stats for namespace {}: {}", namespaceName, e.getMessage(),
-                            e);
+                    log.error()
+                            .attr("namespace", namespaceName)
+                            .exception(e)
+                            .log("Failed to generate namespace stats");
                 }
             });
             if (clusterReplicationMetrics.isMetricsEnabled()) {
@@ -209,7 +213,7 @@ public class PulsarStats implements Closeable {
             // json end
             topicStatsStream.endObject();
         } catch (Exception e) {
-            log.error("Unable to update topic stats", e);
+            log.error().exception(e).log("Unable to update topic stats");
         }
 
         // swap metricsCollection and tempMetricsCollection
@@ -258,7 +262,10 @@ public class PulsarStats implements Closeable {
         try {
             brokerOperabilityMetrics.recordTopicLoadTimeValue(topicLoadLatencyMs);
         } catch (Exception ex) {
-            log.warn("Exception while recording topic load time for topic {}, {}", topic, ex.getMessage());
+            log.warn()
+                    .attr("topic", topic)
+                    .exceptionMessage(ex)
+                    .log("Exception while recording topic load time");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -34,6 +34,7 @@ import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import static org.apache.pulsar.common.protocol.Commands.newLookupErrorResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -191,8 +192,6 @@ import org.apache.pulsar.transaction.coordinator.TransactionCoordinatorID;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.apache.pulsar.utils.TimedSingleThreadRateLimiter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Channel handler for the Pulsar broker.
@@ -201,8 +200,11 @@ import org.slf4j.LoggerFactory;
  * parameter instance lifecycle.
  */
 public class ServerCnx extends PulsarHandler implements TransportCnx {
-    private static final Logger PAUSE_RECEIVING_LOG = LoggerFactory.getLogger(ServerCnx.class.getName()
-            + ".pauseReceiving");
+
+    private static final Logger LOG = Logger.get(ServerCnx.class);
+    private Logger log = LOG;
+
+    private static final Logger PAUSE_RECEIVING_LOG = Logger.get(ServerCnx.class.getName() + ".pauseReceiving");
     private final BrokerService service;
     private final SchemaRegistryService schemaService;
     private final String listenerName;
@@ -391,6 +393,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
+        this.log = LOG.with()
+                .attr("localAddress", ctx.channel().localAddress())
+                .attr("remoteAddress", ctx.channel().remoteAddress())
+                .build();
         ConnectionController.State state = connectionController.increaseConnection(remoteAddress);
         if (!state.equals(ConnectionController.State.OK)) {
             final ByteBuf msg = Commands.newError(-1, ServerError.NotAllowedError,
@@ -400,10 +406,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             NettyChannelUtil.writeAndFlushWithClosePromise(ctx, msg);
             return;
         }
-        if (log.isDebugEnabled()) {
-            // Connection information is logged after a successful Connect command is processed.
-            log.debug("New connection from {}", remoteAddress);
-        }
+        // Connection information is logged after a successful Connect command is processed.
+        log.debug("New connection");
         this.ctx = ctx;
         this.commandSender =
                 new PulsarCommandSenderImpl(brokerInterceptor, this, this.service.getMaxTopicListInFlightLimiter());
@@ -420,7 +424,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         super.channelInactive(ctx);
         connectionController.decreaseConnection(ctx.channel().remoteAddress());
         isActive = false;
-        log.info("Closed connection from {}", remoteAddress);
+        log.info("Closed connection");
         if (brokerInterceptor != null) {
             brokerInterceptor.onConnectionClosed(this);
         }
@@ -460,7 +464,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         brokerInterceptor.consumerClosed(this, consumer, consumer.getMetadata());
                     }
                 } catch (BrokerServiceException e) {
-                    log.warn("Consumer {} was already closed: {}", consumer, e);
+                    log.warn().attr("consumer", consumer).exceptionMessage(e)
+                            .log("Consumer was already closed");
                 }
             }
         });
@@ -479,28 +484,32 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 || cmd.getType() == BaseCommand.Type.PING) {
             return;
         }
-        if (PAUSE_RECEIVING_LOG.isDebugEnabled()) {
-            final ChannelOutboundBuffer outboundBuffer = ctx.channel().unsafe().outboundBuffer();
-            if (outboundBuffer != null) {
-                PAUSE_RECEIVING_LOG.debug("Start to handle request [{}], totalPendingWriteBytes: {}, channel"
-                    + " isWritable: {}", cmd.getType(), outboundBuffer.totalPendingWriteBytes(),
-                    ctx.channel().isWritable());
-            } else {
-                PAUSE_RECEIVING_LOG.debug("Start to handle request [{}], channel isWritable: {}",
-                        cmd.getType(), ctx.channel().isWritable());
-            }
+        final ChannelOutboundBuffer outboundBuffer =
+                ctx.channel().unsafe().outboundBuffer();
+        if (outboundBuffer != null) {
+            PAUSE_RECEIVING_LOG.debug()
+                    .attr("type", cmd.getType())
+                    .attr("totalPendingWriteBytes",
+                            outboundBuffer.totalPendingWriteBytes())
+                    .attr("isWritable", ctx.channel().isWritable())
+                    .log("Start to handle request");
+        } else {
+            PAUSE_RECEIVING_LOG.debug()
+                    .attr("type", cmd.getType())
+                    .attr("isWritable", ctx.channel().isWritable())
+                    .log("Start to handle request");
         }
         // "requestRateLimiter" will return the permits that you acquired if it is not opening(has been called
         // "timingOpen(duration)").
         if (requestRateLimiter.acquire(1) == 0 && !pausedDueToRateLimitation) {
-            log.warn("[{}] Reached rate limitation", this);
+            log.warn("Reached rate limitation");
             // Stop receiving requests.
             pausedDueToRateLimitation = true;
             getThrottleTracker().markThrottled(ThrottleType.ConnectionPauseReceivingCooldownRateLimit);
             // Resume after 1 second.
             ctx.channel().eventLoop().schedule(() -> {
                 if (pausedDueToRateLimitation) {
-                    log.info("[{}] Resuming connection after rate limitation", this);
+                    log.info("Resuming connection after rate limitation");
                     getThrottleTracker().unmarkThrottled(ThrottleType.ConnectionPauseReceivingCooldownRateLimit);
                     pausedDueToRateLimitation = false;
                 }
@@ -511,20 +520,24 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         if (pauseReceivingRequestsIfUnwritable && ctx.channel().isWritable()) {
-            log.info("[{}] is writable, turn on channel auto-read", this);
+            log.info("Channel is writable, turning on auto-read");
             getThrottleTracker().unmarkThrottled(ThrottleType.ConnectionOutboundBufferFull);
             requestRateLimiter.timingOpen(pauseReceivingCooldownMilliSeconds, TimeUnit.MILLISECONDS);
         } else if (pauseReceivingRequestsIfUnwritable && !ctx.channel().isWritable()) {
-            final ChannelOutboundBuffer outboundBuffer = ctx.channel().unsafe().outboundBuffer();
+            final ChannelOutboundBuffer outboundBuffer =
+                    ctx.channel().unsafe().outboundBuffer();
             if (outboundBuffer != null) {
-                if (PAUSE_RECEIVING_LOG.isDebugEnabled()) {
-                    PAUSE_RECEIVING_LOG.debug("[{}] is not writable, turn off channel auto-read,"
-                        + " totalPendingWriteBytes: {}", this, outboundBuffer.totalPendingWriteBytes());
-                }
+                PAUSE_RECEIVING_LOG.debug()
+                        .attr("cnx", this)
+                        .attr("totalPendingWriteBytes",
+                                outboundBuffer.totalPendingWriteBytes())
+                        .log("Not writable, turn off channel"
+                                + " auto-read");
             } else {
-                if (PAUSE_RECEIVING_LOG.isDebugEnabled()) {
-                    PAUSE_RECEIVING_LOG.debug("[{}] is not writable, turn off channel auto-read", this);
-                }
+                PAUSE_RECEIVING_LOG.debug()
+                        .attr("cnx", this)
+                        .log("Not writable, turn off channel"
+                                + " auto-read");
             }
             getThrottleTracker().markThrottled(ThrottleType.ConnectionOutboundBufferFull);
         }
@@ -535,19 +548,23 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (state != State.Failed) {
             // No need to report stack trace for known exceptions that happen in disconnections
-            log.warn("[{}] Got exception {}", remoteAddress,
-                    ClientCnx.isKnownException(cause) ? cause.toString() : ExceptionUtils.getStackTrace(cause));
+            log.warn()
+                    .attr("cause", ClientCnx.isKnownException(cause)
+                            ? cause.toString()
+                            : ExceptionUtils.getStackTrace(cause))
+                    .log("Got exception");
             state = State.Failed;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Failed.name());
-            }
+            log.debug()
+                    .attr("state", State.Failed.name())
+                    .log("Connect state changed");
         } else {
             // At default info level, suppress all subsequent exceptions that are thrown when the connection has already
             // failed
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Got exception {}", remoteAddress,
-                        ClientCnx.isKnownException(cause) ? cause.toString() : ExceptionUtils.getStackTrace(cause));
-            }
+            log.debug()
+                    .attr("cause", ClientCnx.isKnownException(cause)
+                            ? cause.toString()
+                            : ExceptionUtils.getStackTrace(cause))
+                    .log("Got exception");
         }
         ctx.close();
     }
@@ -566,8 +583,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 originalAuthDataSource != null ? originalAuthDataSource : authDataSource, authDataSource);
         result.thenAccept(isAuthorized -> {
             if (!isAuthorized) {
-                log.warn("Role {} or OriginalRole {} is not authorized to perform operation {} on topic {}",
-                        authRole, originalPrincipal, operation, topicName);
+                log.warn()
+                        .attr("authRole", authRole)
+                        .attr("originalPrincipal", originalPrincipal)
+                        .attr("operation", operation)
+                        .attr("topic", topicName)
+                        .log("Role or OriginalRole is not authorized to perform operation on topic");
             }
         });
         return result;
@@ -602,10 +623,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final String advertisedListenerName =
                 lookup.hasAdvertisedListenerName() && StringUtils.isNotBlank(lookup.getAdvertisedListenerName())
                         ? lookup.getAdvertisedListenerName() : this.listenerName;
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Received Lookup from {} for {} requesting listener {}", lookup.getTopic(), remoteAddress,
-                    requestId, StringUtils.isNotBlank(advertisedListenerName) ? advertisedListenerName : "(none)");
-        }
+        log.debug()
+                .attr("topic", lookup.getTopic())
+                .attr("requestId", requestId)
+                .attr("advertisedListenerName",
+                        StringUtils.isNotBlank(advertisedListenerName) ? advertisedListenerName : "(none)")
+                .log("Received Lookup request");
 
         TopicName topicName = validateTopicName(lookup.getTopic(), requestId, lookup);
         if (topicName == null) {
@@ -613,10 +636,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         if (!this.service.getPulsar().isRunning()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed lookup topic {} due to pulsar service is not ready: {} state", remoteAddress,
-                        topicName, this.service.getPulsar().getState().toString());
-            }
+            log.debug()
+                    .attr("topic", topicName)
+                    .attr("state", service.getPulsar().getState())
+                    .log("Failed lookup topic due to pulsar service is not ready");
             writeAndFlush(newLookupErrorResponse(ServerError.ServiceNotReady,
                     "Failed due to pulsar service is not ready", requestId));
             return;
@@ -645,8 +668,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     writeAndFlush(lookupResponse);
                                 } else {
                                     // it should never happen
-                                    log.warn("[{}] lookup failed with error {}, {}", remoteAddress, topicName,
-                                            ex.getMessage(), ex);
+                                    log.warn()
+                                            .attr("topic", topicName)
+
+                                            .exception(ex)
+                                            .log("lookup failed with error");
                                     writeAndFlush(newLookupErrorResponse(ServerError.ServiceNotReady,
                                             ex.getMessage(), requestId));
                                 }
@@ -655,7 +681,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             });
                 } else {
                     final String msg = "Client is not authorized to Lookup";
-                    log.warn("[{}] {} with role {} on topic {}", remoteAddress, msg, getPrincipal(), topicName);
+                    log.warn()
+                            .attr("principal", getPrincipal())
+                            .attr("topic", topicName)
+                            .log(msg);
                     writeAndFlush(newLookupErrorResponse(ServerError.AuthorizationError, msg, requestId));
                     lookupSemaphore.release();
                 }
@@ -668,9 +697,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return null;
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed lookup due to too many lookup-requests {}", remoteAddress, topicName);
-            }
+            log.debug()
+                    .attr("topic", topicName)
+                    .log("Failed lookup due to too many lookup-requests");
             writeAndFlush(newLookupErrorResponse(ServerError.TooManyRequests,
                     "Failed due to too many pending lookup requests", requestId));
         }
@@ -689,10 +718,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 new CommandPartitionedTopicMetadata().copyFrom(partitionMetadataParam);
 
         final long requestId = partitionMetadata.getRequestId();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Received PartitionMetadataLookup from {} for {}", partitionMetadata.getTopic(),
-                    remoteAddress, requestId);
-        }
+        log.debug()
+                .attr("topic", partitionMetadata.getTopic())
+                .attr("requestId", requestId)
+                .log("Received PartitionMetadataLookup from for");
 
         TopicName topicName = validateTopicName(partitionMetadata.getTopic(), requestId, partitionMetadata);
         if (topicName == null) {
@@ -700,12 +729,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         }
 
         if (!this.service.getPulsar().isRunning()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed PartitionMetadataLookup from {} for {} "
-                                + "due to pulsar service is not ready: {} state",
-                        partitionMetadata.getTopic(), remoteAddress, requestId,
-                        this.service.getPulsar().getState().toString());
-            }
+            log.debug()
+                    .attr("topic", partitionMetadata.getTopic())
+                    .attr("requestId", requestId)
+                    .attr("state", service.getPulsar().getState())
+                    .log("Failed PartitionMetadataLookup due to pulsar service is not ready");
             writeAndFlush(Commands.newPartitionMetadataResponse(ServerError.ServiceNotReady,
                     "Failed due to pulsar service is not ready", requestId));
             return;
@@ -737,8 +765,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 topicExistsInfo.recycle();
                             }).exceptionally(ex -> {
                                 lookupSemaphore.release();
-                                log.error("{} {} Failed to get partition metadata", topicName,
-                                        ServerCnx.this.toString(), ex);
+                                log.error()
+                                        .attr("topic", topicName)
+                                        .exception(ex)
+                                        .log("Failed to get partition metadata");
                                 writeAndFlush(
                                         Commands.newPartitionMetadataResponse(ServerError.MetadataError,
                                                 "Failed to get partition metadata",
@@ -755,8 +785,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                         commandSender.sendPartitionMetadataResponse(partitions, requestId);
                                     } else {
                                         if (ex instanceof PulsarClientException) {
-                                            log.warn("Failed to authorize {} at [{}] on topic {} : {}", getRole(),
-                                                    remoteAddress, topicName, ex.getMessage());
+                                            log.warn()
+                                                    .attr("role", getRole())
+                                                    .attr("topic", topicName)
+                                                    .exceptionMessage(ex)
+                                                    .log("Failed to authorize on topic");
                                             commandSender.sendPartitionMetadataResponse(ServerError.AuthorizationError,
                                                     ex.getMessage(), requestId);
                                         } else {
@@ -772,12 +805,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 }
                                             }
                                             if (error == ServerError.TopicNotFound) {
-                                                log.info("Trying to get Partitioned Metadata for a resource not exist"
-                                                                + "[{}] {}: {}", remoteAddress,
-                                                        topicName, ex.getMessage());
+                                                log.info()
+                                                        .attr("topic", topicName)
+                                                        .exceptionMessage(ex)
+                                                        .log("Trying to get Partitioned"
+                                                                + " Metadata for"
+                                                                + " nonexistent resource");
                                             } else {
-                                                log.warn("Failed to get Partitioned Metadata [{}] {}: {}",
-                                                        remoteAddress, topicName, ex.getMessage(), ex);
+                                                log.warn()
+                                                        .attr("topic", topicName)
+
+                                                        .exception(ex)
+                                                        .log("Failed to get Partitioned Metadata");
                                             }
                                             commandSender.sendPartitionMetadataResponse(error, ex.getMessage(),
                                                     requestId);
@@ -788,7 +827,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     });
                 } else {
                     final String msg = "Client is not authorized to Get Partition Metadata";
-                    log.warn("[{}] {} with role {} on topic {}", remoteAddress, msg, getPrincipal(), topicName);
+                    log.warn()
+                            .attr("principal", getPrincipal())
+                            .attr("topic", topicName)
+                            .log(msg);
                     writeAndFlush(
                             Commands.newPartitionMetadataResponse(ServerError.AuthorizationError, msg, requestId));
                     lookupSemaphore.release();
@@ -813,10 +855,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return null;
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed Partition-Metadata lookup due to too many lookup-requests {}", remoteAddress,
-                        topicName);
-            }
+            log.debug()
+                    .attr("topic", topicName)
+                    .log("Failed Partition-Metadata lookup due to too many lookup-requests");
             commandSender.sendPartitionMetadataResponse(ServerError.TooManyRequests,
                     "Failed due to too many pending lookup requests", requestId);
         }
@@ -825,9 +866,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleConsumerStats(CommandConsumerStats commandConsumerStats) {
         checkArgument(state == State.Connected);
-        if (log.isDebugEnabled()) {
-            log.debug("Received CommandConsumerStats call from {}", remoteAddress);
-        }
+        log.debug("Received CommandConsumerStats call");
 
         final long requestId = commandConsumerStats.getRequestId();
         final long consumerId = commandConsumerStats.getConsumerId();
@@ -836,16 +875,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         ByteBuf msg = null;
 
         if (consumer == null) {
-            log.error(
-                    "Failed to get consumer-stats response - Consumer not found for"
-                            + " CommandConsumerStats[remoteAddress = {}, requestId = {}, consumerId = {}]",
-                    remoteAddress, requestId, consumerId);
+            log.error()
+                    .attr("requestId", requestId)
+                    .attr("consumerId", consumerId)
+                    .log("Failed to get consumer-stats response - Consumer not found");
             msg = Commands.newConsumerStatsResponse(ServerError.ConsumerNotFound,
                     "Consumer " + consumerId + " not found", requestId);
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("CommandConsumerStats[requestId = {}, consumer = {}]", requestId, consumer);
-            }
+            log.debug()
+                    .attr("requestId", requestId)
+                    .attr("consumer", consumer)
+                    .log("CommandConsumerStats");
             msg = createConsumerStatsResponse(consumer, requestId);
         }
 
@@ -904,26 +944,36 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         writeAndFlush(Commands.newConnected(clientProtoVersion, maxMessageSize, enableTopicListWatcher));
         state = State.Connected;
         service.getPulsarStats().recordConnectionCreateSuccess();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] connect state change to : [{}]", remoteAddress, State.Connected.name());
-        }
+        log.debug()
+                .attr("state", State.Connected.name())
+                .log("connect state change to");
         setRemoteEndpointProtocolVersion(clientProtoVersion);
         if (isNotBlank(clientVersion)) {
             this.clientVersion = StringInterner.intern(clientVersion);
         }
         if (!service.isAuthenticationEnabled()) {
-            log.info("[{}] connected with clientVersion={}, clientProtocolVersion={}, proxyVersion={}", remoteAddress,
-                    clientVersion, clientProtoVersion, proxyVersion);
+            log.info()
+                    .attr("clientVersion", clientVersion)
+                    .attr("clientProtoVersion", clientProtoVersion)
+                    .attr("proxyVersion", proxyVersion)
+                    .log("connected");
         } else if (originalPrincipal != null) {
-            log.info("[{}] connected role={} and originalAuthRole={} using authMethod={}, clientVersion={}, "
-                            + "clientProtocolVersion={}, proxyVersion={}", remoteAddress,
-                    authenticationRoleLoggingAnonymizer.anonymize(authRole),
-                    authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal), authMethod, clientVersion,
-                    clientProtoVersion, proxyVersion);
+            log.info()
+                    .attr("authRole", authenticationRoleLoggingAnonymizer.anonymize(authRole))
+                    .attr("originalAuthRole", authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal))
+                    .attr("authMethod", authMethod)
+                    .attr("clientVersion", clientVersion)
+                    .attr("clientProtoVersion", clientProtoVersion)
+                    .attr("proxyVersion", proxyVersion)
+                    .log("connected with original auth role");
         } else {
-            log.info("[{}] connected with role={} using authMethod={}, clientVersion={}, clientProtocolVersion={}, "
-                           + "proxyVersion={}", remoteAddress, authenticationRoleLoggingAnonymizer.anonymize(authRole),
-                    authMethod, clientVersion, clientProtoVersion, proxyVersion);
+            log.info()
+                    .attr("authRole", authenticationRoleLoggingAnonymizer.anonymize(authRole))
+                    .attr("authMethod", authMethod)
+                    .attr("clientVersion", clientVersion)
+                    .attr("clientProtoVersion", clientProtoVersion)
+                    .attr("proxyVersion", proxyVersion)
+                    .log("connected");
         }
         if (brokerInterceptor != null) {
             brokerInterceptor.onConnectionCreated(this);
@@ -941,9 +991,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         // credentials.
         AuthenticationState authState = useOriginalAuthState ? originalAuthState : this.authState;
         String authRole = useOriginalAuthState ? originalPrincipal : this.authRole;
-        if (log.isDebugEnabled()) {
-            log.debug("Authenticate using original auth state : {}, role = {}", useOriginalAuthState, authRole);
-        }
+        log.debug()
+                .attr("useOriginalAuthState", useOriginalAuthState)
+                .attr("authRole", authRole)
+                .log("Authenticate using original auth state");
         authState
                 .authenticateAsync(clientData)
                 .whenCompleteAsync((authChallenge, throwable) -> {
@@ -994,20 +1045,24 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     // If the connection was already ready, it means we're doing a refresh
                     if (!StringUtils.isEmpty(authRole)) {
                         if (!authRole.equals(newAuthRole)) {
-                            log.warn("[{}] Principal cannot change during an authentication refresh expected={} got={}",
-                                    remoteAddress, authRole, newAuthRole);
+                            log.warn()
+                                    .attr("expectedAuthRole", authRole)
+                                    .attr("newAuthRole", newAuthRole)
+                                    .log("Principal cannot change during an authentication refresh");
                             ctx.close();
                         } else {
-                            log.info("[{}] Refreshed authentication credentials for role {}", remoteAddress, authRole);
+                            log.info()
+                                    .attr("authRole", authRole)
+                                    .log("Refreshed authentication credentials for role");
                         }
                     }
                 }
             } else {
                 // auth not complete, continue auth with client side.
                 ctx.writeAndFlush(Commands.newAuthChallenge(authMethod, authChallenge, clientProtocolVersion));
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Authentication in progress client by method {}.", remoteAddress, authMethod);
-                }
+                log.debug()
+                        .attr("authMethod", authMethod)
+                        .log("Authentication in progress client by method.");
             }
         } catch (Exception | AssertionError e) {
             authenticationFailed(e);
@@ -1031,10 +1086,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             originalAuthDataCopy = null;
                             originalAuthData = originalAuthState.getAuthDataSource();
                             originalPrincipal = originalAuthState.getAuthRole();
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Authenticated original role (forwarded from proxy): {}",
-                                        remoteAddress, originalPrincipal);
-                            }
+                            log.debug()
+                                    .attr("originalPrincipal", originalPrincipal)
+                                    .log("Authenticated original role (forwarded from proxy)");
                             completeConnect(clientProtoVersion, clientVersion);
                         } catch (Exception | AssertionError e) {
                             authenticationFailed(e);
@@ -1087,44 +1141,42 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // This case is only checked when the authState is expired because we've reached a point where
             // authentication needs to be refreshed, but the protocol does not support it unless the proxy forwards
             // the originalAuthData.
-            log.info(
-                    "[{}] Cannot revalidate user credential when using proxy and"
-                            + " not forwarding the credentials. Closing connection",
-                    remoteAddress);
+            log.info("Cannot revalidate user credential when using proxy and not forwarding the credentials, "
+                    + "closing connection");
             ctx.close();
             return;
         }
 
         if (!supportsAuthenticationRefresh()) {
-            log.warn("[{}] Closing connection because client doesn't support auth credentials refresh",
-                    remoteAddress);
+            log.warn("Closing connection because client doesn't support auth credentials refresh");
             ctx.close();
             return;
         }
 
         if (pendingAuthChallengeResponse) {
-            log.warn("[{}] Closing connection after timeout on refreshing auth credentials",
-                    remoteAddress);
+            log.warn("Closing connection after timeout on refreshing auth credentials");
             ctx.close();
             return;
         }
 
-        log.info("[{}] Refreshing authentication credentials for originalPrincipal {} and authRole {}",
-                remoteAddress, originalPrincipal, this.authRole);
+        log.info()
+                .attr("originalPrincipal", originalPrincipal)
+                .attr("authRole", this.authRole)
+                .log("Refreshing authentication credentials for originalPrincipal and authRole");
         try {
             AuthData brokerData = authState.refreshAuthentication();
 
             writeAndFlush(Commands.newAuthChallenge(authMethod, brokerData,
                     getRemoteEndpointProtocolVersion()));
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Sent auth challenge to client to refresh credentials with method: {}.",
-                        remoteAddress, authMethod);
-            }
+            log.debug()
+                    .attr("authMethod", authMethod)
+                    .log("Sent auth challenge to client to refresh credentials");
 
             pendingAuthChallengeResponse = true;
 
         } catch (AuthenticationException e) {
-            log.warn("[{}] Failed to refresh authentication: {}", remoteAddress, e);
+            log.warn().exceptionMessage(e)
+                    .log("Failed to refresh authentication");
             ctx.close();
         }
     }
@@ -1136,20 +1188,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     protected void handleConnect(CommandConnect connect) {
         checkArgument(state == State.Start);
 
-        if (log.isDebugEnabled()) {
-            log.debug("Received CONNECT from {}, auth enabled: {}:"
-                    + " has original principal = {}, original principal = {}",
-                remoteAddress,
-                service.isAuthenticationEnabled(),
-                connect.hasOriginalPrincipal(),
-                connect.hasOriginalPrincipal() ? connect.getOriginalPrincipal() : null);
-        }
+        log.debug()
+                .attr("isAuthenticationEnabled", service.isAuthenticationEnabled())
+                .attr("hasOriginalPrincipal", connect.hasOriginalPrincipal())
+                .attr("originalPrincipal", connect.hasOriginalPrincipal() ? connect.getOriginalPrincipal() : null)
+                .log("Received CONNECT");
 
         if (!this.service.getPulsar().isRunning()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed CONNECT from {} due to pulsar service is not ready: {} state", remoteAddress,
-                        this.service.getPulsar().getState().toString());
-            }
+            log.debug()
+                    .attr("state", service.getPulsar().getState())
+                    .log("Failed CONNECT due to pulsar service is not ready");
             writeAndFlush(
                     Commands.newError(
                             -1,
@@ -1214,15 +1262,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
 
-            if (log.isDebugEnabled()) {
-                String role = "";
-                if (authState != null && authState.isComplete()) {
-                    role = authState.getAuthRole();
-                } else {
-                    role = "authentication incomplete or null";
-                }
-                log.debug("[{}] Authenticate role : {}", remoteAddress, role);
+            String role = "";
+            if (authState != null && authState.isComplete()) {
+                role = authState.getAuthRole();
+            } else {
+                role = "authentication incomplete or null";
             }
+            log.debug().attr("role", role).log("Authenticate role");
 
             if (connect.hasOriginalPrincipal() && service.getPulsar().getConfig().isAuthenticateOriginalAuthData()
                     && !WEBSOCKET_DUMMY_ORIGINAL_PRINCIPLE.equals(connect.getOriginalPrincipal())) {
@@ -1267,10 +1313,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             } else if (connect.hasOriginalPrincipal()) {
                 originalPrincipal = connect.getOriginalPrincipal();
 
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Setting original role (forwarded from proxy): {}",
-                        remoteAddress, originalPrincipal);
-                }
+                log.debug()
+                        .attr("originalPrincipal", originalPrincipal)
+                        .log("Setting original role (forwarded from proxy)");
             }
 
             doAuthentication(clientData, false, clientProtocolVersion, clientVersion);
@@ -1286,10 +1331,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         pendingAuthChallengeResponse = false;
 
-        if (log.isDebugEnabled()) {
-            log.debug("Received AuthResponse from {}, auth method: {}",
-                remoteAddress, authResponse.getResponse().getAuthMethodName());
-        }
+        log.debug()
+                .attr("authMethodName", authResponse.getResponse().getAuthMethodName())
+                .log("Received AuthResponse from, auth method");
 
         try {
             AuthData clientData = AuthData.of(authResponse.getResponse().getAuthData());
@@ -1310,11 +1354,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Handle subscribe command: auth role = {}, original auth role = {}",
-                remoteAddress, authenticationRoleLoggingAnonymizer.anonymize(authRole),
-                    authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal));
-        }
+        log.debug()
+                .attr("authRole", authenticationRoleLoggingAnonymizer.anonymize(authRole))
+                .attr("originalAuthRole", authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal))
+                .log("Handle subscribe command");
 
         final String subscriptionName = subscribe.getSubscription();
         final SubType subType = subscribe.getSubType();
@@ -1342,10 +1385,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final Optional<Map<String, String>> subscriptionProperties = SubscriptionOption.getPropertiesMap(
                 subscribe.getSubscriptionPropertiesList());
 
-        if (log.isDebugEnabled()) {
-            log.debug("Topic name = {}, subscription name = {}, schema is {}", topicName, subscriptionName,
-                    schema == null ? "absent" : "present");
-        }
+        log.debug()
+                .attr("topic", topicName)
+                .attr("subscription", subscriptionName)
+                .attr("schema", schema == null ? "absent" : "present")
+                .log("Subscribe request received");
 
         CompletableFuture<Boolean> isAuthorizedFuture = isTopicOperationAllowed(
                 topicName,
@@ -1361,13 +1405,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 consumers.putIfAbsent(consumerId, consumerFuture);
         isAuthorizedFuture.thenApplyAsync(isAuthorized -> {
             if (isAuthorized) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Client is authorized to subscribe with role {}",
-                            remoteAddress, getPrincipal());
-                }
+                log.debug()
+                        .attr("principal", getPrincipal())
+                        .log("Client is authorized to subscribe with role");
 
-                log.info("[{}] Subscribing on topic {} / {}. consumerId: {}, role: {}", this.toString(), topicName,
-                        subscriptionName, consumerId, getPrincipal());
+                log.info()
+                        .attr("cnx", this.toString())
+                        .attr("topic", topicName)
+                        .attr("subscription", subscriptionName)
+                        .attr("consumerId", consumerId)
+                        .attr("principal", getPrincipal())
+                        .log("Subscribing on topic");
                 try {
                     Metadata.validateMetadata(metadata,
                             service.getPulsar().getConfiguration().getMaxConsumerMetadataSize());
@@ -1385,13 +1433,19 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         // client timeout is lower the broker timeouts. We need to wait until the previous
                         // consumer
                         // creation request either complete or fails.
-                        log.warn("[{}][{}][{}] Consumer with id is already present on the connection,"
-                                + " consumerId={}", remoteAddress, topicName, subscriptionName, consumerId);
+                        log.warn()
+                                .attr("topic", topicName)
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerId", consumerId)
+                                .log("Consumer with id is already present on the connection," + "consumerId");
                         commandSender.sendErrorResponse(requestId, ServerError.ServiceNotReady,
                                 "Consumer is already present on the connection");
                     } else if (existingConsumerFuture.isCompletedExceptionally()){
-                        log.warn("[{}][{}][{}] A failed consumer with id is already present on the connection,"
-                                + " consumerId={}", remoteAddress, topicName, subscriptionName, consumerId);
+                        log.warn()
+                                .attr("topic", topicName)
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerId", consumerId)
+                                .log("A failed consumer with id is already present on the connection," + "consumerId");
                         ServerError error = getErrorCodeWithErrorLog(existingConsumerFuture, true,
                                 String.format("A failed consumer with id is already present on the connection."
                                                 + " consumerId: %s, remoteAddress: %s, subscription: %s",
@@ -1408,9 +1462,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 "Consumer that failed is already present on the connection");
                     } else {
                         Consumer consumer = existingConsumerFuture.getNow(null);
-                        log.warn("[{}] Consumer with the same id is already created:"
-                                        + " consumerId={}, consumer={}",
-                                remoteAddress, consumerId, consumer);
+                        log.warn()
+                                .attr("consumerId", consumerId)
+                                .attr("consumer", consumer)
+                                .log("Consumer with the same id is already created:" + "consumerId=, consumer");
                         commandSender.sendSuccessResponse(requestId);
                     }
                     return null;
@@ -1431,8 +1486,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             // the new consumer reached max producer limitation, but pulsar did schema check first,
                             // it would waste CPU.
                             if (((AbstractTopic) topic).isConsumersExceededOnTopic()) {
-                                log.warn("[{}] Attempting to add consumer to topic which reached max"
-                                        + " consumers limit", topic);
+                                log.warn()
+                                        .attr("topic", topic)
+                                        .log("Attempting to add consumer to topic which reached max"
+                                                + "consumers limit");
                                 Throwable t =
                                         new ConsumerBusyException("Topic reached max consumers limit");
                                 return FutureUtil.failedFuture(t);
@@ -1493,34 +1550,42 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         })
                         .thenAcceptAsync(consumer -> {
                             if (consumer.checkAndApplyTopicMigration()) {
-                                log.info("[{}] Disconnecting consumer {} on migrated subscription on topic {} / {}",
-                                        remoteAddress, consumerId, subscriptionName, topicName);
+                                log.info()
+                                        .attr("consumerId", consumerId)
+                                        .attr("subscription", subscriptionName)
+                                        .attr("topic", topicName)
+                                        .log("Disconnecting consumer on migrated subscription on topic");
                                 consumers.remove(consumerId, consumerFuture);
                                 return;
                             }
 
                             if (consumerFuture.complete(consumer)) {
-                                log.info("[{}] Created subscription on topic {} / {}",
-                                        remoteAddress, topicName, subscriptionName);
+                                log.info()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subscriptionName)
+                                        .log("Created subscription on topic");
                                 commandSender.sendSuccessResponse(requestId);
                                 if (brokerInterceptor != null) {
                                     try {
                                         brokerInterceptor.consumerCreated(this, consumer, metadata);
                                     } catch (Throwable t) {
-                                        log.error("Exception occur when intercept consumer created.", t);
+                                        log.error()
+                                                .exception(t)
+                                                .log("Exception occur when intercept consumer created.");
                                     }
                                 }
                             } else {
                                 // The consumer future was completed before by a close command
                                 try {
                                     consumer.close();
-                                    log.info("[{}] Cleared consumer created after timeout on client side {}",
-                                            remoteAddress, consumer);
+                                    log.info()
+                                            .attr("consumer", consumer)
+                                            .log("Cleared consumer created after timeout on client side");
                                 } catch (BrokerServiceException e) {
-                                    log.warn(
-                                            "[{}] Error closing consumer created"
-                                                    + " after timeout on client side {}: {}",
-                                            remoteAddress, consumer, e.getMessage());
+                                    log.warn()
+                                            .attr("consumer", consumer)
+                                            .exceptionMessage(e)
+                                            .log("Error closing consumer created after timeout on client side");
                                 }
                                 consumers.remove(consumerId, consumerFuture);
                             }
@@ -1528,39 +1593,50 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         }, ctx.executor())
                         .exceptionallyAsync(exception -> {
                             if (exception.getCause() instanceof ConsumerBusyException) {
-                                if (log.isDebugEnabled()) {
-                                    log.debug(
-                                            "[{}][{}][{}] Failed to create consumer because exclusive consumer"
-                                                    + " is already connected: {}",
-                                            remoteAddress, topicName, subscriptionName,
-                                            exception.getCause().getMessage());
-                                }
+                                log.debug()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subscriptionName)
+                                        .exceptionMessage(exception.getCause())
+                                        .log("Failed to create consumer because exclusive consumer "
+                                                + "is already connected");
                             } else if (exception.getCause() instanceof BrokerServiceException.TopicMigratedException) {
                                 Optional<ClusterUrl> clusterURL = getMigratedClusterUrl(service.getPulsar(),
                                         topicName.toString());
                                 if (clusterURL.isPresent()) {
-                                    log.info("[{}] redirect migrated consumer to topic {}: "
-                                                    + "consumerId={}, subName={}, {}", remoteAddress,
-                                            topicName, consumerId, subscriptionName, exception.getCause().getMessage());
+                                    log.info()
+                                            .attr("topic", topicName)
+                                            .attr("consumerId", consumerId)
+                                            .attr("subscription", subscriptionName)
+                                            .exceptionMessage(exception.getCause())
+                                            .log("Redirect migrated consumer");
                                     boolean msgSent = commandSender.sendTopicMigrated(ResourceType.Consumer, consumerId,
                                             clusterURL.get().getBrokerServiceUrl(),
                                             clusterURL.get().getBrokerServiceUrlTls());
                                     if (!msgSent) {
-                                        log.info("consumer client doesn't support topic migration handling {}-{}-{}",
-                                                topicName, remoteAddress, consumerId);
+                                        log.info()
+                                                .attr("topic", topicName)
+                                                .attr("consumerId", consumerId)
+                                                .log("Consumer client doesn't support topic migration handling");
                                     }
                                     consumers.remove(consumerId, consumerFuture);
                                     closeConsumer(consumerId, Optional.empty());
                                     return null;
                                 }
                             } else if (exception.getCause() instanceof BrokerServiceException) {
-                                log.warn("[{}][{}][{}] Failed to create consumer: consumerId={}, {}",
-                                         remoteAddress, topicName, subscriptionName,
-                                         consumerId,  exception.getCause().getMessage());
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subscriptionName)
+                                        .attr("consumerId", consumerId)
+                                        .exceptionMessage(exception.getCause())
+                                        .log("Failed to create consumer");
                             } else {
-                                log.warn("[{}][{}][{}] Failed to create consumer: consumerId={}, {}",
-                                         remoteAddress, topicName, subscriptionName,
-                                         consumerId, exception.getCause().getMessage(), exception);
+                                log.warn()
+                                        .attr("topic", topicName)
+                                        .attr("subscription", subscriptionName)
+                                        .attr("consumerId", consumerId)
+                                        .exceptionMessage(exception.getCause())
+                                        .exception(exception)
+                                        .log("Failed to create consumer");
                             }
 
                             // If client timed out, the future would have been completed by subsequent close.
@@ -1577,7 +1653,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         }, ctx.executor());
             } else {
                 String msg = "Client is not authorized to subscribe";
-                log.warn("[{}] {} with role {}", remoteAddress, msg, getPrincipal());
+                log.warn()
+                        .attr("principal", getPrincipal())
+                        .log(msg);
                 consumers.remove(consumerId, consumerFuture);
                 writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, msg));
             }
@@ -1646,14 +1724,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         isAuthorizedFuture.thenApplyAsync(isAuthorized -> {
             if (!isAuthorized) {
                 String msg = "Client is not authorized to Produce";
-                log.warn("[{}] {} with role {}", remoteAddress, msg, getPrincipal());
+                log.warn()
+                        .attr("principal", getPrincipal())
+                        .log(msg);
                 writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, msg));
                 return null;
             }
 
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Client is authorized to Produce with role {}", remoteAddress, getPrincipal());
-            }
+            log.debug()
+                    .attr("principal", getPrincipal())
+                    .log("Client is authorized to Produce");
             CompletableFuture<Producer> producerFuture = new CompletableFuture<>();
             CompletableFuture<Producer> existingProducerFuture = producers.putIfAbsent(producerId, producerFuture);
 
@@ -1663,38 +1743,49 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     // This can happen when client timeout is lower than the broker timeouts.
                     // We need to wait until the previous producer creation request
                     // either complete or fails.
-                    log.warn("[{}][{}] Producer with id is already present on the connection, producerId={}",
-                            remoteAddress, topicName, producerId);
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .log("Producer with id is already present on the connection, producerId");
                     commandSender.sendErrorResponse(requestId, ServerError.ServiceNotReady,
                             "Producer is already present on the connection");
                 } else if (existingProducerFuture.isCompletedExceptionally()) {
                     // remove producer with producerId as it's already completed with exception
-                    log.warn("[{}][{}] Producer with id is failed to register present on the connection, producerId={}",
-                            remoteAddress, topicName, producerId);
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .log("Producer with id is failed to register present on the connection, producerId");
                     ServerError error = getErrorCode(existingProducerFuture);
                     producers.remove(producerId, existingProducerFuture);
                     commandSender.sendErrorResponse(requestId, error,
                             "Producer is already failed to register present on the connection");
                 } else {
                     Producer producer = existingProducerFuture.getNow(null);
-                    log.info("[{}] [{}] Producer with the same id is already created:"
-                            + " producerId={}, producer={}", remoteAddress, topicName, producerId, producer);
+                    log.info()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .attr("producer", producer)
+                            .log("Producer with the same id is already created:" + "producerId=, producer");
                     commandSender.sendProducerSuccessResponse(requestId, producer.getProducerName(),
                             producer.getSchemaVersion());
                 }
                 return null;
             }
 
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Creating producer. producerId={}, producerName={}, schema is {}", remoteAddress,
-                        topicName, producerId, producerName, schema == null ? "absent" : "present");
-            }
+            log.debug()
+                    .attr("topic", topicName)
+                    .attr("producerId", producerId)
+                    .attr("producerName", producerName)
+                    .attr("schema", schema == null ? "absent" : "present")
+                    .log("Creating producer");
 
             service.getOrCreateTopic(topicName.toString()).thenComposeAsync((Topic topic) -> {
                 // Check max producer limitation to avoid unnecessary ops wasting resources. For example: the new
                 // producer reached max producer limitation, but pulsar did schema check first, it would waste CPU
                 if (((AbstractTopic) topic).isProducersExceeded(producerName)) {
-                    log.warn("[{}] Attempting to add producer to topic which reached max producers limit", topic);
+                    log.warn()
+                            .attr("topic", topic)
+                            .log("Attempting to add producer to topic which reached max producers limit");
                     String errorMsg = "Topic '" + topicName.toString() + "' reached max producers limit";
                     Throwable t = new BrokerServiceException.ProducerBusyException(errorMsg);
                     return CompletableFuture.failedFuture(t);
@@ -1712,7 +1803,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             && !isEncrypted
                             && !SystemTopicNames.isSystemTopic(topicName)) {
                         String msg = String.format("Encryption is required in %s", topicName);
-                        log.warn("[{}] {}", remoteAddress, msg);
+                        log.warn().attr("msg", msg).log("");
                         if (producerFuture.completeExceptionally(new ServerMetadataException(msg))) {
                             commandSender.sendErrorResponse(requestId, ServerError.MetadataError, msg);
                         }
@@ -1739,12 +1830,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         if (cause instanceof IncompatibleSchemaException) {
                             // ignore it
                         } else if (cause instanceof InvalidSchemaDataException) {
-                            log.warn("Try add schema failed due to invalid schema data, "
-                                    + "remote address {}, topic {}, producerId {}",
-                                remoteAddress, topicName, producerId);
+                            log.warn()
+                                    .attr("topic", topicName)
+                                    .attr("producerId", producerId)
+                                    .log("Try add schema failed due to invalid schema data, "
+                                            + "remote address, topic, producerId");
                         } else {
-                            log.error("Try add schema failed, remote address {}, topic {}, producerId {}",
-                            remoteAddress, topicName, producerId, exception);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .attr("producerId", producerId)
+                                    .exception(exception)
+                                    .log("Try add schema failed, remote address, topic, producerId");
                         }
                         producers.remove(producerId, producerFuture);
                         return null;
@@ -1774,8 +1870,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             if (ex != null) {
                                 final Throwable rc = FutureUtil.unwrapCompletionException(ex);
                                 if (rc instanceof BrokerServiceException.NotAllowedException) {
-                                    log.warn("[{}] {} initialSubscriptionName: {}, topic: {}",
-                                            remoteAddress, rc.getMessage(), initialSubscriptionName, topicName);
+                                    log.warn()
+                                            .exceptionMessage(rc)
+                                            .attr("initialSubscriptionName", initialSubscriptionName)
+                                            .attr("topic", topicName)
+                                            .log("Failed to create initial subscription");
                                     if (producerFuture.completeExceptionally(rc)) {
                                         commandSender.sendErrorResponse(requestId,
                                                 ServerError.NotAllowedError, rc.getMessage());
@@ -1785,8 +1884,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 }
                                 String msg =
                                         "Failed to create the initial subscription: " + ex.getCause().getMessage();
-                                log.warn("[{}] {} initialSubscriptionName: {}, topic: {}",
-                                        remoteAddress, msg, initialSubscriptionName, topicName);
+                                log.warn()
+                                        .attr("msg", msg)
+                                        .attr("initialSubscriptionName", initialSubscriptionName)
+                                        .attr("topic", topicName)
+                                        .log("Failed to create initial subscription");
                                 if (producerFuture.completeExceptionally(ex)) {
                                     commandSender.sendErrorResponse(requestId,
                                             BrokerServiceException.getClientErrorCode(ex), msg);
@@ -1825,14 +1927,19 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 } else if (cause instanceof BrokerServiceException.TopicMigratedException) {
                     Optional<ClusterUrl> clusterURL = getMigratedClusterUrl(service.getPulsar(), topicName.toString());
                     if (clusterURL.isPresent()) {
-                        log.info("[{}] redirect migrated producer to topic {}: "
-                                        + "producerId={}, producerName = {}, {}", remoteAddress,
-                                topicName, producerId, producerName, cause.getMessage());
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("producerId", producerId)
+                                .attr("producerName", producerName)
+                                .exceptionMessage(cause)
+                                .log("redirect migrated producer to topic: " + "producerId=, producerName");
                         boolean msgSent = commandSender.sendTopicMigrated(ResourceType.Producer, producerId,
                                 clusterURL.get().getBrokerServiceUrl(), clusterURL.get().getBrokerServiceUrlTls());
                         if (!msgSent) {
-                            log.info("client doesn't support topic migration handling {}-{}-{}", topicName,
-                                    remoteAddress, producerId);
+                            log.info()
+                                    .attr("topic", topicName)
+                                    .attr("producerId", producerId)
+                                    .log("client doesn't support topic migration handling");
                         }
                         producers.remove(producerId, producerFuture);
                         closeProducer(producerId, -1L, Optional.empty());
@@ -1843,13 +1950,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 // Do not print stack traces for expected exceptions
                 if (cause instanceof NoSuchElementException) {
                     cause = new TopicNotFoundException(String.format("Topic not found %s", topicName.toString()));
-                    log.warn("[{}] Failed to load topic {}, producerId={}: Topic not found", remoteAddress, topicName,
-                            producerId);
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .log("Failed to load topic, producerId=: Topic not found");
                 } else if (!Exceptions.areExceptionsPresentInChain(cause,
                         ServiceUnitNotReadyException.class, ManagedLedgerException.class,
                         BrokerServiceException.ProducerBusyException.class)) {
-                    log.error("[{}] Failed to create topic {}, producerId={}",
-                            remoteAddress, topicName, producerId, exception);
+                    log.error()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .exception(exception)
+                            .log("Failed to create topic, producerId");
                 }
 
                 // If client timed out, the future would have been completed
@@ -1877,8 +1989,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              Optional<Long> topicEpoch, boolean supportsPartialProducer,
                              CompletableFuture<Producer> producerFuture){
         if (producerFuture.isCompletedExceptionally()) {
-            log.info("[{}] Skipped producer creation after timeout on client side. producerId={}, producerName={}",
-                    remoteAddress, producerId, producerName);
+            log.info()
+                    .attr("producerId", producerId)
+                    .attr("producerName", producerName)
+                    .log("Skipped producer creation after timeout on client side");
             producers.remove(producerId, producerFuture);
             return;
         }
@@ -1891,7 +2005,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         topic.addProducer(producer, producerQueuedFuture).thenAcceptAsync(newTopicEpoch -> {
             if (isActive()) {
                 if (producerFuture.complete(producer)) {
-                    log.info("[{}] Created new producer: {}, role: {}", remoteAddress, producer, getPrincipal());
+                    log.info()
+                            .attr("producer", producer)
+                            .attr("principal", getPrincipal())
+                            .log("Created new producer");
                     commandSender.sendProducerSuccessResponse(requestId, producerName,
                             producer.getLastSequenceId(), producer.getSchemaVersion(),
                             newTopicEpoch, true /* producer is ready now */);
@@ -1899,7 +2016,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         try {
                             brokerInterceptor.producerCreated(this, producer, metadata);
                         } catch (Throwable t) {
-                            log.error("Exception occur when intercept producer created.", t);
+                            log.error().exception(t).log("Exception occur when intercept producer created.");
                         }
                     }
                     return;
@@ -1907,14 +2024,15 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     // The producer's future was completed before by
                     // a close command
                     producer.closeNow(true);
-                    log.info("[{}] Cleared producer created after"
-                                    + " timeout on client side {}",
-                            remoteAddress, producer);
+                    log.info()
+                            .attr("producer", producer)
+                            .log("Cleared producer created after" + "timeout on client side");
                 }
             } else {
                 producer.closeNow(true);
-                log.info("[{}] Cleared producer created after connection was closed: {}",
-                        remoteAddress, producer);
+                log.info()
+                        .attr("producer", producer)
+                        .log("Cleared producer created after connection was closed");
                 producerFuture.completeExceptionally(
                         new IllegalStateException(
                                 "Producer created after connection was closed"));
@@ -1926,34 +2044,50 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 Optional<ClusterUrl> clusterURL = getMigratedClusterUrl(service.getPulsar(), topic.getName());
                 if (clusterURL.isPresent()) {
                     if (!topic.shouldProducerMigrate()) {
-                        log.info("Topic {} is migrated but replication backlog exist: "
-                                        + "producerId = {}, producerName = {}, {}", topicName,
-                                producerId, producerName, ex.getCause().getMessage());
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("producerId", producerId)
+                                .attr("producerName", producerName)
+                                .exceptionMessage(ex.getCause())
+                                .log("Topic is migrated but replication backlog exist: "
+                                        + "producerId =, producerName");
                     } else {
-                        log.info("[{}] redirect migrated producer to topic {}: "
-                                        + "producerId={}, producerName = {}, {}", remoteAddress,
-                                topicName, producerId, producerName, ex.getCause().getMessage());
+                        log.info()
+                                .attr("topic", topicName)
+                                .attr("producerId", producerId)
+                                .attr("producerName", producerName)
+                                .exceptionMessage(ex.getCause())
+                                .log("redirect migrated producer to topic: " + "producerId=, producerName");
                         boolean msgSent = commandSender.sendTopicMigrated(ResourceType.Producer, producerId,
                                 clusterURL.get().getBrokerServiceUrl(), clusterURL.get().getBrokerServiceUrlTls());
                         if (!msgSent) {
-                            log.info("client doesn't support topic migration handling {}-{}-{}", topic,
-                                    remoteAddress, producerId);
+                            log.info()
+                                    .attr("topic", topic)
+                                    .attr("producerId", producerId)
+                                    .log("client doesn't support topic migration handling");
                         }
                         closeProducer(producer);
                         return null;
                     }
                 } else {
-                    log.warn("[{}] failed producer because migration url not configured topic {}: producerId={}, {}",
-                            remoteAddress, topicName, producerId, ex.getCause().getMessage());
+                    log.warn()
+                            .attr("topic", topicName)
+                            .attr("producerId", producerId)
+                            .exceptionMessage(ex.getCause())
+                            .log("failed producer because migration url not configured topic: producerId");
                 }
             } else if (ex.getCause() instanceof BrokerServiceException.ProducerFencedException) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to add producer to topic {}: producerId={}, {}",
-                            remoteAddress, topicName, producerId, ex.getCause().getMessage());
-                }
+                log.debug()
+                        .attr("topic", topicName)
+                        .attr("producerId", producerId)
+                        .exceptionMessage(ex.getCause())
+                        .log("Failed to add producer to topic: producerId");
             } else {
-                log.warn("[{}] Failed to add producer to topic {}: producerId={}, {}",
-                        remoteAddress, topicName, producerId, ex.getCause().getMessage());
+                log.warn()
+                        .attr("topic", topicName)
+                        .attr("producerId", producerId)
+                        .exceptionMessage(ex.getCause())
+                        .log("Failed to add producer to topic: producerId");
             }
 
             producer.closeNow(true);
@@ -1968,7 +2102,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // If the producer is queued waiting, we will get an immediate notification
             // that we need to pass to client
             if (isActive()) {
-                log.info("[{}] Producer is waiting in queue: {}", remoteAddress, producer);
+                log.info()
+                        .attr("producer", producer)
+                        .log("Producer is waiting in queue");
                 commandSender.sendProducerSuccessResponse(requestId, producerName,
                         producer.getLastSequenceId(), producer.getSchemaVersion(),
                         Optional.empty(), false/* producer is not ready now */);
@@ -1987,23 +2123,21 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         if (producerFuture == null || !producerFuture.isDone() || producerFuture.isCompletedExceptionally()) {
             if (recentlyClosedProducers.containsKey(send.getProducerId())) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Received message, but the producer was recently closed : {}. Ignoring message.",
-                            remoteAddress, send.getProducerId());
-                }
+                log.debug()
+                        .attr("producerId", send.getProducerId())
+                        .log("Received message, but the producer was recently closed :. Ignoring message.");
                 // We expect these messages because we recently closed the producer. Do not close the connection.
                 return;
             }
-            log.warn("[{}] Received message, but the producer is not ready : {}. Closing the connection.",
-                    remoteAddress, send.getProducerId());
+            log.warn()
+                    .attr("producerId", send.getProducerId())
+                    .log("Received message, but the producer is not ready :. Closing the connection.");
             close();
             return;
         }
 
         Producer producer = producerFuture.getNow(null);
-        if (log.isDebugEnabled()) {
-            printSendCommandDebug(send, headersAndPayload);
-        }
+        printSendCommandDebug(send, headersAndPayload);
 
         // New messages are silently ignored during topic transfer. Note that the transferring flag is only set when the
         // Extensible Load Manager is enabled.
@@ -2012,12 +2146,13 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             var ignoredMsgCount = send.getNumMessages();
             var ignoredSendMsgTotalCount = ExtensibleLoadManagerImpl.get(pulsar).getIgnoredSendMsgCount().
                     addAndGet(ignoredMsgCount);
-            if (log.isDebugEnabled()) {
-                log.debug("Ignoring {} messages from:{}:{} to fenced topic:{} while transferring."
-                                + " Total ignored message count: {}.",
-                        ignoredMsgCount, remoteAddress, send.getProducerId(), producer.getTopic().getName(),
-                        ignoredSendMsgTotalCount);
-            }
+            log.debug()
+                    .attr("ignoredMsgCount", ignoredMsgCount)
+                    .attr("producerId", send.getProducerId())
+                    .attr("name", producer.getTopic().getName())
+                    .attr("ignoredSendMsgTotalCount", ignoredSendMsgTotalCount)
+                    .log("Ignoring messages from:: to fenced topic: while transferring."
+                            + "Total ignored message count:.");
             return;
         }
 
@@ -2065,15 +2200,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         headersAndPayload.markReaderIndex();
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
         headersAndPayload.resetReaderIndex();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Received send message request. producer: {}:{} {}:{} size: {},"
-                            + " partition key is: {}, ordering key is {}, uncompressedSize is {}",
-                    remoteAddress, send.getProducerId(), send.getSequenceId(), msgMetadata.getProducerName(),
-                    msgMetadata.getSequenceId(), headersAndPayload.readableBytes(),
-                    msgMetadata.hasPartitionKey() ? msgMetadata.getPartitionKey() : null,
-                    msgMetadata.hasOrderingKey() ? msgMetadata.getOrderingKey() : null,
-                    msgMetadata.getUncompressedSize());
-        }
+        log.debug()
+                .attr("producerId", send.getProducerId())
+                .attr("sendSequenceId", send.getSequenceId())
+                .attr("producerName", msgMetadata.getProducerName())
+                .attr("metadataSequenceId", msgMetadata.getSequenceId())
+                .attr("readableBytes", headersAndPayload.readableBytes())
+                .attr("partitionKey", msgMetadata.hasPartitionKey() ? msgMetadata.getPartitionKey() : null)
+                .attr("orderingKey", msgMetadata.hasOrderingKey() ? msgMetadata.getOrderingKey() : null)
+                .attr("uncompressedSize", msgMetadata.getUncompressedSize())
+                .log("Received send message request");
     }
 
     @Override
@@ -2096,10 +2232,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 var ignoredAckCount = ack.getMessageIdsCount();
                 var ignoredAckTotalCount = ExtensibleLoadManagerImpl.get(pulsar).getIgnoredAckCount().
                         addAndGet(ignoredAckCount);
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] Ignoring {} message acks during topic transfer. Total ignored ack count: {}",
-                            subscription, consumerId, ignoredAckCount, ignoredAckTotalCount);
-                }
+                log.debug()
+                        .attr("subscription", subscription)
+                        .attr("consumerId", consumerId)
+                        .attr("ignoredAckCount", ignoredAckCount)
+                        .attr("ignoredAckTotalCount", ignoredAckTotalCount)
+                        .log("Ignoring message acks during topic transfer. Total ignored ack count");
                 return;
             }
             consumer.messageAcked(ack).thenRun(() -> {
@@ -2111,7 +2249,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     try {
                         brokerInterceptor.messageAcked(this, consumer, copyOfAckForInterceptor);
                     } catch (Throwable t) {
-                        log.error("Exception occur when intercept message acked.", t);
+                        log.error().exception(t).log("Exception occur when intercept message acked.");
                     }
                 }
             }).exceptionally(e -> {
@@ -2123,21 +2261,20 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return null;
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("Consumer future is not complete(not complete or error), but received command ack. so discard"
-                                + " this command. consumerId: {}, cnx: {}, messageIdCount: {}", ack.getConsumerId(),
-                        this.toString(), ack.getMessageIdsCount());
-            }
+            log.debug()
+                    .attr("consumerId", ack.getConsumerId())
+                    .attr("messageIdsCount", ack.getMessageIdsCount())
+                    .log("Consumer future is not complete (not complete or error), discarding received command ack");
         }
     }
 
     @Override
     protected void handleFlow(CommandFlow flow) {
         checkArgument(state == State.Connected);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Received flow from consumer {} permits: {}", remoteAddress, flow.getConsumerId(),
-                    flow.getMessagePermits());
-        }
+        log.debug()
+                .attr("consumerId", flow.getConsumerId())
+                .attr("messagePermits", flow.getMessagePermits())
+                .log("Received flow from consumer permits");
 
         CompletableFuture<Consumer> consumerFuture = consumers.get(flow.getConsumerId());
 
@@ -2146,7 +2283,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             if (consumer != null) {
                 consumer.flowPermits(flow.getMessagePermits());
             } else {
-                log.info("[{}] Couldn't find consumer {}", remoteAddress, flow.getConsumerId());
+                log.info()
+                        .attr("consumerId", flow.getConsumerId())
+                        .log("Couldn't find consumer");
             }
         }
     }
@@ -2154,11 +2293,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleRedeliverUnacknowledged(CommandRedeliverUnacknowledgedMessages redeliver) {
         checkArgument(state == State.Connected);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] redeliverUnacknowledged from consumer {}, consumerEpoch {}",
-                    remoteAddress, redeliver.getConsumerId(),
-                    redeliver.hasConsumerEpoch() ? redeliver.getConsumerEpoch() : null);
-        }
+        log.debug()
+                .attr("consumerId", redeliver.getConsumerId())
+                .attr("consumerEpoch", redeliver.hasConsumerEpoch() ? redeliver.getConsumerEpoch() : null)
+                .log("redeliverUnacknowledged from consumer");
 
         CompletableFuture<Consumer> consumerFuture = consumers.get(redeliver.getConsumerId());
 
@@ -2223,12 +2361,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
 
             subscription.resetCursor(position).thenRun(() -> {
-                log.info("[{}] [{}][{}] Reset subscription to message id {}", remoteAddress,
-                        subscription.getTopic().getName(), subscription.getName(), position);
+                log.info()
+                        .attr("topic", subscription.getTopic().getName())
+                        .attr("subscription", subscription.getName())
+                        .attr("position", position)
+                        .log("Reset subscription to message id");
                 commandSender.sendSuccessResponse(requestId);
             }).exceptionally(ex -> {
-                log.warn("[{}][{}] Failed to reset subscription: {}",
-                        remoteAddress, subscription, ex.getMessage(), ex);
+                log.warn()
+                        .attr("subscription", subscription)
+                        .exception(ex)
+                        .log("Failed to reset subscription");
                 commandSender.sendErrorResponse(requestId, ServerError.UnknownError,
                         "Error when resetting subscription: " + ex.getCause().getMessage());
                 return null;
@@ -2239,12 +2382,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             long timestamp = seek.getMessagePublishTime();
 
             subscription.resetCursor(timestamp).thenRun(() -> {
-                log.info("[{}] [{}][{}] Reset subscription to publish time {}", remoteAddress,
-                        subscription.getTopic().getName(), subscription.getName(), timestamp);
+                log.info()
+                        .attr("topic", subscription.getTopic().getName())
+                        .attr("subscription", subscription.getName())
+                        .attr("timestamp", timestamp)
+                        .log("Reset subscription to publish time");
                 commandSender.sendSuccessResponse(requestId);
             }).exceptionally(ex -> {
-                log.warn("[{}][{}] Failed to reset subscription: {}", remoteAddress,
-                        subscription, ex.getMessage(), ex);
+                log.warn()
+                        .attr("subscription", subscription)
+                        .exception(ex)
+                        .log("Failed to reset subscription");
                 commandSender.sendErrorResponse(requestId, ServerError.UnknownError,
                         "Reset subscription to publish time error: " + ex.getCause().getMessage());
                 return null;
@@ -2280,7 +2428,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         CompletableFuture<Producer> producerFuture = producers.get(producerId);
         if (producerFuture == null) {
-            log.info("[{}] Producer {} was not registered on the connection", remoteAddress, producerId);
+            log.info()
+                    .attr("producerId", producerId)
+                    .log("Producer was not registered on the connection");
             writeAndFlush(Commands.newSuccess(requestId));
             return;
         }
@@ -2289,14 +2439,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 .completeExceptionally(new IllegalStateException("Closed producer before creation was complete"))) {
             // We have received a request to close the producer before it was actually completed, we have marked the
             // producer future as failed and we can tell the client the close operation was successful.
-            log.info("[{}] Closed producer before its creation was completed. producerId={}",
-                     remoteAddress, producerId);
+            log.info()
+                    .attr("producerId", producerId)
+                    .log("Closed producer before its creation was completed. producerId");
             commandSender.sendSuccessResponse(requestId);
             producers.remove(producerId, producerFuture);
             return;
         } else if (producerFuture.isCompletedExceptionally()) {
-            log.info("[{}] Closed producer that already failed to be created. producerId={}",
-                     remoteAddress, producerId);
+            log.info()
+                    .attr("producerId", producerId)
+                    .log("Closed producer that already failed to be created. producerId");
             commandSender.sendSuccessResponse(requestId);
             producers.remove(producerId, producerFuture);
             return;
@@ -2304,13 +2456,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         // Proceed with normal close, the producer
         Producer producer = producerFuture.getNow(null);
-        log.info("[{}][{}] Closing producer on cnx {}. producerId={}",
-                 producer.getTopic(), producer.getProducerName(), remoteAddress, producerId);
+        log.info()
+                .attr("topic", producer.getTopic())
+                .attr("producerName", producer.getProducerName())
+                .attr("producerId", producerId)
+                .log("Closing producer on cnx. producerId");
 
         producer.close(true).thenAcceptAsync(v -> {
-            log.info("[{}][{}] Closed producer on cnx {}. producerId={}",
-                     producer.getTopic(), producer.getProducerName(),
-                     remoteAddress, producerId);
+            log.info()
+                    .attr("topic", producer.getTopic())
+                    .attr("producerName", producer.getProducerName())
+                    .attr("producerId", producerId)
+                    .log("Closed producer on cnx. producerId");
             commandSender.sendSuccessResponse(requestId);
             producers.remove(producerId, producerFuture);
             if (brokerInterceptor != null) {
@@ -2322,14 +2479,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleCloseConsumer(CommandCloseConsumer closeConsumer) {
         checkArgument(state == State.Connected);
-        log.info("[{}] Closing consumer: consumerId={}", remoteAddress, closeConsumer.getConsumerId());
+        log.info()
+                .attr("consumerId", closeConsumer.getConsumerId())
+                .log("Closing consumer: consumerId");
 
         long requestId = closeConsumer.getRequestId();
         long consumerId = closeConsumer.getConsumerId();
 
         CompletableFuture<Consumer> consumerFuture = consumers.get(consumerId);
         if (consumerFuture == null) {
-            log.info("[{}] Consumer was not registered on the connection: {}", consumerId, remoteAddress);
+            log.info()
+                    .attr("consumerId", consumerId)
+                    .log("Consumer was not registered on the connection");
             writeAndFlush(Commands.newSuccess(requestId));
             return;
         }
@@ -2339,15 +2500,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             // We have received a request to close the consumer before it was actually completed, we have marked the
             // consumer future as failed and we can tell the client the close operation was successful. When the actual
             // create operation will complete, the new consumer will be discarded.
-            log.info("[{}] Closed consumer before its creation was completed. consumerId={}",
-                     remoteAddress, consumerId);
+            log.info()
+                    .attr("consumerId", consumerId)
+                    .log("Closed consumer before its creation was completed. consumerId");
             commandSender.sendSuccessResponse(requestId);
             return;
         }
 
         if (consumerFuture.isCompletedExceptionally()) {
-            log.info("[{}] Closed consumer that already failed to be created. consumerId={}",
-                     remoteAddress, consumerId);
+            log.info()
+                    .attr("consumerId", consumerId)
+                    .log("Closed consumer that already failed to be created. consumerId");
             commandSender.sendSuccessResponse(requestId);
             return;
         }
@@ -2358,12 +2521,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             consumer.close();
             consumers.remove(consumerId, consumerFuture);
             commandSender.sendSuccessResponse(requestId);
-            log.info("[{}] Closed consumer, consumerId={}", remoteAddress, consumerId);
+            log.info()
+                    .attr("consumerId", consumerId)
+                    .log("Closed consumer, consumerId");
             if (brokerInterceptor != null) {
                 brokerInterceptor.consumerClosed(this, consumer, consumer.getMetadata());
             }
         } catch (BrokerServiceException e) {
-            log.warn("[{]] Error closing consumer {} : {}", remoteAddress, consumer, e);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .exception(e)
+                    .log("[{]] Error closing consumer");
             commandSender.sendErrorResponse(requestId, BrokerServiceException.getClientErrorCode(e), e.getMessage());
         }
     }
@@ -2430,7 +2598,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
         compactionHorizonFuture.whenComplete((compactionHorizon, ex) -> {
             if (ex != null) {
-                log.error("Failed to get compactionHorizon.", ex);
+                log.error().exception(ex).log("Failed to get compactionHorizon.");
                 writeAndFlush(Commands.newError(requestId, ServerError.MetadataError, ex.getMessage()));
                 return;
             }
@@ -2500,10 +2668,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 } else {
                     int largestBatchIndex = batchSize > 0 ? batchSize - 1 : -1;
 
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}][{}] Get LastMessageId {} partitionIndex {}", remoteAddress,
-                                topic.getName(), subscriptionName, lastPosition, partitionIndex);
-                    }
+                    log.debug()
+                            .attr("topic", topic.getName())
+                            .attr("subscription", subscriptionName)
+                            .attr("lastPosition", lastPosition)
+                            .attr("partitionIndex", partitionIndex)
+                            .log("Get LastMessageId partitionIndex");
 
                     writeAndFlush(Commands.newGetLastMessageIdResponse(requestId, lastPosition.getLedgerId(),
                             lastPosition.getEntryId(), partitionIndex, largestBatchIndex,
@@ -2544,12 +2714,18 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 namespaceName, operation, authRole, authenticationData);
         return isProxyAuthorizedFuture.thenCombine(isAuthorizedFuture, (isProxyAuthorized, isAuthorized) -> {
             if (!isProxyAuthorized) {
-                log.warn("OriginalRole {} is not authorized to perform operation {} on namespace {}",
-                        authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal), operation, namespaceName);
+                log.warn()
+                        .attr("originalPrincipal", authenticationRoleLoggingAnonymizer.anonymize(originalPrincipal))
+                        .attr("operation", operation)
+                        .attr("namespace", namespaceName)
+                        .log("OriginalRole is not authorized to perform operation on namespace");
             }
             if (!isAuthorized) {
-                log.warn("Role {} is not authorized to perform operation {} on namespace {}",
-                        authenticationRoleLoggingAnonymizer.anonymize(authRole), operation, namespaceName);
+                log.warn()
+                        .attr("authRole", authenticationRoleLoggingAnonymizer.anonymize(authRole))
+                        .attr("operation", operation)
+                        .attr("namespace", namespaceName)
+                        .log("Role is not authorized to perform operation on namespace");
             }
             return isProxyAuthorized && isAuthorized;
         });
@@ -2579,7 +2755,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             topicsHash, properties, lookupSemaphore);
                 } else {
                     final String msg = "Client is not authorized to GetTopicsOfNamespace";
-                    log.warn("[{}] {} with role {} on namespace {}", remoteAddress, msg, getPrincipal(), namespaceName);
+                    log.warn()
+                            .attr("principal", getPrincipal())
+                            .attr("namespace", namespaceName)
+                            .log(msg);
                     commandSender.sendErrorResponse(requestId, ServerError.AuthorizationError, msg);
                     lookupSemaphore.release();
                 }
@@ -2593,10 +2772,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return null;
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed GetTopicsOfNamespace lookup due to too many lookup-requests {}", remoteAddress,
-                        namespaceName);
-            }
+            log.debug()
+                    .attr("namespace", namespaceName)
+                    .log("Failed GetTopicsOfNamespace lookup due to too many lookup-requests");
             commandSender.sendErrorResponse(requestId, ServerError.TooManyRequests,
                     "Failed due to too many pending lookup requests");
         }
@@ -2631,11 +2809,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                                 topicsPattern.get(),
                                                                 topicsPatternImplementation);
                                                     } else {
-                                                        log.info(
-                                                                "[{}] Subscription pattern provided [{}] was longer "
-                                                                        + "than maximum {}.", remoteAddress,
-                                                                topicsPattern.get(),
-                                                                maxSubscriptionPatternLength);
+                                                        log.info()
+                                                                .attr("get", topicsPattern.get())
+                                                                .attr("maxSubscriptionPatternLength",
+                                                                        maxSubscriptionPatternLength)
+                                                                .log("Subscription pattern provided was longer "
+                                                                        + "than maximum.");
                                                     }
                                                 }
                                                 String hash = TopicList.calculateHash(filteredTopics);
@@ -2644,26 +2823,29 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                                 if (hashUnchanged) {
                                                     filteredTopics = Collections.emptyList();
                                                 }
-                                                if (log.isDebugEnabled()) {
-                                                    log.debug("[{}] Received CommandGetTopicsOfNamespace for namespace "
-                                                                    + "[//{}] by {}, size:{}", remoteAddress, namespace,
-                                                            requestId,
-                                                            topics.size());
-                                                }
+                                                log.debug()
+                                                        .attr("namespace", namespace)
+                                                        .attr("requestId", requestId)
+                                                        .attr("size", topics.size())
+                                                        .log("Received CommandGetTopicsOfNamespace for namespace "
+                                                                + "[// by, size");
                                                 return commandSender.sendGetTopicsOfNamespaceResponse(filteredTopics,
                                                         hash,
                                                         filterTopics, !hashUnchanged, requestId, ex -> {
-                                                            log.warn("[{}] Failed to acquire direct memory permits for "
-                                                                            + "GetTopicsOfNamespace: {}", remoteAddress,
-                                                                    ex.getMessage());
+                                                            log.warn()
+                                                                    .exceptionMessage(ex)
+                                                                    .log("Failed to acquire direct memory permits for "
+                                                                            + "GetTopicsOfNamespace");
                                                             commandSender.sendErrorResponse(requestId,
                                                                     ServerError.TooManyRequests,
                                                                     "Cannot acquire permits for direct memory");
                                                             return CompletableFuture.completedFuture(null);
                                                         });
                                             }, t -> {
-                                                log.warn("[{}] Failed to acquire heap memory permits for "
-                                                        + "GetTopicsOfNamespace: {}", remoteAddress, t.getMessage());
+                                                log.warn()
+                                                        .exceptionMessage(t)
+                                                        .log("Failed to acquire heap memory permits for "
+                                                                + "GetTopicsOfNamespace");
                                                 writeAndFlush(Commands.newError(requestId, ServerError.TooManyRequests,
                                                         "Failed due to heap memory limit exceeded"));
                                                 return CompletableFuture.completedFuture(null);
@@ -2671,9 +2853,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                 }).whenComplete((__, ___) -> {
                                     lookupSemaphore.release();
                                 }).exceptionally(ex -> {
-                                    log.warn("[{}] Error GetTopicsOfNamespace for namespace [//{}] by {}",
-                                            remoteAddress,
-                                            namespace, requestId);
+                                    log.warn()
+                                            .attr("namespace", namespace)
+                                            .attr("requestId", requestId)
+                                            .log("Error GetTopicsOfNamespace for namespace [// by");
                                     listSizeHolder.resetIfInitializing();
                                     commandSender.sendErrorResponse(requestId,
                                             BrokerServiceException.getClientErrorCode(new ServerMetadataException(ex)),
@@ -2681,8 +2864,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     return null;
                                 });
                     }, t -> {
-                        log.warn("[{}] Failed to acquire initial heap memory permits for GetTopicsOfNamespace: {}",
-                                remoteAddress, t.getMessage());
+                        log.warn()
+                                .exceptionMessage(t)
+                                .log("Failed to acquire initial heap memory permits for GetTopicsOfNamespace");
                         listSizeHolder.resetIfInitializing();
                         writeAndFlush(Commands.newError(requestId, ServerError.TooManyRequests,
                                 "Failed due to heap memory limit exceeded"));
@@ -2696,16 +2880,17 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleGetSchema(CommandGetSchema commandGetSchema) {
         checkArgument(state == State.Connected);
-        if (log.isDebugEnabled()) {
-            if (commandGetSchema.hasSchemaVersion()) {
-                log.debug("Received CommandGetSchema call from {}, schemaVersion: {}, topic: {}, requestId: {}",
-                        remoteAddress, new String(commandGetSchema.getSchemaVersion()),
-                        commandGetSchema.getTopic(), commandGetSchema.getRequestId());
-            } else {
-                log.debug("Received CommandGetSchema call from {}, schemaVersion: {}, topic: {}, requestId: {}",
-                        remoteAddress, null,
-                        commandGetSchema.getTopic(), commandGetSchema.getRequestId());
-            }
+        if (commandGetSchema.hasSchemaVersion()) {
+            log.debug()
+                    .attr("schemaVersion", new String(commandGetSchema.getSchemaVersion()))
+                    .attr("topic", commandGetSchema.getTopic())
+                    .attr("requestId", commandGetSchema.getRequestId())
+                    .log("Received CommandGetSchema");
+        } else {
+            log.debug()
+                    .attr("topic", commandGetSchema.getTopic())
+                    .attr("requestId", commandGetSchema.getRequestId())
+                    .log("Received CommandGetSchema");
         }
 
         long requestId = commandGetSchema.getRequestId();
@@ -2745,9 +2930,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     @Override
     protected void handleGetOrCreateSchema(CommandGetOrCreateSchema commandGetOrCreateSchema) {
         checkArgument(state == State.Connected);
-        if (log.isDebugEnabled()) {
-            log.debug("Received CommandGetOrCreateSchema call from {}", remoteAddress);
-        }
+        log.debug("Received CommandGetOrCreateSchema call");
         long requestId = commandGetOrCreateSchema.getRequestId();
         final String topicName = commandGetOrCreateSchema.getTopic();
         SchemaData schemaData = getSchema(commandGetOrCreateSchema.getSchema());
@@ -2783,10 +2966,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
-        if (log.isDebugEnabled()) {
-            log.debug("Receive tc client connect request {} to transaction meta store {} from {}.",
-                    requestId, tcId, remoteAddress);
-        }
+        log.debug()
+                .attr("requestId", requestId)
+                .attr("tcId", tcId)
+                .log("Receive tc client connect request to transaction meta store from.");
 
         if (!checkTransactionEnableAndSendError(requestId)) {
             return;
@@ -2796,14 +2979,16 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 service.pulsar().getTransactionMetadataStoreService();
 
         transactionMetadataStoreService.handleTcClientConnect(tcId).thenAccept(connection -> {
-            if (log.isDebugEnabled()) {
-                log.debug("Handle tc client connect request {} to transaction meta store {} from {} success.",
-                        requestId, tcId, remoteAddress);
-            }
+            log.debug()
+                    .attr("requestId", requestId)
+                    .attr("tcId", tcId)
+                    .log("Handle tc client connect request to transaction meta store from success.");
             commandSender.sendTcClientConnectResponse(requestId);
         }).exceptionally(e -> {
-            log.error("Handle tc client connect request {} to transaction meta store {} from {} fail.",
-                    requestId, tcId, remoteAddress, e.getCause());
+            log.error()
+                    .attr("requestId", requestId)
+                    .attr("tcId", tcId)
+                    .log("Handle tc client connect request to transaction meta store from fail.");
             commandSender.sendTcClientConnectResponse(requestId,
                     BrokerServiceException.getClientErrorCode(e), e.getMessage());
             return null;
@@ -2824,20 +3009,22 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private Throwable handleTxnException(Throwable ex, String op, long requestId) {
         Throwable cause = FutureUtil.unwrapCompletionException(ex);
         if (cause instanceof CoordinatorException.CoordinatorNotFoundException) {
-            if (log.isDebugEnabled()) {
-                log.debug("The Coordinator was not found for the request {}", op);
-            }
+            log.debug().attr("op", op).log("The Coordinator was not found for the request");
             return cause;
         }
         if (cause instanceof ManagedLedgerException.ManagedLedgerFencedException) {
-            if (log.isDebugEnabled()) {
-                log.debug("Throw a CoordinatorNotFoundException to client "
-                        + "with the message got from a ManagedLedgerFencedException for the request {}", op);
-            }
+            log.debug()
+                    .attr("op", op)
+                    .log("Throw a CoordinatorNotFoundException to client "
+                            + "with the message got from a ManagedLedgerFencedException for the request");
             return new CoordinatorException.CoordinatorNotFoundException(cause.getMessage());
 
         }
-        log.error("Send response error for {} request {}.", op, requestId, cause);
+        log.error()
+                .attr("op", op)
+                .attr("requestId", requestId)
+                .exception(cause)
+                .log("Send response error for request.");
         return cause;
     }
     @Override
@@ -2845,10 +3032,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         checkArgument(state == State.Connected);
         final long requestId = command.getRequestId();
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTcId());
-        if (log.isDebugEnabled()) {
-            log.debug("Receive new txn request {} to transaction meta store {} from {}.",
-                    requestId, tcId, remoteAddress);
-        }
+        log.debug()
+                .attr("requestId", requestId)
+                .attr("tcId", tcId)
+                .log("Receive new txn request to transaction meta store from.");
 
         if (!checkTransactionEnableAndSendError(requestId)) {
             return;
@@ -2860,17 +3047,21 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         transactionMetadataStoreService.newTransaction(tcId, command.getTxnTtlSeconds(), owner)
             .whenComplete(((txnID, ex) -> {
                 if (ex == null) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Send response {} for new txn request {}", txnID, requestId);
-                    }
+                    log.debug()
+                            .attr("txnID", txnID)
+                            .attr("requestId", requestId)
+                            .log("Send response for new txn request");
                     commandSender.sendNewTxnResponse(requestId, txnID, tcId.getId());
                 } else {
                     if (ex instanceof CoordinatorException.ReachMaxActiveTxnException) {
                         // if new txn throw ReachMaxActiveTxnException, don't return any response to client,
                         // otherwise client will retry, it will wast o lot of resources
                         // link https://github.com/apache/pulsar/issues/15133
-                        log.warn("New txn op reach max active transactions! tcId : {}, requestId : {}",
-                                tcId.getId(), requestId, ex);
+                        log.warn()
+                                .attr("tcId", tcId.getId())
+                                .attr("requestId", requestId)
+                                .exception(ex)
+                                .log("New txn op reached max active transactions");
                         // do-nothing
                     } else {
                         ex = handleTxnException(ex, BaseCommand.Type.NEW_TXN.name(), requestId);
@@ -2890,11 +3081,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
         final long requestId = command.getRequestId();
         final List<String> partitionsList = command.getPartitionsList();
-        if (log.isDebugEnabled()) {
-            partitionsList.forEach(partition ->
-                    log.debug("Receive add published partition to txn request {} "
-                            + "from {} with txnId {}, topic: [{}]", requestId, remoteAddress, txnID, partition));
-        }
+        partitionsList.forEach(partition ->
+                log.debug()
+                        .attr("requestId", requestId)
+                        .attr("txnID", txnID)
+                        .attr("partition", partition)
+                        .log("Receive add published partition to txn request " + "from with txnId, topic"));
 
         if (!checkTransactionEnableAndSendError(requestId)) {
             return;
@@ -2912,9 +3104,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 })
                 .whenComplete((v, ex) -> {
                     if (ex == null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Send response success for add published partition to txn request {}", requestId);
-                        }
+                        log.debug()
+                                .attr("requestId", requestId)
+                                .log("Send response success for add published partition to txn request");
                         writeAndFlush(Commands.newAddPartitionToTxnResponse(requestId,
                                 txnID.getLeastSigBits(), txnID.getMostSigBits()));
                     } else {
@@ -2935,7 +3127,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 "Client (%s) is neither the owner of the transaction %s nor a super user",
                 getPrincipal(), txnID
         );
-        log.warn("[{}] {}", remoteAddress, msg);
+        log.warn().attr("msg", msg).log("");
         return CompletableFuture.failedFuture(new CoordinatorException.TransactionNotFoundException(msg));
     }
 
@@ -2944,7 +3136,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 "TC client (%s) is not a super user, and is not allowed to operate on transaction %s",
                 getPrincipal(), txnID
         );
-        log.warn("[{}] {}", remoteAddress, msg);
+        log.warn().attr("msg", msg).log("");
         return CompletableFuture.failedFuture(new CoordinatorException.TransactionNotFoundException(msg));
     }
 
@@ -3027,10 +3219,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final TxnID txnID = new TxnID(command.getTxnidMostBits(), command.getTxnidLeastBits());
         final long lowWaterMark = command.getTxnidLeastBitsOfLowWatermark();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] handleEndTxnOnPartition txnId: [{}], txnAction: [{}]", topic,
-                    txnID, txnAction);
-        }
+        log.debug()
+                .attr("topic", topic)
+                .attr("txnID", txnID)
+                .attr("txnAction", txnAction)
+                .log("handleEndTxnOnPartition");
         TopicName topicName = TopicName.get(topic);
         CompletableFuture<Optional<Topic>> topicFuture = service.getTopicIfExists(topicName.toString());
         topicFuture.thenAcceptAsync(optionalTopic -> {
@@ -3046,8 +3239,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         .whenComplete((ignored, throwable) -> {
                             if (throwable != null) {
                                 throwable = FutureUtil.unwrapCompletionException(throwable);
-                                log.error("handleEndTxnOnPartition fail!, topic {}, txnId: [{}], "
-                                        + "txnAction: [{}]", topic, txnID, TxnAction.valueOf(txnAction), throwable);
+                                log.error()
+                                        .attr("topic", topic)
+                                        .attr("txnID", txnID)
+                                        .attr("txnAction", TxnAction.valueOf(txnAction))
+                                        .exception(throwable)
+                                        .log("handleEndTxnOnPartition fail");
                                 writeAndFlush(Commands.newEndTxnOnPartitionResponse(
                                         requestId, BrokerServiceException.getClientErrorCode(throwable),
                                         throwable.getMessage(),
@@ -3063,28 +3260,32 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             return managedLedgerFactory.asyncExists(topicName.getPersistenceNamingEncoding())
                                     .thenAccept((b) -> {
                                         if (b) {
-                                            log.error(
-                                                    "handleEndTxnOnPartition fail ! The topic {} does not exist in "
-                                                            + "broker, "
-                                                            + "txnId: [{}], txnAction: [{}]", topic,
-                                                    txnID, TxnAction.valueOf(txnAction));
+                                            log.error()
+                                                    .attr("topic", topic)
+                                                    .attr("txnID", txnID)
+                                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                                    .log("handleEndTxnOnPartition fail ! The topic does not exist in "
+                                                            + "broker");
                                             writeAndFlush(Commands.newEndTxnOnPartitionResponse(requestId,
                                                     ServerError.ServiceNotReady,
                                                     "The topic " + topic + " does not exist in broker.",
                                                     txnID.getLeastSigBits(), txnID.getMostSigBits()));
                                         } else {
-                                            log.warn(
-                                                    "handleEndTxnOnPartition fail ! The topic {} has not been created, "
-                                                            + "txnId: [{}], txnAction: [{}]",
-                                                    topic, txnID, TxnAction.valueOf(txnAction));
+                                            log.warn()
+                                                    .attr("topic", topic)
+                                                    .attr("txnID", txnID)
+                                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                                    .log("handleEndTxnOnPartition: topic not created");
                                             writeAndFlush(Commands.newEndTxnOnPartitionResponse(requestId,
                                                     txnID.getLeastSigBits(), txnID.getMostSigBits()));
                                         }
                                     });
                         }).exceptionally(e -> {
-                            log.error("handleEndTxnOnPartition fail ! topic {}, "
-                                            + "txnId: [{}], txnAction: [{}]", topic, txnID,
-                                    TxnAction.valueOf(txnAction), e.getCause());
+                            log.error()
+                                    .attr("topic", topic)
+                                    .attr("txnID", txnID)
+                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                    .log("handleEndTxnOnPartition fail");
                             writeAndFlush(Commands.newEndTxnOnPartitionResponse(
                                     requestId, ServerError.ServiceNotReady,
                                     e.getMessage(), txnID.getLeastSigBits(), txnID.getMostSigBits()));
@@ -3093,9 +3294,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         });
             }
         }, ctx.executor()).exceptionally(e -> {
-            log.error("handleEndTxnOnPartition fail ! topic {}, "
-                            + "txnId: [{}], txnAction: [{}]", topic, txnID,
-                    TxnAction.valueOf(txnAction), e.getCause());
+            log.error()
+                    .attr("topic", topic)
+                    .attr("txnID", txnID)
+                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                    .log("handleEndTxnOnPartition fail");
             writeAndFlush(Commands.newEndTxnOnPartitionResponse(
                     requestId, ServerError.ServiceNotReady,
                     e.getMessage(), txnID.getLeastSigBits(), txnID.getMostSigBits()));
@@ -3115,10 +3318,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         final TxnID txnID = new TxnID(txnidMostBits, txnidLeastBits);
         final long lowWaterMark = command.getTxnidLeastBitsOfLowWatermark();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] handleEndTxnOnSubscription txnId: [{}], txnAction: [{}]", topic, subName,
-                    new TxnID(txnidMostBits, txnidLeastBits), txnAction);
-        }
+        log.debug()
+                .attr("topic", topic)
+                .attr("subscription", subName)
+                .attr("txnID", new TxnID(txnidMostBits, txnidLeastBits))
+                .attr("txnAction", txnAction)
+                .log("handleEndTxnOnSubscription");
 
         TopicName topicName = TopicName.get(topic);
         CompletableFuture<Optional<Topic>> topicFuture = service.getTopicIfExists(topicName.toString());
@@ -3126,9 +3331,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             if (optionalTopic.isPresent()) {
                 Subscription subscription = optionalTopic.get().getSubscription(subName);
                 if (subscription == null) {
-                    log.warn("handleEndTxnOnSubscription fail! "
-                                    + "topic {} subscription {} does not exist. txnId: [{}], txnAction: [{}]",
-                            optionalTopic.get().getName(), subName, txnID, TxnAction.valueOf(txnAction));
+                    log.warn()
+                            .attr("topic", optionalTopic.get().getName())
+                            .attr("subscription", subName)
+                            .attr("txnID", txnID)
+                            .attr("txnAction", TxnAction.valueOf(txnAction))
+                            .log("handleEndTxnOnSubscription fail! topic subscription does not exist");
                     writeAndFlush(
                             Commands.newEndTxnOnSubscriptionResponse(requestId, txnidLeastBits, txnidMostBits));
                     return;
@@ -3143,9 +3351,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         }).whenComplete((ignored, e) -> {
                             if (e != null) {
                                 e = FutureUtil.unwrapCompletionException(e);
-                                log.error("handleEndTxnOnSubscription fail ! topic: {}, subscription: {}"
-                                                + "txnId: [{}], txnAction: [{}]", topic, subName,
-                                        txnID, TxnAction.valueOf(txnAction), e.getCause());
+                                log.error()
+                                        .attr("topic", topic)
+                                        .attr("subscription", subName)
+                                        .attr("txnID", txnID)
+                                        .attr("txnAction", TxnAction.valueOf(txnAction))
+                                        .log("handleEndTxnOnSubscription failed");
                                 writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(
                                         requestId, txnidLeastBits, txnidMostBits,
                                         BrokerServiceException.getClientErrorCode(e),
@@ -3161,30 +3372,36 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             return managedLedgerFactory.asyncExists(topicName.getPersistenceNamingEncoding())
                                     .thenAccept((b) -> {
                                         if (b) {
-                                            log.error(
-                                                    "handleEndTxnOnSubscription fail! The topic {} does not exist in "
-                                                            + "broker, "
-                                                            + "subscription: {}, txnId: [{}], txnAction: [{}]", topic,
-                                                    subName,
-                                                    txnID, TxnAction.valueOf(txnAction));
+                                            log.error()
+                                                    .attr("topic", topic)
+                                                    .attr("subscription", subName)
+                                                    .attr("txnID", txnID)
+                                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                                    .log("handleEndTxnOnSubscription failed: "
+                                                            + "the topic does not exist in broker");
                                             writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(
                                                     requestId, txnID.getLeastSigBits(), txnID.getMostSigBits(),
                                                     ServerError.ServiceNotReady,
                                                     "The topic " + topic + " does not exist in broker."));
                                         } else {
-                                            log.warn(
-                                                    "handleEndTxnOnSubscription fail ! The topic {} has not been "
-                                                    + "created, "
-                                                            + "subscription: {} txnId: [{}], txnAction: [{}]",
-                                                    topic, subName, txnID, TxnAction.valueOf(txnAction));
+                                            log.warn()
+                                                    .attr("topic", topic)
+                                                    .attr("subscription", subName)
+                                                    .attr("txnID", txnID)
+                                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                                    .log("handleEndTxnOnSubscription failed: "
+                                                            + "the topic has not been created");
                                             writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(requestId,
                                                     txnID.getLeastSigBits(), txnID.getMostSigBits()));
                                         }
                                     });
                         }).exceptionally(e -> {
-                            log.error("handleEndTxnOnSubscription fail ! topic {}, subscription: {}"
-                                            + "txnId: [{}], txnAction: [{}]", topic, subName,
-                                    txnID, TxnAction.valueOf(txnAction), e.getCause());
+                            log.error()
+                                    .attr("topic", topic)
+                                    .attr("subscription", subName)
+                                    .attr("txnID", txnID)
+                                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                                    .log("handleEndTxnOnSubscription failed");
                             writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(
                                     requestId, txnID.getLeastSigBits(), txnID.getMostSigBits(),
                                     ServerError.ServiceNotReady, e.getMessage()));
@@ -3192,9 +3409,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                         });
             }
         }, ctx.executor()).exceptionally(e -> {
-            log.error("handleEndTxnOnSubscription fail ! topic: {}, subscription: {}"
-                            + "txnId: [{}], txnAction: [{}]", topic, subName,
-                    txnID, TxnAction.valueOf(txnAction), e.getCause());
+            log.error()
+                    .attr("topic", topic)
+                    .attr("subscription", subName)
+                    .attr("txnID", txnID)
+                    .attr("txnAction", TxnAction.valueOf(txnAction))
+                    .log("handleEndTxnOnSubscription failed");
             writeAndFlush(Commands.newEndTxnOnSubscriptionResponse(
                     requestId, txnidLeastBits, txnidMostBits,
                     ServerError.ServiceNotReady,
@@ -3208,9 +3428,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             return topic.addSchema(schema);
         } else {
             return topic.hasSchema().thenCompose((hasSchema) -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] {} configured with schema {}", remoteAddress, topic.getName(), hasSchema);
-                }
+                log.debug()
+                        .attr("topic", topic.getName())
+                        .attr("hasSchema", hasSchema)
+                        .log("configured with schema");
                 CompletableFuture<SchemaVersion> result = new CompletableFuture<>();
                 if (hasSchema && (schemaValidationEnforced || topic.getSchemaValidationEnforced())) {
                     result.completeExceptionally(new IncompatibleSchemaException(
@@ -3233,10 +3454,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         for (org.apache.pulsar.common.api.proto.Subscription sub : command.getSubscriptionsList()) {
             subscriptionsList.add(new org.apache.pulsar.common.api.proto.Subscription().copyFrom(sub));
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Receive add published partition to txn request {} from {} with txnId {}",
-                    requestId, remoteAddress, txnID);
-        }
+        log.debug()
+                .attr("requestId", requestId)
+                .attr("txnID", txnID)
+                .log("Receive add published partition to txn request from with txnId");
 
         final TransactionCoordinatorID tcId = TransactionCoordinatorID.get(command.getTxnidMostBits());
 
@@ -3257,10 +3478,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 })
                 .whenComplete((v, ex) -> {
                     if (ex == null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Send response success for add published partition to txn request {}",
-                                    requestId);
-                        }
+                        log.debug()
+                                .attr("requestId", requestId)
+                                .log("Send response success for add published partition to txn request");
                         writeAndFlush(Commands.newAddSubscriptionToTxnResponse(requestId,
                                 txnID.getLeastSigBits(), txnID.getMostSigBits()));
                     } else {
@@ -3297,7 +3517,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                             topicsPatternImplementation, topicsHash, lookupSemaphore);
                 } else {
                     final String msg = "Proxy Client is not authorized to watchTopicList";
-                    log.warn("[{}] {} with role {} on namespace {}", remoteAddress, msg, getPrincipal(), namespaceName);
+                    log.warn()
+                            .attr("principal", getPrincipal())
+                            .attr("namespace", namespaceName)
+                            .log(msg);
                     commandSender.sendErrorResponse(requestId, ServerError.AuthorizationError, msg);
                     lookupSemaphore.release();
                 }
@@ -3311,10 +3534,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 return null;
             });
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed WatchTopicList due to too many lookup-requests {}", remoteAddress,
-                        namespaceName);
-            }
+            log.debug()
+                    .attr("namespace", namespaceName)
+                    .log("Failed WatchTopicList due to too many lookup-requests");
             commandSender.sendErrorResponse(requestId, ServerError.TooManyRequests,
                     "Failed due to too many pending lookup requests");
         }
@@ -3364,7 +3586,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         try {
             return lookupData.toLookupResult(builder.build()).getLookupData();
         } catch (PulsarServerException e) {
-            log.error("Failed to get lookup data", e);
+            log.error().exception(e).log("Failed to get lookup data");
             throw new RuntimeException(e);
         }
     }
@@ -3419,8 +3641,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private void writeCloseConsumerAndCloseConnectionOnFailure(ByteBuf cmd, long consumerId) {
         ctx.writeAndFlush(cmd).addListener(future -> {
             if (!future.isSuccess()) {
-                log.warn("[{}] Forcing connection to close since cannot send close consumer command for consumer {}",
-                        remoteAddress, consumerId, future.cause());
+                log.warn()
+                        .attr("consumerId", consumerId)
+                        .exception(future.cause())
+                        .log("Forcing connection to close since cannot send close consumer command");
                 close();
             }
         });
@@ -3453,9 +3677,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     private void safelyRemoveProducer(Producer producer) {
         long producerId = producer.getProducerId();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Removed producer: producerId={}, producer={}", remoteAddress, producerId, producer);
-        }
+        log.debug()
+                .attr("producerId", producerId)
+                .attr("producer", producer)
+                .log("Removed producer");
         CompletableFuture<Producer> future = producers.get(producerId);
         if (future != null) {
             future.whenCompleteAsync((producer2, exception) -> {
@@ -3468,9 +3693,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
     private void safelyRemoveConsumer(Consumer consumer) {
         long consumerId = consumer.consumerId();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Removed consumer: consumerId={}, consumer={}", remoteAddress, consumerId, consumer);
-        }
+        log.debug()
+                .attr("consumerId", consumerId)
+                .attr("consumer", consumer)
+                .log("Removed consumer");
         CompletableFuture<Consumer> future = consumers.get(consumerId);
         if (future != null) {
             future.whenCompleteAsync((consumer2, exception) -> {
@@ -3544,7 +3770,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             if (logIfError){
                 String finalErrorMessage = StringUtils.isNotBlank(errorMessageIfLog)
                         ? errorMessageIfLog : "Unknown Error";
-                log.error(finalErrorMessage, e);
+                log.error().exception(e).log(finalErrorMessage);
             }
         }
         return error;
@@ -3558,8 +3784,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     ctx.channel().config().setOption(ChannelOption.TCP_NODELAY, false);
                 }
             } catch (Throwable t) {
-                log.warn("[{}] [{}] Failed to remove TCP no-delay property on client cnx {}", topic, producerName,
-                        this.toString());
+                log.warn()
+                        .attr("topic", topic)
+                        .attr("producerName", producerName)
+                        .log("Failed to remove TCP no-delay property on client cnx");
             }
         }
     }
@@ -3568,9 +3796,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         try {
             return TopicName.get(topic);
         } catch (Throwable t) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed to parse topic name '{}'", remoteAddress, topic, t);
-            }
+            log.debug()
+                    .attr("topic", topic)
+                    .exception(t)
+                    .log("Failed to parse topic name ''");
 
             if (requestCommand instanceof CommandLookupTopic) {
                 writeAndFlush(Commands.newLookupErrorResponse(ServerError.InvalidTopicName,
@@ -3601,14 +3830,11 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     brokerInterceptor.messageDispatched(this, consumer, ledgerId, entryId, metadataAndPayload);
                 }
             } catch (Exception e) {
-                log.error("Exception occur when intercept messages.", e);
+                log.error().exception(e).log("Exception occur when intercept messages.");
             }
         }
         return res;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ServerCnx.class);
-
     /**
      * Helper method for testability.
      *
@@ -3809,11 +4035,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                              * {@link #connectionCheckInProgress} will be completed when
                              * {@link #channelInactive(ChannelHandlerContext)} event occurs, so skip set it here.
                              */
-                            log.warn("[{}] Connection check timed out. Closing connection.", this.toString());
+                            log.warn("Connection check timed out, closing connection");
                             ctx.close();
                         } else {
-                            log.error("[{}] Reached unexpected code block. Completing connection check.",
-                                    this.toString());
+                            log.error("Reached unexpected code block, completing connection check");
                             finalConnectionCheckInProgress.complete(Optional.of(true));
                         }
                     }, connectionLivenessCheckTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -3842,31 +4067,55 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         String topicString = topic.map(t -> ", topic=" + t.toString()).orElse("");
         Throwable actEx = FutureUtil.unwrapCompletionException(ex);
         if (actEx instanceof AuthenticationException) {
-            log.info("[{}] Failed to authenticate: operation={}, principal={}{}, reason={}",
-                    remoteAddress, operation, principal, topicString, actEx.getMessage());
+            LOG.info()
+                    .attr("remoteAddress", remoteAddress)
+                    .attr("operation", operation)
+                    .attr("principal", principal)
+                    .attr("topicString", topicString)
+                    .exceptionMessage(actEx)
+                    .log("Failed to authenticate");
             return;
         } else if (actEx instanceof WebApplicationException restException){
             // Do not print error log if users tries to access a not found resource.
             if (restException.getResponse().getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
-                log.info("[{}] Trying to authenticate for a topic which under a namespace not exists: operation={},"
-                                + " principal={}{}, reason: {}",
-                        remoteAddress, operation, principal, topicString, actEx.getMessage());
+                LOG.info()
+                        .attr("remoteAddress", remoteAddress)
+                        .attr("operation", operation)
+                        .attr("principal", principal)
+                        .attr("topicString", topicString)
+                        .exceptionMessage(actEx)
+                        .log("Trying to authenticate for a topic which under a namespace not exists");
                 return;
             }
         }
-        log.error("[{}] Error trying to authenticate: operation={}, principal={}{}",
-                remoteAddress, operation, principal, topicString, ex);
+        LOG.error()
+                .attr("remoteAddress", remoteAddress)
+                .attr("operation", operation)
+                .attr("principal", principal)
+                .attr("topicString", topicString)
+                .exception(ex)
+                .log("Error trying to authenticate");
     }
 
     private static void logNamespaceNameAuthException(SocketAddress remoteAddress, String operation,
                                          String principal, Optional<NamespaceName> namespaceName, Throwable ex) {
         String namespaceNameString = namespaceName.map(t -> ", namespace=" + t.toString()).orElse("");
         if (ex instanceof AuthenticationException) {
-            log.info("[{}] Failed to authenticate: operation={}, principal={}{}, reason={}",
-                    remoteAddress, operation, principal, namespaceNameString, ex.getMessage());
+            LOG.info()
+                    .attr("remoteAddress", remoteAddress)
+                    .attr("operation", operation)
+                    .attr("principal", principal)
+                    .attr("namespaceNameString", namespaceNameString)
+                    .exceptionMessage(ex)
+                    .log("Failed to authenticate");
         } else {
-            log.error("[{}] Error trying to authenticate: operation={}, principal={}{}",
-                    remoteAddress, operation, principal, namespaceNameString, ex);
+            LOG.error()
+                    .attr("remoteAddress", remoteAddress)
+                    .attr("operation", operation)
+                    .attr("principal", principal)
+                    .attr("namespaceNameString", namespaceNameString)
+                    .exception(ex)
+                    .log("Error trying to authenticate");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1262,13 +1262,9 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
 
             authState = authenticationProvider.newAuthState(clientData, remoteAddress, sslSession);
 
-            String role = "";
-            if (authState != null && authState.isComplete()) {
-                role = authState.getAuthRole();
-            } else {
-                role = "authentication incomplete or null";
-            }
-            log.debug().attr("role", role).log("Authenticate role");
+            log.debug().attr("role", () -> (authState != null && authState.isComplete())
+                    ? authState.getAuthRole() : "authentication incomplete or null")
+                    .log("Authenticate role");
 
             if (connect.hasOriginalPrincipal() && service.getPulsar().getConfig().isAuthenticateOriginalAuthData()
                     && !WEBSOCKET_DUMMY_ORIGINAL_PRINCIPLE.equals(connect.getOriginalPrincipal())) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnxThrottleTracker.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 
 /**
@@ -78,7 +78,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
  * @see ThrottleRes
  * @see ServerCnx
  */
-@Slf4j
+@CustomLog
 public final class ServerCnxThrottleTracker {
 
     private final ServerCnx serverCnx;
@@ -306,9 +306,7 @@ public final class ServerCnxThrottleTracker {
         ThrottleRes res = doMarkThrottled(type);
         recordMetricsAfterThrottling(type, res);
         if (res == ThrottleRes.ConnectionStateChanged && isChannelActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Setting auto read to false", serverCnx.toString());
-            }
+            log.debug().attr("cnx", serverCnx).log("Setting auto read to false");
             serverCnx.ctx().channel().config().setAutoRead(false);
         }
     }
@@ -338,9 +336,7 @@ public final class ServerCnxThrottleTracker {
         ThrottleRes res = doUnmarkThrottled(type);
         recordMetricsAfterUnthrottling(type, res);
         if (res == ThrottleRes.ConnectionStateChanged && isChannelActive()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Setting auto read to true", serverCnx.toString());
-            }
+            log.debug().attr("cnx", serverCnx).log("Setting auto read to true");
             serverCnx.ctx().channel().config().setAutoRead(true);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SharedConsumerAssignor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SharedConsumerAssignor.java
@@ -25,15 +25,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 
 /**
  * The assigner to assign entries to the proper {@link Consumer} in the shared subscription.
  */
-@Slf4j
+@CustomLog
 @RequiredArgsConstructor
 public class SharedConsumerAssignor {
 
@@ -63,8 +63,11 @@ public class SharedConsumerAssignor {
         Consumer consumer = getConsumer(numConsumers);
         if (consumer == null) {
             if (subscription != null) {
-                log.info("No consumer found to assign in topic:{}, subscription:{}, redelivering {} messages.",
-                        subscription.getTopic().getName(), subscription.getName(), entryAndMetadataList.size());
+                log.info()
+                        .attr("topic", subscription.getTopic().getName())
+                        .attr("subscription", subscription.getName())
+                        .attr("size", entryAndMetadataList.size())
+                        .log("No consumer found to assign, redelivering messages");
             }
             entryAndMetadataList.forEach(unassignedMessageProcessor);
             return consumerToEntries;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import lombok.CustomLog;
 import org.apache.commons.lang3.concurrent.ConcurrentInitializer;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.apache.commons.lang3.mutable.Mutable;
@@ -68,14 +69,13 @@ import org.apache.pulsar.common.stats.CacheMetricsCollector;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cached topic policies service will cache the system topic reader and the topic policies
  *
  * While reader cache for the namespace was removed, the topic policies will remove automatically.
  */
+@CustomLog
 public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesService {
 
     private final PulsarService pulsarService;
@@ -90,7 +90,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             try {
                 return new NamespaceEventsSystemTopicFactory(pulsarService.getClient());
             } catch (PulsarServerException e) {
-                log.error("Create namespace event system topic factory error.", e);
+                log.error().exception(e).log("Create namespace event system topic factory error.");
                 throw new RuntimeException(e);
             }
         }
@@ -131,7 +131,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     try {
                         ((SystemTopicClient.Writer) writer).close();
                     } catch (Exception e) {
-                        log.error("[{}] Close writer error.", namespaceName, e);
+                        log.error().attr("namespace", namespaceName).exception(e).log("Close writer error.");
                     }
                 })
                 .recordStats()
@@ -187,7 +187,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             // If the system topic named "__change_events" has been deleted, it means all the data in the topic have
             // been deleted, so we do not need to delete the message that we want to delete again.
             if (!exists) {
-                log.info("Skip delete topic-level policies because {} has been removed before", changeEvents);
+                log.info()
+                        .attr("changeEvents", changeEvents)
+                        .log("Skip delete topic-level policies because has been removed before");
                 return CompletableFuture.completedFuture(null);
             }
             // delete local policy
@@ -239,16 +241,19 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             .getPoliciesAsync(topicName.getNamespaceObject())
                             .thenCompose(namespacePolicies -> {
                                 if (namespacePolicies.isPresent() && namespacePolicies.get().deleted) {
-                                    log.debug("[{}] skip sending topic policy event since the namespace is deleted",
-                                            topicName);
+                                    log.debug()
+                                            .attr("topic", topicName)
+                                            .log("skip sending topic policy event since the namespace is deleted");
                                     return CompletableFuture.completedFuture(null);
                                 }
                                 return getTopicPoliciesAsync(partitionedTopicName,
                                         isGlobalPolicy ? GetType.GLOBAL_ONLY : GetType.LOCAL_ONLY)
                                         .thenCompose(currentPolicies -> {
                                             if (currentPolicies.isEmpty() && skipUpdateWhenTopicPolicyDoesntExist) {
-                                                log.debug("[{}] No existing policies, skipping sending event as "
-                                                        + "requested", topicName);
+                                                log.debug()
+                                                        .attr("topic", topicName)
+                                                        .log("No existing policies, skipping sending event as "
+                                                                + "requested");
                                                 return CompletableFuture.completedFuture(null);
                                             }
                                             TopicPolicies policiesToUpdate;
@@ -405,7 +410,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             try {
                 future.complete(null);
             } catch (Exception ex) {
-                log.error("Failed to complete pending future for message id {}.", messageId, ex);
+                log.error()
+                        .attr("messageId", messageId)
+                        .exception(ex)
+                        .log("Failed to complete pending future for message id.");
             }
         }
     }
@@ -428,8 +436,11 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     if (actionType == ActionType.DELETE) {
                         var future = writer.deleteAsync(eventKey, event);
                         future.exceptionally(ex -> {
-                            log.error("Failed to delete {} topic policy [{}] error.",
-                                    isGlobalPolicy ? "global" : "local", topicName, ex);
+                            log.error()
+                                    .attr("policyType", isGlobalPolicy ? "global" : "local")
+                                    .attr("topic", topicName)
+                                    .exception(ex)
+                                    .log("Failed to delete topic policy");
                             return null;
                         });
                         return future;
@@ -477,7 +488,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     try {
                         listener.onUpdate(null);
                     } catch (Throwable error) {
-                        log.error("[{}] call listener error.", topicName, error);
+                        log.error().attr("topic", topicName).exception(error).log("call listener error.");
                     }
                 }
             }
@@ -497,7 +508,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                 try {
                     listener.onUpdate(policies);
                 } catch (Throwable error) {
-                    log.error("[{}] call listener error.", topicName, error);
+                    log.error().attr("topic", topicName).exception(error).log("call listener error.");
                 }
             }
         }
@@ -538,7 +549,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             });
             final var p = policiesFutureHolder.get();
             if (!p.getLeft()) {
-                log.info("The future of {} has been removed from cache, retry getTopicPolicies again", namespace);
+                log.info()
+                        .attr("namespace", namespace)
+                        .log("The future of has been removed from cache, retry getTopicPolicies again");
                 return getTopicPoliciesAsync(topicName, type);
             }
             return CompletableFuture.completedFuture(p.getRight());
@@ -556,8 +569,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         if (previousCount == 0) {
             // initialize policies cache asynchronously on the first bundle load
             prepareInitPoliciesCacheAsync(namespace).exceptionally(t -> {
-                log.warn("Failed to prepare policies cache for namespace {} due to previously logged error ({}).",
-                        namespace, t.getMessage());
+                log.warn()
+                        .attr("namespace", namespace)
+                        .exceptionMessage(t)
+                        .log("Failed to prepare policies cache for namespace due to previously logged error");
                 return null;
             });
         }
@@ -574,8 +589,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         return pulsarService.getPulsarResources().getNamespaceResources().getPoliciesAsync(namespace)
                 .thenCompose(namespacePolicies -> {
                     if (namespacePolicies.isEmpty() || namespacePolicies.get().deleted) {
-                        log.info("[{}] skip prepare init policies cache since the namespace is deleted",
-                                namespace);
+                        log.info()
+                                .attr("namespace", namespace)
+                                .log("skip prepare init policies cache since the namespace is deleted");
                         return CompletableFuture.completedFuture(false);
                     }
 
@@ -598,8 +614,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                                 }).exceptionally(ex -> {
                                     try {
                                         if (readerCompletableFuture.isCompletedExceptionally()) {
-                                            log.error("[{}] Failed to create reader on __change_events topic",
-                                                    namespace, ex);
+                                            log.error()
+                                                    .attr("namespace", namespace)
+                                                    .exception(ex)
+                                                    .log("Failed to create reader on __change_events topic");
                                             initNamespacePolicyFuture.completeExceptionally(ex);
                                             cleanPoliciesCacheInitMap(namespace, true);
                                         } else {
@@ -608,8 +626,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                                         }
                                     } catch (Throwable cleanupEx) {
                                         // Adding this catch to avoid break callback chain
-                                        log.error("[{}] Failed to cleanup reader on __change_events topic",
-                                                namespace, cleanupEx);
+                                        log.error()
+                                                .attr("namespace", namespace)
+                                                .exception(cleanupEx)
+                                                .log("Failed to cleanup reader on __change_events topic");
                                     }
                                     return null;
                                 });
@@ -693,8 +713,10 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         }
         reader.hasMoreEventsAsync().whenComplete((hasMore, ex) -> {
             if (ex != null) {
-                log.error("[{}] Failed to check the move events for the system topic",
-                        reader.getSystemTopic().getTopicName(), ex);
+                log.error()
+                        .attr("topic", reader.getSystemTopic().getTopicName())
+                        .exception(ex)
+                        .log("Failed to check the move events for the system topic");
                 future.completeExceptionally(ex);
                 return;
             }
@@ -705,21 +727,22 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                     } finally {
                         msg.release();
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Loop next event reading for system topic.",
-                                reader.getSystemTopic().getTopicName().getNamespaceObject());
-                    }
+                    log.debug()
+                            .attr("namespaceObject", reader.getSystemTopic().getTopicName().getNamespaceObject())
+                            .log("Loop next event reading for system topic.");
                     initPolicesCache(reader, future);
                 }).exceptionally(e -> {
-                    log.error("[{}] Failed to read event from the system topic.",
-                            reader.getSystemTopic().getTopicName(), e);
+                    log.error()
+                            .attr("topic", reader.getSystemTopic().getTopicName())
+                            .exception(e)
+                            .log("Failed to read event from the system topic.");
                     future.completeExceptionally(e);
                     return null;
                 });
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Reach the end of the system topic.", reader.getSystemTopic().getTopicName());
-                }
+                log.debug()
+                        .attr("topic", reader.getSystemTopic().getTopicName())
+                        .log("Reach the end of the system topic.");
 
                 // replay policy message
                 policiesCache.forEach(((topicName, topicPolicies) -> {
@@ -728,7 +751,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             try {
                                 listener.onUpdate(topicPolicies);
                             } catch (Throwable error) {
-                                log.error("[{}] call listener error.", topicName, error);
+                                log.error().attr("topic", topicName).exception(error).log("call listener error.");
                             }
                         }
                     }
@@ -763,7 +786,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
             readerFuture
                     .thenCompose(SystemTopicClient.Reader::closeAsync)
                     .exceptionally(ex -> {
-                        log.warn("[{}] Close change_event reader fail.", namespace, ex);
+                        log.warn().attr("namespace", namespace).exception(ex).log("Close change_event reader fail.");
                         return null;
                     });
         }
@@ -797,7 +820,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         if (readerFuture != null && !readerFuture.isCompletedExceptionally()) {
             readerFuture.thenCompose(SystemTopicClient.Reader::closeAsync)
                     .exceptionally(ex -> {
-                        log.warn("[{}] Close change_event reader fail.", namespace, ex);
+                        log.warn().attr("namespace", namespace).exception(ex).log("Close change_event reader fail.");
                         return null;
                     });
         }
@@ -844,11 +867,12 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                         readMorePoliciesAsync(reader);
                     } else {
                         if (isAlreadyClosedException(ex)) {
-                            log.info("Closing the topic policies reader for {}",
-                                    reader.getSystemTopic().getTopicName());
+                            log.info()
+                                    .attr("topic", reader.getSystemTopic().getTopicName())
+                                    .log("Closing the topic policies reader for");
                             cleanPoliciesCacheInitMap(namespaceObject, true);
                         } else {
-                            log.warn("Read more topic polices exception, read again.", ex);
+                            log.warn().exception(ex).log("Read more topic polices exception, read again.");
                             readMorePoliciesAsync(reader);
                         }
                     }
@@ -883,7 +907,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             ? globalPoliciesCache.putIfAbsent(topicName, event.getPolicies())
                             : policiesCache.putIfAbsent(topicName, event.getPolicies());
                     if (old != null) {
-                        log.warn("Policy insert failed, the topic: {} policy already exist", topicName);
+                        log.warn()
+                                .attr("topic", topicName)
+                                .log("Policy insert failed, the topic: policy already exist");
                     }
                     break;
                 case UPDATE:
@@ -902,14 +928,17 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             event.getPolicies().isGlobalPolicies())
                             .whenComplete((__, ex) -> {
                                 if (ex != null) {
-                                    log.error("Failed to send delete topic policy event for {}", topicName, ex);
+                                    log.error()
+                                            .attr("topic", topicName)
+                                            .exception(ex)
+                                            .log("Failed to send delete topic policy event for");
                                 }
                             });
                     break;
                 case NONE:
                     break;
                 default:
-                    log.warn("Unknown event action type: {}", msg.getValue().getActionType());
+                    log.warn().attr("actionType", msg.getValue().getActionType()).log("Unknown event action type");
                     break;
             }
         }
@@ -941,7 +970,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         try {
             return namespaceEventsSystemTopicFactoryLazyInitializer.get();
         } catch (Exception e) {
-            log.error("Create namespace event system topic factory error.", e);
+            log.error().exception(e).log("Create namespace event system topic factory error.");
             throw new RuntimeException(e);
         }
     }
@@ -1006,9 +1035,6 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
     protected AsyncLoadingCache<NamespaceName, SystemTopicClient.Writer<PulsarEvent>> getWriterCaches() {
         return writerCaches;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(SystemTopicBasedTopicPoliciesService.class);
-
     @Override
     public void close() throws Exception {
         if (closed.compareAndSet(false, true)) {
@@ -1025,7 +1051,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
                             if (e == null) {
                                 log.info("Closed the reader for topic policies");
                             } else {
-                                log.error("Failed to close the reader for topic policies", e);
+                                log.error().exception(e).log("Failed to close the reader for topic policies");
                             }
                         });
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicTxnBufferSnapshotService.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.systopic.NamespaceEventsSystemTopicFactory;
@@ -36,7 +36,7 @@ import org.apache.pulsar.common.events.EventType;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 
-@Slf4j
+@CustomLog
 public class SystemTopicTxnBufferSnapshotService<T> {
 
     protected final ConcurrentHashMap<NamespaceName, SystemTopicClient<T>> clients;
@@ -72,7 +72,10 @@ public class SystemTopicTxnBufferSnapshotService<T> {
             this.snapshotService = snapshotService;
             this.future = future;
             this.future.exceptionally(t -> {
-                        log.error("[{}] Failed to create TB snapshot writer.", namespaceName, t);
+                        log.error()
+                                .attr("namespace", namespaceName)
+                                .exception(t)
+                                .log("Failed to create TB snapshot writer.");
                 snapshotService.refCountedWriterMap.remove(namespaceName, this);
                 return null;
             });
@@ -93,11 +96,12 @@ public class SystemTopicTxnBufferSnapshotService<T> {
                     final String topicName = writer.getSystemTopicClient().getTopicName().toString();
                     writer.closeAsync().exceptionally(t -> {
                         if (t != null) {
-                            log.error("[{}] Failed to close TB snapshot writer.", topicName, t);
+                            log.error()
+                                    .attr("topic", topicName)
+                                    .exception(t)
+                                    .log("Failed to close TB snapshot writer.");
                         } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Success to close TB snapshot writer.", topicName);
-                            }
+                            log.debug().attr("topic", topicName).log("Success to close TB snapshot writer.");
                         }
                         return null;
                     });
@@ -158,7 +162,10 @@ public class SystemTopicTxnBufferSnapshotService<T> {
             try {
                 entry.getValue().close();
             } catch (Exception e) {
-                log.error("Failed to close system topic client for namespace {}", entry.getKey(), e);
+                log.error()
+                        .attr("key", entry.getKey())
+                        .exception(e)
+                        .log("Failed to close system topic client for namespace");
             }
         }
         clients.clear();
@@ -169,7 +176,10 @@ public class SystemTopicTxnBufferSnapshotService<T> {
                     try {
                         writer.close();
                     } catch (Exception e) {
-                        log.error("Failed to close writer for namespace {}", entry.getKey(), e);
+                        log.error()
+                                .attr("key", entry.getKey())
+                                .exception(e)
+                                .log("Failed to close writer for namespace");
                     }
                 });
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
@@ -23,12 +23,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 
 /**
  * Utility class to dispatch topic events.
  */
-@Slf4j
+@CustomLog
 public class TopicEventsDispatcher {
     private final List<TopicEventsListener> topicEventListeners = new CopyOnWriteArrayList<>();
 
@@ -129,8 +129,13 @@ public class TopicEventsDispatcher {
         try {
             listener.handleEvent(topic, event, stage, t);
         } catch (Throwable ex) {
-            log.error("TopicEventsListener {} exception while handling {}_{} for topic {}",
-                    listener, event, stage, topic, ex);
+            log.error()
+                    .attr("listener", listener)
+                    .attr("event", event)
+                    .attr("stage", stage)
+                    .attr("topic", topic)
+                    .exception(ex)
+                    .log("TopicEventsListener exception while handling_ for topic");
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicListService.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -64,9 +65,8 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
 import org.apache.pulsar.metadata.api.NotificationType;
 import org.apache.pulsar.metadata.api.extended.SessionEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class TopicListService {
     public static class TopicListWatcher implements TopicListener {
         // upper bound for buffered topic list updates
@@ -151,8 +151,10 @@ public class TopicListService {
                 // if sendTopicListSuccess hasn't completed, add to a queue to be executed after it completes
                 if (!sendTopicListUpdateTasks.offer(task)) {
                     if (prepareUpdateTopics(null)) {
-                        log.warn("Update queue was full for watcher id {} matching {}. Performing full refresh.", id,
-                                topicsPattern.inputPattern());
+                        log.warn()
+                                .attr("watcherId", id)
+                                .attr("inputPattern", topicsPattern.inputPattern())
+                                .log("Update queue was full for watcher. Performing full refresh.");
                         executor.execute(() -> topicListService.updateTopicListWatcher(this));
                     }
                 }
@@ -222,7 +224,10 @@ public class TopicListService {
                 try {
                     callback.run();
                 } catch (Exception e) {
-                    log.warn("Error executing topic list update callback: {}", callback, e);
+                    log.warn()
+                            .attr("callback", callback)
+                            .exception(e)
+                            .log("Error executing topic list update callback");
                 }
             }
             updateCallbacks.clear();
@@ -286,10 +291,6 @@ public class TopicListService {
             }
         }
     }
-
-
-    private static final Logger log = LoggerFactory.getLogger(TopicListService.class);
-
     private final NamespaceService namespaceService;
     private final TopicResources topicResources;
     private final PulsarService pulsar;
@@ -350,7 +351,11 @@ public class TopicListService {
             } else {
                 msg += "Pattern longer than maximum: " + maxSubscriptionPatternLength;
             }
-            log.warn("[{}] {} on namespace {}", connection.toString(), msg, namespaceName);
+            log.warn()
+                    .attr("connection", connection)
+                    .attr("maxSubscriptionPatternLength", maxSubscriptionPatternLength)
+                    .attr("namespace", namespaceName)
+                    .log(msg);
             connection.getCommandSender().sendErrorResponse(requestId, ServerError.NotAllowedError, msg);
             lookupSemaphore.release();
             return;
@@ -360,8 +365,11 @@ public class TopicListService {
         try {
             topicsPattern = TopicsPatternFactory.create(topicsPatternString, topicsPatternRegexImplementation);
         } catch (Exception e) {
-            log.warn("[{}] Unable to create topic list watcher: Invalid pattern: {} on namespace {}",
-                    connection.toString(), topicsPatternString, namespaceName);
+            log.warn()
+                    .attr("connection", connection)
+                    .attr("topicsPatternString", topicsPatternString)
+                    .attr("namespace", namespaceName)
+                    .log("Unable to create topic list watcher: Invalid pattern");
             connection.getCommandSender().sendErrorResponse(requestId, ServerError.InvalidTopicName,
                     "Invalid topics pattern: " + e.getMessage());
             lookupSemaphore.release();
@@ -372,10 +380,10 @@ public class TopicListService {
         CompletableFuture<TopicListWatcher> existingWatcherFuture = watchers.putIfAbsent(watcherId, watcherFuture);
 
         if (existingWatcherFuture != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Watcher with the same watcherId={} is already created. Refreshing.", connection,
-                        watcherId);
-            }
+            log.debug()
+                    .attr("connection", connection)
+                    .attr("watcherId", watcherId)
+                    .log("Watcher with the same watcherId is already created. Refreshing.");
             // use the existing watcher if it's already created
             watcherFuture = existingWatcherFuture.thenCompose(watcher -> {
                 CompletableFuture<TopicListWatcher> future = new CompletableFuture<>();
@@ -404,18 +412,22 @@ public class TopicListService {
                     if (hash.equals(topicsHash)) {
                         topicList = Collections.emptyList();
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                                "[{}] Received WatchTopicList for namespace [//{}] by {}",
-                                connection.toString(), namespaceName, requestId);
-                    }
+                    log.debug()
+                            .attr("connection", connection)
+                            .attr("namespace", namespaceName)
+                            .attr("requestId", requestId)
+                            .log("Received WatchTopicList");
                     sendTopicListSuccessWithPermitAcquiringRetries(watcherId, requestId, topicList, hash,
                             watcher::sendingCompleted, watcher::close);
                     lookupSemaphore.release();
                 })
                 .exceptionally(ex -> {
-                    log.warn("[{}] Error WatchTopicList for namespace [//{}] by {}: {}",
-                            connection.toString(), namespaceName, requestId, ex.getMessage());
+                    log.warn()
+                            .attr("connection", connection)
+                            .attr("namespace", namespaceName)
+                            .attr("requestId", requestId)
+                            .exceptionMessage(ex)
+                            .log("Error WatchTopicList");
                     connection.getCommandSender().sendErrorResponse(requestId,
                             BrokerServiceException.getClientErrorCode(
                                     new BrokerServiceException.ServerMetadataException(ex)), ex.getMessage());
@@ -436,8 +448,11 @@ public class TopicListService {
                         .whenComplete((__, t) -> {
                             if (t != null) {
                                 // this is an unexpected case
-                                log.warn("[{}] Failed to send topic list success for watcherId={}. "
-                                        + "Watcher is not active.", connection, watcherId, t);
+                                log.warn()
+                                        .attr("connection", connection)
+                                        .attr("watcherId", watcherId)
+                                        .exception(t)
+                                        .log("Failed to send topic list success. Watcher is not active.");
                                 failedCompletionCallback.run();
                             } else {
                                 // completed successfully, run the callback
@@ -472,21 +487,31 @@ public class TopicListService {
                         || unwrappedException instanceof AsyncSemaphore.PermitAcquireQueueFullException)) {
                     // retry with backoff if permit acquisition fails due to timeout or queue full
                     long retryAfterMillis = this.retryBackoff.next().toMillis();
-                    log.info("[{}] {} when initializing topic list watcher watcherId={} for namespace {}. "
-                                    + "Retrying in {} " + "ms.", connection, unwrappedException.getMessage(), watcherId,
-                            namespace, retryAfterMillis);
+                    log.info()
+                            .attr("connection", connection)
+                            .exceptionMessage(unwrappedException)
+                            .attr("watcherId", watcherId)
+                            .attr("namespace", namespace)
+                            .attr("retryAfterMillis", retryAfterMillis)
+                            .log("when initializing topic list watcher for namespace. Retrying");
                     connection.ctx().executor().schedule(
                             () -> initializeTopicsListWatcher(watcherFuture, namespace, watcherId, topicsPattern),
                             retryAfterMillis, TimeUnit.MILLISECONDS);
                 } else {
-                    log.warn("[{}] Failed to initialize topic list watcher watcherId={} for namespace {}.", connection,
-                            watcherId, namespace, unwrappedException);
+                    log.warn()
+                            .attr("connection", connection)
+                            .attr("watcherId", watcherId)
+                            .attr("namespace", namespace)
+                            .exception(unwrappedException)
+                            .log("Failed to initialize topic list watcher");
                     watcherFuture.completeExceptionally(unwrappedException);
                 }
             } else {
                 if (!watcherFuture.complete(w)) {
-                    log.warn("[{}] Watcher future was already completed. Deregistering " + "watcherId={}.", connection,
-                            watcherId);
+                    log.warn()
+                            .attr("connection", connection)
+                            .attr("watcherId", watcherId)
+                            .log("Watcher future was already completed. Deregistering");
                     w.close();
                     topicResources.deregisterPersistentTopicListener(w);
                     watchers.remove(watcherId, watcherFuture);
@@ -569,15 +594,23 @@ public class TopicListService {
                         || unwrappedException instanceof AsyncSemaphore.PermitAcquireQueueFullException)) {
                     // retry with backoff if permit acquisition fails due to timeout or queue full
                     long retryAfterMillis = this.retryBackoff.next().toMillis();
-                    log.info("[{}] {} when updating topic list watcher watcherId={} for namespace {}. Retrying in {} "
-                                    + "ms.", connection, unwrappedException.getMessage(), watcherId, namespace,
-                            retryAfterMillis);
+                    log.info()
+                            .attr("connection", connection)
+                            .exceptionMessage(unwrappedException)
+                            .attr("watcherId", watcherId)
+                            .attr("namespace", namespace)
+                            .attr("retryAfterMillis", retryAfterMillis)
+                            .log("when updating topic list watcher for namespace. Retrying");
                     connection.ctx().executor()
                             .schedule(() -> internalUpdateTopicListWatcher(watcher, future),
                                     retryAfterMillis, TimeUnit.MILLISECONDS);
                 } else {
-                    log.warn("[{}] Failed to update topic list watcher watcherId={} for namespace {}.", connection,
-                            watcherId, namespace, unwrappedException);
+                    log.warn()
+                            .attr("connection", connection)
+                            .attr("watcherId", watcherId)
+                            .attr("namespace", namespace)
+                            .exception(unwrappedException)
+                            .log("Failed to update topic list watcher");
                     future.completeExceptionally(unwrappedException);
                 }
             } else {
@@ -597,8 +630,10 @@ public class TopicListService {
     public void deleteTopicListWatcher(Long watcherId) {
         CompletableFuture<TopicListWatcher> watcherFuture = watchers.remove(watcherId);
         if (watcherFuture == null) {
-            log.info("[{}] TopicListWatcher was not registered on the connection: {}",
-                    watcherId, connection.toString());
+            log.info()
+                    .attr("watcherId", watcherId)
+                    .attr("value", connection.toString())
+                    .log("TopicListWatcher was not registered on the connection");
             return;
         }
 
@@ -607,8 +642,10 @@ public class TopicListService {
             // We have received a request to close the watcher before it was actually completed, we have marked the
             // watcher future as failed and we can tell the client the close operation was successful. When the actual
             // create operation will complete, the new watcher will be discarded.
-            log.info("[{}] Closed watcher before its creation was completed. watcherId={}",
-                    connection.toString(), watcherId);
+            log.info()
+                    .attr("value", connection.toString())
+                    .attr("watcherId", watcherId)
+                    .log("Closed watcher before its creation was completed. watcherId");
             return;
         }
 
@@ -617,10 +654,15 @@ public class TopicListService {
             if (watcher != null) {
                 topicResources.deregisterPersistentTopicListener(watcher);
                 watcher.close();
-                log.info("[{}] Closed watcher, watcherId={}", connection.toString(), watcherId);
+                log.info()
+                        .attr("value", connection.toString())
+                        .attr("watcherId", watcherId)
+                        .log("Closed watcher, watcherId");
             } else if (t != null) {
-                log.info("[{}] Closed watcher that failed to be created. watcherId={}",
-                        connection.toString(), watcherId);
+                log.info()
+                        .attr("value", connection.toString())
+                        .attr("watcherId", watcherId)
+                        .log("Closed watcher that failed to be created. watcherId");
             }
         });
     }
@@ -638,8 +680,12 @@ public class TopicListService {
                         .whenComplete((__, t) -> {
                             if (t != null) {
                                 // this is an unexpected case
-                                log.warn("[{}] Failed to send topic list update for watcherId={}. Watcher will be in "
-                                        + "inconsistent state.", connection, watcherId, t);
+                                log.warn()
+                                        .attr("connection", connection)
+                                        .attr("watcherId", watcherId)
+                                        .exception(t)
+                                        .log("Failed to send topic list update for watcherId=. Watcher will be in "
+                                                + "inconsistent state.");
                             }
                             completionCallback.run();
                         }));
@@ -689,8 +735,13 @@ public class TopicListService {
             }
             long retryDelay = retryBackoff.next().toMillis();
             retryCount.incrementAndGet();
-            log.info("[{}] Cannot acquire direct memory tokens for sending {}. Retry {} in {} ms. {}", connection,
-                    operationName, retryCount.get(), retryDelay, t.getMessage());
+            log.info()
+                    .attr("connection", connection)
+                    .attr("operationName", operationName)
+                    .attr("get", retryCount.get())
+                    .attr("retryDelay", retryDelay)
+                    .exceptionMessage(t)
+                    .log("Cannot acquire direct memory tokens for sending. Retry in ms.");
             CompletableFuture<Void> future = new CompletableFuture<>();
             scheduledExecutor.schedule(() -> FutureUtil.completeAfter(future, operationRef.get()), retryDelay,
                     TimeUnit.MILLISECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.nonpersistent;
 
+import io.github.merlimat.slog.Logger;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -39,13 +40,14 @@ import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  */
 public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcherMultipleConsumers
         implements NonPersistentDispatcher {
+
+    private static final Logger LOG = Logger.get(NonPersistentDispatcherMultipleConsumers.class);
+    private final Logger log;
 
     private final NonPersistentTopic topic;
     protected final Subscription subscription;
@@ -69,18 +71,24 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
         this.name = topic.getName() + " / " + subscription.getName();
         this.msgDrop = new Rate();
         this.redeliveryTracker = RedeliveryTrackerDisabled.REDELIVERY_TRACKER_DISABLED;
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("subscription", subscription.getName())
+                .build();
     }
 
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed, closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
 
         if (isConsumersExceededOnSubscription()) {
-            log.warn("[{}] Attempting to add consumer to subscription which reached max consumers limit", name);
+            log.warn("Attempting to add consumer to subscription which reached max consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Subscription reached max consumers limit"));
         }
 
@@ -98,10 +106,10 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
-            log.info("Removed consumer {}", consumer);
+            log.info().attr("consumer", consumer).log("Removed consumer");
             if (consumerList.isEmpty()) {
                 if (closeFuture != null) {
-                    log.info("[{}] All consumers removed. Subscription is disconnected", name);
+                    log.info("All consumers removed, subscription is disconnected");
                     closeFuture.complete(null);
                 }
                 TOTAL_AVAILABLE_PERMITS_UPDATER.set(this, 0);
@@ -109,9 +117,7 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
                 TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -consumer.getAvailablePermits());
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
-            }
+            log.debug().attr("consumer", consumer).log("Trying to remove a non-connected consumer");
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -consumer.getAvailablePermits());
         }
     }
@@ -143,16 +149,14 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     @Override
     public synchronized void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
         if (!consumerSet.contains(consumer)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Ignoring flow control from disconnected consumer {}", name, consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control from disconnected consumer");
             return;
         }
 
         TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, additionalNumberOfMessages);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Trigger new read after receiving flow control message", consumer);
-        }
+        log.debug().attr("consumer", consumer).log("Trigger new read after receiving flow control message");
     }
 
     @Override
@@ -234,7 +238,4 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
     protected void reScheduleRead() {
         // No-op
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentDispatcherMultipleConsumers.class);
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import java.util.List;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.Consumer;
@@ -32,7 +32,7 @@ import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.stats.Rate;
 
-@Slf4j
+@CustomLog
 public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractDispatcherSingleActiveConsumer
         implements NonPersistentDispatcher {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -18,12 +18,12 @@
  */
 package org.apache.pulsar.broker.service.nonpersistent;
 
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -43,8 +43,10 @@ import org.apache.pulsar.common.policies.data.stats.NonPersistentReplicatorStats
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.FutureUtil;
 
-@Slf4j
 public class NonPersistentReplicator extends AbstractReplicator implements Replicator {
+
+    private static final Logger LOG = Logger.get(NonPersistentReplicator.class);
+    protected final Logger log;
 
     private final Rate msgOut = new Rate();
     private final Rate msgDrop = new Rate();
@@ -56,6 +58,7 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
                                    PulsarAdmin replicationAdmin) throws PulsarServerException {
         super(localCluster, topic, remoteCluster, topic.getName(), topic.getReplicatorPrefix(), brokerService,
                 replicationClient, replicationAdmin);
+        this.log = LOG.with().ctx(super.log).build();
         // NonPersistentReplicator does not support limitation so far, so reset pending queue size to the default value.
         producerBuilder.maxPendingMessages(1000);
         producerBuilder.blockIfQueueFull(false);
@@ -75,13 +78,10 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
         this.producer = (ProducerImpl) producer;
 
         if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Started)) {
-            log.info("[{}] Created replicator producer", replicatorId);
+            log.info("Created replicator producer");
             backOff.reset();
         } else {
-            log.info(
-                    "[{}] Replicator was stopped while creating the producer."
-                            + " Closing it. Replicator state: {}",
-                    replicatorId, STATE_UPDATER.get(this));
+            log.info("Replicator was stopped while creating the producer, closing it");
             doCloseProducerAsync(producer, () -> {});
             return;
         }
@@ -97,8 +97,11 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
             try {
                 msg = MessageImpl.deserializeSkipBrokerEntryMetaData(headersAndPayload);
             } catch (Throwable t) {
-                log.error("[{}] Failed to deserialize message at {} (buffer size: {}): {}", replicatorId,
-                        entry.getPosition(), length, t.getMessage(), t);
+                log.error()
+                        .attr("position", entry.getPosition())
+                        .attr("length", length)
+                        .exception(t)
+                        .log("Failed to deserialize message");
                 entry.release();
                 return;
             }
@@ -111,10 +114,11 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
             }
 
             if (msg.hasReplicateTo() && !msg.getReplicateTo().contains(remoteCluster)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Skipping message at {} / msg-id: {}: replicateTo {}", replicatorId,
-                            entry.getPosition(), msg.getMessageId(), msg.getReplicateTo());
-                }
+                log.debug()
+                        .attr("position", entry.getPosition())
+                        .attr("messageId", msg.getMessageId())
+                        .attr("replicateTo", msg.getReplicateTo())
+                        .log("Skipping message");
                 entry.release();
                 msg.recycle();
                 return;
@@ -131,10 +135,7 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
             producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
 
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] dropping message because replicator producer is not started/writable",
-                        replicatorId);
-            }
+            log.debug("Dropping message because replicator producer is not started/writable");
             msgDrop.recordEvent();
             stats.incrementMsgDropCount();
             entry.release();
@@ -182,15 +183,15 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
             if (exception != null) {
                 Throwable actEx = FutureUtil.unwrapCompletionException(exception);
                 if (actEx instanceof PulsarClientException.ProducerQueueIsFullError) {
-                    log.warn("[{}] Discard to replicate non-persistent messages to the remote cluster because the"
-                        + " producer pending queue is full", replicator.replicatorId);
+                    replicator.log.warn("Discarding non-persistent message replication because the producer "
+                            + "pending queue is full");
                 } else {
-                    log.error("[{}] Error producing on remote broker", replicator.replicatorId, exception);
+                    replicator.log.error()
+                            .exception(exception)
+                            .log("Error producing on remote broker");
                 }
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Message persisted on remote broker", replicator.replicatorId);
-                }
+                replicator.log.debug("Message persisted on remote broker");
             }
             entry.release();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentStickyKeyDispatcherMultipleConsumers.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -41,9 +42,8 @@ import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersistentDispatcherMultipleConsumers {
 
     private final StickyKeyConsumerSelector selector;
@@ -89,7 +89,10 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("name", name)
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -199,6 +202,4 @@ public class NonPersistentStickyKeyDispatcherMultipleConsumers extends NonPersis
     public boolean hasSameKeySharedPolicy(KeySharedMeta ksm) {
         return (ksm.getKeySharedMode() == this.keySharedMode);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentStickyKeyDispatcherMultipleConsumers.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import com.google.common.base.MoreObjects;
+import io.github.merlimat.slog.Logger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,10 +48,12 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.stats.ConsumerStatsImpl;
 import org.apache.pulsar.common.policies.data.stats.NonPersistentSubscriptionStatsImpl;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class NonPersistentSubscription extends AbstractSubscription {
+
+    private static final Logger LOG = Logger.get(NonPersistentSubscription.class);
+    private final Logger log;
+
     private final NonPersistentTopic topic;
     private volatile NonPersistentDispatcher dispatcher;
     private final String topicName;
@@ -78,6 +81,10 @@ public class NonPersistentSubscription extends AbstractSubscription {
         IS_FENCED_UPDATER.set(this, FALSE);
         this.subscriptionProperties = properties != null
                 ? Collections.unmodifiableMap(properties) : Collections.emptyMap();
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .build();
     }
 
     @Override
@@ -103,7 +110,7 @@ public class NonPersistentSubscription extends AbstractSubscription {
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_FENCED_UPDATER.get(this) == TRUE) {
-            log.warn("Attempting to add consumer {} on a fenced subscription", consumer);
+            log.warn().attr("consumer", consumer).log("Attempting to add consumer on a fenced subscription");
             return FutureUtil.failedFuture(new SubscriptionFencedException("Subscription is fenced"));
         }
 
@@ -151,9 +158,12 @@ public class NonPersistentSubscription extends AbstractSubscription {
 
             if (previousDispatcher != null) {
                 previousDispatcher.close().thenRun(() -> {
-                    log.info("[{}][{}] Successfully closed previous dispatcher", topicName, subName);
+                    log.info()
+                            .log("Successfully closed previous dispatcher");
                 }).exceptionally(ex -> {
-                    log.error("[{}][{}] Failed to close previous dispatcher", topicName, subName, ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to close previous dispatcher");
                     return null;
                 });
             }
@@ -185,10 +195,10 @@ public class NonPersistentSubscription extends AbstractSubscription {
         // invalid consumer remove will throw an exception
         // decrement usage is triggered only for valid consumer close
         topic.decrementUsageCount();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] [{}] Removed consumer -- count: {}", topic.getName(), subName, consumer.consumerName(),
-                    topic.currentUsageCount());
-        }
+        log.debug()
+                .attr("consumerName", consumer.consumerName())
+                .attr("currentUsageCount", topic.currentUsageCount())
+                .log("Removed consumer");
     }
 
     @Override
@@ -290,10 +300,13 @@ public class NonPersistentSubscription extends AbstractSubscription {
                 ? dispatcher.disconnectAllConsumers(false, assignedBrokerLookupData)
                 : CompletableFuture.completedFuture(null))
                 .thenRun(() -> {
-                    log.info("[{}][{}] Successfully disconnected subscription consumers", topicName, subName);
+                    log.info()
+                            .log("Successfully disconnected subscription consumers");
                     closeFuture.complete(null);
                 }).exceptionally(exception -> {
-                    log.error("[{}][{}] Error disconnecting subscription consumers", topicName, subName, exception);
+                    log.error()
+                            .exception(exception)
+                            .log("Error disconnecting subscription consumers");
                     closeFuture.completeExceptionally(exception);
                     return null;
                 });
@@ -325,14 +338,17 @@ public class NonPersistentSubscription extends AbstractSubscription {
                 ? dispatcher.close(disconnectConsumers, assignedBrokerLookupData)
                 : CompletableFuture.completedFuture(null))
                 .thenRun(() -> {
-                    log.info("[{}][{}] Successfully closed subscription", topicName, subName);
+                    log.info()
+                            .log("Successfully closed subscription");
                     closeFuture.complete(null);
                 }).exceptionally(exception -> {
                     IS_FENCED_UPDATER.set(this, FALSE);
                     if (dispatcher != null) {
                         dispatcher.reset();
                     }
-                    log.error("[{}][{}] Error closing subscription", topicName, subName, exception);
+                    log.error()
+                            .exception(exception)
+                            .log("Error closing subscription");
                     closeFuture.completeExceptionally(exception);
                     return null;
                 });
@@ -371,7 +387,7 @@ public class NonPersistentSubscription extends AbstractSubscription {
     private CompletableFuture<Void> delete(boolean closeIfConsumersConnected) {
         CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
 
-        log.info("[{}][{}] Unsubscribing", topicName, subName);
+        log.info().attr("topic", topicName).attr("subscription", subName).log("Unsubscribing");
 
         CompletableFuture<Void> closeSubscriptionFuture = new CompletableFuture<>();
 
@@ -379,7 +395,9 @@ public class NonPersistentSubscription extends AbstractSubscription {
             this.close(true, Optional.empty()).thenRun(() -> {
                 closeSubscriptionFuture.complete(null);
             }).exceptionally(ex -> {
-                log.error("[{}][{}] Error disconnecting and closing subscription", topicName, subName, ex);
+                log.error()
+                        .exception(ex)
+                        .log("Error disconnecting and closing subscription");
                 closeSubscriptionFuture.completeExceptionally(ex);
                 return null;
             });
@@ -387,7 +405,9 @@ public class NonPersistentSubscription extends AbstractSubscription {
             this.fence().thenRun(() -> {
                 closeSubscriptionFuture.complete(null);
             }).exceptionally(exception -> {
-                log.error("[{}][{}] Error closing subscription", topicName, subName, exception);
+                log.error()
+                        .exception(exception)
+                        .log("Error closing subscription");
                 closeSubscriptionFuture.completeExceptionally(exception);
                 return null;
             });
@@ -397,21 +417,26 @@ public class NonPersistentSubscription extends AbstractSubscription {
         closeSubscriptionFuture.thenCompose(v -> topic.unsubscribe(subName)).thenAccept(v -> {
             synchronized (this) {
                 (dispatcher != null ? dispatcher.close() : CompletableFuture.completedFuture(null)).thenRun(() -> {
-                    log.info("[{}][{}] Successfully deleted subscription", topicName, subName);
+                    log.info()
+                            .log("Successfully deleted subscription");
                     deleteFuture.complete(null);
                 }).exceptionally(ex -> {
                     IS_FENCED_UPDATER.set(this, FALSE);
                     if (dispatcher != null) {
                         dispatcher.reset();
                     }
-                    log.error("[{}][{}] Error deleting subscription", topicName, subName, ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Error deleting subscription");
                     deleteFuture.completeExceptionally(ex);
                     return null;
                 });
             }
         }).exceptionally(exception -> {
             IS_FENCED_UPDATER.set(this, FALSE);
-            log.error("[{}][{}] Error deleting subscription", topicName, subName, exception);
+            log.error()
+                    .exception(exception)
+                    .log("Error deleting subscription");
             deleteFuture.completeExceptionally(exception);
             return null;
         });
@@ -450,7 +475,7 @@ public class NonPersistentSubscription extends AbstractSubscription {
             future.completeExceptionally(
                     new ServerMetadataException("Unconnected or shared consumer attempting to unsubscribe"));
         } catch (BrokerServiceException e) {
-            log.warn("Error removing consumer {}", consumer);
+            log.warn().attr("consumer", consumer).log("Error removing consumer");
             future.completeExceptionally(e);
         }
         return future;
@@ -579,9 +604,6 @@ public class NonPersistentSubscription extends AbstractSubscription {
                 new Exception("Unsupported operation analyzeBacklog for NonPersistentSubscription"));
         return completableFuture;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentSubscription.class);
-
     public Map<String, String> getSubscriptionProperties() {
         return subscriptionProperties;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.mledger.impl.EntryImpl.create;
 import static org.apache.pulsar.common.policies.data.BacklogQuota.BacklogQuotaType;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.ArrayList;
@@ -101,10 +102,11 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.utils.StatsOutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPolicyListener {
+
+    private static final Logger LOG = Logger.get(NonPersistentTopic.class);
+    protected final Logger log;
 
     // Subscriptions to this topic
     private final Map<String, NonPersistentSubscription> subscriptions = new ConcurrentHashMap<>();
@@ -154,6 +156,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     public NonPersistentTopic(String topic, BrokerService brokerService) {
         super(topic, brokerService);
+        this.log = LOG.with().ctx(super.log).build();
         this.isFenced = false;
         registerTopicPolicyListener();
     }
@@ -169,7 +172,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 .thenCompose(optPolicies -> {
                     final Policies policies;
                     if (optPolicies.isEmpty()) {
-                        log.warn("[{}] Policies not present and isEncryptionRequired will be set to false", topic);
+                        log.warn("Policies not present and isEncryptionRequired will be set to false");
                         isEncryptionRequired = false;
                         policies = new Policies();
                     } else {
@@ -291,15 +294,17 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
             if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Consumer doesn't support batch-message {}", topic, subscriptionName);
-                }
+                log.debug()
+                        .attr("subscription", subscriptionName)
+                        .log("Consumer doesn't support batch-message");
                 future.completeExceptionally(new UnsupportedVersionException("Consumer doesn't support batch-message"));
                 return future;
             }
 
             if (subscriptionName.startsWith(replicatorPrefix)) {
-                log.warn("[{}] Failed to create subscription for {}", topic, subscriptionName);
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .log("Failed to create subscription");
                 future.completeExceptionally(
                         new NamingException("Subscription with reserved subscription name attempted"));
                 return future;
@@ -313,7 +318,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             lock.readLock().lock();
             try {
                 if (isFenced) {
-                    log.warn("[{}] Attempting to subscribe to a fenced topic", topic);
+                    log.warn("Attempting to subscribe to a fenced topic");
                     future.completeExceptionally(new TopicFencedException("Topic is temporarily unavailable"));
                     return future;
                 }
@@ -339,34 +344,50 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                         consumer.close();
                     } catch (BrokerServiceException e) {
                         if (e instanceof ConsumerBusyException) {
-                            log.warn("[{}][{}] Consumer {} {} already connected", topic, subscriptionName, consumerId,
-                                    consumerName);
+                            log.warn()
+                                    .attr("subscription", subscriptionName)
+                                    .attr("consumerId", consumerId)
+                                    .attr("consumerName", consumerName)
+                                    .log("Consumer already connected");
                         } else if (e instanceof SubscriptionBusyException) {
-                            log.warn("[{}][{}] {}", topic, subscriptionName, e.getMessage());
+                            log.warn()
+                                    .attr("subscription", subscriptionName)
+                                    .exceptionMessage(e)
+                                    .log("Failed to subscribe");
                         }
 
                         decrementUsageCount();
                         future.completeExceptionally(e);
                         return;
                     }
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] [{}] Subscribe failed -- count: {}", topic, subscriptionName,
-                                consumer.consumerName(), currentUsageCount());
-                    }
+                    log.debug()
+                            .attr("subscription", subscriptionName)
+                            .attr("consumerName", consumer.consumerName())
+                            .attr("usageCount", currentUsageCount())
+                            .log("Subscribe failed");
                     future.completeExceptionally(
                             new BrokerServiceException.ConnectionClosedException(
                                     "Connection was closed while the opening the cursor "));
                 } else {
-                    log.info("[{}][{}] Created new subscription for {}", topic, subscriptionName, consumerId);
+                    log.info()
+                            .attr("subscription", subscriptionName)
+                            .attr("consumerId", consumerId)
+                            .log("Created new subscription");
                     future.complete(consumer);
                 }
             }).exceptionally(e -> {
                 Throwable throwable = e.getCause();
                 if (throwable instanceof ConsumerBusyException) {
-                    log.warn("[{}][{}] Consumer {} {} already connected", topic, subscriptionName, consumerId,
-                            consumerName);
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .attr("consumerId", consumerId)
+                            .attr("consumerName", consumerName)
+                            .log("Consumer already connected");
                 } else if (throwable instanceof SubscriptionBusyException) {
-                    log.warn("[{}][{}] {}", topic, subscriptionName, e.getMessage());
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .exceptionMessage(e)
+                            .log("Failed to subscribe");
                 }
 
                 decrementUsageCount();
@@ -406,7 +427,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         lock.writeLock().lock();
         try {
             if (isFenced) {
-                log.warn("[{}] Topic is already being closed or deleted", topic);
+                log.warn("Topic is already being closed or deleted");
                 deleteFuture.completeExceptionally(new TopicFencedException("Topic is already fenced"));
                 return deleteFuture;
             }
@@ -420,7 +441,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 FutureUtil.waitForAll(futures).thenRun(() -> {
                     closeClientFuture.complete(null);
                 }).exceptionally(ex -> {
-                    log.error("[{}] Error closing clients", topic, ex);
+                    log.error().exception(ex).log("Error closing clients");
                     isFenced = false;
                     closeClientFuture.completeExceptionally(ex);
                     return null;
@@ -451,7 +472,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                     futures.add(deleteTopicPolicies());
                     FutureUtil.waitForAll(futures).whenComplete((v, ex) -> {
                         if (ex != null) {
-                            log.error("[{}] Error deleting topic", topic, ex);
+                            log.error().exception(ex).log("Error deleting topic");
                             isFenced = false;
                             deleteFuture.completeExceptionally(ex);
                         } else {
@@ -460,7 +481,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                             brokerService.executor().execute(() -> {
                                 brokerService.removeTopicFromCache(NonPersistentTopic.this);
                                 unregisterTopicPolicyListener();
-                                log.info("[{}] Topic deleted", topic);
+                                log.info("Topic deleted");
                                 deleteFuture.complete(null);
                             });
                         }
@@ -508,7 +529,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             if (!isFenced || closeWithoutWaitingClientDisconnect) {
                 isFenced = true;
             } else {
-                log.warn("[{}] Topic is already being closed or deleted", topic);
+                log.warn("Topic is already being closed or deleted");
                 closeFuture.completeExceptionally(new TopicFencedException("Topic is already fenced"));
                 return closeFuture;
             }
@@ -543,7 +564,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 try {
                     filter.close();
                 } catch (Throwable e) {
-                    log.warn("Error shutting down entry filter {}", filter, e);
+                    log.warn().attr("filter", filter).exception(e).log("Error shutting down entry filter");
                 }
             });
         }
@@ -553,7 +574,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                         : FutureUtil.waitForAll(futures);
 
         clientCloseFuture.thenRun(() -> {
-            log.info("[{}] Topic closed", topic);
+            log.info("Topic closed");
             // unload topic iterates over topics map and removing from the map with the same thread creates deadlock.
             // so, execute it in different thread
             brokerService.executor().execute(() -> {
@@ -566,7 +587,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
             });
         }).exceptionally(exception -> {
-            log.error("[{}] Error closing topic", topic, exception);
+            log.error().exception(exception).log("Error closing topic");
             isFenced = false;
             closeFuture.completeExceptionally(exception);
             return null;
@@ -589,9 +610,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             return CompletableFuture.completedFuture(null);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Checking replication status", name);
-        }
+        log.debug().attr("name", name).log("Checking replication status");
 
         Set<String> configuredClusters = new HashSet<>(topicPolicies.getReplicationClusters().get());
 
@@ -622,7 +641,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     CompletableFuture<Void> startReplicator(String remoteCluster) {
-        log.info("[{}] Starting replicator to remote: {}", topic, remoteCluster);
+        log.info().attr("remoteCluster", remoteCluster).log("Starting replicator to remote");
         String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
         return addReplicationCluster(remoteCluster, NonPersistentTopic.this, localCluster);
     }
@@ -641,7 +660,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                                     remoteCluster, brokerService, (PulsarClientImpl) replicationClient,
                                     replicationAdmin);
                         } catch (PulsarServerException e) {
-                            log.error("[{}] Replicator startup failed {}", topic, remoteCluster, e);
+                            log.error()
+                                    .attr("remoteCluster", remoteCluster)
+                                    .exception(e)
+                                    .log("Replicator startup failed");
                         }
                         return null;
                     });
@@ -654,17 +676,21 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     }
 
     CompletableFuture<Void> removeReplicator(String remoteCluster) {
-        log.info("[{}] Removing replicator to {}", topic, remoteCluster);
+        log.info().attr("remoteCluster", remoteCluster).log("Removing replicator to");
         final CompletableFuture<Void> future = new CompletableFuture<>();
 
         String name = NonPersistentReplicator.getReplicatorName(replicatorPrefix, remoteCluster);
 
         replicators.get(remoteCluster).terminate().thenRun(() -> {
-            log.info("[{}] Successfully removed replicator {}", name, remoteCluster);
+            log.info().attr("name", name).attr("remoteCluster", remoteCluster).log("Successfully removed replicator");
             replicators.remove(remoteCluster);
 
         }).exceptionally(e -> {
-            log.error("[{}] Failed to close replication producer {} {}", topic, name, e.getMessage(), e);
+            log.error()
+                    .attr("name", name)
+
+                    .exception(e)
+                    .log("Failed to close replication producer");
             future.completeExceptionally(e);
             return null;
         });
@@ -675,11 +701,13 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
     private CompletableFuture<Void> checkReplicationAndRetryOnFailure() {
         CompletableFuture<Void> result = new CompletableFuture<Void>();
         checkReplication().thenAccept(res -> {
-            log.info("[{}] Policies updated successfully", topic);
+            log.info("Policies updated successfully");
             result.complete(null);
         }).exceptionally(th -> {
-            log.error("[{}] Policies update failed {}, scheduled retry in {} seconds", topic, th.getMessage(),
-                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, th);
+            log.error()
+                    .exceptionMessage(th)
+                    .attr("POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS", POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS)
+                    .log("Policies update failed, scheduled retry in seconds");
             brokerService.executor().schedule(this::checkReplicationAndRetryOnFailure,
                     POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, TimeUnit.SECONDS);
             result.completeExceptionally(th);
@@ -840,8 +868,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 topicStats.aggMsgThroughputOut += subMsgThroughputOut;
                 nsStats.msgBacklog += subscription.getNumberOfEntriesInBacklog(false);
             } catch (Exception e) {
-                log.error("Got exception when creating consumer stats for subscription {}: {}", subscriptionName,
-                        e.getMessage(), e);
+                log.error()
+                        .attr("subscription", subscriptionName)
+                        .exception(e)
+                        .log("Got exception when creating consumer stats for subscription");
             }
         });
 
@@ -886,7 +916,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         try {
             return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getPreciseBacklog).get();
         } catch (InterruptedException | ExecutionException e) {
-            log.error("[{}] Fail to get stats", topic, e);
+            log.error().exception(e).log("Fail to get stats");
             return null;
         }
     }
@@ -896,7 +926,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         try {
             return asyncGetStats(getStatsOptions).get();
         } catch (InterruptedException | ExecutionException e) {
-            log.error("[{}] Fail to get stats", topic, e);
+            log.error().exception(e).log("Fail to get stats");
             return null;
         }
     }
@@ -1052,25 +1082,23 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 // Close repl producers first.
                 // Once all repl producers are closed, we can delete the topic,
                 // provided no remote producers connected to the broker.
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Topic inactive for {} seconds, closing repl producers.", topic,
-                        maxInactiveDurationInSec);
-                }
+                log.debug()
+                        .attr("maxInactiveDurationInSec", maxInactiveDurationInSec)
+                        .log("Topic inactive for seconds, closing repl producers.");
 
                 stopReplProducers().thenCompose(v -> delete(true, false))
                         .thenCompose(__ -> tryToDeletePartitionedMetadata())
-                        .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
+                        .thenRun(() -> log.info("Topic deleted successfully due to inactivity"))
                         .exceptionally(e -> {
                             Throwable throwable = e.getCause();
                             if (throwable instanceof TopicBusyException) {
                                 // topic became active again
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Did not delete busy topic: {}", topic,
-                                            throwable.getMessage());
-                                }
+                                log.debug()
+                                        .exceptionMessage(throwable)
+                                        .log("Did not delete busy topic");
                                 replicators.forEach((region, replicator) -> replicator.startProducer());
                             } else {
-                                log.warn("[{}] Inactive topic deletion failed", topic, e);
+                                log.warn().exception(e).log("Inactive topic deletion failed");
                             }
                             return null;
                         });
@@ -1120,10 +1148,10 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] isEncryptionRequired changes: {} -> {}", topic, isEncryptionRequired,
-                    data.encryption_required);
-        }
+        log.debug()
+                .attr("isEncryptionRequired", isEncryptionRequired)
+                .attr("encryption_required", data.encryption_required)
+                .log("isEncryptionRequired changes: ->");
 
         updateTopicPolicyByNamespacePolicy(data);
 
@@ -1143,7 +1171,11 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             return FutureUtil.waitForAll(consumerCheckFutures)
                     .thenCompose((___) -> checkReplicationAndRetryOnFailure());
         }).exceptionally(ex -> {
-            log.error("[{}] update namespace polices : {} error", this.getName(), data, ex);
+            log.error()
+                    .attr("name", this.getName())
+                    .attr("data", data)
+                    .exception(ex)
+                    .log("update namespace polices : error");
             throw FutureUtil.wrapToCompletionException(ex);
         });
     }
@@ -1217,9 +1249,6 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
         return FutureUtil.failedFuture(
                 new UnsupportedOperationException("getLastMessageId is not supported on non-persistent topic"));
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopic.class);
-
     @Override
     public CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema) {
         return hasSchema().thenCompose((hasSchema) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -20,15 +20,15 @@ package org.apache.pulsar.broker.service.persistent;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.Policies;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public abstract class DispatchRateLimiter {
     public enum Type {
         TOPIC,
@@ -153,14 +153,18 @@ public abstract class DispatchRateLimiter {
                 dispatchRate = createDispatchRate();
                 break;
             default:
-                log.warn("ignore configured dispatch rate for type {}", type);
+                log.warn().attr("type", type).log("ignore configured dispatch rate for type");
                 return;
         }
         if (type == Type.BROKER) {
-            log.info("configured broker message-dispatch rate {}", dispatchRate);
+            log.info().attr("dispatchRate", dispatchRate).log("configured broker message-dispatch rate");
         } else {
-            log.info("[{}] configured {} message-dispatch rate at broker {} subscriptionName [{}]",
-                    this.topicName, type, subscriptionName == null ? "null" : subscriptionName, dispatchRate);
+            log.info()
+                    .attr("topic", this.topicName)
+                    .attr("type", type)
+                    .attr("subscription", subscriptionName)
+                    .attr("dispatchRate", dispatchRate)
+                    .log("configured message-dispatch rate at broker");
         }
         updateDispatchRate(dispatchRate);
     }
@@ -210,6 +214,4 @@ public abstract class DispatchRateLimiter {
         return dispatchRate != null && (dispatchRate.getDispatchThrottlingRateInMsg() > 0
                 || dispatchRate.getDispatchThrottlingRateInByte() > 0);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(DispatchRateLimiter.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiterAsyncTokenBucketImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiterAsyncTokenBucketImpl.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.qos.AsyncTokenBucketBuilder;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.policies.data.DispatchRate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class DispatchRateLimiterAsyncTokenBucketImpl extends DispatchRateLimiter {
     private volatile AsyncTokenBucket dispatchRateLimiterOnMessage;
     private volatile AsyncTokenBucket dispatchRateLimiterOnByte;
@@ -102,7 +102,7 @@ public class DispatchRateLimiterAsyncTokenBucketImpl extends DispatchRateLimiter
     @Override
     public synchronized void updateDispatchRate(DispatchRate dispatchRate) {
         // synchronized to prevent race condition from concurrent zk-watch
-        log.info("setting message-dispatch-rate {}", dispatchRate);
+        log.info().attr("dispatchRate", dispatchRate).log("setting message-dispatch-rate");
 
         long msgRate = dispatchRate.getDispatchThrottlingRateInMsg();
         long byteRate = dispatchRate.getDispatchThrottlingRateInByte();
@@ -200,6 +200,4 @@ public class DispatchRateLimiterAsyncTokenBucketImpl extends DispatchRateLimiter
             dispatchRateLimiterOnByte = null;
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(DispatchRateLimiterAsyncTokenBucketImpl.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiterClassicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiterClassicImpl.java
@@ -20,12 +20,12 @@ package org.apache.pulsar.broker.service.persistent;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.util.RateLimiter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class DispatchRateLimiterClassicImpl extends DispatchRateLimiter {
     private volatile RateLimiter dispatchRateLimiterOnMessage;
     private volatile RateLimiter dispatchRateLimiterOnByte;
@@ -103,7 +103,7 @@ public class DispatchRateLimiterClassicImpl extends DispatchRateLimiter {
     @Override
     public synchronized void updateDispatchRate(DispatchRate dispatchRate) {
         // synchronized to prevent race condition from concurrent zk-watch
-        log.info("setting message-dispatch-rate {}", dispatchRate);
+        log.info().attr("dispatchRate", dispatchRate).log("setting message-dispatch-rate");
 
         long msgRate = dispatchRate.getDispatchThrottlingRateInMsg();
         long byteRate = dispatchRate.getDispatchThrottlingRateInByte();
@@ -210,6 +210,4 @@ public class DispatchRateLimiterClassicImpl extends DispatchRateLimiter {
             dispatchRateLimiterOnByte = null;
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(DispatchRateLimiterClassicImpl.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/GeoPersistentReplicator.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -37,8 +37,10 @@ import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.util.FutureUtil;
 
-@Slf4j
 public class GeoPersistentReplicator extends PersistentReplicator {
+
+    private static final Logger LOG = Logger.get(GeoPersistentReplicator.class);
+    protected final Logger log;
 
     public GeoPersistentReplicator(PersistentTopic topic, ManagedCursor cursor, String localCluster,
                                    String remoteCluster, BrokerService brokerService,
@@ -46,6 +48,7 @@ public class GeoPersistentReplicator extends PersistentReplicator {
             throws PulsarServerException {
         super(localCluster, topic, cursor, remoteCluster, topic.getName(), brokerService, replicationClient,
                 replicationAdmin);
+        this.log = LOG.with().ctx(super.log).build();
     }
 
     /**
@@ -97,9 +100,9 @@ public class GeoPersistentReplicator extends PersistentReplicator {
         // Remote topic doesn't exist - create it
         if (remotePartitions == -1) {
             if (!brokerService.getPulsar().getConfig().isCreateTopicToRemoteClusterForReplication()) {
-                String errorMsg = String.format("[%s] Can not start replicator because there is no topic on"
+                String errorMsg = String.format("Can not start replicator because there is no topic on"
                                 + " the remote cluster. Please create a %s on the remote cluster",
-                        replicatorId, localPartitions == 0 ? "non-partitioned topic"
+                        localPartitions == 0 ? "non-partitioned topic"
                                 : "partitioned topic with " + localPartitions + " partitions");
                 log.error(errorMsg);
                 return CompletableFuture.failedFuture(new PulsarServerException(errorMsg));
@@ -111,8 +114,10 @@ public class GeoPersistentReplicator extends PersistentReplicator {
 
             return createFuture.whenComplete((__, t) -> {
                 if (t != null) {
-                    log.error("[{}] Failed to create topic on remote cluster. Local has {} partitions",
-                            replicatorId, localPartitions, t);
+                    log.error()
+                            .attr("localPartitions", localPartitions)
+                            .exception(t)
+                            .log("Failed to create topic on remote cluster");
                 }
             });
         }
@@ -123,9 +128,9 @@ public class GeoPersistentReplicator extends PersistentReplicator {
         }
 
         // Incompatible partitions
-        String errorMsg = String.format("[%s] Can not start replicator because the partitions between"
+        String errorMsg = String.format("Can not start replicator because the partitions between"
                         + " local and remote cluster are different. local: %s, remote: %s",
-                replicatorId, localPartitions, remotePartitions);
+                localPartitions, remotePartitions);
         log.error(errorMsg);
         return CompletableFuture.failedFuture(new PulsarServerException(errorMsg));
     }
@@ -166,8 +171,11 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 try {
                     msg = MessageImpl.deserializeSkipBrokerEntryMetaData(headersAndPayload);
                 } catch (Throwable t) {
-                    log.error("[{}] Failed to deserialize message at {} (buffer size: {}): {}", replicatorId,
-                            entry.getPosition(), length, t.getMessage(), t);
+                    log.error()
+                            .attr("position", entry.getPosition())
+                            .attr("length", length)
+                            .exception(t)
+                            .log("Failed to deserialize message");
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -207,10 +215,10 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 }
 
                 if (msg.hasReplicateTo() && !msg.getReplicateTo().contains(remoteCluster)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Skipping message at position {}, replicateTo {}", replicatorId,
-                                entry.getPosition(), msg.getReplicateTo());
-                    }
+                    log.debug()
+                            .attr("position", entry.getPosition())
+                            .attr("replicateTo", msg.getReplicateTo())
+                            .log("Skipping message");
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -220,10 +228,10 @@ public class GeoPersistentReplicator extends PersistentReplicator {
 
                 if (msg.isExpired(messageTTLInSeconds)) {
                     msgExpired.recordEvent(0 /* no value stat */);
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Discarding expired message at position {}, replicateTo {}",
-                                replicatorId, entry.getPosition(), msg.getReplicateTo());
-                    }
+                    log.debug()
+                            .attr("position", entry.getPosition())
+                            .attr("replicateTo", msg.getReplicateTo())
+                            .log("Discarding expired message");
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -234,10 +242,9 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                 if (STATE_UPDATER.get(this) != State.Started || isLocalMessageSkippedOnce) {
                     // The producer is not ready yet after having stopped/restarted. Drop the message because it will
                     // recover when the producer is ready
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Dropping read message at {} because producer is not ready",
-                                replicatorId, entry.getPosition());
-                    }
+                    log.debug()
+                            .attr("position", entry.getPosition())
+                            .log("Dropping read message because producer is not ready");
                     isLocalMessageSkippedOnce = true;
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -269,13 +276,14 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     // Mark the replicator is fetching the schema for now and rewind the cursor
                     // and trigger the next read after complete the schema fetching.
                     skipRemainingMessages = true;
-                    log.info("[{}] Pause the data replication due to new detected schema", replicatorId);
+                    log.info("Pause the data replication due to new detected schema");
                     schemaFuture.whenComplete((__, e) -> {
                         if (e != null) {
-                            log.warn("[{}] Failed to get schema from local cluster, will try in the next loop",
-                                    replicatorId, e);
+                            log.warn()
+                                    .exception(e)
+                                    .log("Failed to get schema from local cluster, will try in the next loop");
                         }
-                        log.info("[{}] Resume the data replication after the schema fetching done", replicatorId);
+                        log.info("Resume the data replication after the schema fetching done");
                         doRewindCursor(true);
                     });
                 } else {
@@ -289,15 +297,18 @@ public class GeoPersistentReplicator extends PersistentReplicator {
                     stats.incrementMsgOutCounter();
                     stats.incrementBytesOutCounter(headersAndPayload.readableBytes());
                     // Increment pending messages for messages produced locally
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Publishing {}:{}", replicatorId, entry.getLedgerId(), entry.getEntryId());
-                    }
+                    log.debug()
+                            .attr("ledgerId", entry.getLedgerId())
+                            .attr("entryId", entry.getEntryId())
+                            .log("Publishing");
                     producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg, inFlightTask));
                     atLeastOneMessageSentForReplication = true;
                 }
             }
         } catch (Exception e) {
-            log.error("[{}] Unexpected exception in replication task: {}", replicatorId, e.getMessage(), e);
+            log.error()
+                    .exception(e)
+                    .log("Unexpected exception in replication task");
         }
         return atLeastOneMessageSentForReplication;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -23,6 +23,7 @@ import static org.apache.bookkeeper.mledger.util.ManagedLedgerUtils.openCursor;
 import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_IS_REPL_MARKER;
 import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import java.util.Iterator;
 import java.util.List;
@@ -46,13 +47,14 @@ import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class that contains all the logic to control and perform the deduplication on the broker side.
  */
 public class MessageDeduplication {
+
+    private static final Logger LOG = Logger.get(MessageDeduplication.class);
+    private final Logger log;
 
     private final PulsarService pulsar;
     private final PersistentTopic topic;
@@ -143,6 +145,7 @@ public class MessageDeduplication {
         this.snapshotCounter = 0;
         this.replicatorPrefix = pulsar.getConfiguration().getReplicatorPrefix();
         this.replayTask = new ManagedLedgerReplayTask("MessageDeduplication", pulsar.getExecutor(), 100);
+        this.log = LOG.with().attr("topic", topic.getName()).build();
     }
 
     public Status getStatus() {
@@ -168,7 +171,7 @@ public class MessageDeduplication {
                             @Override
                             public void deleteCursorComplete(Object ctx) {
                                 status = Status.Disabled;
-                                log.info("[{}] Deleted deduplication cursor", topic.getName());
+                                log.info("Deleted deduplication cursor");
                             }
 
                             @Override
@@ -176,7 +179,9 @@ public class MessageDeduplication {
                                 if (exception instanceof ManagedLedgerException.CursorNotFoundException) {
                                     status = Status.Disabled;
                                 } else {
-                            log.error("[{}] Deleted deduplication cursor error", topic.getName(), exception);
+                            log.error()
+                                    .exception(exception)
+                                    .log("Deleted deduplication cursor error");
                         }
                     }
                 }, null);
@@ -196,7 +201,7 @@ public class MessageDeduplication {
                                 highestSequencedPushed.clear();
                                 highestSequencedPersisted.clear();
                                 future.complete(null);
-                                log.info("[{}] Disabled deduplication", topic.getName());
+                                log.info("Disabled deduplication");
                             }
 
                             @Override
@@ -209,8 +214,9 @@ public class MessageDeduplication {
                                     highestSequencedPersisted.clear();
                                     future.complete(null);
                                 } else {
-                                    log.warn("[{}] Failed to disable deduplication: {}", topic.getName(),
-                                            exception.getMessage());
+                                    log.warn()
+                                            .exceptionMessage(exception)
+                                            .log("Failed to disable deduplication");
                                     status = Status.Failed;
                                     future.completeExceptionally(exception);
                                 }
@@ -224,7 +230,7 @@ public class MessageDeduplication {
                         .thenCompose(this::replayCursor);
                 future.exceptionally(e -> {
                     status = Status.Failed;
-                    log.error("[{}] Failed to enable deduplication", topic.getName(), e);
+                    log.error().exception(e).log("Failed to enable deduplication");
                     future.completeExceptionally(e);
                     return null;
                 });
@@ -245,8 +251,9 @@ public class MessageDeduplication {
             highestSequencedPersisted.put(k, v);
         });
         // Replay all the entries and apply all the sequence ids updates
-        log.info("[{}] Replaying {} entries for deduplication", topic.getName(),
-                managedCursor.getNumberOfEntries());
+        log.info()
+                .attr("numberOfEntries", managedCursor.getNumberOfEntries())
+                .log("Replaying entries for deduplication");
         return replayTask.replay(cursor, (__, buffer) -> {
             final var metadata = Commands.parseMessageMetadata(buffer);
             final var producerName = metadata.getProducerName();
@@ -266,7 +273,7 @@ public class MessageDeduplication {
             }
         }).thenRun(() -> {
             status = Status.Enabled;
-            log.info("[{}] Enabled deduplication", topic.getName());
+            log.info("Enabled deduplication");
         });
     }
 
@@ -334,17 +341,21 @@ public class MessageDeduplication {
             for (KeyValue kvPair : kvPairList) {
                 if (kvPair.getKey().equals(MSG_PROP_REPL_SOURCE_POSITION)) {
                     if (!kvPair.getValue().contains(":")) {
-                        log.warn("[{}] Unexpected {}: {}", publishContext.getProducerName(),
-                                MSG_PROP_REPL_SOURCE_POSITION,
-                                kvPair.getValue());
+                        log.warn()
+                                .attr("producerName", publishContext.getProducerName())
+                                .attr("MSG_PROP_REPL_SOURCE_POSITION", MSG_PROP_REPL_SOURCE_POSITION)
+                                .attr("value", kvPair.getValue())
+                                .log("Unexpected");
                         break;
                     }
                     String[] ledgerIdAndEntryId = kvPair.getValue().split(":");
                     if (ledgerIdAndEntryId.length != 2 || !StringUtils.isNumeric(ledgerIdAndEntryId[0])
                             || !StringUtils.isNumeric(ledgerIdAndEntryId[1])) {
-                        log.warn("[{}] Unexpected {}: {}", publishContext.getProducerName(),
-                                MSG_PROP_REPL_SOURCE_POSITION,
-                                kvPair.getValue());
+                        log.warn()
+                                .attr("producerName", publishContext.getProducerName())
+                                .attr("MSG_PROP_REPL_SOURCE_POSITION", MSG_PROP_REPL_SOURCE_POSITION)
+                                .attr("value", kvPair.getValue())
+                                .log("Unexpected");
                         break;
                     }
                     long[] positionPair = new long[]{Long.valueOf(ledgerIdAndEntryId[0]).longValue(),
@@ -359,12 +370,13 @@ public class MessageDeduplication {
     public MessageDupStatus isDuplicateReplV2(PublishContext publishContext, ByteBuf headersAndPayload) {
         Object positionPairObj = publishContext.getProperty(MSG_PROP_REPL_SOURCE_POSITION);
         if (positionPairObj == null || !(positionPairObj instanceof long[])) {
-            log.error("[{}] Message can not determine whether the message is duplicated due to the acquired messages"
-                            + " props were are invalid. producer={}. supportsReplDedupByLidAndEid: {}, sequence-id {},"
-                            + " prop-{}: not in expected format",
-                    topic.getName(), publishContext.getProducerName(),
-                    publishContext.supportsReplDedupByLidAndEid(), publishContext.getSequenceId(),
-                    MSG_PROP_REPL_SOURCE_POSITION);
+            log.error()
+                    .attr("producerName", publishContext.getProducerName())
+                    .attr("supportsReplDedupByLidAndEid", publishContext.supportsReplDedupByLidAndEid())
+                    .attr("sequenceId", publishContext.getSequenceId())
+                    .attr("propKey", MSG_PROP_REPL_SOURCE_POSITION)
+                    .log("Message cannot determine whether it is duplicated due to the acquired message "
+                            + "props being invalid, prop not in expected format");
             return MessageDupStatus.Unknown;
         }
 
@@ -381,12 +393,13 @@ public class MessageDeduplication {
                 && (replSequenceLId < lastSequenceLIdPushed.longValue()
                         || (replSequenceLId == lastSequenceLIdPushed.longValue()
                         && replSequenceEId <= lastSequenceEIdPushed.longValue()))) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Message identified as duplicated producer={}. publishing {}:{}, latest publishing"
-                            + " in-progress {}:{}",
-                            topic.getName(), publishContext.getProducerName(), lastSequenceLIdPushed,
-                            lastSequenceEIdPushed, lastSequenceLIdPushed, lastSequenceEIdPushed);
-                }
+                log.debug()
+                        .attr("producerName", publishContext.getProducerName())
+                        .attr("replSequenceLId", replSequenceLId)
+                        .attr("replSequenceEId", replSequenceEId)
+                        .attr("lastSequenceLIdPushed", lastSequenceLIdPushed)
+                        .attr("lastSequenceEIdPushed", lastSequenceEIdPushed)
+                        .log("Message identified as duplicated");
 
                 // Also need to check sequence ids that has been persisted.
                 // If current message's seq id is smaller or equals to the
@@ -397,12 +410,13 @@ public class MessageDeduplication {
                 // at a future time
                 Long lastSequenceLIdPersisted = highestSequencedPersisted.get(lastSequenceLIdKey);
                 Long lastSequenceEIdPersisted = highestSequencedPersisted.get(lastSequenceEIdKey);
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Message identified as duplicated producer={}. publishing {}:{}, latest"
-                                    + " persisted {}:{}",
-                            topic.getName(), publishContext.getProducerName(), replSequenceLId,
-                            replSequenceEId, lastSequenceLIdPersisted, lastSequenceEIdPersisted);
-                }
+                log.debug()
+                        .attr("producerName", publishContext.getProducerName())
+                        .attr("replSequenceLId", replSequenceLId)
+                        .attr("replSequenceEId", replSequenceEId)
+                        .attr("lastSequenceLIdPersisted", lastSequenceLIdPersisted)
+                        .attr("lastSequenceEIdPersisted", lastSequenceEIdPersisted)
+                        .log("Message identified as duplicated producer=. publishing:, latest" + "persisted");
                 if (lastSequenceLIdPersisted != null && lastSequenceEIdPersisted != null
                     && (replSequenceLId < lastSequenceLIdPersisted.longValue()
                         || (replSequenceLId == lastSequenceLIdPersisted.longValue()
@@ -415,10 +429,11 @@ public class MessageDeduplication {
             highestSequencedPushed.put(lastSequenceLIdKey, replSequenceLId);
             highestSequencedPushed.put(lastSequenceEIdKey, replSequenceEId);
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Message identified as non-duplicated producer={}. publishing {}:{}",
-                    topic.getName(), publishContext.getProducerName(), replSequenceLId, replSequenceEId);
-        }
+        log.debug()
+                .attr("producerName", publishContext.getProducerName())
+                .attr("replSequenceLId", replSequenceLId)
+                .attr("replSequenceEId", replSequenceEId)
+                .log("Message identified as non-duplicated producer=. publishing");
         return MessageDupStatus.NotDup;
     }
 
@@ -450,10 +465,11 @@ public class MessageDeduplication {
         synchronized (highestSequencedPushed) {
             Long lastSequenceIdPushed = highestSequencedPushed.get(producerName);
             if (lastSequenceIdPushed != null && sequenceId <= lastSequenceIdPushed) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Message identified as duplicated producer={} seq-id={} -- highest-seq-id={}",
-                            topic.getName(), producerName, sequenceId, lastSequenceIdPushed);
-                }
+                log.debug()
+                        .attr("producerName", producerName)
+                        .attr("sequenceId", sequenceId)
+                        .attr("lastSequenceIdPushed", lastSequenceIdPushed)
+                        .log("Message identified as duplicated");
 
                 // Also need to check sequence ids that has been persisted.
                 // If current message's seq id is smaller or equals to the
@@ -496,12 +512,14 @@ public class MessageDeduplication {
     public void recordMessagePersistedRepl(PublishContext publishContext, Position position) {
         Object positionPairObj = publishContext.getProperty(MSG_PROP_REPL_SOURCE_POSITION);
         if (positionPairObj == null || !(positionPairObj instanceof long[])) {
-            log.error("[{}] Can not persist highest sequence-id due to the acquired messages"
-                            + " props are invalid. producer={}. supportsReplDedupByLidAndEid: {}, sequence-id {},"
-                            + " prop-{}: not in expected format",
-                    topic.getName(), publishContext.getProducerName(),
-                    publishContext.supportsReplDedupByLidAndEid(), publishContext.getSequenceId(),
-                    MSG_PROP_REPL_SOURCE_POSITION);
+            log.error()
+                    .attr("producerName", publishContext.getProducerName())
+                    .attr("supportsReplDedupByLidAndEid", publishContext.supportsReplDedupByLidAndEid())
+                    .attr("sequenceId", publishContext.getSequenceId())
+                    .attr("MSG_PROP_REPL_SOURCE_POSITION", MSG_PROP_REPL_SOURCE_POSITION)
+                    .log("Can not persist highest sequence-id due to the acquired messages"
+                            + "props are invalid. producer=. supportsReplDedupByLidAndEid:, sequence-id,"
+                            + "prop-: not in expected format");
             recordMessagePersistedNormal(publishContext, position);
             return;
         }
@@ -537,10 +555,10 @@ public class MessageDeduplication {
             snapshotCounter = 0;
             takeSnapshot(position);
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Waiting for sequence-id snapshot {}/{}", topic.getName(), snapshotCounter,
-                        snapshotInterval);
-            }
+            log.debug()
+                    .attr("snapshotCounter", snapshotCounter)
+                    .attr("snapshotInterval", snapshotInterval)
+                    .log("Waiting for sequence-id snapshot");
         }
     }
 
@@ -556,12 +574,12 @@ public class MessageDeduplication {
     }
 
     private CompletableFuture<Void> takeSnapshot(Position position) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Taking snapshot of sequence ids map", topic.getName());
-        }
+        log.debug("Taking snapshot of sequence ids map");
 
         if (!snapshotTaking.compareAndSet(false, true)) {
-            log.warn("[{}] There is a pending snapshot when taking snapshot for {}", topic.getName(), position);
+            log.warn()
+                    .attr("position", position)
+                    .log("There is a pending snapshot when taking snapshot for");
             return CompletableFuture.completedFuture(null);
         }
 
@@ -574,18 +592,23 @@ public class MessageDeduplication {
 
         final var cursor = managedCursor;
         if (cursor == null) {
-            log.warn("[{}] Cursor is null when taking snapshot for {}", topic.getName(), position);
+            log.warn()
+                    .attr("position", position)
+                    .log("Cursor is null when taking snapshot for");
             return CompletableFuture.completedFuture(null);
         }
         final var future = markDelete(cursor, position, snapshot).thenRun(() -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Stored new deduplication snapshot at {}", topic.getName(), position);
-            }
+            log.debug()
+                    .attr("position", position)
+                    .log("Stored new deduplication snapshot at");
             lastSnapshotTimestamp = System.currentTimeMillis();
             snapshotTaking.set(false);
         });
         future.exceptionally(e -> {
-            log.warn("[{}] Failed to store new deduplication snapshot at {}", topic.getName(), position, e);
+            log.warn()
+                    .attr("position", position)
+                    .exception(e)
+                    .log("Failed to store new deduplication snapshot at");
             snapshotTaking.set(false);
             return null;
         });
@@ -639,7 +662,9 @@ public class MessageDeduplication {
             long lastActiveTimestamp = entry.getValue();
 
             if (lastActiveTimestamp < minimumActiveTimestamp) {
-                log.info("[{}] Purging dedup information for producer {}", topic.getName(), producerName);
+                log.info()
+                        .attr("producerName", producerName)
+                        .log("Purging dedup information for producer");
                 mapIterator.remove();
                 highestSequencedPushed.remove(producerName);
                 highestSequencedPersisted.remove(producerName);
@@ -687,6 +712,4 @@ public class MessageDeduplication {
     Map<String, Long> getInactiveProducers() {
         return inactiveProducers;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(MessageDeduplication.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAG
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import io.github.merlimat.slog.Logger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,13 +77,15 @@ import org.apache.pulsar.common.policies.data.stats.TopicMetricBean;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDispatcherMultipleConsumers {
+
+    private static final Logger LOG = Logger.get(PersistentDispatcherMultipleConsumers.class);
+    protected final Logger log;
+
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
     protected volatile Range<Position> lastIndividualDeletedRangeFromCursorRecovery;
@@ -157,6 +160,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         this.lastIndividualDeletedRangeFromCursorRecovery = cursor.getLastIndividualDeletedRange();
         this.name = topic.getName() + " / " + Codec.decode(cursor.getName());
         this.topic = topic;
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("subscription", Codec.decode(cursor.getName()))
+                .build();
         this.dispatchMessagesThread = topic.getBrokerService().getTopicOrderedExecutor().chooseThread();
         this.redeliveryMessages = new MessageRedeliveryController(allowOutOfOrderDelivery, false);
         this.redeliveryTracker = this.serviceConfig.isSubscriptionRedeliveryTrackerEnabled()
@@ -179,7 +186,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -201,14 +210,17 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
 
         if (isConsumersExceededOnSubscription()) {
-            log.warn("[{}] Attempting to add consumer to subscription which reached max consumers limit {}",
-                    name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Attempting to add consumer to subscription which reached max consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Subscription reached max consumers limit"));
         }
         // This is not an expected scenario, it will never happen in expected. Just print a warn log if the unexpected
         // scenario happens. See more detail: https://github.com/apache/pulsar/pull/22283.
         if (consumerSet.contains(consumer)) {
-            log.warn("[{}] Attempting to add a consumer that already registered {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Attempting to add a consumer that already registered");
         }
 
         consumerList.add(consumer);
@@ -232,13 +244,14 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
-            log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
+            log.info()
+                    .attr("consumer", consumer)
+                    .attr("pendingAcks", consumer.getPendingAcks().size())
+                    .log("Removed consumer with pending acks");
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Consumer are left, reading more entries", name);
-                }
+                log.debug("Consumers are left, reading more entries");
                 MutableBoolean notifyAddedToReplay = new MutableBoolean(false);
                 consumer.getPendingAcks().forEachAndClose((ledgerId, entryId, batchSize, stickyKeyHash) -> {
                     boolean addedToReplay = addMessageToReplay(ledgerId, entryId, stickyKeyHash);
@@ -247,11 +260,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                     }
                 });
                 totalAvailablePermits -= consumer.getAvailablePermits();
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Decreased totalAvailablePermits by {} in PersistentDispatcherMultipleConsumers. "
-                                    + "New dispatcher permit count is {}", name, consumer.getAvailablePermits(),
-                            totalAvailablePermits);
-                }
+                log.debug()
+                        .attr("diffAvailablePermits", consumer.getAvailablePermits())
+                        .attr("totalAvailablePermits", totalAvailablePermits)
+                        .log("Decreased totalAvailablePermits");
                 if (notifyAddedToReplay.booleanValue()) {
                     notifyRedeliveryMessageAdded();
                 }
@@ -262,7 +274,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
              * Just add a defensive code to avoid the topic can not be unloaded anymore: remove the consumers which
              * are not mismatch with {@link #consumerSet}. See more detail: https://github.com/apache/pulsar/pull/22270.
              */
-            log.error("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
+            log.error().attr("consumer", consumer).log("Trying to remove a non-connected consumer");
             consumerList.removeIf(c -> consumer.equals(c));
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
@@ -281,7 +293,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         redeliveryMessages.clear();
         redeliveryTracker.clear();
         if (closeFuture != null) {
-            log.info("[{}] All consumers removed. Subscription is disconnected", name);
+            log.info("All consumers removed. Subscription is disconnected");
             closeFuture.complete(null);
         }
         totalAvailablePermits = 0;
@@ -296,19 +308,19 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     private synchronized void internalConsumerFlow(Consumer consumer, int additionalNumberOfMessages) {
         if (!consumerSet.contains(consumer)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Ignoring flow control from disconnected consumer {}", name, consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control from disconnected consumer");
             return;
         }
 
         totalAvailablePermits += additionalNumberOfMessages;
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Trigger new read after receiving flow control message with permits {} "
-                            + "after adding {} permits", name, consumer,
-                    totalAvailablePermits, additionalNumberOfMessages);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("totalAvailablePermits", totalAvailablePermits)
+                .attr("additionalNumberOfMessages", additionalNumberOfMessages)
+                .log("Trigger new read after receiving flow control message");
         readMoreEntriesAsync();
     }
 
@@ -329,25 +341,17 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     public synchronized void readMoreEntries() {
         if (cursor.isClosed()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor is already closed, skipping read more entries.", cursor.getName());
-            }
+            log.debug("Cursor is already closed, skipping read more entries");
             return;
         }
         if (isSendInProgress()) {
             // we cannot read more entries while sending the previous batch
             // otherwise we could re-read the same entries and send duplicates
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to sending in-progress.",
-                        topic.getName(), getSubscriptionName());
-            }
+            log.debug("Skipping read due to sending in-progress");
             return;
         }
         if (shouldPauseDeliveryForDelayTracker()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to pause delivery for delay tracker.",
-                        topic.getName(), getSubscriptionName());
-            }
+            log.debug("Skipping read due to pause delivery for delay tracker");
             return;
         }
         if (topic.isTransferring()) {
@@ -385,10 +389,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             Set<Position> messagesToReplayNow =
                     canReplayMessages() ? getMessagesToReplayNow(messagesToRead, bytesToRead) : Collections.emptySet();
             if (!messagesToReplayNow.isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Schedule replay of {} messages for {} consumers", name,
-                            messagesToReplayNow.size(), consumerList.size());
-                }
+                log.debug()
+                        .attr("messagesToReplay", messagesToReplayNow.size())
+                        .attr("consumerCount", consumerList.size())
+                        .log("Schedule replay of messages for consumers");
                 havePendingReplayRead = true;
                 updateMinReplayedPosition();
                 Set<? extends Position> deletedMessages = topic.isDelayedDeliveryEnabled()
@@ -404,26 +408,23 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                     readMoreEntriesAsync();
                 }
             } else if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Dispatcher read is blocked due to unackMessages {} reached to max {}", name,
-                            totalUnackedMessages, topic.getMaxUnackedMessagesOnSubscription());
-                }
+                log.debug()
+                        .attr("totalUnackedMessages", totalUnackedMessages)
+                        .attr("maxUnackedMessagesOnSubscription", topic.getMaxUnackedMessagesOnSubscription())
+                        .log("Dispatcher read is blocked due to unackMessages reached to max");
             } else if (doesntHavePendingRead()) {
                 if (!isNormalReadAllowed()) {
                     handleNormalReadNotAllowed();
                     return;
                 }
                 if (shouldPauseOnAckStatePersist(ReadType.Normal)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] Skipping read for the topic, Due to blocked on ack state persistent.",
-                                topic.getName(), getSubscriptionName());
-                    }
+                    log.debug("Skipping read due to blocked on ack state persistent");
                     return;
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Schedule read of {} messages for {} consumers", name, messagesToRead,
-                            consumerList.size());
-                }
+                log.debug()
+                        .attr("messagesToRead", messagesToRead)
+                        .attr("consumersCount", consumerList.size())
+                        .log("Schedule read of messages");
                 havePendingRead = true;
                 updateMinReplayedPosition();
 
@@ -431,14 +432,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 cursor.asyncReadEntriesWithSkipOrWait(messagesToRead, bytesToRead, this, ReadType.Normal,
                         topic.getMaxReadPosition(), createReadEntriesSkipConditionForNormalRead());
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Cannot schedule next read until previous one is done", name);
-                }
+                log.debug("Cannot schedule next read until previous one is done");
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Consumer buffer is full, pause reading", name);
-            }
+            log.debug("Consumer buffer is full, pause reading");
         }
     }
 
@@ -521,9 +518,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     protected void reScheduleReadInMs(long readAfterMs) {
         if (isRescheduleReadInProgress.compareAndSet(false, true)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Reschedule message read in {} ms", topic.getName(), name, readAfterMs);
-            }
+            log.debug()
+                    .attr("readAfterMs", readAfterMs)
+                    .log("Reschedule message read");
             Runnable runnable = () -> {
                 isRescheduleReadInProgress.set(false);
                 readMoreEntries();
@@ -575,9 +572,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
 
         if (havePendingReplayRead) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Skipping replay while awaiting previous read to complete", name);
-            }
+            log.debug("Skipping replay while awaiting previous read to complete");
             return Pair.of(-1, -1L);
         }
 
@@ -683,9 +678,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
         if (readBatchSize < serviceConfig.getDispatcherMaxReadBatchSize()) {
             int newReadBatchSize = Math.min(readBatchSize * 2, serviceConfig.getDispatcherMaxReadBatchSize());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Increasing read batch size from {} to {}", name, readBatchSize, newReadBatchSize);
-            }
+            log.debug()
+                    .attr("readBatchSize", readBatchSize)
+                    .attr("newReadBatchSize", newReadBatchSize)
+                    .log("Increasing read batch size from to");
 
             readBatchSize = newReadBatchSize;
         }
@@ -701,9 +697,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Distributing {} messages to {} consumers", name, entries.size(), consumerList.size());
-        }
+        log.debug()
+                .attr("entryCount", entries.size())
+                .attr("consumerCount", consumerList.size())
+                .log("Distributing messages to consumers");
 
         long totalBytesSize = entries.stream().mapToLong(Entry::getLength).sum();
         updatePendingBytesToDispatch(totalBytesSize);
@@ -829,7 +826,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection
-                log.info("[{}] rewind because no available consumer found from total {}", name, consumerList.size());
+                log.info()
+                        .attr("consumerCount", consumerList.size())
+                        .log("Rewind because no available consumer found");
                 entries.subList(start, entries.size()).forEach(Entry::release);
                 cursor.rewind();
                 lastNumberOfEntriesProcessed = (int) totalEntriesProcessed;
@@ -837,10 +836,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             }
             // round-robin dispatch batch size for this consumer
             int availablePermits = c.isWritable() ? c.getAvailablePermits() : 1;
-            if (log.isDebugEnabled() && !c.isWritable()) {
-                log.debug("[{}-{}] consumer is not writable. dispatching only 1 message to {}; "
-                                + "availablePermits are {}", topic.getName(), name,
-                        c, c.getAvailablePermits());
+            if (!c.isWritable()) {
+                log.debug()
+                        .attr("consumer", c)
+                        .attr("availablePermits", c.getAvailablePermits())
+                        .log("Consumer is not writable, dispatching only 1 message");
             }
 
             int maxEntriesInThisBatch = getMaxEntriesInThisBatch(
@@ -876,11 +876,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             entriesToDispatch -= maxEntriesInThisBatch;
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this,
                     -(msgSent - batchIndexesAcks.getTotalAckedIndexCount()));
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Added -({} minus {}) permits to TOTAL_AVAILABLE_PERMITS_UPDATER in "
-                                + "PersistentDispatcherMultipleConsumers",
-                        name, msgSent, batchIndexesAcks.getTotalAckedIndexCount());
-            }
+            log.debug()
+                    .attr("msgSent", msgSent)
+                    .attr("totalAckedIndexCount", () -> batchIndexesAcks.getTotalAckedIndexCount())
+                    .log("Added permits to TOTAL_AVAILABLE_PERMITS_UPDATER");
             totalMessagesSent += sendMessageInfo.getTotalMessages();
             totalBytesSent += sendMessageInfo.getTotalBytes();
         }
@@ -889,10 +888,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         acquirePermitsForDeliveredMessages(topic, cursor, totalEntries, totalMessagesSent, totalBytesSent);
 
         if (entriesToDispatch > 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] No consumers found with available permits, storing {} positions for later replay", name,
-                        entries.size() - start);
-            }
+            log.debug()
+                    .attr("pending", entries.size() - start)
+                    .log("No consumers found with available permits, storing positions for later replay");
             entries.subList(start, entries.size()).forEach(this::addEntryToReplay);
         }
 
@@ -949,10 +947,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             final Consumer consumer = current.getKey();
             final List<EntryAndMetadata> entryAndMetadataList = current.getValue();
             final int messagesForC = Math.min(consumer.getAvailablePermits(), entryAndMetadataList.size());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] select consumer {} with messages num {}, read type is {}",
-                        name, consumer.consumerName(), messagesForC, readType);
-            }
+            log.debug()
+                    .attr("consumerName", consumer.consumerName())
+                    .attr("messagesForC", messagesForC)
+                    .attr("readType", readType)
+                    .log("select consumer with messages num, read type is");
             if (messagesForC < entryAndMetadataList.size()) {
                 for (int i = messagesForC; i < entryAndMetadataList.size(); i++) {
                     final EntryAndMetadata entry = entryAndMetadataList.get(i);
@@ -1005,9 +1004,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
         // Do not keep reading more entries if the cursor is already closed.
         if (exception instanceof ManagedLedgerException.CursorAlreadyClosedException) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor is already closed, skipping read more entries", cursor.getName());
-            }
+            log.debug("Cursor is already closed, skipping read more entries");
             // Set the wait time to -1 to avoid rescheduling the read.
             waitTimeMillis = -1;
         } else if (exception instanceof NoMoreEntriesToReadException) {
@@ -1019,18 +1016,25 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         } else if (exception.getCause() instanceof TransactionBufferException.TransactionNotSealedException
                 || exception.getCause() instanceof ManagedLedgerException.OffloadReadHandleClosedException) {
             waitTimeMillis = 1;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading transaction entries : {}, Read Type {} - Retrying to read in {} seconds",
-                        name, exception.getMessage(), readType, waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading transaction entries - Retrying to read");
         } else if (!(exception instanceof TooManyRequestsException)) {
-            log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
-                    cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
+            log.error()
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading entries - Retrying to read");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
-                        cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading entries - Retrying to read");
         }
 
         if (shouldRewindBeforeReadingOrReplaying) {
@@ -1063,10 +1067,13 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 // another scheduled read, otherwise we'd be stuck until
                 // more messages are published.
                 if (!havePendingRead || readType == ReadType.Replay) {
-                    log.info("[{}] Retrying read operation", name);
+                    log.info("Retrying read operation");
                     readMoreEntries();
                 } else {
-                    log.info("[{}] Skipping read retry: havePendingRead {}", name, havePendingRead, e);
+                    log.info()
+                            .attr("havePendingRead", havePendingRead)
+                            .exception(e)
+                            .log("Skipping read retry: havePendingRead");
                 }
             }
         }, waitTimeMillis, TimeUnit.MILLISECONDS);
@@ -1113,9 +1120,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 return true;
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] consumer is not writable", topic.getName(), name);
-        }
+        log.debug("Consumer is not writable");
         return false;
     }
 
@@ -1127,10 +1132,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     @Override
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, long consumerEpoch) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer,
-                    redeliveryMessages);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("redeliveryMessages", redeliveryMessages)
+                .log("- Redelivering unacknowledged messages for consumer");
         MutableBoolean addedToReplay = new MutableBoolean(false);
         consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
             if (addMessageToReplay(ledgerId, entryId, stickyKeyHash)) {
@@ -1145,9 +1150,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     @Override
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, List<Position> positions) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer, positions);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("positions", positions)
+                .log("- Redelivering unacknowledged messages for consumer");
         MutableBoolean addedToReplay = new MutableBoolean(false);
         positions.forEach(position -> {
             // TODO: We want to pass a sticky key hash as a third argument to guarantee the order of the messages
@@ -1168,7 +1174,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         // don't block dispatching if maxUnackedMessages = 0
         if (maxUnackedMessages <= 0 && blockedDispatcherOnUnackedMsgs == TRUE
                 && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
-            log.info("[{}] Dispatcher is unblocked, since maxUnackedMessagesPerSubscription=0", name);
+            log.info("Dispatcher is unblocked, since maxUnackedMessagesPerSubscription=0");
             readMoreEntriesAsync();
         }
 
@@ -1176,8 +1182,10 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         if (unAckedMessages >= maxUnackedMessages && maxUnackedMessages > 0
                 && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, FALSE, TRUE)) {
             // block dispatcher if it reaches maxUnAckMsg limit
-            log.debug("[{}] Dispatcher is blocked due to unackMessages {} reached to max {}", name,
-                    unAckedMessages, maxUnackedMessages);
+            log.debug()
+                    .attr("unAckedMessages", unAckedMessages)
+                    .attr("maxUnackedMessages", maxUnackedMessages)
+                    .log("Dispatcher is blocked due to unackMessages reached to max");
         } else if (topic.getBrokerService().isBrokerDispatchingBlocked()
                 && blockedDispatcherOnUnackedMsgs == TRUE) {
             // unblock dispatcher: if dispatcher is blocked due to broker-unackMsg limit and if it ack back enough
@@ -1191,7 +1199,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         } else if (blockedDispatcherOnUnackedMsgs == TRUE && unAckedMessages < maxUnackedMessages / 2) {
             // unblock dispatcher if it acks back enough messages
             if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
-                log.debug("[{}] Dispatcher is unblocked", name);
+                log.debug("Dispatcher is unblocked");
                 readMoreEntriesAsync();
             }
         }
@@ -1318,9 +1326,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     protected synchronized NavigableSet<Position> getMessagesToReplayNow(int maxMessagesToRead, long bytesToRead) {
         int cappedMaxMessagesToRead = cursor.applyMaxSizeCap(maxMessagesToRead, bytesToRead);
-        if (cappedMaxMessagesToRead < maxMessagesToRead && log.isDebugEnabled()) {
-            log.debug("[{}] Capped max messages to read from redelivery list to {} (max was {})",
-                    name, cappedMaxMessagesToRead, maxMessagesToRead);
+        if (cappedMaxMessagesToRead < maxMessagesToRead) {
+            log.debug()
+                    .attr("cappedMaxMessagesToRead", cappedMaxMessagesToRead)
+                    .attr("maxMessagesToRead", maxMessagesToRead)
+                    .log("Capped max messages to read from redelivery list");
         }
         if (delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().hasMessageAvailable()) {
             delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
@@ -1400,9 +1410,11 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
     protected boolean addMessageToReplay(long ledgerId, long entryId, long stickyKeyHash) {
         if (checkIfMessageIsUnacked(ledgerId, entryId)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Adding message to replay for {}:{} hash: {}", name, ledgerId, entryId, stickyKeyHash);
-            }
+            log.debug()
+                    .attr("ledgerId", ledgerId)
+                    .attr("entryId", entryId)
+                    .attr("stickyKeyHash", stickyKeyHash)
+                    .log("Adding message to replay for: hash");
             redeliveryMessages.add(ledgerId, entryId, stickyKeyHash);
             return true;
         } else {
@@ -1440,7 +1452,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         // consider dispatch is stuck if : dispatcher has backlog, available-permits and there is no pending read
         if (isAtleastOneConsumerAvailable() && !havePendingReplayRead && !havePendingRead
                 && cursor.getNumberOfEntriesInBacklog(false) > 0) {
-            log.warn("{}-{} Dispatcher is stuck and unblocking by issuing reads", topic.getName(), name);
+            log.warn("Dispatcher is stuck and unblocking by issuing reads");
             readMoreEntriesAsync();
             return true;
         }
@@ -1499,6 +1511,4 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     public boolean isHavePendingReplayRead() {
         return havePendingReplayRead;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherMultipleConsumers.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAG
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import io.github.merlimat.slog.Logger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -75,8 +76,6 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is the "classic" dispatcher implementation for the Shared subscription that was used before
@@ -85,6 +84,10 @@ import org.slf4j.LoggerFactory;
  * in case of issues with the preferred implementation.
  */
 public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersistentDispatcherMultipleConsumers {
+
+    private static final Logger LOG = Logger.get(PersistentDispatcherMultipleConsumersClassic.class);
+    protected final Logger log;
+
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
     protected volatile Range<Position> lastIndividualDeletedRangeFromCursorRecovery;
@@ -151,6 +154,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         this.lastIndividualDeletedRangeFromCursorRecovery = cursor.getLastIndividualDeletedRange();
         this.name = topic.getName() + " / " + Codec.decode(cursor.getName());
         this.topic = topic;
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("subscription", Codec.decode(cursor.getName()))
+                .build();
         this.dispatchMessagesThread = topic.getBrokerService().getTopicOrderedExecutor().chooseThread();
         this.redeliveryMessages = new MessageRedeliveryController(allowOutOfOrderDelivery, true);
         this.redeliveryTracker = this.serviceConfig.isSubscriptionRedeliveryTrackerEnabled()
@@ -168,7 +175,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -190,14 +199,17 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         }
 
         if (isConsumersExceededOnSubscription()) {
-            log.warn("[{}] Attempting to add consumer to subscription which reached max consumers limit {}",
-                    name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Attempting to add consumer to subscription which reached max consumers limit");
             return FutureUtil.failedFuture(new ConsumerBusyException("Subscription reached max consumers limit"));
         }
         // This is not an expected scenario, it will never happen in expected. Just print a warn log if the unexpected
         // scenario happens. See more detail: https://github.com/apache/pulsar/pull/22283.
         if (consumerSet.contains(consumer)) {
-            log.warn("[{}] Attempting to add a consumer that already registered {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Attempting to add a consumer that already registered");
         }
 
         consumerList.add(consumer);
@@ -221,22 +233,23 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         addUnAckedMessages(-consumer.getUnackedMessages());
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
-            log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());
+            log.info()
+                    .attr("consumer", consumer)
+                    .attr("size", consumer.getPendingAcks().size())
+                    .log("Removed consumer with pending acks");
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Consumer are left, reading more entries", name);
-                }
+                log.debug("Consumer are left, reading more entries");
                 consumer.getPendingAcks().forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
                     addMessageToReplay(ledgerId, entryId, stickyKeyHash);
                 });
                 totalAvailablePermits -= consumer.getAvailablePermits();
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Decreased totalAvailablePermits by {} in PersistentDispatcherMultipleConsumers. "
-                                    + "New dispatcher permit count is {}", name, consumer.getAvailablePermits(),
-                            totalAvailablePermits);
-                }
+                log.debug()
+                        .attr("availablePermits", consumer.getAvailablePermits())
+                        .attr("totalAvailablePermits", totalAvailablePermits)
+                        .log("Decreased totalAvailablePermits by in PersistentDispatcherMultipleConsumers. "
+                                + "New dispatcher permit count is");
                 readMoreEntries();
             }
         } else {
@@ -245,7 +258,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
              * Just add a defensive code to avoid the topic can not be unloaded anymore: remove the consumers which
              * are not mismatch with {@link #consumerSet}. See more detail: https://github.com/apache/pulsar/pull/22270.
              */
-            log.error("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
+            log.error().attr("consumer", consumer).log("Trying to remove a non-connected consumer");
             consumerList.removeIf(c -> consumer.equals(c));
             if (consumerList.isEmpty()) {
                 clearComponentsAfterRemovedAllConsumers();
@@ -259,7 +272,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         redeliveryMessages.clear();
         redeliveryTracker.clear();
         if (closeFuture != null) {
-            log.info("[{}] All consumers removed. Subscription is disconnected", name);
+            log.info("All consumers removed. Subscription is disconnected");
             closeFuture.complete(null);
         }
         totalAvailablePermits = 0;
@@ -274,19 +287,19 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
 
     private synchronized void internalConsumerFlow(Consumer consumer, int additionalNumberOfMessages) {
         if (!consumerSet.contains(consumer)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Ignoring flow control from disconnected consumer {}", name, consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control from disconnected consumer");
             return;
         }
 
         totalAvailablePermits += additionalNumberOfMessages;
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Trigger new read after receiving flow control message with permits {} "
-                            + "after adding {} permits", name, consumer,
-                    totalAvailablePermits, additionalNumberOfMessages);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("totalAvailablePermits", totalAvailablePermits)
+                .attr("additionalNumberOfMessages", additionalNumberOfMessages)
+                .log("- Trigger new read after receiving flow control message with permits " + "after adding permits");
         readMoreEntries();
     }
 
@@ -300,25 +313,17 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
 
     public synchronized void readMoreEntries() {
         if (cursor.isClosed()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor is already closed, skipping read more entries.", cursor.getName());
-            }
+            log.debug("Cursor is already closed, skipping read more entries");
             return;
         }
         if (isSendInProgress()) {
             // we cannot read more entries while sending the previous batch
             // otherwise we could re-read the same entries and send duplicates
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to sending in-progress.",
-                        topic.getName(), getSubscriptionName());
-            }
+            log.debug("Skipping read due to sending in-progress");
             return;
         }
         if (shouldPauseDeliveryForDelayTracker()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to pause delivery for delay tracker.",
-                        topic.getName(), getSubscriptionName());
-            }
+            log.debug("Skipping read due to pause delivery for delay tracker");
             return;
         }
         if (topic.isTransferring()) {
@@ -342,10 +347,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             NavigableSet<Position> messagesToReplayNow = getMessagesToReplayNow(messagesToRead);
             NavigableSet<Position> messagesToReplayFiltered = filterOutEntriesWillBeDiscarded(messagesToReplayNow);
             if (!messagesToReplayFiltered.isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Schedule replay of {} messages for {} consumers", name,
-                            messagesToReplayFiltered.size(), consumerList.size());
-                }
+                log.debug()
+                        .attr("messagesToReplay", messagesToReplayFiltered.size())
+                        .attr("consumerCount", consumerList.size())
+                        .log("Schedule replay of messages for consumers");
 
                 havePendingReplayRead = true;
                 minReplayedPosition = messagesToReplayNow.first();
@@ -363,22 +368,19 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                     readMoreEntriesAsync();
                 }
             } else if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.get(this) == TRUE) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Dispatcher read is blocked due to unackMessages {} reached to max {}", name,
-                            totalUnackedMessages, topic.getMaxUnackedMessagesOnSubscription());
-                }
+                log.debug()
+                        .attr("totalUnackedMessages", totalUnackedMessages)
+                        .attr("maxUnackedMessagesOnSubscription", topic.getMaxUnackedMessagesOnSubscription())
+                        .log("Dispatcher read is blocked due to unackMessages reached to max");
             } else if (!havePendingRead && hasConsumersNeededNormalRead()) {
                 if (shouldPauseOnAckStatePersist(ReadType.Normal)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] [{}] Skipping read for the topic, Due to blocked on ack state persistent.",
-                                topic.getName(), getSubscriptionName());
-                    }
+                    log.debug("Skipping read due to blocked on ack state persistent");
                     return;
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Schedule read of {} messages for {} consumers", name, messagesToRead,
-                            consumerList.size());
-                }
+                log.debug()
+                        .attr("messagesToRead", messagesToRead)
+                        .attr("consumersCount", consumerList.size())
+                        .log("Schedule read of messages");
                 havePendingRead = true;
                 NavigableSet<Position> toReplay = getMessagesToReplayNow(1);
                 if (!toReplay.isEmpty()) {
@@ -403,21 +405,14 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                             topic.getMaxReadPosition());
                 }
             } else {
-                if (log.isDebugEnabled()) {
-                    if (!messagesToReplayNow.isEmpty()) {
-                        log.debug("[{}] [{}] Skipping read for the topic: because all entries in replay queue were"
-                                + " filtered out due to the mechanism of Key_Shared mode, and the left consumers have"
-                                + " no permits now",
-                                topic.getName(), getSubscriptionName());
-                    } else {
-                        log.debug("[{}] Cannot schedule next read until previous one is done", name);
-                    }
+                if (!messagesToReplayNow.isEmpty()) {
+                    log.debug("Skipping read: all replay entries filtered by Key_Shared, no consumer permits");
+                } else {
+                    log.debug("Cannot schedule next read until previous one is done");
                 }
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Consumer buffer is full, pause reading", name);
-            }
+            log.debug("Consumer buffer is full, pause reading");
         }
     }
 
@@ -438,9 +433,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     @Override
     protected void reScheduleRead() {
         if (isRescheduleReadInProgress.compareAndSet(false, true)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Reschedule message read in {} ms", topic.getName(), name, MESSAGE_RATE_BACKOFF_MS);
-            }
+            log.debug()
+                    .attr("backoffMs", MESSAGE_RATE_BACKOFF_MS)
+                    .log("Reschedule message read");
             topic.getBrokerService().executor().schedule(
                     () -> {
                         isRescheduleReadInProgress.set(false);
@@ -489,9 +484,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         }
 
         if (havePendingReplayRead) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Skipping replay while awaiting previous read to complete", name);
-            }
+            log.debug("Skipping replay while awaiting previous read to complete");
             return Pair.of(-1, -1L);
         }
 
@@ -597,9 +590,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
 
         if (readBatchSize < serviceConfig.getDispatcherMaxReadBatchSize()) {
             int newReadBatchSize = Math.min(readBatchSize * 2, serviceConfig.getDispatcherMaxReadBatchSize());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Increasing read batch size from {} to {}", name, readBatchSize, newReadBatchSize);
-            }
+            log.debug()
+                    .attr("readBatchSize", readBatchSize)
+                    .attr("newReadBatchSize", newReadBatchSize)
+                    .log("Increasing read batch size from to");
 
             readBatchSize = newReadBatchSize;
         }
@@ -615,9 +609,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Distributing {} messages to {} consumers", name, entries.size(), consumerList.size());
-        }
+        log.debug()
+                .attr("entryCount", entries.size())
+                .attr("consumerCount", consumerList.size())
+                .log("Distributing messages to consumers");
 
         long size = entries.stream().mapToLong(Entry::getLength).sum();
         updatePendingBytesToDispatch(size);
@@ -717,7 +712,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection
-                log.info("[{}] rewind because no available consumer found from total {}", name, consumerList.size());
+                log.info()
+                        .attr("size", consumerList.size())
+                        .log("rewind because no available consumer found from total");
                 entries.subList(start, entries.size()).forEach(Entry::release);
                 cursor.rewind();
                 return false;
@@ -730,10 +727,12 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 int remainUnAckedMessages = Math.max(c.getMaxUnackedMessages() - c.getUnackedMessages(), 0);
                 availablePermits = Math.min(availablePermits, remainUnAckedMessages);
             }
-            if (log.isDebugEnabled() && !c.isWritable()) {
-                log.debug("[{}-{}] consumer is not writable. dispatching only 1 message to {}; "
-                                + "availablePermits are {}", topic.getName(), name,
-                        c, c.getAvailablePermits());
+            if (!c.isWritable()) {
+                log.debug().attr("topic", topic.getName())
+                        .attr("consumer", c)
+                        .attr("availablePermits", c.getAvailablePermits())
+                        .log("Consumer is not writable, dispatching"
+                                + " only 1 message");
             }
 
             int messagesForC = Math.min(Math.min(remainingMessages, availablePermits),
@@ -767,11 +766,11 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             entriesToDispatch -= messagesForC;
             TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this,
                     -(msgSent - batchIndexesAcks.getTotalAckedIndexCount()));
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Added -({} minus {}) permits to TOTAL_AVAILABLE_PERMITS_UPDATER in "
-                                + "PersistentDispatcherMultipleConsumers",
-                        name, msgSent, batchIndexesAcks.getTotalAckedIndexCount());
-            }
+            log.debug()
+                    .attr("msgSent", msgSent)
+                    .attr("totalAckedIndexCount", batchIndexesAcks.getTotalAckedIndexCount())
+                    .log("Added -( minus) permits to TOTAL_AVAILABLE_PERMITS_UPDATER in "
+                            + "PersistentDispatcherMultipleConsumers");
             totalMessagesSent += sendMessageInfo.getTotalMessages();
             totalBytesSent += sendMessageInfo.getTotalBytes();
         }
@@ -779,10 +778,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         acquirePermitsForDeliveredMessages(topic, cursor, totalEntries, totalMessagesSent, totalBytesSent);
 
         if (entriesToDispatch > 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] No consumers found with available permits, storing {} positions for later replay", name,
-                        entries.size() - start);
-            }
+            log.debug()
+                    .attr("pending", entries.size() - start)
+                    .log("No consumers found with available permits, storing positions for later replay");
             entries.subList(start, entries.size()).forEach(entry -> {
                 long stickyKeyHash = getStickyKeyHash(entry);
                 addMessageToReplay(entry.getLedgerId(), entry.getEntryId(), stickyKeyHash);
@@ -810,10 +808,11 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             final Consumer consumer = current.getKey();
             final List<EntryAndMetadata> entryAndMetadataList = current.getValue();
             final int messagesForC = Math.min(consumer.getAvailablePermits(), entryAndMetadataList.size());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] select consumer {} with messages num {}, read type is {}",
-                        name, consumer.consumerName(), messagesForC, readType);
-            }
+            log.debug()
+                    .attr("consumerName", consumer.consumerName())
+                    .attr("messagesForC", messagesForC)
+                    .attr("readType", readType)
+                    .log("select consumer with messages num, read type is");
             if (messagesForC < entryAndMetadataList.size()) {
                 for (int i = messagesForC; i < entryAndMetadataList.size(); i++) {
                     final EntryAndMetadata entry = entryAndMetadataList.get(i);
@@ -863,9 +862,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
 
         // Do not keep reading more entries if the cursor is already closed.
         if (exception instanceof ManagedLedgerException.CursorAlreadyClosedException) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor is already closed, skipping read more entries", cursor.getName());
-            }
+            log.debug().attr("name", cursor.getName()).log("Cursor is already closed, skipping read more entries");
             // Set the wait time to -1 to avoid rescheduling the read.
             waitTimeMillis = -1;
         } else if (exception instanceof NoMoreEntriesToReadException) {
@@ -877,18 +874,25 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         } else if (exception.getCause() instanceof TransactionBufferException.TransactionNotSealedException
                 || exception.getCause() instanceof ManagedLedgerException.OffloadReadHandleClosedException) {
             waitTimeMillis = 1;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading transaction entries : {}, Read Type {} - Retrying to read in {} seconds",
-                        name, exception.getMessage(), readType, waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading transaction entries - Retrying to read");
         } else if (!(exception instanceof TooManyRequestsException)) {
-            log.error("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
-                    cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
+            log.error()
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading entries - Retrying to read");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading entries at {} : {}, Read Type {} - Retrying to read in {} seconds", name,
-                        cursor.getReadPosition(), exception.getMessage(), readType, waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("readType", readType)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading entries - Retrying to read");
         }
 
         if (shouldRewindBeforeReadingOrReplaying) {
@@ -921,10 +925,13 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 // another scheduled read, otherwise we'd be stuck until
                 // more messages are published.
                 if (!havePendingRead || readType == ReadType.Replay) {
-                    log.info("[{}] Retrying read operation", name);
+                    log.info("Retrying read operation");
                     readMoreEntries();
                 } else {
-                    log.info("[{}] Skipping read retry: havePendingRead {}", name, havePendingRead, e);
+                    log.info()
+                            .attr("havePendingRead", havePendingRead)
+                            .exception(e)
+                            .log("Skipping read retry: havePendingRead");
                 }
             }
         }, waitTimeMillis, TimeUnit.MILLISECONDS);
@@ -971,9 +978,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 return true;
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] consumer is not writable", topic.getName(), name);
-        }
+        log.debug("Consumer is not writable");
         return false;
     }
 
@@ -989,10 +994,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 redeliveryTracker.incrementAndGetRedeliveryCount((PositionFactory.create(ledgerId, entryId)));
             }
         });
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer,
-                    redeliveryMessages);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("redeliveryMessages", redeliveryMessages)
+                .log("- Redelivering unacknowledged messages for consumer");
         readMoreEntries();
     }
 
@@ -1005,9 +1010,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 redeliveryTracker.incrementAndGetRedeliveryCount(position);
             }
         });
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer, positions);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .attr("positions", positions)
+                .log("- Redelivering unacknowledged messages for consumer");
         readMoreEntries();
     }
 
@@ -1017,7 +1023,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         // don't block dispatching if maxUnackedMessages = 0
         if (maxUnackedMessages <= 0 && blockedDispatcherOnUnackedMsgs == TRUE
                 && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
-            log.info("[{}] Dispatcher is unblocked, since maxUnackedMessagesPerSubscription=0", name);
+            log.info("Dispatcher is unblocked, since maxUnackedMessagesPerSubscription=0");
             readMoreEntriesAsync();
         }
 
@@ -1025,8 +1031,10 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         if (unAckedMessages >= maxUnackedMessages && maxUnackedMessages > 0
                 && BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, FALSE, TRUE)) {
             // block dispatcher if it reaches maxUnAckMsg limit
-            log.debug("[{}] Dispatcher is blocked due to unackMessages {} reached to max {}", name,
-                    unAckedMessages, maxUnackedMessages);
+            log.debug()
+                    .attr("unAckedMessages", unAckedMessages)
+                    .attr("maxUnackedMessages", maxUnackedMessages)
+                    .log("Dispatcher is blocked due to unackMessages reached to max");
         } else if (topic.getBrokerService().isBrokerDispatchingBlocked()
                 && blockedDispatcherOnUnackedMsgs == TRUE) {
             // unblock dispatcher: if dispatcher is blocked due to broker-unackMsg limit and if it ack back enough
@@ -1040,7 +1048,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         } else if (blockedDispatcherOnUnackedMsgs == TRUE && unAckedMessages < maxUnackedMessages / 2) {
             // unblock dispatcher if it acks back enough messages
             if (BLOCKED_DISPATCHER_ON_UNACKMSG_UPDATER.compareAndSet(this, TRUE, FALSE)) {
-                log.debug("[{}] Dispatcher is unblocked", name);
+                log.debug("Dispatcher is unblocked");
                 readMoreEntriesAsync();
             }
         }
@@ -1271,7 +1279,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         // consider dispatch is stuck if : dispatcher has backlog, available-permits and there is no pending read
         if (isAtleastOneConsumerAvailable() && !havePendingReplayRead && !havePendingRead
                 && cursor.getNumberOfEntriesInBacklog(false) > 0) {
-            log.warn("{}-{} Dispatcher is stuck and unblocking by issuing reads", topic.getName(), name);
+            log.warn("Dispatcher is stuck and unblocking by issuing reads");
             readMoreEntries();
             return true;
         }
@@ -1329,6 +1337,4 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     public boolean isHavePendingReplayRead() {
         return havePendingReplayRead;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherMultipleConsumersClassic.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.mledger.util.ManagedLedgerUtils.readEntriesW
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
@@ -57,11 +58,12 @@ import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.compaction.CompactedTopicUtils;
 import org.apache.pulsar.compaction.Compactor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcherSingleActiveConsumer
         implements Dispatcher {
+
+    private static final Logger LOG = Logger.get(PersistentDispatcherSingleActiveConsumer.class);
+    private final Logger log;
 
     private final AtomicBoolean isRescheduleReadInProgress = new AtomicBoolean(false);
     protected final PersistentTopic topic;
@@ -87,6 +89,10 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         this.executor = topic.getBrokerService().getTopicOrderedExecutor().chooseThread();
         this.name = topic.getName() + " / " + (cursor.getName() != null ? Codec.decode(cursor.getName())
                 : ""/* NonDurableCursor doesn't have name */);
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("subscription", cursor.getName() != null ? Codec.decode(cursor.getName()) : "")
+                .build();
         this.readBatchSize = serviceConfig.getDispatcherMaxReadBatchSize();
         this.readFailureBackoff = Backoff.builder()
             .initialDelay(Duration.ofMillis(serviceConfig.getDispatcherReadFailureBackoffInitialTimeInMs()))
@@ -108,9 +114,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         // If there is any pending read operation, let it finish and then rewind
 
         if (subscriptionType != SubType.Failover || serviceConfig.getActiveConsumerFailoverDelayTimeMillis() <= 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Rewind cursor and read more entries without delay", name);
-            }
+            log.debug("Rewind cursor and read more entries without delay");
             Consumer activeConsumer = getActiveConsumer();
             cursor.rewind(activeConsumer != null && activeConsumer.readCompacted());
 
@@ -127,10 +131,10 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         }
 
         readOnActiveConsumerTask = topic.getBrokerService().executor().schedule(() -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Rewind cursor and read more entries after {} ms delay", name,
-                        serviceConfig.getActiveConsumerFailoverDelayTimeMillis());
-            }
+            log.debug()
+                    .attr("activeConsumerFailoverDelayTimeMillis",
+                            serviceConfig.getActiveConsumerFailoverDelayTimeMillis())
+                    .log("Rewind cursor and read more entries after ms delay");
             Consumer activeConsumer = getActiveConsumer();
             cursor.rewind(activeConsumer != null && activeConsumer.readCompacted());
 
@@ -156,19 +160,21 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     }
 
     private synchronized void readEntriesComplete(List<Entry> entries, Consumer readConsumer, long epoch) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Got messages: {}", name, readConsumer, entries.size());
-        }
+        log.debug()
+                .attr("readConsumer", readConsumer)
+                .attr("size", entries.size())
+                .log("Got messages");
 
         havePendingRead = false;
         isFirstRead = false;
 
         if (readBatchSize < serviceConfig.getDispatcherMaxReadBatchSize()) {
             int newReadBatchSize = Math.min(readBatchSize * 2, serviceConfig.getDispatcherMaxReadBatchSize());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Increasing read batch size from {} to {}", name, readConsumer, readBatchSize,
-                        newReadBatchSize);
-            }
+            log.debug()
+                    .attr("readConsumer", readConsumer)
+                    .attr("readBatchSize", readBatchSize)
+                    .attr("newReadBatchSize", newReadBatchSize)
+                    .log("Increasing read batch size from to");
 
             readBatchSize = newReadBatchSize;
         }
@@ -194,14 +200,12 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         if (currentConsumer == null || readConsumer != currentConsumer || topic.isTransferring()) {
             // Active consumer has changed since the read request has been issued, or the topic is being transferred to
             // another broker. We need to rewind the cursor and re-issue the read request for the new consumer.
-            if (log.isDebugEnabled()) {
-                if (currentConsumer == null) {
-                    log.debug("[{}] rewind because no available consumer found", name);
-                } else if (readConsumer != currentConsumer) {
-                    log.debug("[{}] rewind because active consumer changed", name);
-                } else {
-                    log.debug("[{}] rewind because topic is transferring", name);
-                }
+            if (currentConsumer == null) {
+                log.debug("rewind because no available consumer found");
+            } else if (readConsumer != currentConsumer) {
+                log.debug("rewind because active consumer changed");
+            } else {
+                log.debug("rewind because topic is transferring");
             }
             entries.forEach(Entry::release);
             cursor.rewind(currentConsumer != null ? currentConsumer.readCompacted() : readConsumer.readCompacted());
@@ -244,24 +248,21 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
 
     private synchronized void internalConsumerFlow(Consumer consumer) {
         if (havePendingRead) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Ignoring flow control message since we already have a pending read req", name,
-                        consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control message since we already have a pending read req");
         } else if (getActiveConsumer() != consumer) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Ignoring flow control message since consumer is not active partition consumer", name,
-                        consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control message since consumer is not active partition consumer");
         } else if (readOnActiveConsumerTask != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Ignoring flow control message since consumer is waiting for cursor to be rewinded",
-                        name, consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Ignoring flow control message since consumer is waiting for cursor to be rewinded");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Trigger new read after receiving flow control message", name, consumer);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .log("Trigger new read after receiving flow control message");
             readMoreEntries(consumer);
         }
     }
@@ -274,30 +275,33 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     private synchronized void internalRedeliverUnacknowledgedMessages(Consumer consumer, long consumerEpoch) {
 
         if (consumerEpoch > consumer.getConsumerEpoch()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Update epoch, old epoch [{}], new epoch [{}]",
-                        name, consumer, consumer.getConsumerEpoch(), consumerEpoch);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .attr("oldEpoch", consumer.getConsumerEpoch())
+                    .attr("newEpoch", consumerEpoch)
+                    .log("Update epoch");
             consumer.setConsumerEpoch(consumerEpoch);
         }
 
         if (consumer != getActiveConsumer()) {
-            log.info("[{}-{}] Ignoring reDeliverUnAcknowledgedMessages: Only the active consumer can call resend",
-                    name, consumer);
+            log.info()
+                    .attr("consumer", consumer)
+                    .log("Ignoring reDeliverUnAcknowledgedMessages: Only the active consumer can call resend");
             return;
         }
 
         if (readOnActiveConsumerTask != null) {
-            log.info("[{}-{}] Ignoring reDeliverUnAcknowledgedMessages: consumer is waiting for cursor to be rewinded",
-                    name, consumer);
+            log.info()
+                    .attr("consumer", consumer)
+                    .log("Ignoring reDeliverUnAcknowledgedMessages: consumer is waiting for cursor to be rewinded");
             return;
         }
         cursor.cancelPendingReadRequest();
         havePendingRead = false;
         cursor.rewind(consumer.readCompacted());
-        if (log.isDebugEnabled()) {
-            log.debug("[{}-{}] Cursor rewinded, redelivering unacknowledged messages. ", name, consumer);
-        }
+        log.debug()
+                .attr("consumer", consumer)
+                .log("Cursor rewinded, redelivering unacknowledged messages.");
         readMoreEntries(consumer);
     }
 
@@ -310,31 +314,21 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     @VisibleForTesting
     void readMoreEntries(Consumer consumer) {
         if (cursor.isClosed()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor is already closed, skipping read more entries", cursor.getName());
-            }
+            log.debug("Cursor is already closed, skipping read more entries");
             return;
         }
         // consumer can be null when all consumers are disconnected from broker.
         // so skip reading more entries if currently there is no active consumer.
         if (null == consumer) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to the current consumer is null", topic.getName(),
-                        getSubscriptionName());
-            }
+            log.debug("Skipping read due to the current consumer is null");
             return;
         }
         if (havePendingRead) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Skipping read for the topic, Due to we have pending read.", topic.getName(),
-                        getSubscriptionName());
-            }
+            log.debug("Skipping read due to pending read");
             return;
         }
         if (topic.isTransferring()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Skipping read for the topic: topic is transferring", topic.getName());
-            }
+            log.debug("Skipping read: topic is transferring");
             return;
         }
 
@@ -342,15 +336,15 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
             synchronized (this) {
                 final Consumer activeConsumer = getActiveConsumer();
                 if (consumer != activeConsumer) {
-                    log.info("[{}] cancel the readMoreEntries because consumer {} is no longer the active consumer {}",
-                            topic.getName(), consumer.consumerName(),
-                            activeConsumer != null ? activeConsumer.consumerName() : null);
+                    log.info()
+                            .attr("consumerName", consumer.consumerName())
+                            .attr("activeConsumerName",
+                                    activeConsumer != null ? activeConsumer.consumerName() : null)
+                            .log("Cancel the readMoreEntries because consumer is no longer the active consumer");
                     return;
                 }
                 if (havePendingRead) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Skipping read for the topic, Due to we have pending read.", topic.getName());
-                    }
+                    log.debug("Skipping read due to pending read");
                     return;
                 }
 
@@ -364,9 +358,10 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 }
 
                 // Schedule read
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}-{}] Schedule read of {} messages", name, consumer, messagesToRead);
-                }
+                log.debug()
+                        .attr("consumer", consumer)
+                        .attr("messagesToRead", messagesToRead)
+                        .log("Schedule read of messages");
                 havePendingRead = true;
                 // TODO: should we pass the consumer epoch for compacted read path? See
                 //   https://github.com/apache/pulsar/issues/13690
@@ -391,9 +386,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                 }, executor);
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Consumer buffer is full, pause reading", name, consumer);
-            }
+            log.debug().attr("consumer", consumer).log("Consumer buffer is full, pause reading");
         }
     }
 
@@ -407,9 +400,9 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
     @Override
     protected void reScheduleRead() {
         if (isRescheduleReadInProgress.compareAndSet(false, true)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] [{}] Reschedule message read in {} ms", topic.getName(), name, MESSAGE_RATE_BACKOFF_MS);
-            }
+            log.debug()
+                    .attr("backoffMs", MESSAGE_RATE_BACKOFF_MS)
+                    .log("Reschedule message read");
             topic.getBrokerService().executor().schedule(() -> {
                 isRescheduleReadInProgress.set(false);
                 Consumer currentConsumer = getActiveConsumer();
@@ -465,9 +458,7 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
 
         // Do not keep reading messages from a closed cursor.
         if (exception instanceof ManagedLedgerException.CursorAlreadyClosedException) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Cursor was already closed, skipping read more entries", cursor.getName());
-            }
+            log.debug("Cursor was already closed, skipping read more entries");
             return;
         }
 
@@ -488,18 +479,24 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         } else if (exception.getCause() instanceof TransactionBufferException.TransactionNotSealedException
                 || exception.getCause() instanceof ManagedLedgerException.OffloadReadHandleClosedException) {
             waitTimeMillis = 1;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error reading transaction entries : {}, - Retrying to read in {} seconds", name,
-                        exception.getMessage(), waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .exceptionMessage(exception)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading transaction entries - Retrying to read");
         } else if (!(exception instanceof TooManyRequestsException)) {
-            log.error("[{}-{}] Error reading entries at {} : {} - Retrying to read in {} seconds", name, consumer,
-                    cursor.getReadPosition(), exception.getMessage(), waitTimeMillis / 1000.0);
+            log.error()
+                    .attr("consumer", consumer)
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Error reading entries - Retrying to read");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}-{}] Got throttled by bookies while reading at {} : {} - Retrying to read in {} seconds",
-                        name, consumer, cursor.getReadPosition(), exception.getMessage(), waitTimeMillis / 1000.0);
-            }
+            log.debug()
+                    .attr("consumer", consumer)
+                    .attr("readPosition", cursor.getReadPosition())
+                    .exceptionMessage(exception)
+                    .attr("retryInSeconds", waitTimeMillis / 1000.0)
+                    .log("Got throttled by bookies while reading - Retrying to read");
         }
 
         // Reduce read batch size to avoid flooding bookies with retries
@@ -518,16 +515,17 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
                     Consumer currentConsumer = getActiveConsumer();
                     // we should retry the read if we have an active consumer and there is no pending read
                     if (currentConsumer != null && !havePendingRead) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}-{}] Retrying read operation", name, c);
-                        }
+                        log.debug().attr("consumer", c).log("Retrying read operation");
                         if (currentConsumer != c) {
                             notifyActiveConsumerChanged(currentConsumer);
                         }
                         readMoreEntries(currentConsumer);
                     } else {
-                        log.info("[{}-{}] Skipping read retry: Current Consumer {}, havePendingRead {}", name, c,
-                                currentConsumer, havePendingRead);
+                        log.info()
+                                .attr("consumer", c)
+                                .attr("currentConsumer", currentConsumer)
+                                .attr("havePendingRead", havePendingRead)
+                                .log("Skipping read retry");
                     }
                 }
             });
@@ -570,12 +568,10 @@ public class PersistentDispatcherSingleActiveConsumer extends AbstractDispatcher
         boolean isConsumerAvailable = !consumer.isBlocked() && consumer.getAvailablePermits() > 0;
         // consider dispatch is stuck if : dispatcher has backlog, available-permits and there is no pending read
         if (isConsumerAvailable && !havePendingRead && cursor.getNumberOfEntriesInBacklog(false) > 0) {
-            log.warn("{}-{} Dispatcher is stuck and unblocking by issuing reads", topic.getName(), name);
+            log.warn("Dispatcher is stuck and unblocking by issuing reads");
             readMoreEntries(consumer);
             return true;
         }
         return false;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentDispatcherSingleActiveConsumer.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -42,11 +43,13 @@ import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.stats.Rate;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 /**
  */
 public class PersistentMessageExpiryMonitor implements FindEntryCallback, MessageExpirer {
+
+    private static final Logger LOG = Logger.get(PersistentMessageExpiryMonitor.class);
+    private final Logger log;
+
     private final ManagedCursor cursor;
     private final String subName;
     private final PersistentTopic topic;
@@ -73,6 +76,10 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         this.subscription = subscription;
         this.msgExpired = new Rate();
         this.totalMsgExpired = new LongAdder();
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subscriptionName)
+                .build();
         int managedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis = topic.getBrokerService().pulsar()
                 .getConfig().getManagedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis();
         this.finder = new PersistentMessageFinder(topicName, cursor,
@@ -94,14 +101,13 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
     @Override
     public boolean expireMessages(int messageTTLInSeconds) {
         if (!expirationCheckInProgressUpdater.compareAndSet(this, FALSE, TRUE)) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Ignore expire-message scheduled task, last check is still running", topicName,
-                        subName);
-            }
+            log.debug()
+                    .log("Ignore expire-message scheduled task, last check is still running");
             return false;
         }
-        log.info("[{}][{}] Starting message expiry check, ttl= {} seconds", topicName, subName,
-                messageTTLInSeconds);
+        log.info()
+                .attr("messageTTLInSeconds", messageTTLInSeconds)
+                .log("Starting message expiry check");
         // First filter the entire Ledger reached TTL based on the Ledger closing time to avoid client clock skew
         checkExpiryByLedgerClosureTime(cursor, messageTTLInSeconds);
         // Some part of entries in active Ledger may have reached TTL, so we need to continue searching.
@@ -156,16 +162,17 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         }
         // Fallback to the slower solution if the managed ledger is not an instance of ManagedLedgerImpl.
         if (topicLastPosition.compareTo(messagePosition) < 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Ignore expire-message scheduled task, given position {} is beyond "
-                                + "current topic's last position {}", topicName, subName, messagePosition,
-                        topicLastPosition);
-            }
+            log.debug()
+                    .attr("messagePosition", messagePosition)
+                    .attr("topicLastPosition", topicLastPosition)
+                    .log("Ignore expire-message scheduled task, given position is beyond "
+                            + "current topic's last position");
             return false;
         }
         if (expirationCheckInProgressUpdater.compareAndSet(this, FALSE, TRUE)) {
-            log.info("[{}][{}] Starting message expiry check, position= {} seconds", topicName, subName,
-                    messagePosition);
+            log.info()
+                    .attr("messagePosition", messagePosition)
+                    .log("Starting message expiry check");
 
             cursor.asyncFindNewestMatching(ManagedCursor.FindPositionConstraint.SearchActiveEntries, entry -> {
                 try {
@@ -177,10 +184,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
             }, this, null);
             return true;
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Ignore expire-message scheduled task, last check is still running", topicName,
-                        subName);
-            }
+            log.debug("Ignore expire-message scheduled task, last check is still running");
             return false;
         }
     }
@@ -201,9 +205,6 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
     public long getTotalMessageExpired() {
         return totalMsgExpired.sum();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentMessageExpiryMonitor.class);
-
     private final MarkDeleteCallback markDeleteCallback = new MarkDeleteCallback() {
         @Override
         public void markDeleteComplete(Object ctx) {
@@ -215,14 +216,16 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                 subscription.getDispatcher().markDeletePositionMoveForward();
             }
             expirationCheckInProgress = FALSE;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Mark deleted {} messages", topicName, subName, numMessagesExpired);
-            }
+            log.debug()
+                    .attr("numMessagesExpired", numMessagesExpired)
+                    .log("Mark deleted messages");
         }
 
         @Override
         public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-            log.warn("[{}][{}] Message expiry failed - mark delete failed", topicName, subName, exception);
+            log.warn()
+                    .exception(exception)
+                    .log("Message expiry failed - mark delete failed");
             expirationCheckInProgress = FALSE;
             updateRates();
         }
@@ -236,7 +239,9 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                 expirationCheckInProgress = FALSE;
                 return;
             }
-            log.info("[{}][{}] Expiring all messages until position {}", topicName, subName, position);
+            log.info()
+                    .attr("position", position)
+                    .log("Expiring all messages until position");
             Position prevMarkDeletePos = cursor.getMarkDeletedPosition();
             cursor.asyncMarkDelete(position, cursor.getProperties(), markDeleteCallback,
                     cursor.getNumberOfEntriesInBacklog(false));
@@ -244,9 +249,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                 subscription.updateLastMarkDeleteAdvancedTimestamp();
             }
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] No messages to expire", topicName, subName);
-            }
+            log.debug("No messages to expire");
             expirationCheckInProgress = FALSE;
             updateRates();
         }
@@ -254,13 +257,15 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
 
     @Override
     public void findEntryFailed(ManagedLedgerException exception, Optional<Position> failedReadPosition, Object ctx) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Finding expired entry operation failed", topicName, subName, exception);
-        }
+        log.debug()
+                .exception(exception)
+                .log("Finding expired entry operation failed");
         if (isAutoSkipNonRecoverableData() && failedReadPosition.isPresent()
                 && (exception instanceof NonRecoverableLedgerException)) {
-            log.warn("[{}][{}] read failed from ledger at position:{} : {}", topicName, subName, failedReadPosition,
-                    exception.getMessage());
+            log.warn()
+                    .attr("failedReadPosition", failedReadPosition)
+                    .exceptionMessage(exception)
+                    .log("Read failed from ledger");
             if (exception instanceof LedgerNotExistException) {
                 long failedLedgerId = failedReadPosition.get().getLedgerId();
                 ManagedLedger ledger = cursor.getManagedLedger();
@@ -270,16 +275,18 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
                             Long nextExistingLedger =
                                 ledger.getLedgersInfo().ceilingKey(failedReadPosition.get().getLedgerId() + 1);
                             if (nextExistingLedger == null) {
-                                log.info("[{}] [{}] Couldn't find next next valid ledger for expiry monitor when find "
-                                                + "entry failed {}", ledger.getName(), ledger.getName(),
-                                        failedReadPosition);
+                                log.info()
+                                        .attr("failedReadPosition", failedReadPosition)
+                                        .log("Couldn't find next valid ledger for expiry monitor "
+                                                + "when find entry failed");
                                 return failedReadPosition.get();
                             } else {
                                 return PositionFactory.create(nextExistingLedger, -1);
                             }
                         });
-                log.info("[{}][{}] ledger not existed, will complete the last position of the non-existed"
-                        + " ledger:{}", topicName, subName, lastPositionInLedger);
+                log.info()
+                        .attr("lastPositionInLedger", lastPositionInLedger)
+                        .log("Ledger does not exist, will complete the last position of the non-existent ledger");
                 findEntryComplete(lastPositionInLedger, ctx);
             } else {
                 findEntryComplete(failedReadPosition.get(), ctx);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageFinder.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -31,13 +32,15 @@ import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo.LedgerInfo;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.util.Codec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * given a timestamp find the first message (position) (published) at or before the timestamp.
  */
 public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback {
+
+    private static final Logger LOG = Logger.get(PersistentMessageFinder.class);
+    protected final Logger log;
+
     protected final ManagedCursor cursor;
     protected final String subName;
     protected final int ledgerCloseTimestampMaxClockSkewMillis;
@@ -57,14 +60,18 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
         this.cursor = cursor;
         this.subName = Codec.decode(cursor.getName());
         this.ledgerCloseTimestampMaxClockSkewMillis = ledgerCloseTimestampMaxClockSkewMillis;
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .build();
     }
 
     public void findMessages(final long timestamp, AsyncCallbacks.FindEntryCallback callback) {
         if (MESSAGE_FIND_IN_PROGRESS.compareAndSet(this, FALSE, TRUE)) {
             this.timestamp = timestamp;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Starting message position find at timestamp {}", subName, timestamp);
-            }
+            log.debug()
+                    .attr("timestamp", timestamp)
+                    .log("Starting message position find at timestamp");
             Pair<Position, Position> range =
                     getFindPositionRange(cursor.getManagedLedger().getLedgersInfo().values(),
                             cursor.getManagedLedger().getLastConfirmedEntry(), timestamp,
@@ -75,17 +82,16 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
                     long entryTimestamp = entry.getEntryTimestamp();
                     return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
                 } catch (Exception e) {
-                    log.error("[{}][{}] Error deserializing message for message position find", topicName, subName, e);
+                    log.error()
+                            .exception(e)
+                            .log("Error deserializing message for message position find");
                 } finally {
                     entry.release();
                 }
                 return false;
             }, range.getLeft(), range.getRight(), this, callback, true);
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Ignore message position find scheduled task, last find is still running", topicName,
-                        subName);
-            }
+            log.debug("Ignore message position find scheduled task, last find is still running");
             callback.findEntryFailed(
                     new ManagedLedgerException.ConcurrentFindCursorPositionException("last find is still running"),
                     Optional.empty(), null);
@@ -140,20 +146,19 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
         }
         return Pair.of(start, end);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentMessageFinder.class);
-
     @Override
     public void findEntryComplete(Position position, Object ctx) {
         checkArgument(ctx instanceof AsyncCallbacks.FindEntryCallback);
         AsyncCallbacks.FindEntryCallback callback = (AsyncCallbacks.FindEntryCallback) ctx;
         if (position != null) {
-            log.info("[{}][{}] Found position {} closest to provided timestamp {}", topicName, subName, position,
-                    timestamp);
+            log.info()
+                    .attr("position", position)
+                    .attr("timestamp", timestamp)
+                    .log("Found position closest to provided timestamp");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] No position found closest to provided timestamp {}", topicName, subName, timestamp);
-            }
+            log.debug()
+                    .attr("timestamp", timestamp)
+                    .log("No position found closest to provided timestamp");
         }
         messageFindInProgress = FALSE;
         callback.findEntryComplete(position, null);
@@ -163,10 +168,10 @@ public class PersistentMessageFinder implements AsyncCallbacks.FindEntryCallback
     public void findEntryFailed(ManagedLedgerException exception, Optional<Position> failedReadPosition, Object ctx) {
         checkArgument(ctx instanceof AsyncCallbacks.FindEntryCallback);
         AsyncCallbacks.FindEntryCallback callback = (AsyncCallbacks.FindEntryCallback) ctx;
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] message position find operation failed for provided timestamp {}", topicName, subName,
-                    timestamp, exception);
-        }
+        log.debug()
+                .attr("timestamp", timestamp)
+                .exception(exception)
+                .log("Message position find operation failed for provided timestamp");
         messageFindInProgress = FALSE;
         callback.findEntryFailed(exception, failedReadPosition, null);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -24,6 +24,7 @@ import static org.apache.pulsar.broker.service.AbstractReplicator.State.Terminat
 import static org.apache.pulsar.broker.service.AbstractReplicator.State.Terminating;
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
@@ -75,11 +76,12 @@ import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.stats.Rate;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.Codec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class PersistentReplicator extends AbstractReplicator
         implements Replicator, ReadEntriesCallback, DeleteCallback, MessageExpirer {
+
+    private static final Logger LOG = Logger.get(PersistentReplicator.class);
+    protected final Logger log;
 
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
@@ -129,6 +131,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
             throws PulsarServerException {
         super(localCluster, localTopic, remoteCluster, remoteTopic, localTopic.getReplicatorPrefix(),
                 brokerService, replicationClient, replicationAdmin);
+        this.log = LOG.with().ctx(super.log).build();
         this.topic = localTopic;
         this.localSchemaTopicName = TopicName.getPartitionedTopicName(localTopicName).toString();
         this.cursor = Objects.requireNonNull(cursor);
@@ -164,14 +167,14 @@ public abstract class PersistentReplicator extends AbstractReplicator
         changeStateRes = compareSetAndGetState(Starting, Started);
         if (changeStateRes.getLeft()) {
             if (!(producer instanceof ProducerImpl)) {
-                log.error("[{}] The partitions count between two clusters is not the same, the replicator can not be"
-                        + " created successfully: {}", replicatorId, state);
+                log.error("The partitions count between two clusters is not the same, "
+                        + "the replicator can not be created successfully");
                 doCloseProducerAsync(producer, () -> {});
                 throw new ClassCastException(producer.getClass().getName() + " can not be cast to ProducerImpl");
             }
             this.producer = (ProducerImpl) producer;
             // Trigger a new read.
-            log.info("[{}] Created replicator producer, Replicator state: {}", replicatorId, state);
+            log.info("Created replicator producer");
             backOff.reset();
             // activate cursor: so, entries can be cached.
             this.cursor.setActive();
@@ -184,14 +187,12 @@ public abstract class PersistentReplicator extends AbstractReplicator
             if (changeStateRes.getRight() == Started) {
                 // Since only one task can call "producerBuilder.createAsync()", this scenario is not expected.
                 // So print a warn log.
-                log.warn("[{}] Replicator was already started by another thread while creating the producer."
-                        + " Closing the producer newly created. Replicator state: {}", replicatorId, state);
+                log.warn("Replicator was already started by another thread while creating the producer, "
+                        + "closing the newly created producer");
             } else if (changeStateRes.getRight() == Terminating || changeStateRes.getRight() == Terminated) {
-                log.info("[{}] Replicator was terminated, so close the producer. Replicator state: {}",
-                        replicatorId, state);
+                log.info("Replicator was terminated, closing the producer");
             } else {
-                log.error("[{}] Replicator state is not expected, so close the producer. Replicator state: {}",
-                        replicatorId, changeStateRes.getRight());
+                log.error("Replicator state is not expected, closing the producer");
             }
             // Close the producer if change the state fail.
             doCloseProducerAsync(producer, () -> {});
@@ -246,10 +247,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
         // return 0, if Producer queue is full, it will pause read entries.
         if (availablePermits <= 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Producer queue is full, availablePermits: {}, pause reading",
-                        replicatorId, availablePermits);
-            }
+            log.debug()
+                    .attr("availablePermits", availablePermits)
+                    .log("Producer queue is full, pausing reads");
             return new AvailablePermits(0, 0);
         }
 
@@ -264,14 +264,11 @@ public abstract class PersistentReplicator extends AbstractReplicator
             availablePermitsOnByte = rateLimiter.getAvailableDispatchRateLimitOnByte();
             // no permits from rate limit
             if (availablePermitsOnByte == 0 || availablePermitsOnMsg == 0) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] message-read exceeded topic replicator message-rate {}/{},"
-                                    + " schedule after a {}",
-                            replicatorId,
-                            rateLimiter.getDispatchRateOnMsg(),
-                            rateLimiter.getDispatchRateOnByte(),
-                            MESSAGE_RATE_BACKOFF_MS);
-                }
+                log.debug()
+                        .attr("dispatchRateOnMsg", rateLimiter.getDispatchRateOnMsg())
+                        .attr("dispatchRateOnByte", rateLimiter.getDispatchRateOnByte())
+                        .attr("backoffMs", MESSAGE_RATE_BACKOFF_MS)
+                        .log("Message-read exceeded topic replicator message-rate, scheduling after a delay");
                 return new AvailablePermits(-1, -1);
             }
         }
@@ -294,9 +291,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         InFlightTask newInFlightTask = acquirePermitsIfNotFetchingSchema();
         if (newInFlightTask == null) {
             // no permits from rate limit
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Not scheduling read due to pending read or no permits.", replicatorId);
-            }
+            log.debug("Not scheduling read due to pending read or no permits");
             if (!hasPendingRead()) {
                 topic.getBrokerService().executor().schedule(
                         () -> readMoreEntries(), MESSAGE_RATE_BACKOFF_MS, TimeUnit.MILLISECONDS);
@@ -315,10 +310,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
         AvailablePermits availablePermits = getRateLimiterAvailablePermits(newInFlightTask.readingEntries);
         if (!availablePermits.isReadable()) {
             // no rate limiter permits from rate limit
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Throttling replication traffic. Messages To Read {}, Bytes To Read {}",
-                        replicatorId, availablePermits.getMessages(), availablePermits.getBytes());
-            }
+            log.debug()
+                    .attr("messages", availablePermits.getMessages())
+                    .attr("bytes", availablePermits.getBytes())
+                    .log("Throttling replication traffic");
             topic.getBrokerService().executor().schedule(
                     () -> readMoreEntries(), MESSAGE_RATE_BACKOFF_MS, TimeUnit.MILLISECONDS);
             return;
@@ -327,9 +322,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         int messagesToRead = availablePermits.getMessages();
         long bytesToRead = availablePermits.getBytes();
         if (!isWritable()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Throttling replication traffic because producer is not writable", replicatorId);
-            }
+            log.debug("Throttling replication traffic because producer is not writable");
             // Minimize the read size if the producer is disconnected or the window is already full
             messagesToRead = 1;
         }
@@ -337,19 +330,19 @@ public abstract class PersistentReplicator extends AbstractReplicator
         if (messagesToRead < newInFlightTask.readingEntries) {
             newInFlightTask.setReadingEntries(messagesToRead);
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Schedule read of {} messages or {} bytes", replicatorId, newInFlightTask.readingEntries,
-                    bytesToRead);
-        }
+        log.debug()
+                .attr("readingEntries", newInFlightTask.readingEntries)
+                .attr("bytesToRead", bytesToRead)
+                .log("Scheduling read");
         cursor.asyncReadEntriesOrWait(newInFlightTask.readingEntries, bytesToRead, this,
                 newInFlightTask/* Context object */, topic.getMaxReadPosition());
     }
 
     @Override
     public void readEntriesComplete(List<Entry> entries, Object ctx) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Read entries complete of {} messages", replicatorId, entries.size());
-        }
+        log.debug()
+                .attr("size", entries.size())
+                .log("Read entries complete");
         InFlightTask inFlightTask = (InFlightTask) ctx;
         inFlightTask.setEntries(entries);
 
@@ -357,10 +350,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
         int maxReadBatchSize = topic.getBrokerService().pulsar().getConfiguration().getDispatcherMaxReadBatchSize();
         if (readBatchSize < maxReadBatchSize) {
             int newReadBatchSize = Math.min(readBatchSize * 2, maxReadBatchSize);
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Increasing read batch size from {} to {}", replicatorId, readBatchSize,
-                        newReadBatchSize);
-            }
+            log.debug()
+                    .attr("readBatchSize", readBatchSize)
+                    .attr("newReadBatchSize", newReadBatchSize)
+                    .log("Increasing read batch size");
 
             readBatchSize = newReadBatchSize;
         }
@@ -371,10 +364,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
         if (atLeastOneMessageSentForReplication && !isWritable()) {
             // Don't read any more entries until the current pending entries are persisted
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Pausing replication traffic. at-least-one: {} is-writable: {}", replicatorId,
-                        atLeastOneMessageSentForReplication, isWritable());
-            }
+            log.debug()
+                    .attr("atLeastOneMessageSentForReplication", atLeastOneMessageSentForReplication)
+                    .attr("isWritable", isWritable())
+                    .log("Pausing replication traffic");
         } else {
             readMoreEntries();
         }
@@ -407,17 +400,18 @@ public abstract class PersistentReplicator extends AbstractReplicator
         @Override
         public void sendComplete(Throwable exception, OpSendMsgStats opSendMsgStats) {
             if (exception != null && !(exception instanceof PulsarClientException.InvalidMessageException)) {
-                log.error("[{}] Error producing on remote broker， in-flight messages: {}, producer pending queue size:"
-                        + " {}",
-                        replicator.replicatorId, replicator.inFlightTasks,
-                        replicator.producer.getPendingQueueSize(), exception);
+                replicator.log.error()
+                        .attr("inFlightTasks", replicator.inFlightTasks)
+                        .attr("pendingQueueSize", replicator.producer.getPendingQueueSize())
+                        .exception(exception)
+                        .log("Error producing on remote broker");
                 // cursor should be rewound since it was incremented when readMoreEntries
                 replicator.beforeTerminateOrCursorRewinding(ReasonOfWaitForCursorRewinding.Failed_Publishing);
                 replicator.doRewindCursor(false);
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Message persisted on remote broker", replicator.replicatorId, exception);
-                }
+                replicator.log.debug()
+                        .exception(exception)
+                        .log("Message persisted on remote broker");
                 inFlightTask.incCompletedEntries();
                 replicator.cursor.asyncDelete(entry.getPosition(), replicator, entry.getPosition());
             }
@@ -433,11 +427,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
                 if (replicator.producerQueueSize == permits || replicator.producer.isWritable()) {
                     replicator.readMoreEntries();
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Not resuming reads. pending: {} is-writable: {}",
-                                replicator.replicatorId, replicator.producerQueueSize - permits,
-                                replicator.producer.isWritable());
-                    }
+                    replicator.log.debug()
+                            .attr("pending", replicator.producerQueueSize - permits)
+                            .attr("isWritable", replicator.producer.isWritable())
+                            .log("Not resuming reads");
                 }
             }
 
@@ -502,9 +495,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
     @Override
     public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
         if (state != Started) {
-            log.info("[{}] Replicator was disconnected while reading entries."
-                            + " Stop reading. Replicator state: {}",
-                    replicatorId, STATE_UPDATER.get(this));
+            log.info("Replicator was disconnected while reading entries, stopping reads");
             return;
         }
 
@@ -514,21 +505,26 @@ public abstract class PersistentReplicator extends AbstractReplicator
         long waitTimeMillis = readFailureBackoff.next().toMillis();
 
         if (exception instanceof CursorAlreadyClosedException) {
-            log.warn("[{}] Error reading entries because replicator is"
-                            + " already deleted and cursor is already closed {}, ({})",
-                    replicatorId, ctx, exception.getMessage(), exception);
+            log.warn()
+                    .attr("ctx", ctx)
+                    .exception(exception)
+                    .log("Error reading entries because replicator is already deleted "
+                            + "and cursor is already closed");
             // replicator is already deleted and cursor is already closed so, producer should also be disconnected.
             terminate();
             return;
         } else if (!(exception instanceof TooManyRequestsException)) {
-            log.error("[{}] Error reading entries at {}. Retrying to read in {}s. ({})",
-                    replicatorId, ctx, waitTimeMillis / 1000.0, exception.getMessage(), exception);
+            log.error()
+                    .attr("ctx", ctx)
+                    .attr("waitTimeSec", waitTimeMillis / 1000.0)
+                    .exception(exception)
+                    .log("Error reading entries, retrying");
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Throttled by bookies while reading at {}. Retrying to read in {}s. ({})",
-                        replicatorId, ctx, waitTimeMillis / 1000.0, exception.getMessage(),
-                        exception);
-            }
+            log.debug()
+                    .attr("ctx", ctx)
+                    .attr("waitTimeSec", waitTimeMillis / 1000.0)
+                    .exception(exception)
+                    .log("Throttled by bookies while reading, retrying");
         }
 
         brokerService.executor().schedule(this::readMoreEntries, waitTimeMillis, TimeUnit.MILLISECONDS);
@@ -537,24 +533,22 @@ public abstract class PersistentReplicator extends AbstractReplicator
     public CompletableFuture<Void> clearBacklog() {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Backlog size before clearing: {}", replicatorId,
-                    cursor.getNumberOfEntriesInBacklog(false));
-        }
+        log.debug()
+                .attr("backlog", cursor.getNumberOfEntriesInBacklog(false))
+                .log("Backlog size before clearing");
 
         cursor.asyncClearBacklog(new ClearBacklogCallback() {
             @Override
             public void clearBacklogComplete(Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Backlog size after clearing: {}", replicatorId,
-                            cursor.getNumberOfEntriesInBacklog(false));
-                }
+                log.debug()
+                        .attr("backlog", cursor.getNumberOfEntriesInBacklog(false))
+                        .log("Backlog size after clearing");
                 future.complete(null);
             }
 
             @Override
             public void clearBacklogFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("[{}] Failed to clear backlog", replicatorId, exception);
+                log.error().exception(exception).log("Failed to clear backlog");
                 future.completeExceptionally(exception);
             }
         }, null);
@@ -565,25 +559,27 @@ public abstract class PersistentReplicator extends AbstractReplicator
     public CompletableFuture<Void> skipMessages(int numMessagesToSkip) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Skipping {} messages, current backlog {}", replicatorId,
-                    numMessagesToSkip, cursor.getNumberOfEntriesInBacklog(false));
-        }
+        log.debug()
+                .attr("numMessagesToSkip", numMessagesToSkip)
+                .attr("backlog", cursor.getNumberOfEntriesInBacklog(false))
+                .log("Skipping messages");
         cursor.asyncSkipEntries(numMessagesToSkip, IndividualDeletedEntries.Exclude,
                 new AsyncCallbacks.SkipEntriesCallback() {
                     @Override
                     public void skipEntriesComplete(Object ctx) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Skipped {} messages, new backlog {}", replicatorId,
-                                    numMessagesToSkip, cursor.getNumberOfEntriesInBacklog(false));
-                        }
+                        log.debug()
+                                .attr("numMessagesToSkip", numMessagesToSkip)
+                                .attr("backlog", cursor.getNumberOfEntriesInBacklog(false))
+                                .log("Skipped messages");
                         future.complete(null);
                     }
 
                     @Override
                     public void skipEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("[{}] Failed to skip {} messages", replicatorId,
-                                numMessagesToSkip, exception);
+                        log.error()
+                                .attr("numMessagesToSkip", numMessagesToSkip)
+                                .exception(exception)
+                                .log("Failed to skip messages");
                         future.completeExceptionally(exception);
                     }
                 }, null);
@@ -594,10 +590,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
     public CompletableFuture<Entry> peekNthMessage(int messagePosition) {
         CompletableFuture<Entry> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Getting message at position {}", replicatorId,
-                    messagePosition);
-        }
+        log.debug()
+                .attr("messagePosition", messagePosition)
+                .log("Getting message at position");
 
         cursor.asyncGetNthEntry(messagePosition, IndividualDeletedEntries.Exclude, new ReadEntryCallback() {
 
@@ -623,18 +618,21 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
     @Override
     public void deleteComplete(Object ctx) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Deleted message at {}", replicatorId, ctx);
-        }
+        log.debug().attr("ctx", ctx).log("Deleted message");
     }
 
     @Override
     public void deleteFailed(ManagedLedgerException exception, Object ctx) {
-        log.error("[{}] Failed to delete message at {}: {}", replicatorId, ctx,
-                exception.getMessage(), exception);
+        log.error()
+                .attr("ctx", ctx)
+                .exception(exception)
+                .log("Failed to delete message");
         if (exception instanceof CursorAlreadyClosedException) {
-            log.warn("[{}] Asynchronous ack failure because replicator is already deleted and cursor is already"
-                            + " closed {}, ({})", replicatorId, ctx, exception.getMessage(), exception);
+            log.warn()
+                    .attr("ctx", ctx)
+                    .exception(exception)
+                    .log("Asynchronous ack failure because replicator is already deleted "
+                            + "and cursor is already closed");
             // replicator is already deleted and cursor is already closed so, producer should also be disconnected.
             terminate();
             return;
@@ -770,9 +768,6 @@ public abstract class PersistentReplicator extends AbstractReplicator
     protected void doReleaseResources() {
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentReplicator.class);
-
     @VisibleForTesting
     public ManagedCursor getCursor() {
         return cursor;
@@ -791,7 +786,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
             if (!CollectionUtils.isEmpty(entries) && completedEntries < entries.size()) {
                 completedEntries++;
             } else {
-                log.error("Unexpected calling of increase completed entries. {}", this.toString());
+                LOG.error()
+                        .attr("replicatorId", replicatorId)
+                        .attr("value", this.toString())
+                        .log("Unexpected calling of increase completed entries");
             }
         }
 
@@ -856,15 +854,15 @@ public abstract class PersistentReplicator extends AbstractReplicator
     protected InFlightTask acquirePermitsIfNotFetchingSchema() {
         synchronized (inFlightTasks) {
             if (hasPendingRead()) {
-                log.info("[{}] Skip the reading because there is a pending read task", replicatorId);
+                log.info("Skip the reading because there is a pending read task");
                 return null;
             }
             if (waitForCursorRewindingRefCnf > 0) {
-                log.info("[{}] Skip the reading due to new detected schema", replicatorId);
+                log.info("Skip the reading due to new detected schema");
                 return null;
             }
             if (state != Started) {
-                log.info("[{}] Skip the reading because producer has not started [{}]", replicatorId, state);
+                log.info("Skip the reading because producer has not started");
                 return null;
             }
             // Guarantee that there is a unique cursor reading task.
@@ -951,8 +949,9 @@ public abstract class PersistentReplicator extends AbstractReplicator
                 task.setSkipReadResultDueToCursorRewind(true);
                 if (task.entries == null) {
                     if (readingTask != null) {
-                        log.error("Unexpected state because there are more than one tasks' state is pending read. {}",
-                            inFlightTasks);
+                        log.error()
+                                .attr("inFlightTasks", inFlightTasks)
+                                .log("Unexpected state because there are more than one tasks' state is pending read.");
                     }
                     readingTask = task;
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.broker.service.StickyKeyConsumerSelector.STICKY_KEY_HASH_NOT_SET;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,11 +59,12 @@ import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.IntOpenHashSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDispatcherMultipleConsumers implements
         StickyKeyDispatcher {
+
+    private static final Logger LOG = Logger.get(PersistentStickyKeyDispatcherMultipleConsumers.class);
+    protected final Logger log;
 
     private final boolean allowOutOfOrderDelivery;
     private final StickyKeyConsumerSelector selector;
@@ -78,6 +80,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
             Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm) {
         super(topic, cursor, subscription, ksm.isAllowOutOfOrderDelivery());
+        this.log = LOG.with().ctx(super.log).build();
 
         this.allowOutOfOrderDelivery = ksm.isAllowOutOfOrderDelivery();
         this.keySharedMode = ksm.getKeySharedMode();
@@ -107,12 +110,12 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     }
 
     private void stickyKeyHashUnblocked(int stickyKeyHash) {
-        if (log.isDebugEnabled()) {
-            if (stickyKeyHash > -1) {
-                log.debug("[{}] Sticky key hash {} is unblocked", getName(), stickyKeyHash);
-            } else {
-                log.debug("[{}] Some sticky key hashes are unblocked", getName());
-            }
+        if (stickyKeyHash > -1) {
+            log.debug()
+                    .attr("stickyKeyHash", stickyKeyHash)
+                    .log("Sticky key hash is unblocked");
+        } else {
+            log.debug("Some sticky key hashes are unblocked");
         }
         reScheduleReadWithKeySharedUnblockingInterval();
     }
@@ -129,7 +132,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -172,7 +177,10 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             if (c != skipConsumer) {
                 c.getPendingAcks().forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
                     if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
-                        log.warn("[{}] Sticky key hash was missing for {}:{}", getName(), ledgerId, entryId);
+                        log.warn()
+                                .attr("ledgerId", ledgerId)
+                                .attr("entryId", entryId)
+                                .log("Sticky key hash was missing for");
                         return;
                     }
                     if (updatedHashRanges.containsStickyKey(stickyKeyHash)) {
@@ -247,11 +255,12 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                     // order to preserver order delivery, we need to discard this read result, and try to trigger a
                     // replay read, that containing "relayPosition", by calling readMoreEntries.
                     if (replayPosition.compareTo(minReplayedPosition) < 0) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Position {} (<{}) is inserted for relay during current {} read, "
-                                            + "discard this read and retry with readMoreEntries.",
-                                    name, replayPosition, minReplayedPosition, readType);
-                        }
+                        log.debug()
+                                .attr("replayPosition", replayPosition)
+                                .attr("minReplayedPosition", minReplayedPosition)
+                                .attr("readType", readType)
+                                .log("Position (<) is inserted for relay during current read, "
+                                        + "discard this read and retry with readMoreEntries.");
                         if (readType == ReadType.Normal) {
                             entries.forEach(this::addEntryToReplay);
                         } else if (readType == ReadType.Replay) {
@@ -275,10 +284,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         for (Map.Entry<Consumer, List<Entry>> current : entriesByConsumerForDispatching.entrySet()) {
             Consumer consumer = current.getKey();
             List<Entry> entriesForConsumer = current.getValue();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] select consumer {} with messages num {}, read type is {}",
-                        name, consumer.consumerName(), entriesForConsumer.size(), readType);
-            }
+            log.debug()
+                    .attr("consumerName", consumer.consumerName())
+                    .attr("size", entriesForConsumer.size())
+                    .attr("readType", readType)
+                    .log("select consumer with messages num, read type is");
             // remove positions first from replay list first : sendMessages recycles entries
             if (readType == ReadType.Replay) {
                 for (Entry entry : entriesForConsumer) {
@@ -347,22 +357,33 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
      */
     private boolean handleAddingPendingAck(Consumer consumer, long ledgerId, long entryId, int stickyKeyHash) {
         if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
-            log.warn("[{}] Sticky key hash is missing for {}:{}", getName(), ledgerId, entryId);
+            log.warn()
+                    .attr("ledgerId", ledgerId)
+                    .attr("entryId", entryId)
+                    .log("Sticky key hash is missing");
             throw new IllegalArgumentException("Sticky key hash is missing for " + ledgerId + ":" + entryId);
         }
         DrainingHashesTracker.DrainingHashEntry drainingHashEntry = drainingHashesTracker.getEntry(stickyKeyHash);
         if (drainingHashEntry != null && drainingHashEntry.getConsumer() != consumer) {
-            log.warn("[{}] Another consumer id {} is already draining hash {}. Skipping adding {}:{} to pending acks "
-                            + "for consumer {}. Adding the message to replay.",
-                    getName(), drainingHashEntry.getConsumer(), stickyKeyHash, ledgerId, entryId, consumer);
+            log.warn()
+                    .attr("drainingConsumer", drainingHashEntry.getConsumer())
+                    .attr("stickyKeyHash", stickyKeyHash)
+                    .attr("ledgerId", ledgerId)
+                    .attr("entryId", entryId)
+                    .attr("consumer", consumer)
+                    .log("Another consumer id is already draining hash. Skipping adding to pending acks "
+                            + "for consumer. Adding the message to replay.");
             addMessageToReplay(ledgerId, entryId, stickyKeyHash);
             // block message from sending
             return false;
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Adding {}:{} to pending acks for consumer id:{} name:{} with sticky key hash {}",
-                    getName(), ledgerId, entryId, consumer.consumerId(), consumer.consumerName(), stickyKeyHash);
-        }
+        log.debug()
+                .attr("ledgerId", ledgerId)
+                .attr("entryId", entryId)
+                .attr("consumerId", consumer.consumerId())
+                .attr("consumerName", consumer.consumerName())
+                .attr("stickyKeyHash", stickyKeyHash)
+                .log("Adding: to pending acks for consumer id: name: with sticky key hash");
         // allow adding the message to pending acks and sending the message to the consumer
         return true;
     }
@@ -569,9 +590,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             if (stickyKeyHash == null) {
                 // the sticky key hash is missing for delayed messages, the filtering will happen at the time of
                 // dispatch after reading the entry from the ledger
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] replay of entry at position {} doesn't contain sticky key hash.", name, position);
-                }
+                log.debug()
+                        .attr("position", position)
+                        .log("replay of entry at position doesn't contain sticky key hash.");
                 return true;
             }
             // check if the hash is already blocked, if so, then replaying of the position should be skipped
@@ -717,10 +738,10 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
      */
     @Override
     protected void handleNormalReadNotAllowed() {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] Skipping read for the topic since normal read isn't allowed. "
-                    + "Rescheduling a read with a backoff.", topic.getName(), getSubscriptionName());
-        }
+        log.debug()
+                .attr("topic", topic.getName())
+                .log("Skipping read for the topic since normal read isn't allowed. "
+                        + "Rescheduling a read with a backoff.");
         reScheduleReadWithBackoff();
     }
 
@@ -750,6 +771,4 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     public Map<Consumer, List<Range>> getConsumerKeyHashRanges() {
         return selector.getConsumerKeyHashRanges();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumers.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,8 +60,6 @@ import org.apache.pulsar.common.api.proto.KeySharedMeta;
 import org.apache.pulsar.common.api.proto.KeySharedMode;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is the "classic" dispatcher implementation for the Key_Shared subscription that was used before
@@ -70,6 +69,9 @@ import org.slf4j.LoggerFactory;
  */
 public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         extends PersistentDispatcherMultipleConsumersClassic implements StickyKeyDispatcher {
+
+    private static final Logger LOG = Logger.get(PersistentStickyKeyDispatcherMultipleConsumersClassic.class);
+    protected final Logger log;
 
     private final boolean allowOutOfOrderDelivery;
     private final StickyKeyConsumerSelector selector;
@@ -108,6 +110,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
                                                   KeySharedMeta ksm,
                                                   @Nullable LinkedHashMap<Consumer, Position> recentlyJoinedConsumers) {
         super(topic, cursor, subscription, ksm.isAllowOutOfOrderDelivery());
+        this.log = LOG.with().ctx(super.log).build();
 
         this.allowOutOfOrderDelivery = ksm.isAllowOutOfOrderDelivery();
         if (recentlyJoinedConsumers == null) {
@@ -146,7 +149,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
     @Override
     public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
         if (IS_CLOSED_UPDATER.get(this) == TRUE) {
-            log.warn("[{}] Dispatcher is already closed. Closing consumer {}", name, consumer);
+            log.warn()
+                    .attr("consumer", consumer)
+                    .log("Dispatcher is already closed. Closing consumer");
             consumer.disconnect();
             return CompletableFuture.completedFuture(null);
         }
@@ -213,10 +218,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         }
         // Something went wrongly, sort the collection.
         if (sortNeeded) {
-            log.error("[{}] [{}] The items in recentlyJoinedConsumers are out-of-order. {}",
-                    topic.getName(), name, recentlyJoinedConsumers.entrySet().stream().map(entry ->
+            log.error()
+                    .attr("recentlyJoinedConsumers", recentlyJoinedConsumers.entrySet().stream().map(entry ->
                             String.format("%s-%s:%s", entry.getKey().consumerName(), entry.getValue().getLedgerId(),
-                                    entry.getValue().getEntryId())).collect(Collectors.toList()));
+                                    entry.getValue().getEntryId())).collect(Collectors.toList()))
+                    .log("The items in recentlyJoinedConsumers are out-of-order");
             List<Map.Entry<Consumer, Position>> sortedList = new ArrayList<>(recentlyJoinedConsumers.entrySet());
             Collections.sort(sortedList, Map.Entry.comparingByValue());
             recentlyJoinedConsumers.clear();
@@ -299,11 +305,12 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
                     // order to preserver order delivery, we need to discard this read result, and try to trigger a
                     // replay read, that containing "relayPosition", by calling readMoreEntries.
                     if (replayPosition.compareTo(minReplayedPosition) < 0) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Position {} (<{}) is inserted for relay during current {} read, "
-                                            + "discard this read and retry with readMoreEntries.",
-                                    name, replayPosition, minReplayedPosition, readType);
-                        }
+                        log.debug()
+                                .attr("replayPosition", replayPosition)
+                                .attr("minReplayedPosition", minReplayedPosition)
+                                .attr("readType", readType)
+                                .log("Position (<) is inserted for relay during current read, "
+                                        + "discard this read and retry with readMoreEntries.");
                         if (readType == ReadType.Normal) {
                             entries.forEach(entry -> {
                                 long stickyKeyHash = getStickyKeyHash(entry);
@@ -350,10 +357,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
             int messagesForC = getRestrictedMaxEntriesForConsumer(consumer,
                     entriesWithSameKey.stream().map(Entry::getPosition).collect(Collectors.toList()), availablePermits,
                     readType, consumerStickyKeyHashesMap.get(consumer));
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] select consumer {} with messages num {}, read type is {}",
-                        name, consumer.consumerName(), messagesForC, readType);
-            }
+            log.debug()
+                    .attr("consumerName", consumer.consumerName())
+                    .attr("messagesForC", messagesForC)
+                    .attr("readType", readType)
+                    .log("select consumer with messages num, read type is");
 
             if (messagesForC < entriesWithSameKeyCount) {
                 // We are not able to push all the messages with given key to its consumer,
@@ -654,8 +662,4 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
         }
         return selector.makeStickyKeyHash(peekStickyKey(entry));
     }
-
-    private static final Logger log =
-            LoggerFactory.getLogger(PersistentStickyKeyDispatcherMultipleConsumersClassic.class);
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -22,6 +22,7 @@ import static org.apache.pulsar.broker.service.AbstractBaseDispatcher.checkAndAp
 import static org.apache.pulsar.common.naming.SystemTopicNames.isEventSystemTopic;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -92,10 +93,12 @@ import org.apache.pulsar.common.policies.data.stats.SubscriptionStatsImpl;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.stats.PositionInPendingAckStats;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PersistentSubscription extends AbstractSubscription {
+
+    private static final Logger LOG = Logger.get(PersistentSubscription.class);
+    protected final Logger log;
+
     protected final PersistentTopic topic;
     protected final ManagedCursor cursor;
     protected volatile Dispatcher dispatcher;
@@ -161,6 +164,10 @@ public class PersistentSubscription extends AbstractSubscription {
         this.topicName = topic.getName();
         this.subName = subscriptionName;
         this.fullName = MoreObjects.toStringHelper(this).add("topic", topicName).add("name", subName).toString();
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .build();
         this.expiryMonitor = new PersistentMessageExpiryMonitor(topic, subscriptionName, cursor, this);
         if (replicated != null) {
             this.setReplicated(replicated);
@@ -216,8 +223,10 @@ public class PersistentSubscription extends AbstractSubscription {
         if (this.cursor != null) {
             if (replicated) {
                 if (!config.isEnableReplicatedSubscriptions()) {
-                    log.warn("[{}][{}] Failed set replicated subscription status to {}, please enable the "
-                            + "configuration enableReplicatedSubscriptions", topicName, subName, replicated);
+                    log.warn()
+                            .attr("replicated", replicated)
+                            .log("Failed set replicated subscription status to, please enable the "
+                                    + "configuration enableReplicatedSubscriptions");
                 } else {
                     return this.cursor.putProperty(REPLICATED_SUBSCRIPTION_PROPERTY, 1L);
                 }
@@ -255,7 +264,7 @@ public class PersistentSubscription extends AbstractSubscription {
                 }
 
                 if (IS_FENCED_UPDATER.get(this) == TRUE) {
-                    log.warn("Attempting to add consumer {} on a fenced subscription", consumer);
+                    log.warn().attr("consumer", consumer).log("Attempting to add consumer on a fenced subscription");
                     return FutureUtil.failedFuture(new SubscriptionFencedException("Subscription is fenced"));
                 }
 
@@ -340,9 +349,12 @@ public class PersistentSubscription extends AbstractSubscription {
 
         if (previousDispatcher != null) {
             previousDispatcher.close().thenRun(() -> {
-                log.info("[{}][{}] Successfully closed previous dispatcher", topicName, subName);
+                log.info()
+                        .log("Successfully closed previous dispatcher");
             }).exceptionally(ex -> {
-                log.error("[{}][{}] Failed to close previous dispatcher", topicName, subName, ex);
+                log.error()
+                        .exception(ex)
+                        .log("Failed to close previous dispatcher");
                 return null;
             });
         }
@@ -382,15 +394,20 @@ public class PersistentSubscription extends AbstractSubscription {
                     synchronized (this) {
                         if (dispatcher != null) {
                             dispatcher.close().thenRun(() -> {
-                                log.info("[{}][{}] Successfully closed dispatcher for reader", topicName, subName);
+                                log.info()
+                                        .log("Successfully closed dispatcher for reader");
                             }).exceptionally(ex -> {
-                                log.error("[{}][{}] Failed to close dispatcher for reader", topicName, subName, ex);
+                                log.error()
+                                        .exception(ex)
+                                        .log("Failed to close dispatcher for reader");
                                 return null;
                             });
                         }
                     }
                 }).exceptionally(exception -> {
-                    log.error("[{}][{}] Failed to close subscription for reader", topicName, subName, exception);
+                    log.error()
+                            .exception(exception)
+                            .log("Failed to close subscription for reader");
                     return null;
                 });
 
@@ -404,7 +421,9 @@ public class PersistentSubscription extends AbstractSubscription {
                             try {
                                 topic.getManagedLedger().deleteCursor(cursor.getName());
                             } catch (InterruptedException | ManagedLedgerException e) {
-                                log.warn("[{}] [{}] Failed to remove non durable cursor", topic.getName(), subName, e);
+                                log.warn()
+                                        .exception(e)
+                                        .log("Failed to remove non durable cursor");
                             }
                         }
                     }, topic.getBrokerService().pulsar().getExecutor());
@@ -415,10 +434,10 @@ public class PersistentSubscription extends AbstractSubscription {
         // invalid consumer remove will throw an exception
         // decrement usage is triggered only for valid consumer close
         topic.decrementUsageCount();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] [{}] Removed consumer -- count: {}", topic.getName(), subName, consumer.consumerName(),
-                    topic.currentUsageCount());
-        }
+        log.debug()
+                .attr("consumerName", consumer.consumerName())
+                .attr("currentUsageCount", topic.currentUsageCount())
+                .log("Removed consumer -- count");
     }
 
     public void deactivateCursor() {
@@ -439,21 +458,22 @@ public class PersistentSubscription extends AbstractSubscription {
         if (ackType == AckType.Cumulative) {
 
             if (positions.size() != 1) {
-                log.warn("[{}][{}] Invalid cumulative ack received with multiple message ids.", topicName, subName);
+                log.warn()
+                        .log("Invalid cumulative ack received with multiple message ids.");
                 return;
             }
 
             Position position = positions.get(0);
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Cumulative ack on {}", topicName, subName, position);
-            }
+            log.debug()
+                    .attr("position", position)
+                    .log("Cumulative ack on");
             cursor.asyncMarkDelete(position, mergeCursorProperties(properties),
                     markDeleteCallback, previousMarkDeletePosition);
 
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Individual acks on {}", topicName, subName, positions);
-            }
+            log.debug()
+                    .attr("positions", positions)
+                    .log("Individual acks on");
             cursor.asyncDelete(positions, deleteCallback, previousMarkDeletePosition);
             if (config.isTransactionCoordinatorEnabled()) {
                 positions.forEach(position -> {
@@ -491,10 +511,10 @@ public class PersistentSubscription extends AbstractSubscription {
         public void markDeleteComplete(Object ctx) {
             Position oldMD = (Position) ctx;
             Position newMD = cursor.getMarkDeletedPosition();
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Mark deleted messages to position {} from position {}",
-                        topicName, subName, newMD, oldMD);
-            }
+            log.debug()
+                    .attr("newMD", newMD)
+                    .attr("oldMD", oldMD)
+                    .log("Mark deleted messages to position from position");
             // Signal the dispatchers to give chance to take extra actions
             if (dispatcher != null) {
                 dispatcher.afterAckMessages(null, ctx);
@@ -506,9 +526,10 @@ public class PersistentSubscription extends AbstractSubscription {
         @Override
         public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
             // TODO: cut consumer connection on markDeleteFailed
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Failed to mark delete for position {}: {}", topicName, subName, ctx, exception);
-            }
+            log.debug()
+                    .attr("ctx", ctx)
+                    .exceptionMessage(exception)
+                    .log("Failed to mark delete for position");
             // Signal the dispatchers to give chance to take extra actions
             if (dispatcher != null) {
                 dispatcher.afterAckMessages(null, ctx);
@@ -519,10 +540,10 @@ public class PersistentSubscription extends AbstractSubscription {
     private final DeleteCallback deleteCallback = new DeleteCallback() {
         @Override
         public void deleteComplete(Object context) {
-            if (log.isDebugEnabled()) {
-                // The value of the param "context" is a position.
-                log.debug("[{}][{}] Deleted message at {}", topicName, subName, context);
-            }
+            // The value of the param "context" is a position.
+            log.debug()
+                    .attr("context", context)
+                    .log("Deleted message");
             // Signal the dispatchers to give chance to take extra actions
             if (dispatcher != null) {
                 dispatcher.afterAckMessages(null, context);
@@ -532,7 +553,10 @@ public class PersistentSubscription extends AbstractSubscription {
 
         @Override
         public void deleteFailed(ManagedLedgerException exception, Object ctx) {
-            log.warn("[{}][{}] Failed to delete message at {}: {}", topicName, subName, ctx, exception);
+            log.warn()
+                    .attr("ctx", ctx)
+                    .exceptionMessage(exception)
+                    .log("Failed to delete message");
             // Signal the dispatchers to give chance to take extra actions
             if (dispatcher != null) {
                 dispatcher.afterAckMessages(exception, ctx);
@@ -626,9 +650,7 @@ public class PersistentSubscription extends AbstractSubscription {
             return CompletableFuture.failedFuture(e);
         }
         long start = System.currentTimeMillis();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Starting to analyze backlog", topicName, subName);
-        }
+        log.debug().log("Starting to analyze backlog");
 
         AtomicLong entries = new AtomicLong();
         AtomicLong accepted = new AtomicLong();
@@ -642,10 +664,9 @@ public class PersistentSubscription extends AbstractSubscription {
 
         Position currentPosition = newNonDurableCursor.getMarkDeletedPosition();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] currentPosition {}",
-                    topicName, subName, currentPosition);
-        }
+        log.debug()
+                .attr("currentPosition", currentPosition)
+                .log("currentPosition");
         final EntryFilterSupport entryFilterSupport = dispatcher != null
                 ? (EntryFilterSupport) dispatcher : new EntryFilterSupport(this);
         // we put some hard limits on the scan, in order to prevent denial of services
@@ -655,9 +676,7 @@ public class PersistentSubscription extends AbstractSubscription {
         AtomicReference<Position> firstPosition = new AtomicReference<>();
         AtomicReference<Position> lastPosition = new AtomicReference<>();
         final Predicate<Entry> condition = entry -> {
-            if (log.isDebugEnabled()) {
-                log.debug("found {}", entry);
-            }
+            log.debug().attr("entry", entry).log("found");
             Position entryPosition = entry.getPosition();
             firstPosition.compareAndSet(null, entryPosition);
             lastPosition.set(entryPosition);
@@ -701,9 +720,10 @@ public class PersistentSubscription extends AbstractSubscription {
 
             if (num % 1000 == 0) {
                 long end = System.currentTimeMillis();
-                log.info(
-                        "[{}][{}] scan running since {} ms - scanned {} entries",
-                        topicName, subName, end - start, num);
+                log.info()
+                        .attr("latencyMs", end - start)
+                        .attr("num", num)
+                        .log("Scan running");
             }
 
             return true;
@@ -731,9 +751,10 @@ public class PersistentSubscription extends AbstractSubscription {
             // sometimes we abort the execution due to a timeout or
             // when we reach a maximum number of entries
             result.setScanOutcome(outcome);
-            log.info(
-                    "[{}][{}] scan took {} ms - {}",
-                    topicName, subName, end - start, result);
+            log.info()
+                    .attr("latencyMs", end - start)
+                    .attr("result", result)
+                    .log("Scan complete");
             return result;
         });
         res.whenComplete((__, ex) -> {
@@ -746,8 +767,9 @@ public class PersistentSubscription extends AbstractSubscription {
 
                     @Override
                     public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                        log.warn("[{}][{}] Delete non-durable cursor[{}] failed when analyze backlog.",
-                                topicName, subName, newNonDurableCursor.getName());
+                        log.warn()
+                                .attr("name", newNonDurableCursor.getName())
+                                .log("Delete non-durable cursor failed when analyze backlog.");
                     }
                 }, null);
         });
@@ -758,18 +780,16 @@ public class PersistentSubscription extends AbstractSubscription {
     public CompletableFuture<Void> clearBacklog() {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Backlog size before clearing: {}", topicName, subName,
-                    cursor.getNumberOfEntriesInBacklog(false));
-        }
+        log.debug()
+                .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
+                .log("Backlog size before clearing");
 
         cursor.asyncClearBacklog(new ClearBacklogCallback() {
             @Override
             public void clearBacklogComplete(Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Backlog size after clearing: {}", topicName, subName,
-                            cursor.getNumberOfEntriesInBacklog(false));
-                }
+                log.debug()
+                        .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
+                        .log("Backlog size after clearing");
                 if (dispatcher != null) {
                     dispatcher.clearDelayedMessages().whenComplete((__, ex) -> {
                         if (ex != null) {
@@ -786,7 +806,9 @@ public class PersistentSubscription extends AbstractSubscription {
 
             @Override
             public void clearBacklogFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("[{}][{}] Failed to clear backlog", topicName, subName, exception);
+                log.error()
+                        .exception(exception)
+                        .log("Failed to clear backlog");
                 future.completeExceptionally(exception);
                 if (dispatcher != null) {
                     dispatcher.afterAckMessages(exception, ctx);
@@ -801,18 +823,18 @@ public class PersistentSubscription extends AbstractSubscription {
     public CompletableFuture<Void> skipMessages(int numMessagesToSkip) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Skipping {} messages, current backlog {}", topicName, subName, numMessagesToSkip,
-                    cursor.getNumberOfEntriesInBacklog(false));
-        }
+        log.debug()
+                .attr("numMessagesToSkip", numMessagesToSkip)
+                .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
+                .log("Skipping messages");
         cursor.asyncSkipEntries(numMessagesToSkip, IndividualDeletedEntries.Exclude,
                 new AsyncCallbacks.SkipEntriesCallback() {
                     @Override
                     public void skipEntriesComplete(Object ctx) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}][{}] Skipped {} messages, new backlog {}", topicName, subName,
-                                    numMessagesToSkip, cursor.getNumberOfEntriesInBacklog(false));
-                        }
+                        log.debug()
+                                .attr("numMessagesToSkip", numMessagesToSkip)
+                                .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
+                                .log("Skipped messages");
                         future.complete(null);
                         if (dispatcher != null) {
                             dispatcher.afterAckMessages(null, ctx);
@@ -821,8 +843,10 @@ public class PersistentSubscription extends AbstractSubscription {
 
                     @Override
                     public void skipEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("[{}][{}] Failed to skip {} messages", topicName, subName, numMessagesToSkip,
-                                exception);
+                        log.error()
+                                .attr("numMessagesToSkip", numMessagesToSkip)
+                                .exception(exception)
+                                .log("Failed to skip messages");
                         future.completeExceptionally(exception);
                         if (dispatcher != null) {
                             dispatcher.afterAckMessages(exception, ctx);
@@ -844,9 +868,9 @@ public class PersistentSubscription extends AbstractSubscription {
         PersistentMessageFinder persistentMessageFinder = new PersistentMessageFinder(topicName, cursor,
                 config.getManagedLedgerCursorResetLedgerCloseTimestampMaxClockSkewMillis());
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Resetting subscription to timestamp {}", topicName, subName, timestamp);
-        }
+        log.debug()
+                .attr("timestamp", timestamp)
+                .log("Resetting subscription to timestamp");
         persistentMessageFinder.findMessages(timestamp, new AsyncCallbacks.FindEntryCallback() {
             @Override
             public void findEntryComplete(Position position, Object ctx) {
@@ -856,9 +880,10 @@ public class PersistentSubscription extends AbstractSubscription {
                     // that spans beyond the retention limits (time/size)
                     finalPosition = cursor.getFirstPosition();
                     if (finalPosition == null) {
-                        log.warn("[{}][{}] Unable to find position for timestamp {}."
-                                        + " Unable to reset cursor to first position",
-                                topicName, subName, timestamp);
+                        log.warn()
+                                .attr("timestamp", timestamp)
+                                .log("Unable to find position for timestamp."
+                                        + "Unable to reset cursor to first position");
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                         inProgressResetCursorFuture = null;
                         future.completeExceptionally(
@@ -866,10 +891,11 @@ public class PersistentSubscription extends AbstractSubscription {
                                         "Unable to find position for specified timestamp"));
                         return;
                     }
-                    log.info(
-                            "[{}][{}] Unable to find position for timestamp {}."
-                                    + " Resetting cursor to first position {} in ledger",
-                            topicName, subName, timestamp, finalPosition);
+                    log.info()
+                            .attr("timestamp", timestamp)
+                            .attr("finalPosition", finalPosition)
+                            .log("Unable to find position for timestamp."
+                                    + "Resetting cursor to first position in ledger");
                 } else {
                     finalPosition = position.getNext();
                 }
@@ -925,7 +951,9 @@ public class PersistentSubscription extends AbstractSubscription {
             }
 
             if (throwable != null) {
-                log.error("[{}][{}] Failed to disconnect consumer from subscription", topicName, subName, throwable);
+                log.error()
+                        .exception(throwable)
+                        .log("Failed to disconnect consumer from subscription");
                 IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                 inProgressResetCursorFuture = null;
                 future.completeExceptionally(
@@ -933,8 +961,8 @@ public class PersistentSubscription extends AbstractSubscription {
                 return;
             }
 
-            log.info("[{}][{}] Successfully disconnected consumers from subscription, proceeding with cursor reset",
-                    topicName, subName);
+            log.info()
+                    .log("Successfully disconnected consumers from subscription, proceeding with cursor reset");
 
             CompletableFuture<Boolean> forceReset = new CompletableFuture<>();
             if (topic.getTopicCompactionService() == null) {
@@ -958,10 +986,9 @@ public class PersistentSubscription extends AbstractSubscription {
                 cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
                     @Override
                     public void resetComplete(Object ctx) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}][{}] Successfully reset subscription to position {}", topicName, subName,
-                                    finalPosition);
-                        }
+                        log.debug()
+                                .attr("finalPosition", finalPosition)
+                                .log("Successfully reset subscription to position");
                         if (dispatcher != null) {
                             dispatcher.cursorIsReset();
                             dispatcher.afterAckMessages(null, finalPosition);
@@ -973,8 +1000,10 @@ public class PersistentSubscription extends AbstractSubscription {
 
                     @Override
                     public void resetFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("[{}][{}] Failed to reset subscription to position {}", topicName, subName,
-                                finalPosition, exception);
+                        log.error()
+                                .attr("finalPosition", finalPosition)
+                                .exception(exception)
+                                .log("Failed to reset subscription to position");
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                         inProgressResetCursorFuture = null;
                         // todo - retry on InvalidCursorPositionException
@@ -989,7 +1018,9 @@ public class PersistentSubscription extends AbstractSubscription {
                     }
                 });
             }).exceptionally((e) -> {
-                log.error("[{}][{}] Error while resetting cursor", topicName, subName, e);
+                log.error()
+                        .exception(e)
+                        .log("Error while resetting cursor");
                 IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                 inProgressResetCursorFuture = null;
                 future.completeExceptionally(new BrokerServiceException(e));
@@ -1003,9 +1034,9 @@ public class PersistentSubscription extends AbstractSubscription {
     public CompletableFuture<Entry> peekNthMessage(int messagePosition) {
         CompletableFuture<Entry> future = new CompletableFuture<>();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Getting message at position {}", topicName, subName, messagePosition);
-        }
+        log.debug()
+                .attr("messagePosition", messagePosition)
+                .log("Getting message at position");
 
         cursor.asyncGetNthEntry(messagePosition, IndividualDeletedEntries.Exclude, new ReadEntryCallback() {
 
@@ -1059,7 +1090,9 @@ public class PersistentSubscription extends AbstractSubscription {
         }
         return this.pendingAckHandle.closeAsync().thenAccept(v -> {
             IS_FENCED_UPDATER.set(this, TRUE);
-            log.info("[{}][{}] Successfully closed subscription [{}]", topicName, subName, cursor);
+            log.info()
+                    .attr("cursor", cursor)
+                    .log("Successfully closed subscription");
         });
     }
 
@@ -1077,10 +1110,13 @@ public class PersistentSubscription extends AbstractSubscription {
                 ? dispatcher.disconnectAllConsumers(false, assignedBrokerLookupData)
                 : CompletableFuture.completedFuture(null))
                 .thenRun(() -> {
-                    log.info("[{}][{}] Successfully disconnected subscription consumers", topicName, subName);
+                    log.info()
+                            .log("Successfully disconnected subscription consumers");
                     disconnectFuture.complete(null);
                 }).exceptionally(exception -> {
-                    log.error("[{}][{}] Error disconnecting subscription consumers", topicName, subName, exception);
+                    log.error()
+                            .exception(exception)
+                            .log("Error disconnecting subscription consumers");
                     disconnectFuture.completeExceptionally(exception);
                     return null;
                 });
@@ -1110,10 +1146,13 @@ public class PersistentSubscription extends AbstractSubscription {
                 : CompletableFuture.completedFuture(null))
                 // checkActiveConsumers is false since we just closed all of them if we wanted.
                 .thenCompose(__ -> closeCursor(false)).thenRun(() -> {
-                    log.info("[{}][{}] Successfully closed the subscription", topicName, subName);
+                    log.info()
+                            .log("Successfully closed the subscription");
                     fenceFuture.complete(null);
                 }).exceptionally(exception -> {
-                    log.error("[{}][{}] Error closing the subscription", topicName, subName, exception);
+                    log.error()
+                            .exception(exception)
+                            .log("Error closing the subscription");
                     fenceFuture.completeExceptionally(exception);
                     resumeAfterFence();
                     return null;
@@ -1138,7 +1177,9 @@ public class PersistentSubscription extends AbstractSubscription {
                         }
                         fenceFuture = null;
                     } catch (Exception ex) {
-                        log.error("[{}] Resume subscription [{}] failure", topicName, subName, ex);
+                        log.error()
+                                .exception(ex)
+                                .log("Resume subscription failure");
                     }
                 }
             });
@@ -1178,7 +1219,7 @@ public class PersistentSubscription extends AbstractSubscription {
     private CompletableFuture<Void> delete(boolean closeIfConsumersConnected) {
         CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
 
-        log.info("[{}][{}] Unsubscribing", topicName, subName);
+        log.info().log("Unsubscribing");
 
         CompletableFuture<Void> closeSubscriptionFuture = new CompletableFuture<>();
 
@@ -1186,7 +1227,9 @@ public class PersistentSubscription extends AbstractSubscription {
             this.close(true, Optional.empty()).thenRun(() -> {
                 closeSubscriptionFuture.complete(null);
             }).exceptionally(ex -> {
-                log.error("[{}][{}] Error disconnecting and closing subscription", topicName, subName, ex);
+                log.error()
+                        .exception(ex)
+                        .log("Error disconnecting and closing subscription");
                 closeSubscriptionFuture.completeExceptionally(ex);
                 return null;
             });
@@ -1194,7 +1237,9 @@ public class PersistentSubscription extends AbstractSubscription {
             this.closeCursor(true).thenRun(() -> {
                 closeSubscriptionFuture.complete(null);
             }).exceptionally(exception -> {
-                log.error("[{}][{}] Error closing subscription", topicName, subName, exception);
+                log.error()
+                        .exception(exception)
+                        .log("Error closing subscription");
                 closeSubscriptionFuture.completeExceptionally(exception);
                 return null;
             });
@@ -1204,21 +1249,26 @@ public class PersistentSubscription extends AbstractSubscription {
         closeSubscriptionFuture.thenCompose(v -> topic.unsubscribe(subName)).thenAccept(v -> {
             synchronized (this) {
                 (dispatcher != null ? dispatcher.close() : CompletableFuture.completedFuture(null)).thenRun(() -> {
-                    log.info("[{}][{}] Successfully deleted subscription", topicName, subName);
+                    log.info()
+                            .log("Successfully deleted subscription");
                     deleteFuture.complete(null);
                 }).exceptionally(ex -> {
                     IS_FENCED_UPDATER.set(this, FALSE);
                     if (dispatcher != null) {
                         dispatcher.reset();
                     }
-                    log.error("[{}][{}] Error deleting subscription", topicName, subName, ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Error deleting subscription");
                     deleteFuture.completeExceptionally(ex);
                     return null;
                 });
             }
         }).exceptionally(exception -> {
             IS_FENCED_UPDATER.set(this, FALSE);
-            log.error("[{}][{}] Error deleting subscription", topicName, subName, exception);
+            log.error()
+                    .exception(exception)
+                    .log("Error deleting subscription");
             deleteFuture.completeExceptionally(exception);
             return null;
         });
@@ -1251,16 +1301,16 @@ public class PersistentSubscription extends AbstractSubscription {
         CompletableFuture<Void> future = new CompletableFuture<>();
         try {
             if (force || dispatcher.canUnsubscribe(consumer)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] unsubscribing forcefully {}-{}", topicName, subName, consumer.consumerName());
-                }
+                log.debug()
+                        .attr("consumerName", consumer.consumerName())
+                        .log("unsubscribing forcefully");
                 consumer.close();
                 return delete(force);
             }
             future.completeExceptionally(
                     new ServerMetadataException("Unconnected or shared consumer attempting to unsubscribe"));
         } catch (BrokerServiceException e) {
-            log.warn("Error removing consumer {}", consumer);
+            log.warn().attr("consumer", consumer).log("Error removing consumer");
             future.completeExceptionally(e);
         }
         return future;
@@ -1485,7 +1535,10 @@ public class PersistentSubscription extends AbstractSubscription {
                     long entryTimestamp = entry.getEntryTimestamp();
                     future.complete(entryTimestamp);
                 } catch (Exception e) {
-                    log.error("Error deserializing message for message position {}", nextPos, e);
+                    log.error()
+                            .attr("nextPos", nextPos)
+                            .exception(e)
+                            .log("Error deserializing message for message position");
                     future.completeExceptionally(e);
                 } finally {
                     entry.release();
@@ -1494,7 +1547,7 @@ public class PersistentSubscription extends AbstractSubscription {
 
             @Override
             public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("Error read entry for position {}", nextPos, exception);
+                log.error().attr("nextPos", nextPos).exception(exception).log("Error read entry for position");
                 future.completeExceptionally(exception);
             }
 
@@ -1560,7 +1613,7 @@ public class PersistentSubscription extends AbstractSubscription {
 
     @Override
     public boolean isSubscriptionMigrated() {
-        log.info("backlog for {} - {}", topicName, cursor.getNumberOfEntriesInBacklog(true));
+        log.info().attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(true)).log("Backlog");
         return topic.isMigrated() && cursor.getNumberOfEntriesInBacklog(true) <= 0;
     }
 
@@ -1671,9 +1724,6 @@ public class PersistentSubscription extends AbstractSubscription {
     public PositionInPendingAckStats checkPositionInPendingAckState(Position position, Integer batchIndex) {
         return pendingAckHandle.checkPositionInPendingAckState(position, batchIndex);
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentSubscription.class);
-
     @VisibleForTesting
     public Boolean getReplicatedControlled() {
         return replicatedControlled;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -29,6 +29,7 @@ import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.time.Clock;
@@ -205,11 +206,12 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.utils.StatsOutputStream;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCallback {
+
+    private static final Logger LOG = Logger.get(PersistentTopic.class);
+    protected final Logger log;
 
     // Managed ledger associated with the topic
     protected final ManagedLedger ledger;
@@ -406,6 +408,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     public PersistentTopic(String topic, ManagedLedger ledger, BrokerService brokerService) {
         super(topic, brokerService);
+        this.log = LOG.with().ctx(super.log).build();
         // null check for backwards compatibility with tests which mock the broker service
         this.orderedExecutor = brokerService.getTopicOrderedExecutor() != null
                 ? brokerService.getTopicOrderedExecutor().chooseThread(topic)
@@ -442,6 +445,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     PersistentTopic(String topic, BrokerService brokerService, ManagedLedger ledger,
                     MessageDeduplication messageDeduplication) {
         super(topic, brokerService);
+        this.log = LOG.with().ctx(super.log).build();
         // null check for backwards compatibility with tests which mock the broker service
         this.orderedExecutor = brokerService.getTopicOrderedExecutor() != null
                 ? brokerService.getTopicOrderedExecutor().chooseThread(topic)
@@ -500,8 +504,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 .thenCompose(ignore -> initTopicPolicy())
                 .thenCompose(ignore -> removeOrphanReplicationCursors())
                 .exceptionally(ex -> {
-                    log.warn("[{}] Error getting policies {} and isEncryptionRequired will be set to false",
-                            topic, ex.getMessage());
+                    log.warn()
+                            .exceptionMessage(ex)
+                            .log("Error getting policies and isEncryptionRequired will be set to false");
                     isEncryptionRequired = false;
                     return null;
                 }));
@@ -552,7 +557,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if (cursor.getName().startsWith(replicatorPrefix)) {
                 String remoteCluster = PersistentReplicator.getRemoteCluster(cursor.getName());
                 if (!replicationClusters.contains(remoteCluster)) {
-                    log.warn("Remove the orphan replicator because the cluster '{}' does not exist", remoteCluster);
+                    log.warn()
+                            .attr("remoteCluster", remoteCluster)
+                            .log("Remove the orphan replicator because the cluster does not exist");
                     futures.add(removeReplicator(remoteCluster));
                 }
             }
@@ -718,7 +725,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             synchronized (this) {
                 if (isFenced && !isClosingOrDeleting) {
                     messageDeduplication.resetHighestSequenceIdPushed();
-                    log.info("[{}] Un-fencing topic...", topic);
+                    log.info("Un-fencing topic...");
                     // signal to managed ledger that we are ready to resume by creating a new ledger
                     ledger.readyToCreateNewLedger();
 
@@ -757,10 +764,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
          At the end of the transfer protocol, at Owned state, the source broker should close the topic properly.
          */
         if (transferring) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Failed to persist msg in store: {} while transferring.",
-                        topic, exception.getMessage(), exception);
-            }
+            log.debug()
+                    .exception(exception)
+                    .log("Failed to persist msg in store while transferring");
             return;
         }
 
@@ -778,8 +784,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 // send migration url metadata to producers before disconnecting them
                 if (isMigrated()) {
                     if (!shouldProducerMigrate()) {
-                        log.info("Topic {} is migrated but replication-backlog exists or "
-                                + "subs not created. Closing producers.", topic);
+                        log.info("Topic is migrated but replication-backlog exists or "
+                                + "subs not created, closing producers");
                     } else {
                         producers.forEach((__, producer) -> producer.topicMigrated(getMigratedClusterUrl()));
                     }
@@ -795,15 +801,17 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             });
 
             if (exception instanceof ManagedLedgerAlreadyClosedException) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
-                }
+                log.debug()
+                        .exceptionMessage(exception)
+                        .log("Failed to persist msg in store");
 
                 callback.completed(new TopicClosedException(exception), -1, -1);
                 return;
 
             } else {
-                log.warn("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
+                log.warn()
+                        .exceptionMessage(exception)
+                        .log("Failed to persist msg in store");
             }
 
             if (exception instanceof ManagedLedgerTerminatedException && !isMigrated()) {
@@ -844,13 +852,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         ledger.asyncSetProperty(TOPIC_EPOCH_PROPERTY_NAME, String.valueOf(newEpoch), new UpdatePropertiesCallback() {
             @Override
             public void updatePropertiesComplete(Map<String, String> properties, Object ctx) {
-                log.info("[{}] Updated topic epoch to {}", getName(), newEpoch);
+                log.info().attr("newEpoch", newEpoch).log("Updated topic epoch to");
                 future.complete(newEpoch);
             }
 
             @Override
             public void updatePropertiesFailed(ManagedLedgerException exception, Object ctx) {
-                log.warn("[{}] Failed to update topic epoch to {}: {}", getName(), newEpoch, exception.getMessage());
+                log.warn()
+                        .attr("newEpoch", newEpoch)
+                        .exceptionMessage(exception)
+                        .log("Failed to update topic epoch");
                 future.completeExceptionally(exception);
             }
         }, null);
@@ -888,9 +899,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         replicators.forEach((region, replicator) -> replicator.startProducer());
                     }
                 }, getOrderedExecutor()).exceptionally(ex -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Error getting policies while starting repl-producers {}", topic, ex.getMessage());
-            }
+            log.debug()
+                    .exceptionMessage(ex)
+                    .log("Error getting policies while starting repl-producers");
             replicators.forEach((region, replicator) -> replicator.startProducer());
             return null;
         });
@@ -949,7 +960,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             Boolean replicatedSubscriptionState = replicatedSubscriptionStateArg;
             if (replicatedSubscriptionState != null && replicatedSubscriptionState
                     && !brokerService.pulsar().getConfiguration().isEnableReplicatedSubscriptions()) {
-                log.warn("[{}] Replicated Subscription is disabled by broker.", getName());
+                log.warn("Replicated Subscription is disabled by broker.");
                 replicatedSubscriptionState = false;
             }
 
@@ -971,23 +982,23 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
 
             if (isBlank(subscriptionName)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Empty subscription name", topic);
-                }
+                log.debug("Empty subscription name");
                 return FutureUtil.failedFuture(new NamingException("Empty subscription name"));
             }
 
             if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Consumer doesn't support batch-message {}", topic, subscriptionName);
-                }
+                log.debug()
+                        .attr("subscription", subscriptionName)
+                        .log("Consumer doesn't support batch-message");
                 return FutureUtil.failedFuture(
                         new UnsupportedVersionException("Consumer doesn't support batch-message"));
             }
 
             if (subscriptionName.startsWith(replicatorPrefix)
                     || subscriptionName.equals(DEDUPLICATION_CURSOR_NAME)) {
-                log.warn("[{}] Failed to create subscription for {}", topic, subscriptionName);
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .log("Failed to create subscription for");
                 return FutureUtil.failedFuture(
                         new NamingException("Subscription with reserved subscription name attempted"));
             }
@@ -998,9 +1009,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         cnx.clientAddress().toString().split(":")[0], consumerName, consumerId);
                 if (!subscribeRateLimiter.get().subscribeAvailable(consumer)
                         || !subscribeRateLimiter.get().tryAcquire(consumer)) {
-                    log.warn("[{}] Failed to create subscription for {} {} limited by {}, available {}",
-                            topic, subscriptionName, consumer, subscribeRateLimiter.get().getSubscribeRate(),
-                            subscribeRateLimiter.get().getAvailableSubscribeRateLimit(consumer));
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .attr("consumer", consumer)
+                            .attr("subscribeRate", subscribeRateLimiter.get().getSubscribeRate())
+                            .attr("arg4", subscribeRateLimiter.get().getAvailableSubscribeRateLimit(consumer))
+                            .log("Failed to create subscription for limited by, available");
                     return FutureUtil.failedFuture(
                             new NotAllowedException("Subscribe limited by subscribe rate limit per consumer."));
                 }
@@ -1009,7 +1023,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             lock.readLock().lock();
             try {
                 if (isFenced) {
-                    log.warn("[{}] Attempting to subscribe to a fenced topic", topic);
+                    log.warn("Attempting to subscribe to a fenced topic");
                     return FutureUtil.failedFuture(new TopicFencedException("Topic is temporarily unavailable"));
                 }
                 handleConsumerAdded(subscriptionName, consumerName);
@@ -1037,19 +1051,27 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             consumer.close();
                         } catch (BrokerServiceException e) {
                             if (e instanceof ConsumerBusyException) {
-                                log.warn("[{}][{}] Consumer {} {} already connected: {}",
-                                        topic, subscriptionName, consumerId, consumerName, e.getMessage());
+                                log.warn()
+                                        .attr("subscription", subscriptionName)
+                                        .attr("consumerId", consumerId)
+                                        .attr("consumerName", consumerName)
+                                        .exceptionMessage(e)
+                                        .log("Consumer already connected");
                             } else if (e instanceof SubscriptionBusyException) {
-                                log.warn("[{}][{}] {}", topic, subscriptionName, e.getMessage());
+                                log.warn()
+                                        .attr("subscription", subscriptionName)
+                                        .exceptionMessage(e)
+                                        .log("");
                             }
 
                             decrementUsageCount();
                             return FutureUtil.failedFuture(e);
                         }
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] [{}] [{}] Subscribe failed -- count: {}", topic, subscriptionName,
-                                    consumer.consumerName(), currentUsageCount());
-                        }
+                        log.debug()
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerName", consumer.consumerName())
+                                .attr("arg3", currentUsageCount())
+                                .log("Subscribe failed -- count");
 
                         decrementUsageCount();
                         return FutureUtil.failedFuture(
@@ -1057,9 +1079,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         "Connection was closed while the opening the cursor "));
                     } else {
                         checkReplicatedSubscriptionControllerState();
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}][{}] Created new subscription for {}", topic, subscriptionName, consumerId);
-                        }
+                        log.debug()
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerId", consumerId)
+                                .log("Created new subscription for");
                         return CompletableFuture.completedFuture(consumer);
                     }
                 });
@@ -1069,8 +1092,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 decrementUsageCount();
 
                 if (ex.getCause() instanceof ConsumerBusyException) {
-                    log.warn("[{}][{}] Consumer {} {} already connected: {}", topic, subscriptionName, consumerId,
-                            consumerName, ex.getCause().getMessage());
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .attr("consumerId", consumerId)
+                            .attr("consumerName", consumerName)
+                            .exceptionMessage(ex.getCause())
+                            .log("Consumer already connected");
                     Consumer consumer = null;
                     try {
                         consumer = subscriptionFuture.isDone() ? getActiveConsumer(subscriptionFuture.get()) : null;
@@ -1079,25 +1106,42 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             consumer.close();
                         }
                     } catch (Exception be) {
-                        log.error("Failed to clean up consumer on closed connection {}, {}", consumer, be.getMessage());
+                        log.error()
+                                .attr("consumer", consumer)
+                                .exceptionMessage(be)
+                                .log("Failed to clean up consumer on closed connection");
                     }
                 } else if (ex.getCause() instanceof SubscriptionBusyException) {
-                    log.warn("[{}][{}] {}", topic, subscriptionName, ex.getMessage());
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .exceptionMessage(ex)
+                            .log("");
                 } else if (ex.getCause() instanceof BrokerServiceException.SubscriptionFencedException
                         && isCompactionSubscription(subscriptionName)) {
-                    log.warn("[{}] Failed to create compaction subscription: {}", topic, ex.getMessage());
+                    log.warn()
+                            .exceptionMessage(ex)
+                            .log("Failed to create compaction subscription");
                 } else if (ex.getCause() instanceof ManagedLedgerFencedException) {
                     // If the topic has been fenced, we cannot continue using it. We need to close and reopen
-                    log.warn("[{}][{}] has been fenced. closing the topic {}", topic, subscriptionName,
-                            ex.getMessage());
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .exceptionMessage(ex)
+                            .log("has been fenced. closing the topic");
                     close();
                 } else if (ex.getCause() instanceof BrokerServiceException.ConnectionClosedException) {
-                    log.warn("[{}][{}] Connection was closed while the opening the cursor", topic, subscriptionName);
+                    log.warn()
+                            .attr("subscription", subscriptionName)
+                            .log("Connection was closed while the opening the cursor");
                 } else if (ex.getCause() instanceof BrokerServiceException.NotAllowedException) {
-                    log.info("[{}][{}] Not allowed to create subscription: {}", topic, subscriptionName,
-                            ex.getCause().getMessage());
+                    log.info()
+                            .attr("subscription", subscriptionName)
+                            .exceptionMessage(ex.getCause())
+                            .log("Not allowed to create subscription");
                 } else {
-                    log.error("[{}] Failed to create subscription: {}", topic, subscriptionName, ex);
+                    log.error()
+                            .attr("subscription", subscriptionName)
+                            .exception(ex)
+                            .log("Failed to create subscription");
                 }
                 return null;
             });
@@ -1137,9 +1181,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 new OpenCursorCallback() {
             @Override
             public void openCursorComplete(ManagedCursor cursor, Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Opened cursor", topic, subscriptionName);
-                }
+                log.debug().attr("subscription", subscriptionName).log("Opened cursor");
 
                 PersistentSubscription subscription = subscriptions.get(subscriptionName);
                 if (subscription == null) {
@@ -1168,8 +1210,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             @Override
             public void openCursorFailed(ManagedLedgerException exception, Object ctx) {
-                log.warn("[{}] Failed to create subscription for {}: {}", topic, subscriptionName,
-                        exception.getMessage());
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .exceptionMessage(exception)
+                        .log("Failed to create subscription for");
                 decrementUsageCount();
                 subscriptionFuture.completeExceptionally(new PersistenceException(exception));
                 if (exception instanceof ManagedLedgerFencedException) {
@@ -1184,8 +1228,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName,
             MessageId startMessageId, InitialPosition initialPosition, long startMessageRollbackDurationSec,
             boolean isReadCompacted, Map<String, String> subscriptionProperties) {
-        log.info("[{}][{}] Creating non-durable subscription at msg id {} - {}",
-                topic, subscriptionName, startMessageId, subscriptionProperties);
+        log.info()
+                .attr("subscription", subscriptionName)
+                .attr("startMessageId", startMessageId)
+                .attr("subscriptionProperties", subscriptionProperties)
+                .log("Creating non-durable subscription at msg id");
 
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
         if (checkMaxSubscriptionsPerTopicExceed(subscriptionName)) {
@@ -1250,8 +1297,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         final Subscription finalSubscription = subscription;
         subscription.resetCursor(timestamp).handle((s, ex) -> {
             if (ex != null) {
-                log.warn("[{}] Failed to reset cursor {} position at timestamp {}, caused by {}", topic,
-                        subscription.getName(), startMessageRollbackDurationSec, ex.getMessage());
+                log.warn()
+                        .attr("name", subscription.getName())
+                        .attr("startMessageRollbackDurationSec", startMessageRollbackDurationSec)
+                        .exceptionMessage(ex)
+                        .log("Failed to reset cursor position at timestamp, caused by");
             }
             subscriptionFuture.complete(finalSubscription);
             return null;
@@ -1300,8 +1350,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             }
 
                             unsubscribeFuture.completeExceptionally(exception);
-                            log.error("[{}][{}] Error deleting subscription pending ack store",
-                                    topic, subscriptionName, exception);
+                            log.error()
+                                    .attr("subscription", subscriptionName)
+                                    .exception(exception)
+                                    .log("Error deleting subscription pending ack store");
                         }
                     }, null);
         } else {
@@ -1315,7 +1367,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                           CompletableFuture<Void> unsubscribeFuture) {
         PersistentSubscription persistentSubscription = subscriptions.get(subscriptionName);
         if (persistentSubscription == null) {
-            log.warn("[{}][{}] Can't find subscription, skip delete cursor", topic, subscriptionName);
+            log.warn()
+                    .attr("subscription", subscriptionName)
+                    .log("Can't find subscription, skip delete cursor");
             unsubscribeFuture.complete(null);
             return;
         }
@@ -1382,16 +1436,24 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 if (compactedTopicContext.isPresent() && compactedTopicContext.get().getLedger() != null) {
                     compactedLedger = compactedTopicContext.get().getLedger().getId();
                 }
-                log.error("[{}][{}][{}] Error cleaning compacted ledger", topic, subscriptionName, compactedLedger, ex);
+                log.error()
+                        .attr("subscription", subscriptionName)
+                        .attr("compactedLedger", compactedLedger)
+                        .exception(ex)
+                        .log("Error cleaning compacted ledger");
             } finally {
                 // Reset the variable: disablingCompaction,
                 disablingCompaction.compareAndSet(true, false);
             }
         }).exceptionally(ex -> {
             if (currentCompaction.isCompletedExceptionally()) {
-                log.warn("[{}][{}] Last compaction task failed", topic, subscriptionName);
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .log("Last compaction task failed");
             } else {
-                log.warn("[{}][{}] Failed to delete cursor task failed", topic, subscriptionName);
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .log("Failed to delete cursor task failed");
             }
             // Reset the variable: disablingCompaction,
             disablingCompaction.compareAndSet(true, false);
@@ -1404,9 +1466,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         ledger.asyncDeleteCursor(Codec.encode(subscriptionName), new DeleteCursorCallback() {
             @Override
             public void deleteCursorComplete(Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Cursor deleted successfully", topic, subscriptionName);
-                }
+                log.debug()
+                        .attr("subscription", subscriptionName)
+                        .log("Cursor deleted successfully");
                 removeSubscription(subscriptionName);
                 unsubscribeFuture.complete(null);
                 lastActive = System.nanoTime();
@@ -1414,10 +1476,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             @Override
             public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] Error deleting cursor for subscription",
-                            topic, subscriptionName, exception);
-                }
+                log.debug()
+                        .attr("subscription", subscriptionName)
+                        .exception(exception)
+                        .log("Error deleting cursor for subscription");
                 if (exception instanceof ManagedLedgerException.ManagedLedgerNotFoundException
                         || exception instanceof ManagedLedgerException.CursorNotFoundException) {
                     removeSubscription(subscriptionName);
@@ -1497,7 +1559,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         lock.writeLock().lock();
         try {
             if (isClosingOrDeleting) {
-                log.warn("[{}] Topic is already being closed or deleted", topic);
+                log.warn("Topic is already being closed or deleted");
                 return FutureUtil.failedFuture(new TopicFencedException("Topic is already fenced"));
             }
             // We can proceed with the deletion if either:
@@ -1571,7 +1633,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         command.run();
                     }
                 }).exceptionally(ex -> {
-                    log.error("[{}] Error closing clients", topic, ex);
+                    log.error().exception(ex).log("Error closing clients");
                     alreadyUnFenced.set(true);
                     unfenceTopicToResume();
                     closeClientFuture.completeExceptionally(ex);
@@ -1587,7 +1649,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                 .thenCompose(ignore -> transactionBufferCleanupAndClose())
                                 .whenComplete((v, ex) -> {
                                     if (ex != null) {
-                                        log.error("[{}] Error deleting topic", topic, ex);
+                                        log.error().exception(ex).log("Error deleting topic");
                                         alreadyUnFenced.set(true);
                                         unfenceTopicToResume();
                                         deleteFuture.completeExceptionally(ex);
@@ -1597,7 +1659,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                                     FutureUtil.waitForAll(subsDeleteFutures).whenComplete((f, e) -> {
                                         if (e != null) {
-                                            log.error("[{}] Error deleting topic", topic, e);
+                                            log.error().exception(e).log("Error deleting topic");
                                             alreadyUnFenced.set(true);
                                             unfenceTopicToResume();
                                             deleteFuture.completeExceptionally(e);
@@ -1613,7 +1675,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                                                     unregisterTopicPolicyListener();
 
-                                                    log.info("[{}] Topic deleted", topic);
+                                                    log.info("Topic deleted");
                                                     deleteFuture.complete(null);
                                                 }
 
@@ -1623,12 +1685,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                                    Object ctx) {
                                                     if (exception.getCause()
                                                             instanceof MetadataStoreException.NotFoundException) {
-                                                        log.info("[{}] Topic is already deleted {}",
-                                                                topic, exception.getMessage());
+                                                        log.info()
+                                                                .exceptionMessage(exception)
+                                                                .log("Topic is already deleted");
                                                         deleteLedgerComplete(ctx);
                                                     } else {
-                                                        log.error("[{}] Error deleting topic",
-                                                                topic, exception);
+                                                        log.error()
+                                                                .exception(exception)
+                                                                .log("Error deleting topic");
                                                         alreadyUnFenced.set(true);
                                                         unfenceTopicToResume();
                                                         deleteFuture.completeExceptionally(
@@ -1653,7 +1717,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return deleteFuture;
                 }).whenComplete((value, ex) -> {
                     if (ex != null) {
-                        log.error("[{}] Error deleting topic", topic, ex);
+                        log.error().exception(ex).log("Error deleting topic");
                         if (!alreadyUnFenced.get()) {
                             unfenceTopicToResume();
                         }
@@ -1770,7 +1834,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 try {
                     filter.close();
                 } catch (Throwable e) {
-                    log.warn("Error shutting down entry filter {}", filter, e);
+                    log.warn().attr("filter", filter).exception(e).log("Error shutting down entry filter");
                 }
             });
         }
@@ -1779,7 +1843,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             try {
                 topicCompactionService.close();
             } catch (Exception e) {
-                log.warn("Error close topicCompactionService ", e);
+                log.warn().exception(e).log("Error close topicCompactionService");
             }
         }
 
@@ -1816,7 +1880,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
             @Override
             public void closeFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("[{}] Failed to close managed ledger, proceeding anyway.", topic, exception);
+                log.error()
+                        .exception(exception)
+                        .log("Failed to close managed ledger, proceeding anyway.");
                 if (closeType != CloseTypes.transferring) {
                     disposeTopic(closeFuture);
                 } else {
@@ -1826,7 +1892,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }, null));
 
         disconnectClientsInCurrentCall.thenRun(closeLedgerAfterCloseClients).exceptionally(exception -> {
-            log.error("[{}] Error closing topic", topic, exception);
+            log.error().exception(exception).log("Error closing topic");
             unfenceTopicToResume();
             closeFuture.completeExceptionally(exception);
             return null;
@@ -1843,8 +1909,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 FutureUtil.completeAfterAll(closeFutures.waitDisconnectClients,
                         closeFuture.thenCompose(ignore -> disconnectClientsToCache.get().exceptionally(ex -> {
                             // Since the managed ledger has been closed, eat the error of clients disconnection.
-                            log.error("[{}] Closed managed ledger, but disconnect clients failed,"
-                                    + " this topic will be marked closed", topic, ex);
+                            log.error()
+                                    .exception(ex)
+                                    .log("Closed managed ledger, but disconnect clients failed,"
+                                            + "this topic will be marked closed");
                             return null;
                         })));
                 break;
@@ -1891,7 +1959,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     subscribeRateLimiter.ifPresent(SubscribeRateLimiter::close);
 
                     unregisterTopicPolicyListener();
-                    log.info("[{}] Topic closed", topic);
+                    log.info("Topic closed");
                     cancelFencedTopicMonitoringTask();
                     closeFuture.complete(null);
                 })
@@ -1910,8 +1978,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         checkReplication().thenAccept(res -> {
             result.complete(null);
         }).exceptionally(th -> {
-            log.error("[{}] Policies update failed {}, scheduled retry in {} seconds", topic, th.getMessage(),
-                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, th);
+            log.error()
+                    .exceptionMessage(th)
+                    .attr("POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS", POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS)
+                    .log("Policies update failed, scheduled retry in seconds");
             if (!(th.getCause() instanceof TopicFencedException)) {
                 // retriable exception
                 brokerService.executor().schedule(this::checkReplicationAndRetryOnFailure,
@@ -1936,7 +2006,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             this.ledger.setConfig(config);
             future.complete(null);
         }).exceptionally(ex -> {
-            log.warn("[{}] Failed to update persistence-policies {}", topic, ex.getMessage());
+            log.warn()
+                    .exceptionMessage(ex)
+                    .log("Failed to update persistence-policies");
             future.completeExceptionally(ex);
             return null;
         });
@@ -1951,12 +2023,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             return CompletableFuture.completedFuture(null);
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Checking replication status", name);
-        }
+        log.debug().attr("name", name).log("Checking replication status");
         List<String> configuredClusters = topicPolicies.getReplicationClusters().get();
         if (CollectionUtils.isEmpty(configuredClusters)) {
-            log.warn("[{}] No replication clusters configured", name);
+            log.warn().attr("name", name).log("No replication clusters configured");
             return CompletableFuture.completedFuture(null);
         }
 
@@ -2033,22 +2103,30 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         .persistentTopicExists(partitionedName.getPartition(i)).thenAccept(b -> {
                             if (!b) {
                                 int leftPartitions = checkedCounter.decrementAndGet();
-                                log.info("[{}] partitions: {}, left: {}", tName, metadataOp.get().partitions,
-                                    leftPartitions);
+                                log.info()
+                                        .attr("topic", tName)
+                                        .attr("partitions", metadataOp.get().partitions)
+                                        .attr("leftPartitions", leftPartitions)
+                                        .log("partitions left");
                                 if (leftPartitions == 0) {
                                     brokerService.getPulsar().getSchemaStorage()
                                         .delete(partitionedName.getSchemaName())
                                         .whenComplete((schemaVersion, ex) -> {
                                             if (ex == null) {
-                                                log.info("Deleted schema[{}] after all partitions[{}] were removed"
-                                                    + " because the current cluster has bee removed from"
-                                                    + " topic/namespace policies",
-                                                    partitionedName, metadataOp.get().partitions);
+                                                log.info()
+                                                        .attr("partitionedName", partitionedName)
+                                                        .attr("arg1", metadataOp.get().partitions)
+                                                        .log("Deleted schema after"
+                                                                + " partitions removed"
+                                                                + " from cluster");
                                             } else {
-                                                log.error("Failed to delete schema[{}] after all partitions[{}] were"
-                                                    + " removed,  when the current cluster has bee removed from"
-                                                    + " topic/namespace policies",
-                                                    partitionedName, metadataOp.get().partitions, ex);
+                                                log.error()
+                                                        .attr("partitionedName", partitionedName)
+                                                        .attr("arg1", metadataOp.get().partitions)
+                                                        .exception(ex)
+                                                        .log("Failed to delete schema"
+                                                                + " after partitions removed"
+                                                                + " from cluster");
                                             }
 
                                     });
@@ -2062,24 +2140,32 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                     boolean changeEventsAlsoBeingDeleted = !topicPolicies.getReplicationClusters()
                                             .getNamespaceValue().contains(localCluster);
                                     if (changeEventsAlsoBeingDeleted) {
-                                        log.info("Skip to deleted topic policies[{}] after all partitions[{}] were"
-                                                + " removed because the system topic __change_events will be removed.",
-                                                partitionedName, metadataOp.get().partitions);
+                                        log.info()
+                                                .attr("partitionedName", partitionedName)
+                                                .attr("arg1", metadataOp.get().partitions)
+                                                .log("Skip deleting topic policies:"
+                                                        + " __change_events will"
+                                                        + " be removed");
                                         return;
                                     }
                                     brokerService.getPulsar().getTopicPoliciesService()
                                         .deleteTopicPoliciesAsync(partitionedName, true)
                                             .whenComplete((__, ex) -> {
                                             if (ex == null) {
-                                                log.info("Deleted topic policies[{}] after all partitions[{}] were"
-                                                    + " removed because the current cluster has bee removed from"
-                                                    + " topic policies. Global policies will not be deleted.",
-                                                    partitionedName, metadataOp.get().partitions);
+                                                log.info()
+                                                        .attr("partitionedName", partitionedName)
+                                                        .attr("arg1", metadataOp.get().partitions)
+                                                        .log("Deleted topic policies"
+                                                                + " after partitions removed"
+                                                                + " from cluster");
                                             } else {
-                                                log.error("Failed to delete topic policies[{}] after all partitions[{}]"
-                                                    + " were removed,  when the current cluster has bee removed from"
-                                                    + " topic policies",
-                                                    partitionedName, metadataOp.get().partitions, ex);
+                                                log.error()
+                                                        .attr("partitionedName", partitionedName)
+                                                        .attr("arg1", metadataOp.get().partitions)
+                                                        .exception(ex)
+                                                        .log("Failed to delete"
+                                                                + " topic policies after"
+                                                                + " partitions removed");
                                             }
                                     });
                                 }
@@ -2118,8 +2204,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     }
                     if (!topicRepls.contains(localCluster)
                             && !allowedClusters.contains(localCluster)) {
-                        log.warn("Local cluster {} is not part of global namespace repl list {} and allowed list {}",
-                                localCluster, topicRepls, allowedClusters);
+                        log.warn()
+                                .attr("localCluster", localCluster)
+                                .attr("topicRepls", topicRepls)
+                                .attr("allowedClusters", allowedClusters)
+                                .log("Local cluster is not part of global namespace repl list and allowed list");
                         return CompletableFuture.completedFuture(false);
                     } else {
                         return CompletableFuture.completedFuture(true);
@@ -2134,9 +2223,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         List<String> configuredShadowTopics = shadowTopics;
         int newMessageTTLInSeconds = topicPolicies.getMessageTTLInSeconds().get();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Checking shadow replication status, shadowTopics={}", topic, configuredShadowTopics);
-        }
+        log.debug()
+                .attr("configuredShadowTopics", configuredShadowTopics)
+                .log("Checking shadow replication status, shadowTopics");
 
         removeTerminatedReplicators(shadowReplicators);
         List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -2212,8 +2301,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             @Override
             public void findEntryFailed(ManagedLedgerException exception, Optional<Position> failedReadPosition,
                                         Object ctx) {
-                log.error("[{}] Error finding expired position, failed reading position is {}", topic,
-                        failedReadPosition.orElse(null), exception);
+                log.error()
+                        .attr("arg1", failedReadPosition.orElse(null))
+                        .exception(exception)
+                        .log("Error finding expired position, failed reading position is");
                 // Since we have logged the error, we can skip to print error log at next step.
                 positionToMarkDelete.complete(null);
             }
@@ -2240,7 +2331,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             shadowReplicators.forEach((__, replicator)
                     -> ((PersistentReplicator) replicator).expireMessages(position));
         }).exceptionally(ex -> {
-            log.error("[{}] Failed to expire messages by position", topic, ex);
+            log.error().exception(ex).log("Failed to expire messages by position");
             return null;
         });
     }
@@ -2276,18 +2367,18 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 }
 
                 if (backlogEstimate > compactionThreshold) {
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                            "topic:{} backlogEstimate:{} is bigger than compactionThreshold:{}. Triggering "
-                                + "compaction", topic, backlogEstimate, compactionThreshold);
-                    }
+                    log.debug()
+                            .attr("backlogEstimate", backlogEstimate)
+                            .attr("compactionThreshold", compactionThreshold)
+                            .log("topic: backlogEstimate: is bigger than compactionThreshold:. Triggering "
+                                    + "compaction");
 
                     triggerCompactionWithCheckHasMoreMessages();
 
                 }
             }
         } catch (Exception e) {
-            log.warn("[{}] Error getting policies and skipping compaction check", topic, e);
+            log.warn().exception(e).log("Error getting policies and skipping compaction check");
         }
     }
 
@@ -2306,7 +2397,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     CompletableFuture<Void> startReplicator(String remoteCluster) {
-        log.info("[{}] Starting replicator to remote: {}", topic, remoteCluster);
+        log.info().attr("remoteCluster", remoteCluster).log("Starting replicator to remote");
         final CompletableFuture<Void> future = new CompletableFuture<>();
 
         String name = PersistentReplicator.getReplicatorName(replicatorPrefix, remoteCluster);
@@ -2353,18 +2444,22 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     PulsarClient replicationClient = brokerService.getReplicationClient(remoteCluster, clusterData);
                     PulsarAdmin replicationAdmin = brokerService.getClusterPulsarAdmin(remoteCluster, clusterData);
                     if (replicationClient == null || replicationAdmin == null) {
-                        log.error("[{}] Can not create replicator because the remote client can not be created."
-                                        + " remote cluster: {}. State of transferring : {}",
-                                topic, remoteCluster, transferring);
+                        log.error()
+                                .attr("remoteCluster", remoteCluster)
+                                .attr("transferring", transferring)
+                                .log("Can not create replicator because the remote client can not be created."
+                                        + "remote cluster:. State of transferring");
                         return;
                     }
                     lock.readLock().lock();
                     try {
                         if (isClosingOrDeleting) {
                             // Whether is "transferring" or not, do not create new replicator.
-                            log.info("[{}] Skip to create replicator because this topic is closing."
-                                    + " remote cluster: {}. State of transferring : {}",
-                                    topic, remoteCluster, transferring);
+                            log.info()
+                                    .attr("remoteCluster", remoteCluster)
+                                    .attr("transferring", transferring)
+                                    .log("Skip to create replicator because this topic is closing."
+                                            + "remote cluster:. State of transferring");
                             return;
                         }
                         Replicator replicator = replicators.computeIfAbsent(remoteCluster, r -> {
@@ -2373,7 +2468,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         remoteCluster, brokerService, (PulsarClientImpl) replicationClient,
                                         replicationAdmin);
                             } catch (PulsarServerException e) {
-                                log.error("[{}] Replicator startup failed {}", topic, remoteCluster, e);
+                                log.error()
+                                        .attr("remoteCluster", remoteCluster)
+                                        .exception(e)
+                                        .log("Replicator startup failed");
                             }
                             return null;
                         });
@@ -2384,7 +2482,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     CompletableFuture<Void> removeReplicator(String remoteCluster) {
-        log.info("[{}] Removing replicator to {}", topic, remoteCluster);
+        log.info().attr("remoteCluster", remoteCluster).log("Removing replicator to");
         final CompletableFuture<Void> future = new CompletableFuture<>();
 
         String name = PersistentReplicator.getReplicatorName(replicatorPrefix, remoteCluster);
@@ -2400,13 +2498,21 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.error("[{}] Failed to delete cursor {} {}", topic, name, exception.getMessage(), exception);
+                    log.error()
+                            .attr("name", name)
+
+                            .exception(exception)
+                            .log("Failed to delete cursor");
                     future.completeExceptionally(new PersistenceException(exception));
                 }
             }, null);
 
         }).exceptionally(e -> {
-            log.error("[{}] Failed to close replication producer {} {}", topic, name, e.getMessage(), e);
+            log.error()
+                    .attr("name", name)
+
+                    .exception(e)
+                    .log("Failed to close replication producer");
             future.completeExceptionally(e);
             return null;
         });
@@ -2415,19 +2521,27 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     CompletableFuture<Void> startShadowReplicator(String shadowTopic) {
-        log.info("[{}] Starting shadow topic replicator to remote: {}", topic, shadowTopic);
+        log.info()
+                .attr("shadowTopic", shadowTopic)
+                .log("Starting shadow topic replicator to remote");
 
         String name = ShadowReplicator.getShadowReplicatorName(replicatorPrefix, shadowTopic);
         ManagedCursor cursor;
         try {
             cursor = ledger.newNonDurableCursor(PositionFactory.LATEST, name);
         } catch (ManagedLedgerException e) {
-            log.error("[{}]Open non-durable cursor for shadow replicator failed, name={}", topic, name, e);
+            log.error()
+                    .attr("name", name)
+                    .exception(e)
+                    .log("Open non-durable cursor for shadow replicator failed, name");
             return FutureUtil.failedFuture(e);
         }
         CompletableFuture<Void> future = addShadowReplicationCluster(shadowTopic, cursor);
         future.exceptionally(ex -> {
-            log.error("[{}] Add shadow replication cluster failed, shadowTopic={}", topic, shadowTopic, ex);
+            log.error()
+                    .attr("shadowTopic", shadowTopic)
+                    .exception(ex)
+                    .log("Add shadow replication cluster failed, shadowTopic");
             return null;
         });
         return future;
@@ -2451,7 +2565,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             return new ShadowReplicator(shadowPartitionTopic, PersistentTopic.this, cursor,
                                     brokerService, (PulsarClientImpl) replicationClient, replicationAdmin);
                         } catch (PulsarServerException e) {
-                            log.error("[{}] ShadowReplicator startup failed {}", topic, shadowTopic, e);
+                            log.error()
+                                    .attr("shadowTopic", shadowTopic)
+                                    .exception(e)
+                                    .log("ShadowReplicator startup failed");
                         }
                         return null;
                     });
@@ -2459,7 +2576,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     }
 
     CompletableFuture<Void> removeShadowReplicator(String shadowTopic) {
-        log.info("[{}] Removing shadow topic replicator to {}", topic, shadowTopic);
+        log.info().attr("shadowTopic", shadowTopic).log("Removing shadow topic replicator to");
         final CompletableFuture<Void> future = new CompletableFuture<>();
         String name = ShadowReplicator.getShadowReplicatorName(replicatorPrefix, shadowTopic);
         shadowReplicators.get(shadowTopic).terminate().thenRun(() -> {
@@ -2473,14 +2590,21 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.error("[{}] Failed to delete shadow topic replication cursor {} {}",
-                            topic, name, exception.getMessage(), exception);
+                    log.error()
+                            .attr("name", name)
+
+                            .exception(exception)
+                            .log("Failed to delete shadow topic replication cursor");
                     future.completeExceptionally(new PersistenceException(exception));
                 }
             }, null);
 
         }).exceptionally(e -> {
-            log.error("[{}] Failed to close shadow topic replication producer {} {}", topic, name, e.getMessage(), e);
+            log.error()
+                    .attr("name", name)
+
+                    .exception(e)
+                    .log("Failed to close shadow topic replication producer");
             future.completeExceptionally(e);
             return null;
         });
@@ -2590,7 +2714,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             try {
                 ((PersistentReplicator) replicator).updateCursorState();
             } catch (Exception e) {
-                log.warn("[{}] Failed to update cursor state ", topic, e);
+                log.warn().exception(e).log("Failed to update cursor state");
             }
 
             // Update replicator stats
@@ -2730,8 +2854,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     subscription.checkAndUnblockIfStuck();
                 }
             } catch (Exception e) {
-                log.error("Got exception when creating consumer stats for subscription {}: {}", subscriptionName,
-                        e.getMessage(), e);
+                log.error()
+                        .attr("subscription", subscriptionName)
+
+                        .exception(e)
+                        .log("Got exception when creating consumer stats for subscription");
             }
         });
 
@@ -2791,7 +2918,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         try {
             return asyncGetStats(getPreciseBacklog, subscriptionBacklogSize, getEarliestTimeInBacklog).get();
         } catch (InterruptedException | ExecutionException e) {
-            log.error("[{}] Fail to get stats", topic, e);
+            log.error().exception(e).log("Fail to get stats");
             return null;
         }
     }
@@ -2801,7 +2928,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         try {
             return asyncGetStats(getStatsOptions).get();
         } catch (InterruptedException | ExecutionException e) {
-            log.error("[{}] Fail to get stats", topic, e);
+            log.error().exception(e).log("Fail to get stats");
             return null;
         }
     }
@@ -2979,7 +3106,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     });
                 // print error log.
                 finalRes.exceptionally(ex -> {
-                    log.error("[{}] Failed to get earliest message publish time in backlog", topic, ex);
+                    log.error()
+                            .exception(ex)
+                            .log("Failed to get earliest message publish time in backlog");
                     return null;
                 });
                 return finalRes;
@@ -3102,10 +3231,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         .getLedgerMetadata(ledgerId);
                                 } catch (NullPointerException e) {
                                     // related to bookkeeper issue https://github.com/apache/bookkeeper/issues/2741
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("{{}} Failed to get ledger metadata for the schema ledger {}",
-                                            topic, ledgerId, e);
-                                    }
+                                    log.debug()
+                                            .attr("ledgerId", ledgerId)
+                                            .exception(e)
+                                            .log("Failed to get ledger metadata for the schema ledger");
                                 }
                                 if (metadataFuture != null) {
                                     metadataFuture.thenAccept(metadata -> {
@@ -3119,8 +3248,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         stats.schemaLedgers.add(schemaLedgerInfo);
                                         completableFuture.complete(null);
                                     }).exceptionally(e -> {
-                                        log.error("[{}] Failed to get ledger metadata for the schema ledger {}",
-                                            topic, ledgerId, e);
+                                        log.error()
+                                                .attr("ledgerId", ledgerId)
+                                                .exception(e)
+                                                .log("Failed to get ledger metadata for the schema ledger");
                                         if ((e.getCause() instanceof BKNoSuchLedgerExistsOnMetadataServerException)
                                             || (e.getCause() instanceof BKNoSuchLedgerExistsException)) {
                                             completableFuture.complete(null);
@@ -3168,7 +3299,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return pulsarCompactedService.getCompactedTopic().getCompactedTopicContext();
             }
         } catch (ExecutionException | InterruptedException | TimeoutException e) {
-            log.warn("[{}]Fail to get ledger information for compacted topic.", topic);
+            log.warn("Fail to get ledger information for compacted topic.");
         }
         return Optional.empty();
     }
@@ -3228,12 +3359,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (isReplicated()) {
             if (isReplicationBacklogExist()) {
                 if (!ledger.isMigrated()) {
-                    log.info("{} applying migration with replication backlog", topic);
+                    log.info("applying migration with replication backlog");
                     ledger.asyncMigrate();
                 }
-                if (log.isDebugEnabled()) {
-                    log.debug("{} has replication backlog and applied migration", topic);
-                }
+                log.debug("has replication backlog and applied migration");
                 return CompletableFuture.completedFuture(null);
             }
         }
@@ -3262,7 +3391,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (migrationSubsCreated) {
             return CompletableFuture.completedFuture(null);
         }
-        log.info("{} initializing subscription created at migration cluster", topic);
+        log.info("initializing subscription created at migration cluster");
         return getMigratedClusterUrlAsync(getBrokerService().getPulsar(), topic).thenCompose(clusterUrl -> {
             if (!brokerService.getPulsar().getConfig().isClusterMigrationAutoResourceCreation()) {
                 return CompletableFuture.completedFuture(null);
@@ -3291,12 +3420,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         CompletableFuture<Void> ts = new CompletableFuture<>();
                         admin.tenants().createTenantAsync(tenant, tenantInfo.get()).handle((__, ex) -> {
                             if (ex == null || ex instanceof ConflictException) {
-                                log.info("[{}] successfully created tenant {} for migration", topic, tenant);
+                                log.info()
+                                        .attr("tenant", tenant)
+                                        .log("successfully created tenant for migration");
                                 ts.complete(null);
                                 return null;
                             }
-                            log.warn("[{}] Failed to create tenant {} on migration cluster {}", topic, tenant,
-                                    ex.getCause().getMessage());
+                            log.warn()
+                                    .attr("tenant", tenant)
+                                    .exceptionMessage(ex.getCause())
+                                    .log("Failed to create tenant on migration cluster");
                             ts.completeExceptionally(ex.getCause());
                             return null;
                         });
@@ -3311,13 +3444,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                     admin.namespaces().createNamespaceAsync(ns.toString(), policies.get())
                                             .handle((__, ex) -> {
                                                 if (ex == null || ex instanceof ConflictException) {
-                                                    log.info("[{}] successfully created namespace {} for migration",
-                                                            topic, ns);
+                                                    log.info()
+                                                            .attr("namespace", ns)
+                                                            .log("successfully created namespace for migration");
                                                     nsFuture.complete(null);
                                                     return null;
                                                 }
-                                                log.warn("[{}] Failed to create namespace {} on migration cluster {}",
-                                                        topic, ns, ex.getCause().getMessage());
+                                                log.warn()
+                                                        .attr("ns", ns)
+                                                        .exceptionMessage(ex.getCause())
+                                                        .log("Failed to create namespace on migration cluster");
                                                 nsFuture.completeExceptionally(ex.getCause());
                                                 return null;
                                             });
@@ -3329,13 +3465,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         admin.topics().createSubscriptionAsync(topic, subName, MessageId.earliest)
                                                 .handle((__, ex) -> {
                                                     if (ex == null || ex instanceof ConflictException) {
-                                                        log.info("[{}] successfully created sub {} for migration",
-                                                                topic, subName);
+                                                        log.info()
+                                                                .attr("subscription", subName)
+                                                                .log("successfully created sub for migration");
                                                         subResult.complete(null);
                                                         return null;
                                                     }
-                                                    log.warn("[{}] Failed to create sub {} on migration cluster, {}",
-                                                            topic, subName, ex.getCause().getMessage());
+                                                    log.warn()
+                                                            .attr("subscription", subName)
+                                                            .exceptionMessage(ex.getCause())
+                                                            .log("Failed to create sub on migration cluster");
                                                     subResult.completeExceptionally(ex.getCause());
                                                     return null;
                                                 });
@@ -3414,10 +3553,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             // Close repl producers first.
             // Once all repl producers are closed, we can delete the topic,
             // provided no remote producers connected to the broker.
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Topic inactive for {} seconds, closing repl producers.", topic,
-                    maxInactiveDurationInSec);
-            }
+            log.debug()
+                    .attr("maxInactiveDurationInSec", maxInactiveDurationInSec)
+                    .log("Topic inactive for seconds, closing repl producers.");
             /**
              * There is a race condition that may cause a NPE:
              * - task 1: a callback of "replicator.cursor.asyncRead" will trigger a replication.
@@ -3429,21 +3567,17 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
              */
             closeReplProducersIfNoBacklog().thenRun(() -> {
                 if (hasRemoteProducers()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Topic has connected remote producers. Not a candidate for GC",
-                                topic);
-                    }
+                    log.debug("Topic has connected remote producers, not a candidate for GC");
                     replCloseFuture
                             .completeExceptionally(new TopicBusyException("Topic has connected remote producers"));
                 } else {
-                    log.info("[{}] Topic inactive for {} seconds, closed repl producers", topic,
-                        maxInactiveDurationInSec);
+                    log.info()
+                            .attr("maxInactiveDurationInSec", maxInactiveDurationInSec)
+                            .log("Topic inactive, closed repl producers");
                     replCloseFuture.complete(null);
                 }
             }).exceptionally(e -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Topic has replication backlog. Not a candidate for GC", topic);
-                }
+                log.debug("Topic has replication backlog. Not a candidate for GC");
                 replCloseFuture.completeExceptionally(e.getCause());
                 return null;
             });
@@ -3451,17 +3585,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             replCloseFuture.thenCompose(v -> delete(deleteMode == InactiveTopicDeleteMode.delete_when_no_subscriptions,
                 deleteMode == InactiveTopicDeleteMode.delete_when_subscriptions_caught_up, false))
                     .thenCompose((res) -> tryToDeletePartitionedMetadata())
-                    .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
+                    .thenRun(() -> log.info("Topic deleted successfully due to inactivity"))
                     .exceptionally(e -> {
                         if (e.getCause() instanceof TopicBusyException) {
                             // topic became active again
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Did not delete busy topic: {}", topic, e.getCause().getMessage());
-                            }
+                            log.debug()
+                                    .exceptionMessage(e.getCause())
+                                    .log("Did not delete busy topic");
                         } else if (e.getCause() instanceof UnsupportedOperationException) {
-                            log.info("[{}] Skip to delete partitioned topic: {}", topic, e.getCause().getMessage());
+                            log.info()
+                                    .exceptionMessage(e.getCause())
+                                    .log("Skip to delete partitioned topic");
                         } else {
-                            log.warn("[{}] Inactive topic deletion failed", topic, e);
+                            log.warn().exception(e).log("Inactive topic deletion failed");
                         }
                         return null;
                     });
@@ -3532,8 +3668,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                         .filter(topicExist -> topicExist)
                                                         .findAny();
                                                 if (anyExistPartition.isPresent()) {
-                                                    log.info("[{}] Delete topic metadata failed because"
-                                                            + " another partition exist.", topicName);
+                                                    log.info("Delete topic metadata failed because "
+                                                            + "another partition exists");
                                                     throw new UnsupportedOperationException(
                                                             String.format("Another partition exists for [%s].",
                                                                     topicName));
@@ -3542,8 +3678,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                         return brokerService.getPulsar().getAdminClient().topics()
                                                                 .deletePartitionedTopicAsync(topicName.toString());
                                                     } catch (PulsarServerException e) {
-                                                        log.info("[{}] Delete topic metadata failed due to failed to"
-                                                                + " get internal admin client.", topicName, e);
+                                                        log.info()
+                                                                .exception(e)
+                                                                .log("Delete topic metadata failed due to failed to"
+                                                                        + "get internal admin client.");
                                                         return CompletableFuture.failedFuture(e);
                                                     }
                                                 }
@@ -3570,8 +3708,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     return;
                 }
                 if (System.currentTimeMillis() - sub.cursor.getLastActive() > expirationTimeMillis) {
-                    sub.delete().thenAccept(v -> log.info("[{}][{}] The subscription was deleted due to expiration "
-                            + "with last active [{}]", topic, subName, sub.cursor.getLastActive()));
+                    sub.delete().thenAccept(v -> log.info()
+                            .attr("subscription", subName)
+                            .attr("lastActive", sub.cursor.getLastActive())
+                            .log("The subscription was deleted due to expiration " + "with last active"));
                 }
             });
         }
@@ -3608,7 +3748,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         try {
             ledger.checkCursorsToCacheEntries();
         } catch (Exception e) {
-            log.warn("Failed to check cursors to cache entries", e);
+            log.warn().exception(e).log("Failed to check cursors to cache entries");
         }
     }
 
@@ -3647,12 +3787,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public CompletableFuture<Void> onPoliciesUpdate(@NonNull Policies data) {
         requireNonNull(data);
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] isEncryptionRequired changes: {} -> {}", topic, isEncryptionRequired,
-                    data.encryption_required);
-        }
+        log.debug()
+                .attr("isEncryptionRequired", isEncryptionRequired)
+                .attr("encryption_required", data.encryption_required)
+                .log("isEncryptionRequired changes: ->");
         if (data.deleted) {
-            log.debug("Ignore the update because it has been deleted : {}", data);
+            log.debug().attr("data", data).log("Ignore the update because it has been deleted");
             return CompletableFuture.completedFuture(null);
         }
 
@@ -3668,9 +3808,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         List<CompletableFuture<Void>> applyPolicyTasks = applyUpdatedTopicPolicies();
         applyPolicyTasks.add(applyUpdatedNamespacePolicies(data));
         return FutureUtil.waitForAll(applyPolicyTasks)
-            .thenAccept(__ -> log.info("[{}] namespace-level policies updated successfully", topic))
+            .thenAccept(__ -> log.info("namespace-level policies updated successfully"))
             .exceptionally(ex -> {
-                log.error("[{}] update namespace polices : {} error", this.getName(), data, ex);
+                log.error()
+                        .attr("name", this.getName())
+                        .attr("data", data)
+                        .exception(ex)
+                        .log("update namespace polices : error");
                 throw FutureUtil.wrapToCompletionException(ex);
             });
     }
@@ -3735,15 +3879,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             if ((retentionPolicy == BacklogQuota.RetentionPolicy.producer_request_hold
                     || retentionPolicy == BacklogQuota.RetentionPolicy.producer_exception)) {
                 if (backlogQuotaType == BacklogQuotaType.destination_storage && isSizeBacklogExceeded()) {
-                    log.debug("[{}] Size backlog quota exceeded. Cannot create producer [{}]", this.getName(),
-                            producerName);
+                    log.debug()
+                            .attr("name", this.getName())
+                            .attr("producerName", producerName)
+                            .log("Size backlog quota exceeded. Cannot create producer");
                     return FutureUtil.failedFuture(new TopicBacklogQuotaExceededException(retentionPolicy));
                 }
                 if (backlogQuotaType == BacklogQuotaType.message_age) {
                     return checkTimeBacklogExceeded(true).thenCompose(isExceeded -> {
                         if (isExceeded) {
-                            log.debug("[{}] Time backlog quota exceeded. Cannot create producer [{}]", this.getName(),
-                                    producerName);
+                            log.debug()
+                                    .attr("name", this.getName())
+                                    .attr("producerName", producerName)
+                                    .log("Time backlog quota exceeded. Cannot create producer");
                             return FutureUtil.failedFuture(new TopicBacklogQuotaExceededException(retentionPolicy));
                         } else {
                             return CompletableFuture.completedFuture(null);
@@ -3768,10 +3916,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         // check if backlog exceeded quota
         long storageSize = getBacklogSize();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Storage size = [{}], backlog quota limit [{}]",
-                    getName(), storageSize, backlogQuotaLimitInBytes);
-        }
+        log.debug()
+                .attr("storageSize", storageSize)
+                .attr("backlogQuotaLimitInBytes", backlogQuotaLimitInBytes)
+                .log("Checked storage size against backlog quota limit");
 
         return (storageSize >= backlogQuotaLimitInBytes);
     }
@@ -3809,9 +3957,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         if (!hasBacklogs(brokerService.pulsar().getConfiguration().isPreciseTimeBasedBacklogQuotaCheck())) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] No backlog. Update old position info is null", topicName);
-            }
+            log.debug("No backlog. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
             return CompletableFuture.completedFuture(null);
         }
@@ -3819,9 +3965,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         // If we have no durable cursor since `ledger.getCursors()` only managed durable cursors
         CursorInfo oldestMarkDeleteCursorInfo = managedCursorContainer.getCursorWithOldestPosition();
         if (oldestMarkDeleteCursorInfo == null || oldestMarkDeleteCursorInfo.getPosition() == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] No durable cursor found. Update old position info is null", topicName);
-            }
+            log.debug("No durable cursor found. Update old position info is null");
             TIME_BASED_BACKLOG_QUOTA_CHECK_RESULT_UPDATER.set(this, null);
             return CompletableFuture.completedFuture(null);
         }
@@ -3838,14 +3982,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         oldestMarkDeleteCursorInfo.getCursor().getName(),
                         lastOldestPositionInfo.getPositionPublishTimestampInMillis(),
                         oldestMarkDeleteCursorInfo.getVersion()));
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Updating cached old position info {}, "
-                                    + "since cursor causing it has changed from {} to {}",
-                            topicName,
-                            oldestMarkDeletePosition,
-                            lastOldestPositionInfo.getCursorName(),
-                            oldestMarkDeleteCursorInfo.getCursor().getName());
-                }
+                log.debug()
+                        .attr("oldestMarkDeletePosition", oldestMarkDeletePosition)
+                        .attr("cursorName", lastOldestPositionInfo.getCursorName())
+                        .attr("name", oldestMarkDeleteCursorInfo.getCursor().getName())
+                        .log("Updating cached old position info, " + "since cursor causing it has changed from to");
             }
             return CompletableFuture.completedFuture(null);
         }
@@ -3866,21 +4007,21 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                                 oldestMarkDeleteCursorInfo.getCursor().getName(),
                                                 entryTimestamp,
                                                 oldestMarkDeleteCursorInfo.getVersion()));
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Precise based update oldest position info. "
-                                                    + "Oldest unacked entry read from BK. "
-                                                    + "Oldest entry in cursor {}'s backlog: {}. "
-                                                    + "Oldest mark-delete position: {}. "
-                                                    + "EntryTimestamp: {}",
-                                            topicName,
-                                            oldestMarkDeleteCursorInfo.getCursor().getName(),
-                                            position,
-                                            oldestMarkDeletePosition,
-                                            entryTimestamp);
-                                }
+                                log.debug()
+                                        .attr("name", oldestMarkDeleteCursorInfo.getCursor().getName())
+                                        .attr("position", position)
+                                        .attr("oldestMarkDeletePosition", oldestMarkDeletePosition)
+                                        .attr("entryTimestamp", entryTimestamp)
+                                        .log("Precise based update oldest position info. "
+                                                + "Oldest unacked entry read from BK. "
+                                                + "Oldest entry in cursor's backlog:. "
+                                                        + "Oldest mark-delete position:. "
+                                                        + "EntryTimestamp");
                                 future.complete(null);
                             } catch (Exception e) {
-                                log.error("[{}][{}] Error deserializing message for update old position", topicName, e);
+                                log.error()
+                                        .exceptionMessage(e)
+                                        .log("Error deserializing message for update old position");
                                 future.completeExceptionally(e);
                             } finally {
                                 entry.release();
@@ -3889,8 +4030,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                         @Override
                         public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                            log.error("[{}][{}] Error reading entry for precise update old position",
-                                    topicName, exception);
+                            log.error()
+                                    .exceptionMessage(exception)
+                                    .log("Error reading entry for precise update old position");
                             future.completeExceptionally(exception);
                         }
                     }, null);
@@ -3912,7 +4054,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 return CompletableFuture.completedFuture(null);
             } catch (Exception e) {
-                log.error("[{}][{}] Error reading entry for update old position", topicName, e);
+                log.error().exceptionMessage(e)
+                        .log("Error reading entry for update old position");
                 return CompletableFuture.failedFuture(e);
             }
         }
@@ -3925,9 +4068,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         TopicName topicName = TopicName.get(getName());
         int backlogQuotaLimitInSecond = getBacklogQuota(BacklogQuotaType.message_age).getLimitTime();
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Time backlog quota = [{}]. Checking if exceeded.", topicName, backlogQuotaLimitInSecond);
-        }
+        log.debug()
+                .attr("backlogQuotaLimitInSecond", backlogQuotaLimitInSecond)
+                .log("Time backlog quota =. Checking if exceeded.");
         CompletableFuture<Void> updateFuture = shouldUpdateOldPositionInfo ? updateOldPositionInfo()
                 : CompletableFuture.completedFuture(null);
         return updateFuture.thenCompose(__ -> {
@@ -3941,7 +4084,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             boolean expired = MessageImpl.isEntryExpired(backlogQuotaLimitInSecond, entryTimestamp);
             return CompletableFuture.completedFuture(expired);
         }).exceptionally(e -> {
-            log.error("[{}][{}] Error checking time backlog exceeded", topicName, e);
+            log.error().exceptionMessage(e)
+                    .log("Error checking time backlog exceeded");
             return false;
         });
     }
@@ -3985,11 +4129,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 && positionToCheckLedgerInfo.getTimestamp() > 0) {
             long estimateMsgAgeMs = clock.millis() - positionToCheckLedgerInfo.getTimestamp();
             boolean shouldTruncateBacklog = estimateMsgAgeMs > SECONDS.toMillis(backlogQuotaLimitInSecond);
-            if (log.isDebugEnabled()) {
-                log.debug("Time based backlog quota exceeded, quota {}[ms], age of ledger "
-                                + "slowest cursor currently on {}[ms]", backlogQuotaLimitInSecond * 1000,
-                        estimateMsgAgeMs);
-            }
+            log.debug()
+                    .attr("arg0", backlogQuotaLimitInSecond * 1000)
+                    .attr("estimateMsgAgeMs", estimateMsgAgeMs)
+                    .log("Time based backlog quota exceeded, quota[ms], age of ledger "
+                            + "slowest cursor currently on[ms]");
 
             return new EstimateTimeBasedBacklogQuotaCheckResult(
                     shouldTruncateBacklog,
@@ -4020,7 +4164,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 Position lastPosition = lastCommittedPosition;
                 MessageId messageId = new MessageIdImpl(lastPosition.getLedgerId(), lastPosition.getEntryId(), -1);
 
-                log.info("[{}] Topic terminated at {}", getName(), messageId);
+                log.info().attr("messageId", messageId).log("Topic terminated at");
                 future.complete(messageId);
             }
 
@@ -4050,7 +4194,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 // if AutoSkipNonRecoverableData is set to true, just return true here.
                 return true;
             } else {
-                log.warn("[{}] [{}] Error while getting the oldest message", topic, cursor.toString(), e);
+                log.warn()
+                        .attr("value", cursor.toString())
+                        .exception(e)
+                        .log("Error while getting the oldest message");
             }
         } finally {
             if (entry != null) {
@@ -4073,7 +4220,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     res.complete(MessageImpl.isEntryExpired(
                             (int) (messageTTLInSeconds * MESSAGE_EXPIRY_THRESHOLD), entryTimestamp));
                 } catch (Exception e) {
-                    log.warn("[{}] [{}] Error while getting the oldest message", topic, cursor.toString(), e);
+                    log.warn()
+                            .attr("value", cursor.toString())
+                            .exception(e)
+                            .log("Error while getting the oldest message");
                     res.complete(false);
                 } finally {
                     if (entry != null) {
@@ -4091,7 +4241,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     // if AutoSkipNonRecoverableData is set to true, just return true here.
                     res.complete(true);
                 } else {
-                    log.warn("[{}] [{}] Error while getting the oldest message", topic, cursor.toString(), e);
+                    log.warn()
+                            .attr("value", cursor.toString())
+                            .exception(e)
+                            .log("Error while getting the oldest message");
                     res.complete(false);
                 }
             }
@@ -4105,7 +4258,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * @return
      */
     public CompletableFuture<Void> clearBacklog() {
-        log.info("[{}] Clearing backlog on all cursors in the topic.", topic);
+        log.info("Clearing backlog on all cursors in the topic.");
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         List<String> cursors = new ArrayList<>(getSubscriptions().keySet());
         cursors.addAll(getReplicators().keySet());
@@ -4126,7 +4279,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * @return
      */
     public CompletableFuture<Void> clearBacklog(String cursorName) {
-        log.info("[{}] Clearing backlog for cursor {} in the topic.", topic, cursorName);
+        log.info().attr("cursorName", cursorName).log("Clearing backlog for cursor in the topic.");
         PersistentSubscription sub = getSubscription(cursorName);
         if (sub != null) {
             return sub.clearBacklog();
@@ -4234,9 +4387,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         Position position = ledger.getLastConfirmedEntry();
         String name = getName();
         int partitionIndex = TopicName.getPartitionIndex(name);
-        if (log.isDebugEnabled()) {
-            log.debug("getLastMessageId {}, partitionIndex{}, position {}", name, partitionIndex, position);
-        }
+        log.debug()
+                .attr("name", name)
+                .attr("partitionIndex", partitionIndex)
+                .attr("position", position)
+                .log("getLastMessageId, partitionIndex, position");
         if (position.getEntryId() == -1) {
             completableFuture
                     .complete(new MessageIdImpl(position.getLedgerId(), position.getEntryId(), partitionIndex));
@@ -4286,7 +4441,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return lastCompactedPosition == null || lastDispatchablePosition.compareTo(lastCompactedPosition) > 0;
             }).thenAccept(hasMoreMessagesToBeCompacted -> {
             if (!hasMoreMessagesToBeCompacted) {
-                log.info("[{}] No more messages to compact, skip triggering compaction", topic);
+                log.info("No more messages to compact, skip triggering compaction");
                 return;
             }
             try {
@@ -4297,7 +4452,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }).whenComplete((__, ex) -> {
             if (ex != null) {
                 ex = FutureUtil.unwrapCompletionException(ex);
-                log.error("[{}] Trigger Compaction failure.", topic, ex);
+                log.error().exception(ex).log("Trigger Compaction failure.");
             }
         });
     }
@@ -4307,16 +4462,16 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             throws PulsarServerException, AlreadyRunningException {
         if (currentCompaction.isDone()) {
             if (!lock.readLock().tryLock()) {
-                log.info("[{}] Conflict topic-close, topic-delete, skip triggering compaction", topic);
+                log.info("Conflict topic-close, topic-delete, skip triggering compaction");
                 return;
             }
             try {
                 if (isClosingOrDeleting) {
-                    log.info("[{}] Topic is closing or deleting, skip triggering compaction", topic);
+                    log.info("Topic is closing or deleting, skip triggering compaction");
                     return;
                 }
                 if (disablingCompaction.get()) {
-                    log.info("[{}] Compaction is disabling, skip triggering compaction", topic);
+                    log.info("Compaction is disabling, skip triggering compaction");
                     return;
                 }
 
@@ -4331,7 +4486,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
             currentCompaction.whenComplete((ignore, ex) -> {
                 if (ex != null) {
-                    log.warn("[{}] Compaction failure.", topic, ex);
+                    log.warn().exception(ex).log("Compaction failure.");
                 }
             });
         } else {
@@ -4362,20 +4517,25 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     public synchronized void triggerOffload(MessageIdImpl messageId) throws AlreadyRunningException {
         if (currentOffload.isDone()) {
             CompletableFuture<MessageIdImpl> promise = currentOffload = new CompletableFuture<>();
-            log.info("[{}] Starting offload operation at messageId {}", topic, messageId);
+            log.info().attr("messageId", messageId).log("Starting offload operation at messageId");
             getManagedLedger().asyncOffloadPrefix(
                     PositionFactory.create(messageId.getLedgerId(), messageId.getEntryId()),
                     new OffloadCallback() {
                         @Override
                         public void offloadComplete(Position pos, Object ctx) {
                             Position impl = pos;
-                            log.info("[{}] Completed successfully offload operation at messageId {}", topic, messageId);
+                            log.info()
+                                    .attr("messageId", messageId)
+                                    .log("Completed successfully offload operation at messageId");
                             promise.complete(new MessageIdImpl(impl.getLedgerId(), impl.getEntryId(), -1));
                         }
 
                         @Override
                         public void offloadFailed(ManagedLedgerException exception, Object ctx) {
-                            log.warn("[{}] Failed offload operation at messageId {}", topic, messageId, exception);
+                            log.warn()
+                                    .attr("messageId", messageId)
+                                    .exception(exception)
+                                    .log("Failed offload operation at messageId");
                             promise.completeExceptionally(exception);
                         }
                     }, null);
@@ -4395,14 +4555,11 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     return OffloadProcessStatus.forSuccess(currentOffload.join());
                 }
             } catch (CancellationException | CompletionException e) {
-                log.warn("Failed to offload", e.getCause());
+                log.warn("Failed to offload");
                 return OffloadProcessStatus.forError(e.getMessage());
             }
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PersistentTopic.class);
-
     @Override
     public CompletableFuture<Void> addSchemaIfIdleOrCheckCompatible(SchemaData schema) {
         return hasSchema().thenCompose((hasSchema) -> {
@@ -4441,9 +4598,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         });
 
         if (!shouldBeEnabled.get()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] There are no replicated subscriptions on the topic", topic);
-            }
+            log.debug("There are no replicated subscriptions on the topic");
         }
 
         checkReplicatedSubscriptionControllerState(shouldBeEnabled.get());
@@ -4456,12 +4611,12 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         boolean replicationEnabled = this.topicPolicies.getReplicationClusters().get().size() > 1;
 
         if (shouldBeEnabled && !isCurrentlyEnabled && isEnableReplicatedSubscriptions && replicationEnabled) {
-            log.info("[{}] Enabling replicated subscriptions controller", topic);
+            log.info("Enabling replicated subscriptions controller");
             replicatedSubscriptionsController = Optional.of(new ReplicatedSubscriptionsController(this,
                     brokerService.pulsar().getConfiguration().getClusterName()));
         } else if (isCurrentlyEnabled && (!shouldBeEnabled || !isEnableReplicatedSubscriptions
                 || !replicationEnabled)) {
-            log.info("[{}] Disabled replicated subscriptions controller", topic);
+            log.info("Disabled replicated subscriptions controller");
             replicatedSubscriptionsController.ifPresent(ReplicatedSubscriptionsController::close);
             replicatedSubscriptionsController = Optional.empty();
         }
@@ -4525,11 +4680,15 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         if (isFenced) {
             final int timeout = brokerService.pulsar().getConfiguration().getTopicFencingTimeoutSeconds();
             if (isClosingOrDeleting) {
-                log.warn("[{}] Topic remained fenced for {} seconds and is already closed (pendingWriteOps: {})", topic,
-                        timeout, pendingWriteOps.get());
+                log.warn()
+                        .attr("timeout", timeout)
+                        .attr("get", pendingWriteOps.get())
+                        .log("Topic remained fenced for seconds and is already closed (pendingWriteOps:)");
             } else {
-                log.error("[{}] Topic remained fenced for {} seconds, so close it (pendingWriteOps: {})", topic,
-                        timeout, pendingWriteOps.get());
+                log.error()
+                        .attr("timeout", timeout)
+                        .attr("get", pendingWriteOps.get())
+                        .log("Topic remained fenced for seconds, so close it (pendingWriteOps:)");
                 close();
             }
         }
@@ -4680,9 +4839,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public void onUpdate(TopicPolicies policies) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] update topic policy: {}", topic, policies);
-        }
+        log.debug().attr("policies", policies).log("Update topic policies");
         if (policies == null) {
             return;
         }
@@ -4695,10 +4852,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
         // Apply policies for components(not contains the specified policies which only defined in namespace policies).
         FutureUtil.waitForAll(applyUpdatedTopicPolicies())
-            .thenAccept(__ -> log.info("[{}] topic-level policies updated successfully", topic))
+            .thenAccept(__ -> log.info("topic-level policies updated successfully"))
             .exceptionally(e -> {
                 Throwable t = FutureUtil.unwrapCompletionException(e);
-                log.error("[{}] update topic-level policy error: {}", topic, t.getMessage(), t);
+                log.error()
+
+                        .exception(t)
+                        .log("update topic-level policy error");
                 return null;
             });
     }
@@ -4881,7 +5041,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         long publishTime = msgMetadata.getPublishTime();
                         future.complete(publishTime);
                     } catch (Exception e) {
-                        log.warn("[{}] Failed to parse message metadata for last publish time", topic, e);
+                        log.warn()
+                                .exception(e)
+                                .log("Failed to parse message metadata for last publish time");
                         future.complete(0L);
                     } finally {
                         entry.release();
@@ -4890,12 +5052,14 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 @Override
                 public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-                    log.warn("[{}] Failed to read last entry for publish time", topic, exception);
+                    log.warn()
+                            .exception(exception)
+                            .log("Failed to read last entry for publish time");
                     future.complete(0L);
                 }
             }, null);
         } catch (Exception e) {
-            log.warn("[{}] Failed to get last position for publish time", topic, e);
+            log.warn().exception(e).log("Failed to get last position for publish time");
             future.complete(0L);
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PulsarCompactorSubscription.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.broker.service.AbstractBaseDispatcher.checkAndApplyReachedEndOfTopicOrTopicMigration;
+import io.github.merlimat.slog.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -32,15 +33,18 @@ import org.apache.pulsar.compaction.CompactedTopic;
 import org.apache.pulsar.compaction.CompactedTopicContext;
 import org.apache.pulsar.compaction.CompactedTopicImpl;
 import org.apache.pulsar.compaction.Compactor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PulsarCompactorSubscription extends PersistentSubscription {
+
+    private static final Logger LOG = Logger.get(PulsarCompactorSubscription.class);
+    protected final Logger log;
+
     private final CompactedTopic compactedTopic;
 
     public PulsarCompactorSubscription(PersistentTopic topic, CompactedTopic compactedTopic,
                                        String subscriptionName, ManagedCursor cursor) {
         super(topic, subscriptionName, cursor, false);
+        this.log = LOG.with().ctx(super.log).build();
         checkArgument(subscriptionName.equals(Compactor.COMPACTION_SUBSCRIPTION));
         this.compactedTopic = compactedTopic;
 
@@ -68,9 +72,9 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
 
         Position position = positions.get(0);
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Cumulative ack on compactor subscription {}", topicName, subName, position);
-        }
+        log.debug()
+                .attr("position", position)
+                .log("Cumulative ack on compactor subscription");
 
         // The newCompactedLedger must be called at the first step because we need to ensure the reader can read
         // complete data from compacted Ledger, otherwise, if the original ledger been deleted the reader cursor
@@ -83,10 +87,9 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
             cursor.asyncMarkDelete(position, properties, new MarkDeleteCallback() {
                 @Override
                 public void markDeleteComplete(Object ctx) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Mark deleted messages until position on compactor subscription {}",
-                                topicName, subName, position);
-                    }
+                    log.debug()
+                            .attr("position", position)
+                            .log("Mark deleted messages until position on compactor subscription");
                     if (previousContext != null) {
                         compactedTopic.deleteCompactedLedger(previousContext.getLedger().getId());
                     }
@@ -95,10 +98,9 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
                 @Override
                 public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
                     // TODO: cut consumer connection on markDeleteFailed
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Failed to mark delete for position on compactor subscription {}",
-                                topicName, subName, ctx, exception);
-                    }
+                    log.debug()
+                            .exception(exception)
+                            .log("Failed to mark delete for position on compactor subscription");
                 }
             }, null);
         });
@@ -122,6 +124,4 @@ public class PulsarCompactorSubscription extends PersistentSubscription {
             return CompletableFuture.completedFuture(null);
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarCompactorSubscription.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCache.java
@@ -237,7 +237,7 @@ public class ReplicatedSubscriptionSnapshotCache {
 
         log.debug()
                 .attr("position", position)
-                .attr("snapshotId", snapshot.getSnapshotId())
+                .attr("snapshotId", snapshot::getSnapshotId)
                 .log("Added new replicated-subscription snapshot");
 
         // append to the double-linked list

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionSnapshotCache.java
@@ -20,12 +20,12 @@ package org.apache.pulsar.broker.service.persistent;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Range;
+import io.github.merlimat.slog.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.ToLongFunction;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.common.api.proto.MarkersMessageIdData;
@@ -35,8 +35,11 @@ import org.apache.pulsar.common.util.StringInterner;
 /**
  * Store the last N snapshots that were scanned by a particular subscription.
  */
-@Slf4j
 public class ReplicatedSubscriptionSnapshotCache {
+
+    private static final Logger LOG = Logger.get(ReplicatedSubscriptionSnapshotCache.class);
+    private final Logger log;
+
     private final String subscription;
     private final ToLongFunction<Range<Position>> distanceFunction;
     private final int maxSnapshotToCache;
@@ -55,6 +58,7 @@ public class ReplicatedSubscriptionSnapshotCache {
         }
         this.maxSnapshotToCache = maxSnapshotToCache;
         this.sortedSnapshots = new TreeSet<>();
+        this.log = LOG.with().attr("subscription", subscription).build();
     }
 
     /**
@@ -231,10 +235,10 @@ public class ReplicatedSubscriptionSnapshotCache {
 
         SnapshotEntry entry = new SnapshotEntry(position, clusterEntryList);
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Added new replicated-subscription snapshot at {} -- {}", subscription, position,
-                    snapshot.getSnapshotId());
-        }
+        log.debug()
+                .attr("position", position)
+                .attr("snapshotId", snapshot.getSnapshotId())
+                .log("Added new replicated-subscription snapshot");
 
         // append to the double-linked list
         if (head == null) {
@@ -337,10 +341,12 @@ public class ReplicatedSubscriptionSnapshotCache {
         while (current != null) {
             if (current.position.compareTo(pos) > 0) {
                 // Snapshot is associated with a higher position, so it cannot be used now
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Snapshot {} is associated with a higher position {} so it cannot be used for mark "
-                            + "delete position {}", subscription, current, current.position, pos);
-                }
+                log.debug()
+                        .attr("current", current)
+                        .attr("position", current.position)
+                        .attr("pos", pos)
+                        .log("Snapshot is associated with a higher position so it cannot be used for "
+                                + "mark-delete position");
                 break;
             }
             // This snapshot is potentially good. Continue the search to see if there is a higher snapshot we
@@ -364,13 +370,15 @@ public class ReplicatedSubscriptionSnapshotCache {
             head.setDistanceToPrevious(0L);
         }
 
-        if (log.isDebugEnabled()) {
-            if (snapshot != null) {
-                log.debug("[{}] Advanced mark-delete position to {} -- found snapshot at {}", subscription, pos,
-                        snapshot.position());
-            } else {
-                log.debug("[{}] Advanced mark-delete position to {} -- snapshot not found", subscription, pos);
-            }
+        if (snapshot != null) {
+            log.debug()
+                    .attr("pos", pos)
+                    .attr("position", snapshot.position())
+                    .log("Advanced mark-delete position -- found snapshot");
+        } else {
+            log.debug()
+                    .attr("pos", pos)
+                    .log("Advanced mark-delete position -- snapshot not found");
         }
 
         return snapshot != null ? new SnapshotResult(snapshot.position(), snapshot.clusters()) : null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
@@ -35,7 +36,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -56,8 +56,11 @@ import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 /**
  * Encapsulate all the logic of replicated subscriptions tracking for a given topic.
  */
-@Slf4j
 public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.PublishContext {
+
+    private static final Logger LOG = Logger.get(ReplicatedSubscriptionsController.class);
+    final Logger log;
+
     private final PersistentTopic topic;
     private final String localCluster;
 
@@ -94,6 +97,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     public ReplicatedSubscriptionsController(PersistentTopic topic, String localCluster) {
         this.topic = topic;
         this.localCluster = localCluster;
+        this.log = LOG.with().attr("topic", topic.getName()).build();
         var pulsar = topic.getBrokerService().pulsar();
         timer = pulsar.getExecutor()
                 .scheduleAtFixedRate(catchingAndLoggingThrowables(this::startNewSnapshot), 0,
@@ -121,18 +125,18 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
                 // Ignore
             }
         } catch (IOException e) {
-            log.warn("[{}] Failed to parse marker: {}", topic.getName(), e);
+            log.warn().exceptionMessage(e).log("Failed to parse marker");
         }
     }
 
     public void localSubscriptionUpdated(String subscriptionName,
                                          ReplicatedSubscriptionSnapshotCache.SnapshotResult snapshot) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Updating subscription to snapshot {}", topic, subscriptionName,
-                    snapshot.clusters().stream()
-                            .map(entry -> String.format("%s -> %s", entry.cluster(), entry.position()))
-                            .collect(Collectors.toList()));
-        }
+        log.debug()
+                .attr("subscription", subscriptionName)
+                .attr("clusters", snapshot.clusters().stream()
+                        .map(entry -> String.format("%s -> %s", entry.cluster(), entry.position()))
+                        .collect(Collectors.toList()))
+                .log("Updating subscription to snapshot");
 
         Map<String, MarkersMessageIdData> clusterIds = new TreeMap<>();
         for (ReplicatedSubscriptionSnapshotCache.ClusterEntry cluster : snapshot.clusters()) {
@@ -148,9 +152,11 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         // if replicator producer is already closed, restart it to send snapshot response
         Replicator replicator = topic.getReplicators().get(request.getSourceCluster());
         if (replicator == null) {
-            log.warn("[{}] Received replicated subscription snapshot request {} from cluster {}, but no replicator is"
-                            + " configured for that cluster. Ignoring the request.",
-                    topic.getName(), request.getSnapshotId(), request.getSourceCluster());
+            log.warn()
+                    .attr("snapshotId", request.getSnapshotId())
+                    .attr("sourceCluster", request.getSourceCluster())
+                    .log("Received replicated subscription snapshot request from cluster, but no replicator is"
+                            + "configured for that cluster. Ignoring the request.");
             return;
         }
         if (!replicator.isConnected()) {
@@ -161,10 +167,10 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         // marker we're publishing locally and then replicating will have a higher
         // message id.
         Position lastMsgId = topic.getLastPosition();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Received snapshot request. Last msg id: {}",
-                    topic.getBrokerService().pulsar().getBrokerId(), topic.getName(), lastMsgId);
-        }
+        log.debug()
+                .attr("brokerId", topic.getBrokerService().pulsar().getBrokerId())
+                .attr("lastMsgId", lastMsgId)
+                .log("Received snapshot request. Last msg id");
 
         ByteBuf marker = Markers.newReplicatedSubscriptionsSnapshotResponse(
                 request.getSnapshotId(),
@@ -178,10 +184,10 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         String snapshotId = response.getSnapshotId();
         ReplicatedSubscriptionsSnapshotBuilder builder = pendingSnapshots.get(snapshotId);
         if (builder == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Received late reply for timed-out snapshot {} from {}", topic.getName(), snapshotId,
-                        response.getCluster().getCluster());
-            }
+            log.debug()
+                    .attr("snapshotId", snapshotId)
+                    .attr("cluster", response.getCluster().getCluster())
+                    .log("Received late reply for timed-out snapshot from");
             return;
         }
 
@@ -204,17 +210,21 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
 
         Position pos = PositionFactory.create(updatedMessageId.getLedgerId(), updatedMessageId.getEntryId());
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Received update for subscription to {}", topic, update.getSubscriptionName(), pos);
-        }
+        log.debug()
+                .attr("subscriptionName", update.getSubscriptionName())
+                .attr("pos", pos)
+                .log("Received update for subscription to");
 
         PersistentSubscription sub = topic.getSubscription(update.getSubscriptionName());
         if (sub != null) {
             sub.acknowledgeMessage(Collections.singletonList(pos), AckType.Cumulative, Collections.emptyMap());
         } else {
             // Subscription doesn't exist. We need to force the creation of the subscription in this cluster.
-            log.info("[{}][{}] Creating subscription at {}:{} after receiving update from replicated subscription",
-                    topic, update.getSubscriptionName(), updatedMessageId.getLedgerId(), pos);
+            log.info()
+                    .attr("subscriptionName", update.getSubscriptionName())
+                    .attr("ledgerId", updatedMessageId.getLedgerId())
+                    .attr("pos", pos)
+                    .log("Creating subscription at: after receiving update from replicated subscription");
             topic.createSubscription(update.getSubscriptionName(), InitialPosition.Earliest,
                             true /* replicateSubscriptionState */, Collections.emptyMap())
                     .thenAccept(subscriptionCreated -> {
@@ -237,20 +247,18 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
             //
             // In other words, when hit this case, The frequency of sending SNAPSHOT_REQUEST
             // will use `replicatedSubscriptionsSnapshotTimeoutSeconds`.
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] PendingSnapshot exists but has never succeeded. "
-                        + "Skipping snapshot creation until pending snapshot timeout.", topic.getName());
-            }
+            log.debug()
+                    .log("PendingSnapshot exists but has never succeeded. "
+                            + "Skipping snapshot creation until pending snapshot timeout.");
             return;
         }
 
         if (topic.getLastMaxReadPositionMovedForwardTimestamp() < lastCompletedSnapshotStartTime
                 || topic.getLastMaxReadPositionMovedForwardTimestamp() == 0) {
             // There was no message written since the last snapshot, we can skip creating a new snapshot
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] There is no new data in topic. Skipping snapshot creation.",
-                        topic.getBrokerService().pulsar().getBrokerId(), topic.getName());
-            }
+            log.debug()
+                    .attr("brokerId", topic.getBrokerService().pulsar().getBrokerId())
+                    .log("There is no new data in topic. Skipping snapshot creation.");
             return;
         }
 
@@ -263,17 +271,14 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
 
         if (anyReplicatorDisconnected.isTrue()) {
             // Do not attempt to create snapshot when some of the clusters are not reachable
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Do not attempt to create snapshot when some of the clusters are not reachable.",
-                        topic.getName());
-            }
+            log.debug()
+                    .log("Do not attempt to create snapshot when some of the clusters are not reachable.");
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Starting snapshot creation.", topic.getBrokerService().pulsar().getBrokerId(),
-                    topic.getName());
-        }
+        log.debug()
+                .attr("brokerId", topic.getBrokerService().pulsar().getBrokerId())
+                .log("Starting snapshot creation.");
 
         pendingSnapshotsMetric.inc();
         stats.recordSnapshotStarted();
@@ -293,9 +298,9 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         while (it.hasNext()) {
             Map.Entry<String, ReplicatedSubscriptionsSnapshotBuilder> entry = it.next();
             if (entry.getValue().isTimedOut()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Snapshot creation timed out for {}", topic.getName(), entry.getKey());
-                }
+                log.debug()
+                        .attr("key", entry.getKey())
+                        .log("Snapshot creation timed out for");
 
                 pendingSnapshotsMetric.dec();
                 timedoutSnapshotsMetric.inc();
@@ -336,10 +341,12 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
     public void completed(Exception e, long ledgerId, long entryId) {
         // Nothing to do in case of publish errors since the retry logic is applied upstream after a snapshot is not
         // closed
-        if (log.isDebugEnabled()) {
-            log.debug("[{}][{}] Published marker at {}:{}. Exception: {}",
-                    topic.getBrokerService().pulsar().getBrokerId(), topic.getName(), ledgerId, entryId, e);
-        }
+        log.debug()
+                .attr("brokerId", topic.getBrokerService().pulsar().getBrokerId())
+                .attr("ledgerId", ledgerId)
+                .attr("entryId", entryId)
+                .exceptionMessage(e)
+                .log("Published marker");
 
         this.positionOfLastLocalMarker = PositionFactory.create(ledgerId, entryId);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.stats.OpenTelemetryReplicatedSubscriptionStats;
@@ -34,6 +35,7 @@ import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshotRespons
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 
+@CustomLog
 public class ReplicatedSubscriptionsSnapshotBuilder {
 
     private final String snapshotId;
@@ -75,7 +77,7 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
     }
 
     void start() {
-        controller.log.debug()
+        log.debug()
                 .attr("snapshotId", snapshotId)
                 .attr("clusters", missingClusters)
                 .log("Starting new snapshot");
@@ -85,14 +87,14 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
     }
 
     synchronized void receivedSnapshotResponse(Position position, ReplicatedSubscriptionsSnapshotResponse response) {
-        controller.log.debug()
+        log.debug()
                 .attr("cluster", response.getCluster().getCluster())
                 .log("Received response");
         String cluster = response.getCluster().getCluster();
         responses.putIfAbsent(cluster, new MarkersMessageIdData().copyFrom(response.getCluster().getMessageId()));
         missingClusters.remove(cluster);
 
-        controller.log.debug()
+        log.debug()
                 .attr("missingClusters", missingClusters)
                 .log("Missing clusters");
 
@@ -113,7 +115,7 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
             return;
         }
 
-        controller.log.debug()
+        log.debug()
                 .attr("snapshotId", snapshotId)
                 .log("Snapshot is complete");
         // Snapshot is now complete, store it in the local topic

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsSnapshotBuilder.java
@@ -26,7 +26,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.stats.OpenTelemetryReplicatedSubscriptionStats;
@@ -35,7 +34,6 @@ import org.apache.pulsar.common.api.proto.ReplicatedSubscriptionsSnapshotRespons
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
 
-@Slf4j
 public class ReplicatedSubscriptionsSnapshotBuilder {
 
     private final String snapshotId;
@@ -77,27 +75,26 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
     }
 
     void start() {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Starting new snapshot {} - Clusters: {}", controller.topic().getName(), snapshotId,
-                    missingClusters);
-        }
+        controller.log.debug()
+                .attr("snapshotId", snapshotId)
+                .attr("clusters", missingClusters)
+                .log("Starting new snapshot");
         startTimeMillis = clock.millis();
         controller.writeMarker(
                 Markers.newReplicatedSubscriptionsSnapshotRequest(snapshotId, controller.localCluster()));
     }
 
     synchronized void receivedSnapshotResponse(Position position, ReplicatedSubscriptionsSnapshotResponse response) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Received response from {}", controller.topic().getName(),
-                    response.getCluster().getCluster());
-        }
+        controller.log.debug()
+                .attr("cluster", response.getCluster().getCluster())
+                .log("Received response");
         String cluster = response.getCluster().getCluster();
         responses.putIfAbsent(cluster, new MarkersMessageIdData().copyFrom(response.getCluster().getMessageId()));
         missingClusters.remove(cluster);
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Missing clusters {}", controller.topic().getName(), missingClusters);
-        }
+        controller.log.debug()
+                .attr("missingClusters", missingClusters)
+                .log("Missing clusters");
 
         if (!missingClusters.isEmpty()) {
             // We're still waiting for more responses to come back
@@ -116,9 +113,9 @@ public class ReplicatedSubscriptionsSnapshotBuilder {
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Snapshot is complete {}", controller.topic().getName(), snapshotId);
-        }
+        controller.log.debug()
+                .attr("snapshotId", snapshotId)
+                .log("Snapshot is complete");
         // Snapshot is now complete, store it in the local topic
         Position p = position;
         controller.writeMarker(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/RescheduleReadHandler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/RescheduleReadHandler.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 
 /**
  * Reschedules reads so that the possible pending read is cancelled if it's waiting for more entries.
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
  * that should be handled. This will also batch multiple calls together to reduce the number of
  * operations.
  */
-@Slf4j
+@CustomLog
 class RescheduleReadHandler {
     private static final int UNSET = -1;
     private static final int NO_PENDING_READ = 0;
@@ -72,27 +72,19 @@ class RescheduleReadHandler {
                 // are entries in the replay queue.
                 if (maxReadOpCount != NO_PENDING_READ && readOpCounterSupplier.getAsLong() == maxReadOpCount
                         && hasEntriesInReplayQueue.getAsBoolean()) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Cancelling pending read request because it's waiting for more entries");
-                    }
+                    log.debug("Cancelling pending read request because it's waiting for more entries");
                     cancelPendingRead.run();
                 }
                 // Re-schedule read immediately, or join the next scheduled read
-                if (log.isDebugEnabled()) {
-                    log.debug("Triggering read");
-                }
+                log.debug("Triggering read");
                 rescheduleReadImmediately.run();
             };
             long rescheduleDelay = readIntervalMsSupplier.getAsLong();
             if (rescheduleDelay > 0) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Scheduling after {} ms", rescheduleDelay);
-                }
+                log.debug().attr("rescheduleDelay", rescheduleDelay).log("Scheduling after ms");
                 executor.schedule(runnable, rescheduleDelay, TimeUnit.MILLISECONDS);
             } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Running immediately");
-                }
+                log.debug("Running immediately");
                 runnable.run();
             }
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ShadowReplicator.java
@@ -20,9 +20,9 @@ package org.apache.pulsar.broker.service.persistent;
 
 
 import static org.apache.pulsar.client.impl.GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -36,8 +36,10 @@ import org.apache.pulsar.common.util.Codec;
 /**
  *  Replicate messages to shadow topic.
  */
-@Slf4j
 public class ShadowReplicator extends PersistentReplicator {
+
+    private static final Logger LOG = Logger.get(ShadowReplicator.class);
+    protected final Logger log;
 
     public ShadowReplicator(String shadowTopic, PersistentTopic sourceTopic, ManagedCursor cursor,
                             BrokerService brokerService, PulsarClientImpl replicationClient,
@@ -46,6 +48,7 @@ public class ShadowReplicator extends PersistentReplicator {
         super(brokerService.pulsar().getConfiguration().getClusterName(), sourceTopic, cursor,
                 brokerService.pulsar().getConfiguration().getClusterName(), shadowTopic, brokerService,
                 replicationClient, replicationAdmin);
+        this.log = LOG.with().ctx(super.log).build();
     }
 
     /**
@@ -81,8 +84,11 @@ public class ShadowReplicator extends PersistentReplicator {
                 try {
                     msg = MessageImpl.deserializeMetadataWithEmptyPayload(headersAndPayload);
                 } catch (Throwable t) {
-                    log.error("[{}] Failed to deserialize message at {} (buffer size: {}): {}", replicatorId,
-                            entry.getPosition(), length, t.getMessage(), t);
+                    log.error()
+                            .attr("position", entry.getPosition())
+                            .attr("length", length)
+                            .exception(t)
+                            .log("Failed to deserialize message");
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -91,10 +97,10 @@ public class ShadowReplicator extends PersistentReplicator {
 
                 if (msg.isExpired(messageTTLInSeconds)) {
                     msgExpired.recordEvent(0 /* no value stat */);
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Discarding expired message at position {}, replicateTo {}",
-                                replicatorId, entry.getPosition(), msg.getReplicateTo());
-                    }
+                    log.debug()
+                            .attr("position", entry.getPosition())
+                            .attr("replicateTo", msg.getReplicateTo())
+                            .log("Discarding expired message");
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -105,10 +111,9 @@ public class ShadowReplicator extends PersistentReplicator {
                 if (STATE_UPDATER.get(this) != State.Started || isLocalMessageSkippedOnce) {
                     // The producer is not ready yet after having stopped/restarted. Drop the message because it will
                     // recovered when the producer is ready
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] Dropping read message at {} because producer is not ready",
-                                replicatorId, entry.getPosition());
-                    }
+                    log.debug()
+                            .attr("position", entry.getPosition())
+                            .log("Dropping read message because producer is not ready");
                     isLocalMessageSkippedOnce = true;
                     inFlightTask.incCompletedEntries();
                     entry.release();
@@ -136,8 +141,9 @@ public class ShadowReplicator extends PersistentReplicator {
                 atLeastOneMessageSentForReplication = true;
             }
         } catch (Exception e) {
-            log.error("[{}] Unexpected exception in replication task for shadow topic: {}",
-                    replicatorId, e.getMessage(), e);
+            log.error()
+                    .exception(e)
+                    .log("Unexpected exception in replication task for shadow topic");
         }
         return atLeastOneMessageSentForReplication;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -24,14 +24,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.SubscribeRate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class SubscribeRateLimiter {
     private final String topicName;
     private final BrokerService brokerService;
@@ -45,7 +45,10 @@ public class SubscribeRateLimiter {
         // get subscribeRate from topic level policies
         this.subscribeRate = topic.getSubscribeRate();
         if (isSubscribeRateEnabled(this.subscribeRate)) {
-            log.info("[{}] configured subscribe-dispatch rate at broker {}", this.topicName, subscribeRate);
+            log.info()
+                    .attr("topic", this.topicName)
+                    .attr("subscribeRate", subscribeRate)
+                    .log("configured subscribe-dispatch rate at broker");
         }
     }
 
@@ -140,7 +143,10 @@ public class SubscribeRateLimiter {
             }
         }
         if (isSubscribeRateEnabled(this.subscribeRate)) {
-            log.info("[{}] configured subscribe-dispatch rate at broker {}", this.topicName, subscribeRate);
+            log.info()
+                    .attr("topic", this.topicName)
+                    .attr("subscribeRate", subscribeRate)
+                    .log("configured subscribe-dispatch rate at broker");
         }
     }
 
@@ -240,6 +246,4 @@ public class SubscribeRateLimiter {
                     .add("consumerId", consumerId).toString();
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(SubscribeRateLimiter.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterProvider.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.nar.NarClassLoader;
@@ -42,7 +42,7 @@ import org.apache.pulsar.common.nar.NarClassLoaderBuilder;
 import org.apache.pulsar.common.policies.data.EntryFilters;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 
-@Slf4j
+@CustomLog
 public class EntryFilterProvider implements AutoCloseable {
 
     @VisibleForTesting
@@ -111,7 +111,7 @@ public class EntryFilterProvider implements AutoCloseable {
             }
             final EntryFilter entryFilter = load(metaData);
             builder.put(filterName, entryFilter);
-            log.info("Successfully loaded entry filter `{}`", filterName);
+            log.info().attr("filterName", filterName).log("Successfully loaded entry filter");
         }
         return builder.build().values().asList();
     }
@@ -123,7 +123,7 @@ public class EntryFilterProvider implements AutoCloseable {
     private void initialize() throws IOException {
         final String entryFiltersDirectory = serviceConfiguration.getEntryFiltersDirectory();
         Path path = Paths.get(entryFiltersDirectory).toAbsolutePath().normalize();
-        log.info("Searching for entry filters in {}", path);
+        log.info().attr("path", path).log("Searching for entry filters");
 
 
         if (!path.toFile().exists()) {
@@ -140,7 +140,10 @@ public class EntryFilterProvider implements AutoCloseable {
                 try {
                     final NarClassLoader narClassLoader = loadNarClassLoader(archive);
                     EntryFilterDefinition def = getEntryFilterDefinition(narClassLoader);
-                    log.info("Found entry filter from {} : {}", archive, def);
+                    log.info()
+                            .attr("archive", archive)
+                            .attr("filterDefinition", def)
+                            .log("Found entry filter");
 
                     checkArgument(StringUtils.isNotBlank(def.getName()));
                     checkArgument(StringUtils.isNotBlank(def.getEntryFilterClass()));
@@ -151,10 +154,13 @@ public class EntryFilterProvider implements AutoCloseable {
 
                     entryFilterDefinitions.put(def.getName(), metadata);
                 } catch (Throwable t) {
-                    log.warn("Failed to load entry filters from {}."
-                            + " It is OK however if you want to use this entry filters,"
-                            + " please make sure you put the correct entry filter NAR"
-                            + " package in the entry filter directory.", archive, t);
+                    log.warn()
+                            .attr("archive", archive)
+                            .exception(t)
+                            .log("Failed to load entry filters from."
+                                    + "It is OK however if you want to use this entry filters,"
+                                    + "please make sure you put the correct entry filter NAR"
+                                            + "package in the entry filter directory.");
                 }
             }
         }
@@ -204,7 +210,10 @@ public class EntryFilterProvider implements AutoCloseable {
             if (e instanceof IOException) {
                 throw (IOException) e;
             }
-            log.error("Failed to load class {}", metadata.getDefinition().getEntryFilterClass(), e);
+            log.error()
+                    .attr("entryFilterClass", metadata.getDefinition().getEntryFilterClass())
+                    .exception(e)
+                    .log("Failed to load class");
             throw new IOException(e);
         }
     }
@@ -240,14 +249,14 @@ public class EntryFilterProvider implements AutoCloseable {
             try {
                 filter.close();
             } catch (Throwable e) {
-                log.warn("Error shutting down entry filter {}", filter, e);
+                log.warn().attr("filter", filter).exception(e).log("Error shutting down entry filter");
             }
         });
         cachedClassLoaders.forEach((name, ncl) -> {
             try {
                 ncl.close();
             } catch (Throwable e) {
-                log.warn("Error closing entry filter class loader {}", name, e);
+                log.warn().attr("name", name).exception(e).log("Error closing entry filter class loader");
             }
         });
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterWithClassLoader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/plugin/EntryFilterWithClassLoader.java
@@ -20,12 +20,12 @@ package org.apache.pulsar.broker.service.plugin;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import lombok.CustomLog;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.pulsar.common.nar.NarClassLoader;
 
-@Slf4j
+@CustomLog
 @ToString
 public class EntryFilterWithClassLoader implements EntryFilter {
     private final EntryFilter entryFilter;
@@ -64,11 +64,14 @@ public class EntryFilterWithClassLoader implements EntryFilter {
             Thread.currentThread().setContextClassLoader(currentClassLoader);
         }
         if (classLoaderOwned) {
-            log.info("Closing classloader {} for EntryFilter {}", classLoader, entryFilter.getClass().getName());
+            log.info()
+                    .attr("classLoader", classLoader)
+                    .attr("name", entryFilter.getClass().getName())
+                    .log("Closing classloader for EntryFilter");
             try {
                 classLoader.close();
             } catch (IOException e) {
-                log.error("close EntryFilterWithClassLoader failed", e);
+                log.error().exception(e).log("close EntryFilterWithClassLoader failed");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaBasedCompatibilityCheck.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Collections;
 import java.util.LinkedList;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.avro.SchemaValidationException;
@@ -36,7 +36,7 @@ import org.apache.pulsar.common.protocol.schema.SchemaData;
 /**
  * The abstract implementation of {@link SchemaCompatibilityCheck} using Avro Schema.
  */
-@Slf4j
+@CustomLog
 abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityCheck {
 
     @Override
@@ -63,7 +63,7 @@ abstract class AvroSchemaBasedCompatibilityCheck implements SchemaCompatibilityC
             SchemaValidator schemaValidator = createSchemaValidator(strategy);
             schemaValidator.validate(toSchema, fromList);
         } catch (SchemaParseException e) {
-            log.warn("Error during schema parsing: {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Error during schema parsing");
             throw new IncompatibleSchemaException(e);
         } catch (SchemaValidationException e) {
             String msg = String.format("Error during schema compatibility check with strategy %s: %s: %s",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -37,8 +37,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -62,12 +62,9 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class BookkeeperSchemaStorage implements SchemaStorage {
-    private static final Logger log = LoggerFactory.getLogger(BookkeeperSchemaStorage.class);
-
     private static final String SchemaPath = "/schemas";
     private static final byte[] LedgerPassword = "".getBytes();
 
@@ -174,9 +171,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     private CompletableFuture<Pair<Optional<LocatorEntry>, List<CompletableFuture<StoredSchema>>>> getAllWithLocator(
             String key) {
         return getLocator(key).thenApply(locator -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Get all schemas - locator: {}", key, locator);
-            }
+            log.debug().attr("key", key).attr("locator", locator).log("Get all schemas");
 
             if (locator.isEmpty()) {
                 return Pair.of(locator, Collections.emptyList());
@@ -206,8 +201,10 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         try {
             locatorEntry = getLocator(key).get();
         } catch (Exception e) {
-            log.warn("Failed to get list of schema-storage ledger for {}, the exception as follow: \n {}", key,
-                    (e instanceof ExecutionException ? e.getCause() : e));
+            log.warn()
+                    .attr("key", key)
+                    .exceptionMessage(e)
+                    .log("Failed to get list of schema-storage ledger");
             throw new IOException("Failed to get schema ledger for" + key);
         }
         LocatorEntry entry = locatorEntry.orElse(null);
@@ -245,13 +242,9 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     private CompletableFuture<StoredSchema> getSchema(String schemaId) {
         // There's already a schema read operation in progress. Just piggyback on that
         return readSchemaOperations.computeIfAbsent(schemaId, key -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Fetching schema from store", schemaId);
-            }
+            log.debug().attr("schemaId", schemaId).log("Fetching schema from store");
             return getSchemaLocator(getSchemaPath(schemaId)).thenCompose(locator -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Got schema locator {}", schemaId, locator);
-                }
+                log.debug().attr("schemaId", schemaId).attr("locator", locator).log("Got schema locator");
                 if (!locator.isPresent()) {
                     return completedFuture(null);
                 }
@@ -263,9 +256,11 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                                 new LongSchemaVersion(schemaLocator.getInfo().getVersion())));
             });
         }).whenComplete((res, ex) -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Get operation completed. res={} -- ex={}", schemaId, res, ex);
-            }
+            log.debug()
+                    .attr("schemaId", schemaId)
+                    .attr("result", res)
+                    .exceptionMessage(ex)
+                    .log("Get operation completed");
             readSchemaOperations.remove(schemaId);
         });
     }
@@ -291,14 +286,14 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
 
     @NonNull
     private CompletableFuture<StoredSchema> getSchema(String schemaId, long version) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Get schema - version: {}", schemaId, version);
-        }
+        log.debug().attr("schemaId", schemaId).attr("version", version).log("Get schema");
 
         return getSchemaLocator(getSchemaPath(schemaId)).thenCompose(locator -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Get schema - version: {} - locator: {}", schemaId, version, locator);
-            }
+            log.debug()
+                    .attr("schemaId", schemaId)
+                    .attr("version", version)
+                    .attr("locator", locator)
+                    .log("Get schema locator");
 
             if (!locator.isPresent()) {
                 return completedFuture(null);
@@ -335,9 +330,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
 
             SchemaLocator locator = optLocatorEntry.get().locator;
 
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] findSchemaEntryByHash - hash={}", schemaId, hash);
-            }
+            log.debug().attr("schemaId", schemaId).attr("hash", hash).log("findSchemaEntryByHash");
 
             //don't check the schema whether already exist
             List<IndexEntry> indexList = new ArrayList<>(locator.getIndexsCount());
@@ -403,7 +396,11 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                             bookKeeper.asyncDeleteLedger(ledgerId, (int rc, Object cnx) -> {
                                 if (rc != BKException.Code.OK) {
                                     // It's not a serious error, we didn't need call future.completeExceptionally()
-                                    log.warn("Failed to delete ledger {} of {}: {}", ledgerId, schemaId, rc);
+                                    log.warn()
+                                            .attr("ledgerId", ledgerId)
+                                            .attr("schemaId", schemaId)
+                                            .attr("rc", rc)
+                                            .log("Failed to delete ledger of");
                                 }
                                 deleteFuture.complete(null);
                             }, null);
@@ -419,9 +416,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                                             // The znode has been deleted by others.
                                             // In some cases, the program may enter this logic.
                                             // Since the znode is gone, we don’t need to deal with it.
-                                            if (log.isDebugEnabled()) {
-                                                log.debug("No node for schema path: {}", path);
-                                            }
+                                            log.debug().attr("path", path).log("No node for schema path");
                                             future.complete(null);
                                         } else {
                                             future.completeExceptionally(zkException);
@@ -484,14 +479,21 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         ).thenApply(ignore -> nextVersion).whenComplete((__, ex) -> {
             if (ex != null) {
                 Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.warn("[{}] Failed to update schema locator with position {}", schemaId, position, cause);
+                log.warn()
+                        .attr("schemaId", schemaId)
+                        .attr("position", position)
+                        .exception(cause)
+                        .log("Failed to update schema locator with position");
                 if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
                     bookKeeper.asyncDeleteLedger(position.getLedgerId(), new AsyncCallback.DeleteCallback() {
                         @Override
                         public void deleteComplete(int rc, Object ctx) {
                             if (rc != BKException.Code.OK) {
-                                log.warn("[{}] Failed to delete ledger {} after updating schema locator failed, rc: {}",
-                                    schemaId, position.getLedgerId(), rc);
+                                log.warn()
+                                        .attr("schemaId", schemaId)
+                                        .attr("ledgerId", position.getLedgerId())
+                                        .attr("rc", rc)
+                                        .log("Failed to delete ledger after updating schema locator failed, rc");
                             }
                         }
                     }, null);
@@ -537,9 +539,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     private CompletableFuture<SchemaEntry> readSchemaEntry(
         PositionInfo position
     ) {
-        if (log.isDebugEnabled()) {
-            log.debug("Reading schema entry from {}", position);
-        }
+        log.debug().attr("position", position).log("Reading schema entry from");
 
         return openLedger(position.getLedgerId())
             .thenCompose((ledger) ->
@@ -626,7 +626,10 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                         }
                     }, null, metadata);
         } catch (Throwable t) {
-            log.error("[{}] Encountered unexpected error when creating schema ledger", schemaId, t);
+            log.error()
+                    .attr("schemaId", schemaId)
+                    .exception(t)
+                    .log("Encountered unexpected error when creating schema ledger");
             return FutureUtil.failedFuture(t);
         }
         return future;
@@ -668,9 +671,10 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
     public CompletableFuture<List<Long>> getStoreLedgerIdsBySchemaId(String schemaId) {
         CompletableFuture<List<Long>> ledgerIdsFuture = new CompletableFuture<>();
         getSchemaLocator(getSchemaPath(schemaId)).thenAccept(locator -> {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Get all store schema ledgerIds - locator: {}", schemaId, locator);
-            }
+            log.debug()
+                    .attr("schemaId", schemaId)
+                    .attr("locator", locator)
+                    .log("Get all store schema ledgerIds - locator");
 
             if (!locator.isPresent()) {
                 ledgerIdsFuture.complete(Collections.emptyList());
@@ -776,9 +780,7 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
                 // NoSuchLedgerExistsOnMetadataServerException when reading schemas in
                 // bookkeeper. This also means that the data has already been deleted by other operations
                 // in deleting schema.
-                if (log.isDebugEnabled()) {
-                    log.debug("Schema data in bookkeeper may be deleted by other operations.", t);
-                }
+                log.debug().exception(t).log("Schema data in bookkeeper may be deleted by other operations.");
                 return null;
             }
             // rethrow other cases

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/NeverSchemaValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/NeverSchemaValidator.java
@@ -21,14 +21,11 @@ package org.apache.pulsar.broker.service.schema;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaValidationException;
 import org.apache.avro.SchemaValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An avro schema validator that always reports as incompatible, if there is an existing schema.
  */
 class NeverSchemaValidator implements SchemaValidator {
-    private static final Logger log = LoggerFactory.getLogger(NeverSchemaValidator.class);
     static final NeverSchemaValidator INSTANCE = new NeverSchemaValidator();
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryServiceImpl.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.avro.Schema;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.commons.collections4.CollectionUtils;
@@ -59,7 +59,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
 
-@Slf4j
+@CustomLog
 public class SchemaRegistryServiceImpl implements SchemaRegistryService {
     private static HashFunction hashFunction = Hashing.sha256();
     private final Map<SchemaType, SchemaCompatibilityCheck> compatibilityChecks;
@@ -112,10 +112,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                         ((LongSchemaVersion) schemaAndMetadata.version).getVersion() == longVersion)
                         .collect(Collectors.toList())
                 ).thenCompose(metadataList -> {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Meta data list size {}", schemaId,
-                                    CollectionUtils.isEmpty(metadataList) ? 0 : metadataList.size());
-                        }
+                        log.debug()
+                                .attr("schemaId", schemaId)
+                                .attr("size", CollectionUtils.isEmpty(metadataList) ? 0 : metadataList.size())
+                                .log("Meta data list size");
                         if (CollectionUtils.isNotEmpty(metadataList)) {
                             return schemaStorage.get(schemaId, version);
                         }
@@ -137,14 +137,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 .whenComplete((v, t) -> {
                     var latencyMs = this.clock.millis() - start;
                     if (t != null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Get schema failed", schemaId);
-                        }
+                        log.debug().attr("schemaId", schemaId).log("Get schema failed");
                         this.stats.recordGetFailed(schemaId, latencyMs);
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug(null == v ? "[{}] Schema not found" : "[{}] Schema is present", schemaId);
-                        }
+                        log.debugf(null == v ? "[%s] Schema not found" : "[%s] Schema is present", schemaId);
                         this.stats.recordGetLatency(schemaId, latencyMs);
                     }
                 });
@@ -177,9 +173,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                                 )
                 ))
                 .collect(Collectors.toList());
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] {} schemas is found", schemaId, list.size());
-        }
+        log.debug().attr("schemaId", schemaId).attr("size", list.size()).log("schemas is found");
         return CompletableFuture.completedFuture(list);
     }
 
@@ -196,9 +190,7 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 .thenCompose(schemaAndMetadataList -> getSchemaVersionBySchemaData(schemaAndMetadataList, schema)
                     .thenCompose(schemaVersion -> {
                         if (schemaVersion != null) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Schema is already exists", schemaId);
-                            }
+                            log.debug().attr("schemaId", schemaId).log("Schema is already exists");
                             promise.complete(schemaVersion);
                             return CompletableFuture.completedFuture(null);
                         }
@@ -231,18 +223,19 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                     var latencyMs = this.clock.millis() - start.longValue();
                     if (ex != null) {
                         if (ex instanceof IncompatibleSchemaException) {
-                            log.warn("[{}] Put schema failed due to incompatible schema", schemaId, ex);
+                            log.warn()
+                                    .attr("schemaId", schemaId)
+                                    .exception(ex)
+                                    .log("Put schema failed due to incompatible schema");
                         } else {
-                            log.error("[{}] Put schema failed", schemaId, ex);
+                            log.error().attr("schemaId", schemaId).exception(ex).log("Put schema failed");
                         }
                         if (start.longValue() != 0) {
                             this.stats.recordPutFailed(schemaId, latencyMs);
                         }
                         promise.completeExceptionally(ex);
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Put schema finished", schemaId);
-                        }
+                        log.debug().attr("schemaId", schemaId).log("Put schema finished");
                         // The schema storage will return null schema version if no schema is persisted to the storage
                         if (v != null) {
                             promise.complete(v);
@@ -268,12 +261,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 .whenComplete((v, t) -> {
                     var latencyMs = this.clock.millis() - start;
                     if (t != null) {
-                        log.error("[{}] User {} delete schema failed", schemaId, user);
+                        log.error().attr("schemaId", schemaId).attr("user", user).log("User delete schema failed");
                         this.stats.recordDelFailed(schemaId, latencyMs);
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] User {} delete schema finished", schemaId, user);
-                        }
+                        log.debug().attr("schemaId", schemaId).attr("user", user).log("User delete schema finished");
                         this.stats.recordDelLatency(schemaId, latencyMs);
                     }
                 });
@@ -293,12 +284,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                     var latencyMs = this.clock.millis() - start;
                     if (t != null) {
                         this.stats.recordDelFailed(schemaId, latencyMs);
-                        log.error("[{}] Delete schema storage failed", schemaId);
+                        log.error().attr("schemaId", schemaId).log("Delete schema storage failed");
                     } else {
                         this.stats.recordDelLatency(schemaId, latencyMs);
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Delete schema storage finished", schemaId);
-                        }
+                        log.debug().attr("schemaId", schemaId).log("Delete schema storage finished");
                     }
                 });
     }
@@ -462,12 +451,10 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 CompletableFuture<Void> result = new CompletableFuture<>();
                 result.whenComplete((__, t) -> {
                     if (t != null) {
-                        log.warn("[{}] Schema is incompatible", schemaId);
+                        log.warn().attr("schemaId", schemaId).log("Schema is incompatible");
                         this.stats.recordSchemaIncompatible(schemaId);
                     } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Schema is compatible", schemaId);
-                        }
+                        log.debug().attr("schemaId", schemaId).log("Schema is compatible");
                         this.stats.recordSchemaCompatible(schemaId);
                     }
                 });
@@ -499,12 +486,16 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
         result.whenComplete((v, t) -> {
             if (t != null) {
                 this.stats.recordSchemaIncompatible(schemaId);
-                log.warn("[{}] Schema is incompatible, schema type {}", schemaId, schema.getType());
+                log.warn()
+                        .attr("schemaId", schemaId)
+                        .attr("type", schema.getType())
+                        .log("Schema is incompatible, schema type");
             } else {
                 this.stats.recordSchemaCompatible(schemaId);
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Schema is compatible, schema type {}", schemaId, schema.getType());
-                }
+                log.debug()
+                        .attr("schemaId", schemaId)
+                        .attr("type", schema.getType())
+                        .log("Schema is compatible, schema type");
             }
         });
 
@@ -570,8 +561,11 @@ public class SchemaRegistryServiceImpl implements SchemaRegistryService {
                 trimDeletedSchemaAndGetList(list);
                 // clean up the broken schema from zk
                 deleteSchemaStorage(schemaId, true).handle((sv, th) -> {
-                    log.info("Clean up non-recoverable schema {}. Deletion of schema {} {}", rc.getMessage(),
-                            schemaId, (th == null ? "successful" : "failed, " + th.getCause().getMessage()));
+                    log.info()
+                            .exceptionMessage(rc)
+                            .attr("schemaId", schemaId)
+                            .attr("arg2", (th == null ? "successful" : "failed, " + th.getCause().getMessage()))
+                            .log("Clean up non-recoverable schema. Deletion of schema");
                     schemaResult.complete(list);
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
@@ -27,11 +27,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 
 /**
  */
+@CustomLog
 public class DimensionStats {
 
     private final String name;
@@ -44,7 +44,6 @@ public class DimensionStats {
             Arrays.stream(QUANTILES).mapToObj(Collector::doubleToGoString)
                     .map(Collections::singletonList)
                     .collect(Collectors.toList()));
-
 
     public DimensionStats(String name, long updateDurationInSec) {
         this(name, updateDurationInSec, true);
@@ -64,7 +63,7 @@ public class DimensionStats {
                 defaultRegistry.register(summary);
             } catch (IllegalArgumentException ie) {
                 // it only happens in test-cases when try to register summary multiple times in registry
-                log.warn("{} is already registered {}", name, ie.getMessage());
+                log.warn().attr("name", name).exceptionMessage(ie).log("is already registered");
             }
         }
     }
@@ -76,7 +75,6 @@ public class DimensionStats {
     public DimensionStatsSnapshot getSnapshot() {
         return new DimensionStatsSnapshot(summary.collect());
     }
-
 
     public class DimensionStatsSnapshot {
         private final List<Collector.MetricFamilySamples> samples;
@@ -151,6 +149,4 @@ public class DimensionStats {
     public void reset() {
         summary.clear();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(DimensionStats.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
@@ -49,7 +49,7 @@ import org.apache.pulsar.compaction.CompactedTopicContext;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.compaction.CompactorMXBean;
 
-@Slf4j
+@CustomLog
 public class NamespaceStatsAggregator {
 
     private static final FastThreadLocal<AggregatedBrokerStats> localBrokerStats =
@@ -592,14 +592,11 @@ public class NamespaceStatsAggregator {
         stream.writeSample(metricName, value, labels);
     }
 
-
     private static void writeMetric(PrometheusMetricStreams stream, String metricName, Number value, String cluster,
                                     String namespace) {
         String[] labels = new String[]{"cluster", cluster, "namespace", namespace};
         stream.writeSample(metricName, value, labels);
     }
-
-
 
     private static void writeReplicationStat(PrometheusMetricStreams stream, String metricName,
                                              AggregatedNamespaceStats namespaceStats,
@@ -614,6 +611,5 @@ public class NamespaceStatsAggregator {
             );
         }
     }
-
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 import org.apache.pulsar.broker.PulsarService;
@@ -69,7 +69,7 @@ import org.apache.pulsar.common.util.SimpleTextOutputStream;
  * Format specification can be found at <a
  * href="https://prometheus.io/docs/instrumenting/exposition_formats/">Exposition Formats</a>
  */
-@Slf4j
+@CustomLog
 public class PrometheusMetricsGenerator implements AutoCloseable {
     private static final int DEFAULT_INITIAL_BUFFER_SIZE = 1024 * 1024; // 1MB
     private static final int MINIMUM_FOR_MAX_COMPONENTS = 64;
@@ -456,7 +456,6 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
                     }
                 } else {
 
-
                     String name = entry.getKey();
                     if (!names.contains(name)) {
                         stream.write("# TYPE ");
@@ -514,7 +513,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             }), StandardCharsets.UTF_8)) {
                 statsProvider.writeAllMetrics(writer);
             } catch (IOException e) {
-                log.error("Failed to write managed ledger bookie client metrics", e);
+                log.error().exception(e).log("Failed to write managed ledger bookie client metrics");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PulsarPrometheusMetricsServlet.java
@@ -33,11 +33,11 @@ import javax.servlet.AsyncListener;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.eclipse.jetty.ee8.nested.HttpOutput;
 
-@Slf4j
+@CustomLog
 public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
     private static final long serialVersionUID = 1L;
     private static final int EXECUTOR_MAX_THREADS = 4;
@@ -57,7 +57,6 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
         gzipCompressionEnabledForMetrics = isGzipCompressionEnabledForEndpoint(
                 pulsar.getConfiguration().getHttpServerGzipCompressionExcludedPaths(), DEFAULT_METRICS_PATH);
     }
-
 
     @Override
     public void destroy() {
@@ -120,8 +119,9 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
                 // so that response writing can continue to up to 2 * timeout
                 if (metricsServletTimeoutMs > 0 && elapsedNanos > TimeUnit.MILLISECONDS.toNanos(
                         metricsServletTimeoutMs)) {
-                    log.warn("Prometheus metrics request was too long in queue ({}ms). Skipping sending metrics.",
-                            TimeUnit.NANOSECONDS.toMillis(elapsedNanos));
+                    log.warn()
+                            .attr("queue", TimeUnit.NANOSECONDS.toMillis(elapsedNanos))
+                            .log("Prometheus metrics request was too long in queue (ms). Skipping sending metrics.");
                     if (!response.isCommitted() && !skipWritingResponse.get()) {
                         response.setStatus(HTTP_STATUS_INTERNAL_SERVER_ERROR_500);
                     }
@@ -136,7 +136,7 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
                     return;
                 }
                 if (ex != null) {
-                    log.error("Failed to generate metrics", ex);
+                    log.error().exception(ex).log("Failed to generate metrics");
                     response.setStatus(HTTP_STATUS_INTERNAL_SERVER_ERROR_500);
                     return;
                 }
@@ -165,7 +165,7 @@ public class PulsarPrometheusMetricsServlet extends PrometheusMetricsServlet {
             } catch (EOFException e) {
                 log.error("Failed to write metrics to response due to EOFException");
             } catch (IOException e) {
-                log.error("Failed to write metrics to response", e);
+                log.error().exception(e).log("Failed to write metrics to response");
             } finally {
                 metricsBuffer.release();
                 context.complete();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.stats.prometheus;
 
 import static org.apache.pulsar.common.naming.SystemTopicNames.isEventSystemTopic;
 import io.netty.util.concurrent.FastThreadLocal;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 import org.apache.pulsar.broker.PulsarService;
@@ -32,7 +32,7 @@ import org.apache.pulsar.transaction.coordinator.impl.MLTransactionLogImpl;
 import org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStore;
 import org.apache.pulsar.transaction.coordinator.impl.TransactionMetadataStoreStats;
 
-@Slf4j
+@CustomLog
 public class TransactionAggregator {
 
     private static final FastThreadLocal<AggregatedTransactionCoordinatorStats> localTransactionCoordinatorStats =
@@ -71,7 +71,9 @@ public class TransactionAggregator {
                                                 stream, cluster, namespace, name, subscription.getName());
                                     }
                                 } catch (Exception e) {
-                                    log.warn("Transaction pending ack generate managedLedgerStats fail!", e);
+                                    log.warn()
+                                            .exception(e)
+                                            .log("Transaction pending ack generate managedLedgerStats fail!");
                                 }
                             });
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/NamespaceEventsSystemTopicFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.systopic;
 
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -27,9 +28,8 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class NamespaceEventsSystemTopicFactory {
 
     private final PulsarClient client;
@@ -40,7 +40,7 @@ public class NamespaceEventsSystemTopicFactory {
 
     public TopicPoliciesSystemTopicClient createTopicPoliciesSystemTopicClient(NamespaceName namespaceName) {
         TopicName topicName = getEventsTopicName(namespaceName);
-        log.info("Create topic policies system topic client {}", topicName.toString());
+        log.info().attr("client", topicName.toString()).log("Create topic policies system topic client");
         return new TopicPoliciesSystemTopicClient(client, topicName);
     }
 
@@ -72,7 +72,9 @@ public class NamespaceEventsSystemTopicFactory {
     public <T> TransactionBufferSnapshotBaseSystemTopicClient<T> createTransactionBufferSystemTopicClient(
             TopicName systemTopicName, SystemTopicTxnBufferSnapshotService<T>
             systemTopicTxnBufferSnapshotService, Class<T> schemaType) {
-        log.info("Create transaction buffer snapshot client, topicName : {}", systemTopicName.toString());
+        log.info()
+                .attr("topic", systemTopicName.toString())
+                .log("Create transaction buffer snapshot client");
         return new TransactionBufferSnapshotBaseSystemTopicClient(client, systemTopicName,
                 systemTopicTxnBufferSnapshotService, schemaType);
     }
@@ -89,6 +91,4 @@ public class NamespaceEventsSystemTopicFactory {
                     SystemTopicNames.TRANSACTION_BUFFER_SNAPSHOT_INDEXES);
         };
     }
-
-    private static final Logger log = LoggerFactory.getLogger(NamespaceEventsSystemTopicFactory.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClientBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClientBase.java
@@ -22,13 +22,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public abstract class SystemTopicClientBase<T> implements SystemTopicClient<T> {
 
     protected final TopicName topicName;
@@ -113,6 +113,4 @@ public abstract class SystemTopicClientBase<T> implements SystemTopicClient<T> {
     public List<Writer<T>> getWriters() {
         return writers;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(SystemTopicClientBase.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TopicPoliciesSystemTopicClient.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -36,12 +37,11 @@ import org.apache.pulsar.common.events.ActionType;
 import org.apache.pulsar.common.events.PulsarEvent;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * System topic for topic policy.
  */
+@CustomLog
 public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<PulsarEvent> {
 
     static Schema<PulsarEvent> avroSchema = DefaultImplementation.getDefaultImplementation()
@@ -59,10 +59,8 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
                 .enableBatching(false)
                 .createAsync()
                 .thenApply(producer -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] A new writer is created", topicName);
-                    }
-                    return new TopicPolicyWriter(producer, TopicPoliciesSystemTopicClient.this);
+                        log.debug().attr("topic", topicName).log("A new writer is created");
+                                        return new TopicPolicyWriter(producer, TopicPoliciesSystemTopicClient.this);
                 });
     }
 
@@ -76,10 +74,8 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
                 .poolMessages(true)
                 .createAsync()
                 .thenApply(reader -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] A new reader is created", topicName);
-                    }
-                    return new TopicPolicyReader(reader, TopicPoliciesSystemTopicClient.this);
+                        log.debug().attr("topic", topicName).log("A new reader is created");
+                                        return new TopicPolicyReader(reader, TopicPoliciesSystemTopicClient.this);
                 });
     }
 
@@ -121,8 +117,6 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
             setReplicateCluster(event, builder);
             return builder.sendAsync();
         }
-
-
 
         @Override
         public void close() throws IOException {
@@ -222,6 +216,4 @@ public class TopicPoliciesSystemTopicClient extends SystemTopicClientBase<Pulsar
             return systemTopic;
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(TopicPoliciesSystemTopicClient.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/TransactionBufferSnapshotBaseSystemTopicClient.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.systopic;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.service.SystemTopicTxnBufferSnapshotService;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -31,7 +31,7 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.SystemTopicNames;
 import org.apache.pulsar.common.naming.TopicName;
 
-@Slf4j
+@CustomLog
 public class  TransactionBufferSnapshotBaseSystemTopicClient<T> extends SystemTopicClientBase<T> {
 
     protected final SystemTopicTxnBufferSnapshotService<T> systemTopicTxnBufferSnapshotService;
@@ -191,10 +191,11 @@ public class  TransactionBufferSnapshotBaseSystemTopicClient<T> extends SystemTo
                 .topic(topicName.toString())
                 .enableBatching(false)
                 .createAsync().thenApply(producer -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] A new {} writer is created", topicName, schemaType.getName());
-                    }
-                    return  new TransactionBufferSnapshotWriter<>(producer, this);
+                        log.debug()
+                                .attr("topic", topicName)
+                                .attr("newSchemaType", schemaType.getName())
+                                .log("A new writer is created");
+                                        return  new TransactionBufferSnapshotWriter<>(producer, this);
                 });
     }
 
@@ -208,10 +209,11 @@ public class  TransactionBufferSnapshotBaseSystemTopicClient<T> extends SystemTo
                 .poolMessages(true)
                 .createAsync()
                 .thenApply(reader -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] A new {} reader is created", topicName, schemaType.getName());
-                    }
-                    return new TransactionBufferSnapshotReader<>(reader, this);
+                        log.debug()
+                                .attr("topic", topicName)
+                                .attr("newSchemaType", schemaType.getName())
+                                .log("A new reader is created");
+                                        return new TransactionBufferSnapshotReader<>(reader, this);
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SingleSnapshotAbortedTxnProcessorImpl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.commons.collections4.map.LinkedMap;
@@ -39,7 +39,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 
-@Slf4j
+@CustomLog
 public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcessor {
     private final PersistentTopic topic;
     private final ReferenceCountedWriter<TransactionBufferSnapshot> takeSnapshotWriter;
@@ -59,7 +59,7 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
                 .getTransactionBufferSnapshotServiceFactory()
                 .getTxnBufferSnapshotService().getReferenceWriter(TopicName.get(topic.getName()).getNamespaceObject());
         this.takeSnapshotWriter.getFuture().exceptionally((ex) -> {
-                    log.error("{} Failed to create snapshot writer", topic.getName());
+                    log.error().attr("topic", topic.getName()).log("Failed to create snapshot writer");
                     topic.close();
                     return null;
                 });
@@ -75,11 +75,12 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
     public void trimExpiredAbortedTxns() {
         while (!aborts.isEmpty() && !topic.getManagedLedger().getLedgersInfo()
                 .containsKey(aborts.get(aborts.firstKey()).getLedgerId())) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Topic transaction buffer clear aborted transaction, TxnId : {}, Position : {}",
-                        topic.getName(), aborts.firstKey(), aborts.get(aborts.firstKey()));
-            }
-            aborts.remove(aborts.firstKey());
+                log.debug()
+                        .attr("topic", topic.getName())
+                        .attr("txnId", aborts.firstKey())
+                        .attr("position", aborts.get(aborts.firstKey()))
+                        .log("Topic transaction buffer clear aborted transaction");
+                        aborts.remove(aborts.firstKey());
         }
     }
 
@@ -126,7 +127,9 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
                         TransactionBufferSnapshot snapshot = new TransactionBufferSnapshot();
                         snapshot.setTopicName(topic.getName());
                         return writer.deleteAsync(snapshot.getTopicName(), snapshot);
-                    }).thenRun(() -> log.info("[{}] Successes to delete the aborted transaction snapshot", this.topic));
+                    }).thenRun(() -> log.info()
+                            .attr("topic", this.topic)
+                            .log("Successes to delete the aborted transaction snapshot"));
                 }
                 return CompletableFuture.completedFuture(null);
             });
@@ -151,12 +154,15 @@ public class SingleSnapshotAbortedTxnProcessorImpl implements AbortedTxnProcesso
             snapshot.setAborts(list);
             return writer.writeAsync(snapshot.getTopicName(), snapshot).thenAccept(messageId -> {
                 this.lastSnapshotTimestamps = System.currentTimeMillis();
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}]Transaction buffer take snapshot success! "
-                            + "messageId : {}", topic.getName(), messageId);
-                }
-            }).exceptionally(e -> {
-                log.warn("[{}]Transaction buffer take snapshot fail! ", topic.getName(), e.getCause());
+                    log.debug()
+                            .attr("topic", topic.getName())
+                            .attr("messageId", messageId)
+                            .log("Transaction buffer take snapshot success");
+                            }).exceptionally(e -> {
+                log.warn()
+                        .attr("topic", topic.getName())
+                        .exception(e.getCause())
+                        .log("Transaction buffer take snapshot fail!");
                 return null;
             });
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/SnapshotSegmentAbortedTxnProcessorImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
@@ -33,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.function.Supplier;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -71,8 +71,10 @@ import org.apache.pulsar.common.policies.data.TransactionBufferStats;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 
-@Slf4j
 public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcessor {
+
+    private static final Logger LOG = Logger.get(SnapshotSegmentAbortedTxnProcessorImpl.class);
+    private final Logger log;
 
     /**
      * Stored the unsealed aborted transaction IDs Whose size is always less than the snapshotSegmentCapacity.
@@ -143,6 +145,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
     public SnapshotSegmentAbortedTxnProcessorImpl(PersistentTopic topic) {
         this.topic = topic;
+        this.log = LOG.with().attr("topic", topic.getName()).build();
         this.persistentWorker = new PersistentWorker(topic);
         /*
            Calculate the segment capital according to its size configuration.
@@ -194,10 +197,9 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         List<Position> positionsNeedToDelete = new ArrayList<>();
         while (!segmentIndex.isEmpty() && !topic.getManagedLedger().getLedgersInfo()
                 .containsKey(segmentIndex.firstKey().getLedgerId())) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Topic transaction buffer clear aborted transactions, maxReadPosition : {}",
-                        topic.getName(), segmentIndex.firstKey());
-            }
+            log.debug()
+                    .attr("maxReadPosition", segmentIndex.firstKey())
+                    .log("Topic transaction buffer clear aborted transactions");
             Position positionNeedToDelete = segmentIndex.firstKey();
             positionsNeedToDelete.add(positionNeedToDelete);
 
@@ -284,9 +286,11 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
             } catch (Throwable throwable) {
                 if (topic.getManagedLedger().getLedgersInfo()
                         .containsKey(index.getAbortedMarkLedgerID())) {
-                    log.error("[{}] Failed to read snapshot segment [{}:{}]",
-                            topic.getName(), index.segmentLedgerID,
-                            index.segmentEntryID, throwable);
+                    log.error()
+                            .attr("segmentLedgerId", index.segmentLedgerID)
+                            .attr("segmentEntryID", index.segmentEntryID)
+                            .exception(throwable)
+                            .log("Failed to read snapshot segment");
                     throw throwable;
                 } else {
                     hasInvalidIndex = true;
@@ -443,7 +447,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
 
     private <T> void closeReader(SystemTopicClient.Reader<T> reader) {
         reader.closeAsync().exceptionally(e -> {
-            log.warn("[{}] Failed to close reader: {}", topic.getName(), e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to close reader");
             return null;
         });
     }
@@ -503,7 +507,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                     .getTxnBufferSnapshotSegmentService()
                     .getReferenceWriter(TopicName.get(topic.getName()).getNamespaceObject());
             this.snapshotSegmentsWriter.getFuture().exceptionally(ex -> {
-                        log.error("{} Failed to create snapshot index writer", topic.getName());
+                        log.error().log("Failed to create snapshot index writer");
                         topic.close();
                         return null;
                     });
@@ -512,7 +516,7 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                     .getTxnBufferSnapshotIndexService()
                     .getReferenceWriter(TopicName.get(topic.getName()).getNamespaceObject());
             this.snapshotIndexWriter.getFuture().exceptionally((ex) -> {
-                        log.error("{} Failed to create snapshot writer", topic.getName());
+                        log.error().log("Failed to create snapshot writer");
                         topic.close();
                         return null;
                     });
@@ -533,8 +537,10 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         return cancelUpdateIndexTask();
                     } else if (STATE_UPDATER.compareAndSet(this, OperationState.None, OperationState.Operating)) {
                         return task.get().whenComplete((ignore, throwable) -> {
-                            if (throwable != null && log.isDebugEnabled()) {
-                                log.debug("[{}] Failed to update index snapshot", topic.getName(), throwable);
+                            if (throwable != null) {
+                                log.debug()
+                                        .exception(throwable)
+                                        .log("Failed to update index snapshot");
                             }
                             STATE_UPDATER.compareAndSet(this, OperationState.Operating, OperationState.None);
                         });
@@ -589,10 +595,8 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
         }
 
         private CompletableFuture<Void> cancelUpdateIndexTask() {
-            if (log.isDebugEnabled()) {
                 log.debug("The operation of updating index is canceled due there is other operation executing");
-            }
-            return FutureUtil.failedFuture(new BrokerServiceException
+                        return FutureUtil.failedFuture(new BrokerServiceException
                     .ServiceUnitNotReadyException("The operation of updating index is canceled"));
         }
 
@@ -609,11 +613,12 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         taskQueue.getFirst();
                 firstTask.getValue().getRight().get().whenComplete((ignore, throwable) -> {
                     if (throwable != null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Failed to do operation do operation of [{}]",
-                                    topic.getName(), firstTask.getKey().name(), throwable);
-                        }
-                        //Do not execute the tasks in the task queue until the next task is appended to the task queue.
+                        log.debug()
+                                .attr("operation", firstTask.getKey().name())
+                                .exception(throwable)
+                                .log("Failed to do operation");
+                        // Do not execute the tasks in the task queue
+                        // until the next task is appended to the task queue.
                         firstTask.getRight().getKey().completeExceptionally(throwable);
                     } else {
                         firstTask.getRight().getKey().complete(null);
@@ -632,21 +637,22 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                                                  Position abortedMarkerPersistentPosition) {
             CompletableFuture<Void> res =  writeSnapshotSegmentAsync(sealedAbortedTxnIdSegment,
                     abortedMarkerPersistentPosition).thenRun(() -> {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Successes to take snapshot segment [{}] at maxReadPosition [{}] "
-                                            + "for the topic [{}], and the size of the segment is [{}]",
-                                    this.sequenceID, abortedMarkerPersistentPosition, topic.getName(),
-                                    sealedAbortedTxnIdSegment.size());
-                        }
+                        log.debug()
+                                .attr("segment", this.sequenceID)
+                                .attr("maxReadPosition", abortedMarkerPersistentPosition)
+                                .attr("segmentSize", sealedAbortedTxnIdSegment.size())
+                                .log("Successfully took snapshot segment");
                         this.sequenceID.getAndIncrement();
                     });
             res.exceptionally(e -> {
                 //Just log the error, and the processor will try to take snapshot again when the transactionBuffer
                 //append aborted txn next time.
-                log.error("Failed to take snapshot segment [{}] at maxReadPosition [{}] "
-                                + "for the topic [{}], and the size of the segment is [{}]",
-                        this.sequenceID, abortedMarkerPersistentPosition, topic.getName(),
-                        sealedAbortedTxnIdSegment.size(), e);
+                log.error()
+                        .attr("segment", this.sequenceID)
+                        .attr("maxReadPosition", abortedMarkerPersistentPosition)
+                        .attr("segmentSize", sealedAbortedTxnIdSegment.size())
+                        .exception(e)
+                        .log("Failed to take snapshot segment");
                 return null;
             });
             return res;
@@ -702,21 +708,26 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                 CompletableFuture<Void> res = snapshotSegmentsWriter.getFuture()
                         .thenCompose(writer -> writer.deleteAsync(buildKey(sequenceIdNeedToDelete), null))
                         .thenCompose(messageId -> {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Successes to delete the snapshot segment, "
-                                                + "whose sequenceId is [{}] and maxReadPosition is [{}]",
-                                        this.topic.getName(), this.sequenceID, positionNeedToDelete);
-                            }
-                            //The index may fail to update but the processor will check
-                            //whether the snapshot segment is null, and update the index when recovering.
-                            //And if the task is not the newest in the queue, it is no need to update the index.
+                            log.debug()
+                                    .attr("topic", this.topic.getName())
+                                    .attr("sequenceId", this.sequenceID)
+                                    .attr("maxReadPosition", positionNeedToDelete)
+                                    .log("Successfully deleted snapshot segment");
+                            // The index may fail to update but the processor
+                            // will check whether the snapshot segment is null,
+                            // and update the index when recovering.
+                            // And if the task is not the newest in the queue,
+                            // it is no need to update the index.
                             indexes.remove(positionNeedToDelete);
                             return updateIndexWhenExecuteTheLatestTask();
                         });
                 res.exceptionally(e -> {
-                    log.warn("[{}] Failed to delete the snapshot segment, "
-                                    + "whose sequenceId is [{}] and maxReadPosition is [{}]",
-                            this.topic.getName(), this.sequenceID, positionNeedToDelete, e);
+                    log.warn()
+                            .attr("topic", this.topic.getName())
+                            .attr("sequenceId", this.sequenceID)
+                            .attr("maxReadPosition", positionNeedToDelete)
+                            .exception(e)
+                            .log("Failed to delete snapshot segment");
                     return null;
                 });
                 results.add(res);
@@ -735,7 +746,10 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                                 .thenCompose(messageId -> CompletableFuture.completedFuture(null));
                     });
             res.thenRun(() -> lastSnapshotTimestamps = System.currentTimeMillis()).exceptionally(e -> {
-                log.error("[{}] Failed to update snapshot segment index", snapshotIndexes.getTopicName(), e);
+                log.error()
+                        .attr("topic", snapshotIndexes.getTopicName())
+                        .exception(e)
+                        .log("Failed to update snapshot segment index");
                 return null;
             });
             return res;
@@ -759,14 +773,15 @@ public class SnapshotSegmentAbortedTxnProcessorImpl implements AbortedTxnProcess
                         if (exists) {
                             return snapshotIndexWriter.getFuture()
                                 .thenCompose(writer -> writer.writeAsync(topic.getName(), null))
-                                .thenRun(() -> log.debug("Successes to clear the snapshot segment and indexes for"
-                                        + " the topic [{}]", topic.getName()));
+                                .thenRun(() -> log.debug()
+                                        .log("Successes to clear the snapshot segment and indexes for the topic"));
                         }
                         return CompletableFuture.completedFuture(null);
                     }));
             res.exceptionally(e -> {
-                log.error("Failed to clear the snapshot segment and indexes for the topic [{}]",
-                        topic.getName(), e);
+                log.error()
+                        .exception(e)
+                        .log("Failed to clear the snapshot segment and indexes for the topic");
                 return null;
             });
             return res;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TableView.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.utils.SimpleCache;
@@ -38,7 +38,7 @@ import org.apache.pulsar.utils.SimpleCache;
  * - Provides just a single public method that reads the latest value synchronously.
  * - Maintains multiple long-lived readers that will be expired after some time (1 minute by default).
  */
-@Slf4j
+@CustomLog
 public class TableView<T> {
 
     // Remove the cached reader and snapshots if there is no refresh request in 1 minute
@@ -96,7 +96,7 @@ public class TableView<T> {
                 throw new RuntimeException(e);
             }
         }, __ -> __.closeAsync().exceptionally(e -> {
-            log.warn("Failed to close reader {}", e.getMessage());
+            log.warn().exceptionMessage(e).log("Failed to close reader");
             return null;
         }));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
@@ -32,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -65,8 +65,10 @@ import org.jctools.queues.SpscArrayQueue;
 /**
  * Transaction buffer based on normal persistent topic.
  */
-@Slf4j
 public class TopicTransactionBuffer extends TopicTransactionBufferState implements TransactionBuffer, TimerTask {
+
+    private static final Logger LOG = Logger.get(TopicTransactionBuffer.class);
+    private final Logger log;
 
     private final PersistentTopic topic;
 
@@ -89,7 +91,6 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
     private final int takeSnapshotIntervalNumber;
 
     private final int takeSnapshotIntervalTime;
-
 
     private final CompletableFuture<Void> transactionBufferFuture = new CompletableFuture<>();
 
@@ -130,6 +131,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                            AbortedTxnProcessor.SnapshotType snapshotType) {
         super(State.None);
         this.topic = topic;
+        this.log = LOG.with()
+                .attr("topic", topic.getName())
+                .attr("state", () -> getState())
+                .build();
         this.timer = topic.getBrokerService().getPulsar().getTransactionTimer();
         this.takeSnapshotIntervalNumber = topic.getBrokerService().getPulsar()
                 .getConfiguration().getTransactionBufferSnapshotMaxTransactionCount();
@@ -153,8 +158,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                                 maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
                             }
                             if (!changeToReadyState()) {
-                                log.error("[{}]Transaction buffer recover fail, current state: {}",
-                                        topic.getName(), getState());
+                                log.error("Transaction buffer recover fail");
                                 getTransactionBufferFuture().completeExceptionally
                                         (new BrokerServiceException.ServiceUnitNotReadyException(
                                                 "Transaction buffer recover failed to change the status to Ready,"
@@ -173,7 +177,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         synchronized (TopicTransactionBuffer.this) {
                             maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
                             if (!changeToNoSnapshotState()) {
-                                log.error("[{}]Transaction buffer recover fail", topic.getName());
+                                log.error().log("Transaction buffer recover fail");
                             } else {
                                 getTransactionBufferFuture().complete(null);
                                 recoverTime.setRecoverEndTime(System.currentTimeMillis());
@@ -208,8 +212,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     @Override
                     public void recoverExceptionally(Throwable e) {
 
-                        log.warn("Closing topic {} due to read transaction buffer snapshot while recovering the "
-                                + "transaction buffer throw exception", topic.getName(), e);
+                        log.warn()
+                                .exception(e)
+                                .log("Closing topic due to read transaction buffer snapshot while recovering the"
+                                        + " transaction buffer throw exception");
                         // when create reader or writer fail throw PulsarClientException,
                         // should close this topic and then reinit this topic
                         if (e instanceof PulsarClientException) {
@@ -280,8 +286,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             // `publishFuture` will be completed after transaction buffer recover completely
             // during initializing, so this case should not happen.
             if (!checkIfReady() && !checkIfNoSnapshot() && !checkIfFirstSnapshotting() && !checkIfInitializing()) {
-                log.error("[{}] unexpected state: {} when try to take the first transaction buffer snapshot",
-                        topic.getName(), getState());
+                log.error("Unexpected state when trying to take the first transaction buffer snapshot");
                 return FutureUtil.failedFuture(new BrokerServiceException.ServiceUnitNotReadyException(
                         "Transaction Buffer recover failed, the current state is: " + getState()));
             }
@@ -327,9 +332,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     }
                 } catch (Exception e) {
                     // If there are some error when adding entries or caching entries, this log will be printed.
-                    log.error("[{}] Failed to flush pending publishing requests after taking the first"
-                                    + " snapshot.",
-                            topic.getName(), e);
+                    log.error()
+                            .exception(e)
+                            .log("Failed to flush pending publishing requests after taking the first snapshot.");
                     if (pendingTask != null) {
                         pendingTask.fail(e);
                     }
@@ -340,31 +345,33 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             // Trigger the first snapshot.
             transactionBufferFuture.whenComplete((ignore1, ex1) -> {
                 if (ex1 != null) {
-                    log.error("[{}] Transaction buffer recover failed", topic.getName(), ex1);
+                    log.error().exception(ex1).log("Transaction buffer recover failed");
                     failPendingTasks.accept(ex1);
                     return;
                 }
                 if (changeToFirstSnapshotting()) {
-                    log.info("[{}] Start to take the first snapshot", topic.getName());
+                    log.info().log("Start to take the first snapshot");
                     // Flush pending publishing after the first snapshot finished.
                     takeFirstSnapshot().whenComplete((ignore2, ex2) -> {
                         if (ex2 != null) {
-                            log.error("[{}] Failed to take the first snapshot, flushing failed publishing requests",
-                                    topic.getName(), ex2);
+                            log.error()
+                                    .exception(ex2)
+                                    .log("Failed to take the first snapshot, flushing failed publishing requests");
                             failPendingTasks.accept(ex2);
                             return;
                         }
-                        log.info("[{}] Finished to take the first snapshot, flushing publishing {} requests",
-                                topic.getName(), pendingAppendingTxnBufferTasks.size());
+                        log.info()
+                                .attr("publishing", pendingAppendingTxnBufferTasks.size())
+                                .log("Finished to take the first snapshot, flushing publishing requests");
                         flushPendingTasks.run();
                     });
                 } else if (checkIfReady()) {
-                    log.info("[{}] No need to take the first snapshot, flushing publishing {} requests",
-                            topic.getName(), pendingAppendingTxnBufferTasks.size());
+                    log.info()
+                            .attr("publishing", pendingAppendingTxnBufferTasks.size())
+                            .log("No need to take the first snapshot, flushing publishing requests");
                     flushPendingTasks.run();
                 } else {
-                    log.error("[{}] Transaction buffer recover failed, current state is {}", topic.getName(),
-                            getState());
+                    log.error("Transaction buffer recover failed");
                     failPendingTasks.accept(new BrokerServiceException.ServiceUnitNotReadyException(
                             "Transaction Buffer recover failed, the current state is: " + getState()));
                 }
@@ -381,14 +388,14 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                         takeSnapshotIntervalTime, TimeUnit.MILLISECONDS);
                 firstSnapshottingFuture.complete(null);
             } else {
-                log.error("[{}]Failed to change state of transaction buffer to Ready from NoSnapshot",
-                        topic.getName());
+                log.error()
+                        .log("Failed to change state of transaction buffer to Ready from NoSnapshot");
                 firstSnapshottingFuture.completeExceptionally(new BrokerServiceException
                         .ServiceUnitNotReadyException(
                         "Transaction Buffer take first snapshot failed, the current state is: " + getState()));
             }
         }).exceptionally(exception -> {
-            log.error("Topic {} failed to take snapshot", this.topic.getName());
+            log.error().attr("topic", this.topic.getName()).log("Topic failed to take snapshot");
             firstSnapshottingFuture.completeExceptionally(exception);
             return null;
         });
@@ -416,7 +423,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
             @Override
             public void addFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("Failed to append buffer to txn {}", txnId, exception);
+                log.error().attr("txn", txnId).exception(exception).log("Failed to append buffer to txn");
                 completableFuture.completeExceptionally(exception);
             }
         }, null);
@@ -446,10 +453,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     @Override
     public CompletableFuture<Void> commitTxn(TxnID txnID, long lowWaterMark) {
-        if (log.isDebugEnabled()) {
-            log.debug("Transaction {} commit on topic {}.", txnID.toString(), topic.getName());
-        }
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            log.debug()
+                    .attr("transaction", txnID.toString())
+                    .log("Transaction commit on topic .");
+                CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         //Wait TB recover completely.
         getTransactionBufferFuture().thenRun(() -> {
             ByteBuf commitMarker = Markers.newTxnCommitMarker(-1L, txnID.getMostSigBits(),
@@ -470,7 +477,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
                     @Override
                     public void addFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("Failed to commit for txn {}", txnID, exception);
+                        log.error().attr("txn", txnID).exception(exception).log("Failed to commit for txn");
                         checkAppendMarkerException(exception);
                         completableFuture.completeExceptionally(new PersistenceException(exception));
                     }
@@ -479,7 +486,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 commitMarker.release();
             }
         }).exceptionally(exception -> {
-            log.error("Transaction {} commit on topic {}.", txnID.toString(), topic.getName(), exception.getCause());
+            log.error()
+                    .attr("transaction", txnID.toString())
+                    .exception(exception.getCause())
+                    .log("Transaction commit on topic .");
             completableFuture.completeExceptionally(exception.getCause());
             return null;
         });
@@ -488,10 +498,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
     @Override
     public CompletableFuture<Void> abortTxn(TxnID txnID, long lowWaterMark) {
-        if (log.isDebugEnabled()) {
-            log.debug("Transaction {} abort on topic {}.", txnID.toString(), topic.getName());
-        }
-        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+            log.debug()
+                    .attr("transaction", txnID.toString())
+                    .log("Transaction abort on topic .");
+                CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         //Wait TB recover completely.
         getTransactionBufferFuture().thenRun(() -> {
             //no message sent, need not to add abort mark by txn timeout.
@@ -517,7 +527,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
 
                     @Override
                     public void addFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("Failed to abort for txn {}", txnID, exception);
+                        log.error().attr("txn", txnID).exception(exception).log("Failed to abort for txn");
                         checkAppendMarkerException(exception);
                         completableFuture.completeExceptionally(new PersistenceException(exception));
                     }
@@ -526,7 +536,10 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 abortMarker.release();
             }
         }).exceptionally(exception -> {
-            log.error("Transaction {} abort on topic {}.", txnID.toString(), topic.getName(), exception.getCause());
+            log.error()
+                    .attr("transaction", txnID.toString())
+                    .exception(exception.getCause())
+                    .log("Transaction abort on topic .");
             completableFuture.completeExceptionally(exception.getCause());
             return null;
         });
@@ -555,14 +568,18 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 if (lowWaterMarkOfFirstTxnId != null && firstTxn.getLeastSigBits() <= lowWaterMarkOfFirstTxnId) {
                     abortTxn(firstTxn, lowWaterMarkOfFirstTxnId)
                             .thenRun(() -> {
-                                log.warn("Successes to abort low water mark for txn [{}], topic [{}],"
-                                        + " lowWaterMark [{}]", firstTxn, topic.getName(), lowWaterMarkOfFirstTxnId);
+                                log.warn()
+                                        .attr("txn", firstTxn)
+                                        .attr("lowWatermark", lowWaterMarkOfFirstTxnId)
+                                        .log("Successfully aborted low water mark for txn");
                                 handleLowWaterMark.release();
                             })
                             .exceptionally(ex -> {
-                                log.warn("Failed to abort low water mark for txn {}, topic [{}], "
-                                        + "lowWaterMark [{}], ", firstTxn, topic.getName(), lowWaterMarkOfFirstTxnId,
-                                        ex);
+                                log.warn()
+                                        .attr("txn", firstTxn)
+                                        .attr("lowWatermark", lowWaterMarkOfFirstTxnId)
+                                        .exception(ex)
+                                        .log("Failed to abort low water mark for txn");
                                 handleLowWaterMark.release();
                                 return null;
                             });
@@ -785,8 +802,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         @Override
         public void run() {
             if (!this.topicTransactionBuffer.changeToInitializingState()) {
-                log.warn("TransactionBuffer {} of topic {} can not change state to Initializing",
-                        this, topic.getName());
+                topicTransactionBuffer.log.warn()
+                        .attr("transactionBuffer", this)
+                        .log("TransactionBuffer of topic can not change state to Initializing");
                 return;
             }
             abortedTxnProcessor.recoverFromSnapshot().thenAccept(startReadCursorPosition -> {
@@ -803,7 +821,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                             .newNonDurableCursor(this.startReadCursorPosition, SUBSCRIPTION_NAME);
                 } catch (ManagedLedgerException e) {
                     callBack.recoverExceptionally(e);
-                    log.error("[{}]Transaction buffer recover fail when open cursor!", topic.getName(), e);
+                    topicTransactionBuffer.log.error()
+                            .exception(e)
+                            .log("Transaction buffer recover fail when open cursor!");
                     return;
                 }
                 Position lastConfirmedEntry =
@@ -837,7 +857,9 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                 callBack.recoverComplete();
             }).exceptionally(e -> {
                 callBack.recoverExceptionally(e.getCause());
-                log.error("[{}]Transaction buffer failed to recover snapshot!", topic.getName(), e);
+                topicTransactionBuffer.log.error()
+                        .exception(e)
+                        .log("Transaction buffer failed to recover snapshot");
                 return null;
             });
         }
@@ -847,25 +869,26 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     new AsyncCallbacks.DeleteCursorCallback() {
                 @Override
                 public void deleteCursorComplete(Object ctx) {
-                    log.info("[{}]Transaction buffer snapshot recover cursor close complete.", topic.getName());
+                    topicTransactionBuffer.log.info("Transaction buffer snapshot recover cursor close complete");
                 }
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.error("[{}]Transaction buffer snapshot recover cursor close fail.", topic.getName());
+                    topicTransactionBuffer.log.error("Transaction buffer snapshot recover cursor close fail");
                 }
 
             }, null);
         }
 
         private void callBackException(ManagedLedgerException e) {
-            log.error("Transaction buffer recover fail when recover transaction entry!", e);
+            topicTransactionBuffer.log.error().exception(e)
+                    .log("Transaction buffer recover fail when recovering transaction entry");
             this.exceptionNumber.getAndIncrement();
         }
 
         private void closeReader(SystemTopicClient.Reader<TransactionBufferSnapshot> reader) {
             reader.closeAsync().exceptionally(e -> {
-                log.error("[{}]Transaction buffer reader close error!", topic.getName(), e);
+                topicTransactionBuffer.log.error().exception(e).log("Transaction buffer reader close error");
                 return null;
             });
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferClientImpl.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 
 import io.netty.util.HashedWheelTimer;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -33,7 +33,7 @@ import org.apache.pulsar.common.api.proto.TxnAction;
 /**
  * The implementation of {@link TransactionBufferClient}.
  */
-@Slf4j
+@CustomLog
 public class TransactionBufferClientImpl implements TransactionBufferClient {
 
     private final TransactionBufferHandler tbHandler;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.broker.transaction.buffer.impl;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -39,7 +39,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 /**
  * Transaction buffer disable.
  */
-@Slf4j
+@CustomLog
 public class TransactionBufferDisable implements TransactionBuffer {
 
     private final Topic topic;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferHandlerImpl.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -51,7 +51,7 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 
-@Slf4j
+@CustomLog
 public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
 
     private final ConcurrentSkipListMap<Long, OpRequestSend> outstandingRequests;
@@ -83,11 +83,12 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
     @Override
     public CompletableFuture<TxnID> endTxnOnTopic(String topic, long txnIdMostBits, long txnIdLeastBits,
                                                   TxnAction action, long lowWaterMark) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] endTxnOnTopic txnId: [{}], txnAction: [{}]",
-                    topic, new TxnID(txnIdMostBits, txnIdLeastBits), action.getValue());
-        }
-        CompletableFuture<TxnID> cb = new CompletableFuture<>();
+            log.debug()
+                    .attr("topic", topic)
+                    .attr("txnId", new TxnID(txnIdMostBits, txnIdLeastBits))
+                    .attr("txnAction", action.getValue())
+                    .log("endTxnOnTopic");
+                CompletableFuture<TxnID> cb = new CompletableFuture<>();
         long requestId = requestIdGenerator.getAndIncrement();
         ByteBuf cmd = Commands.newEndTxnOnPartition(requestId, txnIdLeastBits, txnIdMostBits,
                 topic, action, lowWaterMark);
@@ -103,11 +104,12 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
     public CompletableFuture<TxnID> endTxnOnSubscription(String topic, String subscription,
                                                                       long txnIdMostBits, long txnIdLeastBits,
                                                                       TxnAction action, long lowWaterMark) {
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] endTxnOnSubscription txnId: [{}], txnAction: [{}]",
-                    topic, new TxnID(txnIdMostBits, txnIdLeastBits), action.getValue());
-        }
-        CompletableFuture<TxnID> cb = new CompletableFuture<>();
+            log.debug()
+                    .attr("topic", topic)
+                    .attr("txnId", new TxnID(txnIdMostBits, txnIdLeastBits))
+                    .attr("txnAction", action.getValue())
+                    .log("endTxnOnSubscription");
+                CompletableFuture<TxnID> cb = new CompletableFuture<>();
         long requestId = requestIdGenerator.getAndIncrement();
         ByteBuf cmd = Commands.newEndTxnOnSubscription(requestId, txnIdLeastBits, txnIdMostBits,
                 topic, subscription, action, lowWaterMark);
@@ -159,7 +161,7 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
                 }
             } else {
                 Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.error("endTxn error topic: [{}]", op.topic, cause);
+                log.error().attr("topic", op.topic).exception(cause).log("endTxn error topic");
                 if (cause instanceof PulsarClientException.BrokerMetadataException) {
                     op.cb.complete(null);
                 } else {
@@ -175,23 +177,25 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
     public void handleEndTxnOnTopicResponse(long requestId, CommandEndTxnOnPartitionResponse response) {
         OpRequestSend op = outstandingRequests.remove(requestId);
         if (op == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Got end txn on topic response for timeout {} - {}", response.getTxnidMostBits(),
-                        response.getTxnidLeastBits());
-            }
-            return;
+                log.debug()
+                        .attr("timeout", response.getTxnidMostBits())
+                        .attr("txnidLeastBits", response.getTxnidLeastBits())
+                        .log("Got end txn on topic response for timeout -");
+                        return;
         }
         try {
             if (!response.hasError()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Got end txn on topic response for for request {}", op.topic,
-                            response.getRequestId());
-                }
-                op.cb.complete(new TxnID(response.getTxnidMostBits(), response.getTxnidLeastBits()));
+                    log.debug()
+                            .attr("topic", op.topic)
+                            .attr("request", response.getRequestId())
+                            .log("Got end txn on topic response for for request");
+                                op.cb.complete(new TxnID(response.getTxnidMostBits(), response.getTxnidLeastBits()));
             } else {
-                log.error("[{}] Got end txn on topic response for request {} error {}", op.topic,
-                        response.getRequestId(),
-                        response.getError());
+                log.error()
+                        .attr("topic", op.topic)
+                        .attr("request", response.getRequestId())
+                        .attr("errorCode", response.getError())
+                        .log("Got end txn on topic response error");
                 op.cb.completeExceptionally(ClientCnx.getPulsarClientException(response.getError(),
                         response.getMessage()));
             }
@@ -205,23 +209,26 @@ public class TransactionBufferHandlerImpl implements TransactionBufferHandler {
                                                    CommandEndTxnOnSubscriptionResponse response) {
         OpRequestSend op = outstandingRequests.remove(requestId);
         if (op == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Got end txn on subscription response for timeout {} - {}", response.getTxnidMostBits(),
-                        response.getTxnidLeastBits());
-            }
-            return;
+                log.debug()
+                        .attr("timeout", response.getTxnidMostBits())
+                        .attr("txnidLeastBits", response.getTxnidLeastBits())
+                        .log("Got end txn on subscription response for timeout -");
+                        return;
         }
 
         try {
             if (!response.hasError()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Got end txn on subscription response for for request {}",
-                            op.topic, response.getRequestId());
-                }
-                op.cb.complete(new TxnID(response.getTxnidMostBits(), response.getTxnidLeastBits()));
+                    log.debug()
+                            .attr("topic", op.topic)
+                            .attr("request", response.getRequestId())
+                            .log("Got end txn on subscription response for for request");
+                                op.cb.complete(new TxnID(response.getTxnidMostBits(), response.getTxnidLeastBits()));
             } else {
-                log.error("[{}] Got end txn on subscription response for request {} error {}",
-                        op.topic, response.getRequestId(), response.getError());
+                log.error()
+                        .attr("topic", op.topic)
+                        .attr("request", response.getRequestId())
+                        .attr("errorCode", response.getError())
+                        .log("Got end txn on subscription response error");
                 op.cb.completeExceptionally(ClientCnx.getPulsarClientException(response.getError(),
                         response.getMessage()));
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckReplyCallBack.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckReplyCallBack.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.pendingack.impl;
 
+import io.github.merlimat.slog.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,33 +32,36 @@ import org.apache.pulsar.broker.transaction.pendingack.proto.PendingAckMetadata;
 import org.apache.pulsar.broker.transaction.pendingack.proto.PendingAckMetadataEntry;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.CommandAck.AckType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * MLPendingAckStore reply call back.
  */
 public class MLPendingAckReplyCallBack implements PendingAckReplyCallBack {
 
+    private static final Logger LOG = Logger.get(MLPendingAckReplyCallBack.class);
+    private final Logger log;
+
     private final PendingAckHandleImpl pendingAckHandle;
 
     public MLPendingAckReplyCallBack(PendingAckHandleImpl pendingAckHandle) {
         this.pendingAckHandle = pendingAckHandle;
+        this.log = LOG.with()
+                .attr("topic", pendingAckHandle.getTopicName())
+                .attr("subscription", pendingAckHandle.getSubName())
+                .attr("state", () -> pendingAckHandle.state)
+                .build();
     }
 
     @Override
     public void replayComplete() {
         pendingAckHandle.getInternalPinnedExecutor().execute(() -> {
-            log.info("Topic name : [{}], SubName : [{}] pending ack state reply success!",
-                    pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
+            log.info("Pending ack state reply success");
 
             if (pendingAckHandle.changeToReadyState()) {
                 pendingAckHandle.completeHandleFuture();
-                log.info("Topic name : [{}], SubName : [{}] pending ack handle cache request success!",
-                        pendingAckHandle.getTopicName(), pendingAckHandle.getSubName());
+                log.info("Pending ack handle cache request success");
             } else {
-                log.error("Topic name : [{}], SubName : [{}] pending ack state reply fail! current state: {}",
-                        pendingAckHandle.getTopicName(), pendingAckHandle.getSubName(), pendingAckHandle.state);
+                log.error("Pending ack state reply fail");
                 replayFailed(new BrokerServiceException.ServiceUnitNotReadyException("Failed"
                         + " to change PendingAckHandle state to Ready, current state is : " + pendingAckHandle.state));
             }
@@ -121,6 +125,4 @@ public class MLPendingAckReplyCallBack implements PendingAckReplyCallBack {
 
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(MLPendingAckReplyCallBack.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStore.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWrite
 import static org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriter.BATCHED_ENTRY_DATA_PREFIX_VERSION_LEN;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ComparisonChain;
+import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.FastThreadLocal;
@@ -65,14 +66,14 @@ import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterMetricsStats;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.SpscArrayQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The implement of the pending ack store by manageLedger.
  */
 public class MLPendingAckStore implements PendingAckStore {
 
+    private static final Logger LOG = Logger.get(MLPendingAckStore.class);
+    private final Logger log;
 
     private final ManagedLedger managedLedger;
 
@@ -125,6 +126,10 @@ public class MLPendingAckStore implements PendingAckStore {
                              Timer timer, TxnLogBufferedWriterMetricsStats bufferedWriterMetrics, Executor executor) {
         this.managedLedger = managedLedger;
         this.cursor = cursor;
+        this.log = LOG.with()
+                .attr("managedLedger", managedLedger.getName())
+                .attr("cursor", cursor.getName())
+                .build();
         this.currentLoadPosition = this.cursor.getMarkDeletedPosition();
         this.entryQueue = new SpscArrayQueue<>(2000);
         this.lastConfirmedEntry = managedLedger.getLastConfirmedEntry();
@@ -162,17 +167,16 @@ public class MLPendingAckStore implements PendingAckStore {
 
                     @Override
                     public void closeComplete(Object ctx) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}][{}] MLPendingAckStore closed successfully！", managedLedger.getName(), ctx);
-                        }
+                        log.debug("MLPendingAckStore closed successfully");
                         bufferedWriter.close();
                         completableFuture.complete(null);
                     }
 
                     @Override
                     public void closeFailed(ManagedLedgerException exception, Object ctx) {
-                        log.error("[{}][{}] MLPendingAckStore closed failed,exception={}", managedLedger.getName(),
-                                ctx, exception);
+                        log.error()
+                                .exceptionMessage(exception)
+                                .log("MLPendingAckStore close failed");
                         completableFuture.completeExceptionally(exception);
                     }
                 }, ctx);
@@ -254,10 +258,11 @@ public class MLPendingAckStore implements PendingAckStore {
 
             @Override
             public void addComplete(Position position, Object ctx) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}][{}] MLPendingAckStore message append success at {} txnId: {}, operation : {}",
-                            managedLedger.getName(), ctx, position, txnID, pendingAckMetadataEntry.getPendingAckOp());
-                }
+                log.debug()
+                        .attr("position", position)
+                        .attr("txnId", txnID)
+                        .attr("operation", pendingAckMetadataEntry.getPendingAckOp())
+                        .log("MLPendingAckStore message append success");
                 currentIndexLag.incrementAndGet();
                 /**
                  * If the Batch feature is enabled by {@link #bufferedWriter},
@@ -283,8 +288,10 @@ public class MLPendingAckStore implements PendingAckStore {
 
             @Override
             public void addFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("[{}][{}] MLPendingAckStore message append fail exception : {}, operation : {}",
-                        managedLedger.getName(), ctx, exception, pendingAckMetadataEntry.getPendingAckOp());
+                log.error()
+                        .exceptionMessage(exception)
+                        .attr("operation", pendingAckMetadataEntry.getPendingAckOp())
+                        .log("MLPendingAckStore message append failed");
 
                 if (exception instanceof ManagedLedgerException.ManagedLedgerAlreadyClosedException) {
                     managedLedger.readyToCreateNewLedger();
@@ -366,18 +373,17 @@ public class MLPendingAckStore implements PendingAckStore {
                         new AsyncCallbacks.MarkDeleteCallback() {
                             @Override
                             public void markDeleteComplete(Object ctx) {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Transaction pending ack store mark delete position : "
-                                                    + "[{}] success", managedLedger.getName(),
-                                            finalDeletePosition);
-                                }
+                                log.debug()
+                                        .attr("position", finalDeletePosition)
+                                        .log("Transaction pending ack store mark delete position success");
                             }
 
                             @Override
                             public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
-                                log.error("[{}] Transaction pending ack store mark delete position : "
-                                                + "[{}] fail!", managedLedger.getName(),
-                                        finalDeletePosition, exception);
+                                log.error()
+                                        .attr("position", finalDeletePosition)
+                                        .exception(exception)
+                                        .log("Transaction pending ack store mark delete position fail");
                             }
                         }, null);
             }
@@ -400,8 +406,7 @@ public class MLPendingAckStore implements PendingAckStore {
                 if (cursor.isClosed()) {
                     pendingAckReplyCallBack.replayFailed(new ManagedLedgerException
                             .CursorAlreadyClosedException("MLPendingAckStore cursor have been closed."));
-                    log.warn("[{}] MLPendingAckStore cursor have been closed, close replay thread.",
-                            cursor.getManagedLedger().getName());
+                    log.warn("MLPendingAckStore cursor have been closed, close replay thread");
                     return;
                 }
                 while (lastConfirmedEntry.compareTo(currentLoadPosition) > 0 && fillEntryQueueCallback.fillQueue()) {
@@ -432,15 +437,16 @@ public class MLPendingAckStore implements PendingAckStore {
                             Thread.sleep(1);
                         } catch (InterruptedException e) {
                             if (Thread.interrupted()) {
-                                log.error("[{}]Transaction pending "
-                                        + "replay thread interrupt!", managedLedger.getName(), e);
+                                log.error()
+                                        .exception(e)
+                                        .log("Transaction pending replay thread interrupt!");
                             }
                         }
                     }
                 }
             } catch (Exception e) {
                 pendingAckReplyCallBack.replayFailed(e);
-                log.error("[{}] Pending ack recover fail!", subManagedCursor.getManagedLedger().getName(), e);
+                log.error().exception(e).log("Pending ack recover fail");
                 return;
             }
             pendingAckReplyCallBack.replayComplete();
@@ -506,7 +512,7 @@ public class MLPendingAckStore implements PendingAckStore {
                     || exception instanceof ManagedLedgerException.CursorAlreadyClosedException) {
                 isReadable = false;
             }
-            log.error("MLPendingAckStore of topic [{}] stat reply fail!", managedLedger.getName(), exception);
+            log.error().exception(exception).log("MLPendingAckStore of topic stat reply fail");
             outstandingReadsRequests.decrementAndGet();
         }
 
@@ -523,9 +529,6 @@ public class MLPendingAckStore implements PendingAckStore {
     public static String getTransactionPendingAckStoreCursorName() {
         return SystemTopicNames.PENDING_ACK_STORE_CURSOR_NAME;
     }
-
-    private static final Logger log = LoggerFactory.getLogger(MLPendingAckStore.class);
-
     /**
      * Used only for buffered writer. Since all cmd-writes in buffered writer are in the same thread, so we can use
      * threadLocal variables here. Why need to be on the same thread ?

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/MLPendingAckStoreProvider.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pulsar.broker.transaction.pendingack.impl;
 
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timer;
 import io.prometheus.client.CollectorRegistry;
 import java.util.concurrent.CompletableFuture;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -42,12 +42,12 @@ import org.apache.pulsar.transaction.coordinator.impl.DisabledTxnLogBufferedWrit
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterConfig;
 import org.apache.pulsar.transaction.coordinator.impl.TxnLogBufferedWriterMetricsStats;
 
-
 /**
  * Provider is for MLPendingAckStore.
  */
-@Slf4j
 public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProvider {
+
+    private static final Logger LOG = Logger.get(MLPendingAckStoreProvider.class);
 
     private static volatile TxnLogBufferedWriterMetricsStats bufferedWriterMetrics =
             DisabledTxnLogBufferedWriterMetricsStats.DISABLED_BUFFERED_WRITER_METRICS;
@@ -89,6 +89,13 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
         BrokerService brokerService = originPersistentTopic.getBrokerService();
         PulsarService pulsarService = brokerService.getPulsar();
 
+        // Create a derived logger scoped to this operation so all subsequent log calls carry
+        // topic and subscription context.
+        Logger log = LOG.with()
+                .attr("topic", originPersistentTopic.getName())
+                .attr("subscription", subscription.getName())
+                .build();
+
         final Timer brokerClientSharedTimer =
                 pulsarService.getBrokerClientSharedTimer();
         final ServiceConfiguration serviceConfiguration = pulsarService.getConfiguration();
@@ -118,36 +125,38 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                             topicName = TopicName.get(originPersistentTopic.getName());
                         }
                         brokerService.getManagedLedgerConfig(topicName).thenAccept(config -> {
-                            internalNewPendingAckStore(subscription, config, brokerService, topicName,
+                            internalNewPendingAckStore(log, subscription, config, brokerService, topicName,
                                     pendingAckTopicNameObject, pendingAckStoreFuture, txnLogBufferedWriterConfig,
                                     brokerClientSharedTimer, originPersistentTopic);
                         }).exceptionally(e -> {
                             Throwable t = FutureUtil.unwrapCompletionException(e);
-                            log.error("[{}] [{}] Failed to get managedLedger config when init pending ack "
-                                            + "store!",
-                                    originPersistentTopic, subscription, t);
+                            log.error().exception(t)
+                                    .log("Failed to get managedLedger config when init pending ack store");
                             pendingAckStoreFuture.completeExceptionally(t);
                             return null;
 
                         });
                     }).exceptionally(e -> {
                         Throwable t = FutureUtil.unwrapCompletionException(e);
-                        log.error("[{}] [{}] Failed to check the pending ack topic exist when init pending ack store!",
-                                originPersistentTopic, subscription, t);
+                        log.error().exception(t)
+                                .log("Failed to check the pending ack topic exist when init pending ack store");
                         pendingAckStoreFuture.completeExceptionally(t);
                         return null;
                     });
                 }).exceptionally(e -> {
                     Throwable t = FutureUtil.unwrapCompletionException(e);
-                    log.error("[{}] [{}] Failed to get managedLedger config when init pending ack store!",
-                            pendingAckTopicNameObject, subscription, t);
+                    log.error()
+                            .attr("pendingAckTopic", pendingAckTopicNameObject)
+                            .exception(t)
+                            .log("Failed to get managedLedger config when init pending ack store");
                     pendingAckStoreFuture.completeExceptionally(t);
                     return null;
                 });
         return pendingAckStoreFuture;
     }
 
-    private static void internalNewPendingAckStore(PersistentSubscription subscription, ManagedLedgerConfig config,
+    private static void internalNewPendingAckStore(Logger log,
+                                                   PersistentSubscription subscription, ManagedLedgerConfig config,
                                                    BrokerService brokerService, TopicName topicName,
                                                    TopicName pendingAckTopicNameObject,
                                                    CompletableFuture<PendingAckStore> pendingAckStoreFuture,
@@ -183,24 +192,16 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                                                                         .getPulsar()
                                                                         .getOrderedExecutor()
                                                                         .chooseThread()));
-                                                if (log.isDebugEnabled()) {
-                                                    log.debug(
-                                                            "{},{} open MLPendingAckStore cursor "
-                                                                    + "success",
-                                                            originPersistentTopic.getName(),
-                                                            subscription.getName());
-                                                }
+                                                log.debug("open MLPendingAckStore cursor success");
                                             }
 
                                             @Override
                                             public void openCursorFailed(
                                                     ManagedLedgerException exception,
                                                     Object ctx) {
-                                                log.error(
-                                                        "{},{} open MLPendingAckStore cursor "
-                                                                + "failed."
-                                                        , originPersistentTopic.getName(),
-                                                        subscription.getName(), exception);
+                                                log.error()
+                                                        .exception(exception)
+                                                        .log("open MLPendingAckStore cursor failed");
                                                 pendingAckStoreFuture.completeExceptionally(
                                                         exception);
                                             }
@@ -210,9 +211,9 @@ public class MLPendingAckStoreProvider implements TransactionPendingAckStoreProv
                             @Override
                             public void openLedgerFailed(ManagedLedgerException exception,
                                                          Object ctx) {
-                                log.error("{}, {} open MLPendingAckStore managedLedger failed."
-                                        , originPersistentTopic.getName(), subscription.getName(),
-                                        exception);
+                                log.error()
+                                        .exception(exception)
+                                        .log("open MLPendingAckStore managedLedger failed");
                                 pendingAckStoreFuture.completeExceptionally(exception);
                             }
                         }, () -> CompletableFuture.completedFuture(true), null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/pendingack/impl/PendingAckHandleImpl.java
@@ -24,6 +24,7 @@ import static org.apache.bookkeeper.mledger.util.PositionAckSetUtil.andAckSet;
 import static org.apache.bookkeeper.mledger.util.PositionAckSetUtil.compareToWithAckSet;
 import static org.apache.bookkeeper.mledger.util.PositionAckSetUtil.isAckSetOverlap;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.merlimat.slog.Logger;
 import io.netty.util.Timer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -41,7 +42,6 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.BKException;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -76,8 +76,10 @@ import org.apache.pulsar.transaction.common.exception.TransactionConflictExcepti
 /**
  * The default implementation of {@link PendingAckHandle}.
  */
-@Slf4j
 public class PendingAckHandleImpl extends PendingAckHandleState implements PendingAckHandle {
+
+    private static final Logger LOG = Logger.get(PendingAckHandleImpl.class);
+    private final Logger log;
 
     /**
      * The map is for transaction with position witch was individual acked by this transaction.
@@ -157,6 +159,10 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         this.topicName = persistentSubscription.getTopicName();
         this.subName = persistentSubscription.getName();
         this.persistentSubscription = persistentSubscription;
+        this.log = LOG.with()
+                .attr("topic", topicName)
+                .attr("subscription", subName)
+                .build();
         var pulsar = persistentSubscription.getTopic().getBrokerService().getPulsar();
         internalPinnedExecutor = pulsar.getTransactionExecutorProvider().getExecutor(this);
 
@@ -226,13 +232,11 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                 pendingAckStore.appendIndividualAck(txnID, positions).thenAccept(v -> {
                     synchronized (org.apache.pulsar.broker.transaction.pendingack.impl.PendingAckHandleImpl.this) {
                         for (MutablePair<Position, Integer> positionIntegerMutablePair : positions) {
-
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] individualAcknowledgeMessage position: [{}], "
-                                                + "txnId: [{}], subName: [{}]", topicName,
-                                        positionIntegerMutablePair.left, txnID, subName);
-                            }
-                            Position position = positionIntegerMutablePair.left;
+                                log.debug()
+                                        .attr("position", positionIntegerMutablePair.left)
+                                        .attr("txnId", txnID)
+                                        .log("individualAcknowledgeMessage");
+                                                        Position position = positionIntegerMutablePair.left;
 
                             // If try to ack message already acked by committed transaction or
                             // normal acknowledge,throw exception.
@@ -375,12 +379,11 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
         this.pendingAckStoreFuture.thenAccept(pendingAckStore ->
                 pendingAckStore.appendCumulativeAck(txnID, position).thenAccept(v -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}] cumulativeAcknowledgeMessage position: [{}], "
-                                + "txnID:[{}], subName: [{}].", topicName, txnID, position, subName);
-                    }
-
-                    if (position.compareTo(persistentSubscription.getCursor()
+                        log.debug()
+                                .attr("txnId", txnID)
+                                .attr("position", position)
+                                .log("cumulativeAcknowledgeMessage");
+                                        if (position.compareTo(persistentSubscription.getCursor()
                             .getMarkDeletedPosition()) <= 0) {
                         String errorMsg = "[" + topicName + "][" + subName + "] Transaction:" + txnID
                                 + " try to cumulative ack position: " + position + " within range of cursor's "
@@ -461,18 +464,19 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
             if (cumulativeAckOfTransaction.getKey().equals(txnID)) {
                 pendingAckStoreFuture.thenAccept(pendingAckStore -> pendingAckStore
                         .appendCommitMark(txnID, AckType.Cumulative).thenAccept(v -> {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Transaction pending ack store commit txnId : [{}] "
-                                        + "success! subName: [{}]", topicName, txnID, subName);
-                            }
-                            persistentSubscription.acknowledgeMessage(
+                                log.debug()
+                                        .attr("txnId", txnID)
+                                        .log("Transaction pending ack store commit cumulative success");
+                                                        persistentSubscription.acknowledgeMessage(
                                     Collections.singletonList(cumulativeAckOfTransaction.getValue()),
                                     AckType.Cumulative, properties);
                             cumulativeAckOfTransaction = null;
                             commitFuture.complete(null);
                         }).exceptionally(e -> {
-                            log.error("[{}] Transaction pending ack store commit txnId : [{}] fail!",
-                                    topicName, txnID, e);
+                            log.error()
+                                    .attr("txnId", txnID)
+                                    .exception(e)
+                                    .log("Transaction pending ack store commit fail!");
                             commitFuture.completeExceptionally(e);
                             return null;
                         })).exceptionally(e -> {
@@ -489,11 +493,13 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                             if (individualAckOfTransaction != null && individualAckOfTransaction.containsKey(txnID)) {
                                 HashMap<Position, Position> pendingAckMessageForCurrentTxn =
                                         individualAckOfTransaction.get(txnID);
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Transaction pending ack store commit txnId : "
-                                            + "[{}] success! subName: [{}]", topicName, txnID, subName);
-                                }
-                                individualAckCommitCommon(txnID, pendingAckMessageForCurrentTxn, properties);
+                                    log.debug()
+                                            .attr("txnId", txnID)
+                                            .log("Transaction pending ack store commit individual success");
+                                                                individualAckCommitCommon(
+                                                                        txnID,
+                                                                        pendingAckMessageForCurrentTxn,
+                                                                        properties);
                                 commitFuture.complete(null);
                                 handleLowWaterMark(txnID, lowWaterMark);
                             } else {
@@ -501,8 +507,10 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                             }
                         }
                     }).exceptionally(e -> {
-                        log.error("[{}] Transaction pending ack store commit txnId : [{}] fail!",
-                                topicName, txnID, e);
+                        log.error()
+                                .attr("txnId", txnID)
+                                .exception(e)
+                                .log("Transaction pending ack store commit fail!");
                         commitFuture.completeExceptionally(e.getCause());
                         return null;
                     })).exceptionally(e -> {
@@ -554,11 +562,10 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         if (this.cumulativeAckOfTransaction != null) {
             pendingAckStoreFuture.thenAccept(pendingAckStore ->
                     pendingAckStore.appendAbortMark(txnId, AckType.Cumulative).thenAccept(v -> {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Transaction pending ack store abort txnId : [{}] success! subName: [{}]",
-                                    topicName, txnId, subName);
-                        }
-                        if (cumulativeAckOfTransaction.getKey().equals(txnId)) {
+                            log.debug()
+                                    .attr("txnId", txnId)
+                                    .log("Transaction pending ack store abort cumulative success");
+                                                if (cumulativeAckOfTransaction.getKey().equals(txnId)) {
                             cumulativeAckOfTransaction = null;
                         }
                         abortFuture.complete(null);
@@ -566,8 +573,10 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                         // in cumulative ack with transaction, don't depend on server redeliver message,
                         // it will cause the messages to be out of order
                     }).exceptionally(e -> {
-                        log.error("[{}] Transaction pending ack store abort txnId : [{}] fail!",
-                                topicName, txnId, e);
+                        log.error()
+                                .attr("txnId", txnId)
+                                .exception(e)
+                                .log("Transaction pending ack store abort fail!");
                         abortFuture.completeExceptionally(e);
                         return null;
                     })
@@ -582,11 +591,11 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                             HashMap<Position, Position> pendingAckMessageForCurrentTxn =
                                     individualAckOfTransaction.get(txnId);
                             if (pendingAckMessageForCurrentTxn != null) {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Transaction pending ack store abort txnId : [{}] success! "
-                                            + "subName: [{}]", topicName, txnId, subName);
-                                }
-                                individualAckAbortCommon(txnId, pendingAckMessageForCurrentTxn);
+                                    log.debug()
+                                            .attr("txnId", txnId)
+                                            .log("Transaction pending ack store abort individual success");
+                                                                individualAckAbortCommon(txnId,
+                                                                        pendingAckMessageForCurrentTxn);
                                 persistentSubscription.redeliverUnacknowledgedMessages(consumer,
                                         new ArrayList<>(pendingAckMessageForCurrentTxn.values()));
                                 abortFuture.complete(null);
@@ -596,13 +605,15 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                             }
                         }
                     }).exceptionally(e -> {
-                        log.error("[{}] Transaction pending ack store abort txnId : [{}] fail!",
-                                topicName, txnId, e);
+                        log.error()
+                                .attr("txnId", txnId)
+                                .exception(e)
+                                .log("Transaction pending ack store abort fail!");
                         abortFuture.completeExceptionally(e);
                         return null;
                     })
             ).exceptionally(e -> {
-                log.error("[{}] abortTxn", txnId, e);
+                log.error().attr("txnId", txnId).exception(e).log("abortTxn");
                 abortFuture.completeExceptionally(e);
                 return null;
             });
@@ -657,12 +668,16 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
                 Long lowWaterMarkOfFirstTxnId = lowWaterMarks.get(tCId);
                 if (lowWaterMarkOfFirstTxnId != null && firstTxn.getLeastSigBits() <= lowWaterMarkOfFirstTxnId) {
                     abortTxn(firstTxn, null, lowWaterMarkOfFirstTxnId).thenRun(() -> {
-                        log.warn("[{}] Transaction pending ack handle low water mark success! txnId : [{}], "
-                                + "lowWaterMark : [{}]", topicName, firstTxn, lowWaterMarkOfFirstTxnId);
+                        log.warn()
+                                .attr("txnId", firstTxn)
+                                .attr("lowWatermark", lowWaterMarkOfFirstTxnId)
+                                .log("Transaction pending ack handle low water mark success");
                         handleLowWaterMark.release();
                     }).exceptionally(ex -> {
-                        log.warn("[{}] Transaction pending ack handle low water mark fail! txnId : [{}], "
-                                + "lowWaterMark : [{}]", topicName, firstTxn, lowWaterMarkOfFirstTxnId);
+                        log.warn()
+                                .attr("txnId", firstTxn)
+                                .attr("lowWatermark", lowWaterMarkOfFirstTxnId)
+                                .log("Transaction pending ack handle low water mark failed");
                         handleLowWaterMark.release();
                         return null;
                     });
@@ -783,11 +798,11 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
 
     private void handleIndividualAck(TxnID txnID, List<MutablePair<Position, Integer>> positions) {
         for (int i = 0; i < positions.size(); i++) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] TxnID:[{}] Individual acks on {}", topicName,
-                        subName, txnID.toString(), positions);
-            }
-            if (individualAckOfTransaction == null) {
+                log.debug()
+                        .attr("txnId", txnID.toString())
+                        .attr("positions", positions)
+                        .log("Individual acks");
+                        if (individualAckOfTransaction == null) {
                 individualAckOfTransaction = new LinkedMap<>();
             }
 
@@ -961,12 +976,17 @@ public class PendingAckHandleImpl extends PendingAckHandleState implements Pendi
         if (isRetryableException(t)) {
             this.state = State.None;
             long retryTime = backoff.next().toMillis();
-            log.warn("[{}][{}] Failed to init transaction pending ack. It will be retried in {} Ms",
-                    persistentSubscription.getTopic().getName(), subName, retryTime, t);
+            log.warn()
+                    .attr("name", persistentSubscription.getTopic().getName())
+                    .attr("retryTimeMs", retryTime)
+                    .exception(t)
+                    .log("Failed to init transaction pending ack. It will be retried");
             transactionOpTimer.newTimeout((timeout) -> init(), retryTime, TimeUnit.MILLISECONDS);
             return;
         }
-        log.error("[{}] [{}] PendingAckHandleImpl init fail!", topicName, subName, t);
+        log.error()
+                .exception(t)
+                .log("PendingAckHandleImpl init fail!");
         handleCacheRequest();
         changeToErrorState();
         // ToDo: Add a new serverError `TransactionComponentLoadFailedException`

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/recover/TransactionRecoverTrackerImpl.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.api.proto.TxnAction;
@@ -31,11 +31,10 @@ import org.apache.pulsar.transaction.coordinator.TransactionTimeoutTracker;
 import org.apache.pulsar.transaction.coordinator.exceptions.CoordinatorException.InvalidTxnStatusException;
 import org.apache.pulsar.transaction.coordinator.proto.TxnStatus;
 
-
 /**
  * The transaction recover tracker implementation {@link TransactionRecoverTracker}.
  */
-@Slf4j
+@CustomLog
 public class TransactionRecoverTrackerImpl implements TransactionRecoverTracker {
 
     private final long tcId;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/timeout/TransactionTimeoutTrackerImpl.java
@@ -23,7 +23,7 @@ import io.netty.util.Timer;
 import io.netty.util.TimerTask;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.client.api.transaction.TxnID;
 import org.apache.pulsar.common.util.collections.TripleLongPriorityQueue;
@@ -32,7 +32,7 @@ import org.apache.pulsar.transaction.coordinator.TransactionTimeoutTracker;
 /**
  * An timer-task implementation of {@link TransactionTimeoutTracker}.
  */
-@Slf4j
+@CustomLog
 public class TransactionTimeoutTrackerImpl implements TransactionTimeoutTracker, TimerTask {
 
     private final Timer timer;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ExceptionHandler.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ExceptionHandler.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.common.intercept.InterceptException;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -30,7 +30,7 @@ import org.apache.pulsar.common.util.ObjectMapperFactory;
 /**
  *  Exception handler for handle exception.
  */
-@Slf4j
+@CustomLog
 public class ExceptionHandler {
 
     public void handle(ServletResponse response, Exception ex) throws IOException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
@@ -29,11 +29,11 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.common.intercept.InterceptException;
 
-@Slf4j
+@CustomLog
 public class PreInterceptFilter implements Filter {
 
     private final BrokerInterceptor interceptor;
@@ -53,12 +53,11 @@ public class PreInterceptFilter implements Filter {
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
                          FilterChain filterChain) throws IOException, ServletException {
-        if (log.isDebugEnabled()) {
-            log.debug("PreInterceptFilter: path {}, type {}",
-                    servletRequest.getServletContext().getContextPath(),
-                    servletRequest.getContentType());
-        }
-        String contentType = servletRequest.getContentType();
+            log.debug()
+                    .attr("path", servletRequest.getServletContext().getContextPath())
+                    .attr("type", servletRequest.getContentType())
+                    .log("PreInterceptFilter: path , type");
+                String contentType = servletRequest.getContentType();
         if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains(
                 MediaType.MULTIPART_FORM_DATA.toLowerCase(Locale.ROOT))
                 || contentType.toLowerCase(Locale.ROOT).contains(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PreInterceptFilter.java
@@ -53,11 +53,11 @@ public class PreInterceptFilter implements Filter {
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
                          FilterChain filterChain) throws IOException, ServletException {
-            log.debug()
-                    .attr("path", servletRequest.getServletContext().getContextPath())
-                    .attr("type", servletRequest.getContentType())
-                    .log("PreInterceptFilter: path , type");
-                String contentType = servletRequest.getContentType();
+        log.debug()
+                .attr("path", () -> servletRequest.getServletContext().getContextPath())
+                .attr("type", servletRequest::getContentType)
+                .log("PreInterceptFilter");
+        String contentType = servletRequest.getContentType();
         if (contentType != null && (contentType.toLowerCase(Locale.ROOT).contains(
                 MediaType.MULTIPART_FORM_DATA.toLowerCase(Locale.ROOT))
                 || contentType.toLowerCase(Locale.ROOT).contains(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -96,15 +96,17 @@ import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for Web resources in Pulsar. It provides basic authorization functions.
  */
 public abstract class PulsarWebResource {
 
-    private static final Logger log = LoggerFactory.getLogger(PulsarWebResource.class);
+    private static final io.github.merlimat.slog.Logger LOG =
+            io.github.merlimat.slog.Logger.get(PulsarWebResource.class);
+    protected final io.github.merlimat.slog.Logger log = LOG.with()
+            .attr("clientAppId", () -> clientAppId())
+            .build();
 
     private static final LoadingCache<String, PulsarServiceNameResolver> SERVICE_NAME_RESOLVER_CACHE =
             Caffeine.newBuilder().recordStats().expireAfterAccess(Duration.ofMinutes(5)).build(
@@ -205,11 +207,12 @@ public abstract class PulsarWebResource {
             return CompletableFuture.completedFuture(null);
         }
         String appId = clientAppId();
-        if (log.isDebugEnabled()) {
-            log.debug("[{}] Check super user access: Authenticated: {} -- Role: {}", uri.getRequestUri(),
-                    isClientAuthenticated(appId), appId);
-        }
-        String originalPrincipal = originalPrincipal();
+            log.debug()
+                    .attr("requestUri", uri.getRequestUri())
+                    .attr("authenticated", isClientAuthenticated(appId))
+                    .attr("role", appId)
+                    .log("Check super user access");
+                String originalPrincipal = originalPrincipal();
         try {
             validateOriginalPrincipal(appId, originalPrincipal);
         } catch (RestException e) {
@@ -234,11 +237,11 @@ public abstract class PulsarWebResource {
                                     String.format("Original principal not authorized for super-user operation "
                                                     + "(original:%s)", originalPrincipal));
                         }
-                        if (log.isDebugEnabled()) {
-                            log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                                    originalPrincipal, appId);
-                        }
-                    });
+                            log.debug()
+                                    .attr("authorized", originalPrincipal)
+                                    .attr("proxyAppId", appId)
+                                    .log("Successfully authorized as super-user");
+                                            });
         } else {
             return pulsar.getBrokerService()
                     .getAuthorizationService()
@@ -277,7 +280,7 @@ public abstract class PulsarWebResource {
         } catch (RestException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Failed to get tenant admin data for tenant {}", tenant);
+            log.error().attr("tenant", tenant).log("Failed to get tenant admin data for tenant");
             throw new RestException(e);
         }
     }
@@ -313,11 +316,12 @@ public abstract class PulsarWebResource {
             PulsarService pulsar, String clientAppId,
             String originalPrincipal, String tenant,
             AuthenticationDataSource authenticationData) {
-        if (log.isDebugEnabled()) {
-            log.debug("check admin access on tenant: {} - Authenticated: {} -- role: {}", tenant,
-                    (isClientAuthenticated(clientAppId)), clientAppId);
-        }
-        return pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenant)
+            log.debug()
+                    .attr("tenant", tenant)
+                    .attr("authenticated", (isClientAuthenticated(clientAppId)))
+                    .attr("role", clientAppId)
+                    .log("check admin access on tenant");
+                return pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenant)
                 .thenCompose(tenantInfoOptional -> {
                     if (tenantInfoOptional.isEmpty()) {
                         throw new RestException(Status.NOT_FOUND, "Tenant does not exist");
@@ -335,7 +339,6 @@ public abstract class PulsarWebResource {
                             return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
                                             authenticationData)
                                 .thenCompose(isTenantAdmin -> {
-                                    String debugMsg = "Successfully authorized {} (proxied by {}) on tenant {}";
                                     if (!isTenantAdmin) {
                                             return authorizationService.isSuperUser(clientAppId, authenticationData)
                                                 .thenCombine(authorizationService.isSuperUser(originalPrincipal,
@@ -347,18 +350,21 @@ public abstract class PulsarWebResource {
                                                                                      + "resource (proxy:%s,original:%s)"
                                                                              , clientAppId, originalPrincipal));
                                                          } else {
-                                                             if (log.isDebugEnabled()) {
-                                                                 log.debug(debugMsg, originalPrincipal, clientAppId,
-                                                                         tenant);
-                                                             }
-                                                             return null;
+                                                                 log.debug()
+                                                                         .attr("principal", originalPrincipal)
+                                                                         .attr("proxy", clientAppId)
+                                                                         .attr("tenant", tenant)
+                                                                         .log("Authorized on tenant");
+                                                                 return null;
                                                          }
                                                      });
                                     } else {
-                                        if (log.isDebugEnabled()) {
-                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
-                                        }
-                                        return CompletableFuture.completedFuture(null);
+                                            log.debug().attr("principal", originalPrincipal)
+                                                    .attr("proxy", clientAppId)
+                                                    .attr("tenant", tenant)
+                                                    .log("Successfully authorized on tenant");
+                                                                                return CompletableFuture
+                                                                                        .completedFuture(null);
                                     }
                                 });
                         } else {
@@ -377,7 +383,10 @@ public abstract class PulsarWebResource {
                                             throw new RestException(Status.UNAUTHORIZED,
                                                     "Don't have permission to administrate resources on this tenant");
                                         } else {
-                                            log.debug("Successfully authorized {} on tenant {}", clientAppId, tenant);
+                                            log.debug()
+                                                    .attr("authorized", clientAppId)
+                                                    .attr("tenant", tenant)
+                                                    .log("Successfully authorized on tenant");
                                         }
                                     });
                         }
@@ -403,8 +412,10 @@ public abstract class PulsarWebResource {
             if (peerClusters != null && !peerClusters.isEmpty()) {
                 Sets.SetView<String> conflictPeerClusters = Sets.intersection(peerClusters, replicationClusters);
                 if (!conflictPeerClusters.isEmpty()) {
-                    log.warn("[{}] {}'s peer cluster can't be part of replication clusters {}", clientAppId(),
-                            clusterName, conflictPeerClusters);
+                    log.warn()
+                            .attr("cluster", clusterName)
+                            .attr("conflictingPeerClusters", conflictPeerClusters)
+                            .log("Peer clusters can't be part of replication clusters");
                     throw new RestException(Status.CONFLICT,
                             String.format("%s's peer-clusters %s can't be part of replication-clusters %s", clusterName,
                                     conflictPeerClusters, replicationClusters));
@@ -413,7 +424,10 @@ public abstract class PulsarWebResource {
         } catch (RestException re) {
             throw re;
         } catch (Exception e) {
-            log.warn("[{}] Failed to get cluster-data for {}", clientAppId(), clusterName, e);
+            log.warn()
+                    .attr("cluster", clusterName)
+                    .exception(e)
+                    .log("Failed to get cluster-data");
         }
     }
 
@@ -428,8 +442,10 @@ public abstract class PulsarWebResource {
                         Sets.SetView<String> conflictPeerClusters =
                                 Sets.intersection(peerClusters, replicationClusters);
                         if (!conflictPeerClusters.isEmpty()) {
-                            log.warn("[{}] {}'s peer cluster can't be part of replication clusters {}", clientAppId(),
-                                    clusterName, conflictPeerClusters);
+                            log.warn()
+                                    .attr("cluster", clusterName)
+                                    .attr("conflictingPeerClusters", conflictPeerClusters)
+                                    .log("Peer clusters can't be part of replication clusters");
                             throw new RestException(Status.CONFLICT,
                                     String.format("%s's peer-clusters %s can't be part of replication-clusters %s",
                                             clusterName,
@@ -445,10 +461,10 @@ public abstract class PulsarWebResource {
             tenantInfo = pulsar().getPulsarResources().getTenantResources().getTenant(tenant)
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Tenant does not exist"));
         } catch (RestException e) {
-            log.warn("Failed to get tenant admin data for tenant {}", tenant);
+            log.warn().attr("tenant", tenant).log("Failed to get tenant admin data for tenant");
             throw e;
         } catch (Exception e) {
-            log.error("Failed to get tenant admin data for tenant {}", tenant, e);
+            log.error().attr("tenant", tenant).exception(e).log("Failed to get tenant admin data for tenant");
             throw new RestException(e);
         }
 
@@ -459,7 +475,7 @@ public abstract class PulsarWebResource {
             log.info(msg);
             throw new RestException(Status.FORBIDDEN, msg);
         }
-        log.info("Successfully validated clusters on tenant [{}]", tenant);
+        log.info().attr("tenant", tenant).log("Successfully validated clusters on tenant");
     }
 
     protected CompletableFuture<Void> validateClusterForTenantAsync(String tenant, String cluster) {
@@ -484,11 +500,13 @@ public abstract class PulsarWebResource {
                         try {
                             URI redirect = getRedirectionUrl(differentClusterData);
                             // redirect to the cluster requested
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Redirecting the rest call to {}: cluster={}",
-                                        clientAppId(), redirect, cluster);
-                            }
-                            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                                log.debug()
+                                        .attr("redirect", redirect)
+                                        .attr("cluster", cluster)
+                                        .log("Redirecting the rest call");
+                                throw new WebApplicationException(
+                                        Response.temporaryRedirect(redirect)
+                                                .build());
                         } catch (MalformedURLException ex) {
                             throw new RestException(ex);
                         }
@@ -539,14 +557,18 @@ public abstract class PulsarWebResource {
         pulsar.getPulsarResources().getClusterResources().getClusterAsync(cluster)
                 .whenComplete((clusterDataResult, ex) -> {
                     if (ex != null) {
-                        log.warn("[{}] Load cluster data failed: requested={}", clientAppId, cluster);
+                        LOG.warn()
+                                .attr("requested", cluster)
+                                .log("Load cluster data failed: requested");
                         clusterDataFuture.completeExceptionally(FutureUtil.unwrapCompletionException(ex));
                         return;
                     }
                     if (clusterDataResult.isPresent()) {
                         clusterDataFuture.complete(clusterDataResult.get());
                     } else {
-                        log.warn("[{}] Cluster does not exist: requested={}", clientAppId, cluster);
+                        LOG.warn()
+                                .attr("requested", cluster)
+                                .log("Cluster does not exist: requested");
                         clusterDataFuture.completeExceptionally(new RestException(Status.NOT_FOUND,
                                 "Cluster does not exist: cluster=" + cluster));
                     }
@@ -579,12 +601,18 @@ public abstract class PulsarWebResource {
             nsBundles.validateBundle(nsBundle);
             return nsBundle;
         } catch (IllegalArgumentException e) {
-            log.error("[{}] Invalid bundle range {}/{}, {}", clientAppId(), fqnn.toString(),
-                    bundleRange, e.getMessage());
+            log.error()
+                    .attr("namespace", fqnn.toString())
+                    .attr("bundleRange", bundleRange)
+                    .exceptionMessage(e)
+                    .log("Invalid bundle range");
             throw new RestException(Response.Status.PRECONDITION_FAILED, e.getMessage());
         } catch (Exception e) {
-            log.error("[{}] Failed to validate namespace bundle {}/{}", clientAppId(),
-                    fqnn.toString(), bundleRange, e);
+            log.error()
+                    .attr("bundle", fqnn.toString())
+                    .attr("bundleRange", bundleRange)
+                    .exception(e)
+                    .log("Failed to validate namespace bundle");
             throw new RestException(e);
         }
     }
@@ -619,8 +647,11 @@ public abstract class PulsarWebResource {
         } catch (WebApplicationException wae) {
             throw wae;
         } catch (Exception e) {
-            log.error("[{}] Failed to validate namespace bundle {}/{}", clientAppId(),
-                    fqnn.toString(), bundleRange, e);
+            log.error()
+                    .attr("bundle", fqnn.toString())
+                    .attr("bundleRange", bundleRange)
+                    .exception(e)
+                    .log("Failed to validate namespace bundle");
             throw new RestException(e);
         }
     }
@@ -672,23 +703,23 @@ public abstract class PulsarWebResource {
                 URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(webUrl.get().getHost())
                         .port(webUrl.get().getPort()).replaceQueryParam("authoritative", newAuthoritative).build();
 
-                log.debug("{} is not a service unit owned", bundle);
+                log.debug().attr("bundle", bundle).log("is not a service unit owned");
 
                 // Redirect
-                log.debug("Redirecting the rest call to {}", redirect);
+                log.debug().attr("redirect", redirect).log("Redirecting the rest call");
                 throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
             }
         } catch (TimeoutException te) {
             String msg = String.format("Finding owner for ServiceUnit %s timed out", bundle);
-            log.error(msg, te);
+            log.error().exception(te).log(msg);
             throw new RestException(Status.INTERNAL_SERVER_ERROR, msg);
         } catch (IllegalArgumentException iae) {
             // namespace format is not valid
-            log.debug("Failed to find owner for ServiceUnit {}", bundle, iae);
+            log.debug().attr("serviceUnit", bundle).exception(iae).log("Failed to find owner for ServiceUnit");
             throw new RestException(Status.PRECONDITION_FAILED,
                     "ServiceUnit format is not expected. ServiceUnit " + bundle);
         } catch (IllegalStateException ise) {
-            log.debug("Failed to find owner for ServiceUnit {}", bundle, ise);
+            log.debug().attr("serviceUnit", bundle).exception(ise).log("Failed to find owner for ServiceUnit");
             throw new RestException(Status.PRECONDITION_FAILED, "ServiceUnit bundle is actived. ServiceUnit " + bundle);
         } catch (NullPointerException e) {
             log.warn("Unable to get web service url");
@@ -724,9 +755,9 @@ public abstract class PulsarWebResource {
                                         uriBuilder.replaceQueryParam("destinationBroker", (Object[]) null);
                                     }
                                     URI redirect = uriBuilder.build();
-                                    log.debug("{} is not a service unit owned", bundle);
+                                    log.debug().attr("bundle", bundle).log("is not a service unit owned");
                                     // Redirect
-                                    log.debug("Redirecting the rest call to {}", redirect);
+                                    log.debug().attr("redirect", redirect).log("Redirecting the rest call");
                                     throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
                                 }
                             });
@@ -777,18 +808,19 @@ public abstract class PulsarWebResource {
                                 .replaceQueryParam("authoritative", newAuthoritative)
                                 .build();
                         // Redirect
-                        if (log.isDebugEnabled()) {
-                            log.debug("Redirecting the rest call to {}", redirect);
-                        }
-                        throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                        log.debug()
+                                .attr("redirect", redirect)
+                                .log("Redirecting the rest call");
+                        throw new WebApplicationException(
+                                Response.temporaryRedirect(redirect).build());
                     }
                 }).exceptionally(ex -> {
                     if (ex.getCause() instanceof IllegalArgumentException
                             || ex.getCause() instanceof IllegalStateException) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Failed to find owner for topic: {}", topicName, ex);
-                        }
-                        throw new RestException(Status.PRECONDITION_FAILED, "Can't find owner for topic " + topicName);
+                            log.debug().attr("topic", topicName).exception(ex).log("Failed to find owner for topic");
+                                                throw new RestException(Status.PRECONDITION_FAILED,
+                                                        "Can't find owner for topic "
+                                                        + topicName);
                     } else if (ex.getCause() instanceof WebApplicationException) {
                         throw (WebApplicationException) ex.getCause();
                     } else {
@@ -818,15 +850,16 @@ public abstract class PulsarWebResource {
             if (peerClusterData != null) {
                 URI redirect = getRedirectionUrl(peerClusterData);
                 // redirect to the cluster requested
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(),
-                            redirect, peerClusterData);
+                    log.debug()
+                            .attr("redirect", redirect)
+                            .attr("cluster", peerClusterData)
+                            .log("Redirecting the rest call");
 
-                }
-                throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                                throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
             }
         } catch (InterruptedException e) {
-            log.warn("Time-out {} sec while validating policy on {} ", timeout, namespace);
+            log.warn().attr("timeoutSec", timeout).attr("namespace", namespace)
+                    .log("Timeout while validating policy");
             throw new RestException(Status.SERVICE_UNAVAILABLE, String.format(
                     "Failed to validate global cluster configuration : ns=%s  emsg=%s", namespace, e.getMessage()));
         } catch (WebApplicationException e) {
@@ -850,12 +883,13 @@ public abstract class PulsarWebResource {
                         try {
                             URI redirect = getRedirectionUrl(peerClusterData);
                             // redirect to the cluster requested
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Redirecting the rest call to {}: cluster={}", clientAppId(),
-                                        redirect, peerClusterData);
-
-                            }
-                            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+                                log.debug()
+                                        .attr("redirect", redirect)
+                                        .attr("cluster", peerClusterData)
+                                        .log("Redirecting the rest call");
+                            throw new WebApplicationException(
+                                    Response.temporaryRedirect(redirect)
+                                            .build());
                         } catch (MalformedURLException mue) {
                             throw new RestException(Status.SERVICE_UNAVAILABLE, String.format(
                                     "Failed to validate global cluster configuration : ns=%s  emsg=%s", namespace,
@@ -885,14 +919,14 @@ public abstract class PulsarWebResource {
                 Policies policies = policiesResult.get();
                 if (!allowDeletedNamespace && policies.deleted) {
                     String msg = String.format("Namespace %s is deleted", namespace.toString());
-                    log.warn(msg);
+                    LOG.warn(msg);
                     validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND,
                             "Namespace is deleted"));
                 } else if (policies.replication_clusters.isEmpty() && policies.allowed_clusters.isEmpty()) {
                     String msg = String.format(
                             "Namespace does not have any clusters configured : local_cluster=%s ns=%s",
                             localCluster, namespace.toString());
-                    log.warn(msg);
+                    LOG.warn(msg);
                     validationFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED, msg));
                 } else if (!pulsarService.getBrokerService().isCurrentClusterAllowed(namespace, policies)) {
                     getOwnerFromPeerClusterListAsync(pulsarService, policies.replication_clusters,
@@ -906,7 +940,7 @@ public abstract class PulsarWebResource {
                                             "Namespace missing local cluster name in clusters list: local_cluster=%s"
                                                     + " ns=%s clusters=%s",
                                             localCluster, namespace.toString(), policies.replication_clusters);
-                                    log.warn(msg);
+                                    LOG.warn(msg);
                                     validationFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED,
                                             msg));
                                 }
@@ -921,14 +955,14 @@ public abstract class PulsarWebResource {
                 }
             } else {
                 String msg = String.format("Namespace %s not found", namespace.toString());
-                log.warn(msg);
+                LOG.warn(msg);
                 validationFuture.completeExceptionally(new RestException(Status.NOT_FOUND, "Namespace not found"));
             }
         }).exceptionally(ex -> {
             Throwable cause = FutureUtil.unwrapCompletionException(ex);
             String msg = String.format("Failed to validate global cluster configuration : cluster=%s ns=%s  emsg=%s",
                     localCluster, namespace, cause.getMessage());
-            log.error(msg);
+            LOG.error(msg);
             validationFuture.completeExceptionally(new RestException(cause));
             return null;
         });
@@ -962,7 +996,10 @@ public abstract class PulsarWebResource {
                     }
                     return CompletableFuture.completedFuture(null);
                 }).exceptionally(ex -> {
-                    log.error("Failed to get peer-cluster {}-{}", currentCluster, ex.getMessage());
+                    LOG.error()
+                            .attr("cluster", currentCluster)
+                            .exceptionMessage(ex)
+                            .log("Failed to get peer-cluster -");
                     throw FutureUtil.wrapToCompletionException(ex);
                 });
     }
@@ -979,7 +1016,10 @@ public abstract class PulsarWebResource {
                 TopicOperation.LOOKUP, originalPrinciple, role, originalAuthenticationData, authenticationData)
                 .thenAccept(allow -> {
                     if (!allow) {
-                        log.warn("[{}] Role {} is not allowed to lookup topic", topicName, role);
+                        LOG.warn()
+                                .attr("topic", topicName)
+                                .attr("role", role)
+                                .log("Role is not allowed to lookup topic");
                         throw new RestException(Status.UNAUTHORIZED,
                                 "Don't have permission to connect to this namespace");
                     }
@@ -1033,7 +1073,6 @@ public abstract class PulsarWebResource {
     public void validateNamespaceOperation(NamespaceName namespaceName, NamespaceOperation operation) {
         sync(()-> validateNamespaceOperationAsync(namespaceName, operation));
     }
-
 
     public CompletableFuture<Void> validateNamespaceOperationAsync(NamespaceName namespaceName,
                                                               NamespaceOperation operation) {
@@ -1175,7 +1214,7 @@ public abstract class PulsarWebResource {
                 throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
             }
         } catch (Exception e) {
-            log.warn("Unable to fetch read-only policy config ", e);
+            log.warn().exception(e).log("Unable to fetch read-only policy config");
             throw new RestException(e);
         }
     }
@@ -1183,10 +1222,9 @@ public abstract class PulsarWebResource {
     public CompletableFuture<Void> validatePoliciesReadOnlyAccessAsync() {
         return namespaceResources().getPoliciesReadOnlyAsync().thenAccept(readOnly -> {
             if (readOnly) {
-                if (log.isDebugEnabled()) {
                     log.debug("Policies are read-only. Broker cannot do read-write operations");
-                }
-                throw new RestException(Status.FORBIDDEN, "Broker is forbidden to do read-write operations");
+                                throw new RestException(Status.FORBIDDEN,
+                                        "Broker is forbidden to do read-write operations");
             }
         });
     }
@@ -1204,7 +1242,6 @@ public abstract class PulsarWebResource {
             throw new RestException(e);
         }
     }
-
 
     /**
      * Redirect the call to the specified broker.
@@ -1241,8 +1278,10 @@ public abstract class PulsarWebResource {
                                 .scheme(targetBrokerUri.getScheme())
                                 .host(targetBrokerUri.getHost())
                                 .port(targetBrokerUri.getPort()).build();
-                        log.debug("[{}] Redirecting the rest call to {}: broker={}", clientAppId(), redirect,
-                                cleanedBrokerId);
+                        log.debug()
+                                .attr("redirect", redirect)
+                                .attr("broker", cleanedBrokerId)
+                                .log("Redirecting the rest call");
                         throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
                     });
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/ResponseHandlerFilter.java
@@ -33,16 +33,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
+import lombok.CustomLog;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Servlet filter that hooks up to handle outgoing response.
  */
+@CustomLog
 public class ResponseHandlerFilter implements Filter {
-    private static final Logger LOG = LoggerFactory.getLogger(ResponseHandlerFilter.class);
     private static final String BROKER_ADDRESS_HEADER_NAME = "broker-address";
 
     private final String brokerAddress;
@@ -60,8 +59,10 @@ public class ResponseHandlerFilter implements Filter {
         if (!response.isCommitted()) {
             ((HttpServletResponse) response).addHeader(BROKER_ADDRESS_HEADER_NAME, brokerAddress);
         } else {
-            LOG.warn("Cannot add header {} to request {} since it's already committed.", BROKER_ADDRESS_HEADER_NAME,
-                    request);
+            log.warn()
+                    .attr("header", BROKER_ADDRESS_HEADER_NAME)
+                    .attr("request", request)
+                    .log("Cannot add header to request since it's already committed.");
         }
         chain.doFilter(request, response);
         if (((HttpServletResponse) response).getStatus() == Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
@@ -82,13 +83,16 @@ public class ResponseHandlerFilter implements Filter {
 
                 @Override
                 public void onTimeout(AsyncEvent asyncEvent) {
-                    LOG.warn("Http request {} async context timeout.", request);
+                    log.warn().attr("request", request).log("Http request async context timeout.");
                     handleInterceptor(request, response);
                 }
 
                 @Override
                 public void onError(AsyncEvent asyncEvent) {
-                    LOG.warn("Http request {} async context error.", request, asyncEvent.getThrowable());
+                    log.warn()
+                            .attr("request", request)
+                            .exceptionMessage(asyncEvent.getThrowable())
+                            .log("Http request async context error.");
                     handleInterceptor(request, response);
                 }
 
@@ -112,7 +116,7 @@ public class ResponseHandlerFilter implements Filter {
             try {
                 interceptor.onWebserviceResponse(request, response);
             } catch (Exception e) {
-                LOG.error("Failed to handle interceptor on web service response.", e);
+                log.error().exception(e).log("Failed to handle interceptor on web service response.");
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -36,6 +36,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -75,12 +76,11 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Web Service embedded into Pulsar.
  */
+@CustomLog
 public class WebService implements AutoCloseable {
 
     private static final String MATCH_ALL = "/*";
@@ -421,15 +421,20 @@ public class WebService implements AutoCloseable {
             server.start();
 
             if (httpConnector != null) {
-                log.info("HTTP Service started at http://{}:{}", httpConnector.getHost(), httpConnector.getLocalPort());
+                log.info()
+                        .attr("host", httpConnector.getHost())
+                        .attr("localPort", httpConnector.getLocalPort())
+                        .log("HTTP Service started");
                 pulsar.getConfiguration().setWebServicePort(Optional.of(httpConnector.getLocalPort()));
             } else {
                 log.info("HTTP Service disabled");
             }
 
             if (httpsConnector != null) {
-                log.info("HTTPS Service started at https://{}:{}", httpsConnector.getHost(),
-                        httpsConnector.getLocalPort());
+                log.info()
+                        .attr("host", httpsConnector.getHost())
+                        .attr("localPort", httpsConnector.getLocalPort())
+                        .log("HTTPS Service started");
                 pulsar.getConfiguration().setWebServicePortTls(Optional.of(httpsConnector.getLocalPort()));
             } else {
                 log.info("HTTPS Service disabled");
@@ -453,7 +458,7 @@ public class WebService implements AutoCloseable {
                     try {
                         doClose();
                     } catch (Exception e) {
-                        log.error("Error while closing web service", e);
+                        log.error().exception(e).log("Error while closing web service");
                     }
                 });
                 webServiceTerminator.setName("pulsar-web-service-terminator");
@@ -529,9 +534,7 @@ public class WebService implements AutoCloseable {
         try {
             this.sslFactory.update();
         } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
+            log.error().exception(e).log("Failed to refresh SSL context");
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(WebService.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/CompactionReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/CompactionReaderImpl.java
@@ -22,7 +22,7 @@ import static org.apache.pulsar.compaction.Compactor.COMPACTION_SUBSCRIPTION;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
@@ -40,7 +40,7 @@ import org.apache.pulsar.common.api.proto.CommandAck;
  *  The compaction consumer subscription is durable and consumes compacted messages from the earliest position.
  *  It does not acknowledge the message after each read. (needs to call acknowledgeCumulativeAsync to ack messages.)
  */
-@Slf4j
+@CustomLog
 public class CompactionReaderImpl<T> extends ReaderImpl<T> {
 
     ConsumerBase<T> consumer;
@@ -68,7 +68,6 @@ public class CompactionReaderImpl<T> extends ReaderImpl<T> {
         conf.setCryptoKeyReader(cryptoKeyReader);
         return new CompactionReaderImpl<>(client, conf, client.externalExecutorProvider(), consumerFuture, schema);
     }
-
 
     @Override
     public Message<T> readNext() throws PulsarClientException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
@@ -20,16 +20,14 @@ package org.apache.pulsar.client.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MessageIdData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class RawMessageImpl implements RawMessage {
-    private static final Logger log = LoggerFactory.getLogger(RawMessageImpl.class);
-
     private final MessageIdData id = new MessageIdData();
     private ByteBuf headersAndPayload;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -26,6 +26,7 @@ import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -42,9 +43,8 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class RawReaderImpl implements RawReader {
 
     static final int DEFAULT_RECEIVER_QUEUE_SIZE = 1000;
@@ -74,7 +74,6 @@ public class RawReaderImpl implements RawReader {
         consumer = new RawConsumerImpl(client, consumerConfiguration, consumerFuture, createTopicIfDoesNotExist,
                 retryOnRecoverableErrors);
     }
-
 
     @Override
     public String getTopic() {
@@ -296,6 +295,4 @@ public class RawReaderImpl implements RawReader {
             this.cnx = cnx;
         }
     }
-
-    private static final Logger log = LoggerFactory.getLogger(RawReaderImpl.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -58,12 +59,9 @@ import org.apache.pulsar.common.stats.CacheMetricsCollector;
 import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class NamespaceBundleFactory {
-    private static final Logger LOG = LoggerFactory.getLogger(NamespaceBundleFactory.class);
-
     private final HashFunction hashFunc;
 
     private final AsyncLoadingCache<NamespaceName, NamespaceBundles> bundlesCache;
@@ -92,11 +90,8 @@ public class NamespaceBundleFactory {
     }
 
     private CompletableFuture<NamespaceBundles> loadBundles(NamespaceName namespace, Executor executor) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Loading cache with bundles for {}", namespace);
-        }
-
-        if (pulsar == null) {
+            log.debug().attr("namespace", namespace).log("Loading cache with bundles");
+                if (pulsar == null) {
             return CompletableFuture.completedFuture(getBundles(namespace, Optional.empty()));
         }
 
@@ -137,7 +132,7 @@ public class NamespaceBundleFactory {
         if (e instanceof Error || System.nanoTime() > retryDeadline) {
             future.completeExceptionally(e);
         } else {
-            LOG.warn("Error loading bundle for {}. Retrying exception", namespace, e);
+            log.warn().attr("namespace", namespace).exception(e).log("Error loading bundle. Retrying");
             long retryDelay = backoff.next().toMillis();
             pulsar.getExecutor().schedule(() ->
                     doLoadBundles(namespace, future, backoff, retryDeadline), retryDelay, TimeUnit.MILLISECONDS);
@@ -154,13 +149,12 @@ public class NamespaceBundleFactory {
             throws IOException {
         NamespaceBundles namespaceBundles = getBundles(namespace,
                 Optional.of(Pair.of(localPolicies, version)));
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("[{}] Get bundles from getLocalZkCacheService: bundles: {}, version: {}",
-                    namespace,
-                    (localPolicies.bundles.getBoundaries() != null) ? localPolicies.bundles : "null",
-                    namespaceBundles.getVersion());
-        }
-        return namespaceBundles;
+            log.debug()
+                    .attr("namespace", namespace)
+                    .attr("bundles", (localPolicies.bundles.getBoundaries() != null) ? localPolicies.bundles : "null")
+                    .attr("version", namespaceBundles.getVersion())
+                    .log("Get bundles from getLocalZkCacheService");
+                return namespaceBundles;
     }
 
     private CompletableFuture<NamespaceBundles> copyToLocalPolicies(NamespaceName namespace) {
@@ -189,12 +183,14 @@ public class NamespaceBundleFactory {
                 final Optional<NamespaceName> namespace = NamespaceName.getIfValid(
                         getNamespaceFromPoliciesPath(n.getPath()));
                 if (namespace.isPresent()) {
-                    LOG.info("Policy updated for namespace {}, refreshing the bundle cache.", namespace);
+                    log.info()
+                            .attr("namespace", namespace)
+                            .log("Policy updated for namespace , refreshing the bundle cache.");
                     // Trigger a background refresh to fetch new bundle data from the policies
                     bundlesCache.synchronous().invalidate(namespace.get());
                 }
             } catch (Exception e) {
-                LOG.error("Failed to update the policy change for path {}", n.getPath(), e);
+                log.error().attr("path", n.getPath()).exception(e).log("Failed to update the policy change for path");
             }
         }
     }
@@ -212,7 +208,7 @@ public class NamespaceBundleFactory {
             return getBundleWithHighestTopicsAsync(nsname).get(PulsarResources.DEFAULT_OPERATION_TIMEOUT_SEC,
                     TimeUnit.SECONDS);
         } catch (Exception e) {
-            LOG.info("failed to derive bundle for {}", nsname, e);
+            log.info().attr("namespace", nsname).exception(e).log("failed to derive bundle");
             throw new IllegalStateException(e instanceof ExecutionException ? e.getCause() : e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -46,8 +47,6 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compaction will go through the topic in two passes. The first pass
@@ -58,11 +57,11 @@ import org.slf4j.LoggerFactory;
  * the latest values in memory, as the payload can be many orders of
  * magnitude larger than a message id.
  */
+@CustomLog
 public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
 
   @VisibleForTesting
   static Runnable injectionAfterSeekInPhaseTwo = () -> {};
-  private static final Logger log = LoggerFactory.getLogger(AbstractTwoPhaseCompactor.class);
   protected static final int MAX_OUTSTANDING = 500;
   protected final Duration phaseOneLoopReadTimeout;
   protected final boolean topicCompactionRetainNullKey;
@@ -82,7 +81,6 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
   protected abstract boolean compactMessage(String topic, Map<String, T> latestForKey,
       RawMessage m, MessageMetadata metadata, MessageId id);
 
-
   protected abstract boolean compactBatchMessage(String topic, Map<String, T> latestForKey,
       RawMessage m,
       MessageMetadata metadata, MessageId id);
@@ -96,7 +94,7 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
             return phaseOne(reader).thenCompose(
                 (r) -> phaseTwo(reader, r.from, r.to, r.lastReadId, toLatestMessageIdForKey(r.latestForKey), bk));
           } else {
-            log.info("Skip compaction of the empty topic {}", reader.getTopic());
+            log.info().attr("topic", reader.getTopic()).log("Skip compaction of the empty topic");
             return CompletableFuture.completedFuture(-1L);
           }
         });
@@ -109,8 +107,10 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
 
     reader.getLastMessageIdAsync()
         .thenAccept(lastMessageId -> {
-          log.info("Commencing phase one of compaction for {}, reading to {}",
-              reader.getTopic(), lastMessageId);
+          log.info()
+                  .attr("topic", reader.getTopic())
+                  .attr("lastMessageId", lastMessageId)
+                  .log("Commencing phase one of compaction");
           // Each entry is processed as a whole, discard the batchIndex part deliberately.
           MessageIdImpl lastImpl = (MessageIdImpl) lastMessageId;
           MessageIdImpl lastEntryMessageId = new MessageIdImpl(lastImpl.getLedgerId(),
@@ -180,9 +180,13 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
     Map<String, byte[]> metadata =
         LedgerMetadataUtils.buildMetadataForCompactedLedger(reader.getTopic(), to.toByteArray());
     return createLedger(bk, metadata).thenCompose((ledger) -> {
-      log.info(
-          "Commencing phase two of compaction for {}, from {} to {}, compacting {} keys to ledger {}",
-          reader.getTopic(), from, to, latestForKey.size(), ledger.getId());
+      log.info()
+              .attr("topic", reader.getTopic())
+              .attr("from", from)
+              .attr("to", to)
+              .attr("compactingCount", latestForKey.size())
+              .attr("ledgerId", ledger.getId())
+              .log("Commencing phase two of compaction");
       return phaseTwoSeekThenLoop(reader, from, to, lastReadId, latestForKey, bk, ledger);
     });
   }
@@ -206,7 +210,7 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
           if (exception != null) {
             deleteLedger(bk, ledger).whenComplete((res2, exception2) -> {
               if (exception2 != null) {
-                log.warn("Cleanup of ledger {} for failed", ledger, exception2);
+                log.warn().attr("ledger", ledger).exceptionMessage(exception2).log("Cleanup of ledger failed");
               }
               // complete with original exception
               promise.completeExceptionally(exception);
@@ -249,8 +253,10 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
                 m, metadata, (key, subid) -> subid.equals(latestForKey.get(key)),
                 topicCompactionRetainNullKey);
           } catch (IOException ioe) {
-            log.info("Error decoding batch for message {}. Whole batch will be included in output",
-                id, ioe);
+            log.info()
+                    .attr("message", id)
+                    .exception(ioe)
+                    .log("Error decoding batch for message . Whole batch will be included in output");
             messageToAdd = Optional.of(m);
           }
         } else {
@@ -338,7 +344,7 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
             }
           }, null, metadata);
     } catch (Throwable t) {
-      log.error("Encountered unexpected error when creating compaction ledger", t);
+      log.error().exception(t).log("Encountered unexpected error when creating compaction ledger");
       return FutureUtil.failedFuture(t);
     }
     return bkf;
@@ -412,16 +418,13 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
     }
   }
 
-
   protected Optional<RawMessage> rebatchMessage(String topic, RawMessage msg,
       MessageMetadata metadata,
       BiPredicate<String, MessageId> filter,
       boolean retainNullKey)
       throws IOException {
-    if (log.isDebugEnabled()) {
-      log.debug("Rebatching message {} for topic {}", msg.getMessageId(), topic);
-    }
-    return RawBatchConverter.rebatchMessage(msg, metadata, filter, retainNullKey);
+      log.debug().attr("message", msg.getMessageId()).attr("topic", topic).log("Rebatching message for topic");
+        return RawBatchConverter.rebatchMessage(msg, metadata, filter, retainNullKey);
   }
 
   protected static class PhaseOneResult<T> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -44,13 +45,12 @@ import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.api.proto.MessageIdData;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Note: If you want to guarantee that strong consistency between `compactionHorizon` and `compactedTopicContext`,
  * you need to call getting them method in "synchronized(CompactedTopicImpl){ ... }" lock block.
  */
+@CustomLog
 public class CompactedTopicImpl implements CompactedTopic {
     static final long NEWER_THAN_COMPACTED = -0xfeed0fbaL;
     static final long COMPACT_LEDGER_EMPTY = -0xfeed0fbbL;
@@ -80,9 +80,11 @@ public class CompactedTopicImpl implements CompactedTopic {
                         // Print an error log here, which is not expected.
                         if (previousCtx != null && previousCtx.getLedger() != null
                                 && previousCtx.getLedger().getId() == compactedLedgerId) {
-                            log.error("[__compaction] Using the same compacted ledger to override the old one, which is"
-                                + " not expected and it may cause a ledger lost error. {} -> {}", compactedLedgerId,
-                                ctx.getLedger().getId());
+                            log.error()
+                                    .attr("compactedLedgerId", compactedLedgerId)
+                                    .attr("newLedgerId", ctx.getLedger().getId())
+                                    .log("[__compaction] Using the same compacted ledger to override the old one,"
+                                            + " which is not expected and it may cause a ledger lost error");
                         }
                     });
                     return previousContext;
@@ -145,7 +147,6 @@ public class CompactedTopicImpl implements CompactedTopic {
                 .buildAsync((entryId, executor) -> readOneMessageId(lh, entryId));
     }
 
-
     private static CompletableFuture<MessageIdData> readOneMessageId(LedgerHandle lh, long entryId) {
         CompletableFuture<MessageIdData> promise = new CompletableFuture<>();
 
@@ -194,8 +195,10 @@ public class CompactedTopicImpl implements CompactedTopic {
         bk.asyncDeleteLedger(id,
                              (rc, ctx) -> {
                                  if (rc != BKException.Code.OK) {
-                                     log.warn("Error deleting compacted topic ledger {}",
-                                              id, BKException.create(rc));
+                                     log.warn()
+                                             .attr("ledgerId", id)
+                                             .attr("error", BKException.create(rc))
+                                             .log("Error deleting compacted topic ledger");
                                  } else {
                                      log.debug("Compacted topic ledger deleted successfully");
                                  }
@@ -332,6 +335,5 @@ public class CompactedTopicImpl implements CompactedTopic {
     public CompletableFuture<CompactedTopicContext> getCompactedTopicContextFuture() {
         return compactedTopicContext;
     }
-    private static final Logger log = LoggerFactory.getLogger(CompactedTopicImpl.class);
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
@@ -21,18 +21,17 @@ package org.apache.pulsar.compaction;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RawReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compactor for Pulsar topics.
  */
+@CustomLog
 public abstract class Compactor {
-    private static final Logger log = LoggerFactory.getLogger(Compactor.class);
     public static final String COMPACTION_SUBSCRIPTION = "__compaction";
     public static final String COMPACTED_TOPIC_LEDGER_PROPERTY = "CompactedTopicLedger";
     static final BookKeeper.DigestType COMPACTED_TOPIC_LEDGER_DIGEST_TYPE = BookKeeper.DigestType.CRC32;
@@ -67,7 +66,10 @@ public abstract class Compactor {
                 (ledgerId, exception) -> {
                     reader.closeAsync().whenComplete((v, exception2) -> {
                         if (exception2 != null) {
-                            log.warn("Error closing reader handle {}, ignoring", reader, exception2);
+                            log.warn()
+                                    .attr("handle", reader)
+                                    .exception(exception2)
+                                    .log("Error closing reader handle, ignoring");
                         }
                         if (exception != null) {
                             // complete with original exception

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactorTool.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import lombok.Cleanup;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
 import org.apache.pulsar.broker.BookKeeperClientFactoryImpl;
@@ -44,14 +45,13 @@ import org.apache.pulsar.docs.tools.CmdGenerateDocs;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ScopeType;
 
 @Command(name = "compact-topic", showDefaultValues = true, scope = ScopeType.INHERIT)
+@CustomLog
 public class CompactorTool {
 
     private static class Arguments {
@@ -147,7 +147,6 @@ public class CompactorTool {
         final ServiceConfiguration brokerConfig =
                 PulsarConfigurationLoader.create(filepath, ServiceConfiguration.class);
 
-
         if (isBlank(brokerConfig.getMetadataStoreUrl())) {
             final String message = String.format("""
                     Need to specify `metadataStoreUrl` or `zookeeperServers` in configuration file
@@ -193,8 +192,9 @@ public class CompactorTool {
         }
 
         long ledgerId = compactor.compact(arguments.topic).get();
-        log.info("Compaction of topic {} complete. Compacted to ledger {}", arguments.topic, ledgerId);
+        log.info()
+                .attr("topic", arguments.topic)
+                .attr("ledgerId", ledgerId)
+                .log("Compaction of topic complete");
     }
-
-    private static final Logger log = LoggerFactory.getLogger(CompactorTool.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/EventTimeOrderCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/EventTimeOrderCompactor.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -34,13 +35,9 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.impl.RawBatchConverter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class EventTimeOrderCompactor extends AbstractTwoPhaseCompactor<Pair<MessageId, Long>> {
-
-  private static final Logger log = LoggerFactory.getLogger(EventTimeOrderCompactor.class);
-
   public EventTimeOrderCompactor(ServiceConfiguration conf,
       PulsarClient pulsar,
       BookKeeper bk,
@@ -132,8 +129,10 @@ public class EventTimeOrderCompactor extends AbstractTwoPhaseCompactor<Pair<Mess
         deletedMessage = true;
       }
     } catch (IOException ioe) {
-      log.info("Error decoding batch for message {}. Whole batch will be included in output",
-          id, ioe);
+      log.info()
+              .attr("message", id)
+              .exception(ioe)
+              .log("Error decoding batch for message . Whole batch will be included in output");
     }
     return deletedMessage;
   }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PublishingOrderCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PublishingOrderCompactor.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Pair;
@@ -31,14 +32,9 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.impl.RawBatchConverter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-
+@CustomLog
 public class PublishingOrderCompactor extends AbstractTwoPhaseCompactor<MessageId> {
-
-    private static final Logger log = LoggerFactory.getLogger(PublishingOrderCompactor.class);
-
     public PublishingOrderCompactor(ServiceConfiguration conf,
         PulsarClient pulsar,
         BookKeeper bk,
@@ -110,9 +106,10 @@ public class PublishingOrderCompactor extends AbstractTwoPhaseCompactor<MessageI
                 deletedMessage = true;
             }
         } catch (IOException ioe) {
-            log.info(
-                "Error decoding batch for message {}. Whole batch will be included in output",
-                id, ioe);
+            log.info()
+                    .attr("message", id)
+                    .exception(ioe)
+                    .log("Error decoding batch for message . Whole batch will be included in output");
         }
 
         return deletedMessage;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
@@ -47,8 +48,6 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.RawBatchMessageContainerImpl;
 import org.apache.pulsar.common.topics.TopicCompactionStrategy;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compaction will go through the topic in two passes. The first pass
@@ -59,8 +58,8 @@ import org.slf4j.LoggerFactory;
  * <p>As the first pass caches the entire message(not just offset) for each key into a map,
  * this compaction could be memory intensive if the message payload is large.
  */
+@CustomLog
 public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
-    private static final Logger log = LoggerFactory.getLogger(StrategicTwoPhaseCompactor.class);
     private static final int MAX_OUTSTANDING = 500;
     private static final int MAX_READER_RECONNECT_WAITING_TIME_IN_MILLIS = 20 * 1000;
     private final Duration phaseOneLoopReadTimeout;
@@ -78,7 +77,6 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
     public CompletableFuture<Long> compact(String topic) {
         return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
-
 
     public <T> CompletableFuture<Long> compact(String topic,
                                                TopicCompactionStrategy<T> strategy) {
@@ -112,7 +110,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
                         return phaseOne(reader, strategy)
                                 .thenCompose((result) -> phaseTwo(result, reader, bk));
                     } else {
-                        log.info("Skip compaction of the empty topic {}", reader.getTopic());
+                        log.info().attr("topic", reader.getTopic()).log("Skip compaction of the empty topic");
                         return CompletableFuture.completedFuture(-1L);
                     }
                 });
@@ -123,10 +121,13 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
         mxBean.addCompactionStartOp(reader.getTopic());
         doCompaction(reader, strategy).whenComplete(
                 (ledgerId, exception) -> {
-                    log.info("Completed doCompaction ledgerId:{}", ledgerId);
+                    log.info().attr("ledgerId", ledgerId).log("Completed doCompaction");
                     reader.closeAsync().whenComplete((v, exception2) -> {
                         if (exception2 != null) {
-                            log.warn("Error closing reader handle {}, ignoring", reader, exception2);
+                            log.warn()
+                                    .attr("handle", reader)
+                                    .attr("ignoring", exception2)
+                                    .log("Error closing reader handle , ignoring");
                         }
                         if (exception != null) {
                             // complete with original exception
@@ -213,7 +214,6 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
         }
     }
 
-
     @SuppressWarnings("unchecked")
     private <T> CompletableFuture<PhaseOneResult> phaseOne(Reader<T> reader, TopicCompactionStrategy strategy) {
         CompletableFuture<PhaseOneResult> promise = new CompletableFuture<>();
@@ -221,8 +221,10 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
 
         ((CompactionReaderImpl<T>) reader).getLastMessageIdAsync()
                 .thenAccept(lastMessageId -> {
-                    log.info("Commencing phase one of compaction for {}, reading to {}",
-                            reader.getTopic(), lastMessageId);
+                    log.info()
+                            .attr("topic", reader.getTopic())
+                            .attr("lastMessageId", lastMessageId)
+                            .log("Commencing phase one of compaction");
                     result.lastId = copyMessageId(lastMessageId);
                     phaseOneLoop(reader, promise, result, strategy);
                 }).exceptionally(ex -> {
@@ -276,7 +278,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
             //set ids in the result
             if (result.firstId == null) {
                 result.firstId = copyMessageId(id);
-                log.info("Resetting cursor to firstId:{}", result.firstId);
+                log.info().attr("firstId", result.firstId).log("Resetting cursor to firstId");
                 try {
                     reader.seek(result.firstId);
                 } catch (Throwable e) {
@@ -316,28 +318,31 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
                 log.error(errorMsg);
                 throw new RuntimeException(errorMsg);
             }
-            log.warn(
-                    "Reader has not been reconnected after the cursor reset. elapsed :{} ms. Retrying "
-                            + "soon.", now - started);
+            log.warn()
+                    .attr("elapsed", now - started)
+                    .log("Reader has not been reconnected after the cursor reset. elapsed: ms. Retrying soon.");
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
-                log.warn("The thread got interrupted while waiting. continuing", e);
+                log.warn().exception(e).log("The thread got interrupted while waiting. continuing");
             }
         }
     }
 
     private <T> CompletableFuture<Long> phaseTwo(PhaseOneResult<T> phaseOneResult, Reader<T> reader, BookKeeper bk) {
-        log.info("Completed phase one. Result:{}. ", phaseOneResult);
+        log.info().attr("result", phaseOneResult).log("Completed phase one");
         Map<String, byte[]> metadata =
                 LedgerMetadataUtils.buildMetadataForCompactedLedger(
                         phaseOneResult.topic, phaseOneResult.lastId.toByteArray());
         return createLedger(bk, metadata)
                 .thenCompose((ledger) -> {
-                    log.info(
-                            "Commencing phase two of compaction for {}, from {} to {}, compacting {} keys to ledger {}",
-                            phaseOneResult.topic, phaseOneResult.firstId, phaseOneResult.lastId,
-                            phaseOneResult.cache.size(), ledger.getId());
+                    log.info()
+                            .attr("topic", phaseOneResult.topic)
+                            .attr("firstId", phaseOneResult.firstId)
+                            .attr("lastId", phaseOneResult.lastId)
+                            .attr("compactingCount", phaseOneResult.cache.size())
+                            .attr("ledgerId", ledger.getId())
+                            .log("Commencing phase two of compaction");
                     return runPhaseTwo(phaseOneResult, reader, ledger, bk);
                 });
     }
@@ -350,8 +355,9 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
         phaseTwoLoop(phaseOneResult.topic, phaseOneResult.cache.values().iterator(), ledger,
                 outstanding, loopPromise);
         loopPromise.thenCompose((v) -> {
-                    log.info("Flushing batch container numMessagesInBatch:{}",
-                            batchMessageContainer.getNumMessagesInBatch());
+                    log.info()
+                            .attr("numMessagesInBatch", batchMessageContainer.getNumMessagesInBatch())
+                            .log("Flushing batch container");
                     return addToCompactedLedger(ledger, null, reader.getTopic(), outstanding)
                             .whenComplete((res, exception2) -> {
                                 if (exception2 != null) {
@@ -361,7 +367,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
                             });
                 })
                 .thenCompose(v -> {
-                    log.info("Acking ledger id {}", phaseOneResult.lastId);
+                    log.info().attr("lastId", phaseOneResult.lastId).log("Acking ledger");
                     return ((CompactionReaderImpl<T>) reader)
                             .acknowledgeCumulativeAsync(
                                     phaseOneResult.lastId, Map.of(COMPACTED_TOPIC_LEDGER_PROPERTY,
@@ -372,13 +378,16 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
                     if (exception != null) {
                         deleteLedger(bk, ledger).whenComplete((res2, exception2) -> {
                             if (exception2 != null) {
-                                log.error("Cleanup of ledger {} for failed", ledger, exception2);
+                                log.error()
+                                        .attr("ledger", ledger)
+                                        .exceptionMessage(exception2)
+                                        .log("Cleanup of ledger failed");
                             }
                             // complete with original exception
                             promise.completeExceptionally(exception);
                         });
                     } else {
-                        log.info("kept ledger:{}", ledger.getId());
+                        log.info().attr("ledgerId", ledger.getId()).log("kept ledger");
                         promise.complete(ledger.getId());
                     }
                 });
@@ -459,7 +468,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
                     }, null);
 
         } catch (Throwable t) {
-            log.error("Failed to add entry", t);
+            log.error().exception(t).log("Failed to add entry");
             batchMessageContainer.discard((Exception) t);
             bkf.completeExceptionally(t);
             return bkf;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/TimedSingleThreadRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/TimedSingleThreadRateLimiter.java
@@ -19,10 +19,10 @@
 package org.apache.pulsar.utils;
 
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
+@CustomLog
 public class TimedSingleThreadRateLimiter {
 
     @Getter
@@ -52,17 +52,13 @@ public class TimedSingleThreadRateLimiter {
         mayRenew(now);
         if (remaining > permits) {
             remaining -= permits;
-            if (log.isDebugEnabled()) {
-                log.debug("acquired: {}, remaining:{}", permits, remaining);
-            }
-            return permits;
+                log.debug().attr("acquired", permits).attr("remaining", remaining).log("acquired: , remaining");
+                        return permits;
         } else {
             int acquired = remaining;
             remaining = 0;
-            if (log.isDebugEnabled()) {
-                log.debug("acquired: {}, remaining:{}", acquired, remaining);
-            }
-            return acquired;
+                log.debug().attr("acquired", acquired).attr("remaining", remaining).log("acquired: , remaining");
+                        return acquired;
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/DefaultMetadataNodeSizeStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/DefaultMetadataNodeSizeStats.java
@@ -21,12 +21,12 @@ package org.apache.pulsar.zookeeper;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReferenceArray;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.metadata.api.GetResult;
 import org.apache.pulsar.metadata.api.MetadataNodeSizeStats;
 
-@Slf4j
+@CustomLog
 public class DefaultMetadataNodeSizeStats implements MetadataNodeSizeStats {
 
     public static final int UNSET = -1;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import lombok.CustomLog;
 import org.apache.bookkeeper.bookie.BookieException;
 import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
 import org.apache.bookkeeper.clients.StorageClientBuilder;
@@ -82,11 +83,9 @@ import org.apache.zookeeper.server.DatadirCleanupManager;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@CustomLog
 public class LocalBookkeeperEnsemble {
-    protected static final Logger LOG = LoggerFactory.getLogger(LocalBookkeeperEnsemble.class);
     public static final int CONNECTION_TIMEOUT = 30000;
 
     int numberOfBookies;
@@ -107,7 +106,6 @@ public class LocalBookkeeperEnsemble {
     }
 
     private final Supplier<Integer> portManager;
-
 
     public LocalBookkeeperEnsemble(int numberOfBookies, int zkPort, Supplier<Integer> portManager) {
         this(numberOfBookies, zkPort, 4181, null, null, true, null, portManager);
@@ -151,7 +149,10 @@ public class LocalBookkeeperEnsemble {
         this.clearOldData = clearOldData;
         this.zkPort = zkPort;
         this.advertisedAddress = null == advertisedAddress ? "127.0.0.1" : advertisedAddress;
-        LOG.info("Running {} bookie(s) and advertised them at {}.", this.numberOfBookies, this.advertisedAddress);
+        log.info()
+                .attr("numberOfBookies", this.numberOfBookies)
+                .attr("advertisedAddress", this.advertisedAddress)
+                .log("Running bookie(s)");
     }
 
     private String hostPort;
@@ -187,7 +188,7 @@ public class LocalBookkeeperEnsemble {
 
     private void runZookeeper(int maxCC) throws IOException {
         // create a ZooKeeper server(dataDir, dataLogDir, port)
-        LOG.info("Starting ZK server");
+        log.info("Starting ZK server");
         // ServerStats.registerAsConcrete();
         // ClientBase.setupTestEnv();
 
@@ -195,7 +196,7 @@ public class LocalBookkeeperEnsemble {
                 : createTempDirectory("zktest");
 
         if (this.clearOldData) {
-            LOG.info("Wiping Zookeeper data directory at {}", zkDataDir.getAbsolutePath());
+            log.info().attr("path", zkDataDir.getAbsolutePath()).log("Wiping Zookeeper data directory");
             cleanDirectory(zkDataDir);
         }
 
@@ -211,7 +212,7 @@ public class LocalBookkeeperEnsemble {
             zkDataCleanupManager = new DatadirCleanupManager(zkDataDir, zkDataDir, 3, 1 /* hour */);
             zkDataCleanupManager.start();
         } catch (Exception e) {
-            LOG.error("Exception while instantiating ZooKeeper", e);
+            log.error().exception(e).log("Exception while instantiating ZooKeeper");
 
             if (serverFactory != null) {
                 serverFactory.shutdown();
@@ -224,14 +225,17 @@ public class LocalBookkeeperEnsemble {
 
         boolean b = waitForServerUp(hostPort, CONNECTION_TIMEOUT);
 
-        LOG.info("ZooKeeper server up: {}", b);
-        LOG.debug("Local ZK started (port: {}, data_directory: {})", zkPort, zkDataDir.getAbsolutePath());
+        log.info().attr("up", b).log("ZooKeeper server up");
+        log.debug()
+                .attr("port", zkPort)
+                .attr("directory", zkDataDir.getAbsolutePath())
+                .log("Local ZK started (port: , data_directory: )");
     }
 
     public void disconnectZookeeper(ZooKeeper zooKeeper) {
         ServerCnxn serverCnxn = getZookeeperServerConnection(zooKeeper);
         try {
-            LOG.info("disconnect ZK server side connection {}", serverCnxn);
+            log.info().attr("connection", serverCnxn).log("disconnect ZK server side connection");
             Class<?> disconnectReasonClass = Class.forName("org.apache.zookeeper.server.ServerCnxn$DisconnectReason");
             Method method = serverCnxn.getClass().getMethod("close", disconnectReasonClass);
             method.invoke(serverCnxn, Stream.of(disconnectReasonClass.getEnumConstants()).filter(s ->
@@ -249,7 +253,7 @@ public class LocalBookkeeperEnsemble {
     }
 
     private void initializeZookeper() throws IOException {
-        LOG.info("Instantiate ZK Client");
+        log.info("Instantiate ZK Client");
         // initialize the zk client with values
         try {
             ZKConnectionWatcher zkConnectionWatcher = new ZKConnectionWatcher();
@@ -272,15 +276,15 @@ public class LocalBookkeeperEnsemble {
             // No need to create an entry for each requested bookie anymore as the
             // BookieServers will register themselves with ZooKeeper on startup.
         } catch (KeeperException e) {
-            LOG.error("Exception while creating znodes", e);
+            log.error().exception(e).log("Exception while creating znodes");
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            LOG.error("Interrupted while creating znodes", e);
+            log.error().exception(e).log("Interrupted while creating znodes");
         }
     }
 
     private void runBookies(ServerConfiguration baseConf) throws Exception {
-        LOG.info("Starting Bookie(s)");
+        log.info("Starting Bookie(s)");
         // Create Bookie Servers (B1, B2, B3)
 
         bookieComponents = new LifecycleComponentStack[numberOfBookies];
@@ -293,7 +297,7 @@ public class LocalBookkeeperEnsemble {
                     : createTempDirectory("bk" + i + "test");
 
             if (this.clearOldData) {
-                LOG.info("Wiping Bookie data directory at {}", bkDataDir.getAbsolutePath());
+                log.info().attr("path", bkDataDir.getAbsolutePath()).log("Wiping Bookie data directory");
                 cleanDirectory(bkDataDir);
             }
 
@@ -360,7 +364,7 @@ public class LocalBookkeeperEnsemble {
 
         this.streamStorage = new StreamStorageLifecycleComponent(bkConf, NullStatsLogger.INSTANCE);
         this.streamStorage.start();
-        LOG.debug("Local BK stream storage started (port: {})", streamStoragePort);
+        log.debug().attr("port", streamStoragePort).log("Local BK stream storage started (port: )");
 
         // create a default namespace
         try (StorageAdminClient admin = StorageClientBuilder.newBuilder()
@@ -377,18 +381,18 @@ public class LocalBookkeeperEnsemble {
 
             try {
                 NamespaceProperties ns = FutureUtils.result(admin.getNamespace("default"));
-                LOG.info("'default' namespace for table service : {}", ns);
+                log.info().attr("service", ns).log("'default' namespace for table service");
             } catch (NamespaceNotFoundException nnfe) {
-                LOG.info("Creating default namespace");
+                log.info("Creating default namespace");
                 try {
                     NamespaceProperties ns =
                         FutureUtils.result(admin.createNamespace("default", NamespaceConfiguration.newBuilder()
                             .setDefaultStreamConf(DEFAULT_STREAM_CONF)
                             .build()));
-                    LOG.info("Successfully created 'default' namespace :\n{}", ns);
+                    log.info().attr("n", ns).log("Successfully created 'default' namespace :\n");
                 } catch (NamespaceExistsException nee) {
                     // namespace already exists
-                    LOG.warn("Namespace 'default' already existed.");
+                    log.warn("Namespace 'default' already existed.");
                 }
             }
         }
@@ -396,7 +400,7 @@ public class LocalBookkeeperEnsemble {
 
     @SuppressWarnings("deprecation")
     public void start(boolean enableStreamStorage) throws  Exception {
-        LOG.debug("Local ZK/BK starting ...");
+        log.debug("Local ZK/BK starting ...");
         ServerConfiguration conf = new ServerConfiguration();
         // Use minimal configuration requiring less memory for unit tests
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
@@ -435,7 +439,7 @@ public class LocalBookkeeperEnsemble {
     }
 
     public void startStandalone(ServerConfiguration conf, boolean enableStreamStorage) throws Exception {
-        LOG.debug("Local ZK/BK starting ...");
+        log.debug("Local ZK/BK starting ...");
         conf.setAdvertisedAddress(advertisedAddress);
 
         runZookeeper(1000);
@@ -451,7 +455,7 @@ public class LocalBookkeeperEnsemble {
     }
 
     public void stopBK() {
-        LOG.debug("Local ZK/BK stopping ...");
+        log.debug("Local ZK/BK stopping ...");
         for (LifecycleComponent bookie : bookieComponents) {
             bookie.close();
         }
@@ -465,20 +469,20 @@ public class LocalBookkeeperEnsemble {
                     .buildBookieServer(new BookieConfiguration(bsConfs[i]));
             bookieComponents[i].start();
         } catch (BookieException.InvalidCookieException ice) {
-            LOG.warn("Invalid cookie found for bookie {}", i, ice);
+            log.warn().attr("bookie", i).exception(ice).log("Invalid cookie found for bookie");
 
             // InvalidCookieException can happen if the machine IP has changed
             // Since we are running here a local bookie that is always accessed
             // from localhost, we can ignore the error
             for (String path : zkc.getChildren("/ledgers/cookies", false)) {
-                LOG.info("deleting zk node {}", "/ledgers/cookies/" + path);
+                log.info().attr("node", "/ledgers/cookies/" + path).log("deleting zk node");
                 zkc.delete("/ledgers/cookies/" + path, -1);
             }
 
             // Also clean the on-disk directory and cookie,
             // cookie validation fails on non-empty dirs
             // even if the cookie file is deleted
-            LOG.info("Recursively deleting data directory {}", bkDataDir);
+            log.info().attr("directory", bkDataDir).log("Recursively deleting data directory");
             FileUtils.deleteDirectory(bkDataDir);
 
             bookieComponents[i] = org.apache.bookkeeper.server.Main
@@ -486,9 +490,11 @@ public class LocalBookkeeperEnsemble {
             bookieComponents[i].start();
         }
 
-
-        LOG.info("Local BK[{}] started (port: {}, data_directory: {})", i, bsConfs[i].getBookiePort(),
-                bkDataDir.getAbsolutePath());
+        log.info()
+                .attr("bk", i)
+                .attr("port", bsConfs[i].getBookiePort())
+                .attr("directory", bkDataDir.getAbsolutePath())
+                .log("Local BK started");
     }
 
     public void startBK() throws Exception {
@@ -499,18 +505,18 @@ public class LocalBookkeeperEnsemble {
 
     public void stop() throws Exception {
         if (null != streamStorage) {
-            LOG.debug("Local bk stream storage stopping ...");
+            log.debug("Local bk stream storage stopping ...");
             streamStorage.close();
         }
 
-        LOG.debug("Local ZK/BK stopping ...");
+        log.debug("Local ZK/BK stopping ...");
         for (LifecycleComponent bookie : bookieComponents) {
             try {
                 if (bookie != null) {
                     bookie.close();
                 }
             } catch (Exception e) {
-                LOG.warn("failed to shutdown bookie", e);
+                log.warn().exception(e).log("failed to shutdown bookie");
             }
         }
 
@@ -521,9 +527,9 @@ public class LocalBookkeeperEnsemble {
         if (zkDataCleanupManager != null) {
             zkDataCleanupManager.shutdown();
         }
-        LOG.debug("Local ZK/BK stopped");
+        log.debug("Local ZK/BK stopped");
         for (File managedDir : temporaryDirectories) {
-            LOG.info("deleting test directory {}", managedDir);
+            log.info().attr("directory", managedDir).log("deleting test directory");
             FileUtils.deleteDirectory(managedDir);
         }
         temporaryDirectories.clear();
@@ -569,7 +575,7 @@ public class LocalBookkeeperEnsemble {
                     reader = new BufferedReader(new InputStreamReader(sock.getInputStream()));
                     String line = reader.readLine();
                     if (line != null && line.startsWith("Zookeeper version:")) {
-                        LOG.info("Server UP");
+                        log.info("Server UP");
                         return true;
                     }
                 } finally {
@@ -580,7 +586,7 @@ public class LocalBookkeeperEnsemble {
                 }
             } catch (IOException e) {
                 // ignore as this is expected
-                LOG.info("server " + hp + " not up " + e);
+                log.info().attr("hostPort", hp).exceptionMessage(e).log("server not up");
             }
 
             if (System.currentTimeMillis() > start + timeout) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
@@ -127,7 +127,9 @@ public class PersistentTopicInitializeDelayTest extends BrokerTestBase {
         public CompletableFuture<Void> checkReplication() {
             if (TopicName.get(topic).getLocalName().equalsIgnoreCase("testTopicInitializeDelay")) {
                 checkReplicationInvocationCount.incrementAndGet();
-                log.info("checkReplication, count = {}", checkReplicationInvocationCount.get());
+                log.info()
+                        .attr("count", checkReplicationInvocationCount.get())
+                        .log("checkReplication");
                 List<String> configuredClusters = topicPolicies.getReplicationClusters().get();
                 if (!(configuredClusters.size() == 1
                         && configuredClusters.contains(brokerService.pulsar().getConfiguration().getClusterName()))) {


### PR DESCRIPTION
## Summary
- Convert 210 files in the `pulsar-broker` module from SLF4J to slog structured logging
- Add derived loggers with class-level context attributes (e.g. `topic`, `subscription`, `state`) so that related log lines carry the same structured context automatically
- Subclasses that previously inherited a `protected final Logger log` from their parent now declare their own logger that chains the parent's context via `Logger.get(SubClass.class).with().ctx(super.log).build()`, so the logger name matches the actual runtime class while still inheriting parent attributes
- Rename leftover generic `argN` attrs to meaningful names; strip stale SLF4J `{}` placeholder text from log messages
- Use short form `log.level("msg")` when no attributes are present

## Test plan
- [x] `./gradlew :pulsar-broker:compileJava` passes
- [x] `./gradlew :pulsar-broker:checkstyleMain` passes
- [x] `./gradlew :pulsar-broker:compileTestJava` passes
- [x] `./gradlew :pulsar-broker:checkstyleTest` passes
- [ ] CI passes

### Motivation

PIP-467

> [!NOTE]
> Please label this PR with `ready-to-test`