### PR TITLE
[fix][test] Fix flaky AdminApiOffloadTest.testOffload status race

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -166,9 +166,13 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         // fail first time
         promise.completeExceptionally(new Exception("Some random failure"));
 
-        assertEquals(admin.topics().offloadStatus(topicName).getStatus(),
-                            LongRunningProcessStatus.Status.ERROR);
-        Assert.assertTrue(admin.topics().offloadStatus(topicName).getLastError().contains("Some random failure"));
+        // The failure handler runs asynchronously after the promise completes, so the
+        // offloadStatus may briefly still report RUNNING before transitioning to ERROR.
+        Awaitility.await().untilAsserted(() -> {
+            var status = admin.topics().offloadStatus(topicName);
+            assertEquals(status.getStatus(), LongRunningProcessStatus.Status.ERROR);
+            Assert.assertTrue(status.getLastError().contains("Some random failure"));
+        });
 
         // Try again
         doReturn(CompletableFuture.completedFuture(null))


### PR DESCRIPTION
### Motivation

`AdminApiOffloadTest.testOffload` (parameterized as `testOffloadV1` and `testOffloadV2`) checks the offload status immediately after completing the offload promise exceptionally:

```java
promise.completeExceptionally(new Exception("Some random failure"));

assertEquals(admin.topics().offloadStatus(topicName).getStatus(),
                    LongRunningProcessStatus.Status.ERROR);
```

The failure handler that updates the offload status to `ERROR` runs asynchronously after the promise completes. The synchronous assertion races with that handler and occasionally observes `RUNNING`, producing the flake `expected [ERROR] but found [RUNNING]`.

Example failure: https://scans.gradle.com/s/nv4xn5dwytjvs/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.admin.AdminApiOffloadTest/testOffloadV2/2/output

### Modifications

Wrap the `ERROR` status assertion in `Awaitility.untilAsserted(...)` so the test waits for the failure handler to update the status, mirroring the success path immediately below it (which already used Awaitility).

### Verifying this change

This change is already covered by existing tests:
- `AdminApiOffloadTest.testOffloadV1`
- `AdminApiOffloadTest.testOffloadV2`

Locally I ran both 3 times in a row with fresh Gradle daemons; each run took ~0.4–0.9s and all passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment