### PR TITLE
[fix][test] Make NamespacesTest.cleanupAfterMethod tolerant of transient infra failures

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -186,12 +186,18 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     }
 
     @AfterMethod(alwaysRun = true)
-    public void cleanupAfterMethod() throws Exception{
-        // cleanup.
+    public void cleanupAfterMethod() {
+        // Best-effort cleanup. Transient infra failures (e.g. ZK session expiry from a
+        // long-running test or GC pause) can make the admin call fail here; log and
+        // continue so the test method's actual result is preserved.
         Set<String> existsNsSetAferSetup = Stream.concat(testLocalNamespaces.stream(), testGlobalNamespaces.stream())
                 .map(Objects::toString).collect(Collectors.toSet());
-        cleanupNamespaceByPredicate(this.testTenant, v -> !existsNsSetAferSetup.contains(v));
-        cleanupNamespaceByPredicate(this.testOtherTenant, v -> !existsNsSetAferSetup.contains(v));
+        try {
+            cleanupNamespaceByPredicate(this.testTenant, v -> !existsNsSetAferSetup.contains(v));
+            cleanupNamespaceByPredicate(this.testOtherTenant, v -> !existsNsSetAferSetup.contains(v));
+        } catch (Exception e) {
+            log.warn().exception(e).log("Failed to clean up namespaces after test method");
+        }
     }
 
     protected void customizeNewPulsarClientBuilder(ClientBuilder clientBuilder) {


### PR DESCRIPTION
## Summary

The `@AfterMethod` cleanup calls `admin.namespaces().getNamespaces(tenant)`. Under load (long-running test method, GC pause) the broker's ZK session can expire and that call returns a 500. The actual test method had already passed at that point, so masking the result with a cleanup exception isn't useful.

Wrap the cleanup in try/catch + warn-log. Subsequent test methods either recover (ZK reconnects) or fail-fast with a clearer error than a session-expired stack trace from a teardown hook.

## Test plan

- [x] `testCreateNamespaces` passes locally with the change applied
- [ ] CI is green