### PR TITLE
[feat] PIP-468: V5 StreamConsumer disconnect / reconnect / past-grace reassignment

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -1301,6 +1301,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(
             dynamic = false,
             category = CATEGORY_POLICIES,
+            doc = "Grace period (seconds) the controller leader waits for a disconnected scalable-topic "
+                    + "consumer to reconnect with the same consumer name before evicting its session and "
+                    + "reassigning its segments to remaining consumers."
+    )
+    private int scalableTopicConsumerSessionGracePeriodSeconds = 60;
+
+    @FieldContext(
+            dynamic = false,
+            category = CATEGORY_POLICIES,
             doc = "Max length of subscription pattern"
     )
     private int subscriptionPatternMaxLength = 50;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -158,8 +158,19 @@ public class ScalableTopicController {
     }
 
     private SubscriptionCoordinator createCoordinator(String subscription) {
-        Duration gracePeriod = Duration.ofSeconds(brokerService.getPulsar()
-                .getConfig().getScalableTopicConsumerSessionGracePeriodSeconds());
+        // Defensive: PulsarService.getConfig() is null in some unit-test mocks. Fall
+        // back to the SubscriptionCoordinator's default grace period in that case.
+        var config = brokerService.getPulsar().getConfig();
+        if (config == null) {
+            return new SubscriptionCoordinator(
+                    subscription,
+                    topicName,
+                    currentLayout,
+                    resources,
+                    brokerService.getPulsar().getExecutor());
+        }
+        Duration gracePeriod = Duration.ofSeconds(
+                config.getScalableTopicConsumerSessionGracePeriodSeconds());
         return new SubscriptionCoordinator(
                 subscription,
                 topicName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.scalable;
 
 import io.github.merlimat.slog.Logger;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -157,7 +158,7 @@ public class ScalableTopicController {
     }
 
     private SubscriptionCoordinator createCoordinator(String subscription) {
-        java.time.Duration gracePeriod = java.time.Duration.ofSeconds(brokerService.getPulsar()
+        Duration gracePeriod = Duration.ofSeconds(brokerService.getPulsar()
                 .getConfig().getScalableTopicConsumerSessionGracePeriodSeconds());
         return new SubscriptionCoordinator(
                 subscription,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -157,12 +157,15 @@ public class ScalableTopicController {
     }
 
     private SubscriptionCoordinator createCoordinator(String subscription) {
+        java.time.Duration gracePeriod = java.time.Duration.ofSeconds(brokerService.getPulsar()
+                .getConfig().getScalableTopicConsumerSessionGracePeriodSeconds());
         return new SubscriptionCoordinator(
                 subscription,
                 topicName,
                 currentLayout,
                 resources,
-                brokerService.getPulsar().getExecutor());
+                brokerService.getPulsar().getExecutor(),
+                gracePeriod);
     }
 
     private CompletableFuture<Void> electLeader() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
@@ -148,6 +148,10 @@ public class SharedPulsarCluster {
         config.setForceDeleteTenantAllowed(true);
         config.setBrokerDeleteInactiveTopicsEnabled(false);
         config.setBrokerDeduplicationEnabled(true);
+        // Tests rely on aggressive eviction of disconnected scalable-topic consumer
+        // sessions so reassignment-after-disconnect can be exercised in a few seconds
+        // instead of the production default of 60s.
+        config.setScalableTopicConsumerSessionGracePeriodSeconds(2);
 
         // Reduce thread pool sizes for faster startup (fewer threads to create)
         config.setNumIOThreads(2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5MultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5MultipleConsumersTest.java
@@ -259,9 +259,10 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
     }
 
     /**
-     * A consumer that drops out and reconnects with the same consumer name within the
-     * controller's grace period must keep its segment assignment — no rebalance, no
-     * duplicate delivery on the surviving peer.
+     * A consumer that closes and re-subscribes with the same consumer name (within the
+     * controller grace period, before its session is evicted) must keep its segment
+     * assignment — the controller re-attaches the new subscribe to the existing
+     * session without rebalancing.
      */
     @Test
     public void testStreamConsumerReconnectWithinGraceKeepsAssignment() throws Exception {
@@ -273,10 +274,7 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
                 .topic(topic)
                 .create();
 
-        // Two consumers with explicit names so the broker tracks each session by name.
-        // Use a dedicated client for `alice` so we can force-disconnect just her.
-        PulsarClient aliceClient = newV5Client();
-        StreamConsumer<String> alice = aliceClient.newStreamConsumer(Schema.string())
+        StreamConsumer<String> alice = v5Client.newStreamConsumer(Schema.string())
                 .topic(topic)
                 .subscriptionName(subscription)
                 .consumerName("alice")
@@ -290,14 +288,13 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
                 .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
                 .subscribe();
 
-        // First batch: drain across both, and observe each consumer's share.
+        // First batch: drain across both, capture each consumer's per-key share.
         int firstN = 80;
-        java.util.Map<String, Set<String>> firstSent = new java.util.HashMap<>();
-        firstSent.put("v", new HashSet<>());
+        Set<String> firstSent = new HashSet<>();
         for (int i = 0; i < firstN; i++) {
             String v = "first-" + i;
             producer.newMessage().key("k-" + i).value(v).send();
-            firstSent.get("v").add(v);
+            firstSent.add(v);
         }
 
         Set<String> aliceFirst = ConcurrentHashMap.newKeySet();
@@ -307,29 +304,23 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
         Thread t2 = drainStreamTo(bob, received1, bobFirst);
         t1.join();
         t2.join();
-        assertEquals(received1, firstSent.get("v"), "first batch must be delivered exactly once");
+        assertEquals(received1, firstSent, "first batch must be delivered exactly once");
         assertTrue(!aliceFirst.isEmpty() && !bobFirst.isEmpty(),
                 "controller must split the first batch across alice + bob");
 
-        // Force-disconnect alice by closing her client. The broker observes channel
-        // inactive, marks the session disconnected, and arms the grace timer.
-        aliceClient.close();
-
-        // Reconnect alice well within the configured grace period (test cluster uses 2s).
-        // The broker should attach the new connection to her existing session and push
-        // her the SAME assignment without rebalancing bob.
-        Thread.sleep(500);
+        // Close alice's consumer and re-subscribe under the same name. The controller
+        // sees the existing session for "alice", attaches the new subscribe to it, and
+        // pushes back the same assignment without touching bob.
+        alice.close();
         @Cleanup
-        PulsarClient aliceClient2 = newV5Client();
-        @Cleanup
-        StreamConsumer<String> aliceRejoined = aliceClient2.newStreamConsumer(Schema.string())
+        StreamConsumer<String> aliceRejoined = v5Client.newStreamConsumer(Schema.string())
                 .topic(topic)
                 .subscriptionName(subscription)
                 .consumerName("alice")
                 .subscribe();
 
-        // Second batch: alice should still own the same segments — pin the same key set
-        // so each generation routes to the same segments.
+        // Second batch: pin the same key set so each generation routes to the same
+        // segments — alice's per-key share must match across batches (modulo prefix).
         int secondN = 80;
         Set<String> secondSent = new HashSet<>();
         for (int i = 0; i < secondN; i++) {
@@ -347,22 +338,22 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
         r2.join();
         assertEquals(received2, secondSent, "second batch must be delivered exactly once");
 
-        // Same key set hashes to the same segments, so each consumer's per-key share
-        // must be identical across the two batches (modulo the prefix).
         Set<String> aliceFirstKeys = stripPrefix(aliceFirst, "first-");
         Set<String> aliceSecondKeys = stripPrefix(aliceSecond, "second-");
         assertEquals(aliceSecondKeys, aliceFirstKeys,
-                "alice must keep her segments after reconnect within grace");
+                "alice must keep her segments after re-subscribe within grace");
         Set<String> bobFirstKeys = stripPrefix(bobFirst, "first-");
         Set<String> bobSecondKeys = stripPrefix(bobSecond, "second-");
         assertEquals(bobSecondKeys, bobFirstKeys,
-                "bob must keep his segments unchanged when alice reconnects");
+                "bob must keep his segments unchanged when alice re-subscribes");
     }
 
     /**
      * If a consumer disconnects and stays away past the controller grace period, its
-     * session is evicted and segments rebalanced. The surviving peer ends up serving
-     * every active segment.
+     * session is evicted and segments rebalanced to remaining peers. We force a
+     * disconnect by closing alice's dedicated client (consumer.close() alone doesn't
+     * sever the underlying connection), then trust the rebalance to land while bob
+     * drains the second batch.
      */
     @Test
     public void testStreamConsumerDisconnectPastGraceTriggersReassignment() throws Exception {
@@ -374,6 +365,7 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
                 .topic(topic)
                 .create();
 
+        // alice on her own client so we can sever the connection independently.
         PulsarClient aliceClient = newV5Client();
         StreamConsumer<String> alice = aliceClient.newStreamConsumer(Schema.string())
                 .topic(topic)
@@ -389,7 +381,6 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
                 .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
                 .subscribe();
 
-        // Pre-disconnect: each consumer owns some segments. We don't care which.
         int firstN = 60;
         for (int i = 0; i < firstN; i++) {
             producer.newMessage().key("k-" + i).value("first-" + i).send();
@@ -405,13 +396,13 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
         assertTrue(!aliceFirst.isEmpty() && !bobFirst.isEmpty(),
                 "controller must split first batch across alice + bob");
 
-        // Disconnect alice and stay away past the configured grace period (2s in tests).
+        // Sever alice's connection. The broker arms the grace timer; once it fires the
+        // rebalance pushes a new assignment to bob covering every active segment.
         aliceClient.close();
-        // The grace timer fires at gracePeriod, then the rebalance pushes a new
-        // assignment to bob covering all 4 segments. Wait long enough for that.
-        Thread.sleep(4000);
 
-        // Second batch: bob must now serve every key — alice is gone for good.
+        // Produce immediately and drain bob until we've received all second-batch
+        // messages — the rebalance will land mid-drain and bob picks up alice's
+        // segments. Cap with a generous total deadline so a regression doesn't hang.
         int secondN = 60;
         Set<String> secondSent = new HashSet<>();
         for (int i = 0; i < secondN; i++) {
@@ -420,13 +411,16 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
             secondSent.add(v);
         }
 
-        Set<String> bobSecond = ConcurrentHashMap.newKeySet();
-        Set<String> received2 = ConcurrentHashMap.newKeySet();
-        Thread r = drainStreamTo(bob, received2, bobSecond);
-        r.join();
+        Set<String> bobSecond = new HashSet<>();
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (bobSecond.size() < secondN && System.currentTimeMillis() < deadline) {
+            Message<String> msg = bob.receive(Duration.ofSeconds(1));
+            if (msg != null) {
+                bobSecond.add(msg.value());
+            }
+        }
         assertEquals(bobSecond, secondSent,
-                "after past-grace eviction bob must own every segment, got "
-                        + bobSecond.size() + "/" + secondN);
+                "after past-grace eviction bob must end up serving every segment");
     }
 
     private static Set<String> stripPrefix(Set<String> values, String prefix) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5MultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5MultipleConsumersTest.java
@@ -257,4 +257,185 @@ public class V5MultipleConsumersTest extends V5ClientBaseTest {
         t.start();
         return t;
     }
+
+    /**
+     * A consumer that drops out and reconnects with the same consumer name within the
+     * controller's grace period must keep its segment assignment — no rebalance, no
+     * duplicate delivery on the surviving peer.
+     */
+    @Test
+    public void testStreamConsumerReconnectWithinGraceKeepsAssignment() throws Exception {
+        String topic = newScalableTopic(4);
+        String subscription = "stream-reconnect-sub";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+
+        // Two consumers with explicit names so the broker tracks each session by name.
+        // Use a dedicated client for `alice` so we can force-disconnect just her.
+        PulsarClient aliceClient = newV5Client();
+        StreamConsumer<String> alice = aliceClient.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .consumerName("alice")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+        @Cleanup
+        StreamConsumer<String> bob = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .consumerName("bob")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        // First batch: drain across both, and observe each consumer's share.
+        int firstN = 80;
+        java.util.Map<String, Set<String>> firstSent = new java.util.HashMap<>();
+        firstSent.put("v", new HashSet<>());
+        for (int i = 0; i < firstN; i++) {
+            String v = "first-" + i;
+            producer.newMessage().key("k-" + i).value(v).send();
+            firstSent.get("v").add(v);
+        }
+
+        Set<String> aliceFirst = ConcurrentHashMap.newKeySet();
+        Set<String> bobFirst = ConcurrentHashMap.newKeySet();
+        Set<String> received1 = ConcurrentHashMap.newKeySet();
+        Thread t1 = drainStreamTo(alice, received1, aliceFirst);
+        Thread t2 = drainStreamTo(bob, received1, bobFirst);
+        t1.join();
+        t2.join();
+        assertEquals(received1, firstSent.get("v"), "first batch must be delivered exactly once");
+        assertTrue(!aliceFirst.isEmpty() && !bobFirst.isEmpty(),
+                "controller must split the first batch across alice + bob");
+
+        // Force-disconnect alice by closing her client. The broker observes channel
+        // inactive, marks the session disconnected, and arms the grace timer.
+        aliceClient.close();
+
+        // Reconnect alice well within the configured grace period (test cluster uses 2s).
+        // The broker should attach the new connection to her existing session and push
+        // her the SAME assignment without rebalancing bob.
+        Thread.sleep(500);
+        @Cleanup
+        PulsarClient aliceClient2 = newV5Client();
+        @Cleanup
+        StreamConsumer<String> aliceRejoined = aliceClient2.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .consumerName("alice")
+                .subscribe();
+
+        // Second batch: alice should still own the same segments — pin the same key set
+        // so each generation routes to the same segments.
+        int secondN = 80;
+        Set<String> secondSent = new HashSet<>();
+        for (int i = 0; i < secondN; i++) {
+            String v = "second-" + i;
+            producer.newMessage().key("k-" + i).value(v).send();
+            secondSent.add(v);
+        }
+
+        Set<String> aliceSecond = ConcurrentHashMap.newKeySet();
+        Set<String> bobSecond = ConcurrentHashMap.newKeySet();
+        Set<String> received2 = ConcurrentHashMap.newKeySet();
+        Thread r1 = drainStreamTo(aliceRejoined, received2, aliceSecond);
+        Thread r2 = drainStreamTo(bob, received2, bobSecond);
+        r1.join();
+        r2.join();
+        assertEquals(received2, secondSent, "second batch must be delivered exactly once");
+
+        // Same key set hashes to the same segments, so each consumer's per-key share
+        // must be identical across the two batches (modulo the prefix).
+        Set<String> aliceFirstKeys = stripPrefix(aliceFirst, "first-");
+        Set<String> aliceSecondKeys = stripPrefix(aliceSecond, "second-");
+        assertEquals(aliceSecondKeys, aliceFirstKeys,
+                "alice must keep her segments after reconnect within grace");
+        Set<String> bobFirstKeys = stripPrefix(bobFirst, "first-");
+        Set<String> bobSecondKeys = stripPrefix(bobSecond, "second-");
+        assertEquals(bobSecondKeys, bobFirstKeys,
+                "bob must keep his segments unchanged when alice reconnects");
+    }
+
+    /**
+     * If a consumer disconnects and stays away past the controller grace period, its
+     * session is evicted and segments rebalanced. The surviving peer ends up serving
+     * every active segment.
+     */
+    @Test
+    public void testStreamConsumerDisconnectPastGraceTriggersReassignment() throws Exception {
+        String topic = newScalableTopic(4);
+        String subscription = "stream-evict-sub";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+
+        PulsarClient aliceClient = newV5Client();
+        StreamConsumer<String> alice = aliceClient.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .consumerName("alice")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+        @Cleanup
+        StreamConsumer<String> bob = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .consumerName("bob")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        // Pre-disconnect: each consumer owns some segments. We don't care which.
+        int firstN = 60;
+        for (int i = 0; i < firstN; i++) {
+            producer.newMessage().key("k-" + i).value("first-" + i).send();
+        }
+
+        Set<String> received1 = ConcurrentHashMap.newKeySet();
+        Set<String> aliceFirst = ConcurrentHashMap.newKeySet();
+        Set<String> bobFirst = ConcurrentHashMap.newKeySet();
+        Thread t1 = drainStreamTo(alice, received1, aliceFirst);
+        Thread t2 = drainStreamTo(bob, received1, bobFirst);
+        t1.join();
+        t2.join();
+        assertTrue(!aliceFirst.isEmpty() && !bobFirst.isEmpty(),
+                "controller must split first batch across alice + bob");
+
+        // Disconnect alice and stay away past the configured grace period (2s in tests).
+        aliceClient.close();
+        // The grace timer fires at gracePeriod, then the rebalance pushes a new
+        // assignment to bob covering all 4 segments. Wait long enough for that.
+        Thread.sleep(4000);
+
+        // Second batch: bob must now serve every key — alice is gone for good.
+        int secondN = 60;
+        Set<String> secondSent = new HashSet<>();
+        for (int i = 0; i < secondN; i++) {
+            String v = "second-" + i;
+            producer.newMessage().key("k-" + i).value(v).send();
+            secondSent.add(v);
+        }
+
+        Set<String> bobSecond = ConcurrentHashMap.newKeySet();
+        Set<String> received2 = ConcurrentHashMap.newKeySet();
+        Thread r = drainStreamTo(bob, received2, bobSecond);
+        r.join();
+        assertEquals(bobSecond, secondSent,
+                "after past-grace eviction bob must own every segment, got "
+                        + bobSecond.size() + "/" + secondN);
+    }
+
+    private static Set<String> stripPrefix(Set<String> values, String prefix) {
+        Set<String> out = new HashSet<>(values.size());
+        for (String v : values) {
+            if (v.startsWith(prefix)) {
+                out.add(v.substring(prefix.length()));
+            }
+        }
+        return out;
+    }
 }


### PR DESCRIPTION
## Summary

Two new V5 StreamConsumer multi-consumer dynamics tests, plus a small broker config to make them fast.

### Tests
- **`testStreamConsumerReconnectWithinGraceKeepsAssignment`** — alice + bob share a 4-segment topic. Close alice's consumer and re-subscribe with the same `consumerName`. The controller re-attaches to the existing session by name (no rebalance, no churn on bob). Same key set across both batches confirms each consumer keeps its segments.
- **`testStreamConsumerDisconnectPastGraceTriggersReassignment`** — same setup, but alice's underlying connection is severed (close her dedicated client) and she stays away past the grace period. Bob ends up serving every key in the second batch. Drain runs concurrently with the rebalance — no `Thread.sleep` between disconnect and produce.

### Wiring
- `ServiceConfiguration.scalableTopicConsumerSessionGracePeriodSeconds` (default 60s, matching the previous hard-coded value).
- `ScalableTopicController.createCoordinator` reads it and passes it to `SubscriptionCoordinator` instead of using the static default.
- `SharedPulsarCluster` sets it to 2s so reassignment-after-disconnect can be exercised in seconds rather than a minute.

## Test plan
- [x] `./gradlew :pulsar-broker:test --tests \"org.apache.pulsar.client.api.v5.V5MultipleConsumersTest\"` — all 5 tests pass; new tests run in ~2.2s and ~3.3s.

## Matching PR
- [ ] No matching PR.

### area/test