### PR TITLE
[fix][test] Fix flaky BacklogQuotaManagerTest.createNamespaces (HTTP 409 cascade)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -733,6 +733,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
      */
     public static void deleteNamespaceWithRetry(String ns, boolean force, PulsarAdmin admin) throws Exception {
         Awaitility.await()
+                .atMost(20, TimeUnit.SECONDS)
                 .pollDelay(500, TimeUnit.MILLISECONDS)
                 .until(() -> {
             try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -201,14 +201,28 @@ public class BacklogQuotaManagerTest {
     }
 
     @BeforeMethod(alwaysRun = true)
-    void createNamespaces() throws PulsarAdminException {
+    void createNamespaces() throws Exception {
         config.setPreciseTimeBasedBacklogQuotaCheck(false);
-        admin.namespaces().createNamespace("prop/ns-quota");
-        admin.namespaces().setNamespaceReplicationClusters("prop/ns-quota", Sets.newHashSet("usc"), false);
-        admin.namespaces().createNamespace("prop/quotahold");
-        admin.namespaces().setNamespaceReplicationClusters("prop/quotahold", Sets.newHashSet("usc"), false);
-        admin.namespaces().createNamespace("prop/quotaholdasync");
-        admin.namespaces().setNamespaceReplicationClusters("prop/quotaholdasync", Sets.newHashSet("usc"), false);
+        createNamespaceForTest("prop/ns-quota");
+        createNamespaceForTest("prop/quotahold");
+        createNamespaceForTest("prop/quotaholdasync");
+    }
+
+    /**
+     * If a previous test's @AfterMethod timed out before the namespace was fully removed, the
+     * leftover would otherwise cascade as HTTP 409 here and fail every subsequent test.
+     * Force-delete and retry so each test starts with clean namespace state.
+     */
+    private void createNamespaceForTest(String ns) throws Exception {
+        try {
+            admin.namespaces().createNamespace(ns);
+        } catch (PulsarAdminException.ConflictException e) {
+            log.warn().attr("namespace", ns)
+                    .log("Namespace already exists from previous test — force-deleting and recreating");
+            deleteNamespaceWithRetry(ns, true);
+            admin.namespaces().createNamespace(ns);
+        }
+        admin.namespaces().setNamespaceReplicationClusters(ns, Sets.newHashSet("usc"), false);
     }
 
     @AfterMethod(alwaysRun = true)


### PR DESCRIPTION
### Motivation

When CI runs `BacklogQuotaManagerTest`, two cases fail together as a cascade:

1. `BacklogQuotaManagerTest.clearNamespaces` (the `@AfterMethod`) fails with `org.awaitility.core.ConditionTimeoutException: Condition ... was not fulfilled within 10 seconds.` while force-deleting `prop/ns-quota`.
2. The next test method's `@BeforeMethod` `createNamespaces` then fails with `PulsarAdminException$ConflictException: Namespace already exists` (HTTP 409), because the prior cleanup never finished — and the same 409 keeps cascading for every subsequent test.

Example: https://github.com/apache/pulsar/actions/runs/25387367872/job/74455105884 (PR #25676 attempt 1; the failure is unrelated to that PR's change).

Root cause: PR #25624 added `testConsumerBacklogEvictionSizeQuotaCleansPendingAcks` and `testConsumerBacklogEvictionTimeQuotaNotPreciseCleansPendingAcks`, which leave Key_Shared consumers with unacked messages on `prop/ns-quota` and an active backlog-quota check loop running every 2s. Force-deleting that state can exceed the 10s default `Awaitility` budget used by `MockedPulsarServiceBaseTest.deleteNamespaceWithRetry`. The afterMethod times out, leftover metadata remains, and the next beforeMethod hits 409.

### Modifications

1. **`MockedPulsarServiceBaseTest.deleteNamespaceWithRetry`** now sets `atMost(20, TimeUnit.SECONDS)` instead of relying on Awaitility's 10s default. 2× headroom is enough for the heaviest cleanups while staying conservative for the many tests that share this helper.
2. **`BacklogQuotaManagerTest.createNamespaces`** is split: a new `createNamespaceForTest(String)` helper catches `PulsarAdminException.ConflictException` and recovers by force-deleting the leftover and recreating. Defense in depth — even if cleanup ever exceeds the 20s budget, the next test starts with clean state instead of cascading 409s.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `BacklogQuotaManagerTest.testConsumerBacklogEvictionSizeQuotaCleansPendingAcks` and `BacklogQuotaManagerTest.testConsumerBacklogEvictionTimeQuotaNotPreciseCleansPendingAcks` (the two heavy tests that exposed the cascade). Verified locally with `@Test(invocationCount = 10)` on both: 20/20 passes, all `clearNamespaces` cycles within the new 20s budget.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment