### PR TITLE
[fix][test] Reduce admin client churn in ExtensibleLoadManagerTest.startBroker

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -134,7 +134,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
     }
 
     @BeforeMethod(alwaysRun = true)
-    public void startBroker() {
+    public void startBroker() throws Exception {
         if (pulsarCluster == null) {
             return;
         }
@@ -144,35 +144,49 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
             }
         });
         String topicName = "persistent://" + DEFAULT_NAMESPACE + "/startBrokerCheck";
-        Awaitility.await().atMost(180, TimeUnit.SECONDS).until(
-                () -> {
-                    for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
-                        try (PulsarAdmin brokerAdmin = PulsarAdmin.builder().serviceHttpUrl(
-                                brokerContainer.getHttpServiceUrl()).build()) {
-                            if (brokerAdmin.brokers().getActiveBrokers(clusterName).size() != NUM_BROKERS) {
-                                log.info()
+        // Build admin clients once and reuse across poll iterations to avoid the per-tick
+        // connection churn (3 brokers x N polls of admin builder/close). Connection setup
+        // contends with brokers that are still warming up after a stop/restart.
+        List<BrokerContainer> brokers = new ArrayList<>(pulsarCluster.getBrokers());
+        List<PulsarAdmin> brokerAdmins = new ArrayList<>(brokers.size());
+        try {
+            for (BrokerContainer brokerContainer : brokers) {
+                brokerAdmins.add(PulsarAdmin.builder()
+                        .serviceHttpUrl(brokerContainer.getHttpServiceUrl()).build());
+            }
+            Awaitility.await().atMost(180, TimeUnit.SECONDS).until(
+                    () -> {
+                        for (int i = 0; i < brokers.size(); i++) {
+                            BrokerContainer brokerContainer = brokers.get(i);
+                            PulsarAdmin brokerAdmin = brokerAdmins.get(i);
+                            try {
+                                if (brokerAdmin.brokers().getActiveBrokers(clusterName).size() != NUM_BROKERS) {
+                                    log.info()
+                                            .attr("broker", brokerContainer.getHostName())
+                                            .attr("see", NUM_BROKERS)
+                                            .log("Broker does not see active brokers yet");
+                                    return false;
+                                }
+                                try {
+                                    brokerAdmin.topics().createPartitionedTopic(topicName, 10);
+                                } catch (PulsarAdminException.ConflictException e) {
+                                    // expected - topic already exists
+                                }
+                                brokerAdmin.lookups().lookupPartitionedTopic(topicName);
+                            } catch (Exception e) {
+                                log.warn()
                                         .attr("broker", brokerContainer.getHostName())
-                                        .attr("see", NUM_BROKERS)
-                                        .log("Broker does not see active brokers yet");
+                                        .attr("yet", e.getMessage())
+                                        .log("Broker is not ready yet");
                                 return false;
                             }
-                            try {
-                                brokerAdmin.topics().createPartitionedTopic(topicName, 10);
-                            } catch (PulsarAdminException.ConflictException e) {
-                                // expected - topic already exists
-                            }
-                            brokerAdmin.lookups().lookupPartitionedTopic(topicName);
-                        } catch (Exception e) {
-                            log.warn()
-                                    .attr("broker", brokerContainer.getHostName())
-                                    .attr("yet", e.getMessage())
-                                    .log("Broker is not ready yet");
-                            return false;
                         }
+                        return true;
                     }
-                    return true;
-                }
-        );
+            );
+        } finally {
+            brokerAdmins.forEach(PulsarAdmin::close);
+        }
     }
 
     @Test(timeOut = 40 * 1000)


### PR DESCRIPTION
### Motivation

`ExtensibleLoadManagerTest.startBroker` is a `@BeforeMethod` that runs before each test method (e.g. `testStopBroker`, `testIsolationPolicy`) to make sure all brokers are running and ready. Some test methods intentionally stop brokers, so the next method's `startBroker` waits for those brokers to come back.

The readiness check polled by creating a brand new `PulsarAdmin` per broker on every poll iteration:

```java
for (BrokerContainer brokerContainer : pulsarCluster.getBrokers()) {
    try (PulsarAdmin brokerAdmin = PulsarAdmin.builder()
            .serviceHttpUrl(brokerContainer.getHttpServiceUrl()).build()) {
        ...
    }
}
```

That's 3 brokers × N polls of admin builder/close, each one establishing a new HTTP client. The connection setup work piles up against brokers that are still warming up after a stop/restart and the await can exhaust its 180s budget.

Example failure: https://scans.gradle.com/s/4dgsnjrtxayqa/tests/task/:tests:integration:integrationTest/details/org.apache.pulsar.tests.integration.loadbalance.ExtensibleLoadManagerTest/startBroker?top-execution=1

### Modifications

Build the per-broker `PulsarAdmin` clients once before the await loop and reuse them across all poll iterations. Close them in a `finally` block. The readiness checks themselves (`getActiveBrokers`, `createPartitionedTopic`, `lookupPartitionedTopic`) are unchanged.

### Verifying this change

This change is already covered by the existing `ExtensibleLoadManagerTest` integration test (which runs `startBroker` between every test method).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment