### PR TITLE
[fix][test] Fix flaky ReplicatorTest.testReplicatorClearBacklog NPE on inFlightTask

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static org.apache.pulsar.broker.BrokerTestUtil.newUniqueName;
 import static org.apache.pulsar.broker.service.persistent.BrokerServicePersistInternalMethodInvoker.ensureNoBacklogByInflightTask;
+import static org.apache.pulsar.broker.service.persistent.BrokerServicePersistInternalMethodInvoker.newInFlightTaskCtx;
 import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricDoubleGaugeValue;
 import static org.apache.pulsar.broker.stats.BrokerOpenTelemetryTestUtil.assertMetricLongSumValue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -663,7 +664,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
         PersistentReplicator replicator = (PersistentReplicator) spy(
                 topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
+        Object inFlightTaskCtx = newInFlightTaskCtx(replicator, PositionFactory.create(1, 1), 1);
+        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"),
+                inFlightTaskCtx);
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage
@@ -693,7 +696,9 @@ public class ReplicatorTest extends ReplicatorTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString()).get();
         PersistentReplicator replicator = (PersistentReplicator) spy(
                 topic.getReplicators().get(topic.getReplicators().keySet().stream().toList().get(0)));
-        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
+        Object inFlightTaskCtx = newInFlightTaskCtx(replicator, PositionFactory.create(1, 1), 1);
+        replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"),
+                inFlightTaskCtx);
         replicator.clearBacklog().get();
         Thread.sleep(100);
         replicator.updateRates(); // for code-coverage

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BrokerServicePersistInternalMethodInvoker.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BrokerServicePersistInternalMethodInvoker.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.mledger.Position;
 import org.awaitility.Awaitility;
 
 public class BrokerServicePersistInternalMethodInvoker {
@@ -41,5 +42,9 @@ public class BrokerServicePersistInternalMethodInvoker {
             }
             return true;
         });
+    }
+
+    public static Object newInFlightTaskCtx(PersistentReplicator replicator, Position readPos, int readingEntries) {
+        return new PersistentReplicator.InFlightTask(readPos, readingEntries, replicator.getReplicatorId());
     }
 }


### PR DESCRIPTION
### Motivation

After #25625 (`Replication is stuck because failed to read entries`), `PersistentReplicator.readEntriesFailed` now casts the `ctx` argument to `InFlightTask` and calls `setEntries(Collections.emptyList())` on it. `ReplicatorTest.testReplicatorClearBacklog` and `testReplicatorExpireMsgAsync` were calling that method directly with a \`null\` context as a shortcut, which now NPEs:

```
java.lang.NullPointerException: Cannot invoke "...InFlightTask.setEntries(java.util.List)" because "inFlightTask" is null
    at o.a.p.b.s.persistent.PersistentReplicator.readEntriesFailed(PersistentReplicator.java:518)
    at o.a.p.b.s.ReplicatorTest.testReplicatorClearBacklog(ReplicatorTest.java:666)
```

Failing test scan: https://scans.gradle.com/s/lg3litw5ckegw/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.service.ReplicatorTest/testReplicatorClearBacklog/2/output

### Modifications

Pass a real `InFlightTask` instance instead of `null`. `InFlightTask` is `protected` in `PersistentReplicator` and cannot be instantiated from the `org.apache.pulsar.broker.service` package directly, so the construction is routed through a new helper on `BrokerServicePersistInternalMethodInvoker` — which is already used to expose other package-private replicator internals to tests.

Same fix is applied to `testReplicatorExpireMsgAsync`, which uses the identical pattern.

### Verifying this change

- `ReplicatorTest.testReplicatorClearBacklog` and `testReplicatorExpireMsgAsync` pass locally with the change.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (does it add or upgrade a dependency): no
- [ ] The public API: no
- [ ] The schema: no
- [ ] The default values of configurations: no
- [ ] The threading model: no
- [ ] The binary protocol: no
- [ ] The REST endpoints: no
- [ ] The admin CLI options: no
- [ ] The metrics: no
- [ ] Anything that affects deployment: no