### PR TITLE
Upgrade avro to 1.12.1 to address CVE-2025-33042

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -476,7 +476,7 @@ The Apache Software License, Version 2.0
   * zt-zip
     - org.zeroturnaround-zt-zip-1.17.jar
   * Apache Avro
-    - org.apache.avro-avro-1.12.0.jar
+    - org.apache.avro-avro-1.12.1.jar
     - org.apache.avro-avro-protobuf-1.12.0.jar
   * Apache Curator
     - org.apache.curator-curator-client-5.7.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -420,7 +420,7 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - error_prone_annotations-2.45.0.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro
-    - avro-1.12.0.jar
+    - avro-1.12.1.jar
     - avro-protobuf-1.12.0.jar
  * RE2j -- re2j-1.8.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ bouncycastle-bcpkix-fips = "2.0.11"
 bouncycastle-bcutil-fips = "2.0.6"
 bouncycastle-bc-fips = "2.0.1"
 # Serialization
-avro = "1.12.0"
+avro = "1.12.1"
 gson = "2.13.2"
 snakeyaml = "2.0"
 # Vert.x


### PR DESCRIPTION
Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

### Motivation

Upgrade avro to 1.12.1 to address CVE-2025-33042

### Modifications

Upgrade avro to 1.12.1 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment