### PR TITLE
[fix][broker] Race condition causes perpetual backlog on internal topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
@@ -29,8 +29,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
-import java.util.function.UnaryOperator;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -66,7 +66,8 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
   @VisibleForTesting
   static Runnable injectionAfterSeekInPhaseTwo = () -> {};
   @VisibleForTesting
-  static UnaryOperator<CompletableFuture<Void>> injectionPhaseTwoSeek = UnaryOperator.identity();
+  static BiFunction<RawReader, MessageId, CompletableFuture<Void>> injectionPhaseTwoSeek =
+      RawReader::seekAsync;
   protected static final int MAX_OUTSTANDING = 500;
   protected final Duration phaseOneLoopReadTimeout;
   protected final boolean topicCompactionRetainNullKey;
@@ -252,7 +253,7 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
 
   private void attemptPhaseTwoSeek(RawReader reader, MessageId from, Backoff backoff,
       CompletableFuture<Void> promise) {
-    injectionPhaseTwoSeek.apply(reader.seekAsync(from)).whenComplete((v, ex) -> {
+    injectionPhaseTwoSeek.apply(reader, from).whenComplete((v, ex) -> {
       if (ex == null) {
         promise.complete(null);
         return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/AbstractTwoPhaseCompactor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
+import java.util.function.UnaryOperator;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -39,6 +40,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -46,6 +48,7 @@ import org.apache.pulsar.client.impl.RawBatchConverter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.Markers;
+import org.apache.pulsar.common.util.Backoff;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -62,6 +65,8 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
 
   @VisibleForTesting
   static Runnable injectionAfterSeekInPhaseTwo = () -> {};
+  @VisibleForTesting
+  static UnaryOperator<CompletableFuture<Void>> injectionPhaseTwoSeek = UnaryOperator.identity();
   protected static final int MAX_OUTSTANDING = 500;
   protected final Duration phaseOneLoopReadTimeout;
   protected final boolean topicCompactionRetainNullKey;
@@ -197,7 +202,7 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
       LedgerHandle ledger) {
     CompletableFuture<Long> promise = new CompletableFuture<>();
 
-    reader.seekAsync(from).thenCompose((v) -> {
+    phaseTwoSeekWithRetry(reader, from).thenCompose((v) -> {
           injectionAfterSeekInPhaseTwo.run();
           Semaphore outstanding = new Semaphore(MAX_OUTSTANDING);
           CompletableFuture<Void> loopPromise = new CompletableFuture<>();
@@ -220,6 +225,57 @@ public abstract class AbstractTwoPhaseCompactor<T> extends Compactor {
           }
         });
     return promise;
+  }
+
+  /**
+   * Seek the compaction subscription to {@code from}, retrying on transient
+   * {@link PulsarClientException.ConnectException}.
+   *
+   * <p>Server-side, {@code PersistentSubscription.resetCursorInternal} disconnects the compaction
+   * consumer before resetting the managed cursor, then sends the success response. This races with
+   * the client: {@code channelInactive} fires on the consumer's {@code ClientCnx} and fails the
+   * in-flight seek future with {@code ConnectException} before the broker's success response
+   * arrives. The seek is idempotent and the cursor is already repositioned server-side, so
+   * retrying after a short backoff lets the client reconnect and the next seek complete normally.
+   * Non-transient failures propagate immediately.
+   */
+  private CompletableFuture<Void> phaseTwoSeekWithRetry(RawReader reader, MessageId from) {
+    CompletableFuture<Void> promise = new CompletableFuture<>();
+    Backoff backoff = Backoff.builder()
+        .initialDelay(Duration.ofMillis(100))
+        .maxBackoff(Duration.ofSeconds(1))
+        .mandatoryStop(Duration.ofSeconds(10))
+        .build();
+    attemptPhaseTwoSeek(reader, from, backoff, promise);
+    return promise;
+  }
+
+  private void attemptPhaseTwoSeek(RawReader reader, MessageId from, Backoff backoff,
+      CompletableFuture<Void> promise) {
+    injectionPhaseTwoSeek.apply(reader.seekAsync(from)).whenComplete((v, ex) -> {
+      if (ex == null) {
+        promise.complete(null);
+        return;
+      }
+      Throwable cause = FutureUtil.unwrapCompletionException(ex);
+      if (!(cause instanceof PulsarClientException.ConnectException)) {
+        promise.completeExceptionally(cause);
+        return;
+      }
+      long nextMs = backoff.next().toMillis();
+      if (backoff.isMandatoryStopMade()) {
+        promise.completeExceptionally(cause);
+        return;
+      }
+      log.warn()
+          .attr("topic", reader.getTopic())
+          .attr("from", from)
+          .attr("nextMs", nextMs)
+          .exceptionMessage(cause)
+          .log("Phase two seek failed transiently, will retry");
+      scheduler.schedule(() -> attemptPhaseTwoSeek(reader, from, backoff, promise),
+          nextMs, TimeUnit.MILLISECONDS);
+    });
   }
 
   private void phaseTwoLoop(RawReader reader, MessageId to, Map<String, MessageId> latestForKey,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -56,8 +56,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.function.UnaryOperator;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
@@ -161,6 +163,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     public void beforeMethod() throws Exception {
         admin.namespaces().removeRetention("my-tenant/my-ns");
         AbstractTwoPhaseCompactor.injectionAfterSeekInPhaseTwo = () -> {};
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = UnaryOperator.identity();
     }
 
     protected long compact(String topic) throws ExecutionException, InterruptedException {
@@ -2521,6 +2524,35 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // The original ledger still exists so old values of "key-1" can be read
         verifyReadKeyValues(topic, false, List.of("key-0", "value", "key-1", "value-0", "key-1", "value-1", "key-1",
                 "value-2", "key-2", "value-0", "key-2", "value-1"));
+    }
+
+    @Test
+    public void testPhaseTwoSeekRetriesOnConnectException() throws Exception {
+        final var topic = "persistent://my-tenant/my-ns/phase-two-seek-retry";
+        @Cleanup final var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+        producer.newMessage().key("k").value("v0").send();
+        producer.newMessage().key("k").value("v1").send();
+
+        // Simulate the production race: PersistentSubscription.resetCursorInternal disconnects the
+        // consumer before responding to the seek, which fails the client's in-flight seek future
+        // with ConnectException even though the cursor is repositioned server-side. The first seek
+        // here is replaced with a failed future; the real seek still executes (so the subscription
+        // is actually at the target position), and the compactor's retry picks back up.
+        final var attempts = new AtomicInteger(0);
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = original -> {
+            if (attempts.getAndIncrement() == 0) {
+                return FutureUtil.failedFuture(
+                        new PulsarClientException.ConnectException("simulated disconnect during seek"));
+            }
+            return original;
+        };
+
+        final long compactedLedgerId = compact(topic);
+        assertNotEquals(compactedLedgerId, -1L);
+        assertTrue(attempts.get() >= 2,
+                "Seek should have been retried at least once, attempts=" + attempts.get());
+
+        verifyReadKeyValues(topic, true, List.of("k", "v1"));
     }
 
     private void verifyReadKeyValues(String topic, boolean readCompacted, List<String> expectedKeyValues)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
-import java.util.function.UnaryOperator;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
@@ -93,6 +92,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -163,7 +163,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     public void beforeMethod() throws Exception {
         admin.namespaces().removeRetention("my-tenant/my-ns");
         AbstractTwoPhaseCompactor.injectionAfterSeekInPhaseTwo = () -> {};
-        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = UnaryOperator.identity();
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = RawReader::seekAsync;
     }
 
     protected long compact(String topic) throws ExecutionException, InterruptedException {
@@ -2535,16 +2535,16 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         // Simulate the production race: PersistentSubscription.resetCursorInternal disconnects the
         // consumer before responding to the seek, which fails the client's in-flight seek future
-        // with ConnectException even though the cursor is repositioned server-side. The first seek
-        // here is replaced with a failed future; the real seek still executes (so the subscription
-        // is actually at the target position), and the compactor's retry picks back up.
+        // with ConnectException. The first attempt here returns a synthetic failure without invoking
+        // the real seek (so nothing is in flight on the underlying ConsumerImpl); the retry calls
+        // seekAsync for real and the compaction proceeds.
         final var attempts = new AtomicInteger(0);
-        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = original -> {
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = (reader, msgId) -> {
             if (attempts.getAndIncrement() == 0) {
                 return FutureUtil.failedFuture(
                         new PulsarClientException.ConnectException("simulated disconnect during seek"));
             }
-            return original;
+            return reader.seekAsync(msgId);
         };
 
         final long compactedLedgerId = compact(topic);


### PR DESCRIPTION
### Motivation

Topics with compaction enabled — most visibly `__change_events` system topics — accumulate an unbounded `__compaction` subscription backlog that is never drained, polluting backlog metrics across the cluster.

### Modifications

The broker disconnects the compaction consumer as part of `PersistentSubscription.resetCursorInternal`, then resets the cursor and sends the success response. This races with the client: `channelInactive` fires on the consumer's `ClientCnx` and fails the in-flight seek future with `ConnectException` before the broker's success response arrives.

`AbstractTwoPhaseCompactor.phaseTwoSeekThenLoop` has no retry for this transient failure, so every compaction attempt aborts and the `__compaction` subscription backlog grows without bound. This is most visible on `__change_events` system topics, where compaction is triggered on any non-zero backlog.

The seek is idempotent and the cursor is already repositioned server-side, so retry the seek on `ConnectException` with a bounded backoff (100ms -> 1s, 10s budget). Non-transient failures propagate immediately. A unit test reproduces the race via an injection hook and asserts the compactor recovers.

Fixes #25279

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->



<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->


<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added an integration test following existing styles for testing the race condition that happens and the implemented fix for retrying

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

*NONE of these are affected with this change*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment