### PR TITLE
[fix][doc] Correct loadConf example key in PulsarAdminBuilder

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -45,7 +45,7 @@ public interface PulsarAdminBuilder {
      * <pre>
      * {@code
      * Map<String, Object> config = new HashMap<>();
-     * config.put("serviceHttpUrl", "http://localhost:6650");
+     * config.put("serviceUrl", "pulsar://localhost:6650");
      *
      * PulsarAdminBuilder builder = ...;
      * builder = builder.loadConf(config);


### PR DESCRIPTION
Fixes #24093

### Motivation

`PulsarAdminBuilder.loadConf` documents an example that uses `serviceHttpUrl` as the config map key:

```java
Map<String, Object> config = new HashMap<>();
config.put("serviceHttpUrl", "http://localhost:6650");
```

However, `loadConf` resolves its keys against `ClientConfigurationData`, whose field is declared as `serviceUrl`:

https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java#L60-L65

```java
@ApiModelProperty(
        name = "serviceUrl",
        value = "Pulsar cluster HTTP URL to connect to a broker."
)
private String serviceUrl;
```

Copy-pasting the current example produces a silently ignored configuration entry and no admin service URL is set, which is a frustrating first-contact experience for anyone reading the API docs.

### Modifications

- `pulsar-client-admin-api/.../PulsarAdminBuilder.java`: change the `loadConf` example key from `serviceHttpUrl` to `serviceUrl`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial Javadoc-only fix without any test coverage.

### Does this pull request potentially affect one of the following parts:

None of the listed areas are affected. This is a comment-only change inside a Javadoc example.

### Documentation

- [x] `doc-not-needed`

No user-facing documentation outside of this Javadoc example needs updating; the admin configuration reference already uses the correct `serviceUrl` key.
