### PR TITLE
[fix][client] Apply Avro logical type conversions when decoding schema without classloader

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl.schema.reader;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
@@ -39,32 +40,21 @@ public class AvroReader<T> implements SchemaReader<T> {
             new ThreadLocal<>();
     private final Schema schema;
 
+    @VisibleForTesting
     public AvroReader(Schema schema) {
-        this.reader = new ReflectDatumReader<>(schema);
-        this.schema = schema;
+        this(schema, schema, null, false);
     }
 
     public AvroReader(Schema schema, ClassLoader classLoader, boolean jsr310ConversionEnabled) {
-        this.schema = schema;
-        if (classLoader != null) {
-            ReflectData reflectData = new ReflectData(classLoader);
-            AvroSchema.addLogicalTypeConversions(reflectData, jsr310ConversionEnabled);
-            this.reader = new ReflectDatumReader<>(schema, schema, reflectData);
-        } else {
-            this.reader = new ReflectDatumReader<>(schema);
-        }
+        this(schema, schema, classLoader, jsr310ConversionEnabled);
     }
 
     public AvroReader(Schema writerSchema, Schema readerSchema, ClassLoader classLoader,
         boolean jsr310ConversionEnabled) {
         this.schema = readerSchema;
-        if (classLoader != null) {
-            ReflectData reflectData = new ReflectData(classLoader);
-            AvroSchema.addLogicalTypeConversions(reflectData, jsr310ConversionEnabled);
-            this.reader = new ReflectDatumReader<>(writerSchema, readerSchema, reflectData);
-        } else {
-            this.reader = new ReflectDatumReader<>(writerSchema, readerSchema);
-        }
+        ReflectData reflectData = classLoader != null ? new ReflectData(classLoader) : new ReflectData();
+        AvroSchema.addLogicalTypeConversions(reflectData, jsr310ConversionEnabled);
+        this.reader = new ReflectDatumReader<>(writerSchema, readerSchema, reflectData);
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/schema/AvroSchemaTest.java
@@ -553,4 +553,44 @@ public class AvroSchemaTest {
         LocalDateTimePojo pojo = avroSchema.decode(bytes);
         assertEquals(pojo.getValue().truncatedTo(ChronoUnit.MILLIS), now.truncatedTo(ChronoUnit.MILLIS));
     }
+
+    public static class UuidLogicalTypeDto {
+        public UUID id;
+        public String name;
+
+        public UuidLogicalTypeDto() {
+        }
+
+        public UuidLogicalTypeDto(UUID id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    @Test
+    public void testDecodeUuidLogicalTypeWithClass() {
+        UUID id = UUID.randomUUID();
+        String name = "name";
+        AvroSchema<UuidLogicalTypeDto> schema = AvroSchema.of(UuidLogicalTypeDto.class);
+        byte[] encoded = schema.encode(new UuidLogicalTypeDto(id, name));
+
+        UuidLogicalTypeDto decoded = schema.decode(encoded);
+        assertEquals(decoded.id, id);
+        assertEquals(decoded.name, name);
+    }
+
+    @Test
+    public void testDecodeUuidLogicalTypeWithJsonDef() {
+        UUID id = UUID.randomUUID();
+        String name = "name";
+        AvroSchema<UuidLogicalTypeDto> schemaFromClass = AvroSchema.of(UuidLogicalTypeDto.class);
+        byte[] encoded = schemaFromClass.encode(new UuidLogicalTypeDto(id, name));
+        String jsonDef = schemaFromClass.getSchemaInfo().getSchemaDefinition();
+
+        AvroSchema<UuidLogicalTypeDto> schemaFromJsonDef = AvroSchema.of(
+                SchemaDefinition.<UuidLogicalTypeDto>builder().withJsonDef(jsonDef).build());
+        UuidLogicalTypeDto decoded = schemaFromJsonDef.decode(encoded);
+        assertEquals(decoded.id, id);
+        assertEquals(decoded.name, name);
+    }
 }


### PR DESCRIPTION
### Motivation

`AvroReader` only registered logical-type conversions (UUID, decimal,
date/time, timestamp) when a non-null `ClassLoader` was supplied, while
`AvroWriter` always registers them. This asymmetry caused decoding to
fail for any logical-type field when a schema was constructed via
`SchemaDefinition.builder().withJsonDef(...)`, where no pojo class or
classloader is provided.

For example, a `UUID` field encoded with `Schema.AVRO(class)` could not
be decoded with `Schema.AVRO(SchemaDefinition.builder().withJsonDef(...))`
and failed with:

```
java.lang.IllegalArgumentException: Can not set java.util.UUID field ... to java.lang.String
```

because the `UUIDConversion` was never registered on the reader's
`ReflectData`.

### Modifications

- `AvroReader` now always builds a fresh `ReflectData` (using the
  supplied classloader when present, otherwise the default) and calls
  `AvroSchema.addLogicalTypeConversions(...)` on it, mirroring
  `AvroWriter`'s behavior.
- Added `testDecodeUuidLogicalTypeWithClass` and
  `testDecodeUuidLogicalTypeWithJsonDef` in `AvroSchemaTest` to cover
  the UUID logical-type round-trip for both schema construction paths.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- The new `AvroSchemaTest#testDecodeUuidLogicalTypeWithJsonDef`
  reproduces the original failure and now passes with the fix.
- Existing `pulsar-client` schema tests continue to pass.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment