### PR TITLE
[feat] PIP-468: Add scalable topics and segments admin APIs with CLI

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ScalableTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ScalableTopics.java
@@ -1,0 +1,595 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.v2;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.resources.ScalableTopicMetadata;
+import org.apache.pulsar.broker.resources.ScalableTopicResources;
+import org.apache.pulsar.broker.service.scalable.ScalableTopicController;
+import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.scalable.SegmentInfo;
+import org.apache.pulsar.common.scalable.SegmentTopicName;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+
+/**
+ * Admin REST API for scalable topics (topic:// domain).
+ *
+ * <p>Provides operations to create, delete, list, and inspect scalable topics,
+ * as well as segment split/merge operations.
+ */
+@CustomLog
+@Path("/scalable")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "/scalable", description = "Scalable topic admin APIs", tags = "scalable topic")
+public class ScalableTopics extends AdminResource {
+
+    private ScalableTopicResources resources() {
+        return pulsar().getPulsarResources().getScalableTopicResources();
+    }
+
+    // --- List ---
+
+    @GET
+    @Path("/{tenant}/{namespace}")
+    @ApiOperation(value = "Get the list of scalable topics under a namespace.",
+            response = String.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Tenant or namespace doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void getList(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace) {
+        validateNamespaceName(tenant, namespace);
+        resources().listScalableTopicsAsync(namespaceName)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("namespace", namespaceName)
+                            .exception(ex).log("Failed to list scalable topics");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Create ---
+
+    @PUT
+    @Path("/{tenant}/{namespace}/{topic}")
+    @ApiOperation(value = "Create a new scalable topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Scalable topic created successfully"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 409, message = "Scalable topic already exists"),
+            @ApiResponse(code = 412, message = "Invalid configuration"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void createScalableTopic(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Number of initial segments")
+            @QueryParam("numInitialSegments") @DefaultValue("1") int numInitialSegments,
+            @ApiParam(value = "Key value pair properties for the topic metadata")
+            Map<String, String> properties) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        if (numInitialSegments < 1) {
+            asyncResponse.resume(new RestException(Response.Status.fromStatusCode(412),
+                    "numInitialSegments must be >= 1"));
+            return;
+        }
+
+        Map<String, String> props = properties != null ? properties : Map.of();
+        ScalableTopicMetadata metadata = ScalableTopicController.createInitialMetadata(
+                numInitialSegments, props);
+
+        // Segment persistent topics are auto-created on demand when clients connect,
+        // so we only need to store the metadata here.
+        resources().createScalableTopicAsync(tn, metadata)
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("topic", tn)
+                            .attr("numInitialSegments", numInitialSegments)
+                            .log("Created scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                    if (cause instanceof MetadataStoreException.AlreadyExistsException) {
+                        asyncResponse.resume(new RestException(Response.Status.CONFLICT,
+                                "Scalable topic already exists: " + tn));
+                    } else {
+                        log.error().attr("clientAppId", clientAppId()).attr("topic", tn)
+                                .exception(ex).log("Failed to create scalable topic");
+                        resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    }
+                    return null;
+                });
+    }
+
+    // --- Get metadata ---
+
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}")
+    @ApiOperation(value = "Get scalable topic metadata.", response = ScalableTopicMetadata.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Scalable topic doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void getScalableTopicMetadata(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        resources().getScalableTopicMetadataAsync(tn)
+                .thenAccept(optMd -> {
+                    if (optMd.isEmpty()) {
+                        asyncResponse.resume(new RestException(Response.Status.NOT_FOUND,
+                                "Scalable topic not found: " + tn));
+                    } else {
+                        asyncResponse.resume(optMd.get());
+                    }
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("topic", tn)
+                            .exception(ex).log("Failed to get metadata for scalable topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Delete ---
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/{topic}")
+    @ApiOperation(value = "Delete a scalable topic and all its segments.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Scalable topic deleted successfully"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Scalable topic doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void deleteScalableTopic(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Force deletion even if topic has active subscriptions")
+            @QueryParam("force") @DefaultValue("false") boolean force) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        resources().getScalableTopicMetadataAsync(tn)
+                .thenCompose(optMd -> {
+                    if (optMd.isEmpty()) {
+                        throw new RestException(Response.Status.NOT_FOUND,
+                                "Scalable topic not found: " + tn);
+                    }
+                    // Delete metadata first, then best-effort clean up segment topics
+                    return resources().deleteScalableTopicAsync(tn)
+                            .thenCompose(__ -> deleteSegmentTopics(tn, optMd.get(), force));
+                })
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("topic", tn)
+                            .log("Deleted scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("topic", tn)
+                            .exception(ex).log("Failed to delete scalable topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Stats ---
+
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}/stats")
+    @ApiOperation(value = "Get aggregated stats for a scalable topic.",
+            response = org.apache.pulsar.common.policies.data.ScalableTopicStats.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Scalable topic doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void getStats(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        var scalableTopicService = pulsar().getBrokerService().getScalableTopicService();
+        if (scalableTopicService == null) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                    "Scalable topic service not available"));
+            return;
+        }
+
+        scalableTopicService.getStats(tn)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("topic", tn)
+                            .exception(ex).log("Failed to get stats for scalable topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Subscription operations ---
+
+    @PUT
+    @Path("/{tenant}/{namespace}/{topic}/subscriptions/{subscription}")
+    @ApiOperation(value = "Create a subscription on a scalable topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Subscription created successfully"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Scalable topic doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void createSubscription(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Subscription name", required = true)
+            @PathParam("subscription") String subscription,
+            @ApiParam(value = "Subscription type: STREAM (controller-managed, ordered) "
+                    + "or QUEUE (direct per-segment attach, no controller coordination)")
+            @QueryParam("type") @DefaultValue("STREAM")
+                    org.apache.pulsar.broker.resources.SubscriptionType type) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        var scalableTopicService = pulsar().getBrokerService().getScalableTopicService();
+        if (scalableTopicService == null) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                    "Scalable topic service not available"));
+            return;
+        }
+
+        redirectToControllerLeaderIfNeeded(tn)
+                .thenCompose(__ -> scalableTopicService.createSubscription(tn, subscription, type))
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId())
+                            .attr("subscription", subscription).attr("topic", tn)
+                            .log("Created subscription on scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId())
+                            .attr("subscription", subscription).attr("topic", tn)
+                            .exception(ex).log("Failed to create subscription");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/{topic}/subscriptions/{subscription}")
+    @ApiOperation(value = "Delete a subscription from a scalable topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Subscription deleted successfully"),
+            @ApiResponse(code = 401, message = "Don't have permission to administrate resources on this tenant"),
+            @ApiResponse(code = 403, message = "Don't have admin permission on the namespace"),
+            @ApiResponse(code = 404, message = "Scalable topic or subscription doesn't exist"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void deleteSubscription(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Subscription name", required = true)
+            @PathParam("subscription") String subscription) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        var scalableTopicService = pulsar().getBrokerService().getScalableTopicService();
+        if (scalableTopicService == null) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                    "Scalable topic service not available"));
+            return;
+        }
+
+        redirectToControllerLeaderIfNeeded(tn)
+                .thenCompose(__ -> scalableTopicService.deleteSubscription(tn, subscription))
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId())
+                            .attr("subscription", subscription).attr("topic", tn)
+                            .log("Deleted subscription from scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId())
+                            .attr("subscription", subscription).attr("topic", tn)
+                            .exception(ex).log("Failed to delete subscription");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Segment operations ---
+
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/split/{segmentId}")
+    @ApiOperation(value = "Split a segment into two halves.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Segment split successfully"),
+            @ApiResponse(code = 404, message = "Scalable topic or segment doesn't exist"),
+            @ApiResponse(code = 412, message = "Segment is not active or cannot be split"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void splitSegment(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment ID to split", required = true)
+            @PathParam("segmentId") long segmentId) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        var scalableTopicService = pulsar().getBrokerService().getScalableTopicService();
+        if (scalableTopicService == null) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                    "Scalable topic service not available"));
+            return;
+        }
+
+        redirectToControllerLeaderIfNeeded(tn)
+                .thenCompose(__ -> scalableTopicService.splitSegment(tn, segmentId))
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId())
+                            .attr("segmentId", segmentId).attr("topic", tn)
+                            .log("Split segment of scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId())
+                            .attr("segmentId", segmentId).attr("topic", tn)
+                            .exception(ex).log("Failed to split segment");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/merge/{segmentId1}/{segmentId2}")
+    @ApiOperation(value = "Merge two adjacent segments into one.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Segments merged successfully"),
+            @ApiResponse(code = 404, message = "Scalable topic or segment doesn't exist"),
+            @ApiResponse(code = 412, message = "Segments are not active or not adjacent"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void mergeSegments(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "First segment ID to merge", required = true)
+            @PathParam("segmentId1") long segmentId1,
+            @ApiParam(value = "Second segment ID to merge", required = true)
+            @PathParam("segmentId2") long segmentId2) {
+        validateNamespaceName(tenant, namespace);
+        TopicName tn = TopicName.get(TopicDomain.topic.value(), namespaceName, encodedTopic);
+
+        var scalableTopicService = pulsar().getBrokerService().getScalableTopicService();
+        if (scalableTopicService == null) {
+            asyncResponse.resume(new RestException(Response.Status.SERVICE_UNAVAILABLE,
+                    "Scalable topic service not available"));
+            return;
+        }
+
+        redirectToControllerLeaderIfNeeded(tn)
+                .thenCompose(__ -> scalableTopicService.mergeSegments(tn, segmentId1, segmentId2))
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId())
+                            .attr("segmentId1", segmentId1).attr("segmentId2", segmentId2)
+                            .attr("topic", tn).log("Merged segments of scalable topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId())
+                            .attr("segmentId1", segmentId1).attr("segmentId2", segmentId2)
+                            .attr("topic", tn).exception(ex)
+                            .log("Failed to merge segments");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    // --- Internal helpers ---
+
+    /**
+     * If this broker is not the elected controller leader for {@code tn}, redirect the
+     * request to the leader via HTTP 307. Read-only endpoints (like {@code getStats}) do
+     * not need this guard and should not call it.
+     *
+     * <p>The leader brokerId is read from the controller lock znode and resolved to an HTTP
+     * service URL via {@link org.apache.pulsar.broker.namespace.NamespaceService#createLookupResult}.
+     * Returns a future that completes normally when the local broker is the leader (or no
+     * leader is elected yet, in which case the caller should proceed and let {@code
+     * getOrCreateController} participate in the election). The future completes
+     * exceptionally with {@link WebApplicationException} wrapping a 307 redirect when the
+     * request must be forwarded to another broker.
+     */
+    private CompletableFuture<Void> redirectToControllerLeaderIfNeeded(TopicName tn) {
+        String lockPath = resources().controllerLockPath(tn);
+        return resources().getStore().get(lockPath)
+                .thenCompose(optValue -> {
+                    if (optValue.isEmpty()) {
+                        // No leader elected yet — let the caller's getOrCreateController run
+                        // election. It will either become leader on this broker or fail with
+                        // IllegalStateException, which the caller surfaces to the client.
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    String leaderBrokerId = deserializeLeaderBrokerId(optValue.get().getValue());
+                    if (leaderBrokerId.equals(pulsar().getBrokerId())) {
+                        // We are the leader — proceed with the operation locally.
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    // Someone else is the leader — redirect.
+                    return pulsar().getNamespaceService()
+                            .createLookupResult(leaderBrokerId, false, null)
+                            .thenCompose(lookupResult -> {
+                                String redirectUrl = isRequestHttps()
+                                        ? lookupResult.getLookupData().getHttpUrlTls()
+                                        : lookupResult.getLookupData().getHttpUrl();
+                                if (redirectUrl == null) {
+                                    return FutureUtil.failedFuture(new RestException(
+                                            Response.Status.PRECONDITION_FAILED,
+                                            "Controller leader broker " + leaderBrokerId
+                                                    + " has no web service URL configured"));
+                                }
+                                try {
+                                    URL url = new URL(redirectUrl);
+                                    URI redirect = UriBuilder.fromUri(uri.getRequestUri())
+                                            .host(url.getHost())
+                                            .port(url.getPort())
+                                            .build();
+                                    log.debug().attr("topic", tn).attr("redirect", redirect)
+                                            .log("Redirecting scalable-topic admin request to controller leader");
+                                    return FutureUtil.failedFuture(new WebApplicationException(
+                                            Response.temporaryRedirect(redirect).build()));
+                                } catch (MalformedURLException ex) {
+                                    return FutureUtil.failedFuture(new RestException(ex));
+                                }
+                            });
+                });
+    }
+
+    /**
+     * The controller-lock znode stores the leader's brokerId as a JSON-encoded string
+     * (written by {@link org.apache.pulsar.metadata.api.coordination.LeaderElection#elect}
+     * via Jackson), so the raw bytes include the JSON quotes. Decode it back to a plain
+     * string.
+     */
+    private static String deserializeLeaderBrokerId(byte[] bytes) {
+        try {
+            return org.apache.pulsar.common.util.ObjectMapperFactory.getMapper()
+                    .reader().readValue(bytes, String.class);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(
+                    "Invalid controller-leader znode value: " + new String(bytes), e);
+        }
+    }
+
+    /**
+     * Best-effort delete underlying persistent topics for all segments.
+     * Uses the internal admin client which handles cross-broker routing.
+     */
+    private CompletableFuture<Void> deleteSegmentTopics(TopicName parentTopic,
+                                                         ScalableTopicMetadata metadata,
+                                                         boolean force) {
+        try {
+            var admin = pulsar().getAdminClient();
+            CompletableFuture<?>[] futures = metadata.getSegments().values().stream()
+                    .map(seg -> {
+                        String name = segmentPersistentName(parentTopic, seg);
+                        return admin.topics().deleteAsync(name, force)
+                                .exceptionally(ex -> {
+                                    log.warn().attr("segment", name).exceptionMessage(ex)
+                                            .log("Failed to delete segment topic");
+                                    return null;
+                                });
+                    })
+                    .toArray(CompletableFuture[]::new);
+            return CompletableFuture.allOf(futures);
+        } catch (Exception e) {
+            log.warn().attr("topic", parentTopic).exceptionMessage(e)
+                    .log("Failed to get admin client for segment cleanup");
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /**
+     * Convert a segment:// topic name to persistent:// for the underlying managed ledger topic.
+     */
+    private String segmentPersistentName(TopicName parentTopic, SegmentInfo segment) {
+        TopicName segTopic = SegmentTopicName.fromParent(
+                parentTopic, segment.hashRange(), segment.segmentId());
+        return "persistent://" + segTopic.getTenant() + "/"
+                + segTopic.getNamespacePortion() + "/"
+                + segTopic.getLocalName();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Segments.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Segments.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.v2;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * Admin REST API for segment topic operations.
+ *
+ * <p>These endpoints route to the broker owning the segment's namespace bundle
+ * via {@code validateTopicOwnershipAsync}.
+ */
+@CustomLog
+@Path("/segments")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "/segments", description = "Segment topic admin APIs", tags = "segments")
+public class Segments extends AdminResource {
+
+    private TopicName segmentTopicName(String tenant, String namespace,
+                                       String encodedTopic, String descriptor) {
+        return TopicName.get(TopicDomain.segment.value() + "://" + tenant + "/" + namespace + "/"
+                + encodedTopic + "/" + descriptor);
+    }
+
+    @PUT
+    @Path("/{tenant}/{namespace}/{topic}/{descriptor}")
+    @ApiOperation(value = "Create a segment topic on the owning broker.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Segment topic created successfully"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void createSegment(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify the parent topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment descriptor (e.g. 0000-7fff-1)", required = true)
+            @PathParam("descriptor") String descriptor,
+            @ApiParam(value = "Whether leader broker redirected this call to this broker.")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Subscriptions to create on the new segment")
+            List<String> subscriptions) {
+        validateNamespaceName(tenant, namespace);
+        TopicName segmentTopic = segmentTopicName(tenant, namespace, encodedTopic, descriptor);
+
+        validateTopicOwnershipAsync(segmentTopic, authoritative)
+                .thenCompose(__ -> pulsar().getBrokerService().getOrCreateTopic(segmentTopic.toString()))
+                .thenCompose(topic -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .log("Created segment topic");
+                    if (subscriptions == null || subscriptions.isEmpty()) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    // Create subscriptions at earliest position
+                    List<CompletableFuture<Void>> futures = new java.util.ArrayList<>();
+                    for (String sub : subscriptions) {
+                        futures.add(topic.createSubscription(sub,
+                                CommandSubscribe.InitialPosition.Earliest,
+                                false, null)
+                                .thenAccept(__ -> {}));
+                    }
+                    return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+                })
+                .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .exception(ex).log("Failed to create segment topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @POST
+    @Path("/{tenant}/{namespace}/{topic}/{descriptor}/terminate")
+    @ApiOperation(value = "Terminate a segment topic so no more messages can be published.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Segment topic terminated successfully"),
+            @ApiResponse(code = 404, message = "Segment topic not found"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void terminateSegment(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify the parent topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment descriptor (e.g. 0000-7fff-1)", required = true)
+            @PathParam("descriptor") String descriptor,
+            @ApiParam(value = "Whether leader broker redirected this call to this broker.")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        validateNamespaceName(tenant, namespace);
+        TopicName segmentTopic = segmentTopicName(tenant, namespace, encodedTopic, descriptor);
+
+        validateTopicOwnershipAsync(segmentTopic, authoritative)
+                .thenCompose(__ -> pulsar().getBrokerService().getTopicIfExists(segmentTopic.toString()))
+                .thenCompose(optTopic -> {
+                    if (optTopic.isEmpty()) {
+                        throw new RestException(Response.Status.NOT_FOUND,
+                                "Segment topic not found: " + segmentTopic);
+                    }
+                    if (optTopic.get() instanceof PersistentTopic pt) {
+                        return pt.terminate().thenApply(__ -> null);
+                    }
+                    throw new RestException(Response.Status.BAD_REQUEST,
+                            "Cannot terminate non-persistent topic: " + segmentTopic);
+                })
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .log("Terminated segment topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .exception(ex).log("Failed to terminate segment topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/{topic}/{descriptor}")
+    @ApiOperation(value = "Delete a segment topic.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Segment topic deleted successfully"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void deleteSegment(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify the parent topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment descriptor (e.g. 0000-7fff-1)", required = true)
+            @PathParam("descriptor") String descriptor,
+            @ApiParam(value = "Whether leader broker redirected this call to this broker.")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @ApiParam(value = "Force deletion")
+            @QueryParam("force") @DefaultValue("false") boolean force) {
+        validateNamespaceName(tenant, namespace);
+        TopicName segmentTopic = segmentTopicName(tenant, namespace, encodedTopic, descriptor);
+
+        validateTopicOwnershipAsync(segmentTopic, authoritative)
+                .thenCompose(__ -> pulsar().getBrokerService().getTopicIfExists(segmentTopic.toString()))
+                .thenCompose(optTopic -> {
+                    if (optTopic.isEmpty()) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return optTopic.get().delete().thenApply(__ -> null);
+                })
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .log("Deleted segment topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .exception(ex).log("Failed to delete segment topic");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
@@ -230,10 +230,19 @@ public class DagWatchSession {
                     if (optValue.isEmpty()) {
                         return CompletableFuture.completedFuture(Optional.<String>empty());
                     }
-                    // The leader-election value is the brokerId of the controller leader.
-                    // Resolve it to a pulsar:// service URL via NamespaceService so clients
-                    // can connect to the controller broker for scalable-topic subscribe.
-                    String brokerId = new String(optValue.get().getValue());
+                    // The leader-election value is the brokerId of the controller leader,
+                    // JSON-encoded by LeaderElection.elect(...). Decode it, then resolve
+                    // to a pulsar:// service URL via NamespaceService so clients can
+                    // connect to the controller broker for scalable-topic subscribe.
+                    String brokerId;
+                    try {
+                        brokerId = org.apache.pulsar.common.util.ObjectMapperFactory.getMapper()
+                                .reader().readValue(optValue.get().getValue(), String.class);
+                    } catch (java.io.IOException e) {
+                        log.warn().exceptionMessage(e)
+                                .log("Invalid controller-leader znode value");
+                        return CompletableFuture.completedFuture(Optional.<String>empty());
+                    }
                     return brokerService.getPulsar().getNamespaceService()
                             .createLookupResult(brokerId, false, null)
                             .thenApply(lookupResult ->

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pulsar.broker.service.scalable;
 
+import io.github.merlimat.slog.Logger;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.resources.ScalableTopicMetadata;
 import org.apache.pulsar.broker.resources.ScalableTopicResources;
 import org.apache.pulsar.broker.service.BrokerService;
@@ -32,6 +35,8 @@ import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.scalable.HashRange;
 import org.apache.pulsar.common.scalable.SegmentInfo;
+import org.apache.pulsar.common.scalable.SegmentTopicName;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
 import org.apache.pulsar.metadata.api.coordination.LeaderElection;
 import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
 
@@ -43,8 +48,10 @@ import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
  * ensured by leader election via the metadata store. The leader stores its broker URL
  * so that clients can discover and connect to it.
  */
-@Slf4j
 public class ScalableTopicController {
+
+    private static final Logger LOG = Logger.get(ScalableTopicController.class);
+    private final Logger log;
 
     @Getter
     private final TopicName topicName;
@@ -60,14 +67,35 @@ public class ScalableTopicController {
     @Getter
     private volatile LeaderElectionState leaderState = LeaderElectionState.NoLeader;
 
+    private volatile boolean closed = false;
+
     ScalableTopicController(TopicName topicName,
                             ScalableTopicResources resources,
                             BrokerService brokerService,
-                            LeaderElection<String> leaderElection) {
+                            CoordinationService coordinationService) {
         this.topicName = topicName;
         this.resources = resources;
         this.brokerService = brokerService;
-        this.leaderElection = leaderElection;
+        this.log = LOG.with().attr("topic", topicName).build();
+        this.leaderElection = coordinationService.getLeaderElection(
+                String.class,
+                resources.controllerLockPath(topicName),
+                this::onLeaderStateChange);
+    }
+
+    /**
+     * Reacts to leader election state transitions. On {@link LeaderElectionState#NoLeader}
+     * we kick off another {@link #initialize()} so the cluster always converges toward
+     * having a leader.
+     */
+    private void onLeaderStateChange(LeaderElectionState state) {
+        log.info().attr("state", state).log("Leader state change for scalable topic");
+        if (state == LeaderElectionState.NoLeader && !closed) {
+            initialize().exceptionally(ex -> {
+                log.warn().exceptionMessage(ex).log("Failed to re-elect after NoLeader");
+                return null;
+            });
+        }
     }
 
     /**
@@ -122,8 +150,9 @@ public class ScalableTopicController {
                     SubscriptionCoordinator coordinator = subscriptions.computeIfAbsent(
                             subscription, this::createCoordinator);
                     coordinator.restoreConsumers(consumerNames);
-                    log.info("[{}] restored subscription {} with {} consumer(s)",
-                            topicName, subscription, consumerNames.size());
+                    log.info().attr("subscription", subscription)
+                            .attr("consumerCount", consumerNames.size())
+                            .log("Restored subscription");
                 });
     }
 
@@ -146,7 +175,8 @@ public class ScalableTopicController {
         return leaderElection.elect(brokerId)
                 .thenAccept(state -> {
                     this.leaderState = state;
-                    log.info("Leader election for scalable topic {}: state={}", topicName, state);
+                    log.info().attr("state", state)
+                            .log("Leader election for scalable topic");
                 });
     }
 
@@ -168,6 +198,94 @@ public class ScalableTopicController {
 
     public CompletableFuture<SegmentLayout> getLayout() {
         return CompletableFuture.completedFuture(currentLayout);
+    }
+
+    /**
+     * Split an active segment at its midpoint.
+     *
+     * <p>Critical ordering: child segment topics and their subscription cursors are created
+     * BEFORE the metadata update. This ensures that when producers discover the new segments
+     * (via DAG watch) and start writing, all subscription cursors already exist. Without this,
+     * messages published before a consumer subscribes would be missed.
+     */
+    public CompletableFuture<SegmentLayout> splitSegment(long segmentId) {
+        checkLeader();
+
+        // Compute the new layout locally to derive child segment info
+        SegmentLayout newLayout = currentLayout.splitSegment(segmentId);
+        SegmentInfo child1 = newLayout.getAllSegments().get(newLayout.getNextSegmentId() - 2);
+        SegmentInfo child2 = newLayout.getAllSegments().get(newLayout.getNextSegmentId() - 1);
+        SegmentInfo parent = currentLayout.getAllSegments().get(segmentId);
+        String parentTopicName = toSegmentPersistentName(parent);
+
+        // Step 1: Discover subscriptions on the parent segment, then create child
+        // segment topics with those subscriptions (routed to owning brokers via admin API)
+        return discoverSubscriptions(parentTopicName)
+          .thenCompose(parentSubs -> {
+              var subList = new java.util.ArrayList<>(parentSubs);
+              return createSegmentTopic(child1, subList)
+                      .thenCompose(__ -> createSegmentTopic(child2, subList));
+          })
+
+          // Step 3: Terminate the parent segment topic so producers get TopicTerminated
+          .thenCompose(__ -> terminateSegmentTopic(parentTopicName))
+
+          // Step 4: Atomic metadata update (only after topics + cursors are ready + parent terminated)
+          .thenCompose(__ -> resources.updateScalableTopicAsync(topicName, md -> {
+              SegmentLayout latest = SegmentLayout.fromMetadata(md);
+              SegmentLayout updated = latest.splitSegment(segmentId);
+              return updated.toMetadata(md.getProperties());
+          }))
+          .thenCompose(__ -> resources.getScalableTopicMetadataAsync(topicName, true))
+          .thenCompose(optMd -> {
+              currentLayout = SegmentLayout.fromMetadata(optMd.orElseThrow());
+
+              // Step 5: Notify subscriptions of layout change (triggers consumer reassignment)
+              return notifySubscriptions(currentLayout);
+          }).thenApply(__ -> currentLayout);
+    }
+
+    /**
+     * Merge two adjacent active segments.
+     *
+     * <p>Same ordering invariant as split: merged segment topic and subscription cursors
+     * are created before the metadata update.
+     */
+    public CompletableFuture<SegmentLayout> mergeSegments(long segmentId1, long segmentId2) {
+        checkLeader();
+
+        // Compute the new layout locally to derive merged segment info
+        SegmentLayout newLayout = currentLayout.mergeSegments(segmentId1, segmentId2);
+        SegmentInfo merged = newLayout.getAllSegments().get(newLayout.getNextSegmentId() - 1);
+        SegmentInfo parent1 = currentLayout.getAllSegments().get(segmentId1);
+        SegmentInfo parent2 = currentLayout.getAllSegments().get(segmentId2);
+        String parent1Topic = toSegmentPersistentName(parent1);
+        String parent2Topic = toSegmentPersistentName(parent2);
+
+        // Step 1: Discover subscriptions from both parents (union), then create merged segment
+        return discoverSubscriptions(parent1Topic)
+          .thenCombine(discoverSubscriptions(parent2Topic), (subs1, subs2) -> {
+              Set<String> allSubs = new LinkedHashSet<>(subs1);
+              allSubs.addAll(subs2);
+              return allSubs;
+          })
+          .thenCompose(parentSubs -> createSegmentTopic(merged, new java.util.ArrayList<>(parentSubs)))
+
+          // Step 2: Terminate both parent segment topics
+          .thenCompose(__ -> terminateSegmentTopic(parent1Topic))
+          .thenCompose(__ -> terminateSegmentTopic(parent2Topic))
+
+          // Step 3: Atomic metadata update (only after topic + cursors are ready + parents terminated)
+          .thenCompose(__ -> resources.updateScalableTopicAsync(topicName, md -> {
+              SegmentLayout latest = SegmentLayout.fromMetadata(md);
+              SegmentLayout updated = latest.mergeSegments(segmentId1, segmentId2);
+              return updated.toMetadata(md.getProperties());
+          }))
+          .thenCompose(__ -> resources.getScalableTopicMetadataAsync(topicName, true))
+          .thenCompose(optMd -> {
+              currentLayout = SegmentLayout.fromMetadata(optMd.orElseThrow());
+              return notifySubscriptions(currentLayout);
+          }).thenApply(__ -> currentLayout);
     }
 
     // --- Consumer management ---
@@ -229,9 +347,172 @@ public class ScalableTopicController {
         }
     }
 
+    // --- Subscription management ---
+
+    /**
+     * Create a subscription on the scalable topic. Persists the {@code SubscriptionMetadata}
+     * entry and then propagates the subscription to every active segment topic, creating a
+     * cursor at the earliest position on each so that no messages are lost.
+     *
+     * <p>Idempotent: re-creating an existing subscription succeeds and is a no-op on the
+     * metadata store; per-segment cursor creation tolerates already-existing subscriptions.
+     */
+    public CompletableFuture<Void> createSubscription(String subscription,
+            org.apache.pulsar.broker.resources.SubscriptionType type) {
+        checkLeader();
+        return resources.createSubscriptionAsync(topicName, subscription, type)
+                .exceptionally(ex -> {
+                    Throwable cause = org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException(ex);
+                    if (cause instanceof org.apache.pulsar.metadata.api.MetadataStoreException.AlreadyExistsException) {
+                        return null;
+                    }
+                    throw org.apache.pulsar.common.util.FutureUtil.wrapToCompletionException(cause);
+                })
+                .thenCompose(__ -> createSubscriptionOnActiveSegments(subscription));
+    }
+
+    /**
+     * Delete a subscription from the scalable topic. Unregisters any in-memory consumers on
+     * this leader, deletes the persisted {@code SubscriptionMetadata} (and all its consumer
+     * registration children), and removes the subscription from every segment topic.
+     */
+    public CompletableFuture<Void> deleteSubscription(String subscription) {
+        checkLeader();
+        // Remove in-memory coordinator first so no new consumers attach during teardown.
+        SubscriptionCoordinator coordinator = subscriptions.remove(subscription);
+        CompletableFuture<Void> coordinatorClosed =
+                coordinator == null
+                        ? CompletableFuture.completedFuture(null)
+                        : dropAllConsumers(coordinator);
+        return coordinatorClosed
+                .thenCompose(__ -> resources.deleteSubscriptionAsync(topicName, subscription))
+                .thenCompose(__ -> deleteSubscriptionOnAllSegments(subscription));
+    }
+
+    private CompletableFuture<Void> dropAllConsumers(SubscriptionCoordinator coordinator) {
+        CompletableFuture<?>[] futures = coordinator.getConsumers().stream()
+                .map(session -> coordinator.unregisterConsumer(session.getConsumerName()))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
+    }
+
+    private CompletableFuture<Void> createSubscriptionOnActiveSegments(String subscription) {
+        CompletableFuture<?>[] futures = currentLayout.getActiveSegments().values().stream()
+                .map(segment -> createSubscriptionOnSegment(segment, subscription))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
+    }
+
+    private CompletableFuture<Void> deleteSubscriptionOnAllSegments(String subscription) {
+        // Delete from every segment in the DAG, including sealed ones, so catch-up readers
+        // aren't left with orphaned cursors.
+        CompletableFuture<?>[] futures = currentLayout.getAllSegments().values().stream()
+                .map(segment -> deleteSubscriptionOnSegment(segment, subscription))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
+    }
+
+    private CompletableFuture<Void> createSubscriptionOnSegment(SegmentInfo segment, String subscription) {
+        String persistentName = toSegmentUnderlyingPersistentName(segment);
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .topics().createSubscriptionAsync(persistentName, subscription,
+                            org.apache.pulsar.client.api.MessageId.earliest)
+                    .exceptionally(ex -> {
+                        Throwable cause = org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException(ex);
+                        if (cause instanceof org.apache.pulsar.client.admin.PulsarAdminException.ConflictException) {
+                            // Subscription already exists on this segment — treat as success.
+                            return null;
+                        }
+                        throw org.apache.pulsar.common.util.FutureUtil.wrapToCompletionException(cause);
+                    });
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private CompletableFuture<Void> deleteSubscriptionOnSegment(SegmentInfo segment, String subscription) {
+        String persistentName = toSegmentUnderlyingPersistentName(segment);
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .topics().deleteSubscriptionAsync(persistentName, subscription, true)
+                    .exceptionally(ex -> {
+                        Throwable cause = org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException(ex);
+                        if (cause instanceof org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException) {
+                            return null;
+                        }
+                        log.warn().attr("subscription", subscription)
+                                .attr("segment", persistentName).exceptionMessage(cause)
+                                .log("Failed to delete subscription from segment");
+                        return null;
+                    });
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    // --- Stats ---
+
+    /**
+     * Build an aggregated snapshot of the scalable topic's state: segment counts, per-segment
+     * layout info, and per-subscription consumer counts (loaded from the persisted
+     * registrations so the numbers are consistent across controller leader failovers).
+     */
+    public CompletableFuture<org.apache.pulsar.common.policies.data.ScalableTopicStats> getStats() {
+        SegmentLayout layout = this.currentLayout;
+        var statsBuilder = org.apache.pulsar.common.policies.data.ScalableTopicStats.builder()
+                .epoch(layout.getEpoch());
+
+        Map<Long, org.apache.pulsar.common.policies.data.ScalableTopicStats.SegmentStats> segmentStats =
+                new java.util.LinkedHashMap<>();
+        int active = 0;
+        int sealed = 0;
+        for (SegmentInfo segment : layout.getAllSegments().values()) {
+            boolean isActive = segment.state() == org.apache.pulsar.common.scalable.SegmentState.ACTIVE;
+            if (isActive) {
+                active++;
+            } else {
+                sealed++;
+            }
+            String segmentName = SegmentTopicName.fromParent(
+                    topicName, segment.hashRange(), segment.segmentId()).toString();
+            segmentStats.put(segment.segmentId(),
+                    new org.apache.pulsar.common.policies.data.ScalableTopicStats.SegmentStats(
+                            segmentName, segment.state().name()));
+        }
+        statsBuilder
+                .totalSegments(layout.getAllSegments().size())
+                .activeSegments(active)
+                .sealedSegments(sealed)
+                .segments(segmentStats);
+
+        // Load persisted subscription + consumer counts. This gives a consistent picture
+        // regardless of which broker currently holds the controller leadership.
+        return resources.listSubscriptionsAsync(topicName)
+                .thenCompose(subNames -> {
+                    if (subNames.isEmpty()) {
+                        return CompletableFuture.completedFuture(statsBuilder.build());
+                    }
+                    Map<String, org.apache.pulsar.common.policies.data.ScalableTopicStats.SubscriptionStats>
+                            subStats = new java.util.LinkedHashMap<>();
+                    CompletableFuture<?>[] futures = subNames.stream()
+                            .map(subName -> resources.listConsumersAsync(topicName, subName)
+                                    .thenAccept(consumerNames -> subStats.put(subName,
+                                            new org.apache.pulsar.common.policies.data.ScalableTopicStats
+                                                    .SubscriptionStats(consumerNames.size()))))
+                            .toArray(CompletableFuture[]::new);
+                    return CompletableFuture.allOf(futures)
+                            .thenApply(__ -> {
+                                statsBuilder.subscriptions(subStats);
+                                return statsBuilder.build();
+                            });
+                });
+    }
+
     // --- Lifecycle ---
 
     public CompletableFuture<Void> close() {
+        closed = true;
         subscriptions.clear();
         return leaderElection.asyncClose();
     }
@@ -242,6 +523,78 @@ public class ScalableTopicController {
         if (!isLeader()) {
             throw new IllegalStateException("This broker is not the leader for topic: " + topicName);
         }
+    }
+
+    private String toSegmentPersistentName(SegmentInfo segment) {
+        TopicName segmentTopicName = SegmentTopicName.fromParent(
+                topicName, segment.hashRange(), segment.segmentId());
+        return segmentTopicName.toString();
+    }
+
+    /**
+     * Return the {@code persistent://} form of a segment's underlying managed-ledger topic,
+     * suitable for the standard {@link org.apache.pulsar.client.admin.Topics} admin API.
+     * The segment-owning broker is discovered by the admin client's normal bundle routing.
+     */
+    private String toSegmentUnderlyingPersistentName(SegmentInfo segment) {
+        TopicName segmentTopicName = SegmentTopicName.fromParent(
+                topicName, segment.hashRange(), segment.segmentId());
+        return "persistent://" + segmentTopicName.getTenant() + "/"
+                + segmentTopicName.getNamespacePortion() + "/"
+                + segmentTopicName.getLocalName();
+    }
+
+    private CompletableFuture<Void> terminateSegmentTopic(String segmentTopicName) {
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .scalableTopics().terminateSegmentAsync(segmentTopicName)
+                    .thenRun(() -> log.info().attr("segment", segmentTopicName)
+                            .log("Terminated segment topic"));
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private CompletableFuture<Void> createSegmentTopic(SegmentInfo segment, java.util.List<String> subscriptions) {
+        String segmentName = toSegmentPersistentName(segment);
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .scalableTopics().createSegmentAsync(segmentName, subscriptions)
+                    .thenRun(() -> log.info().attr("segment", segmentName)
+                            .log("Created segment topic"));
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    /**
+     * Discover all subscription names on a segment topic. Works whether the topic is
+     * on this broker or a remote one by using the admin client.
+     */
+    private CompletableFuture<Set<String>> discoverSubscriptions(String segmentTopicName) {
+        // Try local first (avoids RPC if the segment is on this broker)
+        return brokerService.getTopicIfExists(segmentTopicName)
+                .thenCompose(optTopic -> {
+                    if (optTopic.isPresent()) {
+                        return CompletableFuture.completedFuture(
+                                new LinkedHashSet<>(optTopic.get().getSubscriptions().keySet()));
+                    }
+                    // Topic is on a remote broker — use admin client
+                    try {
+                        return brokerService.getPulsar().getAdminClient()
+                                .topics().getSubscriptionsAsync(segmentTopicName)
+                                .thenApply(LinkedHashSet::new);
+                    } catch (PulsarServerException e) {
+                        return CompletableFuture.failedFuture(e);
+                    }
+                });
+    }
+
+    private CompletableFuture<Void> notifySubscriptions(SegmentLayout layout) {
+        CompletableFuture<?>[] futures = subscriptions.values().stream()
+                .map(coordinator -> coordinator.onLayoutChange(layout))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicService.java
@@ -18,20 +18,22 @@
  */
 package org.apache.pulsar.broker.service.scalable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.resources.ScalableTopicMetadata;
 import org.apache.pulsar.broker.resources.ScalableTopicResources;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ScalableTopicStats;
 import org.apache.pulsar.common.scalable.SegmentInfo;
 import org.apache.pulsar.common.scalable.SegmentTopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.CoordinationService;
-import org.apache.pulsar.metadata.api.coordination.LeaderElection;
-import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
 
 /**
  * Central service managing all scalable topics on this broker.
@@ -43,15 +45,20 @@ import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
  *   <li>Admin operations: split/merge</li>
  * </ul>
  */
-@Slf4j
+@CustomLog
 public class ScalableTopicService {
 
     private final BrokerService brokerService;
     private final ScalableTopicResources resources;
     private final CoordinationService coordinationService;
 
-    /** Active controllers for topics this broker coordinates. */
-    private final ConcurrentHashMap<String, ScalableTopicController> controllers = new ConcurrentHashMap<>();
+    /**
+     * Active controllers for topics this broker coordinates. The value is a future so
+     * concurrent {@link #getOrCreateController(TopicName)} callers share a single
+     * initialize() attempt rather than racing to create separate instances.
+     */
+    private final ConcurrentHashMap<String, CompletableFuture<ScalableTopicController>> controllers =
+            new ConcurrentHashMap<>();
 
     public ScalableTopicService(BrokerService brokerService,
                                 ScalableTopicResources resources,
@@ -68,14 +75,17 @@ public class ScalableTopicService {
     }
 
     public void close() {
-        log.info("Closing ScalableTopicService, releasing {} controllers", controllers.size());
-        controllers.values().forEach(controller -> {
-            try {
-                controller.close().join();
-            } catch (Exception e) {
-                log.warn("Error closing controller for topic {}", controller.getTopicName(), e);
-            }
-        });
+        log.info().attr("controllerCount", controllers.size())
+                .log("Closing ScalableTopicService, releasing controllers");
+        List<CompletableFuture<Void>> closeFutures = controllers.values().stream()
+                .map(future -> future
+                        .thenCompose(ScalableTopicController::close)
+                        .exceptionally(ex -> {
+                            log.warn().exceptionMessage(ex).log("Error closing controller");
+                            return null;
+                        }))
+                .toList();
+        FutureUtil.waitForAll(closeFutures).join();
         controllers.clear();
     }
 
@@ -87,34 +97,26 @@ public class ScalableTopicService {
      */
     public CompletableFuture<ScalableTopicController> getOrCreateController(TopicName topic) {
         String key = topic.toString();
-        ScalableTopicController existing = controllers.get(key);
-        if (existing != null) {
-            return CompletableFuture.completedFuture(existing);
-        }
-
-        String lockPath = resources.controllerLockPath(topic);
-        LeaderElection<String> election = coordinationService.getLeaderElection(
-                String.class, lockPath, state -> onLeaderStateChange(topic, state));
-
-        ScalableTopicController controller = new ScalableTopicController(
-                topic, resources, brokerService, election);
-        controllers.put(key, controller);
-
-        return controller.initialize()
-                .thenApply(__ -> controller)
-                .exceptionally(ex -> {
-                    controllers.remove(key);
-                    throw new RuntimeException("Failed to initialize controller for " + topic, ex);
-                });
+        CompletableFuture<ScalableTopicController> stored = controllers.computeIfAbsent(key, k -> {
+            ScalableTopicController controller = new ScalableTopicController(
+                    topic, resources, brokerService, coordinationService);
+            return controller.initialize().thenApply(__ -> controller);
+        });
+        // Evict failed futures so subsequent callers can retry. This runs *outside*
+        // computeIfAbsent, so modifying the map here is safe.
+        return stored.exceptionally(ex -> {
+            controllers.remove(key, stored);
+            throw new RuntimeException("Failed to initialize controller for " + topic, ex);
+        });
     }
 
     /**
      * Release the controller for a topic (e.g., on topic unload).
      */
     public CompletableFuture<Void> releaseController(TopicName topic) {
-        ScalableTopicController controller = controllers.remove(topic.toString());
-        if (controller != null) {
-            return controller.close();
+        CompletableFuture<ScalableTopicController> future = controllers.remove(topic.toString());
+        if (future != null) {
+            return future.thenCompose(ScalableTopicController::close);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -145,11 +147,63 @@ public class ScalableTopicService {
         return resources.createScalableTopicAsync(topic, metadata)
                 .thenCompose(__ -> {
                     // Create underlying persistent topics for each initial segment
-                    CompletableFuture<?>[] segmentFutures = metadata.getSegments().values().stream()
+                    List<CompletableFuture<Void>> segmentFutures = metadata.getSegments().values().stream()
                             .map(segment -> createUnderlyingSegmentTopic(topic, segment))
-                            .toArray(CompletableFuture[]::new);
-                    return CompletableFuture.allOf(segmentFutures);
+                            .toList();
+                    return FutureUtil.waitForAll(segmentFutures);
                 });
+    }
+
+    /**
+     * Split a segment (delegates to controller). Callers must be the controller leader;
+     * the REST layer redirects non-leaders via
+     * {@code ScalableTopics.redirectToControllerLeaderIfNeeded}, and the controller's
+     * {@code checkLeader()} enforces leadership on the service side.
+     */
+    public CompletableFuture<Void> splitSegment(TopicName topic, long segmentId) {
+        return getOrCreateController(topic)
+                .thenCompose(controller -> controller.splitSegment(segmentId))
+                .thenApply(__ -> null);
+    }
+
+    /**
+     * Merge two adjacent segments (delegates to controller). Same leader contract as
+     * {@link #splitSegment(TopicName, long)}.
+     */
+    public CompletableFuture<Void> mergeSegments(TopicName topic, long segmentId1, long segmentId2) {
+        return getOrCreateController(topic)
+                .thenCompose(controller -> controller.mergeSegments(segmentId1, segmentId2))
+                .thenApply(__ -> null);
+    }
+
+    /**
+     * Create a subscription on a scalable topic (delegates to controller leader).
+     * Propagates the subscription to all active segments.
+     */
+    public CompletableFuture<Void> createSubscription(TopicName topic, String subscription,
+            org.apache.pulsar.broker.resources.SubscriptionType type) {
+        return getOrCreateController(topic)
+                .thenCompose(controller -> controller.createSubscription(subscription, type));
+    }
+
+    /**
+     * Delete a subscription from a scalable topic (delegates to controller leader).
+     * Unregisters all consumers and deletes the subscription from every segment.
+     */
+    public CompletableFuture<Void> deleteSubscription(TopicName topic, String subscription) {
+        return getOrCreateController(topic)
+                .thenCompose(controller -> controller.deleteSubscription(subscription));
+    }
+
+    /**
+     * Get aggregated stats for a scalable topic. Read-only: does not require leadership.
+     * Returns segment-DAG counts and per-subscription consumer counts, read from the
+     * metadata store so the answer is consistent regardless of which broker is serving the
+     * request.
+     */
+    public CompletableFuture<ScalableTopicStats> getStats(TopicName topic) {
+        return getOrCreateController(topic)
+                .thenCompose(ScalableTopicController::getStats);
     }
 
     /**
@@ -164,10 +218,11 @@ public class ScalableTopicService {
                     }
                     ScalableTopicMetadata metadata = optMd.get();
                     // Delete all underlying segment topics
-                    CompletableFuture<?>[] deleteFutures = metadata.getSegments().values().stream()
-                            .map(segment -> deleteUnderlyingSegmentTopic(topic, segment))
-                            .toArray(CompletableFuture[]::new);
-                    return CompletableFuture.allOf(deleteFutures);
+                    return FutureUtil.waitForAll(
+                            metadata.getSegments().values().stream()
+                                    .map(segment -> deleteUnderlyingSegmentTopic(topic, segment))
+                                    .toList()
+                    );
                 })
                 .thenCompose(__ -> resources.deleteScalableTopicAsync(topic));
     }
@@ -189,53 +244,41 @@ public class ScalableTopicService {
      * No-op if the controller is not held locally.
      */
     public void onConsumerDisconnect(TopicName topic, String subscription, String consumerName) {
-        ScalableTopicController controller = controllers.get(topic.toString());
-        if (controller != null) {
-            controller.onConsumerDisconnect(subscription, consumerName);
+        CompletableFuture<ScalableTopicController> future = controllers.get(topic.toString());
+        if (future != null) {
+            future.thenAccept(c -> c.onConsumerDisconnect(subscription, consumerName))
+                    .exceptionally(ex -> null);
         }
     }
 
     // --- Internal helpers ---
 
-    private void onLeaderStateChange(TopicName topic, LeaderElectionState state) {
-        log.info("Leader state change for scalable topic {}: {}", topic, state);
-        if (state == LeaderElectionState.NoLeader) {
-            // Try to re-elect
-            ScalableTopicController controller = controllers.get(topic.toString());
-            if (controller != null) {
-                controller.initialize().exceptionally(ex -> {
-                    log.warn("Failed to re-elect for topic {}", topic, ex);
-                    return null;
-                });
-            }
+    private CompletableFuture<Void> createUnderlyingSegmentTopic(TopicName parentTopic, SegmentInfo segment) {
+        String segmentName = SegmentTopicName.fromParent(
+                parentTopic, segment.hashRange(), segment.segmentId()).toString();
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .scalableTopics().createSegmentAsync(segmentName, java.util.List.of())
+                    .thenRun(() -> log.info().attr("segment", segmentName)
+                            .log("Created segment topic"));
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
         }
     }
 
-    private CompletableFuture<Void> createUnderlyingSegmentTopic(TopicName parentTopic, SegmentInfo segment) {
-        TopicName segmentTopic = SegmentTopicName.fromParent(
-                parentTopic, segment.hashRange(), segment.segmentId());
-        String persistentName = toPersistentName(segmentTopic);
-        return brokerService.getOrCreateTopic(persistentName)
-                .thenAccept(t -> log.info("Created segment topic: {}", persistentName));
-    }
-
     private CompletableFuture<Void> deleteUnderlyingSegmentTopic(TopicName parentTopic, SegmentInfo segment) {
-        TopicName segmentTopic = SegmentTopicName.fromParent(
-                parentTopic, segment.hashRange(), segment.segmentId());
-        String persistentName = toPersistentName(segmentTopic);
-        return brokerService.deleteTopic(persistentName, true)
-                .exceptionally(ex -> {
-                    log.warn("Failed to delete segment topic {}: {}", persistentName, ex.getMessage());
-                    return null;
-                });
-    }
-
-    /**
-     * Convert a segment:// topic name to persistent:// for the underlying managed ledger topic.
-     */
-    private String toPersistentName(TopicName segmentTopic) {
-        return "persistent://" + segmentTopic.getTenant() + "/"
-                + segmentTopic.getNamespacePortion() + "/"
-                + segmentTopic.getLocalName();
+        String segmentName = SegmentTopicName.fromParent(
+                parentTopic, segment.hashRange(), segment.segmentId()).toString();
+        try {
+            return brokerService.getPulsar().getAdminClient()
+                    .scalableTopics().deleteSegmentAsync(segmentName, true)
+                    .exceptionally(ex -> {
+                        log.warn().attr("segment", segmentName).exceptionMessage(ex)
+                                .log("Failed to delete segment topic");
+                        return null;
+                    });
+        } catch (PulsarServerException e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.scalable;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.resources.ConsumerRegistration;
+import org.apache.pulsar.broker.resources.ScalableTopicMetadata;
+import org.apache.pulsar.broker.resources.ScalableTopicResources;
+import org.apache.pulsar.broker.resources.SubscriptionMetadata;
+import org.apache.pulsar.broker.resources.SubscriptionType;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.TransportCnx;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.ScalableTopics;
+import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ScalableTopicStats;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+import org.apache.pulsar.metadata.impl.LocalMemoryMetadataStore;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link ScalableTopicController} using an in-memory metadata store
+ * (so leader election and subscription/consumer persistence are exercised for real) with
+ * the cross-broker admin client mocked.
+ */
+public class ScalableTopicControllerTest {
+
+    private static final int INITIAL_SEGMENTS = 4;
+    private static final String BROKER_ID = "broker-test";
+
+    private MetadataStoreExtended store;
+    private CoordinationService coordinationService;
+    private ScalableTopicResources resources;
+    private ScheduledExecutorService scheduler;
+
+    private BrokerService brokerService;
+    private PulsarService pulsar;
+    private PulsarAdmin admin;
+    private Topics topics;
+    private ScalableTopics scalableTopics;
+
+    private TopicName topicName;
+    private ScalableTopicController controller;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        store = new LocalMemoryMetadataStore("memory:local",
+                MetadataStoreConfig.builder().build());
+        coordinationService = new CoordinationServiceImpl(store);
+        resources = new ScalableTopicResources(store, 30);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+
+        topicName = TopicName.get("topic://tenant/ns/my-topic");
+
+        // Seed the topic's initial metadata so initialize() has something to load.
+        ScalableTopicMetadata metadata =
+                ScalableTopicController.createInitialMetadata(INITIAL_SEGMENTS, Map.of());
+        resources.createScalableTopicAsync(topicName, metadata).get();
+
+        // --- Mock the BrokerService / PulsarService / PulsarAdmin chain ---
+        brokerService = mock(BrokerService.class);
+        pulsar = mock(PulsarService.class);
+        admin = mock(PulsarAdmin.class);
+        topics = mock(Topics.class);
+        scalableTopics = mock(ScalableTopics.class);
+
+        when(brokerService.getPulsar()).thenReturn(pulsar);
+        when(brokerService.getTopicIfExists(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+        when(pulsar.getBrokerId()).thenReturn(BROKER_ID);
+        when(pulsar.getExecutor()).thenReturn(scheduler);
+        when(pulsar.getAdminClient()).thenReturn(admin);
+        when(admin.topics()).thenReturn(topics);
+        when(admin.scalableTopics()).thenReturn(scalableTopics);
+
+        // Default: all admin ops succeed.
+        when(topics.getSubscriptionsAsync(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(java.util.List.of()));
+        when(topics.createSubscriptionAsync(anyString(), anyString(), any(MessageId.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(topics.deleteSubscriptionAsync(anyString(), anyString(), anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopics.createSegmentAsync(anyString(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopics.terminateSegmentAsync(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        controller = newController(topicName);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (controller != null) {
+            controller.close().join();
+        }
+        if (coordinationService != null) {
+            coordinationService.close();
+        }
+        if (store != null) {
+            store.close();
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private ScalableTopicController newController(TopicName tn) {
+        return new ScalableTopicController(tn, resources, brokerService, coordinationService);
+    }
+
+    // --- initialize() ---
+
+    @Test
+    public void testInitializeBecomesLeader() throws Exception {
+        controller.initialize().get();
+        assertTrue(controller.isLeader());
+        SegmentLayout layout = controller.getLayout().get();
+        assertEquals(layout.getAllSegments().size(), INITIAL_SEGMENTS);
+        assertEquals(layout.getActiveSegments().size(), INITIAL_SEGMENTS);
+        assertEquals(layout.getEpoch(), 0);
+    }
+
+    @Test
+    public void testInitializeFailsWhenTopicMissing() throws Exception {
+        TopicName missing = TopicName.get("topic://tenant/ns/does-not-exist");
+        ScalableTopicController orphan = newController(missing);
+        try {
+            orphan.initialize().get();
+            fail("expected IllegalStateException for missing topic");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IllegalStateException,
+                    "expected IllegalStateException, got " + e.getCause());
+            assertTrue(e.getCause().getMessage().contains("Scalable topic not found"));
+        } finally {
+            orphan.close().join();
+        }
+    }
+
+    @Test
+    public void testLeaderBrokerIdPersisted() throws Exception {
+        controller.initialize().get();
+        Optional<String> leaderId = controller.getLeaderBrokerId().get();
+        assertEquals(leaderId, Optional.of(BROKER_ID));
+    }
+
+    @Test
+    public void testInitializeRestoresPersistedConsumers() throws Exception {
+        // Pre-populate a subscription and a couple of consumer registrations.
+        resources.createSubscriptionAsync(topicName, "sub-a", SubscriptionType.STREAM).get();
+        resources.registerConsumerAsync(topicName, "sub-a", "c1").get();
+        resources.registerConsumerAsync(topicName, "sub-a", "c2").get();
+
+        controller.initialize().get();
+
+        // Restored consumers should appear in the in-memory coordinator
+        // immediately, even before any client reconnects.
+        var assignment = resources.listConsumersAsync(topicName, "sub-a").get();
+        assertEquals(assignment.size(), 2);
+    }
+
+    // --- checkLeader guard ---
+
+    @Test
+    public void testWriteOperationThrowsWhenNotLeader() {
+        // Controller not initialized → not leader.
+        assertFalse(controller.isLeader());
+        assertThrows(IllegalStateException.class, () -> controller.splitSegment(0));
+        assertThrows(IllegalStateException.class, () -> controller.mergeSegments(0, 1));
+        assertThrows(IllegalStateException.class,
+                () -> controller.createSubscription("sub", SubscriptionType.STREAM));
+        assertThrows(IllegalStateException.class, () -> controller.deleteSubscription("sub"));
+        assertThrows(IllegalStateException.class,
+                () -> controller.registerConsumer("sub", "c1", 1L, mock(TransportCnx.class)));
+        assertThrows(IllegalStateException.class, () -> controller.unregisterConsumer("sub", "c1"));
+    }
+
+    // --- Consumer registration ---
+
+    @Test
+    public void testRegisterConsumerPersistsAndAssigns() throws Exception {
+        controller.initialize().get();
+        ConsumerAssignment assignment =
+                controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+
+        assertEquals(assignment.assignedSegments().size(), INITIAL_SEGMENTS,
+                "single consumer owns all active segments");
+        // Registration is persisted.
+        var persisted = resources.listConsumersAsync(topicName, "sub-a").get();
+        assertEquals(persisted.size(), 1);
+        assertEquals(persisted.get(0), "c1");
+    }
+
+    @Test
+    public void testRegisterConsumerReconnectDoesNotDuplicate() throws Exception {
+        controller.initialize().get();
+        controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+        // Reconnect: same name, new consumerId.
+        ConsumerAssignment assignment =
+                controller.registerConsumer("sub-a", "c1", 99L, mock(TransportCnx.class)).get();
+
+        assertEquals(assignment.assignedSegments().size(), INITIAL_SEGMENTS);
+        // Still just one persisted registration.
+        assertEquals(resources.listConsumersAsync(topicName, "sub-a").get().size(), 1);
+    }
+
+    @Test
+    public void testUnregisterConsumerDeletesPersistedEntry() throws Exception {
+        controller.initialize().get();
+        controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+        controller.registerConsumer("sub-a", "c2", 2L, mock(TransportCnx.class)).get();
+        assertEquals(resources.listConsumersAsync(topicName, "sub-a").get().size(), 2);
+
+        controller.unregisterConsumer("sub-a", "c1").get();
+        assertEquals(resources.listConsumersAsync(topicName, "sub-a").get(),
+                java.util.List.of("c2"));
+    }
+
+    @Test
+    public void testUnregisterConsumerUnknownSubscriptionIsNoop() throws Exception {
+        controller.initialize().get();
+        // No subscription 'ghost' exists; call should complete without error.
+        controller.unregisterConsumer("ghost", "c1").get();
+    }
+
+    @Test
+    public void testOnConsumerDisconnectUnknownSubscriptionIsNoop() throws Exception {
+        controller.initialize().get();
+        // Should not throw even though 'ghost' has no coordinator.
+        controller.onConsumerDisconnect("ghost", "c1");
+    }
+
+    // --- createSubscription / deleteSubscription ---
+
+    @Test
+    public void testCreateSubscriptionStream() throws Exception {
+        controller.initialize().get();
+        controller.createSubscription("sub-stream", SubscriptionType.STREAM).get();
+
+        Optional<SubscriptionMetadata> persisted =
+                resources.getSubscriptionAsync(topicName, "sub-stream").get();
+        assertTrue(persisted.isPresent());
+        assertEquals(persisted.get().type(), SubscriptionType.STREAM);
+        // Propagated to every active segment via admin.topics().createSubscriptionAsync().
+        verify(topics, org.mockito.Mockito.times(INITIAL_SEGMENTS))
+                .createSubscriptionAsync(anyString(), anyString(), any(MessageId.class));
+    }
+
+    @Test
+    public void testCreateSubscriptionQueue() throws Exception {
+        controller.initialize().get();
+        controller.createSubscription("sub-queue", SubscriptionType.QUEUE).get();
+
+        Optional<SubscriptionMetadata> persisted =
+                resources.getSubscriptionAsync(topicName, "sub-queue").get();
+        assertTrue(persisted.isPresent());
+        assertEquals(persisted.get().type(), SubscriptionType.QUEUE);
+    }
+
+    @Test
+    public void testCreateSubscriptionIdempotent() throws Exception {
+        controller.initialize().get();
+        controller.createSubscription("sub-a", SubscriptionType.STREAM).get();
+        // Second call should not fail even though metadata already exists.
+        controller.createSubscription("sub-a", SubscriptionType.STREAM).get();
+    }
+
+    @Test
+    public void testDeleteSubscription() throws Exception {
+        controller.initialize().get();
+        controller.createSubscription("sub-a", SubscriptionType.STREAM).get();
+        assertTrue(resources.getSubscriptionAsync(topicName, "sub-a").get().isPresent());
+
+        controller.deleteSubscription("sub-a").get();
+        assertFalse(resources.getSubscriptionAsync(topicName, "sub-a").get().isPresent());
+        // Propagated a delete to every segment (all segments incl. any sealed ones).
+        verify(topics, org.mockito.Mockito.atLeast(INITIAL_SEGMENTS))
+                .deleteSubscriptionAsync(anyString(), anyString(), anyBoolean());
+    }
+
+    @Test
+    public void testDeleteSubscriptionRemovesInMemoryCoordinator() throws Exception {
+        controller.initialize().get();
+        controller.createSubscription("sub-a", SubscriptionType.STREAM).get();
+        controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+
+        controller.deleteSubscription("sub-a").get();
+        // After delete, the persisted consumer entries should be gone.
+        assertEquals(resources.listConsumersAsync(topicName, "sub-a").get().size(), 0);
+    }
+
+    // --- splitSegment / mergeSegments ---
+
+    @Test
+    public void testSplitSegment() throws Exception {
+        controller.initialize().get();
+        SegmentLayout before = controller.getLayout().get();
+        long epochBefore = before.getEpoch();
+        int activeBefore = before.getActiveSegments().size();
+
+        SegmentLayout after = controller.splitSegment(0).get();
+
+        assertEquals(after.getEpoch(), epochBefore + 1);
+        assertEquals(after.getActiveSegments().size(), activeBefore + 1,
+                "split produces two children in place of one active parent → net +1 active");
+        // Admin API was used to create the two new child segments + terminate the parent.
+        verify(scalableTopics, org.mockito.Mockito.times(2))
+                .createSegmentAsync(anyString(), any());
+        verify(scalableTopics, org.mockito.Mockito.times(1)).terminateSegmentAsync(anyString());
+    }
+
+    @Test
+    public void testMergeSegments() throws Exception {
+        controller.initialize().get();
+        SegmentLayout before = controller.getLayout().get();
+        long epochBefore = before.getEpoch();
+        int activeBefore = before.getActiveSegments().size();
+
+        // Segments 0 and 1 are adjacent by construction of createInitialMetadata.
+        SegmentLayout after = controller.mergeSegments(0, 1).get();
+
+        assertEquals(after.getEpoch(), epochBefore + 1);
+        assertEquals(after.getActiveSegments().size(), activeBefore - 1,
+                "merge fuses two active segments into one → net -1 active");
+        verify(scalableTopics, org.mockito.Mockito.times(1))
+                .createSegmentAsync(anyString(), any());
+        verify(scalableTopics, org.mockito.Mockito.times(2)).terminateSegmentAsync(anyString());
+    }
+
+    @Test
+    public void testSplitSegmentPropagatesToRegisteredConsumer() throws Exception {
+        controller.initialize().get();
+        controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+
+        SegmentLayout after = controller.splitSegment(0).get();
+        // consumer still owns everything after split (single consumer).
+        assertEquals(after.getActiveSegments().size(), INITIAL_SEGMENTS + 1);
+    }
+
+    // --- getStats ---
+
+    @Test
+    public void testGetStatsBaseline() throws Exception {
+        controller.initialize().get();
+        ScalableTopicStats stats = controller.getStats().get();
+
+        assertEquals(stats.getEpoch(), 0);
+        assertEquals(stats.getTotalSegments(), INITIAL_SEGMENTS);
+        assertEquals(stats.getActiveSegments(), INITIAL_SEGMENTS);
+        assertEquals(stats.getSealedSegments(), 0);
+        assertEquals(stats.getSegments().size(), INITIAL_SEGMENTS);
+        // No subscriptions registered yet.
+        assertEquals(stats.getSubscriptions().size(), 0);
+    }
+
+    @Test
+    public void testGetStatsAfterSplitAndSubscriptions() throws Exception {
+        controller.initialize().get();
+        controller.splitSegment(0).get();
+        controller.createSubscription("sub-a", SubscriptionType.STREAM).get();
+        controller.createSubscription("sub-b", SubscriptionType.QUEUE).get();
+        controller.registerConsumer("sub-a", "c1", 1L, mock(TransportCnx.class)).get();
+        controller.registerConsumer("sub-a", "c2", 2L, mock(TransportCnx.class)).get();
+
+        ScalableTopicStats stats = controller.getStats().get();
+
+        assertEquals(stats.getEpoch(), 1);
+        assertEquals(stats.getTotalSegments(), INITIAL_SEGMENTS + 2,
+                "split adds two children, keeps parent as sealed");
+        assertEquals(stats.getActiveSegments(), INITIAL_SEGMENTS + 1);
+        assertEquals(stats.getSealedSegments(), 1);
+        assertEquals(stats.getSubscriptions().size(), 2);
+        assertEquals(stats.getSubscriptions().get("sub-a").consumerCount(), 2);
+        assertEquals(stats.getSubscriptions().get("sub-b").consumerCount(), 0);
+    }
+
+    // --- createInitialMetadata ---
+
+    @Test
+    public void testCreateInitialMetadataDefaults() {
+        ScalableTopicMetadata md = ScalableTopicController.createInitialMetadata(4, Map.of());
+        assertEquals(md.getEpoch(), 0);
+        assertEquals(md.getNextSegmentId(), 4);
+        assertEquals(md.getSegments().size(), 4);
+    }
+
+    @Test
+    public void testCreateInitialMetadataRejectsZeroSegments() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScalableTopicController.createInitialMetadata(0, Map.of()));
+    }
+
+    // --- close / lifecycle ---
+
+    @Test
+    public void testCloseReleasesLeadership() throws Exception {
+        controller.initialize().get();
+        assertTrue(controller.isLeader());
+        controller.close().get();
+        // Replace with null so the teardown doesn't close it again.
+        controller = null;
+
+        // A fresh controller can become leader now.
+        ScalableTopicController second = newController(topicName);
+        try {
+            second.initialize().get();
+            assertTrue(second.isLeader());
+        } finally {
+            second.close().join();
+        }
+    }
+
+    // --- ConsumerRegistration record sanity ---
+
+    @Test
+    public void testConsumerRegistrationIsEmptyRecord() {
+        // If someone adds fields, this test documents the expectation that the znode
+        // value is just a marker.
+        ConsumerRegistration a = new ConsumerRegistration();
+        ConsumerRegistration b = new ConsumerRegistration();
+        assertEquals(a, b);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicServiceTest.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.scalable;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.resources.ScalableTopicMetadata;
+import org.apache.pulsar.broker.resources.ScalableTopicResources;
+import org.apache.pulsar.broker.resources.SubscriptionType;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.TransportCnx;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.ScalableTopics;
+import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ScalableTopicStats;
+import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.coordination.CoordinationService;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
+import org.apache.pulsar.metadata.coordination.impl.CoordinationServiceImpl;
+import org.apache.pulsar.metadata.impl.LocalMemoryMetadataStore;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link ScalableTopicService} using an in-memory metadata store for
+ * real persistence + leader election, with the cross-broker admin client mocked.
+ */
+public class ScalableTopicServiceTest {
+
+    private static final String BROKER_ID = "broker-service-test";
+
+    private MetadataStoreExtended store;
+    private CoordinationService coordinationService;
+    private ScalableTopicResources resources;
+    private ScheduledExecutorService scheduler;
+
+    private BrokerService brokerService;
+    private PulsarService pulsar;
+    private PulsarAdmin admin;
+    private Topics topics;
+    private ScalableTopics scalableTopicsAdmin;
+
+    private ScalableTopicService service;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        store = new LocalMemoryMetadataStore("memory:local",
+                MetadataStoreConfig.builder().build());
+        coordinationService = new CoordinationServiceImpl(store);
+        resources = new ScalableTopicResources(store, 30);
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+
+        brokerService = mock(BrokerService.class);
+        pulsar = mock(PulsarService.class);
+        admin = mock(PulsarAdmin.class);
+        topics = mock(Topics.class);
+        scalableTopicsAdmin = mock(ScalableTopics.class);
+
+        when(brokerService.getPulsar()).thenReturn(pulsar);
+        when(brokerService.getTopicIfExists(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+        when(pulsar.getBrokerId()).thenReturn(BROKER_ID);
+        when(pulsar.getExecutor()).thenReturn(scheduler);
+        when(pulsar.getAdminClient()).thenReturn(admin);
+        when(admin.topics()).thenReturn(topics);
+        when(admin.scalableTopics()).thenReturn(scalableTopicsAdmin);
+
+        when(topics.getSubscriptionsAsync(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(java.util.List.of()));
+        when(topics.createSubscriptionAsync(anyString(), anyString(), any(MessageId.class)))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(topics.deleteSubscriptionAsync(anyString(), anyString(), anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopicsAdmin.createSegmentAsync(anyString(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopicsAdmin.deleteSegmentAsync(anyString(), anyBoolean()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopicsAdmin.terminateSegmentAsync(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        service = new ScalableTopicService(brokerService, resources, coordinationService);
+        service.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (service != null) {
+            service.close();
+        }
+        if (coordinationService != null) {
+            coordinationService.close();
+        }
+        if (store != null) {
+            store.close();
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private TopicName scalableTopic(String name) {
+        return TopicName.get("topic://tenant/ns/" + name);
+    }
+
+    // --- createScalableTopic ---
+
+    @Test
+    public void testCreateScalableTopicStoresMetadataAndCreatesSegments() throws Exception {
+        TopicName tn = scalableTopic("t1");
+
+        service.createScalableTopic(tn, 3).get();
+
+        Optional<ScalableTopicMetadata> md = resources.getScalableTopicMetadataAsync(tn).get();
+        assertTrue(md.isPresent());
+        assertEquals(md.get().getSegments().size(), 3);
+        // Created one segment per initial segment via the segments admin API.
+        verify(scalableTopicsAdmin, org.mockito.Mockito.times(3))
+                .createSegmentAsync(anyString(), any());
+    }
+
+    @Test
+    public void testCreateScalableTopicWithProperties() throws Exception {
+        TopicName tn = scalableTopic("t-props");
+        service.createScalableTopic(tn, 2, Map.of("k", "v")).get();
+
+        ScalableTopicMetadata md = resources.getScalableTopicMetadataAsync(tn).get()
+                .orElseThrow();
+        assertEquals(md.getProperties().get("k"), "v");
+    }
+
+    @Test
+    public void testCreateScalableTopicRejectsZeroSegments() {
+        TopicName tn = scalableTopic("t-bad");
+        try {
+            service.createScalableTopic(tn, 0).get();
+            fail("expected IllegalArgumentException");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue(cause instanceof IllegalArgumentException,
+                    "expected IllegalArgumentException, got " + cause);
+        }
+    }
+
+    @Test
+    public void testCreateScalableTopicRejectsWrongDomain() {
+        TopicName persistent = TopicName.get("persistent://tenant/ns/p");
+        try {
+            service.createScalableTopic(persistent, 1).get();
+            fail("expected IllegalArgumentException");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue(cause instanceof IllegalArgumentException,
+                    "expected IllegalArgumentException, got " + cause);
+        }
+    }
+
+    // --- getOrCreateController ---
+
+    @Test
+    public void testGetOrCreateControllerCachesInstance() throws Exception {
+        TopicName tn = scalableTopic("t-cache");
+        service.createScalableTopic(tn, 1).get();
+
+        ScalableTopicController first = service.getOrCreateController(tn).get();
+        ScalableTopicController second = service.getOrCreateController(tn).get();
+        assertSame(first, second, "same controller returned on re-entry");
+    }
+
+    @Test
+    public void testGetOrCreateControllerFailsIfTopicMissing() throws Exception {
+        TopicName tn = scalableTopic("t-ghost");
+        try {
+            service.getOrCreateController(tn).get();
+            fail("expected failure");
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue(cause instanceof RuntimeException);
+            assertTrue(cause.getMessage().contains("Failed to initialize controller"),
+                    "got: " + cause.getMessage());
+        }
+    }
+
+    @Test
+    public void testReleaseControllerDrops() throws Exception {
+        TopicName tn = scalableTopic("t-release");
+        service.createScalableTopic(tn, 1).get();
+        ScalableTopicController first = service.getOrCreateController(tn).get();
+
+        service.releaseController(tn).get();
+        ScalableTopicController second = service.getOrCreateController(tn).get();
+        assertNotSame(first, second, "a fresh controller should be created after release");
+    }
+
+    // --- split / merge delegation ---
+
+    @Test
+    public void testSplitSegmentDelegates() throws Exception {
+        TopicName tn = scalableTopic("t-split");
+        service.createScalableTopic(tn, 2).get();
+
+        service.splitSegment(tn, 0).get();
+
+        ScalableTopicMetadata md = resources.getScalableTopicMetadataAsync(tn).get()
+                .orElseThrow();
+        assertEquals(md.getEpoch(), 1);
+        assertEquals(md.getSegments().size(), 4,
+                "split adds two children, keeps parent as sealed");
+    }
+
+    @Test
+    public void testMergeSegmentsDelegates() throws Exception {
+        TopicName tn = scalableTopic("t-merge");
+        service.createScalableTopic(tn, 2).get();
+
+        service.mergeSegments(tn, 0, 1).get();
+
+        ScalableTopicMetadata md = resources.getScalableTopicMetadataAsync(tn).get()
+                .orElseThrow();
+        assertEquals(md.getEpoch(), 1);
+        // Two parents sealed + one merged child = 3 segments total.
+        assertEquals(md.getSegments().size(), 3);
+    }
+
+    // --- subscription admin delegation ---
+
+    @Test
+    public void testCreateSubscriptionStream() throws Exception {
+        TopicName tn = scalableTopic("t-cs-stream");
+        service.createScalableTopic(tn, 2).get();
+
+        service.createSubscription(tn, "sub-x", SubscriptionType.STREAM).get();
+
+        var persisted = resources.getSubscriptionAsync(tn, "sub-x").get();
+        assertTrue(persisted.isPresent());
+        assertEquals(persisted.get().type(), SubscriptionType.STREAM);
+    }
+
+    @Test
+    public void testDeleteSubscription() throws Exception {
+        TopicName tn = scalableTopic("t-ds");
+        service.createScalableTopic(tn, 2).get();
+        service.createSubscription(tn, "sub-y", SubscriptionType.STREAM).get();
+
+        service.deleteSubscription(tn, "sub-y").get();
+
+        assertFalse(resources.getSubscriptionAsync(tn, "sub-y").get().isPresent());
+    }
+
+    // --- stats ---
+
+    @Test
+    public void testGetStats() throws Exception {
+        TopicName tn = scalableTopic("t-stats");
+        service.createScalableTopic(tn, 3).get();
+        service.createSubscription(tn, "sub-a", SubscriptionType.STREAM).get();
+
+        ScalableTopicStats stats = service.getStats(tn).get();
+        assertEquals(stats.getActiveSegments(), 3);
+        assertEquals(stats.getTotalSegments(), 3);
+        assertEquals(stats.getSubscriptions().keySet(), java.util.Set.of("sub-a"));
+    }
+
+    // --- consumer registration delegation ---
+
+    @Test
+    public void testRegisterConsumerDelegates() throws Exception {
+        TopicName tn = scalableTopic("t-reg");
+        service.createScalableTopic(tn, 2).get();
+
+        ConsumerAssignment assignment = service.registerConsumer(tn, "sub-z", "c1", 1L,
+                mock(TransportCnx.class)).get();
+        assertEquals(assignment.assignedSegments().size(), 2);
+        assertEquals(resources.listConsumersAsync(tn, "sub-z").get().size(), 1);
+    }
+
+    @Test
+    public void testOnConsumerDisconnectIsNoopIfNoLocalController() {
+        TopicName tn = scalableTopic("t-no-controller");
+        // No controller has been created for this topic → call should be a silent no-op.
+        service.onConsumerDisconnect(tn, "sub", "c1");
+    }
+
+    // --- deleteScalableTopic ---
+
+    @Test
+    public void testDeleteScalableTopicCleansUp() throws Exception {
+        TopicName tn = scalableTopic("t-del");
+        service.createScalableTopic(tn, 2).get();
+        assertTrue(resources.scalableTopicExistsAsync(tn).get());
+
+        service.deleteScalableTopic(tn).get();
+
+        assertFalse(resources.scalableTopicExistsAsync(tn).get());
+        verify(scalableTopicsAdmin, org.mockito.Mockito.atLeast(2))
+                .deleteSegmentAsync(anyString(), anyBoolean());
+    }
+
+    // --- concurrent topic isolation ---
+
+    @Test
+    public void testControllersForDifferentTopicsAreIndependent() throws Exception {
+        TopicName tn1 = scalableTopic("t-indep-1");
+        TopicName tn2 = scalableTopic("t-indep-2");
+        service.createScalableTopic(tn1, 2).get();
+        service.createScalableTopic(tn2, 2).get();
+
+        ScalableTopicController c1 = service.getOrCreateController(tn1).get();
+        ScalableTopicController c2 = service.getOrCreateController(tn2).get();
+
+        assertNotSame(c1, c2);
+        assertEquals(c1.getTopicName(), tn1);
+        assertEquals(c2.getTopicName(), tn2);
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -170,6 +170,11 @@ public interface PulsarAdmin extends Closeable {
     MetadataMigration metadataMigration();
 
     /**
+     * @return the scalable topics management object
+     */
+    ScalableTopics scalableTopics();
+
+    /**
      * Close the PulsarAdminClient and release all the resources.
      *
      */

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ScalableTopics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ScalableTopics.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.policies.data.ScalableSubscriptionType;
+import org.apache.pulsar.common.policies.data.ScalableTopicMetadata;
+import org.apache.pulsar.common.policies.data.ScalableTopicStats;
+
+/**
+ * Admin interface for scalable topic management.
+ *
+ * <p>Scalable topics (topic:// domain) are composed of a DAG of hash-range segments
+ * that can be dynamically split and merged.
+ */
+public interface ScalableTopics {
+
+    /**
+     * Get the list of scalable topics under a namespace.
+     *
+     * @param namespace Namespace name in the format "tenant/namespace"
+     * @return list of scalable topic names
+     */
+    List<String> listScalableTopics(String namespace) throws PulsarAdminException;
+
+    /**
+     * Get the list of scalable topics under a namespace asynchronously.
+     *
+     * @param namespace Namespace name in the format "tenant/namespace"
+     * @return list of scalable topic names
+     */
+    CompletableFuture<List<String>> listScalableTopicsAsync(String namespace);
+
+    /**
+     * Create a new scalable topic.
+     *
+     * @param topic              Topic name in the format "tenant/namespace/topic"
+     * @param numInitialSegments Number of initial segments (must be >= 1)
+     */
+    void createScalableTopic(String topic, int numInitialSegments) throws PulsarAdminException;
+
+    /**
+     * Create a new scalable topic asynchronously.
+     *
+     * @param topic              Topic name in the format "tenant/namespace/topic"
+     * @param numInitialSegments Number of initial segments (must be >= 1)
+     */
+    CompletableFuture<Void> createScalableTopicAsync(String topic, int numInitialSegments);
+
+    /**
+     * Create a new scalable topic with properties.
+     *
+     * @param topic              Topic name in the format "tenant/namespace/topic"
+     * @param numInitialSegments Number of initial segments (must be >= 1)
+     * @param properties         Key-value properties for the topic metadata
+     */
+    void createScalableTopic(String topic, int numInitialSegments, Map<String, String> properties)
+            throws PulsarAdminException;
+
+    /**
+     * Create a new scalable topic with properties asynchronously.
+     *
+     * @param topic              Topic name in the format "tenant/namespace/topic"
+     * @param numInitialSegments Number of initial segments (must be >= 1)
+     * @param properties         Key-value properties for the topic metadata
+     */
+    CompletableFuture<Void> createScalableTopicAsync(String topic, int numInitialSegments,
+                                                      Map<String, String> properties);
+
+    /**
+     * Get scalable topic metadata.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     * @return the scalable topic metadata including segment DAG
+     */
+    ScalableTopicMetadata getMetadata(String topic) throws PulsarAdminException;
+
+    /**
+     * Get scalable topic metadata asynchronously.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     * @return the scalable topic metadata including segment DAG
+     */
+    CompletableFuture<ScalableTopicMetadata> getMetadataAsync(String topic);
+
+    /**
+     * Delete a scalable topic and all its underlying segment topics.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     * @param force Force deletion even if topic has active subscriptions
+     */
+    void deleteScalableTopic(String topic, boolean force) throws PulsarAdminException;
+
+    /**
+     * Delete a scalable topic and all its underlying segment topics asynchronously.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     * @param force Force deletion even if topic has active subscriptions
+     */
+    CompletableFuture<Void> deleteScalableTopicAsync(String topic, boolean force);
+
+    /**
+     * Delete a scalable topic and all its underlying segment topics.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     */
+    default void deleteScalableTopic(String topic) throws PulsarAdminException {
+        deleteScalableTopic(topic, false);
+    }
+
+    /**
+     * Delete a scalable topic and all its underlying segment topics asynchronously.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     */
+    default CompletableFuture<Void> deleteScalableTopicAsync(String topic) {
+        return deleteScalableTopicAsync(topic, false);
+    }
+
+    /**
+     * Get aggregated stats for a scalable topic.
+     *
+     * @param topic Topic name in the format "tenant/namespace/topic"
+     * @return stats including segment counts, per-segment layout info, and per-subscription
+     *         consumer counts
+     */
+    ScalableTopicStats getStats(String topic) throws PulsarAdminException;
+
+    /**
+     * Get aggregated stats for a scalable topic asynchronously.
+     */
+    CompletableFuture<ScalableTopicStats> getStatsAsync(String topic);
+
+    /**
+     * Create a subscription on a scalable topic. The controller leader propagates the
+     * subscription to all active segment topics.
+     *
+     * @param topic        Topic name in the format "tenant/namespace/topic"
+     * @param subscription Name of the subscription to create
+     * @param type         Subscription type: {@link ScalableSubscriptionType#STREAM} for
+     *                     controller-managed ordered subscriptions, or
+     *                     {@link ScalableSubscriptionType#QUEUE} for unordered per-segment
+     *                     fan-out.
+     */
+    void createSubscription(String topic, String subscription, ScalableSubscriptionType type)
+            throws PulsarAdminException;
+
+    /**
+     * Create a subscription on a scalable topic asynchronously.
+     */
+    CompletableFuture<Void> createSubscriptionAsync(String topic, String subscription,
+                                                     ScalableSubscriptionType type);
+
+    /**
+     * Delete a subscription from a scalable topic. Unregisters all consumers and removes
+     * the subscription from every segment topic.
+     *
+     * @param topic        Topic name in the format "tenant/namespace/topic"
+     * @param subscription Name of the subscription to delete
+     */
+    void deleteSubscription(String topic, String subscription) throws PulsarAdminException;
+
+    /**
+     * Delete a subscription from a scalable topic asynchronously.
+     */
+    CompletableFuture<Void> deleteSubscriptionAsync(String topic, String subscription);
+
+    /**
+     * Split a segment into two halves.
+     *
+     * @param topic     Topic name in the format "tenant/namespace/topic"
+     * @param segmentId ID of the segment to split
+     */
+    void splitSegment(String topic, long segmentId) throws PulsarAdminException;
+
+    /**
+     * Split a segment into two halves asynchronously.
+     *
+     * @param topic     Topic name in the format "tenant/namespace/topic"
+     * @param segmentId ID of the segment to split
+     */
+    CompletableFuture<Void> splitSegmentAsync(String topic, long segmentId);
+
+    /**
+     * Merge two adjacent segments into one.
+     *
+     * @param topic      Topic name in the format "tenant/namespace/topic"
+     * @param segmentId1 First segment ID to merge
+     * @param segmentId2 Second segment ID to merge
+     */
+    void mergeSegments(String topic, long segmentId1, long segmentId2) throws PulsarAdminException;
+
+    /**
+     * Merge two adjacent segments into one asynchronously.
+     *
+     * @param topic      Topic name in the format "tenant/namespace/topic"
+     * @param segmentId1 First segment ID to merge
+     * @param segmentId2 Second segment ID to merge
+     */
+    CompletableFuture<Void> mergeSegmentsAsync(String topic, long segmentId1, long segmentId2);
+
+    // --- Segment topic operations ---
+
+    /**
+     * Create a segment topic on the broker that owns its namespace bundle.
+     * Optionally creates subscriptions on the new segment.
+     *
+     * @param segmentTopic Full segment topic name (segment://tenant/namespace/topic/descriptor)
+     * @param subscriptions Optional list of subscription names to create at earliest position
+     */
+    void createSegment(String segmentTopic, List<String> subscriptions) throws PulsarAdminException;
+
+    /**
+     * Create a segment topic asynchronously.
+     */
+    CompletableFuture<Void> createSegmentAsync(String segmentTopic, List<String> subscriptions);
+
+    /**
+     * Terminate a segment topic so that no more messages can be published to it.
+     *
+     * @param segmentTopic Full segment topic name (segment://tenant/namespace/topic/descriptor)
+     */
+    void terminateSegment(String segmentTopic) throws PulsarAdminException;
+
+    /**
+     * Terminate a segment topic asynchronously.
+     */
+    CompletableFuture<Void> terminateSegmentAsync(String segmentTopic);
+
+    /**
+     * Delete a segment topic.
+     *
+     * @param segmentTopic Full segment topic name (segment://tenant/namespace/topic/descriptor)
+     * @param force Force deletion even if topic has active producers/subscriptions
+     */
+    void deleteSegment(String segmentTopic, boolean force) throws PulsarAdminException;
+
+    /**
+     * Delete a segment topic asynchronously.
+     */
+    CompletableFuture<Void> deleteSegmentAsync(String segmentTopic, boolean force);
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableSubscriptionType.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableSubscriptionType.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+/**
+ * Kind of subscription on a scalable topic. Controls whether the scalable-topic
+ * controller coordinates segment-to-consumer assignment for the subscription, or whether
+ * consumers attach to every segment directly without controller involvement.
+ */
+public enum ScalableSubscriptionType {
+
+    /**
+     * Controller-managed: each active segment is assigned to exactly one consumer at a
+     * time to preserve per-segment ordering. Covers both {@code StreamConsumer} (ordered,
+     * cumulative ack) and {@code CheckpointConsumer} (unmanaged, for connectors).
+     */
+    STREAM,
+
+    /**
+     * Controller-bypassing: every consumer attaches directly to every segment (active
+     * and sealed); each segment-owning broker round-robins messages across the attached
+     * consumers. No ordering guarantee.
+     */
+    QUEUE
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableTopicMetadata.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableTopicMetadata.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Metadata for a scalable topic, as returned by the admin API.
+ *
+ * <p>A scalable topic is composed of a DAG of segments, each covering an inclusive
+ * hash range. The epoch is incremented on every layout change (split/merge).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScalableTopicMetadata {
+
+    /** Incremented on every layout change (split/merge/prune). */
+    private long epoch;
+
+    /** Next available segment ID (monotonically increasing). */
+    private long nextSegmentId;
+
+    /** All segments: active + historical (keyed by segmentId). */
+    @Builder.Default
+    private Map<Long, SegmentInfo> segments = new LinkedHashMap<>();
+
+    /** User-defined topic properties. */
+    @Builder.Default
+    private Map<String, String> properties = Map.of();
+
+    /**
+     * Describes a single segment in a scalable topic's DAG.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class SegmentInfo {
+        private long segmentId;
+        private HashRange hashRange;
+        private String state;
+        private List<Long> parentIds;
+        private List<Long> childIds;
+        private long createdAtEpoch;
+        private long sealedAtEpoch;
+
+        public boolean isActive() {
+            return "ACTIVE".equals(state);
+        }
+
+        public boolean isSealed() {
+            return "SEALED".equals(state);
+        }
+    }
+
+    /**
+     * An inclusive hash range [start, end] within a 16-bit hash space.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class HashRange {
+        private int start;
+        private int end;
+
+        @Override
+        public String toString() {
+            return "[" + String.format("%04x", start) + ", " + String.format("%04x", end) + "]";
+        }
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableTopicStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ScalableTopicStats.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Aggregated stats for a scalable topic.
+ *
+ * <p>Combines segment-DAG state (from the topic metadata) with per-subscription consumer
+ * counts (from the persisted consumer registrations). Per-segment throughput rates are
+ * not yet populated — that requires collecting stats from each segment-owning broker and
+ * will be added in a follow-up.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScalableTopicStats {
+
+    /** Current layout epoch. */
+    private long epoch;
+
+    /** Total number of segments in the DAG (active + sealed). */
+    private int totalSegments;
+
+    /** Number of segments currently in ACTIVE state. */
+    private int activeSegments;
+
+    /** Number of segments currently in SEALED state. */
+    private int sealedSegments;
+
+    /** Per-segment stats keyed by segment ID. */
+    @Builder.Default
+    private Map<Long, SegmentStats> segments = new LinkedHashMap<>();
+
+    /** Per-subscription stats keyed by subscription name. */
+    @Builder.Default
+    private Map<String, SubscriptionStats> subscriptions = new LinkedHashMap<>();
+
+    /**
+     * Per-segment stats.
+     *
+     * @param name  full segment topic name (e.g. {@code segment://tenant/ns/topic/<descriptor>}),
+     *              which already encodes the segment ID and hash range
+     * @param state segment state: "ACTIVE" or "SEALED"
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SegmentStats(String name, String state) {
+    }
+
+    /**
+     * Per-subscription stats.
+     *
+     * @param consumerCount number of persisted consumer registrations
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SubscriptionStats(int consumerCount) {
+    }
+}

--- a/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableSubscriptionTypeTest.java
+++ b/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableSubscriptionTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import org.testng.annotations.Test;
+
+public class ScalableSubscriptionTypeTest {
+
+    @Test
+    public void testExpectedValuesExist() {
+        // The wire protocol + admin API identify these by name; a rename or reorder is a
+        // breaking change. This test locks the enum down to its two current values.
+        ScalableSubscriptionType[] values = ScalableSubscriptionType.values();
+        assertEquals(values.length, 2);
+        assertEquals(values[0], ScalableSubscriptionType.STREAM);
+        assertEquals(values[1], ScalableSubscriptionType.QUEUE);
+    }
+
+    @Test
+    public void testValueOfRoundtrip() {
+        assertEquals(ScalableSubscriptionType.valueOf("STREAM"), ScalableSubscriptionType.STREAM);
+        assertEquals(ScalableSubscriptionType.valueOf("QUEUE"), ScalableSubscriptionType.QUEUE);
+    }
+
+    @Test
+    public void testValueOfRejectsUnknown() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScalableSubscriptionType.valueOf("DOES_NOT_EXIST"));
+    }
+}

--- a/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableTopicMetadataTest.java
+++ b/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableTopicMetadataTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class ScalableTopicMetadataTest {
+
+    // --- outer class: ScalableTopicMetadata ---
+
+    @Test
+    public void testNoArgsConstructorDefaults() {
+        ScalableTopicMetadata md = new ScalableTopicMetadata();
+        assertEquals(md.getEpoch(), 0L);
+        assertEquals(md.getNextSegmentId(), 0L);
+        assertNotNull(md.getSegments());
+        assertTrue(md.getSegments().isEmpty());
+        // Properties default is an immutable empty map.
+        assertNotNull(md.getProperties());
+        assertTrue(md.getProperties().isEmpty());
+    }
+
+    @Test
+    public void testBuilderDefaultsAreFreshSegmentsMapPerInstance() {
+        ScalableTopicMetadata a = ScalableTopicMetadata.builder().build();
+        ScalableTopicMetadata b = ScalableTopicMetadata.builder().build();
+        assertNotSame(a.getSegments(), b.getSegments(),
+                "@Builder.Default must create a fresh segments map per instance");
+    }
+
+    @Test
+    public void testBuilderPopulatesFields() {
+        ScalableTopicMetadata.SegmentInfo seg0 = activeSegment(0L, 0x0000, 0x7FFF, 0L);
+        ScalableTopicMetadata.SegmentInfo seg1 = activeSegment(1L, 0x8000, 0xFFFF, 0L);
+
+        ScalableTopicMetadata md = ScalableTopicMetadata.builder()
+                .epoch(5L)
+                .nextSegmentId(2L)
+                .segments(mapOf(seg0, seg1))
+                .properties(Map.of("k", "v"))
+                .build();
+
+        assertEquals(md.getEpoch(), 5L);
+        assertEquals(md.getNextSegmentId(), 2L);
+        assertEquals(md.getSegments().size(), 2);
+        assertEquals(md.getSegments().get(0L), seg0);
+        assertEquals(md.getSegments().get(1L), seg1);
+        assertEquals(md.getProperties().get("k"), "v");
+    }
+
+    @Test
+    public void testAllArgsConstructor() {
+        Map<Long, ScalableTopicMetadata.SegmentInfo> segments = new LinkedHashMap<>();
+        segments.put(0L, activeSegment(0L, 0, 0xFFFF, 0L));
+
+        Map<String, String> props = Map.of("retention", "7d");
+
+        ScalableTopicMetadata md = new ScalableTopicMetadata(3L, 1L, segments, props);
+
+        assertEquals(md.getEpoch(), 3L);
+        assertEquals(md.getNextSegmentId(), 1L);
+        assertEquals(md.getSegments(), segments);
+        assertEquals(md.getProperties(), props);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        ScalableTopicMetadata a = ScalableTopicMetadata.builder().epoch(1L).nextSegmentId(1L).build();
+        ScalableTopicMetadata b = ScalableTopicMetadata.builder().epoch(1L).nextSegmentId(1L).build();
+        ScalableTopicMetadata c = ScalableTopicMetadata.builder().epoch(2L).nextSegmentId(1L).build();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+    }
+
+    // --- nested SegmentInfo ---
+
+    @Test
+    public void testSegmentInfoActiveHelpers() {
+        ScalableTopicMetadata.SegmentInfo seg = activeSegment(0L, 0x0000, 0x7FFF, 0L);
+        assertTrue(seg.isActive());
+        assertFalse(seg.isSealed());
+    }
+
+    @Test
+    public void testSegmentInfoSealedHelpers() {
+        ScalableTopicMetadata.SegmentInfo seg = sealedSegment(0L, 0x0000, 0x7FFF,
+                List.of(), List.of(2L, 3L), 0L, 5L);
+        assertTrue(seg.isSealed());
+        assertFalse(seg.isActive());
+    }
+
+    @Test
+    public void testSegmentInfoHelpersForUnknownStateAreFalse() {
+        ScalableTopicMetadata.SegmentInfo seg = new ScalableTopicMetadata.SegmentInfo(
+                0L, hashRange(0, 0xFFFF), "UNKNOWN", List.of(), List.of(), 0L, -1L);
+        assertFalse(seg.isActive());
+        assertFalse(seg.isSealed());
+    }
+
+    @Test
+    public void testSegmentInfoGetters() {
+        ScalableTopicMetadata.SegmentInfo seg = sealedSegment(
+                7L, 0x0000, 0x3FFF, List.of(0L), List.of(8L, 9L), 2L, 3L);
+        assertEquals(seg.getSegmentId(), 7L);
+        assertEquals(seg.getHashRange().getStart(), 0x0000);
+        assertEquals(seg.getHashRange().getEnd(), 0x3FFF);
+        assertEquals(seg.getState(), "SEALED");
+        assertEquals(seg.getParentIds(), List.of(0L));
+        assertEquals(seg.getChildIds(), List.of(8L, 9L));
+        assertEquals(seg.getCreatedAtEpoch(), 2L);
+        assertEquals(seg.getSealedAtEpoch(), 3L);
+    }
+
+    // --- nested HashRange ---
+
+    @Test
+    public void testHashRangeGettersAndEquality() {
+        ScalableTopicMetadata.HashRange a = hashRange(0, 0x7FFF);
+        ScalableTopicMetadata.HashRange b = hashRange(0, 0x7FFF);
+        ScalableTopicMetadata.HashRange c = hashRange(0, 0x8000);
+
+        assertEquals(a.getStart(), 0);
+        assertEquals(a.getEnd(), 0x7FFF);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+    }
+
+    @Test
+    public void testHashRangeToStringIsLowercaseFourDigitHex() {
+        assertEquals(hashRange(0, 0xFFFF).toString(), "[0000, ffff]");
+        assertEquals(hashRange(0x0, 0x7FFF).toString(), "[0000, 7fff]");
+        assertEquals(hashRange(0x8000, 0xFFFF).toString(), "[8000, ffff]");
+        assertEquals(hashRange(0x1234, 0xabcd).toString(), "[1234, abcd]");
+    }
+
+    // --- helpers ---
+
+    private static ScalableTopicMetadata.SegmentInfo activeSegment(long id, int start, int end,
+                                                                    long createdAtEpoch) {
+        return new ScalableTopicMetadata.SegmentInfo(
+                id, hashRange(start, end), "ACTIVE",
+                List.of(), List.of(), createdAtEpoch, -1L);
+    }
+
+    private static ScalableTopicMetadata.SegmentInfo sealedSegment(long id, int start, int end,
+                                                                    List<Long> parents,
+                                                                    List<Long> children,
+                                                                    long createdAtEpoch,
+                                                                    long sealedAtEpoch) {
+        return new ScalableTopicMetadata.SegmentInfo(
+                id, hashRange(start, end), "SEALED",
+                parents, children, createdAtEpoch, sealedAtEpoch);
+    }
+
+    private static ScalableTopicMetadata.HashRange hashRange(int start, int end) {
+        return new ScalableTopicMetadata.HashRange(start, end);
+    }
+
+    private static Map<Long, ScalableTopicMetadata.SegmentInfo> mapOf(
+            ScalableTopicMetadata.SegmentInfo... segs) {
+        Map<Long, ScalableTopicMetadata.SegmentInfo> m = new LinkedHashMap<>();
+        for (ScalableTopicMetadata.SegmentInfo s : segs) {
+            m.put(s.getSegmentId(), s);
+        }
+        return m;
+    }
+}

--- a/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableTopicStatsTest.java
+++ b/pulsar-client-admin-api/src/test/java/org/apache/pulsar/common/policies/data/ScalableTopicStatsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class ScalableTopicStatsTest {
+
+    // --- outer class: ScalableTopicStats ---
+
+    @Test
+    public void testNoArgsConstructorDefaults() {
+        ScalableTopicStats stats = new ScalableTopicStats();
+        assertEquals(stats.getEpoch(), 0L);
+        assertEquals(stats.getTotalSegments(), 0);
+        assertEquals(stats.getActiveSegments(), 0);
+        assertEquals(stats.getSealedSegments(), 0);
+        // Default maps are non-null — callers can put entries without a NullPointerException.
+        assertNotNull(stats.getSegments());
+        assertNotNull(stats.getSubscriptions());
+        assertTrue(stats.getSegments().isEmpty());
+        assertTrue(stats.getSubscriptions().isEmpty());
+    }
+
+    @Test
+    public void testBuilderPopulatesFields() {
+        Map<Long, ScalableTopicStats.SegmentStats> segMap = new LinkedHashMap<>();
+        segMap.put(0L, new ScalableTopicStats.SegmentStats("segment://t/n/topic/0000-ffff-0", "ACTIVE"));
+
+        Map<String, ScalableTopicStats.SubscriptionStats> subMap = new LinkedHashMap<>();
+        subMap.put("sub-a", new ScalableTopicStats.SubscriptionStats(3));
+
+        ScalableTopicStats stats = ScalableTopicStats.builder()
+                .epoch(7L)
+                .totalSegments(5)
+                .activeSegments(3)
+                .sealedSegments(2)
+                .segments(segMap)
+                .subscriptions(subMap)
+                .build();
+
+        assertEquals(stats.getEpoch(), 7L);
+        assertEquals(stats.getTotalSegments(), 5);
+        assertEquals(stats.getActiveSegments(), 3);
+        assertEquals(stats.getSealedSegments(), 2);
+        assertEquals(stats.getSegments().get(0L).name(), "segment://t/n/topic/0000-ffff-0");
+        assertEquals(stats.getSegments().get(0L).state(), "ACTIVE");
+        assertEquals(stats.getSubscriptions().get("sub-a").consumerCount(), 3);
+    }
+
+    @Test
+    public void testBuilderWithoutMapsUsesEmptyDefaults() {
+        ScalableTopicStats stats = ScalableTopicStats.builder().build();
+        assertNotNull(stats.getSegments());
+        assertNotNull(stats.getSubscriptions());
+        assertTrue(stats.getSegments().isEmpty());
+        assertTrue(stats.getSubscriptions().isEmpty());
+    }
+
+    @Test
+    public void testBuilderDefaultMapIsFreshPerInstance() {
+        // @Builder.Default should give each built instance its own map — otherwise two
+        // instances would share state and mutations to one would leak into the other.
+        ScalableTopicStats a = ScalableTopicStats.builder().build();
+        ScalableTopicStats b = ScalableTopicStats.builder().build();
+        assertNotSame(a.getSegments(), b.getSegments());
+        assertNotSame(a.getSubscriptions(), b.getSubscriptions());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        ScalableTopicStats a = ScalableTopicStats.builder()
+                .epoch(1L).totalSegments(2).activeSegments(2).build();
+        ScalableTopicStats b = ScalableTopicStats.builder()
+                .epoch(1L).totalSegments(2).activeSegments(2).build();
+        ScalableTopicStats c = ScalableTopicStats.builder()
+                .epoch(2L).totalSegments(2).activeSegments(2).build();
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+    }
+
+    @Test
+    public void testAllArgsConstructor() {
+        Map<Long, ScalableTopicStats.SegmentStats> segments = Map.of(
+                0L, new ScalableTopicStats.SegmentStats("segment://t/n/topic/0000-7fff-0", "SEALED"));
+        Map<String, ScalableTopicStats.SubscriptionStats> subs = Map.of(
+                "sub-1", new ScalableTopicStats.SubscriptionStats(0));
+
+        ScalableTopicStats stats = new ScalableTopicStats(3L, 4, 2, 2, segments, subs);
+
+        assertEquals(stats.getEpoch(), 3L);
+        assertEquals(stats.getTotalSegments(), 4);
+        assertEquals(stats.getActiveSegments(), 2);
+        assertEquals(stats.getSealedSegments(), 2);
+        assertEquals(stats.getSegments(), segments);
+        assertEquals(stats.getSubscriptions(), subs);
+    }
+
+    // --- nested record: SegmentStats ---
+
+    @Test
+    public void testSegmentStatsRecordAccessors() {
+        ScalableTopicStats.SegmentStats seg = new ScalableTopicStats.SegmentStats(
+                "segment://tenant/ns/my-topic/0000-3fff-2", "ACTIVE");
+        assertEquals(seg.name(), "segment://tenant/ns/my-topic/0000-3fff-2");
+        assertEquals(seg.state(), "ACTIVE");
+    }
+
+    @Test
+    public void testSegmentStatsEqualsAndHashCode() {
+        ScalableTopicStats.SegmentStats a = new ScalableTopicStats.SegmentStats("seg-a", "ACTIVE");
+        ScalableTopicStats.SegmentStats b = new ScalableTopicStats.SegmentStats("seg-a", "ACTIVE");
+        ScalableTopicStats.SegmentStats c = new ScalableTopicStats.SegmentStats("seg-a", "SEALED");
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+    }
+
+    // --- nested record: SubscriptionStats ---
+
+    @Test
+    public void testSubscriptionStatsRecordAccessor() {
+        ScalableTopicStats.SubscriptionStats sub = new ScalableTopicStats.SubscriptionStats(42);
+        assertEquals(sub.consumerCount(), 42);
+    }
+
+    @Test
+    public void testSubscriptionStatsEqualsAndHashCode() {
+        ScalableTopicStats.SubscriptionStats a = new ScalableTopicStats.SubscriptionStats(3);
+        ScalableTopicStats.SubscriptionStats b = new ScalableTopicStats.SubscriptionStats(3);
+        ScalableTopicStats.SubscriptionStats c = new ScalableTopicStats.SubscriptionStats(4);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+    }
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.client.admin.ProxyStats;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.ResourceGroups;
 import org.apache.pulsar.client.admin.ResourceQuotas;
+import org.apache.pulsar.client.admin.ScalableTopics;
 import org.apache.pulsar.client.admin.Schemas;
 import org.apache.pulsar.client.admin.Sink;
 import org.apache.pulsar.client.admin.Sinks;
@@ -104,6 +105,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
     private final Packages packages;
     private final Transactions transactions;
     private final MetadataMigration metadataMigration;
+    private final ScalableTopics scalableTopics;
     protected final WebTarget root;
     protected final Authentication auth;
     @Getter
@@ -190,6 +192,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
         this.packages = new PackagesImpl(root, auth, asyncHttpConnector, requestTimeoutMs);
         this.transactions = new TransactionsImpl(root, auth, requestTimeoutMs);
         this.metadataMigration = new MetadataMigrationImpl(root, auth, requestTimeoutMs);
+        this.scalableTopics = new ScalableTopicsImpl(root, auth, requestTimeoutMs);
 
         if (originalCtxLoader != null) {
             Thread.currentThread().setContextClassLoader(originalCtxLoader);
@@ -429,6 +432,11 @@ public class PulsarAdminImpl implements PulsarAdmin {
     @Override
     public MetadataMigration metadataMigration() {
         return metadataMigration;
+    }
+
+    @Override
+    public ScalableTopics scalableTopics() {
+        return scalableTopics;
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ScalableTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ScalableTopicsImpl.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.ScalableTopics;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ScalableTopicMetadata;
+import org.apache.pulsar.common.policies.data.ScalableTopicStats;
+
+public class ScalableTopicsImpl extends BaseResource implements ScalableTopics {
+    private final WebTarget adminScalable;
+    private final WebTarget adminSegments;
+
+    public ScalableTopicsImpl(WebTarget web, Authentication auth, long requestTimeoutMs) {
+        super(auth, requestTimeoutMs);
+        adminScalable = web.path("/admin/v2/scalable");
+        adminSegments = web.path("/admin/v2/segments");
+    }
+
+    private WebTarget namespacePath(NamespaceName ns) {
+        return adminScalable.path(ns.getTenant()).path(ns.getLocalName());
+    }
+
+    private WebTarget topicPath(TopicName tn) {
+        return adminScalable.path(tn.getTenant()).path(tn.getNamespacePortion()).path(tn.getLocalName());
+    }
+
+    // --- List ---
+
+    @Override
+    public List<String> listScalableTopics(String namespace) throws PulsarAdminException {
+        return sync(() -> listScalableTopicsAsync(namespace));
+    }
+
+    @Override
+    public CompletableFuture<List<String>> listScalableTopicsAsync(String namespace) {
+        NamespaceName ns = NamespaceName.get(namespace);
+        return asyncGetRequest(namespacePath(ns), new GenericType<List<String>>() {});
+    }
+
+    // --- Create ---
+
+    @Override
+    public void createScalableTopic(String topic, int numInitialSegments) throws PulsarAdminException {
+        sync(() -> createScalableTopicAsync(topic, numInitialSegments));
+    }
+
+    @Override
+    public CompletableFuture<Void> createScalableTopicAsync(String topic, int numInitialSegments) {
+        return createScalableTopicAsync(topic, numInitialSegments, null);
+    }
+
+    @Override
+    public void createScalableTopic(String topic, int numInitialSegments, Map<String, String> properties)
+            throws PulsarAdminException {
+        sync(() -> createScalableTopicAsync(topic, numInitialSegments, properties));
+    }
+
+    @Override
+    public CompletableFuture<Void> createScalableTopicAsync(String topic, int numInitialSegments,
+                                                              Map<String, String> properties) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).queryParam("numInitialSegments", numInitialSegments);
+        Entity<?> entity = (properties != null && !properties.isEmpty())
+                ? Entity.entity(properties, MediaType.APPLICATION_JSON)
+                : Entity.entity("", MediaType.APPLICATION_JSON);
+        return asyncPutRequest(path, entity);
+    }
+
+    // --- Get metadata ---
+
+    @Override
+    public ScalableTopicMetadata getMetadata(String topic) throws PulsarAdminException {
+        return sync(() -> getMetadataAsync(topic));
+    }
+
+    @Override
+    public CompletableFuture<ScalableTopicMetadata> getMetadataAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        return asyncGetRequest(topicPath(tn), ScalableTopicMetadata.class);
+    }
+
+    // --- Delete ---
+
+    @Override
+    public void deleteScalableTopic(String topic, boolean force) throws PulsarAdminException {
+        sync(() -> deleteScalableTopicAsync(topic, force));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteScalableTopicAsync(String topic, boolean force) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).queryParam("force", force);
+        return asyncDeleteRequest(path);
+    }
+
+    // --- Stats ---
+
+    @Override
+    public ScalableTopicStats getStats(String topic) throws PulsarAdminException {
+        return sync(() -> getStatsAsync(topic));
+    }
+
+    @Override
+    public CompletableFuture<ScalableTopicStats> getStatsAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        return asyncGetRequest(topicPath(tn).path("stats"), ScalableTopicStats.class);
+    }
+
+    // --- Subscription operations ---
+
+    @Override
+    public void createSubscription(String topic, String subscription,
+            org.apache.pulsar.common.policies.data.ScalableSubscriptionType type)
+            throws PulsarAdminException {
+        sync(() -> createSubscriptionAsync(topic, subscription, type));
+    }
+
+    @Override
+    public CompletableFuture<Void> createSubscriptionAsync(String topic, String subscription,
+            org.apache.pulsar.common.policies.data.ScalableSubscriptionType type) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).path("subscriptions").path(subscription)
+                .queryParam("type", type.name());
+        return asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void deleteSubscription(String topic, String subscription) throws PulsarAdminException {
+        sync(() -> deleteSubscriptionAsync(topic, subscription));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteSubscriptionAsync(String topic, String subscription) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).path("subscriptions").path(subscription);
+        return asyncDeleteRequest(path);
+    }
+
+    // --- Split ---
+
+    @Override
+    public void splitSegment(String topic, long segmentId) throws PulsarAdminException {
+        sync(() -> splitSegmentAsync(topic, segmentId));
+    }
+
+    @Override
+    public CompletableFuture<Void> splitSegmentAsync(String topic, long segmentId) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).path("split").path(String.valueOf(segmentId));
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    // --- Merge ---
+
+    @Override
+    public void mergeSegments(String topic, long segmentId1, long segmentId2) throws PulsarAdminException {
+        sync(() -> mergeSegmentsAsync(topic, segmentId1, segmentId2));
+    }
+
+    @Override
+    public CompletableFuture<Void> mergeSegmentsAsync(String topic, long segmentId1, long segmentId2) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn).path("merge")
+                .path(String.valueOf(segmentId1))
+                .path(String.valueOf(segmentId2));
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    // --- Segment topic operations ---
+
+    @Override
+    public void createSegment(String segmentTopic, List<String> subscriptions) throws PulsarAdminException {
+        sync(() -> createSegmentAsync(segmentTopic, subscriptions));
+    }
+
+    @Override
+    public CompletableFuture<Void> createSegmentAsync(String segmentTopic, List<String> subscriptions) {
+        TopicName tn = TopicName.get(segmentTopic);
+        WebTarget path = adminSegments
+                .path(tn.getTenant()).path(tn.getNamespacePortion())
+                .path(tn.getLocalName()).path(tn.getSegmentDescriptor());
+        Entity<?> entity = (subscriptions != null && !subscriptions.isEmpty())
+                ? Entity.entity(subscriptions, MediaType.APPLICATION_JSON)
+                : Entity.entity("", MediaType.APPLICATION_JSON);
+        return asyncPutRequest(path, entity);
+    }
+
+    @Override
+    public void terminateSegment(String segmentTopic) throws PulsarAdminException {
+        sync(() -> terminateSegmentAsync(segmentTopic));
+    }
+
+    @Override
+    public CompletableFuture<Void> terminateSegmentAsync(String segmentTopic) {
+        TopicName tn = TopicName.get(segmentTopic);
+        WebTarget path = adminSegments
+                .path(tn.getTenant()).path(tn.getNamespacePortion())
+                .path(tn.getLocalName()).path(tn.getSegmentDescriptor())
+                .path("terminate");
+        return asyncPostRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void deleteSegment(String segmentTopic, boolean force) throws PulsarAdminException {
+        sync(() -> deleteSegmentAsync(segmentTopic, force));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteSegmentAsync(String segmentTopic, boolean force) {
+        TopicName tn = TopicName.get(segmentTopic);
+        WebTarget path = adminSegments
+                .path(tn.getTenant()).path(tn.getNamespacePortion())
+                .path(tn.getLocalName()).path(tn.getSegmentDescriptor())
+                .queryParam("force", force);
+        return asyncDeleteRequest(path);
+    }
+
+    // --- Helpers ---
+
+    private static TopicName validateTopic(String topic) {
+        // Accept "tenant/namespace/topic" or fully qualified "topic://tenant/namespace/topic"
+        if (!topic.contains("://")) {
+            topic = "topic://" + topic;
+        }
+        return TopicName.get(topic);
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdScalableTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdScalableTopics.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.ScalableTopics;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(description = "Operations on scalable topics")
+public class CmdScalableTopics extends CmdBase {
+
+    private ScalableTopics scalableTopics() {
+        return getAdmin().scalableTopics();
+    }
+
+    @Command(description = "Get the list of scalable topics under a namespace")
+    private class ListCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace", arity = "1")
+        private String namespace;
+
+        @Override
+        void run() throws Exception {
+            print(scalableTopics().listScalableTopics(validateNamespace(namespace)));
+        }
+    }
+
+    @Command(description = "Create a new scalable topic")
+    private class CreateCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Option(names = {"-s", "--segments"},
+                description = "Number of initial segments", defaultValue = "1")
+        private int numInitialSegments;
+
+        @Option(names = {"-p", "--property"}, description = "Key-value properties (key=value)",
+                arity = "0..*")
+        private List<String> properties;
+
+        @Override
+        void run() throws Exception {
+            Map<String, String> props = parseListKeyValueMap(properties);
+            if (props != null) {
+                scalableTopics().createScalableTopic(topic, numInitialSegments, props);
+            } else {
+                scalableTopics().createScalableTopic(topic, numInitialSegments);
+            }
+            print("Created scalable topic " + topic + " with " + numInitialSegments + " segment(s)");
+        }
+    }
+
+    @Command(description = "Get scalable topic metadata")
+    private class GetMetadataCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Override
+        void run() throws Exception {
+            prettyPrint(scalableTopics().getMetadata(topic));
+        }
+    }
+
+    @Command(description = "Get aggregated stats for a scalable topic")
+    private class GetStatsCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Override
+        void run() throws Exception {
+            prettyPrint(scalableTopics().getStats(topic));
+        }
+    }
+
+    @Command(description = "Delete a scalable topic and all its segments")
+    private class DeleteCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Option(names = {"-f", "--force"},
+                description = "Force deletion even if topic has active subscriptions")
+        private boolean force;
+
+        @Override
+        void run() throws Exception {
+            scalableTopics().deleteScalableTopic(topic, force);
+            print("Deleted scalable topic " + topic);
+        }
+    }
+
+    @Command(description = "Split a segment into two halves")
+    private class SplitSegmentCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Option(names = {"-s", "--segment-id"},
+                description = "ID of the segment to split", required = true)
+        private long segmentId;
+
+        @Override
+        void run() throws Exception {
+            scalableTopics().splitSegment(topic, segmentId);
+            print("Split segment " + segmentId + " of topic " + topic);
+        }
+    }
+
+    @Command(description = "Merge two adjacent segments into one")
+    private class MergeSegmentsCmd extends CliCommand {
+        @Parameters(description = "tenant/namespace/topic", arity = "1")
+        private String topic;
+
+        @Option(names = {"--segment-id-1"},
+                description = "First segment ID to merge", required = true)
+        private long segmentId1;
+
+        @Option(names = {"--segment-id-2"},
+                description = "Second segment ID to merge", required = true)
+        private long segmentId2;
+
+        @Override
+        void run() throws Exception {
+            scalableTopics().mergeSegments(topic, segmentId1, segmentId2);
+            print("Merged segments " + segmentId1 + " and " + segmentId2 + " of topic " + topic);
+        }
+    }
+
+    public CmdScalableTopics(Supplier<PulsarAdmin> admin) {
+        super("scalable-topics", admin);
+        addCommand("list", new ListCmd());
+        addCommand("create", new CreateCmd());
+        addCommand("get-metadata", new GetMetadataCmd());
+        addCommand("stats", new GetStatsCmd());
+        addCommand("delete", new DeleteCmd());
+        addCommand("split-segment", new SplitSegmentCmd());
+        addCommand("merge-segments", new MergeSegmentsCmd());
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -305,6 +305,7 @@ public class PulsarAdminTool implements CommandHook {
         commandMap.put("transactions", CmdTransactions.class);
 
         commandMap.put("migration", CmdMetadataMigration.class);
+        commandMap.put("scalable-topics", CmdScalableTopics.class);
 
         setupCommands(properties);
     }


### PR DESCRIPTION
> **Stacked on top of #25564** (which is stacked on #25559). Opened as a
> draft; will be rebased on master once the upstream PRs land. Reviewers:
> the new code in this PR is the single commit titled "PIP-468: Add
> scalable topics and segments admin APIs with CLI" — everything else
> comes from #25559 and #25564.

## Summary

Third PR in the PIP-468 series. Wires up the admin/management surface
for scalable topics:

### REST APIs (broker)

- `ScalableTopics` REST resource — create / list / get-metadata / get-stats /
  delete / create-subscription / delete-subscription / split / merge.
  Includes `redirectToControllerLeaderIfNeeded` for write operations so
  non-leader brokers automatically 307 to the leader.
- `Segments` REST resource — cross-broker segment-topic
  create / terminate / delete with ownership-based routing.

### Client-admin API

- `ScalableTopics` interface on `PulsarAdmin` with sync and async
  counterparts for every operation.
- `ScalableTopicsImpl` — REST client wiring.
- Data types under `org.apache.pulsar.common.policies.data`:
  `ScalableTopicMetadata` (plus nested `SegmentInfo` and `HashRange`),
  `ScalableTopicStats` (plus nested `SegmentStats` and `SubscriptionStats`
  records), `ScalableSubscriptionType` enum.

### CLI

- `CmdScalableTopics` `pulsar-admin` subcommand with `list`, `create`,
  `get-metadata`, `stats`, `delete`, `split-segment`, `merge-segments`.

### Broker integration

- `ScalableTopicController` gains `createSubscription`,
  `deleteSubscription`, and `getStats` — exposing admin-visible
  operations on top of the infrastructure added in #25559.
- `ScalableTopicService` gains matching per-topic delegations +
  admin-layer entry points (`createScalableTopic`, `deleteScalableTopic`,
  `splitSegment`, `mergeSegments`, etc.) used by the REST handlers.
- Small tweak to `DagWatchSession` to pick up the reviewed changes from
  #25564.

## Tests

### New test classes (24 tests)

- `ScalableTopicStatsTest` (10 tests) — construction (no-args /
  `@Builder` / all-args), `@Builder.Default` fresh-per-instance
  behavior, equals/hashCode, and the nested `SegmentStats` /
  `SubscriptionStats` records.
- `ScalableTopicMetadataTest` (11 tests) — same construction patterns,
  plus `SegmentInfo.isActive` / `isSealed` (including the unknown-state
  branch), full getters on a sealed segment, and `HashRange.toString()`
  format (lowercase 4-digit hex).
- `ScalableSubscriptionTypeTest` (3 tests) — locks down the enum values
  so a rename breaks the build; `valueOf` roundtrip and rejection of
  unknown names.

### Expanded in this commit

- `ScalableTopicControllerTest` — 24 tests covering all controller
  methods including `createSubscription` / `deleteSubscription` /
  `getStats` / stats-after-split-and-subscriptions / etc.
- `ScalableTopicServiceTest` — 16 tests covering service lifecycle,
  create/delete topic, get-or-create-controller (caching + failure +
  eviction), release, delegation to split / merge / subscriptions /
  stats / register / disconnect, and topic cleanup.

### Coverage on this branch

| Test class | Tests |
|---|---|
| `CommandsScalableTopicTest` (from #25564) | 8 |
| `ConsumerSessionTest` (from #25564) | 15 |
| `DagWatchSessionTest` (from #25564) | 12 |
| `ScalableTopicControllerTest` | 24 |
| `ScalableTopicServiceTest` | 16 |
| `SegmentLayoutTest` (from #25559) | 15 |
| `SubscriptionCoordinatorTest` (from #25559) | 11 |
| `ScalableTopicStatsTest` | 10 |
| `ScalableTopicMetadataTest` | 11 |
| `ScalableSubscriptionTypeTest` | 3 |
| **Total** | **125** |

## Test plan

- [x] `./gradlew :pulsar-client-admin-api:test --tests "org.apache.pulsar.common.policies.data.Scalable*Test"` — 24/24 pass.
- [x] `./gradlew :pulsar-broker:test --tests "org.apache.pulsar.broker.service.scalable.*"` — 93/93 pass.
- [x] `./gradlew :pulsar-common:test --tests "org.apache.pulsar.common.protocol.CommandsScalableTopicTest"` — 8/8 pass.
- [x] `./gradlew :pulsar-client-admin-api:checkstyleMain :pulsar-client-admin-api:checkstyleTest :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest :pulsar-common:checkstyleMain :pulsar-common:checkstyleTest :pulsar-client-admin-original:checkstyleMain :pulsar-client-tools:checkstyleMain` — clean.