### PR TITLE
[feat][ci] Add Gradle dependency submission workflow for Dependabot alerts

### DIFF
--- a/.github/workflows/ci-gradle-dependency-submission.yaml
+++ b/.github/workflows/ci-gradle-dependency-submission.yaml
@@ -67,4 +67,4 @@ jobs:
           cache-read-only: false
 
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e

--- a/.github/workflows/ci-gradle-dependency-submission.yaml
+++ b/.github/workflows/ci-gradle-dependency-submission.yaml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Submits the Gradle dependency graph to GitHub so that Dependabot can raise
+# vulnerability alerts (and updates) for transitive dependencies that are not
+# declared directly in the build scripts. Without this submission, Dependabot
+# only sees the direct dependencies it can parse from build.gradle files and
+# misses CVEs in the resolved transitive graph.
+#
+# See https://github.com/gradle/actions/blob/main/docs/dependency-submission.md
+
+name: CI - Gradle Dependency Submission
+
+on:
+  push:
+    branches: [ 'master' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  JDK_DISTRIBUTION: corretto
+
+jobs:
+  dependency-submission:
+    name: Dependency Submission
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: false
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v6


### PR DESCRIPTION
### Motivation

GitHub Dependabot can only raise vulnerability alerts for dependencies it is aware of. For Gradle projects, Dependabot parses the `build.gradle` files statically and therefore only sees the dependencies declared directly there; it does not see the transitive dependencies pulled in during resolution. As a result, CVEs in transitive dependencies are not surfaced as Dependabot alerts on this repository.

The [`gradle/actions/dependency-submission`](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md) action resolves the full Gradle dependency graph and submits it to GitHub via the Dependency Submission API. Once submitted, the complete (direct + transitive) graph is visible to Dependabot, which can then raise alerts and updates for vulnerabilities anywhere in the graph.

### Modifications

- Added a new workflow `.github/workflows/ci-gradle-dependency-submission.yaml` that runs on each push to `master`. It checks out the repo, sets up JDK 21 and Gradle (with the existing `setup-gradle` composite action), and runs `gradle/actions/dependency-submission@v6` to generate and submit the dependency graph to GitHub.
- The workflow uses `permissions: contents: write` as required by the dependency submission action to upload the graph.
- Concurrency is configured so that overlapping runs on the same ref cancel earlier ones.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial CI configuration change without any test coverage. It will be exercised by the new scheduled workflow on `master` after merge; the produced dependency graph will be visible under the repository's *Insights → Dependency graph* view, and Dependabot alerts for transitive dependencies will start appearing from that point on.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment