### PR TITLE
[fix][sec][branch-4.0] Upgrade avro to 1.11.5 to address CVE-2025-33042

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -479,8 +479,8 @@ The Apache Software License, Version 2.0
   * zt-zip
     - org.zeroturnaround-zt-zip-1.17.jar
   * Apache Avro
-    - org.apache.avro-avro-1.11.4.jar
-    - org.apache.avro-avro-protobuf-1.11.4.jar
+    - org.apache.avro-avro-1.11.5.jar
+    - org.apache.avro-avro-protobuf-1.11.5.jar
   * Apache Curator
     - org.apache.curator-curator-client-5.7.1.jar
     - org.apache.curator-curator-framework-5.7.1.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -417,8 +417,8 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - error_prone_annotations-2.45.0.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro
-    - avro-1.11.4.jar
-    - avro-protobuf-1.11.4.jar
+    - avro-1.11.5.jar
+    - avro-protobuf-1.11.5.jar
  * RE2j -- re2j-1.8.jar
  * Spotify completable-futures -- completable-futures-0.3.6.jar
  * RoaringBitmap -- RoaringBitmap-1.6.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@ flexible messaging model and an intuitive client API.</description>
     <rabbitmq-client.version>5.28.0</rabbitmq-client.version>
     <aws-sdk.version>1.12.788</aws-sdk.version>
     <aws-sdk2.version>2.32.28</aws-sdk2.version>
-    <avro.version>1.11.4</avro.version>
+    <avro.version>1.11.5</avro.version>
     <joda.version>2.10.10</joda.version>
     <jclouds.version>2.6.0</jclouds.version>
     <guice.version>5.1.0</guice.version>
@@ -1967,6 +1967,8 @@ flexible messaging model and an intuitive client API.</description>
             <testRetryCount>${testRetryCount}</testRetryCount>
             <testFailFast>${testFailFast}</testFailFast>
             <testFailFastFile>${testFailFastFile}</testFailFastFile>
+            <!-- See https://github.com/apache/avro/pull/3376 -->
+            <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal,java.math.BigInteger,java.net.URI,java.net.URL,java.io.File,java.lang.Integer</org.apache.avro.SERIALIZABLE_CLASSES>
           </systemPropertyVariables>
           <properties>
             <property>


### PR DESCRIPTION
### Motivation

avro 1.11.4 contains CVE-2025-33042

### Modifications

upgrade avro to 1.11.5 in branch-4.0