### PR TITLE
[fix][sec] Upgrade BouncyCastle to 1.84 (CVE-2026-5588, CVE-2026-0636)

### DIFF
--- a/bouncy-castle/bc/build.gradle.kts
+++ b/bouncy-castle/bc/build.gradle.kts
@@ -27,5 +27,5 @@ dependencies {
         exclude(group = "io.prometheus", module = "simpleclient_caffeine")
     }
     implementation(libs.bcpkix.jdk18on)
-    implementation(libs.bcprov.ext.jdk18on)
+    implementation(libs.bcprov.jdk18on)
 }

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -630,9 +630,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - org.bouncycastle-bcpkix-jdk18on-1.81.jar
-    - org.bouncycastle-bcprov-jdk18on-1.78.1.jar
-    - org.bouncycastle-bcutil-jdk18on-1.81.jar
+    - org.bouncycastle-bcpkix-jdk18on-1.84.jar
+    - org.bouncycastle-bcprov-jdk18on-1.84.jar
+    - org.bouncycastle-bcutil-jdk18on-1.84.jar
 
 ------------------------
 

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -471,9 +471,9 @@ Public Domain (CC0) -- ../licenses/LICENSE-CC0.txt
 
 Bouncy Castle License
  * Bouncy Castle -- ../licenses/LICENSE-bouncycastle.txt
-    - bcpkix-jdk18on-1.81.jar
-    - bcprov-jdk18on-1.78.1.jar
-    - bcutil-jdk18on-1.81.jar
+    - bcpkix-jdk18on-1.84.jar
+    - bcprov-jdk18on-1.84.jar
+    - bcutil-jdk18on-1.84.jar
 
 ------------------------
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,11 +56,9 @@ commons-logging = "1.3.5"
 commons-beanutils = "1.11.0"
 commons-configuration2 = "2.12.0"
 # BouncyCastle
-bouncycastle-bcprov = "1.78.1"
-bouncycastle-bcpkix = "1.81"
-bouncycastle-bcutil = "1.81"
-bouncycastle-bcprov-ext = "1.78.1"
-bouncycastle-bcpkix-fips = "2.0.10"
+bouncycastle = "1.84"
+bouncycastle-bcpkix-fips = "2.0.11"
+bouncycastle-bcutil-fips = "2.0.6"
 bouncycastle-bc-fips = "2.0.1"
 # Serialization
 avro = "1.12.0"
@@ -307,11 +305,10 @@ opentelemetry-instrumentation-runtime-telemetry-java17 = { module = "io.opentele
 opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
 opentelemetry-gcp-resources = { module = "io.opentelemetry.contrib:opentelemetry-gcp-resources", version.ref = "opentelemetry-gcp-resources" }
 # BouncyCastle
-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle-bcpkix" }
-bcprov-ext-jdk18on = { module = "org.bouncycastle:bcprov-ext-jdk18on", version.ref = "bouncycastle-bcprov-ext" }
+bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 bcpkix-fips = { module = "org.bouncycastle:bcpkix-fips", version.ref = "bouncycastle-bcpkix-fips" }
 bc-fips = { module = "org.bouncycastle:bc-fips", version.ref = "bouncycastle-bc-fips" }
-bcutil-fips = "org.bouncycastle:bcutil-fips:2.0.5"
+bcutil-fips = { module = "org.bouncycastle:bcutil-fips", version.ref = "bouncycastle-bcutil-fips" }
 # RocksDB
 rocksdbjni = { module = "org.rocksdb:rocksdbjni", version.ref = "rocksdb" }
 # Error Prone
@@ -440,7 +437,7 @@ athenz-cert-refresher = { module = "com.yahoo.athenz:athenz-cert-refresher", ver
 athenz-auth-core = { module = "com.yahoo.athenz:athenz-auth-core", version.ref = "athenz" }
 athenz-zpe-java-client = { module = "com.yahoo.athenz:athenz-zpe-java-client", version.ref = "athenz" }
 # Misc
-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle-bcprov" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 commons-logging = { module = "commons-logging:commons-logging", version.ref = "commons-logging" }
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commons-beanutils" }
 commons-configuration2 = { module = "org.apache.commons:commons-configuration2", version.ref = "commons-configuration2" }

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -116,7 +116,7 @@ dependencies {
     testImplementation(project(":pulsar-io:pulsar-io-batch-discovery-triggerers"))
     testImplementation(libs.zt.zip)
     testImplementation(libs.asynchttpclient)
-    testImplementation(libs.bcprov.ext.jdk18on)
+    testImplementation(libs.bcprov.jdk18on)
     testImplementation(libs.commons.math3)
     testImplementation(libs.okhttp3)
     testImplementation(libs.spring.core)

--- a/pulsar-client-messagecrypto-bc/build.gradle.kts
+++ b/pulsar-client-messagecrypto-bc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation(project(":pulsar-client-api"))
     implementation(project(":bouncy-castle:bouncy-castle-bc"))
     implementation(libs.bcpkix.jdk18on)
-    implementation(libs.bcprov.ext.jdk18on)
+    implementation(libs.bcprov.jdk18on)
     implementation(libs.guava)
     implementation(libs.caffeine)
     compileOnly(libs.netty.buffer)


### PR DESCRIPTION
### Motivation

Fixes two Bouncy Castle vulnerabilities disclosed against BC-JAVA:

- **CVE-2026-5588** — PKIX draft `CompositeVerifier` accepts an empty signature sequence as valid, bypassing signature verification. Affects `bcpkix` 1.49–1.83. Fixed in 1.84. See [GitLab advisory](https://advisories.gitlab.com/maven/org.bouncycastle/bcpkix-jdk18on/CVE-2026-5588/).
- **CVE-2026-0636** — LDAP injection in `LDAPStoreHelper` inside `bcprov`. Affects 1.74–1.83. Fixed in 1.84. See [BC wiki](https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902026%E2%80%900636).

Pulsar currently ships `bcprov-jdk18on` 1.78.1, `bcpkix-jdk18on` 1.81, and `bcprov-ext-jdk18on` 1.78.1, so it is exposed to both CVEs.

### Modifications

**Non-FIPS (BC-JAVA):**
- Unified `bcprov-jdk18on`, `bcpkix-jdk18on`, and `bcutil-jdk18on` under a single `bouncycastle = \"1.84\"` version catalog key. These three artifacts release in lockstep on Maven Central (verified: identical version histories from 1.71 through 1.84), so one pin keeps them aligned.
- Dropped `bcprov-ext-jdk18on` entirely. It has not been released past 1.78.1, and the BC team has retired the `-ext` variant ([bc-java discussion #2175](https://github.com/bcgit/bc-java/discussions/2175)). Pinning it at 1.78.1 alongside `bcprov` 1.84 would leave the older LDAP classes on the classpath and effectively shadow the CVE-2026-0636 fix. A source audit of the three consumers (`pulsar-client-messagecrypto-bc`, `bouncy-castle/bc`, and `pulsar-broker` tests) confirmed that only classes present in plain `bcprov-jdk18on` are used (`BouncyCastleProvider`, `ASN1*`, `jce.spec.*`, `openssl.*`). Three build files now depend on `libs.bcprov.jdk18on` instead of `libs.bcprov.ext.jdk18on`.

**FIPS:**
- Bumped patches available within the FIPS 140-3 certified 2.0.x line:
  - `bcpkix-fips` 2.0.10 → **2.0.11**
  - `bcutil-fips` 2.0.5 → **2.0.6**
  - `bc-fips` stays at **2.0.1** (latest 2.0.x; no newer 2.0.x exists)
- Deliberately did **not** jump to 2.1.x: bc-fips 2.0.0 received NIST FIPS 140-3 certification on 2024-07-31, while 2.1.x is a separately-certified branch. `bcpkix-fips 2.0.11` and `bcutil-fips 2.0.6` both declare `bc-fips:[2.0.0,2.1.0)`, which is the BC FIPS team's own signal that 2.0 and 2.1 are not drop-in compatible.
- Converted `bcutil-fips` from the inline string form to the standard `module + version.ref` form now that it has its own version key.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Local verification performed:

- Dependency resolution: all non-FIPS consumers (`pulsar-client-messagecrypto-bc`, `pulsar-broker`, `bouncy-castle:bouncy-castle-bc`, `pulsar-functions:pulsar-functions-instance`, `tiered-storage:tiered-storage-file-system`, `pulsar-client-auth-athenz`) consistently resolve `bcprov/bcpkix/bcutil-jdk18on` to 1.84, with no FAILED dependencies. Transitive requests at 1.78/1.80/1.82 upgrade to 1.84 via the enforced platform. The FIPS distribution mutually satisfies the `[2.0.0,2.1.0)` internal ranges.
- Compilation: `compileJava` on `pulsar-client-messagecrypto-bc`, `bouncy-castle:bouncy-castle-bc`, and `bouncy-castle:bcfips`, plus `compileTestJava` on `pulsar-broker`, all pass.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

**Dependency change highlights:**
- `bcprov-jdk18on`: 1.78.1 → 1.84
- `bcpkix-jdk18on`: 1.81 → 1.84
- `bcutil-jdk18on`: 1.81 → 1.84 (transitive, pinned via unified `bouncycastle` key)
- `bcprov-ext-jdk18on`: **removed** (retired by BC; superset of bcprov; not needed by Pulsar)
- `bcpkix-fips`: 2.0.10 → 2.0.11
- `bcutil-fips`: 2.0.5 → 2.0.6
- `bc-fips`: unchanged at 2.0.1