### PR TITLE
[improve][broker] Centralize mark-delete position change handling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -65,6 +65,7 @@ import org.apache.pulsar.broker.service.EntryAndMetadata;
 import org.apache.pulsar.broker.service.EntryBatchIndexesAcks;
 import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.InMemoryRedeliveryTracker;
+import org.apache.pulsar.broker.service.PendingAcksMap;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.RedeliveryTrackerDisabled;
 import org.apache.pulsar.broker.service.SendMessageInfo;
@@ -145,7 +146,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     protected enum ReadType {
         Normal, Replay
     }
-    private Position lastMarkDeletePositionBeforeReadMoreEntries;
     private volatile long readMoreEntriesCallCount;
 
     public PersistentDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
@@ -339,6 +339,24 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         }
     }
 
+    @Override
+    public void markDeletePositionMoveForward() {
+        // When the mark-delete position advances (due to ack or TTL expiry), remove stale entries that are
+        // now below the new mark-delete position from the redelivery tracker and each consumer's pending acks.
+        synchronized (PersistentDispatcherMultipleConsumers.this) {
+            Position mdp = cursor.getMarkDeletedPosition();
+            if (mdp != null) {
+                redeliveryMessages.removeAllUpTo(mdp.getLedgerId(), mdp.getEntryId());
+                for (Consumer consumer : consumerList) {
+                    PendingAcksMap pendingAcks = consumer.getPendingAcks();
+                    if (pendingAcks != null) {
+                        pendingAcks.removeAllUpTo(mdp.getLedgerId(), mdp.getEntryId());
+                    }
+                }
+            }
+        }
+    }
+
     public synchronized void readMoreEntries() {
         if (cursor.isClosed()) {
             log.debug("Cursor is already closed, skipping read more entries");
@@ -361,17 +379,6 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
         // increment the counter for readMoreEntries calls, to track the number of times readMoreEntries is called
         readMoreEntriesCallCount++;
-
-        // remove possible expired messages from redelivery tracker and pending acks
-        Position markDeletePosition = cursor.getMarkDeletedPosition();
-        if (lastMarkDeletePositionBeforeReadMoreEntries != markDeletePosition) {
-            redeliveryMessages.removeAllUpTo(markDeletePosition.getLedgerId(), markDeletePosition.getEntryId());
-            for (Consumer consumer : consumerList) {
-                consumer.getPendingAcks()
-                        .removeAllUpTo(markDeletePosition.getLedgerId(), markDeletePosition.getEntryId());
-            }
-            lastMarkDeletePositionBeforeReadMoreEntries = markDeletePosition;
-        }
 
         // totalAvailablePermits may be updated by other threads
         int firstAvailableConsumerPermits = getFirstAvailableConsumerPermits();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -40,7 +40,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo;
 import org.apache.pulsar.broker.service.MessageExpirer;
 import org.apache.pulsar.client.impl.MessageImpl;
-import org.apache.pulsar.common.api.proto.CommandSubscribe.SubType;
 import org.apache.pulsar.common.stats.Rate;
 import org.jspecify.annotations.Nullable;
 /**
@@ -211,8 +210,7 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
             long numMessagesExpired = (long) ctx - cursor.getNumberOfEntriesInBacklog(false);
             msgExpired.recordMultipleEvents(numMessagesExpired, 0 /* no value stats */);
             totalMsgExpired.add(numMessagesExpired);
-            // If the subscription is a Key_Shared subscription, we should to trigger message dispatch.
-            if (subscription != null && subscription.getType() == SubType.Key_Shared) {
+            if (subscription != null && subscription.getDispatcher() != null) {
                 subscription.getDispatcher().markDeletePositionMoveForward();
             }
             expirationCheckInProgress = FALSE;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -642,6 +642,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     @Override
     public void markDeletePositionMoveForward() {
+        // clean up stale entries from the redelivery tracker and pending acks
+        super.markDeletePositionMoveForward();
         // reschedule a read with a backoff after moving the mark-delete position forward since there might have
         // been consumers that were blocked by hash and couldn't make progress
         reScheduleReadWithKeySharedUnblockingInterval();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -515,12 +515,7 @@ public class PersistentSubscription extends AbstractSubscription {
                     .attr("newMD", newMD)
                     .attr("oldMD", oldMD)
                     .log("Mark deleted messages to position from position");
-            // Signal the dispatchers to give chance to take extra actions
-            if (dispatcher != null) {
-                dispatcher.afterAckMessages(null, ctx);
-            }
-            // Signal the dispatchers to give chance to take extra actions
-            notifyTheMarkDeletePositionChanged(oldMD);
+           notifyTheMarkDeletePositionChanged(oldMD);
         }
 
         @Override
@@ -530,10 +525,6 @@ public class PersistentSubscription extends AbstractSubscription {
                     .attr("ctx", ctx)
                     .exceptionMessage(exception)
                     .log("Failed to mark delete for position");
-            // Signal the dispatchers to give chance to take extra actions
-            if (dispatcher != null) {
-                dispatcher.afterAckMessages(null, ctx);
-            }
         }
     };
 
@@ -544,10 +535,6 @@ public class PersistentSubscription extends AbstractSubscription {
             log.debug()
                     .attr("context", context)
                     .log("Deleted message");
-            // Signal the dispatchers to give chance to take extra actions
-            if (dispatcher != null) {
-                dispatcher.afterAckMessages(null, context);
-            }
             notifyTheMarkDeletePositionChanged((Position) context);
         }
 
@@ -557,10 +544,6 @@ public class PersistentSubscription extends AbstractSubscription {
                     .attr("ctx", ctx)
                     .exceptionMessage(exception)
                     .log("Failed to delete message");
-            // Signal the dispatchers to give chance to take extra actions
-            if (dispatcher != null) {
-                dispatcher.afterAckMessages(exception, ctx);
-            }
         }
     };
 
@@ -579,6 +562,7 @@ public class PersistentSubscription extends AbstractSubscription {
             handleReplicatedSubscriptionsUpdate(newMD);
 
             if (dispatcher != null) {
+                dispatcher.afterAckMessages(null, null);
                 dispatcher.markDeletePositionMoveForward();
             }
         }
@@ -784,6 +768,7 @@ public class PersistentSubscription extends AbstractSubscription {
                 .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
                 .log("Backlog size before clearing");
 
+        final Position oldMarkDeletePosition = cursor.getMarkDeletedPosition();
         cursor.asyncClearBacklog(new ClearBacklogCallback() {
             @Override
             public void clearBacklogComplete(Object ctx) {
@@ -798,10 +783,10 @@ public class PersistentSubscription extends AbstractSubscription {
                             future.complete(null);
                         }
                     });
-                    dispatcher.afterAckMessages(null, ctx);
                 } else {
                     future.complete(null);
                 }
+                notifyTheMarkDeletePositionChanged(oldMarkDeletePosition);
             }
 
             @Override
@@ -810,9 +795,6 @@ public class PersistentSubscription extends AbstractSubscription {
                         .exception(exception)
                         .log("Failed to clear backlog");
                 future.completeExceptionally(exception);
-                if (dispatcher != null) {
-                    dispatcher.afterAckMessages(exception, ctx);
-                }
             }
         }, null);
 
@@ -827,6 +809,7 @@ public class PersistentSubscription extends AbstractSubscription {
                 .attr("numMessagesToSkip", numMessagesToSkip)
                 .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
                 .log("Skipping messages");
+        final Position oldMarkDeletePosition = cursor.getMarkDeletedPosition();
         cursor.asyncSkipEntries(numMessagesToSkip, IndividualDeletedEntries.Exclude,
                 new AsyncCallbacks.SkipEntriesCallback() {
                     @Override
@@ -836,9 +819,7 @@ public class PersistentSubscription extends AbstractSubscription {
                                 .attr("entriesInBacklog", cursor.getNumberOfEntriesInBacklog(false))
                                 .log("Skipped messages");
                         future.complete(null);
-                        if (dispatcher != null) {
-                            dispatcher.afterAckMessages(null, ctx);
-                        }
+                        notifyTheMarkDeletePositionChanged(oldMarkDeletePosition);
                     }
 
                     @Override
@@ -848,9 +829,6 @@ public class PersistentSubscription extends AbstractSubscription {
                                 .exception(exception)
                                 .log("Failed to skip messages");
                         future.completeExceptionally(exception);
-                        if (dispatcher != null) {
-                            dispatcher.afterAckMessages(exception, ctx);
-                        }
                     }
                 }, null);
 
@@ -983,6 +961,7 @@ public class PersistentSubscription extends AbstractSubscription {
             }
 
             forceReset.thenAccept(forceResetValue -> {
+                final Position oldMarkDeletePosition = cursor.getMarkDeletedPosition();
                 cursor.asyncResetCursor(finalPosition, forceResetValue, new AsyncCallbacks.ResetCursorCallback() {
                     @Override
                     public void resetComplete(Object ctx) {
@@ -991,8 +970,8 @@ public class PersistentSubscription extends AbstractSubscription {
                                 .log("Successfully reset subscription to position");
                         if (dispatcher != null) {
                             dispatcher.cursorIsReset();
-                            dispatcher.afterAckMessages(null, finalPosition);
                         }
+                        notifyTheMarkDeletePositionChanged(oldMarkDeletePosition);
                         IS_FENCED_UPDATER.set(PersistentSubscription.this, FALSE);
                         inProgressResetCursorFuture = null;
                         future.complete(null);


### PR DESCRIPTION
### Motivation

Dispatcher notification logic (`afterAckMessages` + `markDeletePositionMoveForward`) was scattered across multiple callback sites in `PersistentSubscription` (markDeleteCallback, deleteCallback, clearBacklog, skipMessages, resetCursor). This led to:

- Duplicated `dispatcher.afterAckMessages()` calls that could fire even when the mark-delete position hadn't actually changed.
- Redelivery tracker and pending acks cleanup was only performed inside `readMoreEntries()` for the `PersistentDispatcherMultipleConsumers` base class, meaning `Key_Shared` subscriptions had to duplicate the logic. Other subscription types (Shared, Failover) missed cleanup opportunities when messages expired via TTL.
- `PersistentMessageExpiryMonitor` only triggered `markDeletePositionMoveForward()` for `Key_Shared` subscriptions, leaving other subscription types without proper cleanup after message expiry.

### Changes

- `PersistentSubscription`
  - Consolidated all `dispatcher.afterAckMessages()` calls into the single `notifyTheMarkDeletePositionChanged()` method, which now also calls `dispatcher.markDeletePositionMoveForward()`.
  - Removed scattered `afterAckMessages` calls from `markDeleteCallback`, `deleteCallback`, `clearBacklog`, `skipMessages`, and `resetCursor`.
  - Added `oldMarkDeletePosition` capture in `clearBacklog`, `skipMessages`, and `resetCursor` to route through the centralized path.

- `PersistentDispatcherMultipleConsumers`
  - Moved redelivery tracker and pending acks cleanup from `readMoreEntries()` into `markDeletePositionMoveForward()`, so it fires precisely when the mark-delete position advances rather than opportunistically on the next read cycle.
  - Removed `lastMarkDeletePositionBeforeReadMoreEntries` field.

- `PersistentStickyKeyDispatcherMultipleConsumers`
  - Added `super.markDeletePositionMoveForward()` call so Key_Shared subscriptions also clean up stale entries from the redelivery tracker and pending acks.

- `PersistentMessageExpiryMonitor`
  - Changed the post-expiry dispatcher notification from a `Key_Shared`-only check to a general `dispatcher != null` check, so all subscription types benefit from cleanup after message TTL expiry.