### PR TITLE
[feat][broker] PIP-466: Add supports_scalable_topics feature flag and broker config

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1292,6 +1292,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = false,
             category = CATEGORY_POLICIES,
+            doc = "Enables the scalable-topics V5 API on this broker. When disabled, "
+                    + "the broker advertises supports_scalable_topics=false in CommandConnected "
+                    + "feature flags and rejects scalable-topic commands from clients."
+    )
+    private boolean scalableTopicsEnabled = true;
+
+    @FieldContext(
+            dynamic = false,
+            category = CATEGORY_POLICIES,
             doc = "Max length of subscription pattern"
     )
     private int subscriptionPatternMaxLength = 50;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSender.java
@@ -68,7 +68,8 @@ public interface PulsarCommandSender {
 
     void sendGetOrCreateSchemaErrorResponse(long requestId, ServerError error, String errorMessage);
 
-    void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers);
+    void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers,
+                               boolean supportsScalableTopics);
 
     void sendLookupResponse(String brokerServiceUrl, String brokerServiceUrlTls, boolean authoritative,
                             CommandLookupTopicResponse.LookupType response, long requestId,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -174,9 +174,10 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     }
 
     @Override
-    public void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers) {
+    public void sendConnectedResponse(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers,
+                                      boolean supportsScalableTopics) {
         BaseCommand command = Commands.newConnectedCommand(
-                clientProtocolVersion, maxMessageSize, supportsTopicWatchers);
+                clientProtocolVersion, maxMessageSize, supportsTopicWatchers, supportsScalableTopics);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
         writeAndFlush(outBuf);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -216,6 +216,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
     private final ConcurrentLongHashMap<CompletableFuture<Consumer>> consumers;
     private final boolean enableSubscriptionPatternEvaluation;
     private final boolean enableTopicListWatcher;
+    private final boolean scalableTopicsEnabled;
     private final int maxSubscriptionPatternLength;
     private final TopicListService topicListService;
     private final BrokerInterceptor brokerInterceptor;
@@ -383,6 +384,7 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         this.maxTopicListInFlightLimiter = pulsar.getBrokerService().getMaxTopicListInFlightLimiter();
         this.enableSubscriptionPatternEvaluation = conf.isEnableBrokerSideSubscriptionPatternEvaluation();
         this.enableTopicListWatcher = conf.isEnableBrokerTopicListWatcher();
+        this.scalableTopicsEnabled = conf.isScalableTopicsEnabled();
         this.maxSubscriptionPatternLength = conf.getSubscriptionPatternMaxLength();
         this.topicListService = new TopicListService(pulsar, this,
                 enableSubscriptionPatternEvaluation, maxSubscriptionPatternLength);
@@ -759,6 +761,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         log.debug().attr("topic", topicStr).attr("sessionId", sessionId)
                 .log("Received ScalableTopicLookup");
 
+        if (!scalableTopicsEnabled) {
+            ctx.writeAndFlush(Commands.newScalableTopicError(sessionId, ServerError.NotAllowedError,
+                    "Scalable topics are disabled on this broker"));
+            return;
+        }
+
         final TopicName topicName;
         try {
             topicName = TopicName.get(topicStr);
@@ -849,6 +857,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
         log.debug().attr("topic", topicStr).attr("subscription", subscription)
                 .attr("consumerName", consumerName).attr("requestId", requestId)
                 .log("Received ScalableTopicSubscribe");
+
+        if (!scalableTopicsEnabled) {
+            getCommandSender().sendScalableTopicSubscribeError(requestId, ServerError.NotAllowedError,
+                    "Scalable topics are disabled on this broker");
+            return;
+        }
 
         final TopicName topicName;
         try {
@@ -1117,7 +1131,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
             }
             maybeScheduleAuthenticationCredentialsRefresh();
         }
-        writeAndFlush(Commands.newConnected(clientProtoVersion, maxMessageSize, enableTopicListWatcher));
+        writeAndFlush(Commands.newConnected(clientProtoVersion, maxMessageSize, enableTopicListWatcher,
+                scalableTopicsEnabled));
         state = State.Connected;
         service.getPulsarStats().recordConnectionCreateSuccess();
         log.debug()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -771,7 +771,7 @@ public class ClientErrorsTest {
         AtomicBoolean msgSent = new AtomicBoolean();
         mockBrokerService.setHandleConnect((ctx, connect) -> {
             channelCtx.set(ctx);
-            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false));
+            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false, false));
             if (numOfConnections.incrementAndGet() == 2) {
                 // close the cnx immediately when trying to connect the 2nd time
                 ctx.channel().close();
@@ -812,7 +812,7 @@ public class ClientErrorsTest {
         CountDownLatch latch = new CountDownLatch(1);
         mockBrokerService.setHandleConnect((ctx, connect) -> {
             channelCtx.set(ctx);
-            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false));
+            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false, false));
             if (numOfConnections.incrementAndGet() == 2) {
                 // close the cnx immediately when trying to connect the 2nd time
                 ctx.channel().close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -145,7 +145,7 @@ public class MockBrokerService {
                 return;
             }
             // default
-            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false));
+            ctx.writeAndFlush(Commands.newConnected(connect.getProtocolVersion(), false, false));
         }
 
         @Override

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/PulsarClientException.java
@@ -743,7 +743,8 @@ public class PulsarClientException extends IOException {
      * "supports_topic_watchers" was introduced at "2.11" and is no longer supported, so skip this enum.
      */
     public enum FailedFeatureCheck {
-        SupportsGetPartitionedMetadataWithoutAutoCreation;
+        SupportsGetPartitionedMetadataWithoutAutoCreation,
+        SupportsScalableTopics;
     }
 
     /**

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
@@ -74,6 +74,13 @@ final class DagWatchClient implements DagWatchSession, AutoCloseable {
         v4Client.getConnection(topicName.toString())
                 .thenAccept(cnx -> {
                     this.cnx = cnx;
+                    if (!cnx.isSupportsScalableTopics()) {
+                        initialLayoutFuture.completeExceptionally(
+                                new PulsarClientException.FeatureNotSupportedException(
+                                        "Broker does not support scalable topics",
+                                        PulsarClientException.FailedFeatureCheck.SupportsScalableTopics));
+                        return;
+                    }
                     // Register this session to receive updates
                     cnx.registerDagWatchSession(sessionId, this);
 

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
@@ -126,6 +126,13 @@ final class ScalableConsumerClient implements ScalableConsumerSession, AutoClose
                 })
                 .thenAccept(cnx -> {
                     this.cnx = cnx;
+                    if (!cnx.isSupportsScalableTopics()) {
+                        initialAssignmentFuture.completeExceptionally(
+                                new PulsarClientException.FeatureNotSupportedException(
+                                        "Broker does not support scalable topics",
+                                        PulsarClientException.FailedFeatureCheck.SupportsScalableTopics));
+                        return;
+                    }
                     cnx.registerScalableConsumerSession(consumerId, this);
 
                     long requestId = v4Client.newRequestId();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -219,6 +219,8 @@ public class ClientCnx extends PulsarHandler {
     private boolean brokerSupportsReplDedupByLidAndEid;
     @Getter
     private boolean supportsTopicWatcherReconcile;
+    @Getter
+    private boolean supportsScalableTopics;
 
     /** Idle stat. **/
     @Getter
@@ -435,6 +437,8 @@ public class ClientCnx extends PulsarHandler {
             connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsReplDedupByLidAndEid();
         supportsTopicWatcherReconcile =
             connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatcherReconcile();
+        supportsScalableTopics =
+            connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsScalableTopics();
 
         // set remote protocol version to the correct version before we complete the connection future
         setRemoteEndpointProtocolVersion(connected.getProtocolVersion());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/protocol/Commands.java
@@ -305,12 +305,14 @@ public class Commands {
         return cmd;
     }
 
-    public static ByteBuf newConnected(int clientProtocoVersion,  boolean supportsTopicWatchers) {
-        return newConnected(clientProtocoVersion, INVALID_MAX_MESSAGE_SIZE, supportsTopicWatchers);
+    public static ByteBuf newConnected(int clientProtocoVersion, boolean supportsTopicWatchers,
+                                       boolean supportsScalableTopics) {
+        return newConnected(clientProtocoVersion, INVALID_MAX_MESSAGE_SIZE, supportsTopicWatchers,
+                supportsScalableTopics);
     }
 
     public static BaseCommand newConnectedCommand(int clientProtocolVersion, int maxMessageSize,
-                                                  boolean supportsTopicWatchers) {
+                                                  boolean supportsTopicWatchers, boolean supportsScalableTopics) {
         BaseCommand cmd = localCmd(Type.CONNECTED);
         CommandConnected connected = cmd.setConnected()
                 .setServerVersion("Pulsar Server" + PulsarVersion.getVersion());
@@ -330,11 +332,14 @@ public class Commands {
         connected.setFeatureFlags().setSupportsGetPartitionedMetadataWithoutAutoCreation(true);
         connected.setFeatureFlags().setSupportsReplDedupByLidAndEid(true);
         connected.setFeatureFlags().setSupportsTopicWatcherReconcile(supportsTopicWatchers);
+        connected.setFeatureFlags().setSupportsScalableTopics(supportsScalableTopics);
         return cmd;
     }
 
-    public static ByteBuf newConnected(int clientProtocolVersion, int maxMessageSize,  boolean supportsTopicWatchers) {
-        return serializeWithSize(newConnectedCommand(clientProtocolVersion, maxMessageSize, supportsTopicWatchers));
+    public static ByteBuf newConnected(int clientProtocolVersion, int maxMessageSize, boolean supportsTopicWatchers,
+                                       boolean supportsScalableTopics) {
+        return serializeWithSize(newConnectedCommand(clientProtocolVersion, maxMessageSize, supportsTopicWatchers,
+                supportsScalableTopics));
     }
 
     public static ByteBuf newAuthChallenge(String authMethod, AuthData brokerData, int clientProtocolVersion) {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -316,6 +316,7 @@ message FeatureFlags {
   optional bool supports_get_partitioned_metadata_without_auto_creation = 5 [default = false];
   optional bool supports_repl_dedup_by_lid_and_eid = 6 [default = false];
   optional bool supports_topic_watcher_reconcile = 7 [default = false];
+  optional bool supports_scalable_topics = 8 [default = false];
 }
 
 message CommandConnected {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -454,7 +454,7 @@ public class ProxyConnection extends PulsarHandler {
             state = State.ProxyLookupRequests;
             lookupProxyHandler = service.newLookupProxyHandler(this);
             startAuthRefreshTaskIfNotStarted();
-            final ByteBuf msg = Commands.newConnected(protocolVersionToAdvertise, false);
+            final ByteBuf msg = Commands.newConnected(protocolVersionToAdvertise, false, false);
             writeAndFlush(msg);
         }
     }
@@ -467,7 +467,8 @@ public class ProxyConnection extends PulsarHandler {
             int maxMessageSize =
                     connected.hasMaxMessageSize() ? connected.getMaxMessageSize() : Commands.INVALID_MAX_MESSAGE_SIZE;
             final ByteBuf msg = Commands.newConnected(connected.getProtocolVersion(), maxMessageSize,
-                    connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatchers());
+                    connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsTopicWatchers(),
+                    connected.hasFeatureFlags() && connected.getFeatureFlags().isSupportsScalableTopics());
             writeAndFlush(msg);
             // Start auth refresh task only if we are not forwarding authorization credentials
             if (!service.getConfiguration().isForwardAuthorizationCredentials()) {


### PR DESCRIPTION
Closes #25597

PIP: PIP-466

### Motivation

PIP-466 introduced six new wire commands for the V5 scalable-topics API
(`SCALABLE_TOPIC_LOOKUP`, `SCALABLE_TOPIC_UPDATE`, `SCALABLE_TOPIC_CLOSE`,
`SCALABLE_TOPIC_SUBSCRIBE`, `SCALABLE_TOPIC_SUBSCRIBE_RESPONSE`,
`SCALABLE_TOPIC_ASSIGNMENT_UPDATE`, types 70–75 in `BaseCommand`). Until now
these commands were emitted by the V5 client unconditionally — there was no
negotiation that the peer broker actually understood them, and no operator
switch to disable the server-side handlers.

This PR adds the missing capability bit and operator switch:

1. A wire capability bit so a V5 client can detect a peer that does not speak
   scalable topics and fail fast with a clear error instead of writing bytes
   the broker will silently drop or close on.
2. A broker-side master switch (default on) so an operator can disable
   scalable topics on a particular broker; that broker then advertises the
   bit as `false` so clients route around it (and rejects any straggler
   scalable-topic command it receives — defense-in-depth).

The pattern mirrors the existing `supports_topic_watchers` /
`enableBrokerTopicListWatcher` flow exactly — no new infrastructure.

### Modifications

**Wire / config**
- `PulsarApi.proto`: new `optional bool supports_scalable_topics = 8` field on
  `FeatureFlags` (default `false`).
- `ServiceConfiguration`: new `scalableTopicsEnabled = true` (default on) in
  `CATEGORY_POLICIES`.

**Broker (advertises + enforces)**
- `Commands.newConnected*` / `newConnectedCommand`: new trailing
  `boolean supportsScalableTopics`, sets the bit on the response's
  `FeatureFlags`.
- `ServerCnx`: caches `conf.isScalableTopicsEnabled()`, threads it into
  `Commands.newConnected(...)`. When disabled, rejects
  `handleCommandScalableTopicLookup` and `handleCommandScalableTopicSubscribe`
  with `ServerError.NotAllowedError`. The close handler is left as a silent
  no-op since close is best-effort.
- `PulsarCommandSender` / `PulsarCommandSenderImpl`: interface and impl
  signatures extended to match.

**Proxy + tests**
- `ProxyConnection`: propagates the broker's bit through the forwarded
  `CommandConnected` (mirrors the existing `supportsTopicWatchers`
  forwarding).
- `MockBrokerService` and `ClientErrorsTest`: updated to the new 3-arg
  `newConnected` signature.

**Client (consumes + fails fast)**
- `ClientCnx`: caches the bit from `CommandConnected.feature_flags` into
  `@Getter private boolean supportsScalableTopics`.
- `PulsarClientException.FailedFeatureCheck`: gains `SupportsScalableTopics`.
- `DagWatchClient.start` and `ScalableConsumerClient.start`: now check
  `cnx.isSupportsScalableTopics()` after acquiring the connection and fail
  the future with
  `FeatureNotSupportedException(SupportsScalableTopics)` before writing any
  wire bytes.

The default-on path is unchanged: broker default is `true` → bit is `true`
on the wire → V5 client check is a no-op. Disabling `scalableTopicsEnabled`
on a broker both advertises `false` to clients (so they fail fast) and
rejects any scalable-topic command that arrives anyway.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a wire-additive default-on feature flag; no new tests are
added in this PR. The default-on path leaves all existing V5 behavior
unchanged. Targeted tests for the disabled-broker path (client receives
`FeatureNotSupportedException(SupportsScalableTopics)`) and the
defense-in-depth path (broker rejects scalable-topic commands with
`NotAllowedError` even when bypassed) are intended as a follow-up.

### Does this pull request potentially affect one of the following parts:

- [x] The default values of configurations — adds `scalableTopicsEnabled`
  defaulting to `true` (preserves current behavior).
- [x] The binary protocol — adds `FeatureFlags.supports_scalable_topics`
  (optional, default `false`). Wire-additive, safe across mixed-version
  clusters: old brokers will not set the bit, V5 clients will then refuse
  to send scalable-topic commands; old clients never read or set the bit.