### PR TITLE
[fix][broker] Use effective offload policies for extra configs

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -3167,8 +3167,12 @@ public abstract class NamespacesBase extends AdminResource {
         validateNamespacePolicyOperation(namespaceName, PolicyName.OFFLOAD, PolicyOperation.READ);
 
         Policies policies = getNamespacePolicies(namespaceName);
+        OffloadPoliciesImpl nsLevelOffloadPolicies = (OffloadPoliciesImpl) policies.offload_policies;
+        OffloadPoliciesImpl offloadPolicies = OffloadPoliciesImpl.mergeConfiguration(null,
+                OffloadPoliciesImpl.oldPoliciesCompatible(nsLevelOffloadPolicies, policies),
+                pulsar().getConfig().getProperties());
         LedgerOffloader managedLedgerOffloader = pulsar()
-                .getManagedLedgerOffloader(namespaceName, (OffloadPoliciesImpl) policies.offload_policies);
+                .getManagedLedgerOffloader(namespaceName, offloadPolicies);
 
         String localClusterName = pulsar().getConfiguration().getClusterName();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -38,7 +38,11 @@
 package org.apache.pulsar.broker.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.pulsar.common.policies.data.OffloadPoliciesImpl.EXTRA_CONFIG_PREFIX;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -56,6 +60,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -78,6 +85,7 @@ import org.apache.pulsar.common.policies.data.OffloadedReadPriority;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes;
 import org.awaitility.Awaitility;
+import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -116,6 +124,44 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
     @Override
     public void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @Test
+    public void testScanOffloadedLedgersUsesMergedNamespaceOffloadPolicies() throws Exception {
+        pulsar.getConfig().getProperties().setProperty("managedLedgerOffloadDriver", "aws-s3");
+        pulsar.getConfig().getProperties().setProperty("managedLedgerOffloadBucket", "broker-bucket");
+        pulsar.getConfig().getProperties().setProperty("managedLedgerOffloadRegion", "us-east-1");
+        pulsar.getConfig().getProperties().setProperty(
+                EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", "broker-prefix");
+
+        admin.namespaces().setOffloadThreshold(myNamespace, 1024L);
+
+        LedgerOffloader offloader = mock(LedgerOffloader.class);
+        doReturn(Map.of()).when(offloader).getOffloadDriverMetadata();
+        doNothing().when(offloader).scanLedgers(any(), anyMap());
+        ArgumentCaptor<OffloadPoliciesImpl> offloadPoliciesCaptor = ArgumentCaptor.forClass(OffloadPoliciesImpl.class);
+        doReturn(offloader).when(pulsar).getManagedLedgerOffloader(eq(NamespaceName.get(myNamespace)),
+                offloadPoliciesCaptor.capture());
+
+        Client client = ClientBuilder.newClient();
+        try {
+            try (Response response = client.target(pulsar.getWebServiceAddress()
+                    + "/admin/v2/namespaces/" + myNamespace + "/scanOffloadedLedgers").request().get()) {
+                assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+                response.readEntity(String.class);
+            }
+        } finally {
+            client.close();
+        }
+
+        OffloadPoliciesImpl offloadPolicies = offloadPoliciesCaptor.getValue();
+        assertEquals(offloadPolicies.getManagedLedgerOffloadDriver(), "aws-s3");
+        assertEquals(offloadPolicies.getManagedLedgerOffloadBucket(), "broker-bucket");
+        assertEquals(offloadPolicies.getManagedLedgerOffloadRegion(), "us-east-1");
+        assertEquals(offloadPolicies.getManagedLedgerOffloadThresholdInBytes(), Long.valueOf(1024L));
+        assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
+                Map.of("tieredStorageBucketPrefix", "broker-prefix"));
+        verify(offloader).scanLedgers(any(), anyMap());
     }
 
     private void testOffload(String topicName, String mlName) throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -37,8 +37,8 @@
  */
 package org.apache.pulsar.broker.admin;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.pulsar.common.policies.data.OffloadPoliciesImpl.EXTRA_CONFIG_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -429,7 +429,10 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             OffloadPoliciesImpl offloadPolicies = new OffloadPoliciesImpl();
             for (Field field : CONFIGURATION_FIELDS) {
                 Object object;
-                if (topicLevelPolicies != null && field.get(topicLevelPolicies) != null) {
+                if (field.getName().equals("managedLedgerExtraConfigurations")) {
+                    object = mergeManagedLedgerExtraConfigurations(topicLevelPolicies, nsLevelPolicies,
+                            brokerProperties, field);
+                } else if (topicLevelPolicies != null && field.get(topicLevelPolicies) != null) {
                     object = field.get(topicLevelPolicies);
                 } else if (nsLevelPolicies != null && field.get(nsLevelPolicies) != null) {
                     object = field.get(nsLevelPolicies);
@@ -452,6 +455,32 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
             log.error().exception(e).log("Failed to merge configuration.");
             return null;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> mergeManagedLedgerExtraConfigurations(OffloadPoliciesImpl topicLevelPolicies,
+                                                                            OffloadPoliciesImpl nsLevelPolicies,
+                                                                            Properties brokerProperties,
+                                                                            Field field)
+            throws IllegalAccessException {
+        Map<String, String> mergedExtraConfigurations = new HashMap<>();
+        Object brokerExtraConfigurations = getCompatibleValue(brokerProperties, field);
+        if (brokerExtraConfigurations instanceof Map) {
+            mergedExtraConfigurations.putAll((Map<String, String>) brokerExtraConfigurations);
+        }
+        if (nsLevelPolicies != null) {
+            Map<String, String> nsExtraConfigurations = (Map<String, String>) field.get(nsLevelPolicies);
+            if (nsExtraConfigurations != null && !nsExtraConfigurations.isEmpty()) {
+                mergedExtraConfigurations.putAll(nsExtraConfigurations);
+            }
+        }
+        if (topicLevelPolicies != null) {
+            Map<String, String> topicExtraConfigurations = (Map<String, String>) field.get(topicLevelPolicies);
+            if (topicExtraConfigurations != null && !topicExtraConfigurations.isEmpty()) {
+                mergedExtraConfigurations.putAll(topicExtraConfigurations);
+            }
+        }
+        return mergedExtraConfigurations.isEmpty() ? null : mergedExtraConfigurations;
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/OffloadPoliciesImpl.java
@@ -431,7 +431,7 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
                 Object object;
                 if (field.getName().equals("managedLedgerExtraConfigurations")) {
                     object = mergeManagedLedgerExtraConfigurations(topicLevelPolicies, nsLevelPolicies,
-                            brokerProperties, field);
+                            brokerProperties);
                 } else if (topicLevelPolicies != null && field.get(topicLevelPolicies) != null) {
                     object = field.get(topicLevelPolicies);
                 } else if (nsLevelPolicies != null && field.get(nsLevelPolicies) != null) {
@@ -457,30 +457,26 @@ public class OffloadPoliciesImpl implements Serializable, OffloadPolicies {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, String> mergeManagedLedgerExtraConfigurations(OffloadPoliciesImpl topicLevelPolicies,
                                                                             OffloadPoliciesImpl nsLevelPolicies,
-                                                                            Properties brokerProperties,
-                                                                            Field field)
-            throws IllegalAccessException {
+                                                                            Properties brokerProperties) {
         Map<String, String> mergedExtraConfigurations = new HashMap<>();
-        Object brokerExtraConfigurations = getCompatibleValue(brokerProperties, field);
-        if (brokerExtraConfigurations instanceof Map) {
-            mergedExtraConfigurations.putAll((Map<String, String>) brokerExtraConfigurations);
-        }
+        putAllExtraConfigurations(mergedExtraConfigurations, getExtraConfigurations(brokerProperties));
         if (nsLevelPolicies != null) {
-            Map<String, String> nsExtraConfigurations = (Map<String, String>) field.get(nsLevelPolicies);
-            if (nsExtraConfigurations != null && !nsExtraConfigurations.isEmpty()) {
-                mergedExtraConfigurations.putAll(nsExtraConfigurations);
-            }
+            putAllExtraConfigurations(mergedExtraConfigurations,
+                    nsLevelPolicies.getManagedLedgerExtraConfigurations());
         }
         if (topicLevelPolicies != null) {
-            Map<String, String> topicExtraConfigurations = (Map<String, String>) field.get(topicLevelPolicies);
-            if (topicExtraConfigurations != null && !topicExtraConfigurations.isEmpty()) {
-                mergedExtraConfigurations.putAll(topicExtraConfigurations);
-            }
+            putAllExtraConfigurations(mergedExtraConfigurations,
+                    topicLevelPolicies.getManagedLedgerExtraConfigurations());
         }
         return mergedExtraConfigurations.isEmpty() ? null : mergedExtraConfigurations;
+    }
+
+    private static void putAllExtraConfigurations(Map<String, String> target, Map<String, String> extraConfigurations) {
+        if (extraConfigurations != null && !extraConfigurations.isEmpty()) {
+            target.putAll(extraConfigurations);
+        }
     }
 
     /**

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/OffloadPoliciesTest.java
@@ -353,16 +353,36 @@ public class OffloadPoliciesTest {
         Properties brokerProperties = new Properties();
         brokerProperties.setProperty("managedLedgerOffloadDriver", "aws-s3");
         brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", "broker-prefix");
+        brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "brokerOnly", "broker-value");
 
         OffloadPoliciesImpl topicLevelPolicies = new OffloadPoliciesImpl();
         topicLevelPolicies.getManagedLedgerExtraConfigurations().put("tieredStorageBucketPrefix", "topic-prefix");
+        topicLevelPolicies.getManagedLedgerExtraConfigurations().put("topicOnly", "topic-value");
 
         OffloadPoliciesImpl offloadPolicies =
                 OffloadPoliciesImpl.mergeConfiguration(topicLevelPolicies, null, brokerProperties);
 
         Assert.assertNotNull(offloadPolicies);
         assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
-                Map.of("tieredStorageBucketPrefix", "topic-prefix"));
+                Map.of("tieredStorageBucketPrefix", "topic-prefix",
+                        "brokerOnly", "broker-value",
+                        "topicOnly", "topic-value"));
+    }
+
+    @Test
+    public void emptyHigherLevelExtraConfigInheritsBrokerExtraConfigMergeTest() {
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("managedLedgerOffloadDriver", "aws-s3");
+        brokerProperties.setProperty(EXTRA_CONFIG_PREFIX + "tieredStorageBucketPrefix", "broker-prefix");
+
+        OffloadPoliciesImpl nsLevelPolicies = new OffloadPoliciesImpl();
+
+        OffloadPoliciesImpl offloadPolicies =
+                OffloadPoliciesImpl.mergeConfiguration(null, nsLevelPolicies, brokerProperties);
+
+        Assert.assertNotNull(offloadPolicies);
+        assertEquals(offloadPolicies.getManagedLedgerExtraConfigurations(),
+                Map.of("tieredStorageBucketPrefix", "broker-prefix"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

#25736 made broker-level `managedLedgerOffloadExtraConfig*` entries available to `OffloadPoliciesImpl.mergeConfiguration(...)`. However, `managedLedgerExtraConfigurations` defaults to an empty map, so a namespace or topic offload policy with no extra config still stops fallback to broker-level extra config.

This can produce runtime offload policies that inherit the broker driver/bucket/region but lose broker-level extra config such as a tiered-storage bucket prefix. The namespace offloaded-ledger scanner also used raw namespace offload policies directly instead of the effective merged policy used by topic loading.

### Modifications

- Merge `managedLedgerExtraConfigurations` as a map from broker -> namespace -> topic.
- Treat null or empty higher-level extra config maps as unset so broker-level entries are inherited.
- Preserve higher-level key overrides, including an explicit empty-string value to clear a broker-level key.
- Use effective merged namespace offload policies when scanning offloaded ledgers.
- Add regression coverage for empty namespace-level extra config inheriting broker-level extra config and for scan using the merged policy.

### Verifying this change

- `./gradlew :pulsar-common:test --tests org.apache.pulsar.common.policies.data.OffloadPoliciesTest`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.admin.AdminApiOffloadTest.testScanOffloadedLedgersUsesMergedNamespaceOffloadPolicies`
