### PR TITLE
[fix][client] Inject trace context into message properties for producer-consumer span correlation

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpenTelemetryTracingIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OpenTelemetryTracingIntegrationTest.java
@@ -21,11 +21,14 @@ package org.apache.pulsar.broker.service;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -70,7 +73,10 @@ public class OpenTelemetryTracingIntegrationTest extends BrokerTestBase {
 
         openTelemetry = OpenTelemetrySdk.builder()
                 .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
                 .build();
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(openTelemetry);
 
         baseSetup();
     }
@@ -82,6 +88,7 @@ public class OpenTelemetryTracingIntegrationTest extends BrokerTestBase {
         if (openTelemetry != null) {
             openTelemetry.close();
         }
+        GlobalOpenTelemetry.resetForTest();
     }
 
     private void flushSpans() throws Exception {
@@ -152,6 +159,60 @@ public class OpenTelemetryTracingIntegrationTest extends BrokerTestBase {
         assertEquals(consumerSpan.getAttributes().get(
                 io.opentelemetry.api.common.AttributeKey.stringKey("messaging.pulsar.acknowledgment.type")),
                 "acknowledge");
+    }
+
+    @Test
+    public void testContextPropagationViaMessageProperties() throws Exception {
+        String topic = "persistent://prop/ns-abc/test-context-propagation";
+        spanExporter.reset();
+
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .openTelemetry(openTelemetry)
+                .enableTracing(true)
+                .build();
+
+        Producer<String> producer = client.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+
+        Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                .topic(topic)
+                .subscriptionName("test-sub")
+                .subscribe();
+
+        // Send and receive message
+        producer.send("test-message");
+
+        Message<String> msg = consumer.receive(5, TimeUnit.SECONDS);
+        assertNotNull(msg);
+        consumer.acknowledge(msg);
+
+        producer.close();
+        consumer.close();
+        client.close();
+
+        flushSpans();
+
+        // Verify spans exist
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertEquals(spans.size(), 2, "Expected 2 spans, got: " + spans.size());
+
+        SpanData producerSpan = spans.stream()
+                .filter(s -> s.getKind() == SpanKind.PRODUCER)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Producer span not found"));
+        SpanData consumerSpan = spans.stream()
+                .filter(s -> s.getKind() == SpanKind.CONSUMER)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Consumer span not found"));
+
+        // Verify trace context was propagated through message properties:
+        // consumer span must share the same traceId and be a child of the producer span
+        assertEquals(producerSpan.getTraceId(), consumerSpan.getTraceId(),
+                "Producer and consumer spans should share the same traceId");
+        assertEquals(consumerSpan.getParentSpanId(), producerSpan.getSpanId(),
+                "Consumer span should be a child of the producer span");
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryProducerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/OpenTelemetryProducerInterceptor.java
@@ -83,6 +83,9 @@ public class OpenTelemetryProducerInterceptor implements ProducerInterceptor {
             if (TracingContext.isValid(span) && message instanceof TraceableMessage) {
                 // Attach the span directly to the message
                 ((TraceableMessage) message).setTracingSpan(span);
+                // Inject trace context into message properties so the consumer
+                // can extract it and correlate its span with this producer span
+                TracingContext.injectContext(message, Context.current().with(span), propagator);
                 log.debug().attr("topic", topic).log("Created producer span");
             }
         } catch (Exception e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/TracingContext.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/TracingContext.java
@@ -27,10 +27,8 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.TopicMessageImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
@@ -54,9 +52,9 @@ public class TracingContext {
         }
     };
 
-    private static final TextMapSetter<Map<String, String>> SETTER = (carrier, key, value) -> {
-        if (carrier != null) {
-            carrier.put(key, value);
+    private static final TextMapSetter<MessageMetadata> SETTER = (metadata, key, value) -> {
+        if (metadata != null) {
+            metadata.addProperty().setKey(key).setValue(value);
         }
     };
 
@@ -75,31 +73,9 @@ public class TracingContext {
     }
 
     /**
-     * Inject trace context into message properties.
-     *
-     * @param messageBuilder the message builder to inject context into
-     * @param context the context to inject
-     * @param propagator the text map propagator to use
-     */
-    public static <T> void injectContext(TypedMessageBuilder<T> messageBuilder, Context context,
-                                          TextMapPropagator propagator) {
-        if (messageBuilder == null || context == null || propagator == null) {
-            return;
-        }
-
-        Map<String, String> carrier = new HashMap<>();
-        propagator.inject(context, carrier, SETTER);
-
-        for (Map.Entry<String, String> entry : carrier.entrySet()) {
-            messageBuilder.property(entry.getKey(), entry.getValue());
-        }
-    }
-
-    /**
      * Inject trace context into a message's properties by directly writing
      * to the underlying {@link MessageMetadata}. This is used by the producer
-     * interceptor at {@code beforeSend} time, where the message has already
-     * been constructed and the {@link TypedMessageBuilder} is no longer available.
+     * interceptor at {@code beforeSend} time.
      *
      * @param message the message to inject context into
      * @param context the context to inject
@@ -113,13 +89,7 @@ public class TracingContext {
         if (metadata == null) {
             return;
         }
-        Map<String, String> carrier = new HashMap<>();
-        propagator.inject(context, carrier, SETTER);
-        for (Map.Entry<String, String> entry : carrier.entrySet()) {
-            metadata.addProperty()
-                    .setKey(entry.getKey())
-                    .setValue(entry.getValue());
-        }
+        propagator.inject(context, metadata, SETTER);
     }
 
     @Nullable

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/TracingContext.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/tracing/TracingContext.java
@@ -31,6 +31,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.TopicMessageImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -90,6 +93,44 @@ public class TracingContext {
         for (Map.Entry<String, String> entry : carrier.entrySet()) {
             messageBuilder.property(entry.getKey(), entry.getValue());
         }
+    }
+
+    /**
+     * Inject trace context into a message's properties by directly writing
+     * to the underlying {@link MessageMetadata}. This is used by the producer
+     * interceptor at {@code beforeSend} time, where the message has already
+     * been constructed and the {@link TypedMessageBuilder} is no longer available.
+     *
+     * @param message the message to inject context into
+     * @param context the context to inject
+     * @param propagator the text map propagator to use
+     */
+    public static void injectContext(Message<?> message, Context context, TextMapPropagator propagator) {
+        if (message == null || context == null || propagator == null) {
+            return;
+        }
+        MessageMetadata metadata = getMessageMetadata(message);
+        if (metadata == null) {
+            return;
+        }
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(context, carrier, SETTER);
+        for (Map.Entry<String, String> entry : carrier.entrySet()) {
+            metadata.addProperty()
+                    .setKey(entry.getKey())
+                    .setValue(entry.getValue());
+        }
+    }
+
+    @Nullable
+    private static MessageMetadata getMessageMetadata(Message<?> message) {
+        if (message instanceof MessageImpl) {
+            return ((MessageImpl<?>) message).getMessageBuilder();
+        }
+        if (message instanceof TopicMessageImpl) {
+            return getMessageMetadata(((TopicMessageImpl<?>) message).getMessage());
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Motivation

The OpenTelemetry producer interceptor creates a send span but does not inject the trace context into message properties. On the consumer side, extractContext finds nothing in the properties and falls back to   
Context.current(), so consumer spans always start a new trace instead of being children of the producer span. Producer and consumer spans are impossible to correlate.   

### Modifications

- Added TracingContext.injectContext(Message, Context, TextMapPropagator) overload that writes trace context directly to the message's underlying MessageMetadata protobuf, handling both MessageImpl and TopicMessageImpl wrappers.                                                                                                                                                                                                                      
- Called it from OpenTelemetryProducerInterceptor.beforeSend() after creating the producer span.    

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Added test: `org.apache.pulsar.broker.service.OpenTelemetryTracingIntegrationTest#testContextPropagationViaMessageProperties`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment