### PR TITLE
[improve][broker] Log only non-default config values on broker startup

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -28,7 +28,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.TreeMap;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -223,5 +225,41 @@ public class PulsarConfigurationLoader {
 
     public static ServiceConfiguration convertFrom(PulsarConfiguration conf) throws RuntimeException {
         return convertFrom(conf, true);
+    }
+
+    /**
+     * Returns the subset of configuration whose values differ from the defaults of a freshly-instantiated
+     * configuration of the same class. Any entries in {@link PulsarConfiguration#getProperties()} that are not
+     * declared fields are also included. Useful to log only the user-provided overrides instead of the full
+     * configuration.
+     */
+    public static Map<String, Object> runtimeConfigurationOverrides(PulsarConfiguration conf) {
+        try {
+            PulsarConfiguration defaults = conf.getClass().getDeclaredConstructor().newInstance();
+            Map<String, Object> overrides = new TreeMap<>();
+            for (Field field : conf.getClass().getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                if (field.getDeclaredAnnotation(FieldContext.class) == null) {
+                    continue;
+                }
+                field.setAccessible(true);
+                Object current = field.get(conf);
+                Object def = field.get(defaults);
+                if (!Objects.equals(current, def)) {
+                    overrides.put(field.getName(), current);
+                }
+            }
+            Properties props = conf.getProperties();
+            if (props != null) {
+                for (String key : props.stringPropertyNames()) {
+                    overrides.putIfAbsent(key, props.getProperty(key));
+                }
+            }
+            return overrides;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to compute configuration overrides", e);
+        }
     }
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -19,11 +19,13 @@
 package org.apache.pulsar.common.configuration;
 
 import static org.apache.pulsar.common.configuration.PulsarConfigurationLoader.isComplete;
+import static org.apache.pulsar.common.configuration.PulsarConfigurationLoader.runtimeConfigurationOverrides;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -31,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.bookkeeper.client.api.DigestType;
@@ -228,6 +231,51 @@ public class PulsarConfigurationLoaderTest {
         assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMin()));
         assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMax()));
         assertThrows(IllegalArgumentException.class, () -> isComplete(new TestInCompleteObjectMix()));
+    }
+
+    @Test
+    public void testRuntimeConfigurationOverrides() {
+        // A fresh configuration has no overrides.
+        assertTrue(runtimeConfigurationOverrides(new ServiceConfiguration()).isEmpty());
+
+        ServiceConfiguration config = new ServiceConfiguration();
+
+        // String override.
+        config.setClusterName("my-cluster");
+        // int override.
+        config.setManagedLedgerDefaultEnsembleSize(5);
+        // long override.
+        config.setMetadataStoreSessionTimeoutMillis(60_000L);
+        // boolean override.
+        config.setBrokerDeleteInactiveTopicsEnabled(false);
+        // double override.
+        config.setManagedLedgerDefaultMarkDeleteRateLimit(5.0);
+        // enum override.
+        config.setManagedLedgerDigestType(DigestType.MAC);
+        // Optional<Integer> override.
+        config.setBrokerServicePort(Optional.of(7777));
+        // Set<String> override.
+        config.setSuperUserRoles(Sets.newHashSet("admin", "ops"));
+        // Setting a field to its default value: should NOT appear in overrides.
+        config.setNumIOThreads(config.getNumIOThreads());
+        // Extra property not backed by a declared FieldContext field.
+        config.getProperties().setProperty("custom.plugin.option", "enabled");
+
+        Map<String, Object> overrides = runtimeConfigurationOverrides(config);
+
+        assertEquals(overrides.get("clusterName"), "my-cluster");
+        assertEquals(overrides.get("managedLedgerDefaultEnsembleSize"), 5);
+        assertEquals(overrides.get("metadataStoreSessionTimeoutMillis"), 60_000L);
+        assertEquals(overrides.get("brokerDeleteInactiveTopicsEnabled"), false);
+        assertEquals(overrides.get("managedLedgerDefaultMarkDeleteRateLimit"), 5.0);
+        assertEquals(overrides.get("managedLedgerDigestType"), DigestType.MAC);
+        assertEquals(overrides.get("brokerServicePort"), Optional.of(7777));
+        assertEquals(overrides.get("superUserRoles"), Sets.newHashSet("admin", "ops"));
+        assertEquals(overrides.get("custom.plugin.option"), "enabled");
+
+        // Unchanged fields must not appear.
+        assertFalse(overrides.containsKey("numIOThreads"));
+        assertFalse(overrides.containsKey("metadataStoreUrl"));
     }
 
     static class TestCompleteObject {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -1093,7 +1093,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     .attr("bootstrapTimeSeconds", bootstrapTimeSeconds)
                     .attr("bootstrapMessage", bootstrapMessage)
                     .attr("cluster", config.getClusterName())
-                    .attr("config", config)
+                    .attr("configOverrides", PulsarConfigurationLoader.runtimeConfigurationOverrides(config))
                     .log("Messaging service is ready");
 
             state = State.Started;


### PR DESCRIPTION
### Motivation

When the broker starts, the `Messaging service is ready` log entry attaches the entire `ServiceConfiguration` object. With hundreds of configuration fields, this produces pages of output on every startup — almost all of it matching the built-in defaults and adding noise without any diagnostic value.

### Modifications

- Added `PulsarConfigurationLoader#runtimeConfigurationOverrides(PulsarConfiguration)` that returns the subset of `@FieldContext`-annotated fields whose current value differs from a freshly-instantiated defaults instance of the same class. Extra entries in `PulsarConfiguration#getProperties()` (not backed by declared fields) are also included.
- Updated the `Messaging service is ready` log in `PulsarService` to attach `configOverrides` (the diff map) instead of the full `config` object.

### Verifying this change

This change added tests and can be verified as follows:

- Added `PulsarConfigurationLoaderTest#testRuntimeConfigurationOverrides` covering overrides of `String`, `int`, `long`, `boolean`, `double`, enum, `Optional<Integer>`, and `Set<String>` fields, an extra non-declared `Properties` entry, a no-op default assignment (must not appear), and the empty-overrides case for a fresh configuration.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment