### PR TITLE
[improve][ci] Document avoiding reflection in tests in Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -249,6 +249,50 @@ Flag any change that may break compatibility.
 * Assertions should prefer using AssertJ library with descriptions over using TestNG assertions
 * Awaitility should be used to handle assertions with asynchronous conditions together with AssertJ
 
+## Avoid Reflection in Tests
+
+Do **not** use reflection to access private fields or methods from tests. This includes
+`WhiteboxImpl.getInternalState`, `WhiteboxImpl.setInternalState`, `Field.setAccessible(true)`,
+`Method.setAccessible(true)`, and similar reflection helpers.
+
+Reflection-based test access is discouraged because it:
+
+* breaks during refactoring without any compile-time signal — renaming or retyping a field
+  silently invalidates the test
+* produces verbose, brittle, and hard-to-read test code
+* couples tests to implementation details that should be free to change
+
+Instead, expose what tests legitimately need through **package-private** methods (or fields
+where appropriate) and annotate them with `@VisibleForTesting`:
+
+```java
+@VisibleForTesting
+Map<String, Subscription> getSubscriptions() {
+    return subscriptions;
+}
+```
+
+The test then accesses state through a normal, statically-typed call:
+
+```java
+var subscriptions = persistentTopic.getSubscriptions();
+```
+
+instead of:
+
+```java
+ConcurrentOpenHashMap<String, PersistentSubscription> subscriptions =
+        WhiteboxImpl.getInternalState(persistentTopic, "subscriptions");
+```
+
+Place the test in the same package as the class under test so package-private visibility is
+sufficient — no need to widen visibility to `public` for testing.
+
+When reviewing PRs, flag any new use of reflection in tests and suggest a `@VisibleForTesting`
+package-private accessor instead. See the dev@ thread
+[Stop using reflection to access private fields in tests](https://lists.apache.org/thread/7gr04sqmzyttx4ln6ydtp3qv0xgo1o6m)
+for the full rationale.
+
 # Testing Expectations
 
 Every feature or bug fix should include tests.
@@ -278,5 +322,7 @@ When reviewing a pull request, Copilot should:
 * ensure logging follows project guidelines
 * verify backward compatibility
 * suggest missing tests when appropriate
+* flag reflection-based access to private fields or methods in tests (e.g. `WhiteboxImpl`,
+  `setAccessible(true)`) and recommend a package-private `@VisibleForTesting` accessor instead
 
 Focus feedback on correctness, reliability, and maintainability.


### PR DESCRIPTION
### Motivation

The Pulsar codebase has accumulated many tests that use reflection (`WhiteboxImpl.getInternalState`, `setAccessible(true)`, etc.) to read or mutate private fields of the class under test. This pattern was discussed on the dev@ mailing list:

[\[DISCUSS\] Stop using reflection to access private fields in tests](https://lists.apache.org/thread/7gr04sqmzyttx4ln6ydtp3qv0xgo1o6m)

Reflection-based test access:

- breaks during refactoring without any compile-time signal — renaming or retyping a field silently invalidates the test
- produces verbose, brittle, and hard-to-read test code
- couples tests to implementation details that should be free to change

The discussion concluded that the preferred approach is to expose what tests legitimately need through **package-private** methods annotated with `@VisibleForTesting`, with the test placed in the same package as the class under test.

This PR teaches the Copilot PR-review bot to flag reflection-based test access in new code, so the project guidance is enforced consistently in reviews going forward.

### Modifications

`.github/copilot-instructions.md`:

- Added an **Avoid Reflection in Tests** subsection under *Testing Guidelines* with the rationale, the preferred `@VisibleForTesting` package-private pattern, before/after examples (`WhiteboxImpl.getInternalState` vs. a typed getter), and a link to the dev@ thread.
- Added a matching item to the **Pull Request Review Guidance** checklist so reviewers proactively flag new reflection use.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. It only modifies Copilot reviewer guidance in `.github/copilot-instructions.md`; there is no production or test code change.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment