### PR TITLE
[fix][test] Fix flaky OffloadPrefixTest.testPositionOnEdgeOfLedger race with ledger rollover

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -57,6 +57,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -233,7 +234,11 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
             String content = "entry-" + i;
             ledger.addEntry(content.getBytes());
         }
-        assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        // After filling exactly 2 ledgers, the 2nd is closed and a 3rd empty ledger starts
+        // being created asynchronously. Wait for that to finish so the rest of the test runs
+        // against a stable state (l1 full, l2 full, l3 empty) instead of racing with rollover.
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(ledger.getLedgersInfoAsList().size(), 3));
 
         Position p = ledger.getLastConfirmedEntry(); // position at end of second ledger
 


### PR DESCRIPTION
### Motivation

`OffloadPrefixTest.testPositionOnEdgeOfLedger` is flaky. The test writes exactly 20 entries with `maxEntriesPerLedger=10`, which fills two ledgers. Once the second ledger is full, it is closed and a third (empty) ledger starts being created asynchronously on the managed-ledger executor. The test's next line asserts that only 2 ledgers exist — this races with the async rollover and the test intermittently fails with a third ledger already present.

#### Example failure

```
Gradle suite > Gradle test > org.apache.bookkeeper.mledger.impl.OffloadPrefixTest > testPositionOnEdgeOfLedger FAILED
    java.lang.AssertionError: expected [2] but found [3]
        at org.testng.Assert.fail(Assert.java:110)
        at org.testng.Assert.failNotEquals(Assert.java:1577)
        at org.testng.Assert.assertEqualsImpl(Assert.java:149)
        at org.testng.Assert.assertEquals(Assert.java:131)
        at org.testng.Assert.assertEquals(Assert.java:1418)
        at org.testng.Assert.assertEquals(Assert.java:1382)
        at org.testng.Assert.assertEquals(Assert.java:1428)
        at org.apache.bookkeeper.mledger.impl.OffloadPrefixTest.testPositionOnEdgeOfLedger(OffloadPrefixTest.java:237)
```

- Failure scan: https://scans.gradle.com/s/5uzx6ammf6lko/tests/task/:managed-ledger:test/details/org.apache.bookkeeper.mledger.impl.OffloadPrefixTest/testPositionOnEdgeOfLedger/2/output
- Failure scan: https://scans.gradle.com/s/lqkj2fztrznro/tests/task/:managed-ledger:test/details/org.apache.bookkeeper.mledger.impl.OffloadPrefixTest/testPositionOnEdgeOfLedger/2/output

### Modifications

Replace the hard-coded `assertEquals(size, 2)` with an `Awaitility.await()` that waits for the 3-ledger steady state (l1 full, l2 full, l3 empty). The rest of the test (`getLastConfirmedEntry` returning the last entry of l2, then `addEntry("entry-blah")` being stored in l3, then the two `offloadPrefix` calls) already works correctly against this stable state, so no other changes are required.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `OffloadPrefixTest.testPositionOnEdgeOfLedger`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment