### PR TITLE
[BUG] Fix stats in PulsarZooKeeperClient multi.

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2168,6 +2168,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean bookkeeperClientExposeStatsToPrometheus = false;
 
     @FieldContext(
+        category = CATEGORY_SERVER,
+        doc = "whether expose metadataStore stats to prometheus"
+    )
+    private boolean metadataStoreExposeStatsToPrometheus = false;
+
+    @FieldContext(
             category = CATEGORY_STORAGE_BK,
             doc = "whether limit per_channel_bookie_client metrics of bookkeeper client stats"
     )

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -82,6 +82,9 @@ import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.NullLedgerOffloader;
 import org.apache.bookkeeper.mledger.offload.Offloaders;
 import org.apache.bookkeeper.mledger.offload.OffloadersCache;
+import org.apache.bookkeeper.stats.NullStatsProvider;
+import org.apache.bookkeeper.stats.StatsProvider;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PulsarVersion;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
@@ -126,6 +129,7 @@ import org.apache.pulsar.broker.stats.PulsarBrokerOpenTelemetry;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsServlet;
 import org.apache.pulsar.broker.stats.prometheus.PrometheusRawMetricsProvider;
 import org.apache.pulsar.broker.stats.prometheus.PulsarPrometheusMetricsServlet;
+import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
 import org.apache.pulsar.broker.storage.BookkeeperManagedLedgerStorageClass;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
@@ -312,6 +316,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
     private String brokerId;
     private final CompletableFuture<Void> readyForIncomingRequestsFuture = new CompletableFuture<>();
     private final List<Runnable> pendingTasksBeforeReadyForIncomingRequests = new ArrayList<>();
+    private StatsProvider metadataStoreStatsProvider = new NullStatsProvider();
 
     public enum State {
         Init, Started, Closing, Closed
@@ -430,6 +435,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         }
         return MetadataStoreFactory.create(config.getConfigurationMetadataStoreUrl(),
                 MetadataStoreConfig.builder()
+                        .statsProvider(metadataStoreStatsProvider)
                         .sessionTimeoutMillis((int) config.getMetadataStoreSessionTimeoutMillis())
                         .allowReadOnlyOperations(config.isMetadataStoreAllowReadOnlyOperations())
                         .configFilePath(configFilePath)
@@ -738,6 +744,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 openTelemetryTopicStats = null;
             }
 
+            if (metadataStoreStatsProvider != null) {
+                metadataStoreStatsProvider.stop();
+            }
             asyncCloseFutures.add(EventLoopUtil.shutdownGracefully(ioEventLoopGroup));
 
             // add timeout handling for closing executors
@@ -886,6 +895,14 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             localMetadataSynchronizer = StringUtils.isNotBlank(config.getMetadataSyncEventTopic())
                     ? new PulsarMetadataEventSynchronizer(this, config.getMetadataSyncEventTopic())
                     : null;
+            Configuration configuration = new ClientConfiguration();
+            if (config.isMetadataStoreExposeStatsToPrometheus()) {
+                configuration.addProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS,
+                        config.getManagedLedgerPrometheusStatsLatencyRolloverSeconds());
+                configuration.addProperty(PrometheusMetricsProvider.CLUSTER_NAME, config.getClusterName());
+                metadataStoreStatsProvider = new PrometheusMetricsProvider();
+            }
+            metadataStoreStatsProvider.start(configuration);
             localMetadataStore = createLocalMetadataStore(localMetadataSynchronizer,
                     openTelemetry.getOpenTelemetryService().getOpenTelemetry());
             localMetadataStore.registerSessionListener(this::handleMetadataSessionEvent);
@@ -1344,6 +1361,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             throws MetadataStoreException, PulsarServerException {
         return MetadataStoreExtended.create(config.getMetadataStoreUrl(),
                 MetadataStoreConfig.builder()
+                        .statsProvider(metadataStoreStatsProvider)
                         .sessionTimeoutMillis((int) config.getMetadataStoreSessionTimeoutMillis())
                         .allowReadOnlyOperations(config.isMetadataStoreAllowReadOnlyOperations())
                         .configFilePath(config.getMetadataStoreConfigPath())

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -343,6 +343,8 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
 
             generateManagedLedgerBookieClientMetrics(pulsar, stream);
 
+            generateMetadataStoreMetrics(pulsar, stream);
+
             if (metricsProviders != null) {
                 for (PrometheusRawMetricsProvider metricsProvider : metricsProviders) {
                     metricsProvider.generate(stream);
@@ -499,8 +501,20 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             if (statsProvider instanceof NullStatsProvider) {
                 return;
             }
+            writeStatsProviderMetrics(statsProvider, stream);
+        }
+    }
 
-            try (Writer writer = new OutputStreamWriter(new BufferedOutputStream(new OutputStream() {
+    private static void generateMetadataStoreMetrics(PulsarService pulsar, SimpleTextOutputStream stream) {
+        StatsProvider statsProvider = pulsar.getMetadataStoreStatsProvider();
+        if (statsProvider instanceof NullStatsProvider) {
+            return;
+        }
+        writeStatsProviderMetrics(statsProvider, stream);
+    }
+
+    private static void writeStatsProviderMetrics(StatsProvider statsProvider, SimpleTextOutputStream stream) {
+        try (Writer writer = new OutputStreamWriter(new BufferedOutputStream(new OutputStream() {
                 @Override
                 public void write(int b) throws IOException {
                     stream.writeByte(b);
@@ -515,7 +529,6 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             } catch (IOException e) {
                 log.error().exception(e).log("Failed to write managed ledger bookie client metrics");
             }
-        }
     }
 
     public MetricsBuffer renderToBuffer(Executor executor, List<PrometheusRawMetricsProvider> metricsProviders) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -527,7 +527,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
             }), StandardCharsets.UTF_8)) {
                 statsProvider.writeAllMetrics(writer);
             } catch (IOException e) {
-                log.error().exception(e).log("Failed to write managed ledger bookie client metrics");
+                log.error().exception(e).log("Failed to write metrics");
             }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -120,26 +120,26 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
             String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsOutput + "\n";
 
             // Verify the "multi" opStats metric exists.
-            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_multi_count"),
+            Assert.assertTrue(metricsMap.containsKey("ZkMetadataStore_storeName_test_zk_prometheus_zk_multi_count"),
                     "Expected ZKMetadataStore_zk_multi_count metric to be present. " + metricsDebugMessage);
 
-            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_multi_sum"),
+            Assert.assertTrue(metricsMap.containsKey("ZkMetadataStore_storeName_test_zk_prometheus_zk_multi_sum"),
                     "Expected ZKMetadataStore_zk_multi_sum metric to be present. " + metricsDebugMessage);
 
             // Verify that multi metrics have the correct cluster tag
-            for (Metric m : metricsMap.get("ZKMetadataStore_zk_multi_count")) {
+            for (Metric m : metricsMap.get("ZkMetadataStore_storeName_test_zk_prometheus_zk_multi_count")) {
                 Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
             }
 
             // Verify other ZK operation metrics are also present
             // (these are registered by PulsarZooKeeperClient in its constructor)
-            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_create_count"),
+            Assert.assertTrue(metricsMap.containsKey("ZkMetadataStore_storeName_test_zk_prometheus_zk_create_count"),
                     "Expected ZKMetadataStore_zk_create_count metric to be present. " + metricsDebugMessage);
 
-            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_get_data_count"),
+            Assert.assertTrue(metricsMap.containsKey("ZkMetadataStore_storeName_test_zk_prometheus_zk_get_data_count"),
                     "Expected ZKMetadataStore_zk_get_data_count metric to be present. " + metricsDebugMessage);
 
-            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_exists_count"),
+            Assert.assertTrue(metricsMap.containsKey("ZkMetadataStore_storeName_test_zk_prometheus_zk_exists_count"),
                     "Expected ZKMetadataStore_zk_exists_count metric to be present. " + metricsDebugMessage);
         } finally {
             prometheusMetricsProvider.stop();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -46,7 +46,6 @@ import org.apache.pulsar.metadata.TestZKServer;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
-import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/MetadataStoreStatsTest.java
@@ -22,23 +22,31 @@ import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import com.google.common.collect.Multimap;
 import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
+import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.PrometheusMetricsTestUtil;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetricsToken;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.stats.prometheus.metrics.PrometheusMetricsProvider;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.metadata.TestZKServer;
+import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -72,6 +80,70 @@ public class MetadataStoreStatsTest extends BrokerTestBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @Test
+    public void testZKMetadataStoreMetricsCollectedByPrometheus() throws Exception {
+        @Cleanup
+        TestZKServer zkServer = new TestZKServer();
+
+        PrometheusMetricsProvider prometheusMetricsProvider = new PrometheusMetricsProvider();
+        ClientConfiguration bkClientConf = new ClientConfiguration();
+        bkClientConf.addProperty(PrometheusMetricsProvider.PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS, 60);
+        bkClientConf.addProperty(PrometheusMetricsProvider.CLUSTER_NAME, "test");
+        prometheusMetricsProvider.start(bkClientConf);
+
+        try {
+            MetadataStoreConfig config = MetadataStoreConfig.builder()
+                    .metadataStoreName("test-zk-prometheus")
+                    .fsyncEnable(false)
+                    .statsProvider(prometheusMetricsProvider)
+                    .build();
+
+            @Cleanup
+            MetadataStore store = MetadataStoreFactory.create(
+                    "zk:" + zkServer.getConnectionString(), config);
+
+            String path = "/test-prometheus-metrics-" + UUID.randomUUID();
+            store.put(path, "test-value".getBytes(), java.util.Optional.empty()).join();
+            store.get(path).join();
+            store.delete(path, Optional.empty()).join();
+
+            // Write all metrics via PrometheusMetricsProvider.writeAllMetrics
+            StringWriter writer = new StringWriter();
+            prometheusMetricsProvider.writeAllMetrics(writer);
+            String metricsOutput = writer.toString();
+
+            // Parse the metrics output
+            Multimap<String, Metric> metricsMap = parseMetrics(metricsOutput);
+
+            String metricsDebugMessage = "Assertion failed with metrics:\n" + metricsOutput + "\n";
+
+            // Verify the "multi" opStats metric exists.
+            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_multi_count"),
+                    "Expected ZKMetadataStore_zk_multi_count metric to be present. " + metricsDebugMessage);
+
+            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_multi_sum"),
+                    "Expected ZKMetadataStore_zk_multi_sum metric to be present. " + metricsDebugMessage);
+
+            // Verify that multi metrics have the correct cluster tag
+            for (Metric m : metricsMap.get("ZKMetadataStore_zk_multi_count")) {
+                Assert.assertEquals(m.tags.get("cluster"), "test", metricsDebugMessage);
+            }
+
+            // Verify other ZK operation metrics are also present
+            // (these are registered by PulsarZooKeeperClient in its constructor)
+            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_create_count"),
+                    "Expected ZKMetadataStore_zk_create_count metric to be present. " + metricsDebugMessage);
+
+            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_get_data_count"),
+                    "Expected ZKMetadataStore_zk_get_data_count metric to be present. " + metricsDebugMessage);
+
+            Assert.assertTrue(metricsMap.containsKey("ZKMetadataStore_zk_exists_count"),
+                    "Expected ZKMetadataStore_zk_exists_count metric to be present. " + metricsDebugMessage);
+        } finally {
+            prometheusMetricsProvider.stop();
+        }
     }
 
     @Test

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.bookkeeper.stats.NullStatsProvider;
 import org.apache.bookkeeper.stats.StatsProvider;
 
 /**
@@ -109,5 +110,6 @@ public class MetadataStoreConfig {
     @Builder.Default
     private final int numSerDesThreads = 1;
 
-    private StatsProvider statsProvider;
+    @Builder.Default
+    private StatsProvider statsProvider = new NullStatsProvider();
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreConfig.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.bookkeeper.stats.StatsProvider;
 
 /**
  * The configuration builder for a {@link MetadataStore} config.
@@ -107,4 +108,6 @@ public class MetadataStoreConfig {
 
     @Builder.Default
     private final int numSerDesThreads = 1;
+
+    private StatsProvider statsProvider;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -511,7 +511,7 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
     public void multi(final Iterable<Op> ops,
                       final MultiCallback cb,
                       final Object context) {
-        final Runnable proc = new ZkRetryRunnable(operationRetryPolicy, rateLimiter, createStats) {
+        final Runnable proc = new ZkRetryRunnable(operationRetryPolicy, rateLimiter, multiStats) {
 
             final MultiCallback multiCb = new MultiCallback() {
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -100,7 +100,9 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             this.rootPath = new ConnectStringParser(zkConnectString).getChrootPath();
 
             isZkManaged = true;
-            StatsLogger statsLogger = metadataStoreConfig.getStatsProvider().getStatsLogger("ZKMetadataStore");
+            StatsLogger statsLogger = metadataStoreConfig.getStatsProvider()
+                    .getStatsLogger("ZkMetadataStore")
+                    .scopeLabel("storeName", metadataStoreConfig.getMetadataStoreName());
             zkc = PulsarZooKeeperClient.newBuilder().connectString(zkConnectString)
                     .connectRetryPolicy(new BoundExponentialBackoffRetryPolicy(100, 60_000, Integer.MAX_VALUE))
                     .allowReadOnlyMode(metadataStoreConfig.isAllowReadOnlyOperations())

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
+import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.zookeeper.BoundExponentialBackoffRetryPolicy;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -99,12 +100,14 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             this.rootPath = new ConnectStringParser(zkConnectString).getChrootPath();
 
             isZkManaged = true;
+            StatsLogger statsLogger = metadataStoreConfig.getStatsProvider().getStatsLogger("ZKMetadataStore");
             zkc = PulsarZooKeeperClient.newBuilder().connectString(zkConnectString)
                     .connectRetryPolicy(new BoundExponentialBackoffRetryPolicy(100, 60_000, Integer.MAX_VALUE))
                     .allowReadOnlyMode(metadataStoreConfig.isAllowReadOnlyOperations())
                     .sessionTimeoutMs(metadataStoreConfig.getSessionTimeoutMillis())
                     .watchers(Collections.singleton(this::processSessionWatcher))
                     .configPath(metadataStoreConfig.getConfigFilePath())
+                    .statsLogger(statsLogger)
                     .build();
             if (enableSessionWatcher) {
                 sessionWatcher = new ZKSessionWatcher(zkc, this::receivedSessionEvent);

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -100,9 +100,12 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             this.rootPath = new ConnectStringParser(zkConnectString).getChrootPath();
 
             isZkManaged = true;
-            StatsLogger statsLogger = metadataStoreConfig.getStatsProvider()
+            StatsLogger statsLogger = null;
+            if (metadataStoreConfig.getStatsProvider() != null) {
+                statsLogger = metadataStoreConfig.getStatsProvider()
                     .getStatsLogger("ZkMetadataStore")
                     .scopeLabel("storeName", metadataStoreConfig.getMetadataStoreName());
+            }
             zkc = PulsarZooKeeperClient.newBuilder().connectString(zkConnectString)
                     .connectRetryPolicy(new BoundExponentialBackoffRetryPolicy(100, 60_000, Integer.MAX_VALUE))
                     .allowReadOnlyMode(metadataStoreConfig.isAllowReadOnlyOperations())


### PR DESCRIPTION
### Motivation

In `PulsarZooKeeperClient.multi()`, the stats were incorrectly using `createStats` instead of `multiStats`.

### Modifications

Changed `createStats` to `multiStats` in the `multi()` method.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment