### PR TITLE
[fix][broker] pulsar admin stats internal with metadata command

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3162,6 +3162,9 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     info.ledgerId = compactedTopicContext.getLedger().getId();
                     info.entries = compactedTopicContext.getLedger().getLastAddConfirmed() + 1;
                     info.size = compactedTopicContext.getLedger().getLength();
+                    if (includeLedgerMetadata) {
+                        info.metadata = compactedTopicContext.getLedger().getLedgerMetadata().toSafeString();
+                    }
                 }
 
                 stats.compactedLedger = info;
@@ -3243,7 +3246,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                         schemaLedgerInfo.entries = metadata.getLastEntryId() + 1;
                                         schemaLedgerInfo.size = metadata.getLength();
                                         if (includeLedgerMetadata) {
-                                            info.metadata = metadata.toSafeString();
+                                            schemaLedgerInfo.metadata = metadata.toSafeString();
                                         }
                                         stats.schemaLedgers.add(schemaLedgerInfo);
                                         completableFuture.complete(null);


### PR DESCRIPTION
Following command returns wrong metadata for compactedLedger (It returns the metadata of schemaLedger):
`pulsar-admin topics stats-internal persistent://t/n/__change_events -m`

To reproduce:
1. Run command: pulsar-admin topics stats-internal persistent://t/n/__change_events -m
2. Check the ensemble of schemaLedgers and compactedLedger from bookie and compare it with the output of above command.




*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment