### PR TITLE
[fix][test] Fix flaky ManagedLedgerTest.testInvalidateReadHandleWhenConsumed

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4023,6 +4023,12 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
             ledger.addEntry(String.valueOf(i).getBytes(Encoding));
         }
 
+        // Wait for all ledger rolls to complete before reading. With maxEntriesPerLedger=1 and 3 entries,
+        // we expect 4 ledgers (3 closed + 1 current empty). If we read before the last roll completes,
+        // the last entry is read from currentLedger directly (not via ledgerCache), causing ledgerCache
+        // to have fewer entries than expected.
+        Awaitility.await().untilAsserted(() -> assertEquals(ledger.ledgers.size(), 4));
+
         // clear the cache to avoid flakiness
         factory.getEntryCacheManager().clear();
 


### PR DESCRIPTION
### Motivation

`ManagedLedgerTest.testInvalidateReadHandleWhenConsumed` is flaky on CI with `expected [3] but found [2]` on `assertEquals(ledger.ledgerCache.size(), 3)`.

With `maxEntriesPerLedger=1` and 3 entries, the test expects 4 ledgers (3 closed + 1 current empty). When the read happens before the last ledger roll completes, the final entry is read directly from `currentLedger` instead of via `ledgerCache`, so `ledgerCache.size()` is 2 instead of the expected 3.

Same root cause and fix as #25495 (which fixed the sibling `testInvalidateReadHandleWhenDeleteLedger`).

### Modifications

Wait for `ledger.ledgers.size() == 4` before clearing the entry cache and reading entries.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.