### PR TITLE
[improve][build] Upgrade lightproto gradle plugin to 0.7.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,7 +139,7 @@ javax-servlet = "3.1.0"
 # Oxia / etcd
 oxia = "0.7.4"
 # Build plugins
-lightproto = "0.6.6"
+lightproto = "0.7.2"
 errorprone = "2.45.0"
 spotbugs = "4.9.6"
 checkerframework = "3.33.0"

--- a/pulsar-functions/proto/build.gradle.kts
+++ b/pulsar-functions/proto/build.gradle.kts
@@ -34,3 +34,7 @@ dependencies {
     }
     runtimeOnly(libs.perfmark.api)
 }
+
+lightproto {
+    generateJson = true
+}


### PR DESCRIPTION
### Motivation

keeping the lightproto gradle plugin up-to-date.
releases: https://github.com/streamnative/lightproto/releases

### Modifications

upgrade to 0.7.2 version

