### PR TITLE
[fix][admin] PIP-369 Change default value of unload-scope in ns-isolation-policy set (branch-3.0)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -738,15 +738,16 @@ public class ClustersBase extends AdminResource {
         } catch (PulsarServerException e) {
             return FutureUtil.failedFuture(e);
         }
-        // compile regex patterns once
-        List<Pattern> namespacePatterns = policyData.getNamespaces().stream().map(Pattern::compile).toList();
-        // TODO for 4.x, we should include both old and new namespace regex pattern for unload `all_matching` option
+        Set<String> combinedNamespaces = new HashSet<>(policyData.getNamespaces());
+        final List<String> oldNamespaces = new ArrayList<>();
+        if (oldPolicy != null) {
+            oldNamespaces.addAll(oldPolicy.getNamespaces());
+            combinedNamespaces.addAll(oldNamespaces);
+        }
         return adminClient.tenants().getTenantsAsync().thenCompose(tenants -> {
             List<CompletableFuture<List<String>>> filteredNamespacesForEachTenant = tenants.stream()
                     .map(tenant -> adminClient.namespaces().getNamespacesAsync(tenant).thenCompose(namespaces -> {
                         List<CompletableFuture<String>> namespaceNamesInCluster = namespaces.stream()
-                                .filter(namespaceName -> namespacePatterns.stream()
-                                        .anyMatch(pattern -> pattern.matcher(namespaceName).matches()))
                                 .map(namespaceName -> adminClient.namespaces().getPoliciesAsync(namespaceName)
                                         .thenApply(policies -> policies.replication_clusters.contains(cluster)
                                                 ? namespaceName : null))
@@ -762,46 +763,44 @@ public class ClustersBase extends AdminResource {
                             .map(CompletableFuture::join)
                             .flatMap(List::stream)
                             .collect(Collectors.toList()));
-        }).thenCompose(shouldUnloadNamespaces -> {
-            if (CollectionUtils.isEmpty(shouldUnloadNamespaces)) {
+        }).thenCompose(clusterLocalNamespaces -> {
+            if (CollectionUtils.isEmpty(clusterLocalNamespaces)) {
                 return CompletableFuture.completedFuture(null);
             }
             // If unload type is 'changed', we need to figure out a further subset of namespaces whose placement might
             // actually have been changed.
 
             log.debug("Old policy: {} ; new policy: {}", oldPolicy, policyData);
-            if (oldPolicy != null && NamespaceIsolationPolicyUnloadScope.changed.equals(policyData.getUnloadScope())) {
-                // We also compare that the previous primary broker list is same as current, in case all namespaces need
-                // to be placed again anyway.
-                if (CollectionUtils.isEqualCollection(oldPolicy.getPrimary(), policyData.getPrimary())) {
-                    // list is same, so we continue finding the changed namespaces.
 
-                    // We create a union regex list contains old + new regexes
-                    Set<String> combinedNamespaces = new HashSet<>(oldPolicy.getNamespaces());
-                    combinedNamespaces.addAll(policyData.getNamespaces());
-                    // We create a intersection of the old and new regexes. These won't need to be unloaded
-                    Set<String> commonNamespaces = new HashSet<>(oldPolicy.getNamespaces());
-                    commonNamespaces.retainAll(policyData.getNamespaces());
-
-                    log.debug("combined regexes: {}; common regexes:{}", combinedNamespaces, combinedNamespaces);
-
-                    // Find the changed regexes (new - new ∩ old). TODO for 4.x, make this (new U old - new ∩ old)
-                    combinedNamespaces.removeAll(commonNamespaces);
-
-                    log.debug("changed regexes: {}", commonNamespaces);
-
-                    // Now we further filter the filtered namespaces based on this combinedNamespaces set
-                    shouldUnloadNamespaces = shouldUnloadNamespaces.stream()
-                            .filter(name -> combinedNamespaces.stream()
-                                    .map(Pattern::compile)
-                                    .anyMatch(pattern -> pattern.matcher(name).matches())
-                            ).toList();
-
-                }
+            boolean unloadAllNamespaces = false;
+            // We also compare that the previous primary broker list is same as current, in case all namespaces need
+            // to be placed again anyway.
+            if (NamespaceIsolationPolicyUnloadScope.all_matching.equals(policyData.getUnloadScope())
+                    || (oldPolicy != null
+                    && !CollectionUtils.isEqualCollection(oldPolicy.getPrimary(), policyData.getPrimary()))) {
+                unloadAllNamespaces = true;
             }
-            // unload type is either null or not in (changed, none), so we proceed to unload all namespaces
-            // TODO - default in 4.x should become `changed`
-            List<CompletableFuture<Void>> futures = shouldUnloadNamespaces.stream()
+            // list is same, so we continue finding the changed namespaces.
+
+            // We create a intersection of the old and new regexes. These won't need to be unloaded.
+            Set<String> commonNamespaces = new HashSet<>(policyData.getNamespaces());
+            commonNamespaces.retainAll(oldNamespaces);
+
+            log.debug("combined regexes: {}; common regexes:{}", combinedNamespaces, commonNamespaces);
+
+            if (!unloadAllNamespaces) {
+                // Find the changed regexes ((new U old) - (new ∩ old)).
+                combinedNamespaces.removeAll(commonNamespaces);
+                log.debug("changed regexes: {}", commonNamespaces);
+            }
+
+            // Now we further filter the filtered namespaces based on this combinedNamespaces set
+            List<Pattern> namespacePatterns = combinedNamespaces.stream().map(Pattern::compile).toList();
+            clusterLocalNamespaces = clusterLocalNamespaces.stream()
+                    .filter(name -> namespacePatterns.stream().anyMatch(pattern -> pattern.matcher(name).matches()))
+                    .toList();
+
+            List<CompletableFuture<Void>> futures = clusterLocalNamespaces.stream()
                     .map(namespaceName -> adminClient.namespaces().unloadAsync(namespaceName))
                     .collect(Collectors.toList());
             return FutureUtil.waitForAll(futures).thenAccept(__ -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -3581,7 +3581,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         parameters1.put("usage_threshold", "100");
         List<String> nsRegexList = new ArrayList<>(namespaces);
 
-        return NamespaceIsolationData.builder()
+        NamespaceIsolationData.Builder build = NamespaceIsolationData.builder()
                 // "prop-ig/ns1" is present in test cluster, policy set on test2 should work
                 .namespaces(nsRegexList)
                 .primary(primaryBrokers)
@@ -3589,9 +3589,11 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
                 .autoFailoverPolicy(AutoFailoverPolicyData.builder()
                         .policyType(AutoFailoverPolicyType.min_available)
                         .parameters(parameters1)
-                        .build())
-                .unloadScope(scope)
-                .build();
+                        .build());
+        if (scope != null) {
+            build.unloadScope(scope);
+        }
+        return build.build();
     }
 
     private boolean allTopicsUnloaded(List<String> topics) {
@@ -3717,18 +3719,42 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         testIsolationPolicyUnloadsNSWithScope(
                 topicType, "policy-all", nsPrefix, List.of("a1", "a2", "b1", "b2", "c1"),
                 all_matching, List.of(".*-unload-test-a.*"), List.of("b1", "b2", "c1"),
-                all_matching, List.of(".*-unload-test-a.*", ".*-unload-test-c.*"), List.of("b1", "b2"),
+                all_matching, List.of(".*-unload-test-c.*"), List.of("b1", "b2"),
                 Collections.singletonList(".*")
         );
     }
 
     @Test(dataProvider = "topicType")
-    public void testIsolationPolicyUnloadsNSWithChangedScope(final String topicType) throws Exception {
+    public void testIsolationPolicyUnloadsNSWithChangedScope1(final String topicType) throws Exception {
+        String nsPrefix1 = newUniqueName(defaultTenant + "/") + "-unload-test-";
+        // Addition case
+        testIsolationPolicyUnloadsNSWithScope(
+                topicType, "policy-changed1", nsPrefix1, List.of("a1", "a2", "b1", "b2", "c1"),
+                all_matching, List.of(".*-unload-test-a.*"), List.of("b1", "b2", "c1"),
+                changed, List.of(".*-unload-test-a.*", ".*-unload-test-c.*"), List.of("a1", "a2", "b1", "b2"),
+                Collections.singletonList(".*")
+        );
+    }
+
+    @Test(dataProvider = "topicType")
+    public void testIsolationPolicyUnloadsNSWithChangedScope2(final String topicType) throws Exception {
+        String nsPrefix2 = newUniqueName(defaultTenant + "/") + "-unload-test-";
+        // removal case
+        testIsolationPolicyUnloadsNSWithScope(
+                topicType, "policy-changed2", nsPrefix2, List.of("a1", "a2", "b1", "b2", "c1"),
+                all_matching, List.of(".*-unload-test-a.*", ".*-unload-test-c.*"), List.of("b1", "b2"),
+                changed, List.of(".*-unload-test-c.*"), List.of("b1", "b2", "c1"),
+                Collections.singletonList(".*")
+        );
+    }
+
+    @Test(dataProvider = "topicType")
+    public void testIsolationPolicyUnloadsNSWithScopeMissing(final String topicType) throws Exception {
         String nsPrefix = newUniqueName(defaultTenant + "/") + "-unload-test-";
         testIsolationPolicyUnloadsNSWithScope(
                 topicType, "policy-changed", nsPrefix, List.of("a1", "a2", "b1", "b2", "c1"),
                 all_matching, List.of(".*-unload-test-a.*"), List.of("b1", "b2", "c1"),
-                changed, List.of(".*-unload-test-a.*", ".*-unload-test-c.*"), List.of("a1", "a2", "b1", "b2"),
+                null, List.of(".*-unload-test-a.*", ".*-unload-test-c.*"), List.of("a1", "a2", "b1", "b2"),
                 Collections.singletonList(".*")
         );
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -75,12 +75,12 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         private Map<String, String> autoFailoverPolicyParams;
 
         @Parameter(names = "--unload-scope", description = "configure the type of unload to do -"
-                + " ['all_matching', 'none', 'changed'] namespaces. By default, all namespaces matching the namespaces"
-                + " regex will be unloaded and placed again. You can choose to not unload any namespace while setting"
-                + " this new policy by choosing `none` or choose to unload only the namespaces whose placement will"
-                + " actually change. If you chose 'none', you will need to manually unload the namespaces for them to"
-                + " be placed correctly, or wait till some namespaces get load balanced automatically based on load"
-                + " shedding configurations.")
+                + " ['all_matching', 'none', 'changed'] namespaces. By default, only namespaces whose placement will"
+                + " actually change would be unloaded and placed again. You can choose to not unload any namespace"
+                + " while setting this new policy by choosing `none` or choose to unload all namespaces matching"
+                + " old (if any) and new namespace regex. If you chose 'none', you will need to manually unload the"
+                + " namespaces for them to be placed correctly, or wait till some namespaces get load balanced"
+                + " automatically based on load shedding configurations.")
         private NamespaceIsolationPolicyUnloadScope unloadScope;
 
         void run() throws PulsarAdminException {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/NamespaceIsolationDataImpl.java
@@ -78,8 +78,8 @@ public class NamespaceIsolationDataImpl implements NamespaceIsolationData {
     @ApiModelProperty(
             name = "unload_scope",
             value = "The type of unload to perform while applying the new isolation policy.",
-            example = "'all_matching' (default) for unloading all matching namespaces. 'none' for not unloading "
-                    + "any namespace. 'changed' for unloading only the namespaces whose placement is actually changing"
+            example = "'changed' (default) for unloading only the namespaces whose placement is actually changing. "
+                    + "'all_matching' for unloading all matching namespaces. 'none' for not unloading any namespaces."
     )
     @JsonProperty("unload_scope")
     private NamespaceIsolationPolicyUnloadScope unloadScope;


### PR DESCRIPTION
Backport of #23253 to `branch-3.0`.

Master Issue: #23253

PIP: #23104

### Motivation

`set-ns-isolation-policy` introduced the `--unload-scope` flag via PIP-369 (cherry-picked into `branch-3.0` as `d7af82eb6d9`). The original implementation defaulted to unloading **all** matching namespaces when `--unload-scope` is not specified (`unloadScope == null`), which is overly aggressive and can cause mass unloads across a cluster.

The upstream fix (#23253, commit `4f002590450`) changed the default so that an unspecified `--unload-scope` behaves like `changed` — only namespaces whose actual broker placement changes are unloaded. This fix was never backported to `branch-3.0`, leaving 3.0.x clusters vulnerable to accidental mass unloads.

In production, this was observed to trigger NamingException reconnect storms and producer/consumer disruptions across all namespaces matching the policy regex when an operator ran `ns-isolation-policy set` without explicitly passing `--unload-scope`.

### Modifications

Cherry-pick of commit `4f002590450` from `master` onto `branch-3.0`, with a minor conflict resolution in `CmdNamespaceIsolationPolicy.java` to preserve the `@Parameter` annotation (branch-3.0 uses Picocli) while adopting the updated description text from the cherry-pick:

- **`ClustersBase.java`**: `filterAndUnloadMatchedNamespaceAsync` now treats `null` `unloadScope` the same as `changed` instead of falling through to the "unload all matching" branch.
- **`CmdNamespaceIsolationPolicy.java`**: Updated `--unload-scope` help text to reflect the new safe default.
- **`NamespaceIsolationDataImpl.java`**: Corresponding default value change.
- **`AdminApi2Test.java`**: Extended test coverage for the new default behavior.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `AdminApi2Test` (extended by this commit to cover the `changed`-default behavior).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

**Changed default**: When `--unload-scope` is omitted, behavior changes from "unload all matching namespaces" to "unload only namespaces whose placement actually changes" — a significantly safer default.