### PR TITLE
[fix][build] Remove jetty-server from avroTools Gradle configuration used in build

### DIFF
--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -90,7 +90,9 @@ sourceSets["main"].proto { exclude("**/*") }
 // Generate Avro test classes from .avsc schema files
 val avroTools by configurations.creating
 dependencies {
-    avroTools("org.apache.avro:avro-tools:${libs.versions.avro.get()}")
+    avroTools("org.apache.avro:avro-tools:${libs.versions.avro.get()}") {
+        exclude(group = "org.eclipse.jetty", module = "jetty-server")
+    }
 }
 
 val generateTestAvro by tasks.registering(JavaExec::class) {


### PR DESCRIPTION
### Motivation

There are GitHub Dependabot security alerts about Jetty 9. The source of them is this build logic:

https://github.com/apache/pulsar/blob/a1613bc2e5fd26cc16fc95b4a3c61bc5e1ae090d/pulsar-client/build.gradle.kts#L90-L104

This is used in pulsar-client's build to generate avro classes from the schema for tests.

The dependency enforcement solution in the Pulsar Gradle build doesn't apply to all Gradle configurations. It's only applied to `implementation` (and configurations extending `implementation`). `avroTools` is an independent configuration.

### Modifications

Exclude `jetty-server` dependency since it's not needed at all.