### PR TITLE
[fix][broker]Namespaces can be created with may empty replication_clusters policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -491,7 +491,7 @@ public abstract class NamespacesBase extends AdminResource {
                                 // There are still more than one clusters configured for the global namespace
                                 throw new RestException(Status.PRECONDITION_FAILED,
                                     "Cannot delete the global namespace " + nsName + ". There are still more than "
-                                    + "one replication clusters configured.");
+                                    + "one replication clusters configured or replication clusters is empty.");
                             }
                             if (!cluster.equals(config().getClusterName())) {
                                 // the only replication cluster is other cluster, redirect

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2392,7 +2392,7 @@ public abstract class NamespacesBase extends AdminResource {
             log.info(msg);
             return FutureUtil.failedFuture(new RestException(Status.BAD_REQUEST, msg));
         }
-        pulsar().getBrokerService().setCurrentClusterAllowedIfNoClusterIsAllowed(ns, policies);
+        pulsar().getBrokerService().setCurrentClusterAllowedWhenCreating(ns, policies);
 
         // Validate cluster names and permissions
         return Stream.concat(policies.replication_clusters.stream(), policies.allowed_clusters.stream())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4153,14 +4153,14 @@ public class BrokerService implements Closeable {
         return nsPolicies.replication_clusters.contains(pulsar.getConfig().getClusterName());
     }
 
-    public void setCurrentClusterAllowedIfNoClusterIsAllowed(NamespaceName nsName, Policies nsPolicies) {
-        if (nsPolicies.replication_clusters.contains(pulsar.getConfig().getClusterName())
-                || nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
-            return;
-        }
+    public void setCurrentClusterAllowedWhenCreating(NamespaceName nsName, Policies nsPolicies) {
         if (nsPolicies.replication_clusters.isEmpty()) {
             nsPolicies.replication_clusters.add(pulsar.getConfig().getClusterName());
-        } else {
+        }
+        if (nsPolicies.allowed_clusters.isEmpty()) {
+            return;
+        }
+        if (!nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
             nsPolicies.allowed_clusters.add(pulsar.getConfig().getClusterName());
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4154,13 +4154,13 @@ public class BrokerService implements Closeable {
     }
 
     public void setCurrentClusterAllowedWhenCreating(NamespaceName nsName, Policies nsPolicies) {
-        if (nsPolicies.replication_clusters.isEmpty()) {
-            nsPolicies.replication_clusters.add(pulsar.getConfig().getClusterName());
-        }
-        if (nsPolicies.allowed_clusters.isEmpty()) {
+        if (nsPolicies.replication_clusters.contains(pulsar.getConfig().getClusterName())
+                || nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
             return;
         }
-        if (!nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
+        if (nsPolicies.replication_clusters.isEmpty()) {
+            nsPolicies.replication_clusters.add(pulsar.getConfig().getClusterName());
+        } else {
             nsPolicies.allowed_clusters.add(pulsar.getConfig().getClusterName());
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4154,13 +4154,13 @@ public class BrokerService implements Closeable {
     }
 
     public void setCurrentClusterAllowedWhenCreating(NamespaceName nsName, Policies nsPolicies) {
-        if (nsPolicies.replication_clusters.contains(pulsar.getConfig().getClusterName())
-                || nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
-            return;
-        }
         if (nsPolicies.replication_clusters.isEmpty()) {
             nsPolicies.replication_clusters.add(pulsar.getConfig().getClusterName());
-        } else {
+        }
+        if (nsPolicies.allowed_clusters.isEmpty()) {
+            return;
+        }
+        if (!nsPolicies.allowed_clusters.contains(pulsar.getConfig().getClusterName())) {
             nsPolicies.allowed_clusters.add(pulsar.getConfig().getClusterName());
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -41,7 +41,11 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -137,6 +141,7 @@ import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.PersistencePolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -1737,6 +1742,35 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         // Global cluster, if there, should be omitted from the results
         assertEquals(admin.namespaces().getNamespaceReplicationClusters(namespace),
                 Collections.singletonList(localCluster));
+    }
+
+    @Test
+    public void testCreateNamespaceWithEmptyReplicationClustersByHttp() throws Exception {
+        String localCluster = pulsar.getConfiguration().getClusterName();
+        String namespacePart = newUniqueName("ns");
+        String namespace = defaultTenant + "/" + namespacePart;
+
+        HttpClient httpClient = HttpClient.newHttpClient();
+        URI adminV2Uri = URI.create(brokerUrl.toString()).resolve("/admin/v2/");
+
+        String namespaceRequestBody = "{\"allowed_clusters\": [\"" + localCluster + "\"]}";
+        HttpRequest createNamespaceRequest =
+                HttpRequest.newBuilder(adminV2Uri.resolve("namespaces/" + namespace))
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(namespaceRequestBody))
+                        .build();
+        HttpResponse<String> createNamespaceResponse = httpClient.send(createNamespaceRequest,
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(createNamespaceResponse.statusCode(), Status.NO_CONTENT.getStatusCode(),
+                "Failed to create namespace by HTTP: " + createNamespaceResponse.body());
+
+        Awaitility.await().untilAsserted(() -> {
+            Policies policies = admin.namespaces().getPolicies(namespace);
+            assertEquals(policies.replication_clusters.size(), 1);
+            assertEquals(policies.allowed_clusters.size(), 1);
+            assertTrue(policies.replication_clusters.contains(localCluster));
+            assertTrue(policies.allowed_clusters.contains(localCluster));
+        });
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1750,9 +1750,9 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         String namespacePart = newUniqueName("ns");
         String namespace = defaultTenant + "/" + namespacePart;
 
+        // Create namespace with "allowed_cluster", and the param "replication_clusters" is empty.
         HttpClient httpClient = HttpClient.newHttpClient();
         URI adminV2Uri = URI.create(brokerUrl.toString()).resolve("/admin/v2/");
-
         String namespaceRequestBody = "{\"allowed_clusters\": [\"" + localCluster + "\"]}";
         HttpRequest createNamespaceRequest =
                 HttpRequest.newBuilder(adminV2Uri.resolve("namespaces/" + namespace))
@@ -1764,6 +1764,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(createNamespaceResponse.statusCode(), Status.NO_CONTENT.getStatusCode(),
                 "Failed to create namespace by HTTP: " + createNamespaceResponse.body());
 
+        // Verify: replication_clusters is not empty.
         Awaitility.await().untilAsserted(() -> {
             Policies policies = admin.namespaces().getPolicies(namespace);
             assertEquals(policies.replication_clusters.size(), 1);


### PR DESCRIPTION
### Motivation

Before https://github.com/apache/pulsar/pull/24860, the namespace-level policy: `replication_clusters` will never be empty; after https://github.com/apache/pulsar/pull/24860, it will be empty if a namespace is created with the following request

```
curl -x PUT http://localhost:50025/admin/v2/namespaces/{tenant}/{namespace}` -D `{"allowed_clusters": ["{current_cluster}"]}`
```

This will lead to some unexpected problems, such as the namespace not being able to be deleted normally and getting an error `Failed to delete namespace {namespace}
java.util.concurrent.CompletionException: org.apache.pulsar.broker.web.RestException: Cannot delete the global namespace {namespace}. There are still more than one replication cluster configured.`


### Modifications

- Recover the default behaviour that was defined before https://github.com/apache/pulsar/pull/24860
- Improve the error message

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment