### PR TITLE
[improve][test] Set diskUsageThreshold to 0.999 for tests to effectively disable the check

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedMultiBrokerPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedMultiBrokerPulsarCluster.java
@@ -162,6 +162,8 @@ public class SharedMultiBrokerPulsarCluster {
         bkConf.setNumLongPollWorkerThreads(1);
         bkConf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
         bkConf.setLedgerStorageClass("org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage");
+        bkConf.setDiskUsageThreshold(0.999F);
+        bkConf.setDiskUsageWarnThreshold(0.99F);
 
         bkCluster = BKCluster.builder()
                 .baseServerConfiguration(bkConf)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SharedPulsarCluster.java
@@ -116,6 +116,8 @@ public class SharedPulsarCluster {
         bkConf.setNumLongPollWorkerThreads(1);
         bkConf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
         bkConf.setLedgerStorageClass("org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage");
+        bkConf.setDiskUsageThreshold(0.999F);
+        bkConf.setDiskUsageWarnThreshold(0.99F);
 
         bkCluster = BKCluster.builder()
                 .baseServerConfiguration(bkConf)


### PR DESCRIPTION
### Motivation

The shared test BookKeeper clusters used by `SharedPulsarCluster` and `SharedMultiBrokerPulsarCluster` rely on BookKeeper's default `diskUsageThreshold` (0.95). When a developer's local disk is more than 95% full, all bookies are flagged as read-only on startup, and tests that need writable bookies fail with the obscure error `Not enough non-faulty bookies available`. The disk-usage check is irrelevant to the behavior these tests are exercising, so the threshold should be effectively disabled to keep the tests environment-agnostic.

### Modifications

- In `SharedPulsarCluster` and `SharedMultiBrokerPulsarCluster`, set `diskUsageThreshold` to `0.999` and `diskUsageWarnThreshold` to `0.99` on the BookKeeper server configuration so the check no longer fails tests on machines with nearly-full disks.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment