### PR TITLE
[fix][client] Fix idle connection release ignoring V5 watch sessions

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -1748,6 +1748,15 @@ public class ClientCnx extends PulsarHandler {
         if (!topicListWatchers.isEmpty()) {
             return false;
         }
+        if (!dagWatchSessions.isEmpty()) {
+            return false;
+        }
+        if (!scalableConsumerSessions.isEmpty()) {
+            return false;
+        }
+        if (!scalableTopicsWatchers.isEmpty()) {
+            return false;
+        }
         return true;
     }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->



<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

When connectionMaxIdleSeconds is enabled, ConnectionPool periodically calls ClientCnxIdleState#doIdleDetect, which uses ClientCnx#idleCheck() to decide whether a pooled connection is idle. idleCheck() did not account for V5 registrations (dagWatchSessions, scalableConsumerSessions, scalableTopicsWatchers), while channelInactive treats them as live sessions on the connection. As a result, connections that still served scalable-topic watches or DAG watches could be marked idle and released, causing unnecessary disconnects and other errors.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

Added checks in ClientCnx#idleCheck() for dagWatchSessions, scalableConsumerSessions, and scalableTopicsWatchers


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Matching PR in forked repository

PR in forked repository: https://github.com/Dream95/pulsar/pull/7