### PR TITLE
[fix][broker] Lower log level of DrainingHashesTracker not-found entry to DEBUG

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -188,7 +188,11 @@ public class DrainingHashesTracker {
                     int hash = hashIterator.nextInt();
                     DrainingHashEntry entry = getEntry(hash);
                     if (entry == null) {
-                        log.warn()
+                        // Not-found entries are expected as a benign race between the draining-hash
+                        // stats read path and the draining-hash removal path (fixed in #23854 to
+                        // avoid deadlocks). Logging at WARN was noisy; DEBUG keeps the signal for
+                        // troubleshooting without polluting broker logs.
+                        log.debug()
                                 .attr("dispatcher", dispatcherName)
                                 .attr("hash", hash)
                                 .attr("consumer", consumer)


### PR DESCRIPTION
Fixes #25277

### Motivation

`DrainingHashesTracker.ConsumerDrainingHashesStats#updateConsumerStats` currently logs a WARN every time the hash iterator observes an entry that was concurrently removed:

https://github.com/apache/pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java#L188-L196

```java
if (entry == null) {
    log.warn()
            .attr("dispatcher", dispatcherName)
            .attr("hash", hash)
            .attr("consumer", consumer)
            .log("Draining hash not found in the tracker for consumer");
    continue;
}
```

In the original PIP-379 design the draining-hash stats were strongly consistent with the tracker state, so a missing entry on this read path would indeed have been unexpected. That strong-consistency guarantee was intentionally dropped in #23854 to break a deadlock — the stats read path is now allowed to race with entry removal.

A null `entry` is therefore a benign, expected outcome during normal broker operation, not an alertable condition. Logging at WARN floods broker logs and drowns out actionable warnings.

The issue author (@lhotari) explicitly notes: *"The warning log no longer makes sense and should be changed to debug logging."*

### Modifications

- `DrainingHashesTracker.java`: change the not-found branch from `log.warn()` to `log.debug()` and add an inline comment explaining why the log is deliberately quiet (pointing at the #23854 context), so future readers don't bump it back up.

No behavioural change — the `continue` and surrounding logic are untouched.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial fix without any test coverage: it only lowers the level of an existing log statement. No functional behaviour changes, so no new tests are required (existing `DrainingHashesTracker` tests still cover the race path).

### Does this pull request potentially affect one of the following parts:

None of the listed areas are affected. Log level only.

### Documentation

- [x] `doc-not-needed`

No user-facing or config documentation references this log line.
