### PR TITLE
[improve][client] Implement tls_client_auth for AuthenticationOAuth2

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -21,9 +21,10 @@ package org.apache.pulsar.client.impl.auth.oauth2;
 import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 
 /**
  * Factory class that allows to create {@link Authentication} instances
@@ -111,6 +112,18 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
+         * Optional token endpoint auth method.
+         * Defaults to {@code client_secret_post}.
+         *
+         * @param tokenEndpointAuthMethod the token endpoint auth method
+         * @return the builder
+         */
+        public ClientCredentialsBuilder tokenEndpointAuthMethod(TokenEndpointAuthMethod tokenEndpointAuthMethod) {
+            this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
+            return this;
+        }
+
+        /**
          * Required issuer URL.
          *
          * @param issuerUrl the issuer URL
@@ -122,7 +135,8 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
-         * Required (when using client_secret) credentials URL.
+         * Required credentials URL.
+         * Only used by {@code client_secret_post}
          *
          * @param credentialsUrl the credentials URL
          * @return the builder
@@ -133,7 +147,8 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
-         * Required (when using tls_client_auth) path to the file for a client certificate.
+         * Optional path to the file for a client certificate.
+         * Required when {@code tokenEndpointAuthMethod} is {@code tls_client_auth}
          *
          * @param tlsCertFile the path to the file for a client certificate
          * @return the builder
@@ -144,7 +159,8 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
-         * Required (when using tls_client_auth) path to the file for a client private key.
+         * Optional path to the file for a client private key.
+         * Required when {@code tokenEndpointAuthMethod} is {@code tls_client_auth}
          *
          * @param tlsKeyFile the path to the file for a client private key
          * @return the builder
@@ -156,7 +172,7 @@ public final class AuthenticationFactoryOAuth2 {
 
         /**
          * Optional client identifier issued by the authorization server.
-         * This parameter can only be set when tls_client_auth.
+         * Only used by {@code tls_client_auth}.
          * Defaults to {@code pulsar-client} when not provided.
          *
          * @param clientId the client identifier
@@ -164,18 +180,6 @@ public final class AuthenticationFactoryOAuth2 {
          */
         public ClientCredentialsBuilder clientId(String clientId) {
             this.clientId = clientId;
-            return this;
-        }
-
-        /**
-         * Optional token endpoint auth method.
-         * Defaults to {@code client_secret_post}.
-         *
-         * @param tokenEndpointAuthMethod the token endpoint auth method
-         * @return the builder
-         */
-        public ClientCredentialsBuilder tokenEndpointAuthMethod(TokenEndpointAuthMethod tokenEndpointAuthMethod) {
-            this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
             return this;
         }
 
@@ -250,8 +254,7 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
-         * Optional Certificate refresh interval in seconds
-         * This parameter can only be set when tls_client_auth.
+         * Optional certificate refresh interval.
          *
          * @param autoCertRefreshDuration the Certificate refresh interval
          * @return the builder
@@ -311,9 +314,15 @@ public final class AuthenticationFactoryOAuth2 {
                         .connectTimeout(connectTimeout)
                         .readTimeout(readTimeout)
                         .trustCertsFilePath(trustCertsFilePath)
+                        .certFile(tlsCertFile)
+                        .keyFile(tlsKeyFile)
+                        .autoCertRefreshDuration(autoCertRefreshDuration)
                         .wellKnownMetadataPath(wellKnownMetadataPath)
                         .build();
             } else {
+                if (StringUtils.isBlank(tlsCertFile) || StringUtils.isBlank(tlsKeyFile)) {
+                    throw new IllegalArgumentException("Required configuration parameters: tlsCertFile, tlsKeyFile");
+                }
                 flow = TlsClientAuthFlow.builder()
                         .issuerUrl(issuerUrl)
                         .clientId(clientId)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl.auth.oauth2;
 import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
 
@@ -92,12 +93,16 @@ public final class AuthenticationFactoryOAuth2 {
 
         private URL issuerUrl;
         private URL credentialsUrl;
+        private String clientId;
+        private String tlsCertFile;
+        private String tlsKeyFile;
         private String audience;
         private String scope;
         private Duration connectTimeout;
         private Duration readTimeout;
         private String trustCertsFilePath;
         private String wellKnownMetadataPath;
+        private Duration autoCertRefreshDuration;
         private double earlyTokenRefreshPercent = AuthenticationOAuth2.EARLY_TOKEN_REFRESH_PERCENT_DEFAULT;
         private ScheduledExecutorService scheduler;
 
@@ -116,13 +121,48 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
-         * Required credentials URL.
+         * Required (when using client_secret) credentials URL.
          *
          * @param credentialsUrl the credentials URL
          * @return the builder
          */
         public ClientCredentialsBuilder credentialsUrl(URL credentialsUrl) {
             this.credentialsUrl = credentialsUrl;
+            return this;
+        }
+
+        /**
+         * Required (when using tls_client_auth) path to the file for a client certificate.
+         *
+         * @param tlsCertFile the path to the file for a client certificate
+         * @return the builder
+         */
+        public ClientCredentialsBuilder tlsCertFile(String tlsCertFile) {
+            this.tlsCertFile = tlsCertFile;
+            return this;
+        }
+
+        /**
+         * Required (when using tls_client_auth) path to the file for a client private key.
+         *
+         * @param tlsKeyFile the path to the file for a client private key
+         * @return the builder
+         */
+        public ClientCredentialsBuilder tlsKeyFile(String tlsKeyFile) {
+            this.tlsKeyFile = tlsKeyFile;
+            return this;
+        }
+
+        /**
+         * Optional client identifier issued by the authorization server.
+         * This parameter can only be set when tls_client_auth.
+         * Defaults to {@code pulsar-client} when not provided.
+         *
+         * @param clientId the client identifier
+         * @return the builder
+         */
+        public ClientCredentialsBuilder clientId(String clientId) {
+            this.clientId = clientId;
             return this;
         }
 
@@ -197,6 +237,18 @@ public final class AuthenticationFactoryOAuth2 {
         }
 
         /**
+         * Optional Certificate refresh interval in seconds
+         * This parameter can only be set when tls_client_auth.
+         *
+         * @param autoCertRefreshDuration the Certificate refresh interval
+         * @return the builder
+         */
+        public ClientCredentialsBuilder autoCertRefreshDuration(Duration autoCertRefreshDuration) {
+            this.autoCertRefreshDuration = autoCertRefreshDuration;
+            return this;
+        }
+
+        /**
          * The fraction of the token's {@code expires_in} time at which the client starts attempting
          * a background refresh. Must be greater than 0. Values &ge; 1 disable early refresh (the default).
          *
@@ -236,16 +288,33 @@ public final class AuthenticationFactoryOAuth2 {
          * @return an Authentication object
          */
         public Authentication build() {
-            ClientCredentialsFlow flow = ClientCredentialsFlow.builder()
-                    .issuerUrl(issuerUrl)
-                    .privateKey(credentialsUrl == null ? null : credentialsUrl.toExternalForm())
-                    .audience(audience)
-                    .scope(scope)
-                    .connectTimeout(connectTimeout)
-                    .readTimeout(readTimeout)
-                    .trustCertsFilePath(trustCertsFilePath)
-                    .wellKnownMetadataPath(wellKnownMetadataPath)
-                    .build();
+            Flow flow;
+            if (StringUtils.isNotBlank(tlsCertFile) && StringUtils.isNotBlank(tlsKeyFile)) {
+                flow = TlsClientAuthFlow.builder()
+                        .issuerUrl(issuerUrl)
+                        .clientId(clientId)
+                        .certFile(tlsCertFile)
+                        .keyFile(tlsKeyFile)
+                        .audience(audience)
+                        .scope(scope)
+                        .connectTimeout(connectTimeout)
+                        .readTimeout(readTimeout)
+                        .trustCertsFilePath(trustCertsFilePath)
+                        .wellKnownMetadataPath(wellKnownMetadataPath)
+                        .autoCertRefreshDuration(autoCertRefreshDuration)
+                        .build();
+            } else {
+                flow = ClientCredentialsFlow.builder()
+                        .issuerUrl(issuerUrl)
+                        .privateKey(credentialsUrl == null ? null : credentialsUrl.toExternalForm())
+                        .audience(audience)
+                        .scope(scope)
+                        .connectTimeout(connectTimeout)
+                        .readTimeout(readTimeout)
+                        .trustCertsFilePath(trustCertsFilePath)
+                        .wellKnownMetadataPath(wellKnownMetadataPath)
+                        .build();
+            }
             return new AuthenticationOAuth2(flow, earlyTokenRefreshPercent, scheduler);
         }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -319,7 +319,7 @@ public final class AuthenticationFactoryOAuth2 {
                         .autoCertRefreshDuration(autoCertRefreshDuration)
                         .wellKnownMetadataPath(wellKnownMetadataPath)
                         .build();
-            } else {
+            } else if (tokenEndpointAuthMethod == TokenEndpointAuthMethod.TLS_CLIENT_AUTH) {
                 if (StringUtils.isBlank(tlsCertFile) || StringUtils.isBlank(tlsKeyFile)) {
                     throw new IllegalArgumentException("Required configuration parameters: tlsCertFile, tlsKeyFile");
                 }
@@ -336,6 +336,8 @@ public final class AuthenticationFactoryOAuth2 {
                         .wellKnownMetadataPath(wellKnownMetadataPath)
                         .autoCertRefreshDuration(autoCertRefreshDuration)
                         .build();
+            } else {
+                throw new IllegalArgumentException("Unsupported auth method: " + tokenEndpointAuthMethod);
             }
             return new AuthenticationOAuth2(flow, earlyTokenRefreshPercent, scheduler);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2.java
@@ -21,8 +21,8 @@ package org.apache.pulsar.client.impl.auth.oauth2;
 import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
 
 /**
@@ -93,6 +93,7 @@ public final class AuthenticationFactoryOAuth2 {
 
         private URL issuerUrl;
         private URL credentialsUrl;
+        private TokenEndpointAuthMethod tokenEndpointAuthMethod = TokenEndpointAuthMethod.CLIENT_SECRET_POST;
         private String clientId;
         private String tlsCertFile;
         private String tlsKeyFile;
@@ -163,6 +164,18 @@ public final class AuthenticationFactoryOAuth2 {
          */
         public ClientCredentialsBuilder clientId(String clientId) {
             this.clientId = clientId;
+            return this;
+        }
+
+        /**
+         * Optional token endpoint auth method.
+         * Defaults to {@code client_secret_post}.
+         *
+         * @param tokenEndpointAuthMethod the token endpoint auth method
+         * @return the builder
+         */
+        public ClientCredentialsBuilder tokenEndpointAuthMethod(TokenEndpointAuthMethod tokenEndpointAuthMethod) {
+            this.tokenEndpointAuthMethod = tokenEndpointAuthMethod;
             return this;
         }
 
@@ -289,7 +302,18 @@ public final class AuthenticationFactoryOAuth2 {
          */
         public Authentication build() {
             Flow flow;
-            if (StringUtils.isNotBlank(tlsCertFile) && StringUtils.isNotBlank(tlsKeyFile)) {
+            if (tokenEndpointAuthMethod == TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
+                flow = ClientCredentialsFlow.builder()
+                        .issuerUrl(issuerUrl)
+                        .privateKey(credentialsUrl == null ? null : credentialsUrl.toExternalForm())
+                        .audience(audience)
+                        .scope(scope)
+                        .connectTimeout(connectTimeout)
+                        .readTimeout(readTimeout)
+                        .trustCertsFilePath(trustCertsFilePath)
+                        .wellKnownMetadataPath(wellKnownMetadataPath)
+                        .build();
+            } else {
                 flow = TlsClientAuthFlow.builder()
                         .issuerUrl(issuerUrl)
                         .clientId(clientId)
@@ -302,17 +326,6 @@ public final class AuthenticationFactoryOAuth2 {
                         .trustCertsFilePath(trustCertsFilePath)
                         .wellKnownMetadataPath(wellKnownMetadataPath)
                         .autoCertRefreshDuration(autoCertRefreshDuration)
-                        .build();
-            } else {
-                flow = ClientCredentialsFlow.builder()
-                        .issuerUrl(issuerUrl)
-                        .privateKey(credentialsUrl == null ? null : credentialsUrl.toExternalForm())
-                        .audience(audience)
-                        .scope(scope)
-                        .connectTimeout(connectTimeout)
-                        .readTimeout(readTimeout)
-                        .trustCertsFilePath(trustCertsFilePath)
-                        .wellKnownMetadataPath(wellKnownMetadataPath)
                         .build();
             }
             return new AuthenticationOAuth2(flow, earlyTokenRefreshPercent, scheduler);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
@@ -158,7 +158,14 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
         Map<String, String> params = parseAuthParameters(encodedAuthParamString);
         String type = params.getOrDefault(CONFIG_PARAM_TYPE, TYPE_CLIENT_CREDENTIALS);
         if (TYPE_CLIENT_CREDENTIALS.equals(type)) {
-            this.flow = ClientCredentialsFlow.fromParameters(params);
+            if (params.containsKey(TlsClientAuthFlow.CONFIG_PARAM_CERT_FILE)
+                && params.containsKey(TlsClientAuthFlow.CONFIG_PARAM_KEY_FILE)
+               && StringUtils.isNotBlank(params.get(TlsClientAuthFlow.CONFIG_PARAM_CERT_FILE))
+               && StringUtils.isNotBlank(params.get(TlsClientAuthFlow.CONFIG_PARAM_KEY_FILE))) {
+                this.flow = TlsClientAuthFlow.fromParameters(params);
+            } else {
+                this.flow = ClientCredentialsFlow.fromParameters(params);
+            }
         } else {
             throw new IllegalArgumentException("Unsupported authentication type: " + type);
         }
@@ -351,4 +358,3 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
         }
     }
 }
-

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
 import org.apache.pulsar.common.util.Backoff;
 
@@ -73,6 +74,7 @@ import org.apache.pulsar.common.util.Backoff;
 public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticationParameterSupport {
 
     public static final String CONFIG_PARAM_TYPE = "type";
+    public static final String CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD = "tokenEndpointAuthMethod";
     public static final String CONFIG_PARAM_EARLY_TOKEN_REFRESH_PERCENT = "earlyTokenRefreshPercent";
     public static final String TYPE_CLIENT_CREDENTIALS = "client_credentials";
     public static final int EARLY_TOKEN_REFRESH_PERCENT_DEFAULT = 1; // feature disabled by default
@@ -158,10 +160,10 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
         Map<String, String> params = parseAuthParameters(encodedAuthParamString);
         String type = params.getOrDefault(CONFIG_PARAM_TYPE, TYPE_CLIENT_CREDENTIALS);
         if (TYPE_CLIENT_CREDENTIALS.equals(type)) {
-            if (params.containsKey(TlsClientAuthFlow.CONFIG_PARAM_CERT_FILE)
-                && params.containsKey(TlsClientAuthFlow.CONFIG_PARAM_KEY_FILE)
-               && StringUtils.isNotBlank(params.get(TlsClientAuthFlow.CONFIG_PARAM_CERT_FILE))
-               && StringUtils.isNotBlank(params.get(TlsClientAuthFlow.CONFIG_PARAM_KEY_FILE))) {
+            TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.fromValue(
+                    params.getOrDefault(CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
+                            TokenEndpointAuthMethod.CLIENT_SECRET_POST.value()));
+            if (authMethod == TokenEndpointAuthMethod.TLS_CLIENT_AUTH) {
                 this.flow = TlsClientAuthFlow.fromParameters(params);
             } else {
                 this.flow = ClientCredentialsFlow.fromParameters(params);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2.java
@@ -163,10 +163,12 @@ public class AuthenticationOAuth2 implements Authentication, EncodedAuthenticati
             TokenEndpointAuthMethod authMethod = TokenEndpointAuthMethod.fromValue(
                     params.getOrDefault(CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
                             TokenEndpointAuthMethod.CLIENT_SECRET_POST.value()));
-            if (authMethod == TokenEndpointAuthMethod.TLS_CLIENT_AUTH) {
+            if (authMethod == TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
+                this.flow = ClientCredentialsFlow.fromParameters(params);
+            } else if (authMethod == TokenEndpointAuthMethod.TLS_CLIENT_AUTH) {
                 this.flow = TlsClientAuthFlow.fromParameters(params);
             } else {
-                this.flow = ClientCredentialsFlow.fromParameters(params);
+                throw new IllegalArgumentException("Unsupported auth method: " + authMethod);
             }
         } else {
             throw new IllegalArgumentException("Unsupported authentication type: " + type);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -81,7 +81,7 @@ class ClientCredentialsFlow extends FlowBase {
     public static ClientCredentialsFlow fromParameters(Map<String, String> params) {
         URL issuerUrl = parseParameterUrl(params, CONFIG_PARAM_ISSUER_URL);
         String privateKeyUrl = parseParameterString(params, CONFIG_PARAM_KEY_FILE);
-        // These are optional parameters, so we only perform a get
+        // These are optional parameters, so we allow null values
         String scope = params.get(CONFIG_PARAM_SCOPE);
         String audience = params.get(CONFIG_PARAM_AUDIENCE);
         Duration connectTimeout = parseParameterDuration(params, CONFIG_PARAM_CONNECT_TIMEOUT);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -91,7 +91,7 @@ class ClientCredentialsFlow extends FlowBase {
         Duration readTimeout = parseParameterDuration(params, CONFIG_PARAM_READ_TIMEOUT);
         String trustCertsFilePath = params.get(CONFIG_PARAM_TRUST_CERTS_FILE_PATH);
         String certFile = params.get(CONFIG_PARAM_CERT_FILE);
-        String keyFile = params.get(CONFIG_PARAM_KEY_FILE);
+        String keyFile = params.get(CONFIG_PARAM_TLS_KEY_FILE);
         Duration autoCertRefreshDuration = parseParameterDuration(params, CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION);
         String wellKnownMetadataPath = params.get(CONFIG_PARAM_WELL_KNOWN_METADATA_PATH);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -34,8 +34,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchanger;
-import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
 
@@ -65,8 +65,10 @@ class ClientCredentialsFlow extends FlowBase {
     @Builder
     public ClientCredentialsFlow(URL issuerUrl, String audience, String privateKey, String scope,
                                  Duration connectTimeout, Duration readTimeout, String trustCertsFilePath,
+                                 String certFile, String keyFile, Duration autoCertRefreshDuration,
                                  String wellKnownMetadataPath) {
-        super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, wellKnownMetadataPath);
+        super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, certFile, keyFile, autoCertRefreshDuration,
+                wellKnownMetadataPath);
         this.audience = audience;
         this.privateKey = privateKey;
         this.scope = scope;
@@ -88,6 +90,9 @@ class ClientCredentialsFlow extends FlowBase {
         Duration connectTimeout = parseParameterDuration(params, CONFIG_PARAM_CONNECT_TIMEOUT);
         Duration readTimeout = parseParameterDuration(params, CONFIG_PARAM_READ_TIMEOUT);
         String trustCertsFilePath = params.get(CONFIG_PARAM_TRUST_CERTS_FILE_PATH);
+        String certFile = params.get(CONFIG_PARAM_CERT_FILE);
+        String keyFile = params.get(CONFIG_PARAM_KEY_FILE);
+        Duration autoCertRefreshDuration = parseParameterDuration(params, CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION);
         String wellKnownMetadataPath = params.get(CONFIG_PARAM_WELL_KNOWN_METADATA_PATH);
 
         return ClientCredentialsFlow.builder()
@@ -98,6 +103,9 @@ class ClientCredentialsFlow extends FlowBase {
                 .connectTimeout(connectTimeout)
                 .readTimeout(readTimeout)
                 .trustCertsFilePath(trustCertsFilePath)
+                .certFile(certFile)
+                .keyFile(keyFile)
+                .autoCertRefreshDuration(autoCertRefreshDuration)
                 .wellKnownMetadataPath(wellKnownMetadataPath)
                 .build();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchanger;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
@@ -157,6 +158,7 @@ class ClientCredentialsFlow extends FlowBase {
                 .clientSecret(keyFile.getClientSecret())
                 .audience(this.audience)
                 .scope(this.scope)
+                .authMethod(TokenEndpointAuthMethod.CLIENT_SECRET_POST)
                 .build();
         TokenResult tr;
         if (!initialized) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -67,14 +67,8 @@ abstract class FlowBase implements Flow {
         this.wellKnownMetadataPath = wellKnownMetadataPath;
     }
 
-    protected FlowBase(URL issuerUrl, AsyncHttpClient httpClient, String wellKnownMetadataPath) {
-        this.issuerUrl = issuerUrl;
-        this.httpClient = httpClient;
-        this.wellKnownMetadataPath = wellKnownMetadataPath;
-    }
-
-    protected static AsyncHttpClient defaultHttpClient(Duration readTimeout, Duration connectTimeout,
-                                                       String trustCertsFilePath) {
+    private AsyncHttpClient defaultHttpClient(Duration readTimeout, Duration connectTimeout,
+                                              String trustCertsFilePath) {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setCookieStore(null);
         confBuilder.setUseProxyProperties(true);
@@ -97,15 +91,15 @@ abstract class FlowBase implements Flow {
         return new DefaultAsyncHttpClient(confBuilder.build());
     }
 
-    protected static int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
+    protected int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
         return (int) getParameterDuration(name, value, defaultValue).toMillis();
     }
 
-    protected static long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
+    protected long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
         return getParameterDuration(name, value, defaultValue).getSeconds();
     }
 
-    private static Duration getParameterDuration(String name, Duration value, Duration defaultValue) {
+    private Duration getParameterDuration(String name, Duration value, Duration defaultValue) {
         Duration duration;
         if (value == null) {
                 log.debug().attr("name", name)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -26,6 +26,9 @@ import java.net.URL;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
@@ -34,9 +37,14 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.Metadata;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.MetadataResolver;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.client.util.PulsarHttpAsyncSslEngineFactory;
+import org.apache.pulsar.common.util.PulsarSslConfiguration;
+import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.SslEngineFactory;
 
 /**
  * An abstract OAuth 2.0 authorization flow.
@@ -47,10 +55,14 @@ abstract class FlowBase implements Flow {
     public static final String CONFIG_PARAM_CONNECT_TIMEOUT = "connectTimeout";
     public static final String CONFIG_PARAM_READ_TIMEOUT = "readTimeout";
     public static final String CONFIG_PARAM_TRUST_CERTS_FILE_PATH = "trustCertsFilePath";
+    public static final String CONFIG_PARAM_CERT_FILE = "tlsCertFile";
+    public static final String CONFIG_PARAM_KEY_FILE = "tlsKeyFile";
+    public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION = "autoCertRefreshDuration";
     public static final String CONFIG_PARAM_WELL_KNOWN_METADATA_PATH = "wellKnownMetadataPath";
 
     protected static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
     protected static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(30);
+    protected static final Duration DEFAULT_AUTO_CERT_REFRESH_DURATION = Duration.ofSeconds(300);
 
     private static final long serialVersionUID = 1L;
 
@@ -58,17 +70,23 @@ abstract class FlowBase implements Flow {
     protected final AsyncHttpClient httpClient;
     protected final String wellKnownMetadataPath;
 
+    protected transient PulsarSslFactory sslFactory;
+    protected transient ScheduledExecutorService sslRefreshScheduler;
     protected transient Metadata metadata;
 
     protected FlowBase(URL issuerUrl, Duration connectTimeout, Duration readTimeout, String trustCertsFilePath,
+                       String certFile, String keyFile, Duration autoCertRefreshDuration,
                        String wellKnownMetadataPath) {
         this.issuerUrl = issuerUrl;
-        this.httpClient = defaultHttpClient(readTimeout, connectTimeout, trustCertsFilePath);
+        this.httpClient = defaultHttpClient(readTimeout, connectTimeout, trustCertsFilePath, certFile, keyFile);
+        long autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
+                autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
+        scheduleSslContextRefreshIfEnabled(autoCertRefreshSeconds);
         this.wellKnownMetadataPath = wellKnownMetadataPath;
     }
 
     private AsyncHttpClient defaultHttpClient(Duration readTimeout, Duration connectTimeout,
-                                              String trustCertsFilePath) {
+                                              String trustCertsFilePath, String certFile, String keyFile) {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setCookieStore(null);
         confBuilder.setUseProxyProperties(true);
@@ -79,7 +97,25 @@ abstract class FlowBase implements Flow {
         confBuilder.setReadTimeout(
                 getParameterDurationToMillis(CONFIG_PARAM_READ_TIMEOUT, readTimeout, DEFAULT_READ_TIMEOUT));
         confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
-        if (StringUtils.isNotBlank(trustCertsFilePath)) {
+        if (StringUtils.isNotBlank(certFile) && StringUtils.isNotBlank(keyFile)) {
+            try {
+                PulsarSslConfiguration sslConfiguration = PulsarSslConfiguration.builder()
+                        .tlsCertificateFilePath(certFile)
+                        .tlsKeyFilePath(keyFile)
+                        .tlsTrustCertsFilePath(trustCertsFilePath)
+                        .allowInsecureConnection(false)
+                        .serverMode(false)
+                        .isHttps(true)
+                        .build();
+                sslFactory = new org.apache.pulsar.common.util.DefaultPulsarSslFactory();
+                sslFactory.initialize(sslConfiguration);
+                sslFactory.createInternalSslContext();
+                SslEngineFactory sslEngineFactory = new PulsarHttpAsyncSslEngineFactory(sslFactory, null);
+                confBuilder.setSslEngineFactory(sslEngineFactory);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Invalid TLS client certificate configuration", e);
+            }
+        } else if (StringUtils.isNotBlank(trustCertsFilePath)) {
             try {
                 confBuilder.setSslContext(SslContextBuilder.forClient()
                         .trustManager(new File(trustCertsFilePath))
@@ -91,11 +127,36 @@ abstract class FlowBase implements Flow {
         return new DefaultAsyncHttpClient(confBuilder.build());
     }
 
-    protected int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
+    protected void scheduleSslContextRefreshIfEnabled(long refreshSeconds) {
+        if (sslFactory == null || refreshSeconds <= 0 || sslRefreshScheduler != null) {
+            return;
+        }
+        sslRefreshScheduler = Executors.newSingleThreadScheduledExecutor(
+                new ExecutorProvider.ExtendedThreadFactory("oauth2-tls-cert-refresher"));
+        sslRefreshScheduler.scheduleAtFixedRate(this::refreshSslContext,
+                refreshSeconds, refreshSeconds, TimeUnit.SECONDS);
+        log.info("Scheduled TLS certificate refresh every {} seconds", refreshSeconds);
+    }
+
+    protected void refreshSslContext() {
+        if (this.sslFactory == null) {
+            return;
+        }
+        try {
+            this.sslFactory.update();
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully refreshed SSL context");
+            }
+        } catch (Exception e) {
+            log.error("Failed to refresh SSL context", e);
+        }
+    }
+
+    private int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
         return (int) getParameterDuration(name, value, defaultValue).toMillis();
     }
 
-    protected long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
+    private long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
         return getParameterDuration(name, value, defaultValue).getSeconds();
     }
 
@@ -160,6 +221,9 @@ abstract class FlowBase implements Flow {
 
     @Override
     public void close() throws Exception {
+        if (sslRefreshScheduler != null) {
+            sslRefreshScheduler.shutdownNow();
+        }
         httpClient.close();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -56,7 +56,7 @@ abstract class FlowBase implements Flow {
     public static final String CONFIG_PARAM_READ_TIMEOUT = "readTimeout";
     public static final String CONFIG_PARAM_TRUST_CERTS_FILE_PATH = "trustCertsFilePath";
     public static final String CONFIG_PARAM_CERT_FILE = "tlsCertFile";
-    public static final String CONFIG_PARAM_KEY_FILE = "tlsKeyFile";
+    public static final String CONFIG_PARAM_TLS_KEY_FILE = "tlsKeyFile";
     public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION = "autoCertRefreshDuration";
     public static final String CONFIG_PARAM_WELL_KNOWN_METADATA_PATH = "wellKnownMetadataPath";
 
@@ -97,7 +97,13 @@ abstract class FlowBase implements Flow {
         confBuilder.setReadTimeout(
                 getParameterDurationToMillis(CONFIG_PARAM_READ_TIMEOUT, readTimeout, DEFAULT_READ_TIMEOUT));
         confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
-        if (StringUtils.isNotBlank(certFile) && StringUtils.isNotBlank(keyFile)) {
+        boolean hasCertFile = StringUtils.isNotBlank(certFile);
+        boolean hasKeyFile = StringUtils.isNotBlank(keyFile);
+        if (hasCertFile != hasKeyFile) {
+            throw new IllegalArgumentException("Invalid TLS client certificate configuration: " + CONFIG_PARAM_CERT_FILE
+                    + " and " + CONFIG_PARAM_TLS_KEY_FILE + " must be provided together");
+        }
+        if (hasCertFile && hasKeyFile) {
             try {
                 PulsarSslConfiguration sslConfiguration = PulsarSslConfiguration.builder()
                         .tlsCertificateFilePath(certFile)
@@ -127,7 +133,7 @@ abstract class FlowBase implements Flow {
         return new DefaultAsyncHttpClient(confBuilder.build());
     }
 
-    protected void scheduleSslContextRefreshIfEnabled(long refreshSeconds) {
+    private void scheduleSslContextRefreshIfEnabled(long refreshSeconds) {
         if (sslFactory == null || refreshSeconds <= 0 || sslRefreshScheduler != null) {
             return;
         }
@@ -138,7 +144,7 @@ abstract class FlowBase implements Flow {
         log.info("Scheduled TLS certificate refresh every {} seconds", refreshSeconds);
     }
 
-    protected void refreshSslContext() {
+    private void refreshSslContext() {
         if (this.sslFactory == null) {
             return;
         }
@@ -225,5 +231,8 @@ abstract class FlowBase implements Flow {
             sslRefreshScheduler.shutdownNow();
         }
         httpClient.close();
+        if (sslFactory != null) {
+            sslFactory.close();
+        }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -138,7 +138,7 @@ abstract class FlowBase implements Flow {
             return;
         }
         sslRefreshScheduler = Executors.newSingleThreadScheduledExecutor(
-                new ExecutorProvider.ExtendedThreadFactory("oauth2-tls-cert-refresher"));
+                new ExecutorProvider.ExtendedThreadFactory("oauth2-tls-cert-refresher", true));
         sslRefreshScheduler.scheduleWithFixedDelay(this::refreshSslContext,
                 refreshSeconds, refreshSeconds, TimeUnit.SECONDS);
         log.info("Scheduled TLS certificate refresh every {} seconds", refreshSeconds);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -139,7 +139,7 @@ abstract class FlowBase implements Flow {
         }
         sslRefreshScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ExecutorProvider.ExtendedThreadFactory("oauth2-tls-cert-refresher"));
-        sslRefreshScheduler.scheduleAtFixedRate(this::refreshSslContext,
+        sslRefreshScheduler.scheduleWithFixedDelay(this::refreshSslContext,
                 refreshSeconds, refreshSeconds, TimeUnit.SECONDS);
         log.info("Scheduled TLS certificate refresh every {} seconds", refreshSeconds);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -98,6 +98,14 @@ abstract class FlowBase implements Flow {
     }
 
     protected static int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
+        return (int) getParameterDuration(name, value, defaultValue).toMillis();
+    }
+
+    protected static long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
+        return getParameterDuration(name, value, defaultValue).getSeconds();
+    }
+
+    private static Duration getParameterDuration(String name, Duration value, Duration defaultValue) {
         Duration duration;
         if (value == null) {
                 log.debug().attr("name", name)
@@ -108,21 +116,7 @@ abstract class FlowBase implements Flow {
                 log.debug().attr("name", name).attr("value", value).log("Configuration");
             duration = value;
         }
-
-        return (int) duration.toMillis();
-    }
-
-    protected static long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
-        Duration duration;
-        if (value == null) {
-            log.info("Configuration for [{}] is using the default value: [{}]", name, defaultValue);
-            duration = defaultValue;
-        } else {
-            log.info("Configuration for [{}] is: [{}]", name, value);
-            duration = value;
-        }
-
-        return duration.getSeconds();
+        return duration;
     }
 
     public void initialize() throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -141,7 +141,7 @@ abstract class FlowBase implements Flow {
                 new ExecutorProvider.ExtendedThreadFactory("oauth2-tls-cert-refresher", true));
         sslRefreshScheduler.scheduleWithFixedDelay(this::refreshSslContext,
                 refreshSeconds, refreshSeconds, TimeUnit.SECONDS);
-        log.info("Scheduled TLS certificate refresh every {} seconds", refreshSeconds);
+        log.info().attr("refreshSeconds", refreshSeconds).log("Scheduled TLS certificate refresh");
     }
 
     private void refreshSslContext() {
@@ -150,11 +150,9 @@ abstract class FlowBase implements Flow {
         }
         try {
             this.sslFactory.update();
-            if (log.isDebugEnabled()) {
-                log.debug("Successfully refreshed SSL context");
-            }
+            log.debug("Successfully refreshed SSL context");
         } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
+            log.error().exception(e).log("Failed to refresh SSL context");
         }
     }
 
@@ -169,12 +167,12 @@ abstract class FlowBase implements Flow {
     private Duration getParameterDuration(String name, Duration value, Duration defaultValue) {
         Duration duration;
         if (value == null) {
-                log.debug().attr("name", name)
-                        .attr("defaultValue", defaultValue)
-                        .log("Configuration is using the default value");
+            log.debug().attr("name", name)
+                    .attr("defaultValue", defaultValue)
+                    .log("Configuration is using the default value");
             duration = defaultValue;
         } else {
-                log.debug().attr("name", name).attr("value", value).log("Configuration");
+            log.debug().attr("name", name).attr("value", value).log("Configuration");
             duration = value;
         }
         return duration;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/FlowBase.java
@@ -67,8 +67,14 @@ abstract class FlowBase implements Flow {
         this.wellKnownMetadataPath = wellKnownMetadataPath;
     }
 
-    private AsyncHttpClient defaultHttpClient(Duration readTimeout, Duration connectTimeout,
-                                              String trustCertsFilePath) {
+    protected FlowBase(URL issuerUrl, AsyncHttpClient httpClient, String wellKnownMetadataPath) {
+        this.issuerUrl = issuerUrl;
+        this.httpClient = httpClient;
+        this.wellKnownMetadataPath = wellKnownMetadataPath;
+    }
+
+    protected static AsyncHttpClient defaultHttpClient(Duration readTimeout, Duration connectTimeout,
+                                                       String trustCertsFilePath) {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setCookieStore(null);
         confBuilder.setUseProxyProperties(true);
@@ -91,7 +97,7 @@ abstract class FlowBase implements Flow {
         return new DefaultAsyncHttpClient(confBuilder.build());
     }
 
-    private int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
+    protected static int getParameterDurationToMillis(String name, Duration value, Duration defaultValue) {
         Duration duration;
         if (value == null) {
                 log.debug().attr("name", name)
@@ -104,6 +110,19 @@ abstract class FlowBase implements Flow {
         }
 
         return (int) duration.toMillis();
+    }
+
+    protected static long getParameterDurationToSeconds(String name, Duration value, Duration defaultValue) {
+        Duration duration;
+        if (value == null) {
+            log.info("Configuration for [{}] is using the default value: [{}]", name, defaultValue);
+            duration = defaultValue;
+        } else {
+            log.info("Configuration for [{}] is: [{}]", name, value);
+            duration = value;
+        }
+
+        return duration.getSeconds();
     }
 
     public void initialize() throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.Map;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
@@ -63,7 +64,7 @@ class TlsClientAuthFlow extends FlowBase {
                              String wellKnownMetadataPath, Duration autoCertRefreshDuration) {
         super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, certFile, keyFile, autoCertRefreshDuration,
                 wellKnownMetadataPath);
-        this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
+        this.clientId = StringUtils.defaultIfBlank(clientId, DEFAULT_CLIENT_ID);
         this.audience = audience;
         this.scope = scope;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -83,11 +83,11 @@ class TlsClientAuthFlow extends FlowBase {
     private TlsClientAuthFlow(URL issuerUrl, String clientId, String audience, String scope,
                               String wellKnownMetadataPath, Duration autoCertRefreshDuration,
                               TlsHttpClientContext tlsHttpClientContext) {
-        super(issuerUrl, tlsHttpClientContext.httpClient, wellKnownMetadataPath);
+        super(issuerUrl, tlsHttpClientContext.httpClient(), wellKnownMetadataPath);
         this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
         this.audience = audience;
         this.scope = scope;
-        this.sslFactory = tlsHttpClientContext.sslFactory;
+        this.sslFactory = tlsHttpClientContext.sslFactory();
         this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
                 autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
     }
@@ -105,7 +105,7 @@ class TlsClientAuthFlow extends FlowBase {
         String clientId = params.getOrDefault(CONFIG_PARAM_CLIENT_ID, DEFAULT_CLIENT_ID);
         String certFile = parseParameterString(params, CONFIG_PARAM_CERT_FILE);
         String keyFile = parseParameterString(params, CONFIG_PARAM_KEY_FILE);
-        // These are optional parameters, so we only perform a get
+        // These are optional parameters, so we allow null values
         String scope = params.get(CONFIG_PARAM_SCOPE);
         String audience = params.get(CONFIG_PARAM_AUDIENCE);
         Duration connectTimeout = parseParameterDuration(params, CONFIG_PARAM_CONNECT_TIMEOUT);
@@ -234,13 +234,5 @@ class TlsClientAuthFlow extends FlowBase {
         }
     }
 
-    private static final class TlsHttpClientContext {
-        private final AsyncHttpClient httpClient;
-        private final PulsarSslFactory sslFactory;
-
-        private TlsHttpClientContext(AsyncHttpClient httpClient, PulsarSslFactory sslFactory) {
-            this.httpClient = httpClient;
-            this.sslFactory = sslFactory;
-        }
-    }
+    private record TlsHttpClientContext(AsyncHttpClient httpClient, PulsarSslFactory sslFactory) { }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.oauth2;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.PulsarVersion;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
+import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.client.util.PulsarHttpAsyncSslEngineFactory;
+import org.apache.pulsar.common.util.PulsarSslConfiguration;
+import org.apache.pulsar.common.util.PulsarSslFactory;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+
+/**
+ * Implementation of OAuth 2.0 Client TLS Authentication flow.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8705">RFC 8705 - OAuth 2.0 Mutual-TLS Client Authentication</a>
+ */
+@Slf4j
+class TlsClientAuthFlow extends FlowBase {
+    public static final String CONFIG_PARAM_ISSUER_URL = "issuerUrl";
+    public static final String CONFIG_PARAM_CLIENT_ID = "clientId";
+    public static final String CONFIG_PARAM_CERT_FILE = "tlsCertFile";
+    public static final String CONFIG_PARAM_KEY_FILE = "tlsKeyFile";
+    public static final String CONFIG_PARAM_AUDIENCE = "audience";
+    public static final String CONFIG_PARAM_SCOPE = "scope";
+    public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION = "autoCertRefreshDuration";
+
+    private static final Duration DEFAULT_AUTO_CERT_REFRESH_DURATION = Duration.ofSeconds(300);
+    private static final String DEFAULT_CLIENT_ID = "pulsar-client";
+
+    private static final long serialVersionUID = 1L;
+
+    private final String clientId;
+    private final String audience;
+    private final String scope;
+    private final long autoCertRefreshSeconds; // Certificate refresh interval in seconds
+
+    private transient TokenClient exchanger;
+    private transient ScheduledExecutorService scheduler;
+    private transient PulsarSslFactory sslFactory;
+
+    private boolean initialized = false;
+
+    @Builder
+    public TlsClientAuthFlow(URL issuerUrl, String clientId, String certFile, String keyFile, String audience,
+                             String scope, Duration connectTimeout, Duration readTimeout, String trustCertsFilePath,
+                             String wellKnownMetadataPath, Duration autoCertRefreshDuration) {
+        this(issuerUrl, clientId, audience, scope, wellKnownMetadataPath, autoCertRefreshDuration,
+                createTlsHttpClientContext(readTimeout, connectTimeout, trustCertsFilePath, certFile, keyFile));
+    }
+
+    private TlsClientAuthFlow(URL issuerUrl, String clientId, String audience, String scope,
+                              String wellKnownMetadataPath, Duration autoCertRefreshDuration,
+                              TlsHttpClientContext tlsHttpClientContext) {
+        super(issuerUrl, tlsHttpClientContext.httpClient, wellKnownMetadataPath);
+        this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
+        this.audience = audience;
+        this.scope = scope;
+        this.sslFactory = tlsHttpClientContext.sslFactory;
+        this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
+                autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
+    }
+
+    /**
+     * Constructs a {@link TlsClientAuthFlow} from configuration parameters.
+     *
+     * @param params Configuration parameters
+     * @return A new TlsClientAuthFlow instance
+     */
+    public static TlsClientAuthFlow fromParameters(Map<String, String> params) {
+        URL issuerUrl = parseParameterUrl(params, CONFIG_PARAM_ISSUER_URL);
+        // In mTLS-based providers, caller input for client_id can be optional.
+        // Keep sending client_id in token request for RFC compatibility by applying a default value.
+        String clientId = params.getOrDefault(CONFIG_PARAM_CLIENT_ID, DEFAULT_CLIENT_ID);
+        String certFile = parseParameterString(params, CONFIG_PARAM_CERT_FILE);
+        String keyFile = parseParameterString(params, CONFIG_PARAM_KEY_FILE);
+        // These are optional parameters, so we only perform a get
+        String scope = params.get(CONFIG_PARAM_SCOPE);
+        String audience = params.get(CONFIG_PARAM_AUDIENCE);
+        Duration connectTimeout = parseParameterDuration(params, CONFIG_PARAM_CONNECT_TIMEOUT);
+        Duration readTimeout = parseParameterDuration(params, CONFIG_PARAM_READ_TIMEOUT);
+        String trustCertsFilePath = params.get(CONFIG_PARAM_TRUST_CERTS_FILE_PATH);
+        String wellKnownMetadataPath = params.get(CONFIG_PARAM_WELL_KNOWN_METADATA_PATH);
+        Duration autoCertRefreshDuration = parseParameterDuration(params, CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION);
+
+        return TlsClientAuthFlow.builder()
+                .issuerUrl(issuerUrl)
+                .clientId(clientId)
+                .certFile(certFile)
+                .keyFile(keyFile)
+                .audience(audience)
+                .scope(scope)
+                .connectTimeout(connectTimeout)
+                .readTimeout(readTimeout)
+                .trustCertsFilePath(trustCertsFilePath)
+                .wellKnownMetadataPath(wellKnownMetadataPath)
+                .autoCertRefreshDuration(autoCertRefreshDuration)
+                .build();
+    }
+
+    @Override
+    public void initialize() throws PulsarClientException {
+        super.initialize();
+        assert this.metadata != null;
+
+        URL tokenUrl = this.metadata.getTokenEndpoint();
+        this.exchanger = new TokenClient(tokenUrl, this.httpClient);
+
+        if (sslFactory != null && autoCertRefreshSeconds > 0) {
+            scheduler = Executors.newSingleThreadScheduledExecutor(new ExecutorProvider
+                            .ExtendedThreadFactory("tls-cert-refresher"));
+            scheduler.scheduleAtFixedRate(this::refreshSslContext,
+                autoCertRefreshSeconds, autoCertRefreshSeconds, TimeUnit.SECONDS);
+
+            log.info("Scheduled TLS certificate refresh every {} seconds", autoCertRefreshSeconds);
+        }
+
+        initialized = true;
+    }
+
+    protected static PulsarSslConfiguration buildSslConfiguration(String certFile, String keyFile,
+                                                                  String trustCertsFilePath) {
+        return PulsarSslConfiguration.builder()
+                .tlsCertificateFilePath(certFile)
+                .tlsKeyFilePath(keyFile)
+                .tlsTrustCertsFilePath(trustCertsFilePath)
+                .allowInsecureConnection(false)
+                .serverMode(false)
+                .isHttps(true)
+                .build();
+    }
+
+    private static TlsHttpClientContext createTlsHttpClientContext(Duration readTimeout, Duration connectTimeout,
+                                                                    String trustCertsFilePath, String certFile,
+                                                                    String keyFile) {
+        try {
+            PulsarSslConfiguration sslConfiguration = buildSslConfiguration(certFile, keyFile, trustCertsFilePath);
+            PulsarSslFactory sslFactory = new org.apache.pulsar.common.util.DefaultPulsarSslFactory();
+            sslFactory.initialize(sslConfiguration);
+            sslFactory.createInternalSslContext();
+
+            DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
+            confBuilder.setCookieStore(null);
+            confBuilder.setUseProxyProperties(true);
+            confBuilder.setFollowRedirect(true);
+            confBuilder.setConnectTimeout(
+                    getParameterDurationToMillis(
+                            CONFIG_PARAM_CONNECT_TIMEOUT, connectTimeout, DEFAULT_CONNECT_TIMEOUT));
+            confBuilder.setReadTimeout(
+                    getParameterDurationToMillis(CONFIG_PARAM_READ_TIMEOUT, readTimeout, DEFAULT_READ_TIMEOUT));
+            confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
+            confBuilder.setSslEngineFactory(new PulsarHttpAsyncSslEngineFactory(sslFactory, null));
+
+            return new TlsHttpClientContext(new DefaultAsyncHttpClient(confBuilder.build()), sslFactory);
+        } catch (Exception e) {
+            log.error("Failed to initialize HTTP client for TLS client authentication", e);
+            return new TlsHttpClientContext(
+                    defaultHttpClient(readTimeout, connectTimeout, trustCertsFilePath), null);
+        }
+    }
+
+    protected void refreshSslContext() {
+        if (this.sslFactory == null) {
+            return;
+        }
+        try {
+            this.sslFactory.update();
+            log.debug("Successfully refreshed SSL context");
+        } catch (Exception e) {
+            log.error("Failed to refresh SSL context", e);
+        }
+    }
+
+    public TokenResult authenticate() throws PulsarClientException {
+        // request an access token using TLS client authentication
+        ClientCredentialsExchangeRequest req = ClientCredentialsExchangeRequest.builder()
+                .clientId(this.clientId)
+                .audience(this.audience)
+                .scope(this.scope)
+                .build();
+        TokenResult tr;
+        if (!initialized) {
+            initialize();
+        }
+        try {
+            tr = this.exchanger.exchangeTlsClientAuth(req);
+        } catch (TokenExchangeException | IOException e) {
+            throw new PulsarClientException.AuthenticationException("Unable to obtain an access token: "
+                    + e.getMessage());
+        }
+
+        return tr;
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+        if (exchanger != null) {
+            exchanger.close();
+        }
+    }
+
+    private static final class TlsHttpClientContext {
+        private final AsyncHttpClient httpClient;
+        private final PulsarSslFactory sslFactory;
+
+        private TlsHttpClientContext(AsyncHttpClient httpClient, PulsarSslFactory sslFactory) {
+            this.httpClient = httpClient;
+            this.sslFactory = sslFactory;
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
@@ -145,5 +146,10 @@ class TlsClientAuthFlow extends FlowBase {
         if (exchanger != null) {
             exchanger.close();
         }
+    }
+
+    @VisibleForTesting
+    String getClientId() {
+        return clientId;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -40,8 +40,6 @@ import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
 class TlsClientAuthFlow extends FlowBase {
     public static final String CONFIG_PARAM_ISSUER_URL = "issuerUrl";
     public static final String CONFIG_PARAM_CLIENT_ID = "clientId";
-    public static final String CONFIG_PARAM_CERT_FILE = FlowBase.CONFIG_PARAM_CERT_FILE;
-    public static final String CONFIG_PARAM_KEY_FILE = FlowBase.CONFIG_PARAM_KEY_FILE;
     public static final String CONFIG_PARAM_AUDIENCE = "audience";
     public static final String CONFIG_PARAM_SCOPE = "scope";
     public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION =
@@ -82,7 +80,7 @@ class TlsClientAuthFlow extends FlowBase {
         // Keep sending client_id in token request for RFC compatibility by applying a default value.
         String clientId = params.getOrDefault(CONFIG_PARAM_CLIENT_ID, DEFAULT_CLIENT_ID);
         String certFile = parseParameterString(params, CONFIG_PARAM_CERT_FILE);
-        String keyFile = parseParameterString(params, CONFIG_PARAM_KEY_FILE);
+        String keyFile = parseParameterString(params, CONFIG_PARAM_TLS_KEY_FILE);
         // These are optional parameters, so we allow null values
         String scope = params.get(CONFIG_PARAM_SCOPE);
         String audience = params.get(CONFIG_PARAM_AUDIENCE);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.SslEngineFactory;
 
 /**
  * Implementation of OAuth 2.0 Client TLS Authentication flow.
@@ -65,10 +66,16 @@ class TlsClientAuthFlow extends FlowBase {
     private final String audience;
     private final String scope;
     private final long autoCertRefreshSeconds; // Certificate refresh interval in seconds
+    private final Duration connectTimeout;
+    private final Duration readTimeout;
+    private final String trustCertsFilePath;
+    private final String certFile;
+    private final String keyFile;
 
     private transient TokenClient exchanger;
     private transient ScheduledExecutorService scheduler;
     private transient PulsarSslFactory sslFactory;
+    private transient AsyncHttpClient tokenHttpClient;
 
     private boolean initialized = false;
 
@@ -76,20 +83,17 @@ class TlsClientAuthFlow extends FlowBase {
     public TlsClientAuthFlow(URL issuerUrl, String clientId, String certFile, String keyFile, String audience,
                              String scope, Duration connectTimeout, Duration readTimeout, String trustCertsFilePath,
                              String wellKnownMetadataPath, Duration autoCertRefreshDuration) {
-        this(issuerUrl, clientId, audience, scope, wellKnownMetadataPath, autoCertRefreshDuration,
-                createTlsHttpClientContext(readTimeout, connectTimeout, trustCertsFilePath, certFile, keyFile));
-    }
-
-    private TlsClientAuthFlow(URL issuerUrl, String clientId, String audience, String scope,
-                              String wellKnownMetadataPath, Duration autoCertRefreshDuration,
-                              TlsHttpClientContext tlsHttpClientContext) {
-        super(issuerUrl, tlsHttpClientContext.httpClient(), wellKnownMetadataPath);
+        super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, wellKnownMetadataPath);
         this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
         this.audience = audience;
         this.scope = scope;
-        this.sslFactory = tlsHttpClientContext.sslFactory();
         this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
                 autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        this.trustCertsFilePath = trustCertsFilePath;
+        this.certFile = certFile;
+        this.keyFile = keyFile;
     }
 
     /**
@@ -135,7 +139,11 @@ class TlsClientAuthFlow extends FlowBase {
         assert this.metadata != null;
 
         URL tokenUrl = this.metadata.getTokenEndpoint();
-        this.exchanger = new TokenClient(tokenUrl, this.httpClient);
+        TlsHttpClientContext tlsHttpClientContext = createTlsHttpClientContext(tokenUrl.getHost());
+        this.tokenHttpClient = tlsHttpClientContext.httpClient();
+        this.sslFactory = tlsHttpClientContext.sslFactory();
+
+        this.exchanger = new TokenClient(tokenUrl, this.tokenHttpClient);
 
         if (sslFactory != null && autoCertRefreshSeconds > 0) {
             scheduler = Executors.newSingleThreadScheduledExecutor(new ExecutorProvider
@@ -149,8 +157,7 @@ class TlsClientAuthFlow extends FlowBase {
         initialized = true;
     }
 
-    protected static PulsarSslConfiguration buildSslConfiguration(String certFile, String keyFile,
-                                                                  String trustCertsFilePath) {
+    private PulsarSslConfiguration buildSslConfiguration() {
         return PulsarSslConfiguration.builder()
                 .tlsCertificateFilePath(certFile)
                 .tlsKeyFilePath(keyFile)
@@ -161,11 +168,9 @@ class TlsClientAuthFlow extends FlowBase {
                 .build();
     }
 
-    private static TlsHttpClientContext createTlsHttpClientContext(Duration readTimeout, Duration connectTimeout,
-                                                                    String trustCertsFilePath, String certFile,
-                                                                    String keyFile) {
+    private TlsHttpClientContext createTlsHttpClientContext(String hostname) throws PulsarClientException {
         try {
-            PulsarSslConfiguration sslConfiguration = buildSslConfiguration(certFile, keyFile, trustCertsFilePath);
+            PulsarSslConfiguration sslConfiguration = buildSslConfiguration();
             PulsarSslFactory sslFactory = new org.apache.pulsar.common.util.DefaultPulsarSslFactory();
             sslFactory.initialize(sslConfiguration);
             sslFactory.createInternalSslContext();
@@ -180,17 +185,16 @@ class TlsClientAuthFlow extends FlowBase {
             confBuilder.setReadTimeout(
                     getParameterDurationToMillis(CONFIG_PARAM_READ_TIMEOUT, readTimeout, DEFAULT_READ_TIMEOUT));
             confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
-            confBuilder.setSslEngineFactory(new PulsarHttpAsyncSslEngineFactory(sslFactory, null));
+            SslEngineFactory sslEngineFactory = new PulsarHttpAsyncSslEngineFactory(sslFactory, hostname);
+            confBuilder.setSslEngineFactory(sslEngineFactory);
 
             return new TlsHttpClientContext(new DefaultAsyncHttpClient(confBuilder.build()), sslFactory);
         } catch (Exception e) {
-            log.error("Failed to initialize HTTP client for TLS client authentication", e);
-            return new TlsHttpClientContext(
-                    defaultHttpClient(readTimeout, connectTimeout, trustCertsFilePath), null);
+            throw new PulsarClientException.InvalidConfigurationException(e);
         }
     }
 
-    protected void refreshSslContext() {
+    private void refreshSslContext() {
         if (this.sslFactory == null) {
             return;
         }
@@ -231,6 +235,8 @@ class TlsClientAuthFlow extends FlowBase {
         }
         if (exchanger != null) {
             exchanger.close();
+        } else if (tokenHttpClient != null) {
+            tokenHttpClient.close();
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
@@ -212,13 +213,14 @@ class TlsClientAuthFlow extends FlowBase {
                 .clientId(this.clientId)
                 .audience(this.audience)
                 .scope(this.scope)
+                .authMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                 .build();
         TokenResult tr;
         if (!initialized) {
             initialize();
         }
         try {
-            tr = this.exchanger.exchangeTlsClientAuth(req);
+            tr = this.exchanger.exchangeClientCredentials(req);
         } catch (TokenExchangeException | IOException e) {
             throw new PulsarClientException.AuthenticationException("Unable to obtain an access token: "
                     + e.getMessage());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -22,26 +22,14 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExchangeRequest;
-import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
-import org.apache.pulsar.client.util.ExecutorProvider;
-import org.apache.pulsar.client.util.PulsarHttpAsyncSslEngineFactory;
-import org.apache.pulsar.common.util.PulsarSslConfiguration;
-import org.apache.pulsar.common.util.PulsarSslFactory;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClientConfig;
-import org.asynchttpclient.SslEngineFactory;
 
 /**
  * Implementation of OAuth 2.0 Client TLS Authentication flow.
@@ -52,31 +40,22 @@ import org.asynchttpclient.SslEngineFactory;
 class TlsClientAuthFlow extends FlowBase {
     public static final String CONFIG_PARAM_ISSUER_URL = "issuerUrl";
     public static final String CONFIG_PARAM_CLIENT_ID = "clientId";
-    public static final String CONFIG_PARAM_CERT_FILE = "tlsCertFile";
-    public static final String CONFIG_PARAM_KEY_FILE = "tlsKeyFile";
+    public static final String CONFIG_PARAM_CERT_FILE = FlowBase.CONFIG_PARAM_CERT_FILE;
+    public static final String CONFIG_PARAM_KEY_FILE = FlowBase.CONFIG_PARAM_KEY_FILE;
     public static final String CONFIG_PARAM_AUDIENCE = "audience";
     public static final String CONFIG_PARAM_SCOPE = "scope";
-    public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION = "autoCertRefreshDuration";
+    public static final String CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION =
+            FlowBase.CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION;
 
-    private static final Duration DEFAULT_AUTO_CERT_REFRESH_DURATION = Duration.ofSeconds(300);
     private static final String DEFAULT_CLIENT_ID = "pulsar-client";
 
     private static final long serialVersionUID = 1L;
 
     private final String clientId;
-    private final String certFile;
-    private final String keyFile;
     private final String audience;
     private final String scope;
-    private final long autoCertRefreshSeconds; // Certificate refresh interval in seconds
-    private final Duration connectTimeout;
-    private final Duration readTimeout;
-    private final String trustCertsFilePath;
 
     private transient TokenClient exchanger;
-    private transient ScheduledExecutorService scheduler;
-    private transient PulsarSslFactory sslFactory;
-    private transient AsyncHttpClient tokenHttpClient;
 
     private boolean initialized = false;
 
@@ -84,17 +63,11 @@ class TlsClientAuthFlow extends FlowBase {
     public TlsClientAuthFlow(URL issuerUrl, String clientId, String certFile, String keyFile, String audience,
                              String scope, Duration connectTimeout, Duration readTimeout, String trustCertsFilePath,
                              String wellKnownMetadataPath, Duration autoCertRefreshDuration) {
-        super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, wellKnownMetadataPath);
+        super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, certFile, keyFile, autoCertRefreshDuration,
+                wellKnownMetadataPath);
         this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
-        this.certFile = certFile;
-        this.keyFile = keyFile;
         this.audience = audience;
         this.scope = scope;
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
-        this.trustCertsFilePath = trustCertsFilePath;
-        this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
-                autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
     }
 
     /**
@@ -140,71 +113,9 @@ class TlsClientAuthFlow extends FlowBase {
         assert this.metadata != null;
 
         URL tokenUrl = this.metadata.getTokenEndpoint();
-        TlsHttpClientContext tlsHttpClientContext = createTlsHttpClientContext(tokenUrl.getHost());
-        this.tokenHttpClient = tlsHttpClientContext.httpClient();
-        this.sslFactory = tlsHttpClientContext.sslFactory();
-
-        this.exchanger = new TokenClient(tokenUrl, this.tokenHttpClient);
-
-        if (sslFactory != null && autoCertRefreshSeconds > 0) {
-            scheduler = Executors.newSingleThreadScheduledExecutor(new ExecutorProvider
-                            .ExtendedThreadFactory("tls-cert-refresher"));
-            scheduler.scheduleAtFixedRate(this::refreshSslContext,
-                autoCertRefreshSeconds, autoCertRefreshSeconds, TimeUnit.SECONDS);
-
-            log.info("Scheduled TLS certificate refresh every {} seconds", autoCertRefreshSeconds);
-        }
+        this.exchanger = new TokenClient(tokenUrl, httpClient);
 
         initialized = true;
-    }
-
-    private PulsarSslConfiguration buildSslConfiguration() {
-        return PulsarSslConfiguration.builder()
-                .tlsCertificateFilePath(certFile)
-                .tlsKeyFilePath(keyFile)
-                .tlsTrustCertsFilePath(trustCertsFilePath)
-                .allowInsecureConnection(false)
-                .serverMode(false)
-                .isHttps(true)
-                .build();
-    }
-
-    private TlsHttpClientContext createTlsHttpClientContext(String hostname) throws PulsarClientException {
-        try {
-            PulsarSslConfiguration sslConfiguration = buildSslConfiguration();
-            PulsarSslFactory sslFactory = new org.apache.pulsar.common.util.DefaultPulsarSslFactory();
-            sslFactory.initialize(sslConfiguration);
-            sslFactory.createInternalSslContext();
-
-            DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
-            confBuilder.setCookieStore(null);
-            confBuilder.setUseProxyProperties(true);
-            confBuilder.setFollowRedirect(true);
-            confBuilder.setConnectTimeout(
-                    getParameterDurationToMillis(
-                            CONFIG_PARAM_CONNECT_TIMEOUT, connectTimeout, DEFAULT_CONNECT_TIMEOUT));
-            confBuilder.setReadTimeout(
-                    getParameterDurationToMillis(CONFIG_PARAM_READ_TIMEOUT, readTimeout, DEFAULT_READ_TIMEOUT));
-            confBuilder.setUserAgent(String.format("Pulsar-Java-v%s", PulsarVersion.getVersion()));
-            SslEngineFactory sslEngineFactory = new PulsarHttpAsyncSslEngineFactory(sslFactory, hostname);
-            confBuilder.setSslEngineFactory(sslEngineFactory);
-
-            return new TlsHttpClientContext(new DefaultAsyncHttpClient(confBuilder.build()), sslFactory);
-        } catch (Exception e) {
-            throw new PulsarClientException.InvalidConfigurationException(e);
-        }
-    }
-
-    private void refreshSslContext() {
-        if (this.sslFactory == null) {
-            return;
-        }
-        try {
-            this.sslFactory.update();
-            log.debug("Successfully refreshed SSL context");
-        } catch (Exception e) {
-            log.error("Failed to refresh SSL context", e);
-        }
     }
 
     public TokenResult authenticate() throws PulsarClientException {
@@ -232,15 +143,8 @@ class TlsClientAuthFlow extends FlowBase {
     @Override
     public void close() throws Exception {
         super.close();
-        if (scheduler != null) {
-            scheduler.shutdownNow();
-        }
         if (exchanger != null) {
             exchanger.close();
-        } else if (tokenHttpClient != null) {
-            tokenHttpClient.close();
         }
     }
-
-    private record TlsHttpClientContext(AsyncHttpClient httpClient, PulsarSslFactory sslFactory) { }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlow.java
@@ -63,14 +63,14 @@ class TlsClientAuthFlow extends FlowBase {
     private static final long serialVersionUID = 1L;
 
     private final String clientId;
+    private final String certFile;
+    private final String keyFile;
     private final String audience;
     private final String scope;
     private final long autoCertRefreshSeconds; // Certificate refresh interval in seconds
     private final Duration connectTimeout;
     private final Duration readTimeout;
     private final String trustCertsFilePath;
-    private final String certFile;
-    private final String keyFile;
 
     private transient TokenClient exchanger;
     private transient ScheduledExecutorService scheduler;
@@ -85,15 +85,15 @@ class TlsClientAuthFlow extends FlowBase {
                              String wellKnownMetadataPath, Duration autoCertRefreshDuration) {
         super(issuerUrl, connectTimeout, readTimeout, trustCertsFilePath, wellKnownMetadataPath);
         this.clientId = clientId == null ? DEFAULT_CLIENT_ID : clientId;
+        this.certFile = certFile;
+        this.keyFile = keyFile;
         this.audience = audience;
         this.scope = scope;
-        this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
-                autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.trustCertsFilePath = trustCertsFilePath;
-        this.certFile = certFile;
-        this.keyFile = keyFile;
+        this.autoCertRefreshSeconds = getParameterDurationToSeconds(CONFIG_PARAM_AUTO_CERT_REFRESH_DURATION,
+                autoCertRefreshDuration, DEFAULT_AUTO_CERT_REFRESH_DURATION);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -53,14 +53,13 @@ public class TokenClient implements ClientCredentialsExchanger {
      * Constructing http request parameters.
      *
      * @param req object with relevant request parameters
-     * @param includeSecret whether to include client_secret in the request body
      * @return Generate the final request body from a map.
      */
-    String buildClientCredentialsBody(ClientCredentialsExchangeRequest req, boolean includeSecret) {
+    String buildClientCredentialsBody(ClientCredentialsExchangeRequest req) {
         Map<String, String> bodyMap = new TreeMap<>();
         bodyMap.put("grant_type", "client_credentials");
         bodyMap.put("client_id", req.getClientId());
-        if (includeSecret) {
+        if (req.getAuthMethod() == TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
             bodyMap.put("client_secret", req.getClientSecret());
         }
         // Only set audience and scope if they are non-empty.
@@ -85,31 +84,7 @@ public class TokenClient implements ClientCredentialsExchanger {
      */
     public TokenResult exchangeClientCredentials(ClientCredentialsExchangeRequest req)
             throws TokenExchangeException, IOException {
-        String body = buildClientCredentialsBody(req, true);
-        return executeTokenRequest(body);
-    }
-
-    /**
-     * Performs a token exchange using TLS client authentication.
-     *
-     * @param req the client credentials request details for TLS client auth
-     * @return a token result
-     * @throws TokenExchangeException
-     */
-    public TokenResult exchangeTlsClientAuth(ClientCredentialsExchangeRequest req)
-            throws TokenExchangeException, IOException {
-        String body = buildClientCredentialsBody(req, false);
-        return executeTokenRequest(body);
-    }
-
-    /**
-     * Executes a token request with the given body.
-     *
-     * @param body the request body
-     * @return a token result
-     * @throws TokenExchangeException
-     */
-    private TokenResult executeTokenRequest(String body) throws TokenExchangeException, IOException {
+        String body = buildClientCredentialsBody(req);
         try {
 
             Response res = httpClient.preparePost(tokenUrl.toString())

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -56,10 +56,13 @@ public class TokenClient implements ClientCredentialsExchanger {
      * @return Generate the final request body from a map.
      */
     String buildClientCredentialsBody(ClientCredentialsExchangeRequest req) {
+        TokenEndpointAuthMethod authMethod = req.getAuthMethod() == null
+                ? TokenEndpointAuthMethod.CLIENT_SECRET_POST
+                : req.getAuthMethod();
         Map<String, String> bodyMap = new TreeMap<>();
         bodyMap.put("grant_type", "client_credentials");
         bodyMap.put("client_id", req.getClientId());
-        if (req.getAuthMethod() == TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
+        if (authMethod == TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
             bodyMap.put("client_secret", req.getClientSecret());
         }
         // Only set audience and scope if they are non-empty.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClient.java
@@ -53,13 +53,16 @@ public class TokenClient implements ClientCredentialsExchanger {
      * Constructing http request parameters.
      *
      * @param req object with relevant request parameters
+     * @param includeSecret whether to include client_secret in the request body
      * @return Generate the final request body from a map.
      */
-    String buildClientCredentialsBody(ClientCredentialsExchangeRequest req) {
+    String buildClientCredentialsBody(ClientCredentialsExchangeRequest req, boolean includeSecret) {
         Map<String, String> bodyMap = new TreeMap<>();
         bodyMap.put("grant_type", "client_credentials");
         bodyMap.put("client_id", req.getClientId());
-        bodyMap.put("client_secret", req.getClientSecret());
+        if (includeSecret) {
+            bodyMap.put("client_secret", req.getClientSecret());
+        }
         // Only set audience and scope if they are non-empty.
         if (!StringUtils.isBlank(req.getAudience())) {
             bodyMap.put("audience", req.getAudience());
@@ -82,8 +85,31 @@ public class TokenClient implements ClientCredentialsExchanger {
      */
     public TokenResult exchangeClientCredentials(ClientCredentialsExchangeRequest req)
             throws TokenExchangeException, IOException {
-        String body = buildClientCredentialsBody(req);
+        String body = buildClientCredentialsBody(req, true);
+        return executeTokenRequest(body);
+    }
 
+    /**
+     * Performs a token exchange using TLS client authentication.
+     *
+     * @param req the client credentials request details for TLS client auth
+     * @return a token result
+     * @throws TokenExchangeException
+     */
+    public TokenResult exchangeTlsClientAuth(ClientCredentialsExchangeRequest req)
+            throws TokenExchangeException, IOException {
+        String body = buildClientCredentialsBody(req, false);
+        return executeTokenRequest(body);
+    }
+
+    /**
+     * Executes a token request with the given body.
+     *
+     * @param body the request body
+     * @return a token result
+     * @throws TokenExchangeException
+     */
+    private TokenResult executeTokenRequest(String body) throws TokenExchangeException, IOException {
         try {
 
             Response res = httpClient.preparePost(tokenUrl.toString())

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenEndpointAuthMethod.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenEndpointAuthMethod.java
@@ -18,31 +18,26 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2.protocol;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Data;
+public enum TokenEndpointAuthMethod {
+    CLIENT_SECRET_POST("client_secret_post"),
+    TLS_CLIENT_AUTH("tls_client_auth");
 
-/**
- * A token request based on the exchange of client credentials.
- *
- * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">OAuth 2.0 RFC 6749, section 4.4</a>
- */
-@Data
-@Builder
-public class ClientCredentialsExchangeRequest {
+    private final String value;
 
-    @JsonProperty("client_id")
-    private String clientId;
+    TokenEndpointAuthMethod(String value) {
+        this.value = value;
+    }
 
-    @JsonProperty("client_secret")
-    private String clientSecret;
+    public String value() {
+        return value;
+    }
 
-    @JsonProperty("audience")
-    private String audience;
-
-    @JsonProperty("scope")
-    private String scope;
-
-    @JsonProperty("token_endpoint_auth_method")
-    private TokenEndpointAuthMethod authMethod;
+    public static TokenEndpointAuthMethod fromValue(String value) {
+        for (TokenEndpointAuthMethod method : values()) {
+            if (method.value.equalsIgnoreCase(value)) {
+                return method;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported token endpoint auth method: " + value);
+    }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.testng.annotations.Test;
 
 public class AuthenticationFactoryOAuth2Test {
@@ -60,6 +61,7 @@ public class AuthenticationFactoryOAuth2Test {
         Duration autoCertRefreshDuration = Duration.ofSeconds(123);
         try (Authentication authentication =
                      AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
+                             .tokenEndpointAuthMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                              .clientId(clientId)
                              .tlsCertFile(tlsCertFile)
                              .tlsKeyFile(tlsKeyFile)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl.auth.oauth2;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URL;
@@ -38,20 +39,22 @@ public class AuthenticationFactoryOAuth2Test {
         Duration connectTimeout = Duration.parse("PT11S");
         Duration readTimeout = Duration.ofSeconds(31);
         String trustCertsFilePath = null;
+        String tlsCertFile = "";
+        String tlsKeyFile = "";
         String wellKnownMetadataPath = "/.well-known/custom-path";
         try (Authentication authentication =
                      AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
                              .credentialsUrl(credentialsUrl).audience(audience).scope(scope)
                              .connectTimeout(connectTimeout).readTimeout(readTimeout)
-                             .trustCertsFilePath(trustCertsFilePath)
-                             .wellKnownMetadataPath(wellKnownMetadataPath).build()) {
+                             .trustCertsFilePath(trustCertsFilePath).tlsCertFile(tlsCertFile)
+                             .tlsKeyFile(tlsKeyFile).wellKnownMetadataPath(wellKnownMetadataPath).build()) {
             assertTrue(authentication instanceof AuthenticationOAuth2);
             assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), ClientCredentialsFlow.class);
         }
     }
 
     @Test
-    public void testBuilderWithTlsClientAuthFlow() throws IOException {
+    public void testBuilderWithTlsClientAuthFlow() throws Exception {
         URL issuerUrl = new URL("http://localhost");
         String clientId = "test-client";
         String tlsCertFile = "/path/to/cert.pem";
@@ -59,34 +62,31 @@ public class AuthenticationFactoryOAuth2Test {
         String audience = "audience";
         String scope = "scope";
         Duration autoCertRefreshDuration = Duration.ofSeconds(123);
-        try (Authentication authentication =
-                     AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
-                             .tokenEndpointAuthMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
-                             .clientId(clientId)
-                             .tlsCertFile(tlsCertFile)
-                             .tlsKeyFile(tlsKeyFile)
-                             .audience(audience)
-                             .scope(scope)
-                             .autoCertRefreshDuration(autoCertRefreshDuration)
-                             .build()) {
-            assertTrue(authentication instanceof AuthenticationOAuth2);
-            assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), TlsClientAuthFlow.class);
-        }
+        OAuth2MockHttpClient.withMockedSslFactory(() -> {
+            try (Authentication authentication =
+                         AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
+                                 .tokenEndpointAuthMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
+                                 .clientId(clientId)
+                                 .tlsCertFile(tlsCertFile)
+                                 .tlsKeyFile(tlsKeyFile)
+                                 .audience(audience)
+                                 .scope(scope)
+                                 .autoCertRefreshDuration(autoCertRefreshDuration)
+                                 .build()) {
+                assertTrue(authentication instanceof AuthenticationOAuth2);
+                assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), TlsClientAuthFlow.class);
+            }
+        });
     }
 
     @Test
-    public void testBuilderWithEmptyTlsClientAuth() throws IOException {
+    public void testBuilderWithTlsClientAuthMissingCertOrKey() throws IOException {
         URL issuerUrl = new URL("http://localhost");
-        URL credentialsUrl = new URL("http://localhost");
-        try (Authentication authentication =
-                     AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
-                             .credentialsUrl(credentialsUrl)
-                             .tlsCertFile("")
-                             .tlsKeyFile("")
-                             .build()) {
-            assertTrue(authentication instanceof AuthenticationOAuth2);
-            assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), ClientCredentialsFlow.class);
-        }
+        assertThrows(IllegalArgumentException.class, () ->
+                AuthenticationFactoryOAuth2.clientCredentialsBuilder()
+                        .issuerUrl(issuerUrl)
+                        .tokenEndpointAuthMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
+                        .build());
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationFactoryOAuth2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URL;
@@ -44,6 +45,45 @@ public class AuthenticationFactoryOAuth2Test {
                              .trustCertsFilePath(trustCertsFilePath)
                              .wellKnownMetadataPath(wellKnownMetadataPath).build()) {
             assertTrue(authentication instanceof AuthenticationOAuth2);
+            assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), ClientCredentialsFlow.class);
+        }
+    }
+
+    @Test
+    public void testBuilderWithTlsClientAuthFlow() throws IOException {
+        URL issuerUrl = new URL("http://localhost");
+        String clientId = "test-client";
+        String tlsCertFile = "/path/to/cert.pem";
+        String tlsKeyFile = "/path/to/key.pem";
+        String audience = "audience";
+        String scope = "scope";
+        Duration autoCertRefreshDuration = Duration.ofSeconds(123);
+        try (Authentication authentication =
+                     AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
+                             .clientId(clientId)
+                             .tlsCertFile(tlsCertFile)
+                             .tlsKeyFile(tlsKeyFile)
+                             .audience(audience)
+                             .scope(scope)
+                             .autoCertRefreshDuration(autoCertRefreshDuration)
+                             .build()) {
+            assertTrue(authentication instanceof AuthenticationOAuth2);
+            assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), TlsClientAuthFlow.class);
+        }
+    }
+
+    @Test
+    public void testBuilderWithEmptyTlsClientAuth() throws IOException {
+        URL issuerUrl = new URL("http://localhost");
+        URL credentialsUrl = new URL("http://localhost");
+        try (Authentication authentication =
+                     AuthenticationFactoryOAuth2.clientCredentialsBuilder().issuerUrl(issuerUrl)
+                             .credentialsUrl(credentialsUrl)
+                             .tlsCertFile("")
+                             .tlsKeyFile("")
+                             .build()) {
+            assertTrue(authentication instanceof AuthenticationOAuth2);
+            assertEquals(((AuthenticationOAuth2) authentication).flow.getClass(), ClientCredentialsFlow.class);
         }
     }
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -41,6 +41,7 @@ import lombok.Cleanup;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
+import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -228,6 +229,8 @@ public class AuthenticationOAuth2Test {
     public void testConfigureWithTlsClientAuth() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("type", "client_credentials");
+        params.put(AuthenticationOAuth2.CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
+                TokenEndpointAuthMethod.TLS_CLIENT_AUTH.value());
         params.put("clientId", "test-client");
         params.put("tlsCertFile", "/path/to/cert.pem");
         params.put("tlsKeyFile", "/path/to/key.pem");
@@ -259,6 +262,8 @@ public class AuthenticationOAuth2Test {
     public void testConfigureWithTlsClientAuthAndOptionalParams() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("type", "client_credentials");
+        params.put(AuthenticationOAuth2.CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
+                TokenEndpointAuthMethod.TLS_CLIENT_AUTH.value());
         params.put("clientId", "test-client");
         params.put("tlsCertFile", "/path/to/cert.pem");
         params.put("tlsKeyFile", "/path/to/key.pem");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -225,6 +225,55 @@ public class AuthenticationOAuth2Test {
     }
 
     @Test
+    public void testConfigureWithTlsClientAuth() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "client_credentials");
+        params.put("clientId", "test-client");
+        params.put("tlsCertFile", "/path/to/cert.pem");
+        params.put("tlsKeyFile", "/path/to/key.pem");
+        params.put("issuerUrl", "http://localhost");
+        ObjectMapper mapper = new ObjectMapper();
+        String authParams = mapper.writeValueAsString(params);
+        this.auth.configure(authParams);
+        assertNotNull(this.auth.flow);
+        assertEquals(this.auth.flow.getClass(), TlsClientAuthFlow.class);
+    }
+
+    @Test
+    public void testConfigureWithEmptyTlsClientAuthValues() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "client_credentials");
+        params.put("privateKey", "data:base64,e30=");
+        params.put("clientId", "test-client");
+        params.put("tlsCertFile", "");
+        params.put("tlsKeyFile", "");
+        params.put("issuerUrl", "http://localhost");
+        ObjectMapper mapper = new ObjectMapper();
+        String authParams = mapper.writeValueAsString(params);
+        this.auth.configure(authParams);
+        assertNotNull(this.auth.flow);
+        assertEquals(this.auth.flow.getClass(), ClientCredentialsFlow.class);
+    }
+
+    @Test
+    public void testConfigureWithTlsClientAuthAndOptionalParams() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "client_credentials");
+        params.put("clientId", "test-client");
+        params.put("tlsCertFile", "/path/to/cert.pem");
+        params.put("tlsKeyFile", "/path/to/key.pem");
+        params.put("issuerUrl", "http://localhost");
+        params.put("audience", "test-audience");
+        params.put("scope", "test-scope");
+        params.put("autoCertRefreshDuration", "PT300S");
+        ObjectMapper mapper = new ObjectMapper();
+        String authParams = mapper.writeValueAsString(params);
+        this.auth.configure(authParams);
+        assertNotNull(this.auth.flow);
+        assertEquals(this.auth.flow.getClass(), TlsClientAuthFlow.class);
+    }
+
+    @Test
     public void testStart() throws Exception {
         this.auth.start();
         verify(this.flow).initialize();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.DefaultMetadataResolver;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenEndpointAuthMethod;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -62,6 +63,13 @@ public class AuthenticationOAuth2Test {
         this.clock = new MockClock(Instant.EPOCH, ZoneOffset.UTC);
         this.flow = mock(Flow.class);
         this.auth = new AuthenticationOAuth2(flow, this.clock, 1, null);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void after() throws Exception {
+        if (this.auth != null) {
+            this.auth.close();
+        }
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/AuthenticationOAuth2Test.java
@@ -111,6 +111,42 @@ public class AuthenticationOAuth2Test {
         assertNotNull(this.auth.flow);
     }
 
+    @Test
+    public void testConfigureWithTlsClientAuth() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "client_credentials");
+        params.put(AuthenticationOAuth2.CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
+                TokenEndpointAuthMethod.TLS_CLIENT_AUTH.value());
+        params.put("clientId", "test-client");
+        params.put("tlsCertFile", "/path/to/cert.pem");
+        params.put("tlsKeyFile", "/path/to/key.pem");
+        params.put("issuerUrl", "http://localhost");
+        ObjectMapper mapper = new ObjectMapper();
+        String authParams = mapper.writeValueAsString(params);
+        OAuth2MockHttpClient.withMockedSslFactory(() -> {
+            this.auth.configure(authParams);
+            assertNotNull(this.auth.flow);
+            assertEquals(this.auth.flow.getClass(), TlsClientAuthFlow.class);
+        });
+    }
+
+    @Test
+    public void testConfigureCredentialsWithTlsValues() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "client_credentials");
+        params.put("privateKey", "data:base64,e30=");
+        params.put("tlsCertFile", "/path/to/cert.pem");
+        params.put("tlsKeyFile", "/path/to/key.pem");
+        params.put("issuerUrl", "http://localhost");
+        ObjectMapper mapper = new ObjectMapper();
+        String authParams = mapper.writeValueAsString(params);
+        OAuth2MockHttpClient.withMockedSslFactory(() -> {
+            this.auth.configure(authParams);
+            assertNotNull(this.auth.flow);
+            assertEquals(this.auth.flow.getClass(), ClientCredentialsFlow.class);
+        });
+    }
+
     // ----- configure() via default constructor -----
 
     @Test
@@ -223,59 +259,6 @@ public class AuthenticationOAuth2Test {
         params.put("issuerUrl", "http://localhost");
         params.put(AuthenticationOAuth2.CONFIG_PARAM_EARLY_TOKEN_REFRESH_PERCENT, earlyRefreshValue);
         return new ObjectMapper().writeValueAsString(params);
-    }
-
-    @Test
-    public void testConfigureWithTlsClientAuth() throws Exception {
-        Map<String, String> params = new HashMap<>();
-        params.put("type", "client_credentials");
-        params.put(AuthenticationOAuth2.CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
-                TokenEndpointAuthMethod.TLS_CLIENT_AUTH.value());
-        params.put("clientId", "test-client");
-        params.put("tlsCertFile", "/path/to/cert.pem");
-        params.put("tlsKeyFile", "/path/to/key.pem");
-        params.put("issuerUrl", "http://localhost");
-        ObjectMapper mapper = new ObjectMapper();
-        String authParams = mapper.writeValueAsString(params);
-        this.auth.configure(authParams);
-        assertNotNull(this.auth.flow);
-        assertEquals(this.auth.flow.getClass(), TlsClientAuthFlow.class);
-    }
-
-    @Test
-    public void testConfigureWithEmptyTlsClientAuthValues() throws Exception {
-        Map<String, String> params = new HashMap<>();
-        params.put("type", "client_credentials");
-        params.put("privateKey", "data:base64,e30=");
-        params.put("clientId", "test-client");
-        params.put("tlsCertFile", "");
-        params.put("tlsKeyFile", "");
-        params.put("issuerUrl", "http://localhost");
-        ObjectMapper mapper = new ObjectMapper();
-        String authParams = mapper.writeValueAsString(params);
-        this.auth.configure(authParams);
-        assertNotNull(this.auth.flow);
-        assertEquals(this.auth.flow.getClass(), ClientCredentialsFlow.class);
-    }
-
-    @Test
-    public void testConfigureWithTlsClientAuthAndOptionalParams() throws Exception {
-        Map<String, String> params = new HashMap<>();
-        params.put("type", "client_credentials");
-        params.put(AuthenticationOAuth2.CONFIG_PARAM_TOKEN_ENDPOINT_AUTH_METHOD,
-                TokenEndpointAuthMethod.TLS_CLIENT_AUTH.value());
-        params.put("clientId", "test-client");
-        params.put("tlsCertFile", "/path/to/cert.pem");
-        params.put("tlsKeyFile", "/path/to/key.pem");
-        params.put("issuerUrl", "http://localhost");
-        params.put("audience", "test-audience");
-        params.put("scope", "test-scope");
-        params.put("autoCertRefreshDuration", "PT300S");
-        ObjectMapper mapper = new ObjectMapper();
-        String authParams = mapper.writeValueAsString(params);
-        this.auth.configure(authParams);
-        assertNotNull(this.auth.flow);
-        assertEquals(this.auth.flow.getClass(), TlsClientAuthFlow.class);
     }
 
     @Test

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/OAuth2MockHttpClient.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/OAuth2MockHttpClient.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.oauth2;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockConstruction;
+import org.apache.pulsar.common.util.DefaultPulsarSslFactory;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.mockito.MockedConstruction;
+
+final class OAuth2MockHttpClient {
+
+    private OAuth2MockHttpClient() {
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    static void withMockedSslFactory(ThrowingRunnable runnable) throws Exception {
+        try (MockedConstruction<DefaultPulsarSslFactory> ignoredSslFactory =
+                     mockConstruction(DefaultPulsarSslFactory.class, (mock, context) -> {
+                         doNothing().when(mock).initialize(any());
+                         doNothing().when(mock).createInternalSslContext();
+                     });
+             MockedConstruction<DefaultAsyncHttpClient> ignoredHttpClient =
+                     mockConstruction(DefaultAsyncHttpClient.class)) {
+            runnable.run();
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
@@ -33,13 +33,12 @@ public class TlsClientAuthFlowTest {
         params.put("tlsKeyFile", "/path/to/key.pem");
         params.put("issuerUrl", "http://localhost");
         params.put("scope", "http://localhost");
-        TlsClientAuthFlow flow = TlsClientAuthFlow.fromParameters(params);
-        try {
+        OAuth2MockHttpClient.withMockedSslFactory(() -> {
+            TlsClientAuthFlow flow = TlsClientAuthFlow.fromParameters(params);
             Field clientIdField = flow.getClass().getDeclaredField("clientId");
             clientIdField.setAccessible(true);
             assertEquals((String) clientIdField.get(flow), "pulsar-client");
-        } finally {
             flow.close();
-        }
+        });
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.oauth2;
+
+import static org.testng.Assert.assertEquals;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class TlsClientAuthFlowTest {
+
+    @Test
+    public void testFromParametersWithoutClientId() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("tlsCertFile", "/path/to/cert.pem");
+        params.put("tlsKeyFile", "/path/to/key.pem");
+        params.put("issuerUrl", "http://localhost");
+        params.put("scope", "http://localhost");
+        TlsClientAuthFlow flow = TlsClientAuthFlow.fromParameters(params);
+        try {
+            Field clientIdField = flow.getClass().getDeclaredField("clientId");
+            clientIdField.setAccessible(true);
+            assertEquals((String) clientIdField.get(flow), "pulsar-client");
+        } finally {
+            flow.close();
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/TlsClientAuthFlowTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl.auth.oauth2;
 
 import static org.testng.Assert.assertEquals;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -35,9 +34,7 @@ public class TlsClientAuthFlowTest {
         params.put("scope", "http://localhost");
         OAuth2MockHttpClient.withMockedSslFactory(() -> {
             TlsClientAuthFlow flow = TlsClientAuthFlow.fromParameters(params);
-            Field clientIdField = flow.getClass().getDeclaredField("clientId");
-            clientIdField.setAccessible(true);
-            assertEquals((String) clientIdField.get(flow), "pulsar-client");
+            assertEquals(flow.getClientId(), "pulsar-client");
             flow.close();
         });
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2.protocol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
@@ -51,6 +52,12 @@ public class TokenClientTest {
                 .authMethod(TokenEndpointAuthMethod.CLIENT_SECRET_POST)
                 .build();
         String body = tokenClient.buildClientCredentialsBody(request);
+        assertThat(body)
+                .contains("grant_type=")
+                .contains("client_id=")
+                .contains("client_secret=")
+                .contains("audience=")
+                .contains("scope=");
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -80,9 +87,12 @@ public class TokenClientTest {
         ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
-                .authMethod(TokenEndpointAuthMethod.CLIENT_SECRET_POST)
                 .build();
         String body = tokenClient.buildClientCredentialsBody(request);
+        assertThat(body)
+                .contains("grant_type=")
+                .contains("client_id=")
+                .contains("client_secret=");
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -116,6 +126,12 @@ public class TokenClientTest {
                 .authMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                 .build();
         String body = tokenClient.buildClientCredentialsBody(request);
+        assertThat(body)
+                .contains("grant_type=")
+                .contains("client_id=")
+                .contains("audience=")
+                .contains("scope=")
+                .doesNotContain("client_secret=");
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -147,6 +163,10 @@ public class TokenClientTest {
                 .authMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                 .build();
         String body = tokenClient.buildClientCredentialsBody(request);
+        assertThat(body)
+                .contains("grant_type=")
+                .contains("client_id=")
+                .doesNotContain("client_secret=");
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -49,7 +49,7 @@ public class TokenClientTest {
                 .clientSecret("test-client-secret")
                 .scope("test-scope")
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request);
+        String body = tokenClient.buildClientCredentialsBody(request, true);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -80,7 +80,7 @@ public class TokenClientTest {
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request);
+        String body = tokenClient.buildClientCredentialsBody(request, true);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -97,6 +97,68 @@ public class TokenClientTest {
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
         TokenResult tr = tokenClient.exchangeClientCredentials(request);
+        assertNotNull(tr);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void exchangeTlsClientAuthSuccessTest() throws
+            IOException, TokenExchangeException, ExecutionException, InterruptedException {
+        DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
+        URL url = new URL("http://localhost");
+        TokenClient tokenClient = new TokenClient(url, defaultAsyncHttpClient);
+        ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
+                .clientId("test-client-id")
+                .audience("test-audience")
+                .scope("test-scope")
+                .build();
+        String body = tokenClient.buildClientCredentialsBody(request, false);
+        BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
+        Response response = mock(Response.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
+        when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type",
+                "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(listenableFuture.get()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(200);
+        TokenResult tokenResult = new TokenResult();
+        tokenResult.setAccessToken("test-access-token");
+        tokenResult.setIdToken("test-id");
+        when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
+        TokenResult tr = tokenClient.exchangeTlsClientAuth(request);
+        assertNotNull(tr);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void exchangeTlsClientAuthSuccessWithoutOptionalParamsTest() throws
+            IOException, TokenExchangeException, ExecutionException, InterruptedException {
+        DefaultAsyncHttpClient defaultAsyncHttpClient = mock(DefaultAsyncHttpClient.class);
+        URL url = new URL("http://localhost");
+        TokenClient tokenClient = new TokenClient(url, defaultAsyncHttpClient);
+        ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
+                .clientId("test-client-id")
+                .build();
+        String body = tokenClient.buildClientCredentialsBody(request, false);
+        BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
+        Response response = mock(Response.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
+        when(defaultAsyncHttpClient.preparePost(url.toString())).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Accept", "application/json")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setHeader("Content-Type",
+                "application/x-www-form-urlencoded")).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.setBody(body)).thenReturn(boundRequestBuilder);
+        when(boundRequestBuilder.execute()).thenReturn(listenableFuture);
+        when(listenableFuture.get()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(200);
+        TokenResult tokenResult = new TokenResult();
+        tokenResult.setAccessToken("test-access-token");
+        tokenResult.setIdToken("test-id");
+        when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
+        TokenResult tr = tokenClient.exchangeTlsClientAuth(request);
         assertNotNull(tr);
     }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/protocol/TokenClientTest.java
@@ -48,8 +48,9 @@ public class TokenClientTest {
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
                 .scope("test-scope")
+                .authMethod(TokenEndpointAuthMethod.CLIENT_SECRET_POST)
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request, true);
+        String body = tokenClient.buildClientCredentialsBody(request);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -79,8 +80,9 @@ public class TokenClientTest {
         ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
+                .authMethod(TokenEndpointAuthMethod.CLIENT_SECRET_POST)
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request, true);
+        String body = tokenClient.buildClientCredentialsBody(request);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -111,8 +113,9 @@ public class TokenClientTest {
                 .clientId("test-client-id")
                 .audience("test-audience")
                 .scope("test-scope")
+                .authMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request, false);
+        String body = tokenClient.buildClientCredentialsBody(request);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -128,7 +131,7 @@ public class TokenClientTest {
         tokenResult.setAccessToken("test-access-token");
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
-        TokenResult tr = tokenClient.exchangeTlsClientAuth(request);
+        TokenResult tr = tokenClient.exchangeClientCredentials(request);
         assertNotNull(tr);
     }
 
@@ -141,8 +144,9 @@ public class TokenClientTest {
         TokenClient tokenClient = new TokenClient(url, defaultAsyncHttpClient);
         ClientCredentialsExchangeRequest request = ClientCredentialsExchangeRequest.builder()
                 .clientId("test-client-id")
+                .authMethod(TokenEndpointAuthMethod.TLS_CLIENT_AUTH)
                 .build();
-        String body = tokenClient.buildClientCredentialsBody(request, false);
+        String body = tokenClient.buildClientCredentialsBody(request);
         BoundRequestBuilder boundRequestBuilder = mock(BoundRequestBuilder.class);
         Response response = mock(Response.class);
         ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
@@ -158,7 +162,7 @@ public class TokenClientTest {
         tokenResult.setAccessToken("test-access-token");
         tokenResult.setIdToken("test-id");
         when(response.getResponseBodyAsBytes()).thenReturn(new Gson().toJson(tokenResult).getBytes());
-        TokenResult tr = tokenClient.exchangeTlsClientAuth(request);
+        TokenResult tr = tokenClient.exchangeClientCredentials(request);
         assertNotNull(tr);
     }
 }


### PR DESCRIPTION
### Motivation

Currently, the Client Credentials Flow in AuthenticationOAuth2 supports only authentication using `client_secret`.
This PR adds `tls_client_auth` using a certificate.
https://datatracker.ietf.org/doc/rfc8705/

### Modifications
Added `TlsClientAuthFlow` class for the flow using a certificate.
- The `client_id` is treated as an optional parameter for users.
  - Although `client_id` is required by the RFC, it may not be necessary in cases such as Athenz. Allowing it to be optional as a client input provides greater flexibility. As long as the pulsar client includes `client_id` internally, it remains compliant with the RFC.
  - https://github.com/apache/pulsar/pull/25538/changes#diff-979a00edf42b23b8e525310f703a0ac1203538ed742f907bfd658af53f8b49f2R109
- ~Since a certificate is only required when obtaining a token, a different HTTP client is used than the one used for retrieving metadata.~
  - ~https://github.com/apache/pulsar/pull/25538/changes#diff-979a00edf42b23b8e525310f703a0ac1203538ed742f907bfd658af53f8b49f2R141-R146~

### Verifying this change

- [x] Make sure that the change passes the CI checks.
  - https://github.com/izumo27/pulsar/pull/7

This change added tests and can be verified as follows:

- Added tests for tls_client_auth
- Modify existing tests for cilent_sercre

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment