### PR TITLE
[fix][sec] Upgrade thrift to 0.23.0 to address CVE-2026-43869

### DIFF
--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -75,6 +75,22 @@ dependencies {
                 }
             }
         }
+        // libthrift is a transitive dependency of distributedlog-core.
+        // libthrift 0.23.0 upgraded to jakarta.* and HttpComponents 5 deps for its HTTP/servlet
+        // transports, which distributedlog-core does not use (only TJSON/TMemory serialization is needed).
+        // Add a component metadata rule to exclude the unnecessary dependencies.
+        withModule("org.apache.thrift:libthrift") {
+            allVariants {
+                withDependencies {
+                    removeAll {
+                        (it.group == "jakarta.annotation" && it.name == "jakarta.annotation-api") ||
+                        (it.group == "jakarta.servlet" && it.name == "jakarta.servlet-api") ||
+                        it.group == "org.apache.httpcomponents.client5" ||
+                        it.group == "org.apache.httpcomponents.core5"
+                    }
+                }
+            }
+        }
     }
 
     // Enforced platform pins all dependency versions from the version catalog.

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -432,7 +432,7 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
  * RocksDB - org.rocksdb-rocksdbjni-7.9.2.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
- * Apache Thrift - org.apache.thrift-libthrift-0.14.2.jar
+ * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar
  * OkHttp3
      - com.squareup.okhttp3-logging-interceptor-5.3.1.jar
      - com.squareup.okhttp3-okhttp-jvm-5.3.1.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,6 +167,7 @@ kubernetesclient = "23.0.0"
 aws-sdk = "1.12.788"
 hadoop3 = "3.5.0"
 jclouds = "2.6.0"
+thrift = "0.23.0"
 # Shading
 shadow = "9.4.1"
 
@@ -247,6 +248,8 @@ bookkeeper-stream-storage-service-impl = { module = "org.apache.bookkeeper:strea
 bookkeeper-tools-framework = { module = "org.apache.bookkeeper:bookkeeper-tools-framework", version.ref = "bookkeeper" }
 bookkeeper-http-vertx-server = { module = "org.apache.bookkeeper.http:vertx-http-server", version.ref = "bookkeeper" }
 distributedlog-core = { module = "org.apache.distributedlog:distributedlog-core", version.ref = "bookkeeper" }
+# thrift is a transitive dependency of distributedlog-core
+thrift = { module = "org.apache.thrift:libthrift", version.ref = "thrift" }
 # ZooKeeper
 zookeeper = { module = "org.apache.zookeeper:zookeeper", version.ref = "zookeeper" }
 zookeeper-tests = { module = "org.apache.zookeeper:zookeeper", version.ref = "zookeeper" }


### PR DESCRIPTION
### Motivation

thrift contains CVE-2026-43869

### Modifications

- upgrade thrift to 0.23.0 to address CVE-2026-43869
- exclude unwanted Http/Servlet thrift transport dependencies