### PR TITLE
[improve][misc] Upgrade Caffeine to 3.2.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -260,7 +260,7 @@ The Apache Software License, Version 2.0
      - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.21.2.jar
      - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.21.2.jar
      - com.fasterxml.jackson.module-jackson-module-parameter-names-2.21.2.jar
- * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.3.jar
+ * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.4.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Proto Google Common Protos -- com.google.api.grpc-proto-google-common-protos-2.59.2.jar
  * Bitbucket -- org.bitbucket.b_c-jose4j-0.9.6.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -324,7 +324,7 @@ The Apache Software License, Version 2.0
      - jackson-datatype-jdk8-2.21.2.jar
      - jackson-datatype-jsr310-2.21.2.jar
      - jackson-module-parameter-names-2.21.2.jar
- * Caffeine -- caffeine-3.2.3.jar
+ * Caffeine -- caffeine-3.2.4.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson
     - gson-2.13.2.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ opencensus = "0.28.0"
 opentelemetry-gcp-resources = "1.48.0-alpha"
 # Data structures / Utils
 guava = "33.4.8-jre"
-caffeine = "3.2.3"
+caffeine = "3.2.4"
 jctools = "4.0.5"
 roaringbitmap = "1.6.9"
 hppc = "0.9.1"


### PR DESCRIPTION
### Motivation

Upgrade [Caffeine](https://github.com/ben-manes/caffeine) from 3.2.3 to 3.2.4 to pick up upstream improvements and fixes.

Highlights from the [Caffeine 3.2.4 release notes](https://github.com/ben-manes/caffeine/releases/tag/v3.2.4):

- Improved access expiration's read performance by avoiding false sharing effects from timestamp updates
- Fixed head-of-line blocking of expiration queues caused by in-flight async entries ([ben-manes/caffeine#1954](https://github.com/ben-manes/caffeine/issues/1954))
- Resolved various minor issues identified through AI security audits
- Integrated `ObjectInputFilter` support for JCache compatibility

### Modifications

- Bump `caffeine` version in `gradle/libs.versions.toml` from `3.2.3` to `3.2.4`.
- Update Caffeine entries in `distribution/server/src/assemble/LICENSE.bin.txt` and `distribution/shell/src/assemble/LICENSE.bin.txt` to reference the new jar version.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment