### PR TITLE
[fix][sec] Upgrade vert.x to 4.5.25 to address CVE-2026-6860

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -507,11 +507,11 @@ The Apache Software License, Version 2.0
     - org.jctools-jctools-core-4.0.6.jar
     - org.jctools-jctools-core-jdk11-4.0.6.jar
   * Vertx
-    - io.vertx-vertx-auth-common-4.5.24.jar
-    - io.vertx-vertx-bridge-common-4.5.24.jar
-    - io.vertx-vertx-core-4.5.24.jar
-    - io.vertx-vertx-web-4.5.24.jar
-    - io.vertx-vertx-web-common-4.5.24.jar
+    - io.vertx-vertx-auth-common-4.5.25.jar
+    - io.vertx-vertx-bridge-common-4.5.25.jar
+    - io.vertx-vertx-core-4.5.25.jar
+    - io.vertx-vertx-web-4.5.25.jar
+    - io.vertx-vertx-web-common-4.5.25.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-jute-3.9.5.jar
   * Snappy Java

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ avro = "1.12.0"
 gson = "2.13.2"
 snakeyaml = "2.0"
 # Vert.x
-vertx = "4.5.24"
+vertx = "4.5.25"
 # Networking / HTTP
 asynchttpclient = "2.14.5"
 conscrypt = "2.5.2"


### PR DESCRIPTION
### Motivation

Address CVE-2026-6860 in vert.x 4.5.24

### Modifications

Upgrade vert.x to 4.5.25