### PR TITLE
[fix][test] Flaky SameAuthParamsLookupAutoClusterFailoverTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -80,7 +80,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
                 .pulsarServiceUrlArray(urlArray)
                 .failoverThreshold(5)
                 .recoverThreshold(5)
-                .checkHealthyIntervalMs(300)
+                .checkHealthyIntervalMs(100)
                 .testTopic("a/b/c")
                 .markTopicNotFoundAsAvailable(true)
                 .build();


### PR DESCRIPTION
Fixes #24526

### Motivation

The `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` test is flaky. A prior fix (#25388) addressed one root cause (stale `Healthy` state in `findFailoverTo`), but the test still times out intermittently at the "Test recover 2 --> 1" step, where Awaitility waits up to 60s for state to reach `[Failed, Healthy, Healthy]`.

Root cause: with `checkHealthyIntervalMs(300)` and `recoverThreshold(5)`, recovery of index 1 requires 5 successful probe cycles. Each cycle sequentially probes every index up to `currentPulsarServiceIndex` (so 3 probes per cycle once `currentIndex=2`). Each probe is bounded by a 3s deadline in `SameAuthParamsLookupAutoClusterFailover.probeAvailable()`. Under CI load, the accumulated wall time (cycles × probes × per-probe time) can approach or exceed the 60s Awaitility budget — especially if a transient probe failure of index 1 resets the PreRecover counter, forcing another 5 cycles.

### Modifications

Reduce `checkHealthyIntervalMs` from 300ms to 100ms in the test. This tightens the cycle cadence so recovery completes sooner without weakening the threshold-based state machine — the full five-step `PreRecover -> Healthy` transition is still exercised.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover`. Verified locally with `@Test(invocationCount = 5)` (10 runs total across both `enabledTls` values): 10/10 passes, each invocation consistent at ~16.5s (vs. the flaky runs that previously exceeded the 60s awaitility budget).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`