### PR TITLE
[fix][test] Relax BrokerRegistryIntegrationTest broker-close threshold

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryIntegrationTest.java
@@ -70,7 +70,11 @@ public class BrokerRegistryIntegrationTest {
         if (bk != null) {
             bk.stop();
         }
-        if (elapsedMs > 5000) {
+        // Guard against regressions where the broker hangs on shutdown (e.g. blocked health
+        // checks or stuck registrations). Keep the threshold generous enough to tolerate CI
+        // variability in BrokerRegistryMetadataStoreIntegrationTest, while still catching the
+        // multi-minute hangs this assertion was originally added to detect.
+        if (elapsedMs > 15000) {
             throw new RuntimeException("Broker took " + elapsedMs + "ms to close");
         }
     }


### PR DESCRIPTION
### Motivation

`BrokerRegistryIntegrationTest` and its subclass `BrokerRegistryMetadataStoreIntegrationTest` fail their `@AfterClass` cleanup method if `pulsar.close()` takes more than 5 seconds. On slower CI agents (or for the metadata-store variant), the broker shutdown can legitimately exceed 5 seconds, producing spurious failures.

The assertion was originally added by PR #23371 as a regression detector for multi-minute hangs caused by blocked health checks / stuck registrations. A 15-second threshold still catches those hangs but tolerates normal CI variability.

#### Example failure

```
org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryMetadataStoreIntegrationTest.cleanup FAILED
    java.lang.RuntimeException: Broker took 10173ms to close
        at org.apache.pulsar.broker.loadbalance.extensions.BrokerRegistryIntegrationTest.cleanup(BrokerRegistryIntegrationTest.java:74)
        ...
969 tests completed, 1 failed, 5 skipped
```

### Modifications

Raise the cleanup-threshold from 5000ms to 15000ms. Add a comment explaining the intent so future readers understand why the check exists and why it is intentionally loose.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework of an existing test-only assertion and is already covered by existing tests (`BrokerRegistryIntegrationTest`, `BrokerRegistryMetadataStoreIntegrationTest`).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment