### PR TITLE
[fix][client] Fix bug Improper Neutralization in TransactionMetaStoreHandler (CWE-74)

### DIFF
--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
         exclude(group = "io.netty")
     }
     implementation(libs.commons.lang3)
+    implementation(libs.commons.text)
     implementation(libs.asynchttpclient)
     implementation(libs.netty.reactive.streams)
     implementation(libs.slog)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.apache.commons.text.StringEscapeUtils.escapeJava;
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
@@ -29,6 +30,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -393,7 +395,7 @@ public class TransactionMetaStoreHandler extends HandlerState
     }
 
     public CompletableFuture<Void> addSubscriptionToTxn(TxnID txnID, List<Subscription> subscriptionList) {
-            log.debug().attr("subscription", subscriptionList).attr("txn", txnID).log("Add subscription to txn.");
+        log.debug().attr("subscription", subscriptionList).attr("txn", txnID).log("Add subscription to txn.");
 
         CompletableFuture<Void> callback = new CompletableFuture<>();
         if (!canSendRequest(callback)) {
@@ -403,7 +405,7 @@ public class TransactionMetaStoreHandler extends HandlerState
         ByteBuf cmd = Commands.newAddSubscriptionToTxn(
                 requestId, txnID.getLeastSigBits(), txnID.getMostSigBits(), subscriptionList);
         String description = String.format("Add subscription %s to TXN %s", toStringSubscriptionList(subscriptionList),
-                String.valueOf(txnID));
+                txnID);
         OpForVoidCallBack op = OpForVoidCallBack.create(cmd, callback, client, description, cnx());
         internalPinnedExecutor.execute(() -> {
             pendingRequests.put(requestId, op);
@@ -419,11 +421,13 @@ public class TransactionMetaStoreHandler extends HandlerState
         if (list == null || list.isEmpty()) {
             return "[]";
         }
-        StringBuilder builder = new StringBuilder("[");
+
+        StringJoiner joiner = new StringJoiner("", "[", "]");
         for (Subscription subscription : list) {
-            builder.append(String.format("%s %s", subscription.getTopic(), subscription.getSubscription()));
+            joiner.add(escapeJava(subscription.getTopic()) + " " + escapeJava(subscription.getSubscription()));
         }
-        return builder.append("]").toString();
+
+        return joiner.toString();
     }
 
     public void handleAddSubscriptionToTxnResponse(CommandAddSubscriptionToTxnResponse response) {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandlerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TransactionMetaStoreHandlerTest.java
@@ -26,10 +26,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 import io.netty.channel.Channel;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.common.api.proto.Subscription;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
@@ -59,6 +63,65 @@ public class TransactionMetaStoreHandlerTest {
         assertTrue(connectFuture.isCompletedExceptionally());
         assertEquals(handler.getState(), HandlerState.State.Terminated);
         verify(cnx, times(0)).registerTransactionMetaStoreHandler(anyLong(), any());
+
+        client.close();
+    }
+
+    @Test
+    public void testAddSubscriptionToTxnDescriptionSanitized() throws Exception {
+        final PulsarClientImpl client = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650").build();
+        final CompletableFuture<Void> connectFuture = new CompletableFuture<>();
+        final TransactionMetaStoreHandler handler = new TransactionMetaStoreHandler(
+                0L, client, "topic", connectFuture);
+
+        handler.setState(HandlerState.State.Terminated);
+
+        Subscription subscription = new Subscription();
+        subscription.setTopic("topic\nnewline");
+        subscription.setSubscription("subscription\ttab");
+
+        CompletableFuture<Void> future = handler.addSubscriptionToTxn(
+                new TxnID(1L, 1L), List.of(subscription));
+
+        Awaitility.await().atMost(Duration.ofSeconds(3)).until(future::isDone);
+        assertTrue(future.isCompletedExceptionally());
+
+        future.exceptionally(exception -> {
+            assertTrue(exception.getMessage().contains("topic\\nnewline"));
+            assertTrue(exception.getMessage().contains("subscription\\ttab"));
+            assertFalse(exception.getMessage().contains("\n"));
+            assertFalse(exception.getMessage().contains("\t"));
+            return null;
+        });
+
+        client.close();
+    }
+
+    @Test
+    public void testAddSubscriptionToTxnDescriptionBracketInjection() throws Exception {
+        final PulsarClientImpl client = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl("pulsar://localhost:6650").build();
+        final CompletableFuture<Void> connectFuture = new CompletableFuture<>();
+        final TransactionMetaStoreHandler handler = new TransactionMetaStoreHandler(
+                0L, client, "topic", connectFuture);
+
+        handler.setState(HandlerState.State.Terminated);
+
+        Subscription subscription = new Subscription();
+        subscription.setTopic("topic] [injected");
+        subscription.setSubscription("sub");
+
+        CompletableFuture<Void> future = handler.addSubscriptionToTxn(
+                new TxnID(1L, 1L), List.of(subscription));
+
+        Awaitility.await().atMost(Duration.ofSeconds(3)).until(future::isDone);
+        assertTrue(future.isCompletedExceptionally());
+
+        future.exceptionally(exception -> {
+            assertFalse(exception.getMessage().contains("] [injected"));
+            return null;
+        });
 
         client.close();
     }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/25324

## Motivation

`TransactionMetaStoreHandler.toStringSubscriptionList()` builds a string from user-controlled `topic` and `subscription` fields without sanitizing them. This violates CWE-74 (Injection) — malicious input containing special characters such as newlines (`\n`), tabs (`\t`), or brackets could forge log entries or corrupt exception messages that surface to callers.

## Modifications

- Applied `StringEscapeUtils.escapeJava()` from Apache Commons Text (already a transitive dependency) to sanitize `topic` and `subscription` fields in `toStringSubscriptionList()`
- Replaced manual `StringBuilder` concatenation with `StringJoiner` for cleaner output formatting

## Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added `testAddSubscriptionToTxnDescriptionSanitized` to verify that non-printable characters (`\n`, `\t`) in topic/subscription fields are escaped in the output
- Added `testAddSubscriptionToTxnDescriptionBracketInjection` to verify that bracket injection attempts in topic fields do not corrupt the output structure

## Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment