### PR TITLE
[fix][doc] Correct default idle timeout in ClientBuilder and PulsarAdminBuilder docs

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -372,7 +372,7 @@ public interface PulsarAdminBuilder {
     /**
      * Sets the maximum idle time for a pooled connection. If a connection is idle for more than the specified
      * amount of seconds, it will be released back to the connection pool.
-     * Defaults to 25 seconds.
+     * Defaults to 60 seconds.
      *
      * @param connectionMaxIdleSeconds the maximum idle time, in seconds, for a pooled connection
      * @return the PulsarAdminBuilder instance

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -167,7 +167,7 @@ public interface ClientBuilder extends Serializable, Cloneable {
 
     /**
      * Release the connection if it is not used for more than {@param connectionMaxIdleSeconds} seconds.
-     * Defaults to 25 seconds.
+     * Defaults to 60 seconds.
      *
      * @return the client builder instance
      */


### PR DESCRIPTION
[fix][doc] Correct default idle timeout in ClientBuilder and PulsarAdminBuilder docs

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->



<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

ClientBuilder and PulsarAdminBuilder document connectionMaxIdleSeconds as defaulting to 25 seconds, but ClientConfigurationData sets the default to 60 seconds.

### Modifications

<!-- Describe the modifications you've done. -->

Update the JavaDoc for connectionMaxIdleSeconds on ClientBuilder and PulsarAdminBuilder so the documented default matches ClientConfigurationData (60 seconds).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment