### PR TITLE
[fix][test] Fix flaky testGetExcludedBookiesWithIsolationGroups

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -746,6 +746,13 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
+        // Wait for the async cache load triggered by initialize() to complete; otherwise
+        // getExcludedBookiesWithIsolationGroups returns an empty set when cachedRackConfiguration
+        // is still null. Same pattern used in testBookieInfoChange (#25473).
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertNotNull(isolationPolicy.getBookieMappingCache()
+                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
+
         /* Test common cases */
         MutablePair<Set<String>, Set<String>> groups = new MutablePair<>();
         groups.setLeft(Sets.newHashSet(isolationGroup1));


### PR DESCRIPTION
## Summary

`IsolatedBookieEnsemblePlacementPolicy.initialize()` triggers a fire-and-forget cache load on `bookieMappingCache`. The test calls `getExcludedBookiesWithIsolationGroups` immediately after, sees `cachedRackConfiguration == null`, and gets back an empty set instead of the expected 2 excluded bookies.

Apply the same Awaitility wait pattern used in [#25473](https://github.com/apache/pulsar/pull/25473) for `testBookieInfoChange`: after `onClusterChanged()`, wait for the cache to be populated before asserting.

## Test plan

- [x] Five consecutive local runs pass
- [ ] CI is green