### PR TITLE
[fix] Fix flaky BrokerDispatchRateLimiterTest.testBrokerDispatchThrottledMetrics

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerDispatchRateLimiterTest.java
@@ -20,11 +20,14 @@ package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.pulsar.PrometheusMetricsTestUtil;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient;
@@ -35,6 +38,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.awaitility.Awaitility;
+import org.mockito.exceptions.misusing.DisabledMockException;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -109,10 +113,18 @@ public class BrokerDispatchRateLimiterTest extends BrokerTestBase {
         }
 
         // Assert broker metrics
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        PrometheusMetricsTestUtil.generate(pulsar, true, false, false, output);
-        String metricsStr = output.toString();
-        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsStr);
+        AtomicReference<String> metricsString = new AtomicReference<>();
+        Awaitility.await()
+                .pollInterval(Duration.ofMillis(200))
+                .atMost(Duration.ofSeconds(5))
+                .ignoreExceptionsMatching(exception -> exception.getCause() instanceof DisabledMockException)
+                .untilAsserted(() -> {
+                    ByteArrayOutputStream output = new ByteArrayOutputStream();
+                    PrometheusMetricsTestUtil.generate(pulsar, true, false, false, output);
+                    metricsString.set(output.toString());
+                    assertFalse(metricsString.get().isEmpty());
+                });
+        Multimap<String, PrometheusMetricsClient.Metric> metrics = parseMetrics(metricsString.get());
 
         // Assert subscription metrics reason by broker limit
         Collection<PrometheusMetricsClient.Metric> subscriptionDispatchThrottledMsgCountMetrics =


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25122

### Motivation

The test `BrokerDispatchRateLimiterTest.testBrokerDispatchThrottledMetrics` is currently flaky and occasionally fails with a `java.io.IOException` wrapping a `mockito.exceptions.misusing.DisabledMockException`.

The failure occurs during the metrics generation phase:

```java
java.io.IOException: java.util.concurrent.ExecutionException: org.mockito.exceptions.misusing.DisabledMockException: Mock accessed after inline mocks were cleared
at org.apache.pulsar.PrometheusMetricsTestUtil.generate(PrometheusMetricsTestUtil.java:63)
```

### Modifications

* **Wrap metrics generation in Awaitility:** Instead of a single call to `PrometheusMetricsTestUtil.generate`, the scrape is now wrapped in an `Awaitility` block.
* **Ignore Mockito lifecycle exceptions:** The retry logic specifically ignores `DisabledMockException`. If the race condition occurs, the test will retry the scrape until it succeeds within the provided timeout.
* **Ensure stability:** This ensures that the test waits for the asynchronous metrics collection to settle and successfully complete before proceeding to assertions.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment