### PR TITLE
[improve][test] Upgrade Mockito to 5.23.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,7 +146,7 @@ checkerframework = "3.33.0"
 jsr305 = "3.0.2"
 # Test
 testng = "7.7.1"
-mockito = "5.19.0"
+mockito = "5.23.0"
 awaitility = "4.2.0"
 assertj = "3.27.7"
 hamcrest = "2.2"


### PR DESCRIPTION
### Motivation

Pulsar relies on Mockito for unit testing across many modules. Since Mockito remains an actively used and integral test dependency, it should be kept up to date so that the project benefits from upstream bug fixes, JDK compatibility improvements, and reduced security/maintenance risk caused by drifting behind on widely-used libraries.

This PR bumps Mockito from `5.19.0` to `5.23.0`, the current latest release.

#### Notable changes between 5.19.0 and 5.23.0 (per https://github.com/mockito/mockito/releases)

- **5.23.0** — Fix `StackOverflowError` with `AbstractList` after using `mockSingleton`; mark `Mockito.when` parameters `@Nullable`; (Android-only breaking change replacing the `mockito-android` mock-maker — does not affect Pulsar, which only consumes `mockito-core`).
- **5.22.0** — Avoid mocking of internal static utilities; fix static mocking of `UUID.class` corruption under JDK 25; add core API to enable Kotlin singleton mocking.
- **5.21.0** — Output matchers in potential mismatch messages (#2468); forbid mocking `WeakReference` with the inline mock maker (fixes `StackOverflowError`); support primitives in `GenericArrayReturnType` (fixes Android `ClassNotFoundException` for primitive arrays).
- **5.20.0** — Mock construction of generic types (#2401); JDK 21 sequenced collection support; ByteBuddy bump to 1.17.7.

The Mockito 5.23.0 transitive dependency on `byte-buddy` (1.17.7) already matches the version pinned in Pulsar's `gradle/libs.versions.toml`, and `objenesis` remains at 3.3 (unchanged from 5.19.0), so no other version updates are required.

### Modifications

- Updated `mockito` version in `gradle/libs.versions.toml` from `5.19.0` to `5.23.0`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial dependency upgrade without functional code changes. It is covered by the existing test suite — verified locally with:

- `./gradlew assemble` — BUILD SUCCESSFUL
- `./gradlew testClasses` — BUILD SUCCESSFUL (all test sources compile against Mockito 5.23.0)
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` — BUILD SUCCESSFUL

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency) — Mockito test dependency upgraded from 5.19.0 to 5.23.0. Test scope only; no production code or runtime dependencies affected.
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment