### PR TITLE
[feat] PIP-468: segment-aware admin endpoints for cursor lifecycle

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ScalableTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ScalableTopics.java
@@ -57,7 +57,6 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
-import org.apache.pulsar.common.scalable.SegmentInfo;
 import org.apache.pulsar.common.scalable.SegmentTopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
@@ -675,8 +674,9 @@ public class ScalableTopics extends AdminResource {
     }
 
     /**
-     * Best-effort delete underlying persistent topics for all segments.
-     * Uses the internal admin client which handles cross-broker routing.
+     * Best-effort delete the underlying topic for every segment in the DAG. Uses the
+     * segment-aware admin endpoint, which routes to the segment-owning broker via the
+     * standard bundle-ownership lookup.
      */
     private CompletableFuture<Void> deleteSegmentTopics(TopicName parentTopic,
                                                          ScalableTopicMetadata metadata,
@@ -685,10 +685,11 @@ public class ScalableTopics extends AdminResource {
             var admin = pulsar().getAdminClient();
             CompletableFuture<?>[] futures = metadata.getSegments().values().stream()
                     .map(seg -> {
-                        String name = segmentPersistentName(parentTopic, seg);
-                        return admin.topics().deleteAsync(name, force)
+                        String segmentTopicName = SegmentTopicName.fromParent(
+                                parentTopic, seg.hashRange(), seg.segmentId()).toString();
+                        return admin.scalableTopics().deleteSegmentAsync(segmentTopicName, force)
                                 .exceptionally(ex -> {
-                                    log.warn().attr("segment", name).exceptionMessage(ex)
+                                    log.warn().attr("segment", segmentTopicName).exceptionMessage(ex)
                                             .log("Failed to delete segment topic");
                                     return null;
                                 });
@@ -700,16 +701,5 @@ public class ScalableTopics extends AdminResource {
                     .log("Failed to get admin client for segment cleanup");
             return CompletableFuture.completedFuture(null);
         }
-    }
-
-    /**
-     * Convert a segment:// topic name to persistent:// for the underlying managed ledger topic.
-     */
-    private String segmentPersistentName(TopicName parentTopic, SegmentInfo segment) {
-        TopicName segTopic = SegmentTopicName.fromParent(
-                parentTopic, segment.hashRange(), segment.segmentId());
-        return "persistent://" + segTopic.getTenant() + "/"
-                + segTopic.getNamespacePortion() + "/"
-                + segTopic.getLocalName();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Segments.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Segments.java
@@ -175,6 +175,107 @@ public class Segments extends AdminResource {
                 });
     }
 
+    @PUT
+    @Path("/{tenant}/{namespace}/{topic}/{descriptor}/subscription/{subscription}")
+    @ApiOperation(value = "Create a subscription cursor on the segment topic at the earliest"
+            + " position. Super-user only.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Subscription cursor created (or already existed)"),
+            @ApiResponse(code = 401, message = "This operation requires super-user access"),
+            @ApiResponse(code = 403, message = "This operation requires super-user access"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void createSubscription(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify the parent topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment descriptor (e.g. 0000-7fff-1)", required = true)
+            @PathParam("descriptor") String descriptor,
+            @ApiParam(value = "Subscription name", required = true)
+            @PathParam("subscription") String subscription,
+            @ApiParam(value = "Whether leader broker redirected this call to this broker.")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        validateNamespaceName(tenant, namespace);
+        TopicName segmentTopic = segmentTopicName(tenant, namespace, encodedTopic, descriptor);
+
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> validateTopicOwnershipAsync(segmentTopic, authoritative))
+                .thenCompose(__ -> pulsar().getBrokerService().getOrCreateTopic(segmentTopic.toString()))
+                .thenCompose(topic -> topic.createSubscription(subscription,
+                        CommandSubscribe.InitialPosition.Earliest, false, null))
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .attr("subscription", subscription)
+                            .log("Created subscription on segment topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .attr("subscription", subscription)
+                            .exception(ex).log("Failed to create subscription on segment");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @DELETE
+    @Path("/{tenant}/{namespace}/{topic}/{descriptor}/subscription/{subscription}")
+    @ApiOperation(value = "Delete a subscription cursor on the segment topic. Super-user only.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Subscription cursor deleted (or never existed)"),
+            @ApiResponse(code = 401, message = "This operation requires super-user access"),
+            @ApiResponse(code = 403, message = "This operation requires super-user access"),
+            @ApiResponse(code = 500, message = "Internal server error")})
+    public void deleteSubscription(
+            @Suspended final AsyncResponse asyncResponse,
+            @ApiParam(value = "Specify the tenant", required = true)
+            @PathParam("tenant") String tenant,
+            @ApiParam(value = "Specify the namespace", required = true)
+            @PathParam("namespace") String namespace,
+            @ApiParam(value = "Specify the parent topic name", required = true)
+            @PathParam("topic") @Encoded String encodedTopic,
+            @ApiParam(value = "Segment descriptor (e.g. 0000-7fff-1)", required = true)
+            @PathParam("descriptor") String descriptor,
+            @ApiParam(value = "Subscription name", required = true)
+            @PathParam("subscription") String subscription,
+            @ApiParam(value = "Whether leader broker redirected this call to this broker.")
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        validateNamespaceName(tenant, namespace);
+        TopicName segmentTopic = segmentTopicName(tenant, namespace, encodedTopic, descriptor);
+
+        validateSuperUserAccessAsync()
+                .thenCompose(__ -> validateTopicOwnershipAsync(segmentTopic, authoritative))
+                .thenCompose(__ -> pulsar().getBrokerService().getTopicIfExists(segmentTopic.toString()))
+                .thenCompose(optTopic -> {
+                    if (optTopic.isEmpty()) {
+                        // Topic not loaded → no cursor to delete. Idempotent success.
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    var sub = optTopic.get().getSubscription(subscription);
+                    if (sub == null) {
+                        // Subscription doesn't exist on this segment — idempotent success.
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    return sub.delete();
+                })
+                .thenAccept(__ -> {
+                    log.info().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .attr("subscription", subscription)
+                            .log("Deleted subscription on segment topic");
+                    asyncResponse.resume(Response.noContent().build());
+                })
+                .exceptionally(ex -> {
+                    log.error().attr("clientAppId", clientAppId()).attr("segment", segmentTopic)
+                            .attr("subscription", subscription)
+                            .exception(ex).log("Failed to delete subscription on segment");
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
     @GET
     @Path("/{tenant}/{namespace}/{topic}/{descriptor}/subscription/{subscription}/backlog")
     @ApiOperation(value = "Number of unconsumed entries in the segment topic for the "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -711,11 +711,11 @@ public class ScalableTopicController {
     }
 
     private CompletableFuture<Void> createSubscriptionOnSegment(SegmentInfo segment, String subscription) {
-        String persistentName = toSegmentUnderlyingPersistentName(segment);
+        String segmentTopicName = toSegmentPersistentName(segment);
         try {
             return brokerService.getPulsar().getAdminClient()
-                    .topics().createSubscriptionAsync(persistentName, subscription,
-                            org.apache.pulsar.client.api.MessageId.earliest)
+                    .scalableTopics()
+                    .createSegmentSubscriptionAsync(segmentTopicName, subscription)
                     .exceptionally(ex -> {
                         Throwable cause = org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException(ex);
                         if (cause instanceof org.apache.pulsar.client.admin.PulsarAdminException.ConflictException) {
@@ -730,17 +730,18 @@ public class ScalableTopicController {
     }
 
     private CompletableFuture<Void> deleteSubscriptionOnSegment(SegmentInfo segment, String subscription) {
-        String persistentName = toSegmentUnderlyingPersistentName(segment);
+        String segmentTopicName = toSegmentPersistentName(segment);
         try {
             return brokerService.getPulsar().getAdminClient()
-                    .topics().deleteSubscriptionAsync(persistentName, subscription, true)
+                    .scalableTopics()
+                    .deleteSegmentSubscriptionAsync(segmentTopicName, subscription)
                     .exceptionally(ex -> {
                         Throwable cause = org.apache.pulsar.common.util.FutureUtil.unwrapCompletionException(ex);
                         if (cause instanceof org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException) {
                             return null;
                         }
                         log.warn().attr("subscription", subscription)
-                                .attr("segment", persistentName).exceptionMessage(cause)
+                                .attr("segment", segmentTopicName).exceptionMessage(cause)
                                 .log("Failed to delete subscription from segment");
                         return null;
                     });
@@ -1094,19 +1095,6 @@ public class ScalableTopicController {
         TopicName segmentTopicName = SegmentTopicName.fromParent(
                 topicName, segment.hashRange(), segment.segmentId());
         return segmentTopicName.toString();
-    }
-
-    /**
-     * Return the {@code persistent://} form of a segment's underlying managed-ledger topic,
-     * suitable for the standard {@link org.apache.pulsar.client.admin.Topics} admin API.
-     * The segment-owning broker is discovered by the admin client's normal bundle routing.
-     */
-    private String toSegmentUnderlyingPersistentName(SegmentInfo segment) {
-        TopicName segmentTopicName = SegmentTopicName.fromParent(
-                topicName, segment.hashRange(), segment.segmentId());
-        return "persistent://" + segmentTopicName.getTenant() + "/"
-                + segmentTopicName.getNamespacePortion() + "/"
-                + segmentTopicName.getLocalName();
     }
 
     private CompletableFuture<Void> terminateSegmentTopic(String segmentTopicName) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -47,7 +47,6 @@ import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.ScalableTopics;
 import org.apache.pulsar.client.admin.Topics;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ScalableTopicStats;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -117,13 +117,13 @@ public class ScalableTopicControllerTest {
         // Default: all admin ops succeed.
         when(topics.getSubscriptionsAsync(anyString()))
                 .thenReturn(CompletableFuture.completedFuture(java.util.List.of()));
-        when(topics.createSubscriptionAsync(anyString(), anyString(), any(MessageId.class)))
-                .thenReturn(CompletableFuture.completedFuture(null));
-        when(topics.deleteSubscriptionAsync(anyString(), anyString(), anyBoolean()))
-                .thenReturn(CompletableFuture.completedFuture(null));
         when(scalableTopics.createSegmentAsync(anyString(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
         when(scalableTopics.terminateSegmentAsync(anyString()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopics.createSegmentSubscriptionAsync(anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(scalableTopics.deleteSegmentSubscriptionAsync(anyString(), anyString()))
                 .thenReturn(CompletableFuture.completedFuture(null));
 
         controller = newController(topicName);
@@ -288,9 +288,9 @@ public class ScalableTopicControllerTest {
                 resources.getSubscriptionAsync(topicName, "sub-stream").get();
         assertTrue(persisted.isPresent());
         assertEquals(persisted.get().type(), SubscriptionType.STREAM);
-        // Propagated to every active segment via admin.topics().createSubscriptionAsync().
-        verify(topics, org.mockito.Mockito.times(INITIAL_SEGMENTS))
-                .createSubscriptionAsync(anyString(), anyString(), any(MessageId.class));
+        // Propagated to every active segment via the segment-subscription admin endpoint.
+        verify(scalableTopics, org.mockito.Mockito.times(INITIAL_SEGMENTS))
+                .createSegmentSubscriptionAsync(anyString(), anyString());
     }
 
     @Test
@@ -321,8 +321,8 @@ public class ScalableTopicControllerTest {
         controller.deleteSubscription("sub-a").get();
         assertFalse(resources.getSubscriptionAsync(topicName, "sub-a").get().isPresent());
         // Propagated a delete to every segment (all segments incl. any sealed ones).
-        verify(topics, org.mockito.Mockito.atLeast(INITIAL_SEGMENTS))
-                .deleteSubscriptionAsync(anyString(), anyString(), anyBoolean());
+        verify(scalableTopics, org.mockito.Mockito.atLeast(INITIAL_SEGMENTS))
+                .deleteSegmentSubscriptionAsync(anyString(), anyString());
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5ScalableSubscriptionAdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5ScalableSubscriptionAdminTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api.v5;
+
+import static org.testng.Assert.assertEquals;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.policies.data.ScalableSubscriptionType;
+import org.testng.annotations.Test;
+
+/**
+ * Coverage for {@code admin.scalableTopics().createSubscription(...)}: the admin
+ * API must materialize a cursor on every active segment so a consumer that
+ * subscribes <em>after</em> messages are produced still receives those
+ * messages — the whole point of pre-creating the subscription.
+ *
+ * <p>The behavioural assertion (a late consumer sees pre-subscription messages)
+ * is the user-facing guarantee, and any regression in
+ * {@code ScalableTopicController.createSubscriptionOnSegment} — which converts
+ * each {@code SegmentInfo} to the underlying {@code persistent://} topic and
+ * pre-creates the cursor through the standard topic admin API — would surface
+ * here as messages going missing.
+ */
+public class V5ScalableSubscriptionAdminTest extends V5ClientBaseTest {
+
+    @Test
+    public void testPreCreatedSubscriptionRetainsPreProductionMessages() throws Exception {
+        String topic = newScalableTopic(3);
+        String subscription = "pre-created-sub";
+
+        // Pre-create the subscription on the scalable topic. This must materialize a
+        // cursor on every active segment so that subsequent produces are retained
+        // until the consumer drains them.
+        admin.scalableTopics().createSubscription(topic, subscription,
+                ScalableSubscriptionType.QUEUE);
+
+        // Produce *before* any consumer subscribes.
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        int n = 30;
+        Set<String> sent = new HashSet<>();
+        for (int i = 0; i < n; i++) {
+            String v = "msg-" + i;
+            producer.newMessage().key("k-" + i).value(v).send();
+            sent.add(v);
+        }
+
+        // Subscribe with the SAME subscription name. If createSubscription truly
+        // pre-created cursors on every segment, the consumer must receive every
+        // message produced above. If it didn't, the consumer attaches at "latest"
+        // by default and drops the entire backlog.
+        @Cleanup
+        QueueConsumer<String> consumer = v5Client.newQueueConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscribe();
+
+        Set<String> received = new HashSet<>();
+        long deadline = System.currentTimeMillis() + 30_000L;
+        while (received.size() < n && System.currentTimeMillis() < deadline) {
+            Message<String> msg = consumer.receive(Duration.ofSeconds(1));
+            if (msg != null) {
+                received.add(msg.value());
+                consumer.acknowledge(msg.id());
+            }
+        }
+        assertEquals(received, sent,
+                "pre-created subscription must retain every message produced before consumer subscribed");
+    }
+}

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ScalableTopics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ScalableTopics.java
@@ -314,6 +314,32 @@ public interface ScalableTopics {
     CompletableFuture<Void> deleteSegmentAsync(String segmentTopic, boolean force);
 
     /**
+     * Create a subscription cursor on the given segment topic at the earliest position.
+     * The call routes to the broker that owns the segment.
+     *
+     * <p>Used internally by {@link org.apache.pulsar.broker.service.scalable.ScalableTopicController
+     * ScalableTopicController} to fan a new scalable-topic subscription out across every
+     * active segment so a future consumer doesn't drop the backlog.
+     *
+     * @param segmentTopic Full segment topic name ({@code segment://tenant/namespace/topic/descriptor})
+     * @param subscription Subscription name
+     */
+    CompletableFuture<Void> createSegmentSubscriptionAsync(String segmentTopic, String subscription);
+
+    /**
+     * Delete a subscription cursor on the given segment topic. The call routes to the broker
+     * that owns the segment.
+     *
+     * <p>Used internally by {@link org.apache.pulsar.broker.service.scalable.ScalableTopicController
+     * ScalableTopicController} when a scalable-topic subscription is deleted, so no orphan
+     * cursors remain on any segment in the DAG.
+     *
+     * @param segmentTopic Full segment topic name ({@code segment://tenant/namespace/topic/descriptor})
+     * @param subscription Subscription name
+     */
+    CompletableFuture<Void> deleteSegmentSubscriptionAsync(String segmentTopic, String subscription);
+
+    /**
      * Returns the number of unconsumed entries in the given subscription's cursor on the
      * segment topic — i.e. the per-subscription backlog. The call routes to the broker
      * that owns the segment topic, so it works whether the caller is colocated with the

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ScalableTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ScalableTopicsImpl.java
@@ -291,6 +291,28 @@ public class ScalableTopicsImpl extends BaseResource implements ScalableTopics {
     }
 
     @Override
+    public CompletableFuture<Void> createSegmentSubscriptionAsync(String segmentTopic,
+                                                                   String subscription) {
+        TopicName tn = TopicName.get(segmentTopic);
+        WebTarget path = adminSegments
+                .path(tn.getTenant()).path(tn.getNamespacePortion())
+                .path(tn.getLocalName()).path(tn.getSegmentDescriptor())
+                .path("subscription").path(subscription);
+        return asyncPutRequest(path, Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteSegmentSubscriptionAsync(String segmentTopic,
+                                                                   String subscription) {
+        TopicName tn = TopicName.get(segmentTopic);
+        WebTarget path = adminSegments
+                .path(tn.getTenant()).path(tn.getNamespacePortion())
+                .path(tn.getLocalName()).path(tn.getSegmentDescriptor())
+                .path("subscription").path(subscription);
+        return asyncDeleteRequest(path);
+    }
+
+    @Override
     public CompletableFuture<Long> getSegmentSubscriptionBacklogAsync(String segmentTopic,
                                                                       String subscription) {
         TopicName tn = TopicName.get(segmentTopic);


### PR DESCRIPTION
## Summary

Supersedes #25709, which had the right intent but produced an invalid `persistent://t/n/parent/{descriptor}` URL that `TopicName` parses as a legacy V1 topic name and rejects synchronously — making the admin call hard-fail before any HTTP request goes out.

`createSubscription` / `deleteSubscription` on a scalable topic was silently broken before either change. `ScalableTopicController.createSubscriptionOnSegment` built a `persistent://t/n/parent` URL (no descriptor) and handed it to the generic `topics().createSubscriptionAsync` admin API. That URL addresses the parent scalable topic, which has no managed-ledger backing, so the admin call hit `Subscription Busy` / `NotFound` and the `.exceptionally` block swallowed it. Per-segment cursors were never pre-created. Lazy cursor creation by the V5 client on first consumer subscribe masked the bug in the happy path; admin `createSubscription` had no observable effect beyond writing the `SubscriptionMetadata` to the metadata store. The same shape of bug existed in `ScalableTopics.deleteSegmentTopics` (whole-scalable-topic teardown).

The clean fix is segment-specific admin endpoints, all the way down — no `persistent://` conversion.

### New REST endpoints (`Segments.java`, super-user only, segment-domain only)
- `PUT /segments/{tenant}/{namespace}/{topic}/{descriptor}/subscription/{subscription}` — create a cursor at earliest position
- `DELETE /segments/{tenant}/{namespace}/{topic}/{descriptor}/subscription/{subscription}` — delete the cursor

Same `validateSuperUserAccessAsync` → `validateTopicOwnershipAsync` → `getOrCreateTopic` (or `getTopicIfExists` for delete) pattern as the existing `/segments/.../subscription/{sub}/backlog`, `/seek`, `/skip-all`.

### New admin client methods (`ScalableTopics`)
- `createSegmentSubscriptionAsync(segmentTopic, subscription)`
- `deleteSegmentSubscriptionAsync(segmentTopic, subscription)`

Both take a `segment://...` URI directly. `ScalableTopicsImpl` builds the REST path from `TopicName` parts — same pattern as the existing `getSegmentSubscriptionBacklogAsync` / `seekSegmentSubscriptionAsync` / `clearSegmentSubscriptionBacklogAsync` helpers.

### Caller updates
- `ScalableTopicController.createSubscriptionOnSegment` / `deleteSubscriptionOnSegment` now call `scalableTopics().createSegmentSubscriptionAsync` / `deleteSegmentSubscriptionAsync`. Removed the broken `toSegmentUnderlyingPersistentName` helper.
- `ScalableTopics.deleteSegmentTopics` (whole-scalable-topic teardown) now uses `admin.scalableTopics().deleteSegmentAsync(segmentTopicName, force)` — the existing segment-aware admin endpoint already used for split-segment teardown — instead of fabricating a `persistent://` URL.

## Test plan

- [x] `V5ScalableSubscriptionAdminTest` (new, 1 test) — behavioral round trip: create scalable topic → `admin.scalableTopics().createSubscription` → produce 30 messages with no consumer attached → subscribe and assert all 30 are received. **Fails on master**, **passes here**.
- [x] `ScalableTopicControllerTest` 31/31 — updated mocks: `topics.createSubscriptionAsync` / `deleteSubscriptionAsync` → `scalableTopics.createSegmentSubscriptionAsync` / `deleteSegmentSubscriptionAsync`. Verifies the controller calls the new admin path.
- [x] `ScalableTopicServiceTest` 16/16 — unchanged, no regressions.
- [x] Full V5 broker test suite green (153/153).
- [x] `pulsar-client-admin-api`, `pulsar-client-admin-original`, `pulsar-broker` checkstyle clean.