### PR TITLE
[fix][broker] Fix pending publish state leak when transfer-time writes fail on PersistentTopic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -758,19 +758,21 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
     @Override
     public synchronized void addFailed(ManagedLedgerException exception, Object ctx) {
+        PublishContext callback = (PublishContext) ctx;
         /* If the topic is being transferred(in the Releasing bundle state),
-         we don't want to forcefully close topic here.
-         Instead, we will rely on the service unit state channel's bundle(topic) transfer protocol.
-         At the end of the transfer protocol, at Owned state, the source broker should close the topic properly.
+         we don't want to forcefully close the topic here.
+         Instead, complete the broker-side publish callback and let the transfer protocol finish the topic close on the
+         source broker.
          */
         if (transferring) {
             log.debug()
                     .exception(exception)
                     .log("Failed to persist msg in store while transferring");
+            callback.completed(new TopicClosedException(exception), -1, -1);
+            decrementPendingWriteOpsAndCheck();
             return;
         }
 
-        PublishContext callback = (PublishContext) ctx;
         if (exception instanceof ManagedLedgerFencedException) {
             // If the managed ledger has been fenced, we cannot continue using it. We need to close and reopen
             close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -73,6 +73,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1917,6 +1918,51 @@ public class ServerCnxTest {
         channel.finish();
     }
 
+    @Test(timeOut = 30000)
+    public void testInFlightSendFailureDuringTransferReleasesBrokerStateWithoutSendError() throws Exception {
+        resetChannel();
+        setChannelConnected();
+
+        ByteBuf clientCommand = Commands.newProducer(successTopicName, 1 /* producer id */, 1 /* request id */,
+                "prod-name", Collections.emptyMap(), false);
+        channel.writeInbound(clientCommand);
+        assertTrue(getResponse() instanceof CommandProducerSuccess);
+
+        PersistentTopic topic = (PersistentTopic) brokerService.getTopicReference(successTopicName).orElseThrow();
+        Producer producer = topic.getProducers().values().iterator().next();
+        CountDownLatch addEntryStarted = new CountDownLatch(1);
+        AtomicReference<AddEntryCallback> addEntryCallback = new AtomicReference<>();
+        AtomicReference<Object> addEntryContext = new AtomicReference<>();
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            addEntryCallback.set(invocationOnMock.getArgument(2));
+            addEntryContext.set(invocationOnMock.getArgument(3));
+            addEntryStarted.countDown();
+            return null;
+        }).when(ledgerMock).asyncAddEntry(any(ByteBuf.class), anyInt(), any(AddEntryCallback.class), any());
+
+        sendMessage();
+
+        assertTrue(addEntryStarted.await(1, TimeUnit.SECONDS));
+        assertEquals(topic.getPendingWriteOps().get(), 1L);
+        assertEquals(producer.getPendingPublishAcks(), 1L);
+
+        setTopicTransferring(topic);
+        addEntryCallback.get().addFailed(
+                new ManagedLedgerException.ManagedLedgerAlreadyClosedException("Managed ledger was already closed"),
+                addEntryContext.get());
+
+        Awaitility.await().during(200, TimeUnit.MILLISECONDS).atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            channel.runPendingTasks();
+            assertNull(tryPeekResponse(channel, clientChannelHelper));
+        });
+        assertTrue(channel.isActive());
+        Awaitility.await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(topic.getPendingWriteOps().get(), 0L);
+                    assertEquals(producer.getPendingPublishAcks(), 0L);
+                });
+    }
+
     private void sendMessage() {
         MessageMetadata messageMetadata = new MessageMetadata()
                 .setPublishTime(System.currentTimeMillis())
@@ -1928,6 +1974,20 @@ public class ServerCnxTest {
                 ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
+    }
+
+    private void setTopicTransferring(PersistentTopic topic) throws Exception {
+        Field transferringField = AbstractTopic.class.getDeclaredField("transferring");
+        transferringField.setAccessible(true);
+        transferringField.set(topic, true);
+
+        Field isFencedField = AbstractTopic.class.getDeclaredField("isFenced");
+        isFencedField.setAccessible(true);
+        isFencedField.set(topic, true);
+
+        Field isClosingOrDeletingField = PersistentTopic.class.getDeclaredField("isClosingOrDeleting");
+        isClosingOrDeletingField.setAccessible(true);
+        isClosingOrDeletingField.set(topic, true);
     }
 
     @Test(timeOut = 30000)


### PR DESCRIPTION
### Motivation

  During bundle transfer, Pulsar intentionally keeps producer connections alive in the releasing phase and avoids triggering client reconnection until the later close step defined by PIP-307. However, if an in-flight publish reaches PersistentTopic.addFailed() while the topic is already transferring, the broker currently
  returns early without completing the publish callback.

  That leaves broker-side publish state stuck:

  - pendingWriteOps is not decremented
  - producer pendingPublishAcks is not decremented

  This creates a real leak in the transfer path and can block proper producer/topic cleanup, while the wire protocol semantics during transfer should remain unchanged.

### Modifications

  - Update PersistentTopic.addFailed() to complete the broker-side publish callback even when the topic is in transferring state.
  - Use TopicClosedException in that transfer-time failure path so the broker releases internal publish bookkeeping without sending a SendError to the client.
  - Decrement pendingWriteOps in that path to avoid stuck write state on the source broker.
  - Add a focused regression test covering an in-flight publish failure during transfer and asserting that:
      - no SendError is sent to the client
      - pendingWriteOps returns to zero
      - producer pendingPublishAcks returns to zero

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment