### PR TITLE
[fix][proxy] Close channel on connection failure

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -199,6 +199,10 @@ public class DirectProxyHandler {
                         .attr("brokerHost", brokerHostAndPort)
                         .exception(future.cause())
                         .log("Establishing connection failed. Closing inbound channel.");
+                Channel channel = f.channel();
+                if (channel != null) {
+                    channel.close();
+                }
                 inboundChannel.close();
             }
         });


### PR DESCRIPTION
### Motivation

When establishing a direct proxy connection fails, the outbound channel may remain open until it is cleaned up asynchronously. In some cases, this can leave stale connections or unreleased resources behind, especially during rapid reconnects or connection timeouts.

This change ensures the outbound channel is explicitly closed before closing the inbound channel when connection establishment fails, improving resource cleanup consistency and reducing the risk of leaked or half-open channels.

### Modifications

* Explicitly closes the outbound channel (`f.channel()`) when the connection attempt fails before closing the inbound channel.