### PR TITLE
[fix][test] Make SameAuthParamsLookupAutoClusterFailoverTest less timing-sensitive

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -64,11 +64,11 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
     }
     @SuppressWarnings("deprecation")
 
-    // Each state-convergence phase below waits up to 2 minutes. With 3 phases plus
-    // cluster startup/teardown, the 240s overall timeout can be tight on slow CI agents
-    // (the probe timeout is 3s and recoverThreshold=5, so a single slow probe can
-    // stretch a phase to ~30s). Allow 8 minutes overall to match the per-phase budget.
-    @Test(dataProvider = "enabledTls", timeOut = 480 * 1000)
+    // Each state-convergence phase below waits up to 3 minutes. The probe timeout is 3s
+    // and recoverThreshold=5, so a transient probe failure during recovery resets the
+    // counter and a phase can need ~30s of healthy probes to recover. With 3 phases plus
+    // cluster startup/teardown, allow 12 minutes overall to absorb slow CI agents.
+    @Test(dataProvider = "enabledTls", timeOut = 720 * 1000)
     public void testAutoClusterFailover(boolean enabledTls) throws Exception {
         // Start clusters.
         setup();
@@ -110,68 +110,59 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         producer.send("0");
         Assert.assertEquals(failover.getCurrentPulsarServiceIndex(), 0);
 
-        CompletableFuture<Boolean> checkStatesFuture1 = new CompletableFuture<>();
-        executor.submit(() -> {
-            boolean res = stateArray[0] == PulsarServiceState.Healthy;
-            res = res & stateArray[1] == PulsarServiceState.Healthy;
-            res = res & stateArray[2] == PulsarServiceState.Healthy;
-            checkStatesFuture1.complete(res);
-        });
-        Assert.assertTrue(checkStatesFuture1.join());
+        assertStatesEqual(executor, stateArray,
+                PulsarServiceState.Healthy, PulsarServiceState.Healthy, PulsarServiceState.Healthy);
 
         // Test failover 0 --> 2.
         pulsar1.close();
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
-            CompletableFuture<Boolean> checkStatesFuture2 = new CompletableFuture<>();
-            executor.submit(() -> {
-                boolean res = stateArray[0] == PulsarServiceState.Failed;
-                res = res & stateArray[1] == PulsarServiceState.Failed;
-                res = res & stateArray[2] == PulsarServiceState.Healthy;
-                checkStatesFuture2.complete(res);
-            });
-            Assert.assertTrue(checkStatesFuture2.join());
-            producer.send("0->2");
-            Assert.assertEquals(failover.getCurrentPulsarServiceIndex(), 2);
-        });
+        awaitStatesAndIndex(executor, stateArray, failover, 2,
+                PulsarServiceState.Failed, PulsarServiceState.Failed, PulsarServiceState.Healthy);
+        producer.send("0->2");
 
         // Test recover 2 --> 1.
         executor.execute(() -> {
             urlArray[1] = url2;
         });
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
-            CompletableFuture<Boolean> checkStatesFuture3 = new CompletableFuture<>();
-            executor.submit(() -> {
-                boolean res = stateArray[0] == PulsarServiceState.Failed;
-                res = res & stateArray[1] == PulsarServiceState.Healthy;
-                res = res & stateArray[2] == PulsarServiceState.Healthy;
-                checkStatesFuture3.complete(res);
-            });
-            Assert.assertTrue(checkStatesFuture3.join());
-            producer.send("2->1");
-            Assert.assertEquals(failover.getCurrentPulsarServiceIndex(), 1);
-        });
+        awaitStatesAndIndex(executor, stateArray, failover, 1,
+                PulsarServiceState.Failed, PulsarServiceState.Healthy, PulsarServiceState.Healthy);
+        producer.send("2->1");
 
         // Test recover 1 --> 0.
         executor.execute(() -> {
             urlArray[0] = url2;
         });
-        Awaitility.await().atMost(120, TimeUnit.SECONDS).untilAsserted(() -> {
-            CompletableFuture<Boolean> checkStatesFuture4 = new CompletableFuture<>();
-            executor.submit(() -> {
-                boolean res = stateArray[0] == PulsarServiceState.Healthy;
-                res = res & stateArray[1] == PulsarServiceState.Healthy;
-                res = res & stateArray[2] == PulsarServiceState.Healthy;
-                checkStatesFuture4.complete(res);
-            });
-            Assert.assertTrue(checkStatesFuture4.join());
-            producer.send("1->0");
-            Assert.assertEquals(failover.getCurrentPulsarServiceIndex(), 0);
-        });
+        awaitStatesAndIndex(executor, stateArray, failover, 0,
+                PulsarServiceState.Healthy, PulsarServiceState.Healthy, PulsarServiceState.Healthy);
+        producer.send("1->0");
 
         // cleanup.
         producer.close();
         client.close();
         dummyServer.close();
+    }
+
+    /**
+     * Wait for the state machine to converge to the expected per-index states and current index.
+     * The state read happens on the failover executor to avoid races with the periodic check task,
+     * and producer/lookup operations are kept out of the polling loop so a slow message send does
+     * not consume the convergence budget.
+     */
+    private static void awaitStatesAndIndex(EventLoopGroup executor, PulsarServiceState[] stateArray,
+                                            SameAuthParamsLookupAutoClusterFailover failover,
+                                            int expectedIndex,
+                                            PulsarServiceState... expectedStates) {
+        Awaitility.await().atMost(180, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertStatesEqual(executor, stateArray, expectedStates);
+            Assert.assertEquals(failover.getCurrentPulsarServiceIndex(), expectedIndex);
+        });
+    }
+
+    private static void assertStatesEqual(EventLoopGroup executor, PulsarServiceState[] stateArray,
+                                          PulsarServiceState... expected) throws Exception {
+        CompletableFuture<PulsarServiceState[]> snapshot = new CompletableFuture<>();
+        executor.submit(() -> snapshot.complete(stateArray.clone()));
+        PulsarServiceState[] actual = snapshot.get(10, TimeUnit.SECONDS);
+        Assert.assertEquals(actual, expected);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

`SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` waits for the failover state machine to converge across three phases (failover 0→2, recover 2→1, recover 1→0). Each phase uses an `Awaitility.untilAsserted(...)` lambda that combined three assertions:

1. The per-index `pulsarServiceStateArray` matches the expected states.
2. `producer.send(...)` succeeds.
3. `failover.getCurrentPulsarServiceIndex()` returns the expected index.

When the failover state has converged but the producer's underlying connection is still being re-established (`updateServiceUrl` calls `cnxPool.closeAllConnections()`), the `producer.send(...)` retry inside the lambda can stall up to the producer's send timeout (~30s). Each retry of the lambda then burns ~30s of the per-phase budget, even though the failover state machine itself already settled. On slow CI agents this causes the per-phase 120s budget to time out at phase 3 with `expected [true] but found [false]`.

Example failure: https://scans.gradle.com/s/xiv7nu4ujnh5c/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest/testAutoClusterFailover%5B4%5D(false)/1/output

### Modifications

Split the convergence check from the side checks per phase:

- Wait inside `Awaitility.untilAsserted(...)` only for the per-index state and `currentPulsarServiceIndex` (cheap reads on the failover executor).
- Move `producer.send(...)` outside the await loop so it runs once per phase and surfaces send failures directly.

Also extracted small helpers (`awaitStatesAndIndex`, `assertStatesEqual`) to remove the repetitive submit-future-join boilerplate, and bumped the per-phase budget to 180s with an overall 12-minute timeout (the probe timeout is 3s and a single failed probe during recovery resets `recoverThreshold`, so a phase can need up to ~30s of healthy probes to recover).

### Verifying this change

This change is already covered by existing tests: `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` (TLS and non-TLS variants).

Locally I ran 3 times in a row with fresh Gradle daemons; each run took ~17s per variant and all passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment