### PR TITLE
[fix][test] Extend SameAuthParamsLookupAutoClusterFailoverTest phase timeouts

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -64,7 +64,11 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
     }
     @SuppressWarnings("deprecation")
 
-    @Test(dataProvider = "enabledTls", timeOut = 240 * 1000)
+    // Each state-convergence phase below waits up to 2 minutes. With 3 phases plus
+    // cluster startup/teardown, the 240s overall timeout can be tight on slow CI agents
+    // (the probe timeout is 3s and recoverThreshold=5, so a single slow probe can
+    // stretch a phase to ~30s). Allow 8 minutes overall to match the per-phase budget.
+    @Test(dataProvider = "enabledTls", timeOut = 480 * 1000)
     public void testAutoClusterFailover(boolean enabledTls) throws Exception {
         // Start clusters.
         setup();
@@ -117,7 +121,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
 
         // Test failover 0 --> 2.
         pulsar1.close();
-        Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
             CompletableFuture<Boolean> checkStatesFuture2 = new CompletableFuture<>();
             executor.submit(() -> {
                 boolean res = stateArray[0] == PulsarServiceState.Failed;
@@ -134,7 +138,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         executor.execute(() -> {
             urlArray[1] = url2;
         });
-        Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
             CompletableFuture<Boolean> checkStatesFuture3 = new CompletableFuture<>();
             executor.submit(() -> {
                 boolean res = stateArray[0] == PulsarServiceState.Failed;
@@ -151,7 +155,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         executor.execute(() -> {
             urlArray[0] = url2;
         });
-        Awaitility.await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
             CompletableFuture<Boolean> checkStatesFuture4 = new CompletableFuture<>();
             executor.submit(() -> {
                 boolean res = stateArray[0] == PulsarServiceState.Healthy;


### PR DESCRIPTION
### Motivation

`SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` drives three state-convergence phases — failover 0->2, recover 2->1, recover 1->0 — each bounded by `Awaitility.await().atMost(60, SECONDS)`. The probe timeout inside `SameAuthParamsLookupAutoClusterFailover` is 3 seconds and `recoverThreshold` is 5, so a single slow or failing probe per iteration can stretch one phase close to 30 seconds. On slow CI agents the cumulative variance pushes the final phase past 60 seconds and the test fails with `ConditionTimeoutException`.

#### Example failure

```
Gradle suite > Gradle test > org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest > testAutoClusterFailover[4](false) FAILED
    org.awaitility.core.ConditionTimeoutException: Assertion condition expected [true] but found [false] within 1 minutes.
        at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
        at app//org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
        at app//org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:769)
        at app//org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover(SameAuthParamsLookupAutoClusterFailoverTest.java:154)

        Caused by:
        java.lang.AssertionError: expected [true] but found [false]
            at org.testng.Assert.assertTrue(Assert.java:56)
            at org.testng.Assert.assertTrue(Assert.java:66)
            at org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest.lambda$testAutoClusterFailover$8(SameAuthParamsLookupAutoClusterFailoverTest.java:162)
```

- Failure scan: https://scans.gradle.com/s/btzgcc3x3eiak/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest/testAutoClusterFailover%5B4%5D(false)/1/output

### Modifications

- Raise each `Awaitility.atMost` from 60s to 120s so a single phase can still complete even when every check cycle is stretched by slow probes.
- Raise the overall test `timeOut` from 240s to 480s so the three per-phase budgets still fit comfortably along with setup and teardown.
- Add a comment explaining the sizing decision.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, specifically `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment