### PR TITLE
[improve][misc] Upgrade jctools to 4.0.6 (jctools-core-jdk11)

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -504,7 +504,8 @@ The Apache Software License, Version 2.0
     - io.jsonwebtoken-jjwt-impl-0.13.0.jar
     - io.jsonwebtoken-jjwt-jackson-0.13.0.jar
   * JCTools - Java Concurrency Tools for the JVM
-    - org.jctools-jctools-core-4.0.5.jar
+    - org.jctools-jctools-core-4.0.6.jar
+    - org.jctools-jctools-core-jdk11-4.0.6.jar
   * Vertx
     - io.vertx-vertx-auth-common-4.5.24.jar
     - io.vertx-vertx-bridge-common-4.5.24.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ opentelemetry-gcp-resources = "1.48.0-alpha"
 # Data structures / Utils
 guava = "33.4.8-jre"
 caffeine = "3.2.4"
-jctools = "4.0.5"
+jctools = "4.0.6"
 roaringbitmap = "1.6.9"
 hppc = "0.9.1"
 aircompressor = "2.0.3"
@@ -316,6 +316,7 @@ error-prone-annotations = { module = "com.google.errorprone:error_prone_annotati
 # Data structures
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 jctools-core = { module = "org.jctools:jctools-core", version.ref = "jctools" }
+jctools-core-jdk11 = { module = "org.jctools:jctools-core-jdk11", version.ref = "jctools" }
 roaringbitmap = { module = "org.roaringbitmap:RoaringBitmap", version.ref = "roaringbitmap" }
 hppc = { module = "com.carrotsearch:hppc", version.ref = "hppc" }
 aircompressor = { module = "io.airlift:aircompressor", version.ref = "aircompressor" }

--- a/managed-ledger/build.gradle.kts
+++ b/managed-ledger/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.bookkeeper.server)
     implementation(libs.guava)
     implementation(libs.roaringbitmap)
-    implementation(libs.jctools.core)
+    implementation(libs.jctools.core.jdk11)
     implementation(libs.slog)
     implementation(libs.simpleclient)
     implementation(libs.commons.lang3)

--- a/pulsar-transaction/coordinator/build.gradle.kts
+++ b/pulsar-transaction/coordinator/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation(libs.commons.collections4)
     implementation(libs.netty.buffer)
     implementation(libs.netty.common)
-    implementation(libs.jctools.core)
+    implementation(libs.jctools.core.jdk11)
     implementation(libs.simpleclient)
     implementation(libs.guava)
     implementation(libs.bookkeeper.server)


### PR DESCRIPTION
### Motivation

The JCTools 4.0.6 release is available, with various fixes since 4.0.5. Keeping the dependency current is generally desirable.

Starting with 4.0.6, JCTools publishes a separate `jctools-core-jdk11` Maven artifact that adds proper Java 9 module support (a `module-info` descriptor) on top of `jctools-core`. Switching to this artifact is the recommended way to consume JCTools on JDK 9+.

BookKeeper is also upgrading to JCTools 4.0.6 (apache/bookkeeper#4776), so aligning the version in Pulsar avoids classpath skew between the two projects and lets Pulsar pick up the `jctools-core-jdk11` enhancements at the same time.

JCTools is used in Pulsar by `managed-ledger` and `pulsar-transaction-coordinator`.

### Modifications

- Bump `jctools` version from `4.0.5` to `4.0.6` in `gradle/libs.versions.toml`.
- Add a `jctools-core-jdk11` library entry to the version catalog alongside the existing `jctools-core`. Both share the same `version.ref = "jctools"` so they stay aligned.
- Switch the `implementation` declarations in `managed-ledger` and `pulsar-transaction/coordinator` from `libs.jctools.core` to `libs.jctools.core.jdk11`. The `jdk11` variant transitively depends on `jctools-core`, so both jars end up bundled in the server distribution.
- Update `distribution/server/src/assemble/LICENSE.bin.txt` to list both `org.jctools-jctools-core-4.0.6.jar` and `org.jctools-jctools-core-jdk11-4.0.6.jar`.

Verified locally with:

```
./gradlew assemble
./src/check-binary-license.sh distribution/server/build/distributions/apache-pulsar-*-bin.tar.gz
./src/check-binary-license.sh distribution/shell/build/distributions/apache-pulsar-*-bin.tar.gz
```

(All exit 0; the shell distribution does not bundle jctools.)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Dependency change details:
- `org.jctools:jctools-core` 4.0.5 → 4.0.6
- New direct dependency on `org.jctools:jctools-core-jdk11` 4.0.6 (replacing the previous direct `jctools-core` declaration; `jctools-core` itself is still bundled transitively through `jctools-core-jdk11`).

### References

- Release notes: https://github.com/JCTools/JCTools/releases/tag/v4.0.6
- Changelog: https://github.com/JCTools/JCTools/compare/v4.0.5...v4.0.6
- Related: apache/bookkeeper#4776