### PR TITLE
[fix][test] Absorb Backoff jitter in PulsarServiceNameResolverTest.testRemoveUnavailableHost

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarServiceNameResolverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarServiceNameResolverTest.java
@@ -161,8 +161,10 @@ public class PulsarServiceNameResolverTest {
             assertTrue(expectedHostUrls.contains(uri));
         }
 
-        // After backoff time, host1 should be recovery from the unavailable hosts
-        Uninterruptibles.sleepUninterruptibly(INIT_QUARANTINE_TIME_MS, java.util.concurrent.TimeUnit.MILLISECONDS);
+        // After backoff time, host1 should be recovery from the unavailable hosts.
+        // Sleep slightly longer than the configured init duration to absorb the Backoff jitter (±5%).
+        Uninterruptibles.sleepUninterruptibly(INIT_QUARANTINE_TIME_MS + 200,
+                java.util.concurrent.TimeUnit.MILLISECONDS);
         // trigger the recovery of host1
         resolver.markHostAvailability(InetSocketAddress.createUnresolved("host2", 6651), true);
 


### PR DESCRIPTION
### Motivation

The Backoff refactor in #25278 changed jitter from a one-sided "decrease only, clamped to initial" model to symmetric ±5%. As a result, the first call to `Backoff.next()` with `initialDelay=1000ms` can now return up to ~1050ms, whereas before it always returned exactly 1000ms.

`PulsarServiceNameResolverTest.testRemoveUnavailableHost` sleeps for exactly `INIT_QUARANTINE_TIME_MS` (1000ms) and then expects `host1` to recover. With positive jitter, the recovery delay can exceed the sleep, so the elapsed-time check in `computeEndpointStatus` returns false and `host1` stays unavailable, producing a flaky assertion failure on CI:

```
java.lang.AssertionError: Sets differ:
  expected [host2/<unresolved>:6651, host1/<unresolved>:6651, host3/<unresolved>:6651]
       but got [host2/<unresolved>:6651, host3/<unresolved>:6651]
```

### Modifications

Sleep `INIT_QUARANTINE_TIME_MS + 200ms` instead of exactly `INIT_QUARANTINE_TIME_MS`, to absorb the ±5% jitter applied by the new Backoff implementation.

### Verifying this change

This change is a trivial test fix.

Verified locally by running the test 5x with `--rerun-tasks`:
```
./gradlew :pulsar-client-original:test --tests \
  "org.apache.pulsar.client.impl.PulsarServiceNameResolverTest.testRemoveUnavailableHost" \
  --rerun-tasks
```
All 5 runs passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment