### PR TITLE
[fix][test] Recreate EventLoop in PublishRateLimiterTest setup

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
@@ -57,11 +57,12 @@ public class PublishRateLimiterTest {
     private ServerCnx serverCnx;
     private PublishRateLimiterImpl publishRateLimiter;
     private ServerCnxThrottleTracker throttleTracker;
-    private DefaultThreadFactory threadFactory = new DefaultThreadFactory("pulsar-io");
-    private EventLoop eventLoop = new DefaultEventLoop(threadFactory);
+    private final DefaultThreadFactory threadFactory = new DefaultThreadFactory("pulsar-io");
+    private EventLoop eventLoop;
 
     @BeforeMethod
     public void setup() throws Exception {
+        eventLoop = new DefaultEventLoop(threadFactory);
         policies.publishMaxMessageRate = new HashMap<>();
         policies.publishMaxMessageRate.put(CLUSTER_NAME, publishRate);
         manualClockSource = new AtomicLong(TimeUnit.SECONDS.toNanos(100));


### PR DESCRIPTION
## Summary

`PublishRateLimiterTest` has a latent bug: the class-level `eventLoop`
field is initialized once (at instance construction), but
`@AfterMethod tearDown()` calls `eventLoop.shutdownGracefully()` after
every test. TestNG reuses a single instance per class, so the second
test method to run in the class hits
`RejectedExecutionException: event executor terminated` when it calls
`eventLoop.execute(...)`.

Two recent additions to the class
(`shouldUnthrottleImmediatelyAfterDisablingLimitsDespiteLongPendingDelay`
and `shouldUnthrottleImmediatelyAfterRaisingByteLimitDespiteLongPendingDelay`,
added in #25502) exposed the latent bug — in TestNG's alphabetical
default order, they run before `testPublishRateLimiterImplExceed`, and
their `tearDown` terminates the shared event loop.

The fix: move `eventLoop` creation into `@BeforeMethod` so each test
gets a fresh instance. `@AfterMethod tearDown()` continues to shut
it down at the end of each test.

## Test plan

- [x] `./gradlew :pulsar-broker:test --tests "org.apache.pulsar.broker.service.PublishRateLimiterTest"`
      all 4 tests pass.