### PR TITLE
[fix][sec] Upgrade to async-http-client 2.14.5 to address CVE-2026-40490

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -389,8 +389,8 @@ The Apache Software License, Version 2.0
  * AirCompressor
     - io.airlift-aircompressor-2.0.3.jar
  * AsyncHttpClient
-    - org.asynchttpclient-async-http-client-2.12.4.jar
-    - org.asynchttpclient-async-http-client-netty-utils-2.12.4.jar
+    - org.asynchttpclient-async-http-client-2.14.5.jar
+    - org.asynchttpclient-async-http-client-netty-utils-2.14.5.jar
  * Jetty
     - org.eclipse.jetty-jetty-alpn-client-12.1.8.jar
     - org.eclipse.jetty-jetty-alpn-conscrypt-server-12.1.8.jar

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -624,7 +624,7 @@ Eclipse Public License - v2.0 -- ../licenses/LICENSE-EPL-2.0.txt
  * Jakarta Transactions API -- jakarta.transaction-jakarta.transaction-api-1.3.3.jar
 
 Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
- * Reactive Streams -- org.reactivestreams-reactive-streams-1.0.3.jar
+ * Reactive Streams -- org.reactivestreams-reactive-streams-1.0.4.jar
 
 
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -401,8 +401,8 @@ The Apache Software License, Version 2.0
   * AirCompressor
      - aircompressor-2.0.3.jar
  * AsyncHttpClient
-    - async-http-client-2.12.4.jar
-    - async-http-client-netty-utils-2.12.4.jar
+    - async-http-client-2.14.5.jar
+    - async-http-client-netty-utils-2.14.5.jar
  * Jetty
     - jetty-alpn-client-12.1.8.jar
     - jetty-client-12.1.8.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -465,7 +465,7 @@ Eclipse Public License - v2.0 -- ../licenses/LICENSE-EPL-2.0.txt
  * Jakarta Injection -- jakarta.inject-2.6.1.jar
 
 Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
- * Reactive Streams -- reactive-streams-1.0.3.jar
+ * Reactive Streams -- reactive-streams-1.0.4.jar
 
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ snakeyaml = "2.0"
 # Vert.x
 vertx = "4.5.24"
 # Networking / HTTP
-asynchttpclient = "2.12.4"
+asynchttpclient = "2.14.5"
 conscrypt = "2.5.2"
 okhttp3 = "5.3.1"
 okio = "3.16.3"

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorTest.java
@@ -19,7 +19,9 @@
 package org.apache.pulsar.client.admin.internal.http;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.testng.Assert.assertEquals;
@@ -280,6 +282,60 @@ public class AsyncHttpConnectorTest {
 
         Response response = connector.executeRequest(request).get();
         assertEquals(response.getResponseBody(), "OK");
+    }
+
+    /**
+     * Locks in that AsyncHttpConnector forwards the {@code Authorization} header across a cross-origin
+     * HTTP redirect (different host:port — serverA → serverB). The admin connector disables AHC's
+     * built-in follow-redirect and runs its own redirect loop that copies the original request headers,
+     * so it must remain unaffected by the async-http-client &gt;= 2.14.5 {@code Authorization} stripping
+     * on cross-origin redirects (CVE-2026-40490 fix). Regressing {@code setFollowRedirect(true)} would
+     * break this test.
+     */
+    @Test
+    void testAuthorizationHeaderOnCrossOriginRedirect() throws ExecutionException, InterruptedException {
+        WireMockServer serverB = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        serverB.start();
+        try {
+            server.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                    .willReturn(aResponse()
+                            .withStatus(307)
+                            .withHeader("Location",
+                                    "http://127.0.0.1:" + serverB.port() + "/admin/v2/clusters")));
+
+            serverB.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                    .atPriority(2)
+                    .willReturn(aResponse().withStatus(401).withBody("missing auth")));
+            serverB.stubFor(get(urlEqualTo("/admin/v2/clusters"))
+                    .atPriority(1)
+                    .withHeader("Authorization", equalTo("Bearer test-token"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("[\"test-cluster\"]")));
+
+            ClientConfigurationData conf = new ClientConfigurationData();
+            conf.setServiceUrl("http://127.0.0.1:" + server.port());
+
+            @Cleanup
+            AsyncHttpConnector connector = new AsyncHttpConnector(5000, 5000,
+                    5000, 0, conf, false, null);
+
+            Request request = new RequestBuilder("GET")
+                    .setUrl("http://127.0.0.1:" + server.port() + "/admin/v2/clusters")
+                    .addHeader("Authorization", "Bearer test-token")
+                    .build();
+
+            Response response = connector.executeRequest(request).get();
+
+            assertEquals(response.getStatusCode(), 200,
+                    "cross-origin redirect should forward Authorization and return the stubbed body");
+            assertEquals(response.getResponseBody(), "[\"test-cluster\"]");
+            serverB.verify(getRequestedFor(urlEqualTo("/admin/v2/clusters"))
+                    .withHeader("Authorization", equalTo("Bearer test-token")));
+        } finally {
+            serverB.stop();
+        }
     }
 
     @Test

--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
 
     testImplementation(libs.jsonassert)
     testImplementation(libs.awaitility)
+    testImplementation(libs.wiremock)
     testImplementation(libs.protobuf.java)
     testImplementation(libs.protobuf.java.util)
     testImplementation(libs.opentelemetry.sdk)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -177,7 +177,7 @@ public class HttpClient implements Closeable {
             InetSocketAddress originalHost = InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort());
             executeGet(requestUrl, originalHost, clientConf.getMaxLookupRedirects(), future, clazz);
         } catch (Exception e) {
-            log.warn().attr("path", path).exceptionMessage(e).log("PulsarClientImpl");
+            log.warn().attr("path", path).exceptionMessage(e).log("Failed to initiate HTTP get request");
             if (e instanceof PulsarClientException) {
                 future.completeExceptionally(e);
             } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HttpClient.java
@@ -56,6 +56,7 @@ import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
 import org.asynchttpclient.SslEngineFactory;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
 
@@ -88,7 +89,12 @@ public class HttpClient implements Closeable {
         DefaultAsyncHttpClientConfig.Builder confBuilder = new DefaultAsyncHttpClientConfig.Builder();
         confBuilder.setCookieStore(null);
         confBuilder.setUseProxyProperties(true);
-        confBuilder.setFollowRedirect(true);
+        // Follow redirects manually in executeGet(...) so we can re-invoke authentication per hop and
+        // carry the Authorization header across cross-origin redirects. async-http-client >= 2.14.5
+        // (CVE-2026-40490 fix) strips the Authorization header when it follows redirects itself; Pulsar
+        // HTTP lookups routinely redirect to another broker's httpUrl/httpUrlTls which is a different
+        // host/port, i.e. cross-origin.
+        confBuilder.setFollowRedirect(false);
         confBuilder.setMaxRedirects(conf.getMaxLookupRedirects());
         confBuilder.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_IN_SECONDS * 1000);
         confBuilder.setReadTimeout(DEFAULT_READ_TIMEOUT_IN_SECONDS * 1000);
@@ -168,10 +174,28 @@ public class HttpClient implements Closeable {
         try {
             URI hostUri = serviceNameResolver.resolveHostUri();
             String requestUrl = new URL(hostUri.toURL(), path).toString();
-            String remoteHostName = hostUri.getHost();
+            InetSocketAddress originalHost = InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort());
+            executeGet(requestUrl, originalHost, clientConf.getMaxLookupRedirects(), future, clazz);
+        } catch (Exception e) {
+            log.warn().attr("path", path).exceptionMessage(e).log("PulsarClientImpl");
+            if (e instanceof PulsarClientException) {
+                future.completeExceptionally(e);
+            } else {
+                future.completeExceptionally(new PulsarClientException(e));
+            }
+        }
+
+        return future;
+    }
+
+    private <T> void executeGet(String requestUrl, InetSocketAddress originalHost,
+                                int redirectsRemaining, CompletableFuture<T> future, Class<T> clazz) {
+        try {
+            URI currentUri = URI.create(requestUrl);
+            String remoteHostName = currentUri.getHost();
             AuthenticationDataProvider authData = authentication.getAuthData(remoteHostName);
 
-            CompletableFuture<Map<String, String>>  authFuture = new CompletableFuture<>();
+            CompletableFuture<Map<String, String>> authFuture = new CompletableFuture<>();
 
             // bring a authenticationStage for sasl auth.
             if (authData.hasDataForHttp()) {
@@ -180,11 +204,9 @@ public class HttpClient implements Closeable {
                 authFuture.complete(null);
             }
 
-            // auth complete, do real request
             authFuture.whenComplete((respHeaders, ex) -> {
                 if (ex != null) {
-                    serviceNameResolver.markHostAvailability(
-                            InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()), false);
+                    serviceNameResolver.markHostAvailability(originalHost, false);
                     log.warn().attr("requestUrl", requestUrl)
                             .exceptionMessage(ex)
                             .log("Failed to perform http request at authentication stage");
@@ -192,7 +214,6 @@ public class HttpClient implements Closeable {
                     return;
                 }
 
-                // auth complete, use a new builder
                 BoundRequestBuilder builder = httpClient.prepareGet(requestUrl)
                         // share the DNS resolver and cache with Pulsar client
                         .setNameResolver(nameResolver)
@@ -221,19 +242,24 @@ public class HttpClient implements Closeable {
 
                 builder.execute().toCompletableFuture().whenComplete((response2, t) -> {
                     if (t != null) {
-                        serviceNameResolver.markHostAvailability(
-                                InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()), false);
+                        serviceNameResolver.markHostAvailability(originalHost, false);
                         log.warn().attr("requestUrl", requestUrl)
                                 .exceptionMessage(t)
                                 .log("Failed to perform http request");
                         future.completeExceptionally(new PulsarClientException(t));
                         return;
                     }
-                    serviceNameResolver.markHostAvailability(
-                            InetSocketAddress.createUnresolved(hostUri.getHost(), hostUri.getPort()), true);
+                    serviceNameResolver.markHostAvailability(originalHost, true);
+
+                    int statusCode = response2.getStatusCode();
+                    if (isRedirectStatusCode(statusCode)) {
+                        handleRedirect(requestUrl, currentUri, response2, originalHost,
+                                redirectsRemaining, future, clazz);
+                        return;
+                    }
 
                     // request not success
-                    if (response2.getStatusCode() != HttpURLConnection.HTTP_OK) {
+                    if (statusCode != HttpURLConnection.HTTP_OK) {
                         String errorReason = response2.getStatusText();
                         if ("application/json".equals(response2.getContentType()) || "text/json".equals(
                                 response2.getContentType())) {
@@ -257,7 +283,7 @@ public class HttpClient implements Closeable {
                                 .attr("failed", errorReason)
                                 .log("HTTP get request failed");
                         Exception e;
-                        if (response2.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+                        if (statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
                             e = new NotFoundException("Not found: " + errorReason);
                         } else {
                             e = new PulsarClientException("HTTP get request failed: " + errorReason);
@@ -279,15 +305,48 @@ public class HttpClient implements Closeable {
                 });
             });
         } catch (Exception e) {
-            log.warn().attr("path", path).exceptionMessage(e).log("PulsarClientImpl");
+            log.warn().attr("requestUrl", requestUrl).exceptionMessage(e).log("HTTP request setup failed");
             if (e instanceof PulsarClientException) {
                 future.completeExceptionally(e);
             } else {
                 future.completeExceptionally(new PulsarClientException(e));
             }
         }
+    }
 
-        return future;
+    private <T> void handleRedirect(String requestUrl, URI currentUri,
+                                    Response response,
+                                    InetSocketAddress originalHost, int redirectsRemaining,
+                                    CompletableFuture<T> future, Class<T> clazz) {
+        String location = response.getHeader("Location");
+        if (location == null || location.isEmpty()) {
+            future.completeExceptionally(new PulsarClientException(
+                    "HTTP redirect " + response.getStatusCode() + " without Location header: " + requestUrl));
+            return;
+        }
+        if (redirectsRemaining <= 0) {
+            future.completeExceptionally(new PulsarClientException(
+                    "Maximum redirects exceeded (" + clientConf.getMaxLookupRedirects()
+                            + ") while following HTTP redirect for " + requestUrl));
+            return;
+        }
+        String newUrl;
+        try {
+            newUrl = currentUri.resolve(location).toString();
+        } catch (Exception e) {
+            future.completeExceptionally(new PulsarClientException(
+                    "Invalid redirect Location \"" + location + "\" for " + requestUrl));
+            return;
+        }
+        executeGet(newUrl, originalHost, redirectsRemaining - 1, future, clazz);
+    }
+
+    private static boolean isRedirectStatusCode(int statusCode) {
+        return statusCode == HttpURLConnection.HTTP_MOVED_PERM   // 301
+                || statusCode == HttpURLConnection.HTTP_MOVED_TEMP   // 302
+                || statusCode == HttpURLConnection.HTTP_SEE_OTHER    // 303
+                || statusCode == 307                                 // Temporary Redirect
+                || statusCode == 308;                                // Permanent Redirect
     }
 
     protected PulsarSslConfiguration buildSslConfiguration(ClientConfigurationData config, String host)

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HttpClientTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HttpClientTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.resolver.NameResolver;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.common.util.netty.DnsResolverUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@link HttpClient} carries the {@code Authorization} header across cross-origin HTTP redirects.
+ *
+ * <p>Pulsar's HTTP lookup endpoint returns {@code 307 Temporary Redirect} to whichever broker owns the bundle for a
+ * topic. The redirect target is that broker's {@code httpUrl}/{@code httpUrlTls}, i.e. typically a different host or
+ * port from the original request. Auth plugins ({@code AuthenticationToken}, {@code AuthenticationBasic},
+ * {@code AuthenticationOAuth2}, {@code AuthenticationAthenz}) inject the {@code Authorization} header — that header
+ * must reach the redirect target for lookup to succeed.
+ *
+ * <p>async-http-client 2.14.5 strips {@code Authorization} on cross-origin redirects when its built-in follow-redirect
+ * is enabled (CVE-2026-40490 fix). This test drives two WireMock servers on different ports to exercise that path.
+ */
+public class HttpClientTest {
+
+    private static final String LOOKUP_PATH = "/lookup/v2/topic/persistent/public/default/test-topic";
+    private static final String EXPECTED_BODY = "{\"brokerUrl\":\"pulsar://broker-b:6650\","
+            + "\"brokerUrlTls\":\"pulsar+ssl://broker-b:6651\","
+            + "\"httpUrl\":\"http://broker-b:8080\","
+            + "\"httpUrlTls\":\"https://broker-b:8443\","
+            + "\"nativeUrl\":\"pulsar://broker-b:6650\"}";
+
+    private WireMockServer serverA;
+    private WireMockServer serverB;
+    private EventLoopGroup eventLoopGroup;
+    private Timer timer;
+    private NameResolver<InetAddress> nameResolver;
+
+    @BeforeClass(alwaysRun = true)
+    void beforeClass() {
+        eventLoopGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("HttpClientTest"));
+        timer = new HashedWheelTimer(new DefaultThreadFactory("HttpClientTest-timer"));
+        // Default JDK-backed resolver is sufficient; we only hit 127.0.0.1.
+        nameResolver = DnsResolverUtil.adaptToNameResolver(null);
+    }
+
+    @AfterClass(alwaysRun = true)
+    void afterClass() {
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully();
+        }
+        if (timer != null) {
+            timer.stop();
+        }
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    void beforeMethod() {
+        serverA = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        serverB = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        serverA.start();
+        serverB.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void afterMethod() {
+        if (serverA != null) {
+            serverA.stop();
+        }
+        if (serverB != null) {
+            serverB.stop();
+        }
+    }
+
+    @Test
+    public void testCrossOriginRedirectCarriesAuthorizationHeader() throws Exception {
+        // serverA (origin host:port) returns 307 Temporary Redirect to serverB (different port -> cross-origin).
+        serverA.stubFor(get(urlPathMatching(LOOKUP_PATH))
+                .willReturn(aResponse()
+                        .withStatus(307)
+                        .withHeader("Location",
+                                "http://127.0.0.1:" + serverB.port() + LOOKUP_PATH)));
+
+        // serverB only responds 200 when the Authorization header is present with the expected token.
+        // Priorities: lower = higher priority; the specific-Authorization stub must be checked first.
+        serverB.stubFor(get(urlPathMatching(LOOKUP_PATH))
+                .atPriority(2)
+                .willReturn(aResponse().withStatus(401).withBody("missing auth")));
+        serverB.stubFor(get(urlPathMatching(LOOKUP_PATH))
+                .atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer test-token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(EXPECTED_BODY)));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://127.0.0.1:" + serverA.port());
+        conf.setAuthentication(AuthenticationFactory.token("test-token"));
+
+        try (HttpClient httpClient = new HttpClient(conf, eventLoopGroup, timer, nameResolver)) {
+            LookupData result = httpClient.get(LOOKUP_PATH, LookupData.class)
+                    .get(30, TimeUnit.SECONDS);
+
+            assertNotNull(result, "Expected lookup payload after cross-origin redirect");
+            assertEquals(result.getBrokerUrl(), "pulsar://broker-b:6650");
+            assertEquals(result.getHttpUrl(), "http://broker-b:8080");
+
+            // Lock the invariant: the final hop on serverB must carry the Authorization header.
+            serverB.verify(getRequestedFor(urlPathMatching(LOOKUP_PATH))
+                    .withHeader("Authorization", equalTo("Bearer test-token")));
+        }
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HttpLookupServiceTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HttpLookupServiceTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.netty.DnsResolverUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end check that {@link HttpLookupService#getBroker} carries the {@code Authorization} header
+ * across a cross-origin redirect — the production scenario where a broker returns
+ * {@code 307 Temporary Redirect} with a {@code Location} pointing at another broker's
+ * {@code httpUrl}/{@code httpUrlTls}.
+ */
+public class HttpLookupServiceTest {
+
+    private static final String TOPIC = "persistent://public/default/cross-origin-lookup-topic";
+    private static final String LOOKUP_PATH_REGEX =
+            "/lookup/v2/topic/persistent/public/default/cross-origin-lookup-topic";
+    private static final String LOOKUP_BODY = "{\"brokerUrl\":\"pulsar://broker-b.example:6650\","
+            + "\"brokerUrlTls\":\"pulsar+ssl://broker-b.example:6651\","
+            + "\"httpUrl\":\"http://broker-b.example:8080\","
+            + "\"httpUrlTls\":\"https://broker-b.example:8443\","
+            + "\"nativeUrl\":\"pulsar://broker-b.example:6650\"}";
+
+    private WireMockServer serverA;
+    private WireMockServer serverB;
+    private EventLoopGroup eventLoopGroup;
+    private Timer timer;
+
+    @BeforeClass(alwaysRun = true)
+    void beforeClass() {
+        eventLoopGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("HttpLookupServiceTest"));
+        timer = new HashedWheelTimer(new DefaultThreadFactory("HttpLookupServiceTest-timer"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    void afterClass() {
+        if (eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully();
+        }
+        if (timer != null) {
+            timer.stop();
+        }
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    void beforeMethod() {
+        serverA = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        serverB = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        serverA.start();
+        serverB.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    void afterMethod() {
+        if (serverA != null) {
+            serverA.stop();
+        }
+        if (serverB != null) {
+            serverB.stop();
+        }
+    }
+
+    @Test
+    public void testGetBrokerFollowsCrossOriginRedirect() throws Exception {
+        serverA.stubFor(get(urlPathMatching(LOOKUP_PATH_REGEX))
+                .willReturn(aResponse()
+                        .withStatus(307)
+                        .withHeader("Location",
+                                "http://127.0.0.1:" + serverB.port() + LOOKUP_PATH_REGEX)));
+
+        serverB.stubFor(get(urlPathMatching(LOOKUP_PATH_REGEX))
+                .atPriority(2)
+                .willReturn(aResponse().withStatus(401).withBody("missing auth")));
+        serverB.stubFor(get(urlPathMatching(LOOKUP_PATH_REGEX))
+                .atPriority(1)
+                .withHeader("Authorization", equalTo("Bearer test-token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(LOOKUP_BODY)));
+
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("http://127.0.0.1:" + serverA.port());
+        conf.setAuthentication(AuthenticationFactory.token("test-token"));
+
+        HttpLookupService lookupService = new HttpLookupService(
+                InstrumentProvider.NOOP, conf, eventLoopGroup, timer, DnsResolverUtil.adaptToNameResolver(null));
+        try {
+            LookupTopicResult result = lookupService.getBroker(TopicName.get(TOPIC), null)
+                    .get(30, TimeUnit.SECONDS);
+
+            assertNotNull(result);
+            assertEquals(result.getLogicalAddress().getHostString(), "broker-b.example");
+            assertEquals(result.getLogicalAddress().getPort(), 6650);
+
+            serverB.verify(getRequestedFor(urlPathMatching(LOOKUP_PATH_REGEX))
+                    .withHeader("Authorization", equalTo("Bearer test-token")));
+        } finally {
+            lookupService.close();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

async-http-client 2.12.4 contains GHSA-cmxv-58fp-fm3g / CVE-2026-40490.

The CVE fix in async-http-client 2.14.5 strips the `Authorization` and `Proxy-Authorization` headers on cross-origin redirects (different scheme/host/port) when AHC's built-in follow-redirect is enabled. There is no opt-out.

Impact on Pulsar:

- **`pulsar-client-admin`**: safe. `AsyncHttpConnector` already sets `setFollowRedirect(false)` and runs a manual redirect loop, so AHC's new stripping never runs. No test previously guarded this invariant, though — a future regression to built-in follow-redirect would silently break cross-broker admin calls.
- **`pulsar-client` `HttpLookupService` → `HttpClient`**: broken. `HttpClient` set `setFollowRedirect(true)` and only invoked `authentication.newRequestHeader(...)` once on the initial request. After the AHC upgrade, `HttpLookupService.getBroker(...)` and `getPartitionedTopicMetadata(...)` would receive 401 on any cross-broker 307 redirect (Pulsar's `TopicLookupBase` routinely redirects to a different broker's `httpUrl`/`httpUrlTls`). Affects `AuthenticationToken`, `AuthenticationBasic`, `AuthenticationOAuth2`, `AuthenticationAthenz`, `AuthenticationSasl`, and any custom plugin that sets the `Authorization` header.

### Modifications

- Upgrade `async-http-client` from 2.12.4 to 2.14.5 (note: skips 2.12.5 — [explanation](https://github.com/AsyncHttpClient/async-http-client/issues/2167#issuecomment-4263817905)).
- `pulsar-client` `HttpClient`: disable AHC's built-in follow-redirect (`setFollowRedirect(false)`) and drive the redirect loop in Pulsar code. The new `executeGet(...)` / `handleRedirect(...)` re-invokes `authentication.getAuthData(...)` + `authentication.newRequestHeader(...)` per hop, so the `Authorization` header (and per-hop auth data — useful for OAuth2 / SASL) is applied to the redirect target. Handles 301/302/303/307/308, bounded by `conf.getMaxLookupRedirects()`. Mirrors the pattern already used by `pulsar-client-admin`'s `AsyncHttpConnector`.
- Minor: replaced the opaque `"PulsarClientImpl"` setup-failure log in `HttpClient.get(...)` with a descriptive message.

### Verifying this change

This change added tests and can be verified as follows:

- `HttpClientTest.testCrossOriginRedirectCarriesAuthorizationHeader` (new, `pulsar-client`) — two WireMock servers on different ports; serverA returns 307 to serverB; serverB requires `Authorization: Bearer test-token`. Fails without the fix (401 from serverB — AHC 2.14.5 stripped the header), passes with the fix.
- `HttpLookupServiceTest.testGetBrokerFollowsCrossOriginRedirect` (new, `pulsar-client`) — end-to-end `HttpLookupService.getBroker(TopicName)` against the same cross-origin setup.
- `AsyncHttpConnectorTest.testAuthorizationHeaderOnCrossOriginRedirect` (new, `pulsar-client-admin`) — locks in that the admin connector continues to forward `Authorization` across cross-origin redirects. Passes without any admin code change — guards a future regression (e.g., flipping `setFollowRedirect` back to `true`).

Added `wiremock` as a test dependency in `pulsar-client` (already available in the version catalog and in use by `pulsar-client-admin`).

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency) — `async-http-client` 2.12.4 → 2.14.5; `wiremock` added to `pulsar-client` test scope.
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment