### PR TITLE
[fix][client] Stabilize scaleReceiverQueueHint against concurrent enqueue/take

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2290,8 +2290,13 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     @Override
     protected void updateAutoScaleReceiverQueueHint() {
+        // Called from the enqueue path right after offer(): the message we just added may
+        // already have been drained by a concurrent take() (which doesn't hold
+        // incomingQueueLock), so clamp incomingMessages.size() to at least 1 to reflect the
+        // post-enqueue state and avoid spuriously clearing the hint in that race.
         boolean prev = scaleReceiverQueueHint.getAndSet(
-                getAvailablePermits() + incomingMessages.size() >= getCurrentReceiverQueueSize());
+                getAvailablePermits() + Math.max(1, incomingMessages.size())
+                        >= getCurrentReceiverQueueSize());
         log.debug().attr("updateautoscalereceiverqueuehint", prev)
                 .attr("get", scaleReceiverQueueHint.get())
                 .log("updateAutoScaleReceiverQueueHint ->");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/ConsumerImplTest.java
@@ -309,4 +309,36 @@ public class ConsumerImplTest {
         Pattern consumerNamePattern = Pattern.compile("[a-zA-Z0-9]{5}");
         assertTrue(consumerNamePattern.matcher(consumer.getConsumerName()).matches());
     }
+
+    @Test(invocationTimeOut = 1000)
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testUpdateAutoScaleReceiverQueueHintRaceWithConcurrentDrain() {
+        // Regression test: ConsumerBase.enqueueMessageAndCheckBatchReceive() calls
+        // updateAutoScaleReceiverQueueHint() after incomingMessages.offer(message) under
+        // incomingQueueLock, but incomingMessages.take()/poll() does NOT acquire that lock.
+        // A consumer thread draining the queue in parallel with the client-IO thread's
+        // enqueue can therefore remove the just-offered message before the hint read of
+        // incomingMessages.size() runs. The hint would then see size() == 0 and be
+        // spuriously cleared, even though the pipeline was full at enqueue time.
+        consumerConf = new ConsumerConfigurationData<>();
+        consumerConf.setAutoScaledReceiverQueueSizeEnabled(true);
+        createConsumer(consumerConf);
+        consumer.setCurrentReceiverQueueSize(1);
+
+        // Simulate the race: enqueue a message and drain it before the hint is computed.
+        MessageImpl message = mock(MessageImpl.class);
+        when(message.size()).thenReturn(100);
+        consumer.incomingMessages.offer(message);
+        consumer.incomingMessages.poll();
+
+        Assert.assertEquals(consumer.incomingMessages.size(), 0);
+        Assert.assertEquals(consumer.getAvailablePermits(), 0);
+        Assert.assertEquals(consumer.getCurrentReceiverQueueSize(), 1);
+
+        consumer.updateAutoScaleReceiverQueueHint();
+
+        Assert.assertTrue(consumer.scaleReceiverQueueHint.get(),
+                "Hint must reflect the post-enqueue state (pipeline had >=1 message); "
+                        + "a concurrent drain of the just-enqueued message must not clear it.");
+    }
 }


### PR DESCRIPTION
### Motivation

`ConsumerImpl.updateAutoScaleReceiverQueueHint()` is invoked from `ConsumerBase.enqueueMessageAndCheckBatchReceive()` immediately after `incomingMessages.offer(message)`, under `incomingQueueLock`. The hint is then derived from `getAvailablePermits() + incomingMessages.size()`. But `incomingMessages.take()` (and `poll()`) do not acquire `incomingQueueLock`, so a consumer-thread `take()` that races with the enqueue can drain the just-offered message before the hint is recomputed. The read of `incomingMessages.size()` then observes zero, and the hint is spuriously cleared to `false` even though the pipeline was momentarily full.

This produces flakiness in `ConsumerMemoryLimitTest#testMultiPulsarClientConsumerShareMemoryLimitController` — inside its receive() loop the consumer-thread `take()` frequently overlaps with the client IO thread enqueue, so the hint ends up `false` even though the queue was at capacity for every message. The subsequent `receiveAsync()` therefore fails to trigger `expectMoreIncomingMessages()` (the `CAS true→false` fails) and the receiver queue never expands to 2, causing the `Awaitility.await()` to time out.

Example failing CI run: https://github.com/apache/pulsar/actions/runs/24909862708/job/72949410128

I reproduced it locally with `@Test(invocationCount = 100)` — roughly 1 in ~50 runs fails; 100/100 pass after the fix.

### Modifications

`ConsumerImpl.updateAutoScaleReceiverQueueHint()`: clamp `incomingMessages.size()` to at least 1 in the enqueue-time hint calculation. The method is only called from the enqueue path, where a message was just added, so the post-enqueue state of the pipeline is at least 1 regardless of any concurrent drain. In the non-racy case `incomingMessages.size() >= 1` and `Math.max(1, …)` is a no-op.

Adds `ConsumerImplTest#testUpdateAutoScaleReceiverQueueHintRaceWithConcurrentDrain`, a focused unit test that simulates the `offer + concurrent drain` sequence deterministically and asserts the hint is retained. It fails without the clamp and passes with it.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added `ConsumerImplTest#testUpdateAutoScaleReceiverQueueHintRaceWithConcurrentDrain` covering the race deterministically.
- Locally confirmed that `testMultiPulsarClientConsumerShareMemoryLimitController` passes 100/100 with the fix (and reliably fails within a handful of invocations without it).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment