### PR TITLE
[feat] PIP-468: Implement V5 client with scalable topic producer and consumer types

### DIFF
--- a/pulsar-client-v5/build.gradle.kts
+++ b/pulsar-client-v5/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id("pulsar.java-conventions")
+}
+
+dependencies {
+    implementation(project(":pulsar-client-api-v5"))
+    implementation(project(":pulsar-client-original"))
+    implementation(project(":pulsar-common"))
+    implementation(libs.slf4j.api)
+    implementation(libs.slog)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.protobuf.java)
+    implementation(libs.netty.handler)
+    implementation(libs.jackson.annotations)
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+    testImplementation(libs.testng)
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncCheckpointConsumerV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncCheckpointConsumerV5.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.async.AsyncCheckpointConsumer;
+
+/**
+ * Async view of a {@link ScalableCheckpointConsumer}.
+ */
+final class AsyncCheckpointConsumerV5<T> implements AsyncCheckpointConsumer<T> {
+
+    private final ScalableCheckpointConsumer<T> consumer;
+
+    AsyncCheckpointConsumerV5(ScalableCheckpointConsumer<T> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public CompletableFuture<Message<T>> receive() {
+        return consumer.receiveAsync();
+    }
+
+    @Override
+    public CompletableFuture<Message<T>> receive(Duration timeout) {
+        return consumer.receiveAsync(timeout);
+    }
+
+    @Override
+    public CompletableFuture<List<Message<T>>> receiveMulti(int maxMessages, Duration timeout) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                var msgs = consumer.receiveMulti(maxMessages, timeout);
+                List<Message<T>> result = new java.util.ArrayList<>();
+                msgs.forEach(result::add);
+                return result;
+            } catch (Exception e) {
+                throw new java.util.concurrent.CompletionException(e);
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Checkpoint> checkpoint() {
+        return consumer.checkpointAsync();
+    }
+
+    @Override
+    public CompletableFuture<Void> seek(Checkpoint checkpoint) {
+        return consumer.seekAsync(checkpoint);
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        return consumer.closeAsync();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncMessageBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncMessageBuilderV5.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncMessageBuilder;
+
+/**
+ * V5 async message builder. Accumulates metadata and delegates send
+ * to ScalableTopicProducer asynchronously.
+ */
+final class AsyncMessageBuilderV5<T> implements AsyncMessageBuilder<T> {
+
+    private final ScalableTopicProducer<T> producer;
+    private T value;
+    private String key;
+    private Map<String, String> properties;
+    private Instant eventTime;
+    private Long sequenceId;
+    private Duration deliverAfter;
+    private Instant deliverAt;
+    private List<String> replicationClusters;
+
+    AsyncMessageBuilderV5(ScalableTopicProducer<T> producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public CompletableFuture<MessageId> send() {
+        return producer.sendInternalAsync(
+                key, value, properties, eventTime, sequenceId,
+                deliverAfter, deliverAt, replicationClusters)
+                .thenApply(id -> id);
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> value(T value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> key(String key) {
+        this.key = key;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> transaction(Transaction txn) {
+        // TODO: Wire up transaction support
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> property(String name, String value) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> properties(Map<String, String> properties) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.putAll(properties);
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> eventTime(Instant eventTime) {
+        this.eventTime = eventTime;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> sequenceId(long sequenceId) {
+        this.sequenceId = sequenceId;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> deliverAfter(Duration delay) {
+        this.deliverAfter = delay;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> deliverAt(Instant timestamp) {
+        this.deliverAt = timestamp;
+        return this;
+    }
+
+    @Override
+    public AsyncMessageBuilderV5<T> replicationClusters(List<String> clusters) {
+        this.replicationClusters = clusters;
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncProducerV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncProducerV5.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.async.AsyncMessageBuilder;
+import org.apache.pulsar.client.api.v5.async.AsyncProducer;
+
+/**
+ * V5 async producer view. Wraps a ScalableTopicProducer and provides
+ * CompletableFuture-based operations.
+ */
+final class AsyncProducerV5<T> implements AsyncProducer<T> {
+
+    private final ScalableTopicProducer<T> producer;
+
+    AsyncProducerV5(ScalableTopicProducer<T> producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public AsyncMessageBuilder<T> newMessage() {
+        return new AsyncMessageBuilderV5<>(producer);
+    }
+
+    @Override
+    public CompletableFuture<Void> flush() {
+        return producer.flushAsync();
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        return producer.closeAsync();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncQueueConsumerV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncQueueConsumerV5.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncQueueConsumer;
+
+/**
+ * Async view of a {@link ScalableQueueConsumer}.
+ */
+final class AsyncQueueConsumerV5<T> implements AsyncQueueConsumer<T> {
+
+    private final ScalableQueueConsumer<T> consumer;
+
+    AsyncQueueConsumerV5(ScalableQueueConsumer<T> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public CompletableFuture<Message<T>> receive() {
+        return consumer.receiveAsync();
+    }
+
+    @Override
+    public void acknowledge(MessageId messageId) {
+        consumer.acknowledge(messageId);
+    }
+
+    @Override
+    public void acknowledge(Message<T> message) {
+        consumer.acknowledge(message.id());
+    }
+
+    @Override
+    public void acknowledge(MessageId messageId, Transaction txn) {
+        consumer.acknowledge(messageId, txn);
+    }
+
+    @Override
+    public void negativeAcknowledge(MessageId messageId) {
+        consumer.negativeAcknowledge(messageId);
+    }
+
+    @Override
+    public void negativeAcknowledge(Message<T> message) {
+        consumer.negativeAcknowledge(message.id());
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        return consumer.closeAsync();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncStreamConsumerV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AsyncStreamConsumerV5.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncStreamConsumer;
+
+/**
+ * Async view of a {@link ScalableStreamConsumer}.
+ */
+final class AsyncStreamConsumerV5<T> implements AsyncStreamConsumer<T> {
+
+    private final ScalableStreamConsumer<T> consumer;
+
+    AsyncStreamConsumerV5(ScalableStreamConsumer<T> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public CompletableFuture<Message<T>> receive() {
+        return consumer.receiveAsync();
+    }
+
+    @Override
+    public CompletableFuture<Message<T>> receive(Duration timeout) {
+        return consumer.receiveAsync(timeout);
+    }
+
+    @Override
+    public CompletableFuture<List<Message<T>>> receiveMulti(int maxNumMessages, Duration timeout) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                var msgs = consumer.receiveMulti(maxNumMessages, timeout);
+                List<Message<T>> result = new java.util.ArrayList<>();
+                msgs.forEach(result::add);
+                return result;
+            } catch (Exception e) {
+                throw new java.util.concurrent.CompletionException(e);
+            }
+        });
+    }
+
+    @Override
+    public void acknowledgeCumulative(MessageId messageId) {
+        consumer.acknowledgeCumulative(messageId);
+    }
+
+    @Override
+    public void acknowledgeCumulative(MessageId messageId, Transaction txn) {
+        consumer.acknowledgeCumulative(messageId, txn);
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        return consumer.closeAsync();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AuthenticationAdapter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AuthenticationAdapter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.auth.Authentication;
+import org.apache.pulsar.client.api.v5.auth.AuthenticationData;
+import org.apache.pulsar.client.impl.auth.AuthenticationTls;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+
+/**
+ * Adapts between v5 Authentication and v4 Authentication interfaces.
+ */
+final class AuthenticationAdapter {
+
+    private AuthenticationAdapter() {
+    }
+
+    /**
+     * Create a v5 Authentication wrapping a v4 token auth.
+     */
+    static Authentication token(String token) {
+        return new V5AuthWrapper(new AuthenticationToken(token));
+    }
+
+    /**
+     * Create a v5 Authentication wrapping a v4 token supplier auth.
+     */
+    static Authentication token(Supplier<String> tokenSupplier) {
+        return new V5AuthWrapper(new AuthenticationToken(tokenSupplier));
+    }
+
+    /**
+     * Create a v5 Authentication wrapping a v4 TLS auth.
+     */
+    static Authentication tls(String certFilePath, String keyFilePath) {
+        return new V5AuthWrapper(new AuthenticationTls(certFilePath, keyFilePath));
+    }
+
+    /**
+     * Create a v5 Authentication by loading a v4 auth plugin by class name.
+     */
+    static Authentication create(String className, String params) throws PulsarClientException {
+        try {
+            var v4Auth = org.apache.pulsar.client.api.AuthenticationFactory.create(className, params);
+            return new V5AuthWrapper(v4Auth);
+        } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+            throw new PulsarClientException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Create a v5 Authentication by loading a v4 auth plugin by class name and params map.
+     */
+    static Authentication create(String className, Map<String, String> params)
+            throws PulsarClientException {
+        try {
+            var v4Auth = org.apache.pulsar.client.api.AuthenticationFactory.create(className, params);
+            return new V5AuthWrapper(v4Auth);
+        } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+            throw new PulsarClientException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Unwrap a v5 Authentication to get the v4 Authentication.
+     */
+    static org.apache.pulsar.client.api.Authentication toV4(Authentication v5Auth) {
+        if (v5Auth instanceof V5AuthWrapper wrapper) {
+            return wrapper.v4Auth;
+        }
+        throw new IllegalArgumentException("Unknown v5 Authentication type: " + v5Auth.getClass());
+    }
+
+    /**
+     * V5 Authentication that wraps a v4 Authentication.
+     */
+    private static final class V5AuthWrapper implements Authentication {
+        final org.apache.pulsar.client.api.Authentication v4Auth;
+
+        V5AuthWrapper(org.apache.pulsar.client.api.Authentication v4Auth) {
+            this.v4Auth = v4Auth;
+        }
+
+        @Override
+        public String authMethodName() {
+            return v4Auth.getAuthMethodName();
+        }
+
+        @Override
+        public AuthenticationData authData() throws PulsarClientException {
+            // TODO: Implement AuthenticationData adapter when needed
+            return null;
+        }
+
+        @Override
+        public void initialize() throws PulsarClientException {
+            try {
+                v4Auth.start();
+            } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+                throw new PulsarClientException(e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                v4Auth.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CheckpointConsumerBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CheckpointConsumerBuilderV5.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+import org.apache.pulsar.client.api.v5.CheckpointConsumer;
+import org.apache.pulsar.client.api.v5.CheckpointConsumerBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.config.EncryptionPolicy;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * V5 CheckpointConsumerBuilder implementation.
+ */
+final class CheckpointConsumerBuilderV5<T> implements CheckpointConsumerBuilder<T> {
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private String topicName;
+    private Checkpoint startPosition = CheckpointV5.LATEST;
+    private String consumerName;
+    private EncryptionPolicy encryptionPolicy;
+
+    CheckpointConsumerBuilderV5(PulsarClientV5 client, Schema<T> v5Schema) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+    }
+
+    @Override
+    public CheckpointConsumer<T> create() throws PulsarClientException {
+        try {
+            return createAsync().join();
+        } catch (java.util.concurrent.CompletionException e) {
+            if (e.getCause() instanceof PulsarClientException pce) {
+                throw pce;
+            }
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<CheckpointConsumer<T>> createAsync() {
+        if (topicName == null || topicName.isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Topic name is required"));
+        }
+
+        TopicName topic = V5Utils.asScalableTopicName(topicName);
+        DagWatchClient dagWatch = new DagWatchClient(client.v4Client(), topic);
+
+        return dagWatch.start()
+                .thenCompose(initialLayout -> ScalableCheckpointConsumer.createAsync(
+                        client, v5Schema, dagWatch, initialLayout, startPosition, consumerName));
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> topic(String topicName) {
+        this.topicName = topicName;
+        return this;
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> startPosition(Checkpoint checkpoint) {
+        this.startPosition = checkpoint;
+        return this;
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> consumerName(String name) {
+        this.consumerName = name;
+        return this;
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> encryptionPolicy(EncryptionPolicy policy) {
+        this.encryptionPolicy = policy;
+        return this;
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> property(String key, String value) {
+        // Properties will be passed to readers when created
+        return this;
+    }
+
+    @Override
+    public CheckpointConsumerBuilderV5<T> properties(Map<String, String> properties) {
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CheckpointV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CheckpointV5.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+
+/**
+ * V5 Checkpoint implementation that stores a position vector across all segments.
+ * Each entry maps a segment ID to a v4 MessageId position within that segment.
+ */
+final class CheckpointV5 implements Checkpoint {
+
+    // Sentinel type markers for serialization
+    private static final byte TYPE_REGULAR = 0;
+    private static final byte TYPE_EARLIEST = 1;
+    private static final byte TYPE_LATEST = 2;
+    private static final byte TYPE_TIMESTAMP = 3;
+
+    static final Checkpoint EARLIEST = new SentinelCheckpoint(TYPE_EARLIEST, Instant.EPOCH);
+    static final Checkpoint LATEST = new SentinelCheckpoint(TYPE_LATEST, Instant.EPOCH);
+
+    private final Map<Long, org.apache.pulsar.client.api.MessageId> segmentPositions;
+    private final Instant creationTime;
+
+    CheckpointV5(Map<Long, org.apache.pulsar.client.api.MessageId> segmentPositions, Instant creationTime) {
+        this.segmentPositions = Map.copyOf(segmentPositions);
+        this.creationTime = creationTime;
+    }
+
+    /**
+     * Get the position map. Package-private for internal use.
+     */
+    Map<Long, org.apache.pulsar.client.api.MessageId> segmentPositions() {
+        return segmentPositions;
+    }
+
+    @Override
+    public Instant creationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        // Format: [1 byte type] [8 bytes creationTimeMillis] [4 bytes numEntries]
+        //         [for each entry: [8 bytes segmentId] [4 bytes msgIdLen] [msgIdBytes]]
+        int totalSize = 1 + 8 + 4;
+        Map<Long, byte[]> serializedIds = new HashMap<>();
+        for (var entry : segmentPositions.entrySet()) {
+            byte[] idBytes = entry.getValue().toByteArray();
+            serializedIds.put(entry.getKey(), idBytes);
+            totalSize += 8 + 4 + idBytes.length;
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(totalSize);
+        buf.put(TYPE_REGULAR);
+        buf.putLong(creationTime.toEpochMilli());
+        buf.putInt(segmentPositions.size());
+        for (var entry : serializedIds.entrySet()) {
+            buf.putLong(entry.getKey());
+            buf.putInt(entry.getValue().length);
+            buf.put(entry.getValue());
+        }
+        return buf.array();
+    }
+
+    static Checkpoint fromByteArray(byte[] data) throws IOException {
+        if (data == null || data.length < 1) {
+            throw new IOException("Invalid checkpoint data: empty");
+        }
+
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        byte type = buf.get();
+
+        return switch (type) {
+            case TYPE_EARLIEST -> EARLIEST;
+            case TYPE_LATEST -> LATEST;
+            case TYPE_TIMESTAMP -> {
+                long millis = buf.getLong();
+                yield new TimestampCheckpoint(Instant.ofEpochMilli(millis));
+            }
+            case TYPE_REGULAR -> {
+                long creationMillis = buf.getLong();
+                int numEntries = buf.getInt();
+                Map<Long, org.apache.pulsar.client.api.MessageId> positions = new HashMap<>();
+                for (int i = 0; i < numEntries; i++) {
+                    long segmentId = buf.getLong();
+                    int msgIdLen = buf.getInt();
+                    byte[] msgIdBytes = new byte[msgIdLen];
+                    buf.get(msgIdBytes);
+                    positions.put(segmentId,
+                            org.apache.pulsar.client.api.MessageId.fromByteArray(msgIdBytes));
+                }
+                yield new CheckpointV5(positions, Instant.ofEpochMilli(creationMillis));
+            }
+            default -> throw new IOException("Unknown checkpoint type: " + type);
+        };
+    }
+
+    static Checkpoint atTimestamp(Instant timestamp) {
+        return new TimestampCheckpoint(timestamp);
+    }
+
+    /**
+     * Sentinel checkpoint for earliest/latest positions.
+     */
+    private record SentinelCheckpoint(byte type, Instant creation) implements Checkpoint {
+        @Override
+        public byte[] toByteArray() {
+            ByteBuffer buf = ByteBuffer.allocate(1);
+            buf.put(type);
+            return buf.array();
+        }
+
+        @Override
+        public Instant creationTime() {
+            return creation;
+        }
+    }
+
+    /**
+     * Checkpoint that positions at a specific timestamp.
+     */
+    private record TimestampCheckpoint(Instant timestamp) implements Checkpoint {
+        @Override
+        public byte[] toByteArray() {
+            ByteBuffer buf = ByteBuffer.allocate(1 + 8);
+            buf.put(TYPE_TIMESTAMP);
+            buf.putLong(timestamp.toEpochMilli());
+            return buf.array();
+        }
+
+        @Override
+        public Instant creationTime() {
+            return timestamp;
+        }
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+import org.apache.pulsar.common.api.proto.ScalableTopicDAG;
+import org.apache.pulsar.common.api.proto.SegmentBrokerAddress;
+import org.apache.pulsar.common.api.proto.SegmentInfoProto;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.scalable.HashRange;
+import org.apache.pulsar.common.scalable.SegmentTopicName;
+
+/**
+ * Client-side view of the segment layout for a scalable topic.
+ * Built from a ScalableTopicDAG protobuf message received from the broker.
+ */
+final class ClientSegmentLayout {
+
+    private final long epoch;
+    private final List<ActiveSegment> activeSegments;
+    private final Map<Long, String> segmentBrokerUrls;
+    private final String controllerBrokerUrl;
+    private final String controllerBrokerUrlTls;
+
+    private ClientSegmentLayout(long epoch,
+                                List<ActiveSegment> activeSegments,
+                                Map<Long, String> segmentBrokerUrls,
+                                String controllerBrokerUrl,
+                                String controllerBrokerUrlTls) {
+        this.epoch = epoch;
+        this.activeSegments = Collections.unmodifiableList(activeSegments);
+        this.segmentBrokerUrls = Map.copyOf(segmentBrokerUrls);
+        this.controllerBrokerUrl = controllerBrokerUrl;
+        this.controllerBrokerUrlTls = controllerBrokerUrlTls;
+    }
+
+    /**
+     * Build a client layout from the protobuf DAG received from the broker.
+     */
+    static ClientSegmentLayout fromProto(ScalableTopicDAG dag, TopicName parentTopic) {
+        long epoch = dag.getEpoch();
+
+        // Build broker URL map
+        Map<Long, String> brokerUrls = new java.util.HashMap<>();
+        for (int i = 0; i < dag.getSegmentBrokersCount(); i++) {
+            SegmentBrokerAddress addr = dag.getSegmentBrokerAt(i);
+            brokerUrls.put(addr.getSegmentId(), addr.getBrokerUrl());
+        }
+
+        // Build active segments list
+        List<ActiveSegment> activeSegments = new ArrayList<>();
+        for (int i = 0; i < dag.getSegmentsCount(); i++) {
+            SegmentInfoProto seg = dag.getSegmentAt(i);
+            if (seg.getState() == org.apache.pulsar.common.api.proto.SegmentState.ACTIVE) {
+                HashRange range = HashRange.of((int) seg.getHashStart(), (int) seg.getHashEnd());
+                String segTopicName = SegmentTopicName.fromParent(
+                        parentTopic, range, seg.getSegmentId()).toString();
+                activeSegments.add(new ActiveSegment(seg.getSegmentId(), range, segTopicName));
+            }
+        }
+
+        // Sort by hash range start for efficient routing
+        activeSegments.sort(Comparator.comparingInt(s -> s.hashRange().start()));
+
+        String controllerUrl = dag.hasControllerBrokerUrl() ? dag.getControllerBrokerUrl() : null;
+        String controllerUrlTls = dag.hasControllerBrokerUrlTls() ? dag.getControllerBrokerUrlTls() : null;
+
+        return new ClientSegmentLayout(epoch, activeSegments, brokerUrls, controllerUrl, controllerUrlTls);
+    }
+
+    long epoch() {
+        return epoch;
+    }
+
+    List<ActiveSegment> activeSegments() {
+        return activeSegments;
+    }
+
+    Map<Long, String> segmentBrokerUrls() {
+        return segmentBrokerUrls;
+    }
+
+    String controllerBrokerUrl() {
+        return controllerBrokerUrl;
+    }
+
+    String controllerBrokerUrlTls() {
+        return controllerBrokerUrlTls;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CryptoKeyReaderAdapter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/CryptoKeyReaderAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.Map;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.EncryptionKeyInfo;
+
+/**
+ * Adapts a V5 {@link org.apache.pulsar.client.api.v5.auth.CryptoKeyReader} to the V4
+ * {@link CryptoKeyReader} interface used by the underlying client implementation.
+ */
+final class CryptoKeyReaderAdapter implements CryptoKeyReader {
+
+    private final org.apache.pulsar.client.api.v5.auth.CryptoKeyReader v5Reader;
+
+    private CryptoKeyReaderAdapter(org.apache.pulsar.client.api.v5.auth.CryptoKeyReader v5Reader) {
+        this.v5Reader = v5Reader;
+    }
+
+    static CryptoKeyReader wrap(org.apache.pulsar.client.api.v5.auth.CryptoKeyReader v5Reader) {
+        return new CryptoKeyReaderAdapter(v5Reader);
+    }
+
+    @Override
+    public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> metadata) {
+        var v5Key = v5Reader.getPublicKey(keyName, metadata);
+        return new EncryptionKeyInfo(v5Key.key(), v5Key.metadata());
+    }
+
+    @Override
+    public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> metadata) {
+        var v5Key = v5Reader.getPrivateKey(keyName, metadata);
+        return new EncryptionKeyInfo(v5Key.key(), v5Key.metadata());
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.github.merlimat.slog.Logger;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.DagWatchSession;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.api.proto.ScalableTopicDAG;
+import org.apache.pulsar.common.api.proto.ServerError;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.protocol.Commands;
+
+/**
+ * Client-side manager for a DAG watch session on a scalable topic.
+ *
+ * <p>Connects to any broker, sends a ScalableTopicLookup to initiate a watch session,
+ * and receives pushed updates when the segment layout changes (split/merge).
+ *
+ * <p>Maintains the current {@link ClientSegmentLayout} and notifies a listener
+ * when it changes.
+ */
+final class DagWatchClient implements DagWatchSession, AutoCloseable {
+
+    private static final Logger LOG = Logger.get(DagWatchClient.class);
+    private final Logger log;
+
+    private static final AtomicLong SESSION_ID_GENERATOR = new AtomicLong(0);
+
+    private final PulsarClientImpl v4Client;
+    private final TopicName topicName;
+    private final long sessionId;
+    private final AtomicReference<ClientSegmentLayout> currentLayout = new AtomicReference<>();
+    private final CompletableFuture<ClientSegmentLayout> initialLayoutFuture = new CompletableFuture<>();
+    private volatile LayoutChangeListener listener;
+    private volatile ClientCnx cnx;
+    private volatile boolean closed = false;
+
+    DagWatchClient(PulsarClientImpl v4Client, TopicName topicName) {
+        this.v4Client = v4Client;
+        this.topicName = topicName;
+        this.sessionId = SESSION_ID_GENERATOR.incrementAndGet();
+        this.log = LOG.with().attr("topic", topicName).attr("sessionId", sessionId).build();
+    }
+
+    /**
+     * Start the DAG watch session. Connects to any broker and sends a
+     * ScalableTopicLookup to initiate the watch session.
+     *
+     * @return a future that completes with the initial layout
+     */
+    CompletableFuture<ClientSegmentLayout> start() {
+        // Get any broker connection and send the lookup command
+        v4Client.getConnection(topicName.toString())
+                .thenAccept(cnx -> {
+                    this.cnx = cnx;
+                    // Register this session to receive updates
+                    cnx.registerDagWatchSession(sessionId, this);
+
+                    // Send the lookup command
+                    cnx.ctx().writeAndFlush(
+                            Commands.newScalableTopicLookup(sessionId, topicName.toString()))
+                            .addListener(writeFuture -> {
+                                if (!writeFuture.isSuccess()) {
+                                    cnx.removeDagWatchSession(sessionId);
+                                    initialLayoutFuture.completeExceptionally(
+                                            new PulsarClientException(writeFuture.cause()));
+                                }
+                            });
+                })
+                .exceptionally(ex -> {
+                    initialLayoutFuture.completeExceptionally(ex);
+                    return null;
+                });
+
+        return initialLayoutFuture;
+    }
+
+    /**
+     * Called when the broker pushes a ScalableTopicUpdate for this session.
+     * This is invoked from the Netty I/O thread.
+     */
+    @Override
+    public void onUpdate(ScalableTopicDAG dag) {
+        if (closed) {
+            return;
+        }
+
+        ClientSegmentLayout newLayout = ClientSegmentLayout.fromProto(dag, topicName);
+        ClientSegmentLayout oldLayout = currentLayout.getAndSet(newLayout);
+
+        log.info().attr("oldEpoch", oldLayout != null ? oldLayout.epoch() : "none")
+                .attr("newEpoch", newLayout.epoch())
+                .attr("activeSegmentCount", newLayout.activeSegments().size())
+                .log("Layout updated");
+
+        // Complete the initial layout future if this is the first update
+        initialLayoutFuture.complete(newLayout);
+
+        LayoutChangeListener l = listener;
+        if (l != null) {
+            try {
+                l.onLayoutChange(newLayout, oldLayout);
+            } catch (Exception e) {
+                log.error().exception(e).log("Error in layout change listener");
+            }
+        }
+    }
+
+    @Override
+    public void onError(ServerError error, String message) {
+        log.error().attr("error", error).attr("message", message)
+                .log("DAG watch session error");
+        initialLayoutFuture.completeExceptionally(
+                new PulsarClientException(
+                        "Scalable topic lookup failed: " + error + " - " + message));
+    }
+
+    @Override
+    public void connectionClosed() {
+        log.warn("DAG watch session connection closed");
+        cnx = null;
+        initialLayoutFuture.completeExceptionally(
+                new PulsarClientException("Connection closed while waiting for scalable topic layout"));
+        // TODO: implement automatic reconnection with backoff
+    }
+
+    ClientSegmentLayout currentLayout() {
+        return currentLayout.get();
+    }
+
+    void setListener(LayoutChangeListener listener) {
+        this.listener = listener;
+    }
+
+    long sessionId() {
+        return sessionId;
+    }
+
+    TopicName topicName() {
+        return topicName;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        ClientCnx c = cnx;
+        if (c != null) {
+            c.removeDagWatchSession(sessionId);
+            c.ctx().writeAndFlush(Commands.newScalableTopicClose(sessionId));
+        }
+    }
+
+    interface LayoutChangeListener {
+        void onLayoutChange(ClientSegmentLayout newLayout, ClientSegmentLayout oldLayout);
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageBuilderV5.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.client.api.v5.MessageBuilder;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.Transaction;
+
+/**
+ * V5 synchronous MessageBuilder implementation.
+ * Accumulates metadata and delegates send to ScalableTopicProducer.
+ */
+final class MessageBuilderV5<T> implements MessageBuilder<T> {
+
+    private final ScalableTopicProducer<T> producer;
+    private T value;
+    private String key;
+    private Map<String, String> properties;
+    private Instant eventTime;
+    private Long sequenceId;
+    private Duration deliverAfter;
+    private Instant deliverAt;
+    private List<String> replicationClusters;
+
+    MessageBuilderV5(ScalableTopicProducer<T> producer) {
+        this.producer = producer;
+    }
+
+    @Override
+    public MessageId send() throws PulsarClientException {
+        return producer.sendInternal(
+                key, value, properties, eventTime, sequenceId,
+                deliverAfter, deliverAt, replicationClusters);
+    }
+
+    @Override
+    public MessageBuilderV5<T> value(T value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> key(String key) {
+        this.key = key;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> transaction(Transaction txn) {
+        // TODO: Wire up transaction support
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> property(String name, String value) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put(name, value);
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> properties(Map<String, String> properties) {
+        if (this.properties == null) {
+            this.properties = new HashMap<>();
+        }
+        this.properties.putAll(properties);
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> eventTime(Instant eventTime) {
+        this.eventTime = eventTime;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> sequenceId(long sequenceId) {
+        this.sequenceId = sequenceId;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> deliverAfter(Duration delay) {
+        this.deliverAfter = delay;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> deliverAt(Instant timestamp) {
+        this.deliverAt = timestamp;
+        return this;
+    }
+
+    @Override
+    public MessageBuilderV5<T> replicationClusters(List<String> clusters) {
+        this.replicationClusters = clusters;
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageIdV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageIdV5.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.pulsar.client.api.v5.MessageId;
+
+/**
+ * V5 MessageId implementation that wraps a v4 MessageId and includes a position
+ * vector across all segments.
+ *
+ * <p>The position vector captures the latest delivered message ID per segment at the
+ * moment this message was dequeued. This enables correct cumulative acknowledgment:
+ * when the application acknowledges this message, all segments are advanced to the
+ * positions recorded in the vector, not just the segment this message came from.
+ *
+ * <p>For non-cumulative consumers (QueueConsumer) and readers (CheckpointConsumer),
+ * only the single segment ID and v4 message ID are needed; the position vector is
+ * empty.
+ */
+public final class MessageIdV5 implements MessageId {
+
+    static final long NO_SEGMENT = -1;
+
+    static final MessageIdV5 EARLIEST = new MessageIdV5(
+            org.apache.pulsar.client.api.MessageId.earliest, NO_SEGMENT, Map.of());
+    static final MessageIdV5 LATEST = new MessageIdV5(
+            org.apache.pulsar.client.api.MessageId.latest, NO_SEGMENT, Map.of());
+
+    private final org.apache.pulsar.client.api.MessageId v4MessageId;
+    private final long segmentId;
+
+    /**
+     * Position vector: snapshot of the latest delivered message ID per segment,
+     * taken at the moment this message was delivered to the application.
+     * Used by StreamConsumer for cumulative ack across all segments.
+     */
+    private final Map<Long, org.apache.pulsar.client.api.MessageId> positionVector;
+
+    /**
+     * Create a MessageIdV5 with a position vector for cumulative ack support.
+     */
+    public MessageIdV5(org.apache.pulsar.client.api.MessageId v4MessageId,
+                       long segmentId,
+                       Map<Long, org.apache.pulsar.client.api.MessageId> positionVector) {
+        this.v4MessageId = Objects.requireNonNull(v4MessageId);
+        this.segmentId = segmentId;
+        this.positionVector = Map.copyOf(positionVector);
+    }
+
+    /**
+     * Create a MessageIdV5 without a position vector (for individual ack / reader use).
+     */
+    public MessageIdV5(org.apache.pulsar.client.api.MessageId v4MessageId, long segmentId) {
+        this(v4MessageId, segmentId, Map.of());
+    }
+
+    /**
+     * Get the underlying v4 MessageId. Package-private for internal use.
+     */
+    org.apache.pulsar.client.api.MessageId v4MessageId() {
+        return v4MessageId;
+    }
+
+    /**
+     * Get the segment ID this message belongs to. Package-private for internal routing.
+     */
+    long segmentId() {
+        return segmentId;
+    }
+
+    /**
+     * Get the position vector — the latest delivered message ID per segment at the
+     * time this message was delivered. Used by StreamConsumer for cumulative ack.
+     */
+    Map<Long, org.apache.pulsar.client.api.MessageId> positionVector() {
+        return positionVector;
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        byte[] v4Bytes = v4MessageId.toByteArray();
+        // Format: [8 bytes segmentId] [4 bytes v4Length] [v4Bytes]
+        //         [4 bytes numPositions] [for each: [8 bytes segId] [4 bytes idLen] [idBytes]]
+        int totalSize = 8 + 4 + v4Bytes.length + 4;
+        var serializedPositions = new java.util.HashMap<Long, byte[]>();
+        for (var entry : positionVector.entrySet()) {
+            byte[] idBytes = entry.getValue().toByteArray();
+            serializedPositions.put(entry.getKey(), idBytes);
+            totalSize += 8 + 4 + idBytes.length;
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(totalSize);
+        buf.putLong(segmentId);
+        buf.putInt(v4Bytes.length);
+        buf.put(v4Bytes);
+        buf.putInt(positionVector.size());
+        for (var entry : serializedPositions.entrySet()) {
+            buf.putLong(entry.getKey());
+            buf.putInt(entry.getValue().length);
+            buf.put(entry.getValue());
+        }
+        return buf.array();
+    }
+
+    static MessageIdV5 fromByteArray(byte[] data) throws IOException {
+        if (data == null || data.length < 12) {
+            throw new IOException("Invalid MessageIdV5 data: too short");
+        }
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        long segmentId = buf.getLong();
+        int v4Length = buf.getInt();
+        if (v4Length < 0 || v4Length > buf.remaining()) {
+            throw new IOException("Invalid MessageIdV5 data: bad v4 length");
+        }
+        byte[] v4Bytes = new byte[v4Length];
+        buf.get(v4Bytes);
+        org.apache.pulsar.client.api.MessageId v4Id =
+                org.apache.pulsar.client.api.MessageId.fromByteArray(v4Bytes);
+
+        // Read position vector if present
+        Map<Long, org.apache.pulsar.client.api.MessageId> positions = Map.of();
+        if (buf.hasRemaining()) {
+            int numPositions = buf.getInt();
+            var posMap = new java.util.HashMap<Long, org.apache.pulsar.client.api.MessageId>();
+            for (int i = 0; i < numPositions; i++) {
+                long posSegId = buf.getLong();
+                int idLen = buf.getInt();
+                byte[] idBytes = new byte[idLen];
+                buf.get(idBytes);
+                posMap.put(posSegId,
+                        org.apache.pulsar.client.api.MessageId.fromByteArray(idBytes));
+            }
+            positions = posMap;
+        }
+
+        return new MessageIdV5(v4Id, segmentId, positions);
+    }
+
+    @Override
+    public int compareTo(MessageId other) {
+        if (!(other instanceof MessageIdV5 o)) {
+            throw new IllegalArgumentException("Cannot compare with " + other.getClass());
+        }
+        int cmp = Long.compare(this.segmentId, o.segmentId);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return this.v4MessageId.compareTo(o.v4MessageId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof MessageIdV5 o)) {
+            return false;
+        }
+        return segmentId == o.segmentId && v4MessageId.equals(o.v4MessageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(v4MessageId, segmentId);
+    }
+
+    @Override
+    public String toString() {
+        return "MessageIdV5{segment=" + segmentId + ", id=" + v4MessageId
+                + ", positions=" + positionVector.size() + "}";
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessageV5.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+
+/**
+ * V5 Message implementation that wraps a v4 Message.
+ */
+final class MessageV5<T> implements Message<T> {
+
+    private final org.apache.pulsar.client.api.Message<T> v4Message;
+    private final MessageIdV5 messageId;
+
+    /**
+     * Create with a simple segment ID (for queue consumer, checkpoint consumer, producer).
+     */
+    MessageV5(org.apache.pulsar.client.api.Message<T> v4Message, long segmentId) {
+        this.v4Message = v4Message;
+        this.messageId = new MessageIdV5(v4Message.getMessageId(), segmentId);
+    }
+
+    /**
+     * Create with a pre-built MessageIdV5 that carries a position vector
+     * (for stream consumer cumulative ack support).
+     */
+    MessageV5(org.apache.pulsar.client.api.Message<T> v4Message, MessageIdV5 messageId) {
+        this.v4Message = v4Message;
+        this.messageId = messageId;
+    }
+
+    @Override
+    public T value() {
+        return v4Message.getValue();
+    }
+
+    @Override
+    public byte[] data() {
+        return v4Message.getData();
+    }
+
+    @Override
+    public MessageId id() {
+        return messageId;
+    }
+
+    @Override
+    public Optional<String> key() {
+        return v4Message.hasKey() ? Optional.of(v4Message.getKey()) : Optional.empty();
+    }
+
+    @Override
+    public Map<String, String> properties() {
+        return v4Message.getProperties();
+    }
+
+    @Override
+    public Instant publishTime() {
+        return Instant.ofEpochMilli(v4Message.getPublishTime());
+    }
+
+    @Override
+    public Optional<Instant> eventTime() {
+        long eventTime = v4Message.getEventTime();
+        return eventTime > 0 ? Optional.of(Instant.ofEpochMilli(eventTime)) : Optional.empty();
+    }
+
+    @Override
+    public long sequenceId() {
+        return v4Message.getSequenceId();
+    }
+
+    @Override
+    public Optional<String> producerName() {
+        String name = v4Message.getProducerName();
+        return name != null && !name.isEmpty() ? Optional.of(name) : Optional.empty();
+    }
+
+    @Override
+    public String topic() {
+        return v4Message.getTopicName();
+    }
+
+    @Override
+    public int redeliveryCount() {
+        return v4Message.getRedeliveryCount();
+    }
+
+    @Override
+    public int size() {
+        return v4Message.size();
+    }
+
+    @Override
+    public Optional<String> replicatedFrom() {
+        String from = v4Message.getReplicatedFrom();
+        return from != null && !from.isEmpty() ? Optional.of(from) : Optional.empty();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessagesV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/MessagesV5.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.Messages;
+
+/**
+ * Simple implementation of Messages wrapping a list of Message instances.
+ */
+final class MessagesV5<T> implements Messages<T> {
+
+    private final List<Message<T>> messages;
+
+    MessagesV5(List<Message<T>> messages) {
+        this.messages = messages;
+    }
+
+    @Override
+    public int count() {
+        return messages.size();
+    }
+
+    @Override
+    public MessageId lastId() {
+        if (messages.isEmpty()) {
+            throw new IllegalStateException("Empty message batch");
+        }
+        return messages.get((messages.size() - 1)).id();
+    }
+
+    @Override
+    public Iterator<Message<T>> iterator() {
+        return messages.iterator();
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ProducerBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ProducerBuilderV5.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.v5.Producer;
+import org.apache.pulsar.client.api.v5.ProducerBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.config.BatchingPolicy;
+import org.apache.pulsar.client.api.v5.config.ChunkingPolicy;
+import org.apache.pulsar.client.api.v5.config.CompressionPolicy;
+import org.apache.pulsar.client.api.v5.config.EncryptionPolicy;
+import org.apache.pulsar.client.api.v5.config.ProducerAccessMode;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * V5 ProducerBuilder implementation.
+ * Accumulates configuration and creates a ScalableTopicProducer when create() is called.
+ */
+final class ProducerBuilderV5<T> implements ProducerBuilder<T> {
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final ProducerConfigurationData conf = new ProducerConfigurationData();
+
+    ProducerBuilderV5(PulsarClientV5 client, Schema<T> v5Schema) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+    }
+
+    @Override
+    public Producer<T> create() throws PulsarClientException {
+        try {
+            return createAsync().join();
+        } catch (java.util.concurrent.CompletionException e) {
+            if (e.getCause() instanceof PulsarClientException pce) {
+                throw pce;
+            }
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<Producer<T>> createAsync() {
+        String topicStr = conf.getTopicName();
+        if (topicStr == null || topicStr.isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Topic name is required"));
+        }
+
+        TopicName topicName = V5Utils.asScalableTopicName(topicStr);
+
+        // Create DAG watch client and start the session
+        DagWatchClient dagWatch = new DagWatchClient(client.v4Client(), topicName);
+
+        return dagWatch.start()
+                .thenApply(initialLayout -> {
+                    ScalableTopicProducer<T> producer = new ScalableTopicProducer<>(
+                            client, v5Schema, conf, dagWatch, initialLayout);
+                    return (Producer<T>) producer;
+                });
+    }
+
+    @Override
+    public ProducerBuilderV5<T> topic(String topicName) {
+        conf.setTopicName(topicName);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> producerName(String producerName) {
+        conf.setProducerName(producerName);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> accessMode(ProducerAccessMode accessMode) {
+        conf.setAccessMode(org.apache.pulsar.client.api.ProducerAccessMode.valueOf(accessMode.name()));
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> sendTimeout(Duration timeout) {
+        conf.setSendTimeoutMs(timeout.toMillis());
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> blockIfQueueFull(boolean blockIfQueueFull) {
+        conf.setBlockIfQueueFull(blockIfQueueFull);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> compressionPolicy(CompressionPolicy policy) {
+        conf.setCompressionType(
+                org.apache.pulsar.client.api.CompressionType.valueOf(policy.type().name()));
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> batchingPolicy(BatchingPolicy policy) {
+        conf.setBatchingEnabled(policy.enabled());
+        conf.setBatchingMaxPublishDelayMicros(
+                policy.maxPublishDelay().toNanos() / 1000, TimeUnit.MICROSECONDS);
+        conf.setBatchingMaxMessages(policy.maxMessages());
+        conf.setBatchingMaxBytes((int) policy.maxSize().bytes());
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> chunkingPolicy(ChunkingPolicy policy) {
+        conf.setChunkingEnabled(policy.enabled());
+        if (policy.chunkSize() > 0) {
+            conf.setChunkMaxMessageSize(policy.chunkSize());
+        }
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> encryptionPolicy(EncryptionPolicy policy) {
+        conf.setCryptoKeyReader(CryptoKeyReaderAdapter.wrap(policy.keyReader()));
+        conf.setEncryptionKeys(new HashSet<>(policy.keyNames()));
+        conf.setCryptoFailureAction(
+                org.apache.pulsar.client.api.ProducerCryptoFailureAction.valueOf(
+                        policy.failureAction().name()));
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> initialSequenceId(long initialSequenceId) {
+        conf.setInitialSequenceId(initialSequenceId);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> property(String key, String value) {
+        conf.getProperties().put(key, value);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilderV5<T> properties(Map<String, String> properties) {
+        conf.getProperties().putAll(properties);
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientBuilderV5.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.opentelemetry.api.OpenTelemetry;
+import java.time.Duration;
+import org.apache.pulsar.client.api.v5.PulsarClient;
+import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.auth.Authentication;
+import org.apache.pulsar.client.api.v5.config.ConnectionPolicy;
+import org.apache.pulsar.client.api.v5.config.MemorySize;
+import org.apache.pulsar.client.api.v5.config.TlsPolicy;
+import org.apache.pulsar.client.api.v5.config.TransactionPolicy;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+
+/**
+ * V5 implementation of PulsarClientBuilder.
+ * Builds a v4 ClientConfigurationData internally and wraps the v4 PulsarClientImpl.
+ */
+final class PulsarClientBuilderV5 implements PulsarClientBuilder {
+
+    private final ClientConfigurationData conf = new ClientConfigurationData();
+    private String description;
+
+    PulsarClientBuilderV5() {
+        conf.setStatsIntervalSeconds(0);
+    }
+
+    @Override
+    public PulsarClient build() throws PulsarClientException {
+        try {
+            var v4Client = new PulsarClientImpl(conf);
+            return new PulsarClientV5(v4Client, description);
+        } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+            throw new PulsarClientException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public PulsarClientBuilder serviceUrl(String serviceUrl) {
+        conf.setServiceUrl(serviceUrl);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder authentication(Authentication authentication) {
+        conf.setAuthentication(AuthenticationAdapter.toV4(authentication));
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder authentication(String authPluginClassName, String authParamsString)
+            throws PulsarClientException {
+        conf.setAuthPluginClassName(authPluginClassName);
+        conf.setAuthParams(authParamsString);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder operationTimeout(Duration timeout) {
+        conf.setOperationTimeoutMs(timeout.toMillis());
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder connectionPolicy(ConnectionPolicy policy) {
+        conf.setConnectionTimeoutMs((int) policy.connectionTimeout().toMillis());
+        conf.setConnectionsPerBroker(policy.connectionsPerBroker());
+        conf.setUseTcpNoDelay(policy.enableTcpNoDelay());
+        conf.setKeepAliveIntervalSeconds((int) policy.keepAliveInterval().toSeconds());
+        conf.setConnectionMaxIdleSeconds((int) policy.connectionMaxIdleTime().toSeconds());
+        conf.setNumIoThreads(policy.ioThreads());
+        conf.setNumListenerThreads(policy.callbackThreads());
+        if (policy.proxyServiceUrl() != null) {
+            conf.setProxyServiceUrl(policy.proxyServiceUrl());
+            if (policy.proxyProtocol() != null) {
+                conf.setProxyProtocol(
+                        org.apache.pulsar.client.api.ProxyProtocol.valueOf(policy.proxyProtocol().name()));
+            }
+        }
+        // BackoffPolicy adaptation will be implemented when the v4 client exposes
+        // a public way to override the reconnection backoff.
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder transactionPolicy(TransactionPolicy policy) {
+        // TransactionPolicy enables transactions with a default timeout
+        conf.setEnableTransaction(true);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder tlsPolicy(TlsPolicy policy) {
+        // TlsPolicy configures TLS settings
+        // For now, just enable TLS — full TLS config adaptation will be
+        // implemented when TlsPolicy internals are defined
+        conf.setUseTls(true);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder openTelemetry(OpenTelemetry openTelemetry) {
+        conf.setOpenTelemetry(openTelemetry);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder memoryLimit(MemorySize size) {
+        conf.setMemoryLimitBytes(size.bytes());
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder listenerName(String name) {
+        conf.setListenerName(name);
+        return this;
+    }
+
+    @Override
+    public PulsarClientBuilder description(String description) {
+        this.description = description;
+        conf.setDescription(description);
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientProviderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientProviderV5.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.PulsarClientBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.auth.Authentication;
+import org.apache.pulsar.client.api.v5.internal.PulsarClientProvider;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+
+/**
+ * ServiceLoader-registered implementation of PulsarClientProvider.
+ * Bridges v5 API types to v4 implementation classes.
+ */
+public final class PulsarClientProviderV5 implements PulsarClientProvider {
+
+    @Override
+    public PulsarClientBuilder newClientBuilder() {
+        return new PulsarClientBuilderV5();
+    }
+
+    // --- MessageId ---
+
+    @Override
+    public MessageId messageIdFromBytes(byte[] data) throws IOException {
+        return MessageIdV5.fromByteArray(data);
+    }
+
+    @Override
+    public MessageId earliestMessageId() {
+        return MessageIdV5.EARLIEST;
+    }
+
+    @Override
+    public MessageId latestMessageId() {
+        return MessageIdV5.LATEST;
+    }
+
+    // --- Schemas ---
+
+    @Override
+    public Schema<byte[]> bytesSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.BYTES);
+    }
+
+    @Override
+    public Schema<String> stringSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.STRING);
+    }
+
+    @Override
+    public Schema<Boolean> booleanSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.BOOL);
+    }
+
+    @Override
+    public Schema<Byte> byteSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.INT8);
+    }
+
+    @Override
+    public Schema<Short> shortSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.INT16);
+    }
+
+    @Override
+    public Schema<Integer> intSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.INT32);
+    }
+
+    @Override
+    public Schema<Long> longSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.INT64);
+    }
+
+    @Override
+    public Schema<Float> floatSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.FLOAT);
+    }
+
+    @Override
+    public Schema<Double> doubleSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.DOUBLE);
+    }
+
+    @Override
+    public <T> Schema<T> jsonSchema(Class<T> pojo) {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.JSON(pojo));
+    }
+
+    @Override
+    public <T> Schema<T> avroSchema(Class<T> pojo) {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.AVRO(pojo));
+    }
+
+    @Override
+    public <T extends com.google.protobuf.Message> Schema<T> protobufSchema(Class<T> clazz) {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.PROTOBUF(clazz));
+    }
+
+    @Override
+    public Schema<byte[]> autoProduceBytesSchema() {
+        return SchemaAdapter.toV5(org.apache.pulsar.client.api.Schema.AUTO_PRODUCE_BYTES());
+    }
+
+    // --- Checkpoint ---
+
+    @Override
+    public Checkpoint checkpointFromBytes(byte[] data) throws IOException {
+        return CheckpointV5.fromByteArray(data);
+    }
+
+    @Override
+    public Checkpoint earliestCheckpoint() {
+        return CheckpointV5.EARLIEST;
+    }
+
+    @Override
+    public Checkpoint latestCheckpoint() {
+        return CheckpointV5.LATEST;
+    }
+
+    @Override
+    public Checkpoint checkpointAtTimestamp(Instant timestamp) {
+        return CheckpointV5.atTimestamp(timestamp);
+    }
+
+    // --- Authentication ---
+
+    @Override
+    public Authentication authenticationToken(String token) {
+        return AuthenticationAdapter.token(token);
+    }
+
+    @Override
+    public Authentication authenticationToken(Supplier<String> tokenSupplier) {
+        return AuthenticationAdapter.token(tokenSupplier);
+    }
+
+    @Override
+    public Authentication authenticationTls(String certFilePath, String keyFilePath) {
+        return AuthenticationAdapter.tls(certFilePath, keyFilePath);
+    }
+
+    @Override
+    public Authentication createAuthentication(String className, String params)
+            throws PulsarClientException {
+        return AuthenticationAdapter.create(className, params);
+    }
+
+    @Override
+    public Authentication createAuthentication(String className, Map<String, String> params)
+            throws PulsarClientException {
+        return AuthenticationAdapter.create(className, params);
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/PulsarClientV5.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.v5.CheckpointConsumerBuilder;
+import org.apache.pulsar.client.api.v5.ProducerBuilder;
+import org.apache.pulsar.client.api.v5.PulsarClient;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.QueueConsumerBuilder;
+import org.apache.pulsar.client.api.v5.StreamConsumerBuilder;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+
+/**
+ * V5 PulsarClient implementation that wraps the v4 PulsarClientImpl for
+ * connection management and transport. Adds scalable topic routing on top.
+ */
+final class PulsarClientV5 implements PulsarClient {
+
+    private final PulsarClientImpl v4Client;
+    private final String description;
+
+    PulsarClientV5(PulsarClientImpl v4Client, String description) {
+        this.v4Client = v4Client;
+        this.description = description;
+    }
+
+    /**
+     * Get the underlying v4 client. Package-private for use by internal components.
+     */
+    PulsarClientImpl v4Client() {
+        return v4Client;
+    }
+
+    @Override
+    public <T> ProducerBuilder<T> newProducer(Schema<T> schema) {
+        return new ProducerBuilderV5<>(this, schema);
+    }
+
+    @Override
+    public <T> StreamConsumerBuilder<T> newStreamConsumer(Schema<T> schema) {
+        return new StreamConsumerBuilderV5<>(this, schema);
+    }
+
+    @Override
+    public <T> QueueConsumerBuilder<T> newQueueConsumer(Schema<T> schema) {
+        return new QueueConsumerBuilderV5<>(this, schema);
+    }
+
+    @Override
+    public <T> CheckpointConsumerBuilder<T> newCheckpointConsumer(Schema<T> schema) {
+        return new CheckpointConsumerBuilderV5<>(this, schema);
+    }
+
+    @Override
+    public Transaction newTransaction() throws PulsarClientException {
+        throw new PulsarClientException("Transactions not yet implemented");
+    }
+
+    @Override
+    public CompletableFuture<Transaction> newTransactionAsync() {
+        return CompletableFuture.failedFuture(
+                new PulsarClientException("Transactions not yet implemented"));
+    }
+
+    @Override
+    public void close() throws PulsarClientException {
+        try {
+            v4Client.close();
+        } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+            throw new PulsarClientException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return v4Client.closeAsync().exceptionally(ex -> {
+            throw new java.util.concurrent.CompletionException(
+                    new PulsarClientException(ex.getMessage(), ex));
+        });
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            v4Client.shutdown();
+        } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/QueueConsumerBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/QueueConsumerBuilderV5.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.QueueConsumer;
+import org.apache.pulsar.client.api.v5.QueueConsumerBuilder;
+import org.apache.pulsar.client.api.v5.config.BackoffPolicy;
+import org.apache.pulsar.client.api.v5.config.DeadLetterPolicy;
+import org.apache.pulsar.client.api.v5.config.EncryptionPolicy;
+import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * V5 QueueConsumerBuilder implementation.
+ */
+final class QueueConsumerBuilderV5<T> implements QueueConsumerBuilder<T> {
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final ConsumerConfigurationData<T> conf = new ConsumerConfigurationData<>();
+    private String topicName;
+
+    QueueConsumerBuilderV5(PulsarClientV5 client, Schema<T> v5Schema) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+    }
+
+    @Override
+    public QueueConsumer<T> subscribe() throws PulsarClientException {
+        try {
+            return subscribeAsync().join();
+        } catch (java.util.concurrent.CompletionException e) {
+            if (e.getCause() instanceof PulsarClientException pce) {
+                throw pce;
+            }
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<QueueConsumer<T>> subscribeAsync() {
+        if (topicName == null || topicName.isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Topic name is required"));
+        }
+        if (conf.getSubscriptionName() == null || conf.getSubscriptionName().isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Subscription name is required"));
+        }
+
+        TopicName topic = V5Utils.asScalableTopicName(topicName);
+        DagWatchClient dagWatch = new DagWatchClient(client.v4Client(), topic);
+
+        return dagWatch.start()
+                .thenCompose(initialLayout -> ScalableQueueConsumer.createAsync(
+                        client, v5Schema, conf, dagWatch, initialLayout));
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> topic(String... topicNames) {
+        if (topicNames.length > 0) {
+            this.topicName = topicNames[0];
+        }
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> topics(List<String> topicNames) {
+        if (!topicNames.isEmpty()) {
+            this.topicName = topicNames.get(0);
+        }
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> topicsPattern(Pattern pattern) {
+        conf.setTopicsPattern(pattern);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> topicsPattern(String regex) {
+        conf.setTopicsPattern(Pattern.compile(regex));
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> subscriptionName(String subscriptionName) {
+        conf.setSubscriptionName(subscriptionName);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> subscriptionProperties(Map<String, String> properties) {
+        conf.setSubscriptionProperties(properties);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> subscriptionInitialPosition(SubscriptionInitialPosition position) {
+        conf.setSubscriptionInitialPosition(switch (position) {
+            case LATEST -> org.apache.pulsar.client.api.SubscriptionInitialPosition.Latest;
+            case EARLIEST -> org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest;
+        });
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> consumerName(String consumerName) {
+        conf.setConsumerName(consumerName);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> receiverQueueSize(int receiverQueueSize) {
+        conf.setReceiverQueueSize(receiverQueueSize);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> priorityLevel(int priorityLevel) {
+        conf.setPriorityLevel(priorityLevel);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> ackTimeout(Duration timeout) {
+        conf.setAckTimeoutMillis(timeout.toMillis());
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> acknowledgmentGroupTime(Duration delay) {
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.MICROSECONDS.convert(delay));
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> maxAcknowledgmentGroupSize(int size) {
+        conf.setMaxAcknowledgmentGroupSize(size);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> negativeAckRedeliveryBackoff(BackoffPolicy backoff) {
+        conf.setNegativeAckRedeliveryBackoff(
+                org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff.builder()
+                        .minDelayMs(backoff.initialInterval().toMillis())
+                        .maxDelayMs(backoff.maxInterval().toMillis())
+                        .multiplier(backoff.multiplier())
+                        .build());
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> ackTimeoutRedeliveryBackoff(BackoffPolicy backoff) {
+        conf.setAckTimeoutRedeliveryBackoff(
+                org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff.builder()
+                        .minDelayMs(backoff.initialInterval().toMillis())
+                        .maxDelayMs(backoff.maxInterval().toMillis())
+                        .multiplier(backoff.multiplier())
+                        .build());
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> deadLetterPolicy(DeadLetterPolicy policy) {
+        var builder = org.apache.pulsar.client.api.DeadLetterPolicy.builder()
+                .maxRedeliverCount(policy.maxRedeliverCount());
+        if (policy.retryLetterTopic() != null) {
+            builder.retryLetterTopic(policy.retryLetterTopic());
+        }
+        if (policy.deadLetterTopic() != null) {
+            builder.deadLetterTopic(policy.deadLetterTopic());
+        }
+        if (policy.initialSubscriptionName() != null) {
+            builder.initialSubscriptionName(policy.initialSubscriptionName());
+        }
+        conf.setDeadLetterPolicy(builder.build());
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> patternAutoDiscoveryPeriod(Duration interval) {
+        conf.setPatternAutoDiscoveryPeriod((int) interval.getSeconds());
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> encryptionPolicy(EncryptionPolicy policy) {
+        conf.setCryptoKeyReader(CryptoKeyReaderAdapter.wrap(policy.keyReader()));
+        conf.setCryptoFailureAction(
+                org.apache.pulsar.client.api.ConsumerCryptoFailureAction.valueOf(
+                        policy.failureAction().name()));
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> property(String key, String value) {
+        conf.getProperties().put(key, value);
+        return this;
+    }
+
+    @Override
+    public QueueConsumerBuilderV5<T> properties(Map<String, String> properties) {
+        conf.getProperties().putAll(properties);
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableCheckpointConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableCheckpointConsumer.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.github.merlimat.slog.Logger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+import org.apache.pulsar.client.api.v5.CheckpointConsumer;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.Messages;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.async.AsyncCheckpointConsumer;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+
+/**
+ * V5 CheckpointConsumer implementation for scalable topics.
+ *
+ * <p>Maintains per-segment v4 Readers (no subscription). Messages from all segments
+ * are multiplexed into a single receive queue. Supports creating checkpoints (atomic
+ * snapshots of positions across all segments) and seeking to previously saved checkpoints.
+ */
+final class ScalableCheckpointConsumer<T> implements CheckpointConsumer<T>, DagWatchClient.LayoutChangeListener {
+
+    private static final Logger LOG = Logger.get(ScalableCheckpointConsumer.class);
+    private final Logger log;
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final org.apache.pulsar.client.api.Schema<T> v4Schema;
+    private final DagWatchClient dagWatch;
+    private final String topicName;
+    private final Checkpoint startPosition;
+    private final String consumerName;
+
+    /**
+     * Per-segment v4 readers. Stores futures so concurrent operations (seek, close)
+     * can chain on in-flight reader creation without racing against completion.
+     */
+    private final ConcurrentHashMap<Long, CompletableFuture<Reader<T>>> segmentReaders = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, org.apache.pulsar.client.api.MessageId> lastReceivedPositions =
+            new ConcurrentHashMap<>();
+    private final LinkedTransferQueue<MessageV5<T>> messageQueue = new LinkedTransferQueue<>();
+
+    private volatile boolean closed = false;
+    private final AsyncCheckpointConsumerV5<T> asyncView;
+
+    private ScalableCheckpointConsumer(PulsarClientV5 client,
+                                       Schema<T> v5Schema,
+                                       DagWatchClient dagWatch,
+                                       Checkpoint startPosition,
+                                       String consumerName) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+        this.v4Schema = SchemaAdapter.toV4(v5Schema);
+        this.dagWatch = dagWatch;
+        this.topicName = dagWatch.topicName().toString();
+        this.startPosition = startPosition;
+        this.consumerName = consumerName;
+        this.log = LOG.with().attr("topic", topicName).build();
+        this.asyncView = new AsyncCheckpointConsumerV5<>(this);
+    }
+
+    /**
+     * Create a fully initialized consumer asynchronously. The returned future completes
+     * only after every initial segment reader has been successfully created. If any
+     * reader creation fails, all already-created readers are closed and the future
+     * completes exceptionally.
+     */
+    static <T> CompletableFuture<CheckpointConsumer<T>> createAsync(PulsarClientV5 client,
+                                                                    Schema<T> v5Schema,
+                                                                    DagWatchClient dagWatch,
+                                                                    ClientSegmentLayout initialLayout,
+                                                                    Checkpoint startPosition,
+                                                                    String consumerName) {
+        ScalableCheckpointConsumer<T> consumer = new ScalableCheckpointConsumer<>(
+                client, v5Schema, dagWatch, startPosition, consumerName);
+        return consumer.createSegmentReaders(initialLayout)
+                .thenApply(__ -> {
+                    dagWatch.setListener(consumer);
+                    return (CheckpointConsumer<T>) consumer;
+                })
+                .exceptionallyCompose(ex -> consumer.closeAsync().handle((__, ___) -> {
+                    throw ex instanceof CompletionException ce ? ce : new CompletionException(ex);
+                }));
+    }
+
+    @Override
+    public String topic() {
+        return topicName;
+    }
+
+    @Override
+    public Message<T> receive() throws PulsarClientException {
+        try {
+            return messageQueue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public Message<T> receive(Duration timeout) throws PulsarClientException {
+        try {
+            return messageQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public Messages<T> receiveMulti(int maxMessages, Duration timeout) throws PulsarClientException {
+        List<Message<T>> batch = new ArrayList<>();
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+
+        while (batch.size() < maxMessages) {
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                break;
+            }
+            try {
+                MessageV5<T> msg = messageQueue.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                if (msg == null) {
+                    break;
+                }
+                batch.add(msg);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new PulsarClientException("Receive interrupted", e);
+            }
+            messageQueue.drainTo(batch, maxMessages - batch.size());
+        }
+        return new MessagesV5<>(batch);
+    }
+
+    @Override
+    public Checkpoint checkpoint() {
+        Map<Long, org.apache.pulsar.client.api.MessageId> positions = new HashMap<>(lastReceivedPositions);
+        return new CheckpointV5(positions, Instant.now());
+    }
+
+    @Override
+    public void seek(Checkpoint checkpoint) throws PulsarClientException {
+        try {
+            seekAsync(checkpoint).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Seek interrupted", e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof PulsarClientException pce) {
+                throw pce;
+            }
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    @Override
+    public AsyncCheckpointConsumer<T> async() {
+        return asyncView;
+    }
+
+    @Override
+    public void close() throws PulsarClientException {
+        try {
+            closeAsync().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Close interrupted", e);
+        } catch (ExecutionException e) {
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    // --- Async internals ---
+
+    CompletableFuture<Message<T>> receiveAsync() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return receive();
+            } catch (PulsarClientException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    CompletableFuture<Message<T>> receiveAsync(Duration timeout) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return receive(timeout);
+            } catch (PulsarClientException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    CompletableFuture<Checkpoint> checkpointAsync() {
+        return CompletableFuture.completedFuture(checkpoint());
+    }
+
+    CompletableFuture<Void> seekAsync(Checkpoint checkpoint) {
+        if (checkpoint instanceof CheckpointV5 cp) {
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (var entry : cp.segmentPositions().entrySet()) {
+                var readerFuture = segmentReaders.get(entry.getKey());
+                if (readerFuture != null) {
+                    futures.add(readerFuture.thenCompose(r -> r.seekAsync(entry.getValue())));
+                }
+            }
+            return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                    .whenComplete((__, ___) -> messageQueue.clear());
+        } else if (checkpoint == CheckpointV5.EARLIEST) {
+            return seekAllAsync(org.apache.pulsar.client.api.MessageId.earliest);
+        } else if (checkpoint == CheckpointV5.LATEST) {
+            return seekAllAsync(org.apache.pulsar.client.api.MessageId.latest);
+        } else {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException("Unsupported checkpoint type: " + checkpoint.getClass()));
+        }
+    }
+
+    private CompletableFuture<Void> seekAllAsync(org.apache.pulsar.client.api.MessageId position) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var readerFuture : segmentReaders.values()) {
+            futures.add(readerFuture.thenCompose(r -> r.seekAsync(position)));
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                .whenComplete((__, ___) -> messageQueue.clear());
+    }
+
+    CompletableFuture<Void> closeAsync() {
+        closed = true;
+        dagWatch.close();
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var future : segmentReaders.values()) {
+            futures.add(future
+                    .handle((reader, ex) -> reader)
+                    .thenCompose(reader -> reader != null ? reader.closeAsync()
+                            : CompletableFuture.completedFuture(null)));
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                .whenComplete((__, ___) -> segmentReaders.clear());
+    }
+
+    // --- Layout change handling ---
+
+    @Override
+    public void onLayoutChange(ClientSegmentLayout newLayout, ClientSegmentLayout oldLayout) {
+        // Fully async: safe to run on the netty IO thread that delivered the update.
+        createSegmentReaders(newLayout).exceptionally(ex -> {
+            log.warn().exceptionMessage(ex).log("Failed to apply layout update");
+            return null;
+        });
+    }
+
+    private CompletableFuture<Void> createSegmentReaders(ClientSegmentLayout layout) {
+        var activeIds = ConcurrentHashMap.<Long>newKeySet();
+        for (var seg : layout.activeSegments()) {
+            activeIds.add(seg.segmentId());
+        }
+
+        // Close readers for segments that are no longer active (fire-and-forget).
+        for (var entry : segmentReaders.entrySet()) {
+            if (!activeIds.contains(entry.getKey())) {
+                log.info().attr("segmentId", entry.getKey())
+                        .log("Closing reader for sealed segment");
+                entry.getValue().thenAccept(r -> r.closeAsync());
+                segmentReaders.remove(entry.getKey());
+            }
+        }
+
+        // Create readers for new segments asynchronously.
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (var seg : layout.activeSegments()) {
+            futures.add(segmentReaders.computeIfAbsent(seg.segmentId(),
+                    id -> createSegmentReaderAsync(seg)));
+        }
+
+        log.info().attr("epoch", layout.epoch())
+                .attr("segments", activeIds).log("Checkpoint consumer layout applied");
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    private CompletableFuture<Reader<T>> createSegmentReaderAsync(ActiveSegment segment) {
+        PulsarClientImpl v4Client = client.v4Client();
+        org.apache.pulsar.client.api.MessageId startMsgId = resolveStartPosition(segment.segmentId());
+
+        var builder = v4Client.newReader(v4Schema)
+                .topic(segment.segmentTopicName())
+                .startMessageId(startMsgId);
+        if (consumerName != null) {
+            builder.readerName(consumerName + "-seg-" + segment.segmentId());
+        }
+
+        return builder.createAsync()
+                .thenApply(reader -> {
+                    startReadLoop(reader, segment.segmentId());
+                    return reader;
+                });
+    }
+
+    private org.apache.pulsar.client.api.MessageId resolveStartPosition(long segmentId) {
+        // If we have a regular checkpoint, use the segment's position
+        if (startPosition instanceof CheckpointV5 cp) {
+            var pos = cp.segmentPositions().get(segmentId);
+            if (pos != null) {
+                return pos;
+            }
+        }
+        // For sentinel checkpoints or missing segments, use earliest/latest
+        if (startPosition == CheckpointV5.EARLIEST) {
+            return org.apache.pulsar.client.api.MessageId.earliest;
+        }
+        // Default to latest
+        return org.apache.pulsar.client.api.MessageId.latest;
+    }
+
+    private void startReadLoop(Reader<T> reader, long segmentId) {
+        reader.readNextAsync().thenAccept(v4Msg -> {
+            lastReceivedPositions.put(segmentId, v4Msg.getMessageId());
+            messageQueue.add(new MessageV5<>(v4Msg, segmentId));
+            if (!closed) {
+                startReadLoop(reader, segmentId);
+            }
+        }).exceptionally(ex -> {
+            if (!closed) {
+                log.warn().attr("segmentId", segmentId)
+                        .exception(ex).log("Error reading from segment, retrying");
+                startReadLoop(reader, segmentId);
+            }
+            return null;
+        });
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableQueueConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableQueueConsumer.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.github.merlimat.slog.Logger;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.QueueConsumer;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncQueueConsumer;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+import org.apache.pulsar.common.util.Backoff;
+
+/**
+ * V5 QueueConsumer implementation for scalable topics.
+ *
+ * <p>Maintains per-segment v4 Consumers with Shared subscription type.
+ * Messages from all segments are multiplexed into a single receive queue.
+ * Individual acknowledgments and negative acknowledgments are routed to
+ * the correct segment consumer via the segment ID in {@link MessageIdV5}.
+ */
+final class ScalableQueueConsumer<T> implements QueueConsumer<T>, DagWatchClient.LayoutChangeListener {
+
+    private static final Logger LOG = Logger.get(ScalableQueueConsumer.class);
+    private final Logger log;
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final org.apache.pulsar.client.api.Schema<T> v4Schema;
+    private final ConsumerConfigurationData<T> consumerConf;
+    private final DagWatchClient dagWatch;
+    private final String topicName;
+    private final String subscriptionName;
+
+    /**
+     * Per-segment v4 consumers. Stores futures (not consumers) so concurrent
+     * operations (ack, close) can chain on in-flight subscribes without
+     * racing against subscribe completion.
+     */
+    private final ConcurrentHashMap<Long, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>>>
+            segmentConsumers = new ConcurrentHashMap<>();
+    private final LinkedTransferQueue<MessageV5<T>> messageQueue = new LinkedTransferQueue<>();
+
+    private volatile boolean closed = false;
+    private final AsyncQueueConsumerV5<T> asyncView;
+
+    /** Most recent layout target. Reconciles always converge toward this value. */
+    private volatile ClientSegmentLayout latestLayout;
+    /** Coalesces concurrent reconcile attempts; only one runs at a time. */
+    private final AtomicBoolean reconcileInProgress = new AtomicBoolean(false);
+    private final Backoff reconcileBackoff = Backoff.builder()
+            .initialDelay(Duration.ofMillis(100))
+            .maxBackoff(Duration.ofSeconds(30))
+            .build();
+
+    private ScalableQueueConsumer(PulsarClientV5 client,
+                                  Schema<T> v5Schema,
+                                  ConsumerConfigurationData<T> consumerConf,
+                                  DagWatchClient dagWatch) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+        this.v4Schema = SchemaAdapter.toV4(v5Schema);
+        this.consumerConf = consumerConf;
+        this.dagWatch = dagWatch;
+        this.topicName = dagWatch.topicName().toString();
+        this.subscriptionName = consumerConf.getSubscriptionName();
+        this.log = LOG.with().attr("topic", topicName).attr("subscription", subscriptionName).build();
+        this.asyncView = new AsyncQueueConsumerV5<>(this);
+    }
+
+    /**
+     * Create a fully initialized consumer asynchronously. The returned future completes
+     * only after every initial segment has been successfully subscribed. If any segment
+     * fails to subscribe, all already-subscribed segments are closed and the future
+     * completes exceptionally.
+     */
+    static <T> CompletableFuture<QueueConsumer<T>> createAsync(PulsarClientV5 client,
+                                                               Schema<T> v5Schema,
+                                                               ConsumerConfigurationData<T> consumerConf,
+                                                               DagWatchClient dagWatch,
+                                                               ClientSegmentLayout initialLayout) {
+        ScalableQueueConsumer<T> consumer = new ScalableQueueConsumer<>(client, v5Schema, consumerConf, dagWatch);
+        return consumer.subscribeSegments(initialLayout)
+                .thenApply(__ -> {
+                    dagWatch.setListener(consumer);
+                    return (QueueConsumer<T>) consumer;
+                })
+                .exceptionallyCompose(ex -> consumer.closeAsync().handle((__, ___) -> {
+                    throw ex instanceof CompletionException ce ? ce : new CompletionException(ex);
+                }));
+    }
+
+    @Override
+    public String topic() {
+        return topicName;
+    }
+
+    @Override
+    public String subscription() {
+        return subscriptionName;
+    }
+
+    @Override
+    public String consumerName() {
+        return consumerConf.getConsumerName();
+    }
+
+    @Override
+    public Message<T> receive() throws PulsarClientException {
+        try {
+            return messageQueue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public Message<T> receive(Duration timeout) throws PulsarClientException {
+        try {
+            return messageQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public void acknowledge(MessageId messageId) {
+        if (!(messageId instanceof MessageIdV5 id)) {
+            throw new IllegalArgumentException("Expected MessageIdV5, got: " + messageId.getClass());
+        }
+        var future = segmentConsumers.get(id.segmentId());
+        if (future != null) {
+            future.thenAccept(c -> c.acknowledgeAsync(id.v4MessageId()));
+        }
+    }
+
+    @Override
+    public void acknowledge(MessageId messageId, Transaction txn) {
+        throw new UnsupportedOperationException("Transactional ack not yet implemented");
+    }
+
+    @Override
+    public void negativeAcknowledge(MessageId messageId) {
+        if (!(messageId instanceof MessageIdV5 id)) {
+            throw new IllegalArgumentException("Expected MessageIdV5, got: " + messageId.getClass());
+        }
+        var future = segmentConsumers.get(id.segmentId());
+        if (future != null) {
+            future.thenAccept(c -> c.negativeAcknowledge(id.v4MessageId()));
+        }
+    }
+
+    @Override
+    public AsyncQueueConsumer<T> async() {
+        return asyncView;
+    }
+
+    @Override
+    public void close() throws PulsarClientException {
+        try {
+            closeAsync().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Close interrupted", e);
+        } catch (ExecutionException e) {
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    // --- Async internals ---
+
+    CompletableFuture<Message<T>> receiveAsync() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return receive();
+            } catch (PulsarClientException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    CompletableFuture<Void> closeAsync() {
+        closed = true;
+        dagWatch.close();
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var future : segmentConsumers.values()) {
+            futures.add(future
+                    .handle((consumer, ex) -> consumer)
+                    .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
+                            : CompletableFuture.completedFuture(null)));
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                .whenComplete((__, ___) -> segmentConsumers.clear());
+    }
+
+    // --- Layout change handling ---
+
+    @Override
+    public void onLayoutChange(ClientSegmentLayout newLayout, ClientSegmentLayout oldLayout) {
+        // Fully async: safe to run on the netty IO thread that delivered the update.
+        // Store the target and kick off a reconcile. If a reconcile is already running,
+        // it will re-read latestLayout once it finishes. On failure, the reconcile
+        // reschedules itself with exponential backoff until it succeeds (or we close).
+        latestLayout = newLayout;
+        reconcile();
+    }
+
+    private void reconcile() {
+        if (closed) {
+            return;
+        }
+        if (!reconcileInProgress.compareAndSet(false, true)) {
+            // A reconcile is already in progress; it will observe the updated latestLayout
+            // when it finishes and re-run if needed.
+            return;
+        }
+        ClientSegmentLayout target = latestLayout;
+        subscribeSegments(target).whenComplete((__, ex) -> {
+            reconcileInProgress.set(false);
+            if (closed) {
+                return;
+            }
+            if (ex == null) {
+                reconcileBackoff.reset();
+                // If a newer layout arrived during this reconcile, run again to converge.
+                if (latestLayout != target) {
+                    reconcile();
+                }
+                return;
+            }
+            // Evict failed subscribe futures so the next attempt can re-try them.
+            evictFailedSegmentConsumers();
+            Duration delay = reconcileBackoff.next();
+            log.warn().attr("delayMs", delay.toMillis()).exceptionMessage(ex)
+                    .log("Failed to apply layout update, retrying after backoff");
+            scheduler().schedule(this::reconcile, delay.toMillis(), TimeUnit.MILLISECONDS);
+        });
+    }
+
+    private void evictFailedSegmentConsumers() {
+        for (var entry : segmentConsumers.entrySet()) {
+            var future = entry.getValue();
+            if (future.isCompletedExceptionally()) {
+                segmentConsumers.remove(entry.getKey(), future);
+            }
+        }
+    }
+
+    private ScheduledExecutorService scheduler() {
+        return (ScheduledExecutorService) client.v4Client().getScheduledExecutorProvider().getExecutor();
+    }
+
+    private CompletableFuture<Void> subscribeSegments(ClientSegmentLayout layout) {
+        var activeIds = ConcurrentHashMap.<Long>newKeySet();
+        for (var seg : layout.activeSegments()) {
+            activeIds.add(seg.segmentId());
+        }
+
+        // Close consumers for segments that are no longer active (fire-and-forget).
+        for (var entry : segmentConsumers.entrySet()) {
+            if (!activeIds.contains(entry.getKey())) {
+                log.info().attr("segmentId", entry.getKey())
+                        .log("Closing consumer for sealed segment");
+                entry.getValue().thenAccept(c -> c.closeAsync());
+                segmentConsumers.remove(entry.getKey());
+            }
+        }
+
+        // Subscribe to new segments. The returned future completes when all subscribes
+        // finish (successfully or with error).
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (var seg : layout.activeSegments()) {
+            futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(),
+                    id -> createSegmentConsumerAsync(seg)));
+        }
+
+        log.info().attr("epoch", layout.epoch())
+                .attr("segments", activeIds).log("Queue consumer layout applied");
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    private CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> createSegmentConsumerAsync(
+            ActiveSegment segment) {
+        PulsarClientImpl v4Client = client.v4Client();
+        var builder = v4Client.newConsumer(v4Schema)
+                .topic(segment.segmentTopicName())
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared);
+        if (consumerConf.getConsumerName() != null) {
+            builder.consumerName(consumerConf.getConsumerName() + "-seg-" + segment.segmentId());
+        }
+        return builder.subscribeAsync()
+                .thenApply(consumer -> {
+                    startReceiveLoop(consumer, segment.segmentId());
+                    return consumer;
+                });
+    }
+
+    private void startReceiveLoop(org.apache.pulsar.client.api.Consumer<T> v4Consumer, long segmentId) {
+        v4Consumer.receiveAsync().thenAccept(v4Msg -> {
+            messageQueue.add(new MessageV5<>(v4Msg, segmentId));
+            if (!closed) {
+                startReceiveLoop(v4Consumer, segmentId);
+            }
+        }).exceptionally(ex -> {
+            Throwable cause = ex instanceof CompletionException ce && ce.getCause() != null ? ce.getCause() : ex;
+            if (closed
+                    || cause instanceof org.apache.pulsar.client.api.PulsarClientException.AlreadyClosedException) {
+                // This segment consumer is done (either the whole consumer is closing,
+                // or the segment was sealed and its v4 consumer closed by a layout update).
+                return null;
+            }
+            log.warn().attr("segmentId", segmentId)
+                    .exception(ex).log("Error receiving from segment, retrying");
+            // Hop to the v4 client's internal executor so repeated synchronous failures
+            // don't grow the stack unboundedly.
+            client.v4Client().getInternalExecutorService()
+                    .execute(() -> startReceiveLoop(v4Consumer, segmentId));
+            return null;
+        });
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.github.merlimat.slog.Logger;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.v5.Message;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.Messages;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.StreamConsumer;
+import org.apache.pulsar.client.api.v5.Transaction;
+import org.apache.pulsar.client.api.v5.async.AsyncStreamConsumer;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+
+/**
+ * V5 StreamConsumer implementation for scalable topics.
+ *
+ * <p>Maintains per-segment v4 Consumers with Exclusive subscription type.
+ * Messages from all segments are multiplexed into a single receive queue.
+ *
+ * <p>Each delivered message carries a <em>position vector</em>: a snapshot of the
+ * latest delivered message ID per segment at the moment that message enters the
+ * queue. When the application calls {@link #acknowledgeCumulative(MessageId)},
+ * every segment is cumulatively acknowledged up to the position recorded in that
+ * vector. This ensures that acknowledging a single message correctly advances
+ * all segments, not just the one it came from.
+ */
+final class ScalableStreamConsumer<T> implements StreamConsumer<T>, DagWatchClient.LayoutChangeListener {
+
+    private static final Logger LOG = Logger.get(ScalableStreamConsumer.class);
+    private final Logger log;
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final org.apache.pulsar.client.api.Schema<T> v4Schema;
+    private final ConsumerConfigurationData<T> consumerConf;
+    private final DagWatchClient dagWatch;
+    private final String topicName;
+    private final String subscriptionName;
+
+    /**
+     * Per-segment v4 consumers. Stores futures so concurrent operations (ack, close)
+     * can chain on in-flight subscribes without racing against subscribe completion.
+     */
+    private final ConcurrentHashMap<Long, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>>>
+            segmentConsumers = new ConcurrentHashMap<>();
+
+    /**
+     * Tracks the latest message ID delivered from each segment. Updated atomically
+     * inside {@link #startReceiveLoop} before the message is enqueued, and snapshot
+     * into each {@link MessageIdV5} so cumulative acks cover all segments.
+     */
+    private final ConcurrentHashMap<Long, org.apache.pulsar.client.api.MessageId> latestDelivered =
+            new ConcurrentHashMap<>();
+
+    private final LinkedTransferQueue<MessageV5<T>> messageQueue = new LinkedTransferQueue<>();
+
+    private volatile boolean closed = false;
+    private final AsyncStreamConsumerV5<T> asyncView;
+
+    private ScalableStreamConsumer(PulsarClientV5 client,
+                                   Schema<T> v5Schema,
+                                   ConsumerConfigurationData<T> consumerConf,
+                                   DagWatchClient dagWatch) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+        this.v4Schema = SchemaAdapter.toV4(v5Schema);
+        this.consumerConf = consumerConf;
+        this.dagWatch = dagWatch;
+        this.topicName = dagWatch.topicName().toString();
+        this.subscriptionName = consumerConf.getSubscriptionName();
+        this.log = LOG.with().attr("topic", topicName).attr("subscription", subscriptionName).build();
+        this.asyncView = new AsyncStreamConsumerV5<>(this);
+    }
+
+    /**
+     * Create a fully initialized consumer asynchronously. The returned future completes
+     * only after every initial segment has been successfully subscribed. If any segment
+     * fails to subscribe, all already-subscribed segments are closed and the future
+     * completes exceptionally.
+     */
+    static <T> CompletableFuture<StreamConsumer<T>> createAsync(PulsarClientV5 client,
+                                                                Schema<T> v5Schema,
+                                                                ConsumerConfigurationData<T> consumerConf,
+                                                                DagWatchClient dagWatch,
+                                                                ClientSegmentLayout initialLayout) {
+        ScalableStreamConsumer<T> consumer = new ScalableStreamConsumer<>(client, v5Schema, consumerConf, dagWatch);
+        return consumer.subscribeSegments(initialLayout)
+                .thenApply(__ -> {
+                    dagWatch.setListener(consumer);
+                    return (StreamConsumer<T>) consumer;
+                })
+                .exceptionallyCompose(ex -> consumer.closeAsync().handle((__, ___) -> {
+                    throw ex instanceof CompletionException ce ? ce : new CompletionException(ex);
+                }));
+    }
+
+    @Override
+    public String topic() {
+        return topicName;
+    }
+
+    @Override
+    public String subscription() {
+        return subscriptionName;
+    }
+
+    @Override
+    public String consumerName() {
+        return consumerConf.getConsumerName();
+    }
+
+    @Override
+    public Message<T> receive() throws PulsarClientException {
+        try {
+            return messageQueue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public Message<T> receive(Duration timeout) throws PulsarClientException {
+        try {
+            return messageQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Receive interrupted", e);
+        }
+    }
+
+    @Override
+    public Messages<T> receiveMulti(int maxNumMessages, Duration timeout) throws PulsarClientException {
+        List<Message<T>> batch = new ArrayList<>();
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+
+        while (batch.size() < maxNumMessages) {
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                break;
+            }
+            try {
+                MessageV5<T> msg = messageQueue.poll(remainingNanos, TimeUnit.NANOSECONDS);
+                if (msg == null) {
+                    break;
+                }
+                batch.add(msg);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new PulsarClientException("Receive interrupted", e);
+            }
+            // Drain any immediately available messages
+            messageQueue.drainTo(batch, maxNumMessages - batch.size());
+        }
+        return new MessagesV5<>(batch);
+    }
+
+    @Override
+    public void acknowledgeCumulative(MessageId messageId) {
+        if (!(messageId instanceof MessageIdV5 id)) {
+            throw new IllegalArgumentException("Expected MessageIdV5, got: " + messageId.getClass());
+        }
+
+        // Ack each segment up to the position recorded in the vector
+        for (var entry : id.positionVector().entrySet()) {
+            var future = segmentConsumers.get(entry.getKey());
+            if (future != null) {
+                future.thenAccept(c -> c.acknowledgeCumulativeAsync(entry.getValue()));
+            }
+        }
+    }
+
+    @Override
+    public void acknowledgeCumulative(MessageId messageId, Transaction txn) {
+        // Transaction support not yet implemented
+        throw new UnsupportedOperationException("Transactional ack not yet implemented");
+    }
+
+    @Override
+    public AsyncStreamConsumer<T> async() {
+        return asyncView;
+    }
+
+    @Override
+    public void close() throws PulsarClientException {
+        try {
+            closeAsync().get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException("Close interrupted", e);
+        } catch (ExecutionException e) {
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    // --- Async internals ---
+
+    CompletableFuture<Message<T>> receiveAsync() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return receive();
+            } catch (PulsarClientException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    CompletableFuture<Message<T>> receiveAsync(Duration timeout) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return receive(timeout);
+            } catch (PulsarClientException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    CompletableFuture<Void> closeAsync() {
+        closed = true;
+        dagWatch.close();
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var future : segmentConsumers.values()) {
+            futures.add(future
+                    .handle((consumer, ex) -> consumer)
+                    .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
+                            : CompletableFuture.completedFuture(null)));
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                .whenComplete((__, ___) -> segmentConsumers.clear());
+    }
+
+    // --- Layout change handling ---
+
+    @Override
+    public void onLayoutChange(ClientSegmentLayout newLayout, ClientSegmentLayout oldLayout) {
+        // Fully async: safe to run on the netty IO thread that delivered the update.
+        subscribeSegments(newLayout).exceptionally(ex -> {
+            log.warn().exceptionMessage(ex).log("Failed to apply layout update");
+            return null;
+        });
+    }
+
+    private CompletableFuture<Void> subscribeSegments(ClientSegmentLayout layout) {
+        var activeIds = ConcurrentHashMap.<Long>newKeySet();
+        for (var seg : layout.activeSegments()) {
+            activeIds.add(seg.segmentId());
+        }
+
+        // Close consumers for segments that are no longer active (fire-and-forget).
+        for (var entry : segmentConsumers.entrySet()) {
+            if (!activeIds.contains(entry.getKey())) {
+                log.info().attr("segmentId", entry.getKey())
+                        .log("Closing consumer for sealed segment");
+                entry.getValue().thenAccept(c -> c.closeAsync());
+                segmentConsumers.remove(entry.getKey());
+                latestDelivered.remove(entry.getKey());
+            }
+        }
+
+        // Subscribe to new segments asynchronously.
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (var seg : layout.activeSegments()) {
+            futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(),
+                    id -> createSegmentConsumerAsync(seg)));
+        }
+
+        log.info().attr("epoch", layout.epoch())
+                .attr("segments", activeIds).log("Stream consumer layout applied");
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    private CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> createSegmentConsumerAsync(
+            ActiveSegment segment) {
+        PulsarClientImpl v4Client = client.v4Client();
+        var builder = v4Client.newConsumer(v4Schema)
+                .topic(segment.segmentTopicName())
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Exclusive);
+        if (consumerConf.getConsumerName() != null) {
+            builder.consumerName(consumerConf.getConsumerName() + "-seg-" + segment.segmentId());
+        }
+        return builder.subscribeAsync()
+                .thenApply(consumer -> {
+                    startReceiveLoop(consumer, segment.segmentId());
+                    return consumer;
+                });
+    }
+
+    /**
+     * Async receive loop for a single segment consumer. Each received message:
+     * 1. Updates {@link #latestDelivered} for this segment
+     * 2. Snapshots the current position vector across all segments
+     * 3. Wraps the message with a {@link MessageIdV5} carrying that vector
+     * 4. Enqueues the wrapped message for the application to receive
+     */
+    private void startReceiveLoop(org.apache.pulsar.client.api.Consumer<T> v4Consumer, long segmentId) {
+        v4Consumer.receiveAsync().thenAccept(v4Msg -> {
+            // Update the latest delivered position for this segment
+            latestDelivered.put(segmentId, v4Msg.getMessageId());
+
+            // Snapshot the position vector (all segments, including this one)
+            Map<Long, org.apache.pulsar.client.api.MessageId> positionVector =
+                    new HashMap<>(latestDelivered);
+
+            // Create the V5 message with the position vector embedded in the ID
+            var msgId = new MessageIdV5(v4Msg.getMessageId(), segmentId, positionVector);
+            messageQueue.add(new MessageV5<>(v4Msg, msgId));
+
+            if (!closed) {
+                startReceiveLoop(v4Consumer, segmentId);
+            }
+        }).exceptionally(ex -> {
+            if (!closed) {
+                log.warn().attr("segmentId", segmentId)
+                        .exception(ex).log("Error receiving from segment, retrying");
+                startReceiveLoop(v4Consumer, segmentId);
+            }
+            return null;
+        });
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import io.github.merlimat.slog.Logger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pulsar.client.api.v5.MessageBuilder;
+import org.apache.pulsar.client.api.v5.Producer;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.async.AsyncProducer;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+
+/**
+ * V5 Producer implementation for scalable topics.
+ *
+ * <p>Maintains a per-segment v4 ProducerImpl and routes messages by hashing
+ * the message key to find the target segment. When the layout changes (split/merge),
+ * segment producers are created/closed accordingly.
+ */
+final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.LayoutChangeListener {
+
+    private static final Logger LOG = Logger.get(ScalableTopicProducer.class);
+    private final Logger log;
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final org.apache.pulsar.client.api.Schema<T> v4Schema;
+    private final ProducerConfigurationData producerConf;
+    private final DagWatchClient dagWatch;
+    private final SegmentRouter router;
+    private final String topicName;
+
+    // Per-segment v4 producers. Key is segmentId.
+    private final ConcurrentHashMap<Long, org.apache.pulsar.client.api.Producer<T>> segmentProducers =
+            new ConcurrentHashMap<>();
+
+    // Current active segments (volatile for visibility across threads)
+    private volatile List<ActiveSegment> activeSegments = List.of();
+
+    private volatile boolean closed = false;
+    private final AsyncProducerV5<T> asyncView;
+
+    ScalableTopicProducer(PulsarClientV5 client,
+                          Schema<T> v5Schema,
+                          ProducerConfigurationData producerConf,
+                          DagWatchClient dagWatch,
+                          ClientSegmentLayout initialLayout) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+        this.v4Schema = SchemaAdapter.toV4(v5Schema);
+        this.producerConf = producerConf;
+        this.dagWatch = dagWatch;
+        this.router = new SegmentRouter();
+        this.topicName = dagWatch.topicName().toString();
+        this.log = LOG.with().attr("topic", topicName).build();
+        this.asyncView = new AsyncProducerV5<>(this);
+
+        // Register for layout changes
+        dagWatch.setListener(this);
+
+        // Initialize with the current layout
+        applyLayout(initialLayout);
+    }
+
+    @Override
+    public String topic() {
+        return topicName;
+    }
+
+    @Override
+    public String producerName() {
+        return producerConf.getProducerName();
+    }
+
+    @Override
+    public MessageBuilder<T> newMessage() {
+        return new MessageBuilderV5<>(this);
+    }
+
+    @Override
+    public long lastSequenceId() {
+        // Aggregate: return the max across all segment producers
+        long max = -1;
+        for (var producer : segmentProducers.values()) {
+            max = Math.max(max, producer.getLastSequenceId());
+        }
+        return max;
+    }
+
+    @Override
+    public AsyncProducer<T> async() {
+        return asyncView;
+    }
+
+    @Override
+    public void close() throws PulsarClientException {
+        closed = true;
+        dagWatch.close();
+
+        List<Exception> errors = new ArrayList<>();
+        for (var producer : segmentProducers.values()) {
+            try {
+                producer.close();
+            } catch (Exception e) {
+                errors.add(e);
+            }
+        }
+        segmentProducers.clear();
+
+        if (!errors.isEmpty()) {
+            PulsarClientException ex = new PulsarClientException("Failed to close some segment producers");
+            errors.forEach(ex::addSuppressed);
+            throw ex;
+        }
+    }
+
+    /**
+     * Send a message synchronously with routing. Called by MessageBuilderV5.
+     * Returns a MessageIdV5 that includes the segment ID for ack routing.
+     */
+    MessageIdV5 sendInternal(
+            String key, T value, java.util.Map<String, String> properties,
+            java.time.Instant eventTime, Long sequenceId,
+            java.time.Duration deliverAfter, java.time.Instant deliverAt,
+            java.util.List<String> replicationClusters) throws PulsarClientException {
+
+        for (int attempt = 0; attempt < 3; attempt++) {
+            long segmentId = routeMessage(key);
+            var producer = getOrCreateSegmentProducer(segmentId);
+
+            try {
+                var v4MsgId = buildV4Message(producer, key, value, properties,
+                        eventTime, sequenceId, deliverAfter, deliverAt, replicationClusters)
+                        .send();
+                return new MessageIdV5(v4MsgId, segmentId);
+            } catch (org.apache.pulsar.client.api.PulsarClientException.TopicTerminatedException e) {
+                // Segment was terminated (split/merge) — remove stale producer and retry
+                // with the updated layout (which should arrive via DagWatchClient)
+                log.info().attr("segmentId", segmentId)
+                        .attr("attempt", attempt + 1)
+                        .log("Segment terminated, waiting for layout update");
+                segmentProducers.remove(segmentId);
+                try {
+                    Thread.sleep(100L * (attempt + 1));
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new PulsarClientException("Interrupted while waiting for layout update", ie);
+                }
+            } catch (org.apache.pulsar.client.api.PulsarClientException e) {
+                throw new PulsarClientException(e.getMessage(), e);
+            }
+        }
+        throw new PulsarClientException("Failed to send after segment termination retries");
+    }
+
+    /**
+     * Send a message asynchronously with routing. Called by AsyncMessageBuilderV5.
+     * Returns a future of MessageIdV5 that includes the segment ID.
+     */
+    CompletableFuture<MessageIdV5> sendInternalAsync(
+            String key, T value, java.util.Map<String, String> properties,
+            java.time.Instant eventTime, Long sequenceId,
+            java.time.Duration deliverAfter, java.time.Instant deliverAt,
+            java.util.List<String> replicationClusters) {
+
+        return sendInternalAsyncWithRetry(key, value, properties,
+                eventTime, sequenceId, deliverAfter, deliverAt, replicationClusters, 0);
+    }
+
+    private CompletableFuture<MessageIdV5> sendInternalAsyncWithRetry(
+            String key, T value, java.util.Map<String, String> properties,
+            java.time.Instant eventTime, Long sequenceId,
+            java.time.Duration deliverAfter, java.time.Instant deliverAt,
+            java.util.List<String> replicationClusters, int attempt) {
+
+        long segmentId;
+        try {
+            segmentId = routeMessage(key);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
+        org.apache.pulsar.client.api.Producer<T> producer;
+        try {
+            producer = getOrCreateSegmentProducer(segmentId);
+        } catch (PulsarClientException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
+        return buildV4Message(producer, key, value, properties,
+                eventTime, sequenceId, deliverAfter, deliverAt, replicationClusters)
+                .sendAsync()
+                .thenApply(v4MsgId -> new MessageIdV5(v4MsgId, segmentId))
+                .exceptionallyCompose(ex -> {
+                    Throwable cause = ex instanceof java.util.concurrent.CompletionException
+                            ? ex.getCause() : ex;
+                    if (cause instanceof org.apache.pulsar.client.api.PulsarClientException
+                            .TopicTerminatedException && attempt < 3) {
+                        log.info().attr("segmentId", segmentId)
+                                .attr("attempt", attempt + 1).log("Segment terminated, retrying");
+                        segmentProducers.remove(segmentId);
+                        return CompletableFuture.supplyAsync(() -> null,
+                                CompletableFuture.delayedExecutor(
+                                        100L * (attempt + 1),
+                                        java.util.concurrent.TimeUnit.MILLISECONDS))
+                                .thenCompose(__ -> sendInternalAsyncWithRetry(
+                                        key, value, properties, eventTime, sequenceId,
+                                        deliverAfter, deliverAt, replicationClusters, attempt + 1));
+                    }
+                    return CompletableFuture.failedFuture(ex);
+                });
+    }
+
+    private org.apache.pulsar.client.api.TypedMessageBuilder<T> buildV4Message(
+            org.apache.pulsar.client.api.Producer<T> producer,
+            String key, T value, java.util.Map<String, String> properties,
+            java.time.Instant eventTime, Long sequenceId,
+            java.time.Duration deliverAfter, java.time.Instant deliverAt,
+            java.util.List<String> replicationClusters) {
+
+        var msgBuilder = producer.newMessage().value(value);
+
+        if (key != null) {
+            msgBuilder.key(key);
+        }
+        if (properties != null && !properties.isEmpty()) {
+            msgBuilder.properties(properties);
+        }
+        if (eventTime != null) {
+            msgBuilder.eventTime(eventTime.toEpochMilli());
+        }
+        if (sequenceId != null) {
+            msgBuilder.sequenceId(sequenceId);
+        }
+        if (deliverAfter != null) {
+            msgBuilder.deliverAfter(deliverAfter.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+        if (deliverAt != null) {
+            msgBuilder.deliverAt(deliverAt.toEpochMilli());
+        }
+        if (replicationClusters != null) {
+            msgBuilder.replicationClusters(replicationClusters);
+        }
+
+        return msgBuilder;
+    }
+
+    /**
+     * Flush all segment producers asynchronously.
+     */
+    CompletableFuture<Void> flushAsync() {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var producer : segmentProducers.values()) {
+            futures.add(producer.flushAsync());
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    CompletableFuture<Void> closeAsync() {
+        closed = true;
+        dagWatch.close();
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (var producer : segmentProducers.values()) {
+            futures.add(producer.closeAsync());
+        }
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                .whenComplete((__, ___) -> segmentProducers.clear());
+    }
+
+    // --- Layout change handling ---
+
+    @Override
+    public void onLayoutChange(ClientSegmentLayout newLayout, ClientSegmentLayout oldLayout) {
+        applyLayout(newLayout);
+    }
+
+    private void applyLayout(ClientSegmentLayout layout) {
+        this.activeSegments = layout.activeSegments();
+
+        // Determine which segments are new and which are gone
+        Set<Long> newSegmentIds = ConcurrentHashMap.newKeySet();
+        for (var seg : layout.activeSegments()) {
+            newSegmentIds.add(seg.segmentId());
+        }
+
+        // Close producers for segments that are no longer active
+        for (var entry : segmentProducers.entrySet()) {
+            if (!newSegmentIds.contains(entry.getKey())) {
+                log.info().attr("segmentId", entry.getKey())
+                        .log("Closing producer for sealed segment");
+                entry.getValue().closeAsync().whenComplete((__, ex) -> {
+                    if (ex != null) {
+                        log.warn().attr("segmentId", entry.getKey())
+                                .exceptionMessage(ex).log("Error closing producer for segment");
+                    }
+                });
+                segmentProducers.remove(entry.getKey());
+            }
+        }
+
+        // New segment producers will be created lazily on first message
+        log.info().attr("epoch", layout.epoch())
+                .attr("activeSegments", newSegmentIds).log("Layout applied");
+    }
+
+    // --- Internal ---
+
+    private long routeMessage(String key) {
+        List<ActiveSegment> segments = activeSegments;
+        if (key != null) {
+            return router.route(key, segments);
+        } else {
+            return router.routeRoundRobin(segments);
+        }
+    }
+
+    private org.apache.pulsar.client.api.Producer<T> getOrCreateSegmentProducer(long segmentId)
+            throws PulsarClientException {
+        var existing = segmentProducers.get(segmentId);
+        if (existing != null) {
+            return existing;
+        }
+
+        return segmentProducers.computeIfAbsent(segmentId, id -> {
+            // Find the segment topic name
+            String segmentTopicName = null;
+            for (var seg : activeSegments) {
+                if (seg.segmentId() == id) {
+                    segmentTopicName = seg.segmentTopicName();
+                    break;
+                }
+            }
+            if (segmentTopicName == null) {
+                throw new RuntimeException("Segment " + id + " not found in active segments");
+            }
+
+            try {
+                PulsarClientImpl v4Client = client.v4Client();
+                var segConf = new org.apache.pulsar.client.impl.conf.ProducerConfigurationData();
+                segConf.setTopicName(segmentTopicName);
+                segConf.setSendTimeoutMs(producerConf.getSendTimeoutMs());
+                segConf.setBlockIfQueueFull(producerConf.isBlockIfQueueFull());
+                if (producerConf.getProducerName() != null
+                        && !producerConf.getProducerName().isEmpty()) {
+                    segConf.setProducerName(producerConf.getProducerName() + "-seg-" + id);
+                }
+                return v4Client.createSegmentProducerAsync(segConf, v4Schema)
+                        .get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SchemaAdapter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SchemaAdapter.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.api.v5.schema.SchemaInfo;
+import org.apache.pulsar.client.api.v5.schema.SchemaType;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+
+/**
+ * Adapts between v5 Schema and v4 Schema interfaces.
+ */
+final class SchemaAdapter {
+
+    private SchemaAdapter() {
+    }
+
+    /**
+     * Wrap a v4 Schema as a v5 Schema.
+     */
+    static <T> Schema<T> toV5(org.apache.pulsar.client.api.Schema<T> v4Schema) {
+        return new V5SchemaWrapper<>(v4Schema);
+    }
+
+    /**
+     * Unwrap a v5 Schema to get the underlying v4 Schema.
+     * If it's already a wrapper, extract the inner v4 schema.
+     * Otherwise, create a v4 adapter around the v5 schema.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> org.apache.pulsar.client.api.Schema<T> toV4(Schema<T> v5Schema) {
+        if (v5Schema instanceof V5SchemaWrapper<T> wrapper) {
+            return wrapper.v4Schema;
+        }
+        return new V4SchemaWrapper<>(v5Schema);
+    }
+
+    /**
+     * Wraps a v4 Schema as a v5 Schema.
+     */
+    private static final class V5SchemaWrapper<T> implements Schema<T> {
+        final org.apache.pulsar.client.api.Schema<T> v4Schema;
+
+        V5SchemaWrapper(org.apache.pulsar.client.api.Schema<T> v4Schema) {
+            this.v4Schema = v4Schema;
+        }
+
+        @Override
+        public byte[] encode(T message) {
+            return v4Schema.encode(message);
+        }
+
+        @Override
+        public T decode(byte[] bytes) {
+            return v4Schema.decode(bytes);
+        }
+
+        @Override
+        public T decode(byte[] bytes, byte[] schemaVersion) {
+            return v4Schema.decode(bytes, schemaVersion);
+        }
+
+        @Override
+        public T decode(ByteBuffer data) {
+            return v4Schema.decode(data);
+        }
+
+        @Override
+        public SchemaInfo schemaInfo() {
+            var v4Info = v4Schema.getSchemaInfo();
+            if (v4Info == null) {
+                return null;
+            }
+            return new SchemaInfoV5(v4Info);
+        }
+    }
+
+    /**
+     * Wraps a v5 Schema as a v4 Schema (for passing to ProducerImpl/ConsumerImpl).
+     */
+    private static final class V4SchemaWrapper<T> implements org.apache.pulsar.client.api.Schema<T> {
+        final Schema<T> v5Schema;
+
+        V4SchemaWrapper(Schema<T> v5Schema) {
+            this.v5Schema = v5Schema;
+        }
+
+        @Override
+        public byte[] encode(T message) {
+            return v5Schema.encode(message);
+        }
+
+        @Override
+        public T decode(byte[] bytes) {
+            return v5Schema.decode(bytes);
+        }
+
+        @Override
+        public T decode(byte[] bytes, byte[] schemaVersion) {
+            return v5Schema.decode(bytes, schemaVersion);
+        }
+
+        @Override
+        public org.apache.pulsar.common.schema.SchemaInfo getSchemaInfo() {
+            var v5Info = v5Schema.schemaInfo();
+            if (v5Info == null) {
+                return null;
+            }
+            return SchemaInfoImpl.builder()
+                    .name(v5Info.name())
+                    .type(org.apache.pulsar.common.schema.SchemaType.valueOf(v5Info.type().name()))
+                    .schema(v5Info.schema())
+                    .properties(v5Info.properties())
+                    .build();
+        }
+
+        @Override
+        public org.apache.pulsar.client.api.Schema<T> clone() {
+            return this;
+        }
+
+        @Override
+        public void validate(byte[] message) {
+        }
+
+        @Override
+        public boolean supportSchemaVersioning() {
+            return false;
+        }
+
+        @Override
+        public Optional<Object> getNativeSchema() {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean requireFetchingSchemaInfo() {
+            return false;
+        }
+
+        @Override
+        public void configureSchemaInfo(String topic, String componentName,
+                                        org.apache.pulsar.common.schema.SchemaInfo schemaInfo) {
+        }
+    }
+
+    /**
+     * Adapts a v4 SchemaInfo to the v5 SchemaInfo interface.
+     */
+    private record SchemaInfoV5(
+            org.apache.pulsar.common.schema.SchemaInfo v4Info
+    ) implements SchemaInfo {
+
+        @Override
+        public String name() {
+            return v4Info.getName();
+        }
+
+        @Override
+        public SchemaType type() {
+            return SchemaType.valueOf(v4Info.getType().name());
+        }
+
+        @Override
+        public byte[] schema() {
+            return v4Info.getSchema();
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return v4Info.getProperties();
+        }
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pulsar.common.scalable.HashRange;
+
+/**
+ * Routes messages to the correct segment based on key hashing.
+ *
+ * <p>Uses MurmurHash3 masked to a 16-bit hash space (0x0000-0xFFFF)
+ * and finds the active segment whose hash range contains the hash.
+ */
+final class SegmentRouter {
+
+    private final AtomicInteger roundRobinCounter = new AtomicInteger(0);
+
+    /**
+     * Route a message key to the segment that owns its hash range.
+     *
+     * @param key the message key
+     * @param activeSegments the currently active segments (sorted by hash range)
+     * @return the segment ID to route to
+     * @throws IllegalStateException if no segment covers the hash
+     */
+    long route(String key, List<ActiveSegment> activeSegments) {
+        if (activeSegments.isEmpty()) {
+            throw new IllegalStateException("No active segments");
+        }
+        int hash = hash(key);
+        for (var segment : activeSegments) {
+            if (segment.hashRange().contains(hash)) {
+                return segment.segmentId();
+            }
+        }
+        throw new IllegalStateException("No segment covers hash " + hash + " for key: " + key);
+    }
+
+    /**
+     * Route a message without a key using round-robin across active segments.
+     */
+    long routeRoundRobin(List<ActiveSegment> activeSegments) {
+        if (activeSegments.isEmpty()) {
+            throw new IllegalStateException("No active segments");
+        }
+        int idx = Math.abs(roundRobinCounter.getAndIncrement() % activeSegments.size());
+        return activeSegments.get(idx).segmentId();
+    }
+
+    /**
+     * Compute the 16-bit hash for a key using MurmurHash3.
+     */
+    static int hash(String key) {
+        return hash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Compute the 16-bit hash for key bytes.
+     */
+    static int hash(byte[] keyBytes) {
+        int hash32 = org.apache.pulsar.common.util.Murmur3_32Hash.getInstance().makeHash(keyBytes);
+        return hash32 & HashRange.MAX_HASH;
+    }
+
+    /**
+     * Represents an active segment with its hash range and ID.
+     */
+    record ActiveSegment(long segmentId, HashRange hashRange, String segmentTopicName) {
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/StreamConsumerBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/StreamConsumerBuilderV5.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.client.api.v5.MessageId;
+import org.apache.pulsar.client.api.v5.PulsarClientException;
+import org.apache.pulsar.client.api.v5.StreamConsumer;
+import org.apache.pulsar.client.api.v5.StreamConsumerBuilder;
+import org.apache.pulsar.client.api.v5.config.EncryptionPolicy;
+import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * V5 StreamConsumerBuilder implementation.
+ */
+final class StreamConsumerBuilderV5<T> implements StreamConsumerBuilder<T> {
+
+    private final PulsarClientV5 client;
+    private final Schema<T> v5Schema;
+    private final ConsumerConfigurationData<T> conf = new ConsumerConfigurationData<>();
+    private String topicName;
+
+    StreamConsumerBuilderV5(PulsarClientV5 client, Schema<T> v5Schema) {
+        this.client = client;
+        this.v5Schema = v5Schema;
+    }
+
+    @Override
+    public StreamConsumer<T> subscribe() throws PulsarClientException {
+        try {
+            return subscribeAsync().join();
+        } catch (java.util.concurrent.CompletionException e) {
+            if (e.getCause() instanceof PulsarClientException pce) {
+                throw pce;
+            }
+            throw new PulsarClientException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<StreamConsumer<T>> subscribeAsync() {
+        if (topicName == null || topicName.isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Topic name is required"));
+        }
+        if (conf.getSubscriptionName() == null || conf.getSubscriptionName().isEmpty()) {
+            return CompletableFuture.failedFuture(
+                    new PulsarClientException.InvalidConfigurationException("Subscription name is required"));
+        }
+
+        TopicName topic = V5Utils.asScalableTopicName(topicName);
+        DagWatchClient dagWatch = new DagWatchClient(client.v4Client(), topic);
+
+        return dagWatch.start()
+                .thenCompose(initialLayout -> ScalableStreamConsumer.createAsync(
+                        client, v5Schema, conf, dagWatch, initialLayout));
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> topic(String... topicNames) {
+        if (topicNames.length > 0) {
+            this.topicName = topicNames[0];
+        }
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> subscriptionName(String subscriptionName) {
+        conf.setSubscriptionName(subscriptionName);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> seek(MessageId messageId) {
+        // Seek will be applied after consumer creation
+        // Store for later use
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> seek(Instant timestamp) {
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> subscriptionProperties(Map<String, String> properties) {
+        conf.setSubscriptionProperties(properties);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> subscriptionInitialPosition(SubscriptionInitialPosition position) {
+        conf.setSubscriptionInitialPosition(switch (position) {
+            case LATEST -> org.apache.pulsar.client.api.SubscriptionInitialPosition.Latest;
+            case EARLIEST -> org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest;
+        });
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> consumerName(String consumerName) {
+        conf.setConsumerName(consumerName);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> acknowledgmentGroupTime(Duration delay) {
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.MICROSECONDS.convert(delay));
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> readCompacted(boolean readCompacted) {
+        conf.setReadCompacted(readCompacted);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> replicateSubscriptionState(boolean replicate) {
+        conf.setReplicateSubscriptionState(replicate);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> encryptionPolicy(EncryptionPolicy policy) {
+        conf.setCryptoKeyReader(CryptoKeyReaderAdapter.wrap(policy.keyReader()));
+        conf.setCryptoFailureAction(
+                org.apache.pulsar.client.api.ConsumerCryptoFailureAction.valueOf(
+                        policy.failureAction().name()));
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> property(String key, String value) {
+        conf.getProperties().put(key, value);
+        return this;
+    }
+
+    @Override
+    public StreamConsumerBuilderV5<T> properties(Map<String, String> properties) {
+        conf.getProperties().putAll(properties);
+        return this;
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/V5Utils.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/V5Utils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * Internal utilities for the V5 client implementation.
+ */
+final class V5Utils {
+
+    private V5Utils() {
+    }
+
+    /**
+     * Parse a topic string and ensure it uses the {@code topic://} domain.
+     *
+     * <p>V5 scalable topics always use the {@code topic://} domain. If the user passes
+     * a bare name (e.g. {@code "my-topic"} or {@code "tenant/ns/my-topic"}), the standard
+     * {@link TopicName#get(String)} would default to {@code persistent://}. This method
+     * re-wraps the parsed name with the correct domain.
+     *
+     * <p>If the input already has the {@code topic://} scheme it is returned as-is.
+     */
+    static TopicName asScalableTopicName(String topic) {
+        TopicName tn = TopicName.get(topic);
+        if (tn.getDomain() == TopicDomain.topic) {
+            return tn;
+        }
+        return TopicName.get(TopicDomain.topic.value(),
+                tn.getNamespaceObject(), tn.getLocalName());
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/package-info.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;

--- a/pulsar-client-v5/src/main/resources/META-INF/services/org.apache.pulsar.client.api.v5.internal.PulsarClientProvider
+++ b/pulsar-client-v5/src/main/resources/META-INF/services/org.apache.pulsar.client.api.v5.internal.PulsarClientProvider
@@ -1,0 +1,1 @@
+org.apache.pulsar.client.impl.v5.PulsarClientProviderV5

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/CheckpointV5Test.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/CheckpointV5Test.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.v5.Checkpoint;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.testng.annotations.Test;
+
+public class CheckpointV5Test {
+
+    private static MessageId v4(long ledger, long entry) {
+        return new MessageIdImpl(ledger, entry, 0);
+    }
+
+    // --- Regular checkpoint roundtrip ---
+
+    @Test
+    public void testRegularCheckpointRoundtrip() throws Exception {
+        Instant created = Instant.ofEpochMilli(1_700_000_000_000L);
+        Map<Long, MessageId> positions = Map.of(
+                0L, v4(10, 20),
+                1L, v4(30, 40),
+                2L, v4(50, 60));
+        CheckpointV5 original = new CheckpointV5(positions, created);
+
+        byte[] bytes = original.toByteArray();
+        Checkpoint decoded = CheckpointV5.fromByteArray(bytes);
+
+        assertTrue(decoded instanceof CheckpointV5,
+                "expected CheckpointV5, got " + decoded.getClass());
+        CheckpointV5 decodedV5 = (CheckpointV5) decoded;
+        assertEquals(decodedV5.creationTime(), created);
+        assertEquals(decodedV5.segmentPositions().size(), 3);
+        assertEquals(decodedV5.segmentPositions().get(0L), v4(10, 20));
+        assertEquals(decodedV5.segmentPositions().get(1L), v4(30, 40));
+        assertEquals(decodedV5.segmentPositions().get(2L), v4(50, 60));
+    }
+
+    @Test
+    public void testRegularCheckpointWithEmptyPositions() throws Exception {
+        Instant created = Instant.ofEpochMilli(42L);
+        CheckpointV5 original = new CheckpointV5(Map.of(), created);
+
+        CheckpointV5 decoded = (CheckpointV5) CheckpointV5.fromByteArray(original.toByteArray());
+        assertEquals(decoded.creationTime(), created);
+        assertEquals(decoded.segmentPositions().size(), 0);
+    }
+
+    @Test
+    public void testSegmentPositionsIsImmutable() {
+        CheckpointV5 cp = new CheckpointV5(Map.of(0L, v4(1, 2)), Instant.EPOCH);
+        assertThrows(UnsupportedOperationException.class,
+                () -> cp.segmentPositions().put(1L, v4(5, 6)));
+    }
+
+    // --- EARLIEST / LATEST sentinels ---
+
+    @Test
+    public void testEarliestSentinelRoundtrip() throws Exception {
+        byte[] bytes = CheckpointV5.EARLIEST.toByteArray();
+        Checkpoint decoded = CheckpointV5.fromByteArray(bytes);
+        assertSame(decoded, CheckpointV5.EARLIEST,
+                "EARLIEST should deserialize back to the same singleton");
+    }
+
+    @Test
+    public void testLatestSentinelRoundtrip() throws Exception {
+        byte[] bytes = CheckpointV5.LATEST.toByteArray();
+        Checkpoint decoded = CheckpointV5.fromByteArray(bytes);
+        assertSame(decoded, CheckpointV5.LATEST);
+    }
+
+    @Test
+    public void testSentinelsHaveCompactEncoding() {
+        // Sentinels are a single type byte — keep the wire as tight as possible.
+        assertEquals(CheckpointV5.EARLIEST.toByteArray().length, 1);
+        assertEquals(CheckpointV5.LATEST.toByteArray().length, 1);
+    }
+
+    // --- Timestamp checkpoint ---
+
+    @Test
+    public void testTimestampCheckpointRoundtrip() throws Exception {
+        Instant ts = Instant.ofEpochMilli(1_234_567_890L);
+        Checkpoint cp = CheckpointV5.atTimestamp(ts);
+
+        assertEquals(cp.creationTime(), ts);
+
+        Checkpoint decoded = CheckpointV5.fromByteArray(cp.toByteArray());
+        assertEquals(decoded.creationTime(), ts);
+    }
+
+    @Test
+    public void testTimestampCheckpointEncodesTypeAndMillis() {
+        Instant ts = Instant.ofEpochMilli(555L);
+        byte[] bytes = CheckpointV5.atTimestamp(ts).toByteArray();
+        assertEquals(bytes.length, 1 + 8, "timestamp wire: [type][millis]");
+    }
+
+    // --- Error handling ---
+
+    @Test
+    public void testFromByteArrayRejectsNull() {
+        assertThrows(java.io.IOException.class, () -> CheckpointV5.fromByteArray(null));
+    }
+
+    @Test
+    public void testFromByteArrayRejectsEmpty() {
+        assertThrows(java.io.IOException.class, () -> CheckpointV5.fromByteArray(new byte[0]));
+    }
+
+    @Test
+    public void testFromByteArrayRejectsUnknownType() {
+        assertThrows(java.io.IOException.class,
+                () -> CheckpointV5.fromByteArray(new byte[]{127, 0, 0, 0, 0, 0, 0, 0, 0}));
+    }
+}

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayoutTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayoutTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+import org.apache.pulsar.common.api.proto.ScalableTopicDAG;
+import org.apache.pulsar.common.api.proto.SegmentState;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.Test;
+
+public class ClientSegmentLayoutTest {
+
+    private static final TopicName PARENT = TopicName.get("topic://tenant/ns/my-topic");
+
+    private static ScalableTopicDAG buildDag(long epoch) {
+        return new ScalableTopicDAG().setEpoch(epoch);
+    }
+
+    private static void addSegment(ScalableTopicDAG dag, long id, int start, int end,
+                                   SegmentState state) {
+        dag.addSegment()
+                .setSegmentId(id)
+                .setHashStart(start)
+                .setHashEnd(end)
+                .setState(state)
+                .setCreatedAtEpoch(0L);
+    }
+
+    // --- epoch / simple accessors ---
+
+    @Test
+    public void testEpochAndEmptyOptionalsFromEmptyDag() {
+        ScalableTopicDAG dag = buildDag(42L);
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertEquals(layout.epoch(), 42L);
+        assertTrue(layout.activeSegments().isEmpty());
+        assertTrue(layout.segmentBrokerUrls().isEmpty());
+        assertNull(layout.controllerBrokerUrl());
+        assertNull(layout.controllerBrokerUrlTls());
+    }
+
+    // --- active segments ---
+
+    @Test
+    public void testOnlyActiveSegmentsAreIncluded() {
+        ScalableTopicDAG dag = buildDag(1L);
+        addSegment(dag, 0L, 0x0000, 0x7FFF, SegmentState.SEALED);
+        addSegment(dag, 1L, 0x8000, 0xFFFF, SegmentState.ACTIVE);
+        addSegment(dag, 2L, 0x0000, 0x3FFF, SegmentState.ACTIVE);
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertEquals(layout.activeSegments().size(), 2);
+        for (ActiveSegment seg : layout.activeSegments()) {
+            assertFalse(seg.segmentId() == 0L, "sealed segment must be excluded");
+        }
+    }
+
+    @Test
+    public void testActiveSegmentsSortedByHashRangeStart() {
+        // Intentionally add segments in a non-sorted order.
+        ScalableTopicDAG dag = buildDag(1L);
+        addSegment(dag, 0L, 0x8000, 0xBFFF, SegmentState.ACTIVE);
+        addSegment(dag, 1L, 0x0000, 0x3FFF, SegmentState.ACTIVE);
+        addSegment(dag, 2L, 0xC000, 0xFFFF, SegmentState.ACTIVE);
+        addSegment(dag, 3L, 0x4000, 0x7FFF, SegmentState.ACTIVE);
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        // Sorted by hashRange.start ascending.
+        var segs = layout.activeSegments();
+        assertEquals(segs.size(), 4);
+        assertEquals(segs.get(0).hashRange().start(), 0x0000);
+        assertEquals(segs.get(1).hashRange().start(), 0x4000);
+        assertEquals(segs.get(2).hashRange().start(), 0x8000);
+        assertEquals(segs.get(3).hashRange().start(), 0xC000);
+    }
+
+    @Test
+    public void testActiveSegmentTopicNameBuiltFromParent() {
+        ScalableTopicDAG dag = buildDag(3L);
+        addSegment(dag, 5L, 0x0000, 0x7FFF, SegmentState.ACTIVE);
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertEquals(layout.activeSegments().size(), 1);
+        ActiveSegment seg = layout.activeSegments().get(0);
+        assertNotNull(seg.segmentTopicName());
+        // Segment topic names embed tenant/namespace/parent/descriptor — verify those pieces.
+        assertTrue(seg.segmentTopicName().contains("tenant"));
+        assertTrue(seg.segmentTopicName().contains("ns"));
+        assertTrue(seg.segmentTopicName().contains("my-topic"));
+    }
+
+    // --- immutability ---
+
+    @Test
+    public void testReturnedCollectionsAreImmutable() {
+        ScalableTopicDAG dag = buildDag(0L);
+        addSegment(dag, 0L, 0x0000, 0xFFFF, SegmentState.ACTIVE);
+        dag.addSegmentBroker().setSegmentId(0L).setBrokerUrl("pulsar://broker:6650");
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> layout.activeSegments().add(null));
+        assertThrows(UnsupportedOperationException.class,
+                () -> layout.segmentBrokerUrls().put(99L, "x"));
+    }
+
+    // --- broker URLs ---
+
+    @Test
+    public void testSegmentBrokerUrlsCollected() {
+        ScalableTopicDAG dag = buildDag(0L);
+        addSegment(dag, 0L, 0x0000, 0x7FFF, SegmentState.ACTIVE);
+        addSegment(dag, 1L, 0x8000, 0xFFFF, SegmentState.ACTIVE);
+        dag.addSegmentBroker().setSegmentId(0L).setBrokerUrl("pulsar://broker-a:6650");
+        dag.addSegmentBroker().setSegmentId(1L).setBrokerUrl("pulsar://broker-b:6650");
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertEquals(layout.segmentBrokerUrls().size(), 2);
+        assertEquals(layout.segmentBrokerUrls().get(0L), "pulsar://broker-a:6650");
+        assertEquals(layout.segmentBrokerUrls().get(1L), "pulsar://broker-b:6650");
+    }
+
+    // --- controller URL ---
+
+    @Test
+    public void testControllerBrokerUrlPropagated() {
+        ScalableTopicDAG dag = buildDag(0L);
+        dag.setControllerBrokerUrl("pulsar://controller:6650");
+        dag.setControllerBrokerUrlTls("pulsar+ssl://controller:6651");
+
+        ClientSegmentLayout layout = ClientSegmentLayout.fromProto(dag, PARENT);
+
+        assertEquals(layout.controllerBrokerUrl(), "pulsar://controller:6650");
+        assertEquals(layout.controllerBrokerUrlTls(), "pulsar+ssl://controller:6651");
+    }
+}

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/MessageIdV5Test.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/MessageIdV5Test.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.testng.annotations.Test;
+
+public class MessageIdV5Test {
+
+    private static MessageId v4(long ledger, long entry, int partition) {
+        return new MessageIdImpl(ledger, entry, partition);
+    }
+
+    // --- construction ---
+
+    @Test
+    public void testConstructorRejectsNullV4MessageId() {
+        assertThrows(NullPointerException.class,
+                () -> new MessageIdV5(null, 0L, Map.of()));
+    }
+
+    @Test
+    public void testConstructorWithoutPositionVectorUsesEmptyMap() {
+        MessageIdV5 id = new MessageIdV5(v4(1, 2, 0), 7L);
+        assertEquals(id.segmentId(), 7L);
+        assertEquals(id.positionVector().size(), 0);
+    }
+
+    @Test
+    public void testPositionVectorIsImmutable() {
+        Map<Long, MessageId> mutable = new HashMap<>();
+        mutable.put(0L, v4(1, 2, 0));
+        MessageIdV5 id = new MessageIdV5(v4(1, 2, 0), 0L, mutable);
+        // Mutating the source map after construction must not affect the stored vector.
+        mutable.put(1L, v4(3, 4, 0));
+        assertEquals(id.positionVector().size(), 1);
+        // The returned map is unmodifiable.
+        assertThrows(UnsupportedOperationException.class,
+                () -> id.positionVector().put(99L, v4(0, 0, 0)));
+    }
+
+    // --- equals / hashCode ---
+
+    @Test
+    public void testEqualsIsByV4IdAndSegmentId() {
+        MessageIdV5 a = new MessageIdV5(v4(1, 2, 0), 7L);
+        MessageIdV5 b = new MessageIdV5(v4(1, 2, 0), 7L);
+        MessageIdV5 c = new MessageIdV5(v4(1, 2, 0), 8L);
+        MessageIdV5 d = new MessageIdV5(v4(1, 3, 0), 7L);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertFalse(a.equals(c));
+        assertFalse(a.equals(d));
+        assertFalse(a.equals("not-a-message-id"));
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void testEqualsIgnoresPositionVector() {
+        // Position vector is diagnostic state for cumulative ack, not part of identity.
+        Map<Long, MessageId> posA = Map.of(0L, v4(1, 2, 0));
+        Map<Long, MessageId> posB = Map.of(0L, v4(1, 2, 0), 1L, v4(5, 6, 0));
+
+        MessageIdV5 a = new MessageIdV5(v4(1, 2, 0), 7L, posA);
+        MessageIdV5 b = new MessageIdV5(v4(1, 2, 0), 7L, posB);
+        assertEquals(a, b);
+    }
+
+    // --- compareTo ---
+
+    @Test
+    public void testCompareToBySegmentIdFirst() {
+        MessageIdV5 a = new MessageIdV5(v4(10, 10, 0), 1L);
+        MessageIdV5 b = new MessageIdV5(v4(0, 0, 0), 2L);
+        assertTrue(a.compareTo(b) < 0, "lower segmentId compares less regardless of v4 id");
+        assertTrue(b.compareTo(a) > 0);
+    }
+
+    @Test
+    public void testCompareToByV4WithinSameSegment() {
+        MessageIdV5 a = new MessageIdV5(v4(1, 2, 0), 0L);
+        MessageIdV5 b = new MessageIdV5(v4(1, 3, 0), 0L);
+        assertTrue(a.compareTo(b) < 0);
+        assertTrue(b.compareTo(a) > 0);
+        assertEquals(new MessageIdV5(v4(1, 2, 0), 0L).compareTo(a), 0);
+    }
+
+    @Test
+    public void testCompareToRejectsForeignType() {
+        MessageIdV5 id = new MessageIdV5(v4(1, 2, 0), 0L);
+        // A v5 MessageId that isn't a MessageIdV5 must be rejected by compareTo.
+        org.apache.pulsar.client.api.v5.MessageId foreign =
+                new org.apache.pulsar.client.api.v5.MessageId() {
+                    @Override
+                    public byte[] toByteArray() {
+                        return new byte[0];
+                    }
+
+                    @Override
+                    public int compareTo(org.apache.pulsar.client.api.v5.MessageId o) {
+                        return 0;
+                    }
+                };
+        assertThrows(IllegalArgumentException.class, () -> id.compareTo(foreign));
+    }
+
+    // --- byte-array roundtrip ---
+
+    @Test
+    public void testRoundtripWithoutPositionVector() throws Exception {
+        MessageIdV5 original = new MessageIdV5(v4(42, 99, 3), 7L);
+
+        byte[] bytes = original.toByteArray();
+        MessageIdV5 decoded = MessageIdV5.fromByteArray(bytes);
+
+        assertEquals(decoded.segmentId(), 7L);
+        assertEquals(decoded.v4MessageId(), v4(42, 99, 3));
+        assertEquals(decoded.positionVector().size(), 0);
+        assertEquals(decoded, original);
+    }
+
+    @Test
+    public void testRoundtripWithPositionVector() throws Exception {
+        Map<Long, MessageId> positions = Map.of(
+                0L, v4(1, 2, 0),
+                1L, v4(3, 4, 0),
+                2L, v4(5, 6, 0));
+        MessageIdV5 original = new MessageIdV5(v4(10, 20, 0), 1L, positions);
+
+        byte[] bytes = original.toByteArray();
+        MessageIdV5 decoded = MessageIdV5.fromByteArray(bytes);
+
+        assertEquals(decoded.segmentId(), 1L);
+        assertEquals(decoded.v4MessageId(), v4(10, 20, 0));
+        assertEquals(decoded.positionVector().size(), 3);
+        assertEquals(decoded.positionVector().get(0L), v4(1, 2, 0));
+        assertEquals(decoded.positionVector().get(1L), v4(3, 4, 0));
+        assertEquals(decoded.positionVector().get(2L), v4(5, 6, 0));
+    }
+
+    @Test
+    public void testFromByteArrayRejectsNull() {
+        assertThrows(java.io.IOException.class, () -> MessageIdV5.fromByteArray(null));
+    }
+
+    @Test
+    public void testFromByteArrayRejectsTooShort() {
+        assertThrows(java.io.IOException.class, () -> MessageIdV5.fromByteArray(new byte[3]));
+    }
+
+    @Test
+    public void testFromByteArrayRejectsGarbage() {
+        // Crafted header that advertises an implausibly large v4 payload length.
+        java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(12);
+        buf.putLong(0L);
+        buf.putInt(Integer.MAX_VALUE);
+        assertThrows(java.io.IOException.class,
+                () -> MessageIdV5.fromByteArray(buf.array()));
+    }
+
+    // --- sentinels ---
+
+    @Test
+    public void testEarliestAndLatestSentinels() {
+        assertNotNull(MessageIdV5.EARLIEST);
+        assertNotNull(MessageIdV5.LATEST);
+        assertEquals(MessageIdV5.EARLIEST.segmentId(), MessageIdV5.NO_SEGMENT);
+        assertEquals(MessageIdV5.LATEST.segmentId(), MessageIdV5.NO_SEGMENT);
+    }
+
+    // --- toString is non-fragile ---
+
+    @Test
+    public void testToStringContainsSegmentAndPositionInfo() {
+        MessageIdV5 id = new MessageIdV5(v4(1, 2, 0), 7L, Map.of(0L, v4(1, 1, 0)));
+        String s = id.toString();
+        assertTrue(s.contains("7"), s);
+        assertTrue(s.contains("positions="), s);
+    }
+}

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+import org.apache.pulsar.common.scalable.HashRange;
+import org.testng.annotations.Test;
+
+public class SegmentRouterTest {
+
+    private static ActiveSegment seg(long id, int start, int end) {
+        return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id);
+    }
+
+    // --- route(key, ...) ---
+
+    @Test
+    public void testRouteByKeyLandsOnCorrectSegment() {
+        SegmentRouter router = new SegmentRouter();
+        // 4 equal segments covering 0x0000..0xFFFF.
+        List<ActiveSegment> segments = List.of(
+                seg(0, 0x0000, 0x3FFF),
+                seg(1, 0x4000, 0x7FFF),
+                seg(2, 0x8000, 0xBFFF),
+                seg(3, 0xC000, 0xFFFF));
+
+        // Route a handful of keys and verify each hash falls inside the assigned range.
+        for (String key : new String[]{"a", "b", "c", "d", "e", "f", "g", "order-42", "customer-99"}) {
+            long id = router.route(key, segments);
+            ActiveSegment picked = segments.stream()
+                    .filter(s -> s.segmentId() == id)
+                    .findFirst().orElseThrow();
+            int hash = SegmentRouter.hash(key);
+            assertTrue(picked.hashRange().contains(hash),
+                    "key=" + key + " hash=" + hash + " picked=" + picked);
+        }
+    }
+
+    @Test
+    public void testRouteByKeyIsDeterministic() {
+        SegmentRouter router = new SegmentRouter();
+        List<ActiveSegment> segments = List.of(
+                seg(0, 0x0000, 0x7FFF),
+                seg(1, 0x8000, 0xFFFF));
+        long first = router.route("stable-key", segments);
+        for (int i = 0; i < 20; i++) {
+            assertEquals(router.route("stable-key", segments), first);
+        }
+    }
+
+    @Test
+    public void testRouteWithSingleSegmentAlwaysReturnsThatSegment() {
+        SegmentRouter router = new SegmentRouter();
+        List<ActiveSegment> segments = List.of(seg(0, 0x0000, 0xFFFF));
+        for (String key : new String[]{"a", "b", "zzzzzz", ""}) {
+            assertEquals(router.route(key, segments), 0L);
+        }
+    }
+
+    @Test
+    public void testRouteWithEmptyListThrows() {
+        SegmentRouter router = new SegmentRouter();
+        assertThrows(IllegalStateException.class, () -> router.route("k", List.of()));
+    }
+
+    @Test
+    public void testRouteWithIncompleteCoverageThrowsForUncoveredHash() {
+        // Only segments covering the first half of the hash space. Find a key whose hash
+        // lands in the uncovered half and verify the router throws.
+        SegmentRouter router = new SegmentRouter();
+        List<ActiveSegment> segments = List.of(seg(0, 0x0000, 0x7FFF));
+        String uncoveredKey = findKeyInRange(0x8000, 0xFFFF);
+        assertThrows(IllegalStateException.class,
+                () -> router.route(uncoveredKey, segments));
+    }
+
+    // --- routeRoundRobin ---
+
+    @Test
+    public void testRoundRobinCyclesThroughSegments() {
+        SegmentRouter router = new SegmentRouter();
+        List<ActiveSegment> segments = List.of(seg(0, 0, 0x3FFF), seg(1, 0x4000, 0x7FFF),
+                seg(2, 0x8000, 0xBFFF));
+        long first = router.routeRoundRobin(segments);
+        long second = router.routeRoundRobin(segments);
+        long third = router.routeRoundRobin(segments);
+        long fourth = router.routeRoundRobin(segments);
+
+        // Three distinct segments across three consecutive calls; fourth wraps to `first`.
+        Set<Long> distinct = new HashSet<>();
+        distinct.add(first);
+        distinct.add(second);
+        distinct.add(third);
+        assertEquals(distinct.size(), 3, "round-robin must visit every segment once per cycle");
+        assertEquals(fourth, first, "fourth call wraps back to the first segment");
+    }
+
+    @Test
+    public void testRoundRobinWithEmptyListThrows() {
+        SegmentRouter router = new SegmentRouter();
+        assertThrows(IllegalStateException.class, () -> router.routeRoundRobin(List.of()));
+    }
+
+    // --- hash ---
+
+    @Test
+    public void testHashIsWithin16BitSpace() {
+        // Every hash must fit in the 16-bit hash space [0, 0xFFFF].
+        for (int i = 0; i < 1000; i++) {
+            int h = SegmentRouter.hash("key-" + i);
+            assertTrue(h >= 0 && h <= 0xFFFF, "hash out of 16-bit space: " + h);
+        }
+    }
+
+    @Test
+    public void testHashIsDeterministic() {
+        assertEquals(SegmentRouter.hash("deterministic-key"),
+                SegmentRouter.hash("deterministic-key"));
+        assertEquals(SegmentRouter.hash(""), SegmentRouter.hash(""));
+    }
+
+    @Test
+    public void testHashStringAndBytesAgree() {
+        String key = "some-key";
+        int fromString = SegmentRouter.hash(key);
+        int fromBytes = SegmentRouter.hash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        assertEquals(fromString, fromBytes);
+    }
+
+    // --- helpers ---
+
+    /**
+     * Find any key whose hash lands in [start, end].
+     */
+    private static String findKeyInRange(int start, int end) {
+        for (int i = 0; i < 100_000; i++) {
+            String k = "probe-" + i;
+            int h = SegmentRouter.hash(k);
+            if (h >= start && h <= end) {
+                return k;
+            }
+        }
+        throw new AssertionError("Failed to find a key hashing into [" + start + ", " + end + "]");
+    }
+}

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/V5UtilsTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/V5UtilsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.Test;
+
+public class V5UtilsTest {
+
+    @Test
+    public void testAsScalableTopicNameKeepsExistingTopicDomain() {
+        TopicName tn = V5Utils.asScalableTopicName("topic://tenant/ns/my-topic");
+        assertEquals(tn.getDomain(), TopicDomain.topic);
+        assertEquals(tn.getTenant(), "tenant");
+        assertEquals(tn.getNamespacePortion(), "ns");
+        assertEquals(tn.getLocalName(), "my-topic");
+    }
+
+    @Test
+    public void testAsScalableTopicNameReturnsSameInstanceWhenAlreadyTopicDomain() {
+        // asScalableTopicName returns the parsed TopicName as-is when it already has the
+        // topic:// domain. TopicName.get caches by fully-qualified name, so the same string
+        // should yield an identical cached instance on the second call too.
+        TopicName first = V5Utils.asScalableTopicName("topic://tenant/ns/my-topic");
+        TopicName second = V5Utils.asScalableTopicName("topic://tenant/ns/my-topic");
+        assertSame(first, second);
+    }
+
+    @Test
+    public void testAsScalableTopicNameRewrapsBareLocalName() {
+        // A bare name parses as persistent:// by default; V5 must rewrap it as topic://.
+        TopicName tn = V5Utils.asScalableTopicName("my-topic");
+        assertEquals(tn.getDomain(), TopicDomain.topic);
+        assertEquals(tn.getLocalName(), "my-topic");
+        // default namespace is public/default
+        assertEquals(tn.getTenant(), "public");
+        assertEquals(tn.getNamespacePortion(), "default");
+    }
+
+    @Test
+    public void testAsScalableTopicNameRewrapsFullyQualifiedNonTopicDomain() {
+        // A persistent://... name must be rewrapped as topic://...
+        TopicName tn = V5Utils.asScalableTopicName("persistent://tenant/ns/my-topic");
+        assertEquals(tn.getDomain(), TopicDomain.topic);
+        assertEquals(tn.getTenant(), "tenant");
+        assertEquals(tn.getNamespacePortion(), "ns");
+        assertEquals(tn.getLocalName(), "my-topic");
+    }
+
+    @Test
+    public void testAsScalableTopicNameRewrapsShortForm() {
+        // tenant/ns/my-topic (no scheme) is parsed with the default persistent:// prefix.
+        TopicName tn = V5Utils.asScalableTopicName("tenant/ns/my-topic");
+        assertEquals(tn.getDomain(), TopicDomain.topic);
+        assertEquals(tn.getTenant(), "tenant");
+        assertEquals(tn.getNamespacePortion(), "ns");
+        assertEquals(tn.getLocalName(), "my-topic");
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -423,7 +423,7 @@ public class PulsarClientImpl implements PulsarClient {
         if (isScalableDomain(topic)) {
             return FutureUtil.failedFuture(
                 new PulsarClientException.InvalidTopicNameException(
-                    "Scalable topic domains (topic://, segment://) require the V5 client SDK."
+                    "Scalable topics (topic://) require the V5 client SDK."
                     + " Topic: '" + topic + "'"));
         }
 
@@ -482,6 +482,34 @@ public class PulsarClientImpl implements PulsarClient {
             return null;
         });
         return checkPartitions;
+    }
+
+    /**
+     * Create a producer bypassing the scalable domain check.
+     * This is intended for internal use by the V5 client to create segment producers.
+     */
+    public <T> CompletableFuture<Producer<T>> createSegmentProducerAsync(
+            ProducerConfigurationData conf, Schema<T> schema) {
+        if (conf == null) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.InvalidConfigurationException("Producer configuration undefined"));
+        }
+        String topic = conf.getTopicName();
+        if (!TopicName.isValid(topic)) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.InvalidTopicNameException("Invalid topic name: '" + topic + "'"));
+        }
+        return createProducerAsync(topic, conf, schema, null);
+    }
+
+    /**
+     * Reject {@code topic://} (PIP-460 scalable topics) — users on the V4 SDK must switch
+     * to the V5 SDK for those. The {@code segment://} domain is <em>internal</em>: it is
+     * how the V5 client talks to the individual backing topics of a scalable topic, so we
+     * deliberately let it through here.
+     */
+    private static boolean isScalableDomain(String topic) {
+        return TopicName.get(topic).isScalable();
     }
 
     private <T> CompletableFuture<Producer<T>> createProducerAsync(String topic,
@@ -592,7 +620,7 @@ public class PulsarClientImpl implements PulsarClient {
             if (isScalableDomain(topic)) {
                 return FutureUtil.failedFuture(
                     new PulsarClientException.InvalidTopicNameException(
-                        "Scalable topic domains (topic://, segment://) require the V5 client SDK."
+                        "Scalable topics (topic://) require the V5 client SDK."
                         + " Topic: '" + topic + "'"));
             }
         }
@@ -765,7 +793,7 @@ public class PulsarClientImpl implements PulsarClient {
             if (isScalableDomain(topic)) {
                 return FutureUtil.failedFuture(
                     new PulsarClientException.InvalidTopicNameException(
-                        "Scalable topic domains (topic://, segment://) require the V5 client SDK."
+                        "Scalable topics (topic://) require the V5 client SDK."
                         + " Topic: '" + topic + "'"));
             }
         }
@@ -1285,6 +1313,14 @@ public class PulsarClientImpl implements PulsarClient {
 
         try {
             TopicName topicName = TopicName.get(topic);
+            // Segment topics are internal storage units of a scalable topic and are never
+            // partitioned. Skip the broker partitioned-metadata lookup — the standard path
+            // isn't set up for the 4-component segment://tenant/ns/parent/descriptor name
+            // and will time out.
+            if (topicName.isSegment()) {
+                metadataFuture.complete(new PartitionedTopicMetadata(0));
+                return metadataFuture;
+            }
             AtomicLong opTimeoutMs = new AtomicLong(conf.getLookupTimeoutMs());
             Backoff backoff = Backoff.builder()
                     .initialDelay(Duration.ofNanos(conf.getInitialBackoffIntervalNanos()))
@@ -1468,10 +1504,5 @@ public class PulsarClientImpl implements PulsarClient {
 
     NameResolver<InetAddress> getNameResolver() {
         return DnsResolverUtil.adaptToNameResolver(addressResolver);
-    }
-
-    private static boolean isScalableDomain(String topic) {
-        TopicName topicName = TopicName.get(topic);
-        return topicName.isScalable() || topicName.isSegment();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -503,13 +503,13 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     /**
-     * Reject {@code topic://} (PIP-460 scalable topics) — users on the V4 SDK must switch
-     * to the V5 SDK for those. The {@code segment://} domain is <em>internal</em>: it is
-     * how the V5 client talks to the individual backing topics of a scalable topic, so we
-     * deliberately let it through here.
+     * Reject {@code topic://} (PIP-460 scalable topics) and {@code segment://} (the internal
+     * backing-topic domain used by V5 scalable topics). Users on the V4 SDK must switch to the
+     * V5 SDK for either.
      */
     private static boolean isScalableDomain(String topic) {
-        return TopicName.get(topic).isScalable();
+        TopicName topicName = TopicName.get(topic);
+        return topicName.isScalable() || topicName.isSegment();
     }
 
     private <T> CompletableFuture<Producer<T>> createProducerAsync(String topic,

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -262,4 +262,84 @@ public class PulsarClientImplTest {
                 .internalExecutorProvider(executorProvider)
                 .build();
     }
+
+    @Test
+    public void testRejectScalableDomainOnProducer() throws Exception {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        initializeEventLoopGroup(conf);
+        @Cleanup
+        PulsarClientImpl client = new PulsarClientImpl(conf, eventLoopGroup);
+
+        // topic:// domain should be rejected
+        var topicFuture = client.newProducer().topic("topic://tenant/ns/my-topic").createAsync();
+        var ex = topicFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+
+        // segment:// domain should be rejected
+        var segFuture = client.newProducer()
+                .topic("segment://tenant/ns/my-topic/0000-ffff-0").createAsync();
+        ex = segFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+    }
+
+    @Test
+    public void testRejectScalableDomainOnConsumer() throws Exception {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        initializeEventLoopGroup(conf);
+        @Cleanup
+        PulsarClientImpl client = new PulsarClientImpl(conf, eventLoopGroup);
+
+        // topic:// domain should be rejected
+        ConsumerConfigurationData<byte[]> consConf = new ConsumerConfigurationData<>();
+        consConf.getTopicNames().add("topic://tenant/ns/my-topic");
+        consConf.setSubscriptionName("sub");
+        var topicFuture = client.subscribeAsync(consConf);
+        var ex = topicFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException,
+                "Expected InvalidTopicNameException but got: " + ex);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+
+        // segment:// domain should be rejected
+        ConsumerConfigurationData<byte[]> segConf = new ConsumerConfigurationData<>();
+        segConf.getTopicNames().add("segment://tenant/ns/my-topic/0000-ffff-0");
+        segConf.setSubscriptionName("sub");
+        var segFuture = client.subscribeAsync(segConf);
+        ex = segFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+    }
+
+    @Test
+    public void testRejectScalableDomainOnReader() throws Exception {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        initializeEventLoopGroup(conf);
+        @Cleanup
+        PulsarClientImpl client = new PulsarClientImpl(conf, eventLoopGroup);
+
+        // topic:// domain should be rejected
+        org.apache.pulsar.client.impl.conf.ReaderConfigurationData<byte[]> readerConf =
+                new org.apache.pulsar.client.impl.conf.ReaderConfigurationData<>();
+        readerConf.getTopicNames().add("topic://tenant/ns/my-topic");
+        readerConf.setStartMessageId(org.apache.pulsar.client.api.MessageId.earliest);
+        var topicFuture = client.createReaderAsync(readerConf, org.apache.pulsar.client.api.Schema.BYTES);
+        var ex = topicFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException,
+                "Expected InvalidTopicNameException but got: " + ex);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+
+        // segment:// domain should be rejected
+        org.apache.pulsar.client.impl.conf.ReaderConfigurationData<byte[]> segReaderConf =
+                new org.apache.pulsar.client.impl.conf.ReaderConfigurationData<>();
+        segReaderConf.getTopicNames().add("segment://tenant/ns/my-topic/0000-ffff-0");
+        segReaderConf.setStartMessageId(org.apache.pulsar.client.api.MessageId.earliest);
+        var segFuture = client.createReaderAsync(segReaderConf, org.apache.pulsar.client.api.Schema.BYTES);
+        ex = segFuture.handle((v, t) -> t).join();
+        assertTrue(ex instanceof PulsarClientException.InvalidTopicNameException);
+        assertTrue(ex.getMessage().contains("V5 client SDK"));
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,6 +91,7 @@ project(":pulsar-client-original").projectDir = file("pulsar-client")
 include("pulsar-metadata")
 include("pulsar-opentelemetry")
 include("pulsar-client-messagecrypto-bc")
+include("pulsar-client-v5")
 
 
 // Tier 4


### PR DESCRIPTION
> **Stacked on top of #25565** (which is on top of #25564, which is on top of
> #25559). Opened as a draft; will be rebased on master once the upstream PRs
> land. Reviewers: the new code in this PR is the single commit titled
> "PIP-468: Implement V5 client with scalable topic producer and consumer
> types" — everything else comes from #25559 / #25564 / #25565.

## Summary

Fourth (and final for this series) PR in PIP-468. Adds the
`pulsar-client-v5` module that implements the V5 client API (PIP-466) for
scalable topics.

### Core pieces

- **`PulsarClientV5`** + **`PulsarClientBuilderV5`** — wraps the existing
  v4 `PulsarClientImpl` and adds the scalable-topic routing layer on top.
- **`PulsarClientProviderV5`** — ServiceLoader SPI implementation for the
  V5 API.
- **`ScalableTopicProducer`** — key-hashing segment routing, round-robin
  for unkeyed messages, per-segment underlying v4 producers.
- **`ScalableStreamConsumer`** — ordered, cumulative-ack consumer that
  receives segment assignments from the controller leader and drives v4
  per-segment consumers.
- **`ScalableQueueConsumer`** — controller-bypassing consumer that
  attaches to every segment and drains them with the receive-loop fix
  from the earlier iterations.
- **`ScalableCheckpointConsumer`** — unmanaged connector-style consumer
  that can resume from a caller-supplied `Checkpoint` across all
  segments.
- **`DagWatchClient`** — client-side handle for the DAG watch session;
  implements the `DagWatchSession` callback from the protocol PR.
- **`MessageIdV5`** — V5 message-id wrapping a v4 id with a per-segment
  position vector for cumulative ack.
- **`CheckpointV5`** — caller-durable checkpoint including
  `EARLIEST` / `LATEST` sentinels and timestamp variants.
- **`ClientSegmentLayout`** — client-side view of the DAG built from a
  `ScalableTopicDAG` protobuf.
- **`SegmentRouter`** — 16-bit Murmur3 key-hash routing and round-robin
  for empty keys.
- **`AuthenticationAdapter`**, **`CryptoKeyReaderAdapter`**,
  **`SchemaAdapter`** — bridge V5 API types to the underlying v4
  implementations.
- **`V5Utils`** — small helpers (e.g. `asScalableTopicName` which rewraps
  a parsed name with the `topic://` domain).

### Supporting v4 change

- `PulsarClientImpl.createSegmentProducerAsync` — internal entry point
  for the V5 client to create producers on `segment://` topics,
  bypassing the scalable-domain guard that's meant for user-facing
  producer creation.

## Tests

### New unit test classes (48 tests)

- **`V5UtilsTest`** (5 tests) — `asScalableTopicName` on bare name /
  short form / persistent:// / topic:// inputs; also pins the
  caching behavior for the topic:// fast path.
- **`SegmentRouterTest`** (10 tests) — key-routing determinism and
  correctness (hash lands inside the picked segment's range),
  single-segment, empty-segments error, uncovered-hash error,
  round-robin cycling + wrap, hash 16-bit bound, string/bytes agree.
- **`MessageIdV5Test`** (15 tests) — constructor + null-rejection,
  immutable position vector, equals/hashCode (position vector is
  diagnostic, not identity), compareTo by segment then v4 id, foreign-
  type rejection, byte-array roundtrip with and without position
  vector, malformed input handling, EARLIEST/LATEST sentinels,
  `toString`.
- **`ClientSegmentLayoutTest`** (7 tests) — `fromProto` filters active
  segments, sorts by hash-range start, builds segment topic names,
  collects broker URLs, propagates the controller URL (plus TLS
  variant), and the returned collections are immutable.
- **`CheckpointV5Test`** (11 tests) — regular checkpoint roundtrip
  with multi-segment positions, empty positions, EARLIEST/LATEST
  sentinel roundtrip (sentinel identity preserved, 1-byte compact
  wire), timestamp variant roundtrip + wire shape, null / empty /
  unknown-type input rejection, immutable positions map.

### Already exercised by prior PRs in this stack

- `PulsarClientImplTest.createSegmentProducerAsync*` — on #25565 (the
  small v4 change we added here is also exercised there).
- Scalable tests for the broker side — 93 tests in #25565 / #25564 /
  #25559.
- Admin-API data-class tests — 24 tests in #25565.
- Protocol-command roundtrip tests — 8 tests in #25564.

## Test plan

- [x] `./gradlew :pulsar-client-v5:test --tests
      "org.apache.pulsar.client.impl.v5.*"` — 48/48 new tests pass.
- [x] Full compile of all impacted modules
      (`pulsar-client-v5`, `pulsar-client-original`, `pulsar-broker`,
      `pulsar-common`, `pulsar-client-admin-api`).
- [x] Checkstyle clean on all modules touched.