### PR TITLE
[fix][test] Fix flaky ExtensibleLoadManagerImplTest.testLoadBalancerServiceUnitTableViewSyncer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -1376,10 +1376,15 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 assertTrue(pulsar2.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
         makeSecondaryAsLeader();
         makePrimaryAsLeader();
-        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        // playLeader()/playFollower() run on a single-threaded loadManagerExecutor, so
+        // playLeader() on the new leader can be queued behind a still-running playFollower()
+        // from the prior demotion. Under CI load this serial chain plus the syncer.start()
+        // work (which opens both table views and runs syncExistingItems/syncTailItems)
+        // can take longer than 30s, so use a more generous timeout here.
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertTrue(primaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
-        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertFalse(secondaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
         ServiceConfiguration defaultConf = getDefaultConf();
@@ -1590,10 +1595,10 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         Awaitility.await().untilAsserted(() ->
                 assertFalse(pulsar2.getConfiguration().isLoadBalancerServiceUnitTableViewSyncerEnabled()));
         makeSecondaryAsLeader();
-        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertFalse(primaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
-        Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        Awaitility.await().atMost(60, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertFalse(secondaryLoadManager.getServiceUnitStateTableViewSyncer()
                         .isActive()));
     }


### PR DESCRIPTION
### Motivation

`testLoadBalancerServiceUnitTableViewSyncer` is flaky with `expected [true] but found [false]` after the 30s wait for `primaryLoadManager.getServiceUnitStateTableViewSyncer().isActive()`.

The `loadManagerExecutor` is a single-threaded scheduled executor. After `makeSecondaryAsLeader()` followed immediately by `makePrimaryAsLeader()`, the new leader's `playLeader()` is queued behind any still-running `playFollower()` from the prior demotion. `syncer.start()` itself opens both table views and runs `syncExistingItems` + `syncTailItems`. Under CI load this serial chain can exceed 30s.

### Modifications

Increase the timeout from 30s to 60s for the syncer-state checks after both leader transitions, and apply the same to the symmetric pair in the cleanup section after the dynamic config is removed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Locally verified with 3 successful back-to-back runs of the test.