### PR TITLE
[improve][build] Upgrade lightproto gradle plugin to 0.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,7 +139,7 @@ javax-servlet = "3.1.0"
 # Oxia / etcd
 oxia = "0.7.4"
 # Build plugins
-lightproto = "0.7.2"
+lightproto = "0.7.3"
 errorprone = "2.45.0"
 spotbugs = "4.9.6"
 checkerframework = "3.33.0"


### PR DESCRIPTION
### Motivation

The lightproto Gradle plugin was upgraded to 0.7.2 in #25751. Version 0.7.3 picks up CVE fixes in the dependencies of the lightproto code generator.

### Modifications

Bump the `lightproto` Gradle plugin version from `0.7.2` to `0.7.3` in `gradle/libs.versions.toml`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Verified locally that `io.streamnative.lightproto:0.7.3` resolves from the plugin repository and that `:pulsar-common:generateLightProto` runs successfully.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment