### PR TITLE
[improve] PIP-467: Remove now-dead slf4j.api dependency from modules converted to slog

### DIFF
--- a/bouncy-castle/bc/build.gradle.kts
+++ b/bouncy-castle/bc/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     compileOnly(project(":pulsar-common")) {
         exclude(group = "io.prometheus", module = "simpleclient_caffeine")
     }
-    compileOnly(libs.slf4j.api)
     implementation(libs.bcpkix.jdk18on)
     implementation(libs.bcprov.ext.jdk18on)
 }

--- a/bouncy-castle/bcfips/build.gradle.kts
+++ b/bouncy-castle/bcfips/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     compileOnly(project(":pulsar-common")) {
         exclude(group = "io.prometheus", module = "simpleclient_caffeine")
     }
-    compileOnly(libs.slf4j.api)
     implementation(libs.bcutil.fips)
     implementation(libs.bc.fips)
     implementation(libs.bcpkix.fips)

--- a/microbench/build.gradle.kts
+++ b/microbench/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     implementation(project(":pulsar-broker"))
     implementation(libs.bookkeeper.server)
     implementation(libs.guava)
-    implementation(libs.slf4j.api)
     implementation("org.openjdk.jmh:jmh-core:1.37")
     annotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 }

--- a/pulsar-broker-auth-athenz/build.gradle.kts
+++ b/pulsar-broker-auth-athenz/build.gradle.kts
@@ -33,5 +33,4 @@ dependencies {
     implementation(libs.athenz.auth.core)
     implementation(libs.commons.lang3)
     implementation(libs.guava)
-    implementation(libs.slf4j.api)
 }

--- a/pulsar-broker-auth-sasl/build.gradle.kts
+++ b/pulsar-broker-auth-sasl/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     implementation(libs.commons.lang3)
     implementation(libs.commons.codec)
     implementation(libs.javax.servlet.api)
-    implementation(libs.slf4j.api)
     implementation(libs.simpleclient.caffeine)
 
     testImplementation(libs.commons.io)

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
     implementation(libs.commons.codec)
     implementation(libs.commons.collections4)
     implementation(libs.commons.lang3)
-    implementation(libs.slf4j.api)
     implementation(libs.netty.transport)
     implementation(libs.protobuf.java)
     implementation(libs.curator.recipes)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicPoliciesService.java
@@ -29,8 +29,6 @@ import org.apache.pulsar.common.events.PulsarEvent;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TopicPolicies;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Topic policies service.
@@ -40,8 +38,6 @@ import org.slf4j.LoggerFactory;
 public interface TopicPoliciesService extends AutoCloseable {
 
     String GLOBAL_POLICIES_MSG_KEY_PREFIX = "__G__";
-
-    Logger LOG = LoggerFactory.getLogger(TopicPoliciesService.class);
 
     TopicPoliciesService DISABLED = new TopicPoliciesServiceDisabled();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaRegistryService.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service.schema;
 
+import io.github.merlimat.slog.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -26,11 +27,9 @@ import org.apache.pulsar.broker.service.schema.validator.SchemaRegistryServiceWi
 import org.apache.pulsar.common.protocol.schema.SchemaStorage;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.common.util.Reflections;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public interface SchemaRegistryService extends SchemaRegistry {
-    Logger LOG = LoggerFactory.getLogger(SchemaRegistryService.class);
+    Logger LOG = Logger.get(SchemaRegistryService.class);
     long NO_SCHEMA_VERSION = -1L;
 
     static Map<SchemaType, SchemaCompatibilityCheck> getCheckers(Set<String> checkerClasses) throws Exception {
@@ -63,7 +62,7 @@ public interface SchemaRegistryService extends SchemaRegistry {
                         new SchemaRegistryServiceImpl(schemaStorage, checkers, pulsarService),
                         allowLegacyJacksonFormat);
             } catch (Exception e) {
-                LOG.warn("Unable to create schema registry storage, defaulting to empty storage", e);
+                LOG.warn().exception(e).log("Unable to create schema registry storage, defaulting to empty storage");
             }
         }
         return new DefaultSchemaRegistryService();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/SchemaDataValidator.java
@@ -18,19 +18,18 @@
  */
 package org.apache.pulsar.broker.service.schema.validator;
 
+import io.github.merlimat.slog.Logger;
 import org.apache.pulsar.broker.service.schema.KeyValueSchemaCompatibilityCheck;
 import org.apache.pulsar.broker.service.schema.exceptions.InvalidSchemaDataException;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.schema.KeyValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A validator to validate the schema data is well formed.
  */
 public interface SchemaDataValidator {
 
-    Logger LOGGER = LoggerFactory.getLogger(SchemaDataValidator.class);
+    Logger LOGGER = Logger.get(SchemaDataValidator.class);
 
     /**
      * Validate if the schema data is well formed.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/validator/StructSchemaDataValidator.java
@@ -98,7 +98,7 @@ public class StructSchemaDataValidator implements SchemaDataValidator {
                 default: {
                     // INT, LONG, FLOAT, DOUBLE, BOOLEAN, STRING, BYTES.
                     // ARRAY, MAP, FIXED, NULL.
-                    LOGGER.info("Registering a special avro schema typed [{}]", schema.getType());
+                    LOGGER.info().attr("type", schema.getType()).log("Registering a special avro schema");
                 }
             }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/TestLogAppender.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/TestLogAppender.java
@@ -32,7 +32,6 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.slf4j.Logger;
 
 /**
  * Log4J appender that captures all log events for a specified logger.
@@ -58,16 +57,6 @@ public class TestLogAppender extends AbstractAppender implements AutoCloseable {
         context.updateLoggers();
         return testAppender;
     }
-    /**
-     * Create a new TestLogAppender for a given logger. Use the {@link #close()} method to stop it and unregister it
-     * from Log4J.
-     * @param log The name of the logger instance will be used as the logger name to register the appender to.
-     * @return return the new TestLogAppender instance.
-     */
-    public static TestLogAppender create(Logger log) {
-        return create(Optional.of(log.getName()));
-    }
-
     /**
      * Create a new TestLogAppender for a given slog logger. Use the {@link #close()} method to stop it and unregister
      * it from Log4J.

--- a/pulsar-client-admin-api/build.gradle.kts
+++ b/pulsar-client-admin-api/build.gradle.kts
@@ -25,5 +25,4 @@ dependencies {
     implementation(libs.slog)
     api(project(":pulsar-client-api"))
     implementation(libs.jackson.annotations)
-    implementation(libs.slf4j.api)
 }

--- a/pulsar-client-auth-athenz/build.gradle.kts
+++ b/pulsar-client-auth-athenz/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     implementation(libs.athenz.cert.refresher)
     implementation(libs.athenz.auth.core)
     implementation(libs.guava)
-    implementation(libs.slf4j.api)
     implementation(libs.jackson.databind)
     implementation(libs.jackson.dataformat.yaml)
     implementation(libs.commons.lang3)

--- a/pulsar-client-auth-sasl/build.gradle.kts
+++ b/pulsar-client-auth-sasl/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(libs.slog)
     compileOnly(project(":pulsar-client-original"))
     implementation(project(":pulsar-common"))
-    implementation(libs.slf4j.api)
     implementation(libs.guava)
     implementation(libs.commons.lang3)
     implementation(libs.jakarta.ws.rs.api)

--- a/pulsar-client-messagecrypto-bc/build.gradle.kts
+++ b/pulsar-client-messagecrypto-bc/build.gradle.kts
@@ -24,7 +24,6 @@ plugins {
 dependencies {
     implementation(libs.slog)
     compileOnly(project(":pulsar-common"))
-    compileOnly(libs.slf4j.api)
     implementation(project(":pulsar-client-api"))
     implementation(project(":bouncy-castle:bouncy-castle-bc"))
     implementation(libs.bcpkix.jdk18on)

--- a/pulsar-client-tools-customcommand-example/build.gradle.kts
+++ b/pulsar-client-tools-customcommand-example/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(libs.slog)
     compileOnly(project(":pulsar-client-tools-api"))
     compileOnly(libs.picocli)
-    compileOnly(libs.slf4j.api)
 }
 
 // Match Maven's nifi-nar-maven-plugin output: customCommands-nar.nar

--- a/pulsar-config-validation/build.gradle.kts
+++ b/pulsar-config-validation/build.gradle.kts
@@ -23,5 +23,4 @@ plugins {
 
 dependencies {
     implementation(libs.slog)
-    implementation(libs.slf4j.api)
 }

--- a/pulsar-package-management/filesystem-storage/build.gradle.kts
+++ b/pulsar-package-management/filesystem-storage/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(libs.slog)
     api(project(":pulsar-package-management:pulsar-package-core"))
     implementation(libs.guava)
-    implementation(libs.slf4j.api)
 
     testImplementation(project(":testmocks"))
     testImplementation(libs.commons.lang3)

--- a/pulsar-transaction/coordinator/build.gradle.kts
+++ b/pulsar-transaction/coordinator/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":managed-ledger"))
     implementation(libs.commons.lang3)
     implementation(libs.commons.collections4)
-    implementation(libs.slf4j.api)
     implementation(libs.netty.buffer)
     implementation(libs.netty.common)
     implementation(libs.jctools.core)

--- a/tests/docker-images/java-test-plugins/build.gradle.kts
+++ b/tests/docker-images/java-test-plugins/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     // Use compileOnly so the plugin JAR doesn't bundle broker deps,
     // but need the full transitive classpath for compilation
     compileOnly(project(":pulsar-broker"))
-    compileOnly(libs.slf4j.api)
     compileOnly(libs.netty.transport)
     compileOnly(libs.javax.servlet.api)
 }


### PR DESCRIPTION
## Summary
- Drop `libs.slf4j.api` from 15 Gradle modules that no longer use SLF4J in their source code after the PIP-467 slog conversion
- Convert the last three SLF4J loggers still in `pulsar-broker/src/main` to slog (interface-level shared loggers in `SchemaDataValidator`, `SchemaRegistryService`, and an unused one in `TopicPoliciesService`)
- Remove an unused `TestLogAppender.create(org.slf4j.Logger)` overload
- Goal: prevent new code from inadvertently re-introducing an SLF4J logger in modules where everything is already on slog

## Modules where `slf4j.api` is kept (intentional)
- `pulsar-functions/api-java`, `pulsar-functions/java-examples` — part of the public user-facing Functions API
- `pulsar-functions/runtime-all` — shadow fat-jar explicitly bundles slf4j-api + log4j-slf4j2 bridge for the functions-instance runtime
- `pulsar-testclient` — excludes slf4j from the zookeeper transitive and re-adds it explicitly so it stays on the runtime classpath

## Test plan
- [x] `compileJava`, `compileTestJava`, `checkstyleMain`, `checkstyleTest` pass for every touched module
- [x] `grep` confirms zero `org.slf4j` / `LoggerFactory` / `@Slf4j` usages in `src/main` and `src/test` of the modules that dropped the dependency
- [ ] CI passes

### Motivation

PIP-467