### PR TITLE
[fix][broker] Merge broker offload extra configurations

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -265,13 +265,10 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             }
         }
 
-        Map<String, String> extraConfigurations = properties.entrySet().stream()
-                .filter(entry -> entry.getKey().toString().startsWith(EXTRA_CONFIG_PREFIX))
-                .collect(Collectors.toMap(
-                        entry -> entry.getKey().toString().replaceFirst(EXTRA_CONFIG_PREFIX, ""),
-                        entry -> entry.getValue().toString()));
-
-        data.getManagedLedgerExtraConfigurations().putAll(extraConfigurations);
+        Map<String, String> extraConfigurations = getExtraConfigurations(properties);
+        if (extraConfigurations != null) {
+            data.getManagedLedgerExtraConfigurations().putAll(extraConfigurations);
+        }
 
         data.compatibleWithBrokerConfigFile(properties);
         return data;
@@ -470,7 +467,9 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
      */
     private static Object getCompatibleValue(Properties properties, Field field) {
         Object object;
-        if (field.getName().equals("managedLedgerOffloadThresholdInBytes")) {
+        if (field.getName().equals("managedLedgerExtraConfigurations")) {
+            return getExtraConfigurations(properties);
+        } else if (field.getName().equals("managedLedgerOffloadThresholdInBytes")) {
             object = properties.getProperty("managedLedgerOffloadThresholdInBytes",
                     properties.getProperty(OFFLOAD_THRESHOLD_NAME_IN_CONF_FILE));
         } else if (field.getName().equals("managedLedgerOffloadDeletionLagInMillis")) {
@@ -483,6 +482,15 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             object = properties.get(field.getName());
         }
         return value((String) object, field);
+    }
+
+    private static Map<String, String> getExtraConfigurations(Properties properties) {
+        Map<String, String> extraConfigurations = properties.entrySet().stream()
+                .filter(entry -> entry.getKey().toString().startsWith(EXTRA_CONFIG_PREFIX))
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().toString().replaceFirst(EXTRA_CONFIG_PREFIX, ""),
+                        entry -> entry.getValue().toString()));
+        return extraConfigurations.isEmpty() ? null : extraConfigurations;
     }
 
     public static class OffloadPoliciesImplBuilder implements OffloadPolicies.Builder {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
@@ -333,6 +333,55 @@ public class OffloadPoliciesTest {
         Assert.assertNull(offloadPolicies.getS3ManagedLedgerOffloadRegion());
     }
 
+    @Test
+    public void brokerExtraConfigMergeTest() {
+        final String bucketPrefix = "o-123/c-456";
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("managedLedgerOffloadDriver", "aws-s3");
+        brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", bucketPrefix);
+
+        OffloadPoliciesImpl offloadPolicies =
+                OffloadPoliciesImpl.mergeConfiguration(null, null, brokerProperties);
+
+        Assert.assertNotNull(offloadPolicies);
+        assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
+                Map.of("tieredStorageBucketPrefix", bucketPrefix));
+    }
+
+    @Test
+    public void higherLevelExtraConfigOverridesBrokerExtraConfigMergeTest() {
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("managedLedgerOffloadDriver", "aws-s3");
+        brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", "broker-prefix");
+
+        OffloadPoliciesImpl topicLevelPolicies = new OffloadPoliciesImpl();
+        topicLevelPolicies.getManagedLedgerExtraConfigurations().put("tieredStorageBucketPrefix", "topic-prefix");
+
+        OffloadPoliciesImpl offloadPolicies =
+                OffloadPoliciesImpl.mergeConfiguration(topicLevelPolicies, null, brokerProperties);
+
+        Assert.assertNotNull(offloadPolicies);
+        assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
+                Map.of("tieredStorageBucketPrefix", "topic-prefix"));
+    }
+
+    @Test
+    public void emptyHigherLevelExtraConfigOverridesBrokerExtraConfigMergeTest() {
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("managedLedgerOffloadDriver", "aws-s3");
+        brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", "broker-prefix");
+
+        OffloadPoliciesImpl topicLevelPolicies = new OffloadPoliciesImpl();
+        topicLevelPolicies.getManagedLedgerExtraConfigurations().put("tieredStorageBucketPrefix", "");
+
+        OffloadPoliciesImpl offloadPolicies =
+                OffloadPoliciesImpl.mergeConfiguration(topicLevelPolicies, null, brokerProperties);
+
+        Assert.assertNotNull(offloadPolicies);
+        assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
+                Map.of("tieredStorageBucketPrefix", ""));
+    }
+
 
     @Test
     public void brokerPropertyCompatibleTest() {


### PR DESCRIPTION
### Motivation

`OffloadPoliciesImpl.create(Properties)` recognizes broker config entries with the `managedLedgerOffloadExtraConfig` prefix and stores them in `managedLedgerExtraConfigurations`.

However, `OffloadPoliciesImpl.mergeConfiguration(...)` did not apply the same parsing when broker properties were used as the fallback layer. As a result, applied offload policies could omit broker-level extra offloader configuration.

### Modifications

- Reuse a helper to parse `managedLedgerOffloadExtraConfig*` entries from `Properties`.
- Apply that parsing in `mergeConfiguration(...)` for `managedLedgerExtraConfigurations`.
- Add tests for broker-level extra config merge and higher-level overrides, including empty-string override.

### Verifying this change

- `./gradlew :pulsar-common:test --tests org.apache.pulsar.common.policies.data.OffloadPoliciesTest`
