### PR TITLE
[fix][sec] Prevent path traversal in PackageName toRestPath

### DIFF
--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.packages.management.core.common;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
@@ -108,6 +109,18 @@ public class PackageName {
             String.format("%s://%s/%s/%s@%s", type.toString(), tenant, namespace, name, version);
     }
 
+    @VisibleForTesting
+    PackageName(PackageType type, String tenant, String namespace, String name, String version) {
+        this.type = type;
+        this.tenant = tenant;
+        this.namespace = namespace;
+        this.name = name;
+        this.version = version;
+        this.completeName = String.format("%s/%s/%s", tenant, namespace, name);
+        this.completePackageName =
+                String.format("%s://%s/%s/%s@%s", type.toString(), tenant, namespace, name, version);
+    }
+
     public PackageType getPkgType() {
         return this.type;
     }
@@ -137,13 +150,14 @@ public class PackageName {
     }
 
     public String toRestPath() {
-        // Use Guava's urlPathSegmentEscaper to safely encode each segment and prevents Path Traversal (CWE-22)
+        // Use Guava's URL path segment escaper to safely encode each segment and prevent path traversal (CWE-22).
+        var escaper = UrlEscapers.urlPathSegmentEscaper();
         return String.format("%s/%s/%s/%s/%s",
                 type.toString(),
-                UrlEscapers.urlPathSegmentEscaper().escape(tenant),
-                UrlEscapers.urlPathSegmentEscaper().escape(namespace),
-                UrlEscapers.urlPathSegmentEscaper().escape(name),
-                UrlEscapers.urlPathSegmentEscaper().escape(version));
+                escaper.escape(tenant),
+                escaper.escape(namespace),
+                escaper.escape(name),
+                escaper.escape(version));
     }
 
     @Override

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
@@ -23,6 +23,8 @@ import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -136,7 +138,12 @@ public class PackageName {
     }
 
     public String toRestPath() {
-        return String.format("%s/%s/%s/%s/%s", type, tenant, namespace, name, version);
+        return String.format("%s/%s/%s/%s/%s",
+                type,
+                URLEncoder.encode(tenant, StandardCharsets.UTF_8),
+                URLEncoder.encode(namespace, StandardCharsets.UTF_8),
+                URLEncoder.encode(name, StandardCharsets.UTF_8),
+                URLEncoder.encode(version, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
@@ -23,8 +23,7 @@ import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import com.google.common.net.UrlEscapers;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -138,12 +137,13 @@ public class PackageName {
     }
 
     public String toRestPath() {
+        // Use Guava's urlPathSegmentEscaper to safely encode each segment and prevents Path Traversal (CWE-22)
         return String.format("%s/%s/%s/%s/%s",
-                type,
-                URLEncoder.encode(tenant, StandardCharsets.UTF_8),
-                URLEncoder.encode(namespace, StandardCharsets.UTF_8),
-                URLEncoder.encode(name, StandardCharsets.UTF_8),
-                URLEncoder.encode(version, StandardCharsets.UTF_8));
+                type.toString(),
+                UrlEscapers.urlPathSegmentEscaper().escape(tenant),
+                UrlEscapers.urlPathSegmentEscaper().escape(namespace),
+                UrlEscapers.urlPathSegmentEscaper().escape(name),
+                UrlEscapers.urlPathSegmentEscaper().escape(version));
     }
 
     @Override

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
@@ -119,19 +119,24 @@ public class PackageNameTest {
 
     @Test
     public void testPathTraversalBypassConstructor() throws Exception {
-        // Create a normal, valid package to bypass the splitter
-        PackageName packageName = PackageName.get("function://tenant-a/ns/name@v1");
+        // Use the package-private constructor annotated with @VisibleForTesting
+        // to inject a traversal payload directly, bypassing normal Splitter validation.
+        PackageName packageName = new PackageName(
+                PackageType.FUNCTION,
+                "tenant-a/../../system-tenant",
+                "ns",
+                "name",
+                "v1"
+        );
 
-        java.lang.reflect.Field tenantField = PackageName.class.getDeclaredField("tenant");
-        tenantField.setAccessible(true);
-        tenantField.set(packageName, "tenant-a/../../system-tenant");
-        // Define what the SAFE, patched output should look like
+        // Verify that path separators in package components are percent-encoded in the generated REST path.
         String expectedSafePath = "function/tenant-a%2F..%2F..%2Fsystem-tenant/ns/name/v1";
 
-        // Trigger the vulnerable method
+        // Invoke the method under test
         String actualPath = packageName.toRestPath();
-        // The Trap: This will fail, because actualPath will still contain unencoded slashes
+
+        // This assertion verifies that traversal characters are encoded rather than emitted as raw slashes.
         Assert.assertEquals(actualPath, expectedSafePath,
-                "VULNERABILITY REPLICATED: The toRestPath method failed to encode path traversal characters!");
+                "The toRestPath method must encode path traversal characters in package components.");
     }
 }

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
@@ -116,4 +116,22 @@ public class PackageNameTest {
         PackageName name = PackageName.get("function://public/default/test");
         Assert.assertEquals("function://public/default/test@latest", name.toString());
     }
+
+    @Test
+    public void testPathTraversalBypassConstructor() throws Exception {
+        // Create a normal, valid package to bypass the splitter
+        PackageName packageName = PackageName.get("function://tenant-a/ns/name@v1");
+
+        java.lang.reflect.Field tenantField = PackageName.class.getDeclaredField("tenant");
+        tenantField.setAccessible(true);
+        tenantField.set(packageName, "tenant-a/../../system-tenant");
+        // Define what the SAFE, patched output should look like (URL Encoded)
+        String expectedSafePath = "function/tenant-a%2F..%2F..%2Fsystem-tenant/ns/name/v1";
+
+        // Trigger the vulnerable method
+        String actualPath = packageName.toRestPath();
+        // The Trap: This will fail, because actualPath will still contain unencoded slashes
+        Assert.assertEquals(actualPath, expectedSafePath,
+                "VULNERABILITY REPLICATED: The toRestPath method failed to encode path traversal characters!");
+    }
 }

--- a/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
+++ b/pulsar-package-management/core/src/test/java/org/apache/pulsar/packages/management/core/common/PackageNameTest.java
@@ -125,7 +125,7 @@ public class PackageNameTest {
         java.lang.reflect.Field tenantField = PackageName.class.getDeclaredField("tenant");
         tenantField.setAccessible(true);
         tenantField.set(packageName, "tenant-a/../../system-tenant");
-        // Define what the SAFE, patched output should look like (URL Encoded)
+        // Define what the SAFE, patched output should look like
         String expectedSafePath = "function/tenant-a%2F..%2F..%2Fsystem-tenant/ns/name/v1";
 
         // Trigger the vulnerable method


### PR DESCRIPTION
Fixes #25323

### Motivation

A potential path traversal vulnerability (CWE-22) exists in `PackageName.toRestPath()`.

The method builds REST path segments using package fields such as tenant, namespace, name, and version. These values were previously concatenated directly into the generated path without URL encoding.

Although current constructor validation blocks malformed input (like extra slashes) in normal flows, relying only on upstream validation violates the principle of Defense in Depth. If object construction is bypassed through reflection, deserialization, future code changes, or alternate call paths, malicious values containing traversal sequences such as `../` could be propagated directly into generated REST paths.

This change applies defense-in-depth by ensuring `toRestPath()` safely encodes path components according to RFC 3986 before constructing the final path.


### Modifications

- Updated `PackageName.toRestPath()` to safely encode:
  - `tenant`
  - `namespace`
  - `name`
  - `version`

- Used Guava's `UrlEscapers.urlPathSegmentEscaper().escape(...)` to construct the components. This correctly follows RFC 3986 for URL paths (converting spaces to `%20` and slashes to `%2F`) and avoids the `+` space-encoding issue caused by standard `URLEncoder`, without requiring new external HTTP dependencies.

- Added a reflection-based unit test (`testPathTraversalBypassConstructor`) to explicitly verify traversal payloads are encoded safely even when constructor validation is bypassed.

### Verifying this change

This change added tests and can be verified as follows:

- Ran package management module tests successfully.
- Added a test that injects traversal-like values (for example `../../`) and verifies the output path is safely encoded.
- Confirmed normal package name inputs continue to behave correctly.

Example verification command:

```bash
./gradlew :pulsar-package-management:pulsar-package-core:test --tests "PackageNameTest"
```

*Does this pull request potentially affect one of the following parts:*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment