### PR TITLE
[fix][broker] Fix PulsarService.closeAsync where Condition.signalAll was called without holding a lock

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -755,7 +755,12 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     log.warn().exception(t).log("Closed with errors");
                 }
                 state = State.Closed;
-                isClosedCondition.signalAll();
+                mutex.lock();
+                try {
+                    isClosedCondition.signalAll();
+                } finally {
+                    mutex.unlock();
+                }
                 return null;
             });
             return closeFuture;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -754,9 +754,9 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 } else {
                     log.warn().exception(t).log("Closed with errors");
                 }
-                state = State.Closed;
                 mutex.lock();
                 try {
+                    state = State.Closed;
                     isClosedCondition.signalAll();
                 } finally {
                     mutex.unlock();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -21,11 +21,9 @@ package org.apache.pulsar.broker;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-
 import lombok.CustomLog;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/PulsarServiceCloseTest.java
@@ -18,9 +18,14 @@
  */
 package org.apache.pulsar.broker;
 
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import lombok.CustomLog;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -73,4 +78,29 @@ public class PulsarServiceCloseTest extends MockedPulsarServiceBaseTest {
         }
     }
 
+    @Test(timeOut = 60_000)
+    public void testWaitUntilClosedConcurrentWithCloseAsync() throws Exception {
+        // Start closeAsync() - it initiates close and returns a future
+        CompletableFuture<Void> closeFuture = pulsar.closeAsync();
+
+        // Start waitUntilClosed() in a separate thread BEFORE close completes.
+        // This thread will enter mutex.lock() -> await() and block there,
+        // relying on signalAll() to be woken up when close finishes.
+        CompletableFuture<Void> waitFuture = CompletableFuture.runAsync(() -> {
+            try {
+                pulsar.waitUntilClosed();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            closeFuture.get(30, TimeUnit.SECONDS);
+            waitFuture.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("Should not throw exception");
+        }
+        log.info("waitUntilClosed() returned successfully while closeAsync() was in progress");
+    }
 }


### PR DESCRIPTION
### Motivation

In `PulsarService.closeAsync()`, the `closeFuture.handle()` callback calls `isClosedCondition.signalAll()` without acquiring the associated mutex lock. 

### Modifications

* Fix: Wrap isClosedCondition.signalAll() inside mutex.lock()/unlock() in the closeFuture.handle() callback.
* Test: Add `testWaitUntilClosedConcurrentWithCloseAsync` in `PulsarServiceCloseTest` that calls `waitUntilClosed()` concurrently with `closeAsync()`. 

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment