### PR TITLE
[improve][offload] Coalesce automatic offload triggers to reduce retry loops and ledger scans

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AutomaticOffloadTriggerController.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AutomaticOffloadTriggerController.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Coalesces repeated automatic offload triggers into at most one active run and one follow-up run.
+ */
+final class AutomaticOffloadTriggerController {
+    private static final int IDLE = 0;
+    private static final int RUNNING = 1;
+    private static final int RUNNING_WITH_PENDING_TRIGGER = 2;
+
+    private final AtomicInteger state = new AtomicInteger(IDLE);
+
+    /**
+     * Records an automatic offload trigger.
+     *
+     * @return true when the caller must start a new automatic offload run
+     */
+    boolean requestRun() {
+        while (true) {
+            int current = state.get();
+            switch (current) {
+                case IDLE:
+                    if (state.compareAndSet(IDLE, RUNNING)) {
+                        return true;
+                    }
+                    break;
+                case RUNNING:
+                    if (state.compareAndSet(RUNNING, RUNNING_WITH_PENDING_TRIGGER)) {
+                        return false;
+                    }
+                    break;
+                case RUNNING_WITH_PENDING_TRIGGER:
+                    return false;
+                default:
+                    throw new IllegalStateException("Unknown automatic offload trigger state: " + current);
+            }
+        }
+    }
+
+    /**
+     * Records completion of the current automatic offload run.
+     *
+     * @return true when the caller must immediately start one coalesced follow-up run
+     */
+    boolean completeRun() {
+        while (true) {
+            int current = state.get();
+            switch (current) {
+                case IDLE:
+                    return false;
+                case RUNNING:
+                    if (state.compareAndSet(RUNNING, IDLE)) {
+                        return false;
+                    }
+                    break;
+                case RUNNING_WITH_PENDING_TRIGGER:
+                    if (state.compareAndSet(RUNNING_WITH_PENDING_TRIGGER, RUNNING)) {
+                        return true;
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown automatic offload trigger state: " + current);
+            }
+        }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -19,7 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
-import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.NULL_OFFLOAD_PROMISE;
+import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
@@ -496,7 +496,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                                     future.complete(newledger);
                                     // May need to trigger offloading
                                     if (config.isTriggerOffloadOnTopicLoad()) {
-                                        newledger.maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+                                        newledger.maybeOffloadInBackground(AUTOMATIC_OFFLOAD_TRIGGER);
                                     }
                                 });
                             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -231,10 +231,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     protected final CallbackMutex trimmerMutex = new CallbackMutex();
 
     protected final CallbackMutex offloadMutex = new CallbackMutex();
-    // Automatic offload has no caller-visible future. Coalesce concurrent automatic triggers into at most one
-    // running offload and one follow-up run.
-    private final AtomicBoolean automaticOffloadInProgress = new AtomicBoolean(false);
-    private final AtomicBoolean automaticOffloadRerunRequested = new AtomicBoolean(false);
+    private final AutomaticOffloadTriggerController automaticOffloadTriggerController =
+            new AutomaticOffloadTriggerController();
     // Identity sentinel for automatic offload requests. The completed Position value is not used.
     public static final CompletableFuture<Position> AUTOMATIC_OFFLOAD_TRIGGER = CompletableFuture
             .completedFuture(PositionFactory.LATEST);
@@ -242,6 +240,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private enum OffloadRequestSource {
         AUTOMATIC,
         EXPLICIT
+    }
+
+    private record OffloadThresholds(long thresholdInBytes, long thresholdInSeconds) {
     }
 
     @VisibleForTesting
@@ -2816,36 +2817,44 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     public void maybeOffloadInBackground(CompletableFuture<Position> promise) {
         if (promise == AUTOMATIC_OFFLOAD_TRIGGER) {
-            if (!automaticOffloadInProgress.compareAndSet(false, true)) {
-                automaticOffloadRerunRequested.set(true);
-                return;
+            if (automaticOffloadTriggerController.requestRun()) {
+                startAutomaticOffload();
             }
-            CompletableFuture<Position> automaticOffloadCompletion = new CompletableFuture<>();
-            automaticOffloadCompletion.whenComplete((res, ex) -> finishAutomaticOffload(ex));
-            maybeOffloadInBackground(automaticOffloadCompletion, OffloadRequestSource.AUTOMATIC);
             return;
         }
 
         maybeOffloadInBackground(promise, OffloadRequestSource.EXPLICIT);
     }
 
+    private void startAutomaticOffload() {
+        CompletableFuture<Position> automaticOffloadCompletion = new CompletableFuture<>();
+        automaticOffloadCompletion.whenComplete((res, ex) -> finishAutomaticOffload(ex));
+        try {
+            maybeOffloadInBackground(automaticOffloadCompletion, OffloadRequestSource.AUTOMATIC);
+        } catch (RuntimeException e) {
+            automaticOffloadCompletion.completeExceptionally(e);
+        }
+    }
+
     private void maybeOffloadInBackground(CompletableFuture<Position> promise, OffloadRequestSource source) {
-        Optional<Pair<Long, Long>> offloadThresholds = getOffloadThresholds();
+        Optional<OffloadThresholds> offloadThresholds = getOffloadThresholds();
         if (offloadThresholds.isEmpty()) {
-            // Explicit callers keep the previous no-completion behavior. The internal automatic completion must be
-            // finished so automaticOffloadInProgress can be cleared.
             if (source == OffloadRequestSource.AUTOMATIC) {
                 promise.complete(PositionFactory.LATEST);
             }
             return;
         }
 
-        Pair<Long, Long> thresholds = offloadThresholds.get();
-        executor.execute(() -> maybeOffload(thresholds.getLeft(), thresholds.getRight(), promise,
-                source));
+        OffloadThresholds thresholds = offloadThresholds.get();
+        try {
+            executor.execute(() -> maybeOffload(thresholds.thresholdInBytes(), thresholds.thresholdInSeconds(),
+                    promise, source));
+        } catch (RuntimeException e) {
+            promise.completeExceptionally(e);
+        }
     }
 
-    private Optional<Pair<Long, Long>> getOffloadThresholds() {
+    private Optional<OffloadThresholds> getOffloadThresholds() {
         Optional<OffloadPolicies> optionalOffloadPolicies = getOffloadPoliciesIfAppendable();
         if (optionalOffloadPolicies.isEmpty()) {
             return Optional.empty();
@@ -2857,7 +2866,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         final long offloadThresholdInSeconds =
                 Optional.ofNullable(policies.getManagedLedgerOffloadThresholdInSeconds()).orElse(-1L);
         if (offloadThresholdInBytes >= 0 || offloadThresholdInSeconds >= 0) {
-            return Optional.of(Pair.of(offloadThresholdInBytes, offloadThresholdInSeconds));
+            return Optional.of(new OffloadThresholds(offloadThresholdInBytes, offloadThresholdInSeconds));
         }
 
         return Optional.empty();
@@ -2865,11 +2874,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private void finishAutomaticOffload(Throwable exception) {
         if (exception != null) {
-            log.warn().exception(exception).log("Failed to automatically offload ledgers");
+            log.debug().exception(exception).log("Failed to automatically offload ledgers");
         }
-        automaticOffloadInProgress.set(false);
-        if (automaticOffloadRerunRequested.getAndSet(false)) {
-            maybeOffloadInBackground(AUTOMATIC_OFFLOAD_TRIGGER);
+        if (automaticOffloadTriggerController.completeRun()) {
+            startAutomaticOffload();
         }
     }
 
@@ -2889,8 +2897,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         if (!offloadMutex.tryLock()) {
-            scheduledExecutor.schedule(() -> maybeOffloadInBackground(finalPromise, source),
-                    100, TimeUnit.MILLISECONDS);
+            try {
+                scheduledExecutor.schedule(() -> maybeOffloadInBackground(finalPromise, source),
+                        100, TimeUnit.MILLISECONDS);
+            } catch (RuntimeException e) {
+                finalPromise.completeExceptionally(e);
+            }
             return;
         }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -231,8 +231,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     protected final CallbackMutex trimmerMutex = new CallbackMutex();
 
     protected final CallbackMutex offloadMutex = new CallbackMutex();
-    public static final CompletableFuture<Position> NULL_OFFLOAD_PROMISE = CompletableFuture
+    // Automatic offload has no caller-visible future. Coalesce concurrent automatic triggers into at most one
+    // running offload and one follow-up run.
+    private final AtomicBoolean automaticOffloadInProgress = new AtomicBoolean(false);
+    private final AtomicBoolean automaticOffloadRerunRequested = new AtomicBoolean(false);
+    // Identity sentinel for automatic offload requests. The completed Position value is not used.
+    public static final CompletableFuture<Position> AUTOMATIC_OFFLOAD_TRIGGER = CompletableFuture
             .completedFuture(PositionFactory.LATEST);
+
+    private enum OffloadRequestSource {
+        AUTOMATIC,
+        EXPLICIT
+    }
+
     @VisibleForTesting
     @Getter
     protected volatile LedgerHandle currentLedger;
@@ -1968,7 +1979,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         trimConsumedLedgersInBackground();
 
-        maybeOffloadInBackground(NULL_OFFLOAD_PROMISE);
+        maybeOffloadInBackground(AUTOMATIC_OFFLOAD_TRIGGER);
 
         createLedgerAfterClosed();
     }
@@ -2804,22 +2815,66 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     public void maybeOffloadInBackground(CompletableFuture<Position> promise) {
-        if (getOffloadPoliciesIfAppendable().isEmpty()) {
+        if (promise == AUTOMATIC_OFFLOAD_TRIGGER) {
+            if (!automaticOffloadInProgress.compareAndSet(false, true)) {
+                automaticOffloadRerunRequested.set(true);
+                return;
+            }
+            CompletableFuture<Position> automaticOffloadCompletion = new CompletableFuture<>();
+            automaticOffloadCompletion.whenComplete((res, ex) -> finishAutomaticOffload(ex));
+            maybeOffloadInBackground(automaticOffloadCompletion, OffloadRequestSource.AUTOMATIC);
             return;
         }
 
-        final OffloadPolicies policies = config.getLedgerOffloader().getOffloadPolicies();
+        maybeOffloadInBackground(promise, OffloadRequestSource.EXPLICIT);
+    }
+
+    private void maybeOffloadInBackground(CompletableFuture<Position> promise, OffloadRequestSource source) {
+        Optional<Pair<Long, Long>> offloadThresholds = getOffloadThresholds();
+        if (offloadThresholds.isEmpty()) {
+            // Explicit callers keep the previous no-completion behavior. The internal automatic completion must be
+            // finished so automaticOffloadInProgress can be cleared.
+            if (source == OffloadRequestSource.AUTOMATIC) {
+                promise.complete(PositionFactory.LATEST);
+            }
+            return;
+        }
+
+        Pair<Long, Long> thresholds = offloadThresholds.get();
+        executor.execute(() -> maybeOffload(thresholds.getLeft(), thresholds.getRight(), promise,
+                source));
+    }
+
+    private Optional<Pair<Long, Long>> getOffloadThresholds() {
+        Optional<OffloadPolicies> optionalOffloadPolicies = getOffloadPoliciesIfAppendable();
+        if (optionalOffloadPolicies.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final OffloadPolicies policies = optionalOffloadPolicies.get();
         final long offloadThresholdInBytes =
                 Optional.ofNullable(policies.getManagedLedgerOffloadThresholdInBytes()).orElse(-1L);
         final long offloadThresholdInSeconds =
                 Optional.ofNullable(policies.getManagedLedgerOffloadThresholdInSeconds()).orElse(-1L);
         if (offloadThresholdInBytes >= 0 || offloadThresholdInSeconds >= 0) {
-            executor.execute(() -> maybeOffload(offloadThresholdInBytes, offloadThresholdInSeconds, promise));
+            return Optional.of(Pair.of(offloadThresholdInBytes, offloadThresholdInSeconds));
+        }
+
+        return Optional.empty();
+    }
+
+    private void finishAutomaticOffload(Throwable exception) {
+        if (exception != null) {
+            log.warn().exception(exception).log("Failed to automatically offload ledgers");
+        }
+        automaticOffloadInProgress.set(false);
+        if (automaticOffloadRerunRequested.getAndSet(false)) {
+            maybeOffloadInBackground(AUTOMATIC_OFFLOAD_TRIGGER);
         }
     }
 
     private void maybeOffload(long offloadThresholdInBytes, long offloadThresholdInSeconds,
-                              CompletableFuture<Position> finalPromise) {
+                              CompletableFuture<Position> finalPromise, OffloadRequestSource source) {
         if (getOffloadPoliciesIfAppendable().isEmpty()) {
             String msg = String.format("[%s] Nothing to offload due to offloader or offloadPolicies is NULL", name);
             finalPromise.completeExceptionally(new IllegalArgumentException(msg));
@@ -2834,7 +2889,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         if (!offloadMutex.tryLock()) {
-            scheduledExecutor.schedule(() -> maybeOffloadInBackground(finalPromise),
+            scheduledExecutor.schedule(() -> maybeOffloadInBackground(finalPromise, source),
                     100, TimeUnit.MILLISECONDS);
             return;
         }
@@ -2926,12 +2981,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private Optional<OffloadPolicies> getOffloadPoliciesIfAppendable() {
         LedgerOffloader ledgerOffloader = config.getLedgerOffloader();
-        if (ledgerOffloader == null
-                || !ledgerOffloader.isAppendable()
-                || ledgerOffloader.getOffloadPolicies() == null) {
+        if (ledgerOffloader == null || !ledgerOffloader.isAppendable()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(ledgerOffloader.getOffloadPolicies());
+        OffloadPolicies offloadPolicies = ledgerOffloader.getOffloadPolicies();
+        return Optional.ofNullable(offloadPolicies);
     }
 
     @VisibleForTesting

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/AutomaticOffloadTriggerControllerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/AutomaticOffloadTriggerControllerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+public class AutomaticOffloadTriggerControllerTest {
+
+    @Test
+    public void triggersCoalesceWhileRunIsActive() {
+        AutomaticOffloadTriggerController controller = new AutomaticOffloadTriggerController();
+
+        assertThat(controller.requestRun()).isTrue();
+        assertThat(controller.requestRun()).isFalse();
+        assertThat(controller.requestRun()).isFalse();
+    }
+
+    @Test
+    public void pendingTriggerSchedulesOneFollowUpRun() {
+        AutomaticOffloadTriggerController controller = new AutomaticOffloadTriggerController();
+
+        assertThat(controller.requestRun()).isTrue();
+        assertThat(controller.requestRun()).isFalse();
+
+        assertThat(controller.completeRun()).isTrue();
+        assertThat(controller.completeRun()).isFalse();
+        assertThat(controller.requestRun()).isTrue();
+    }
+
+    @Test(timeOut = 30000)
+    public void concurrentTriggerAndCompletionAlwaysReserveOneFollowUpRun() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < 1000; i++) {
+                AutomaticOffloadTriggerController controller = new AutomaticOffloadTriggerController();
+                assertThat(controller.requestRun()).isTrue();
+
+                // Completion and a new trigger can race; exactly one side must reserve the follow-up run.
+                CyclicBarrier barrier = new CyclicBarrier(3);
+                Future<Boolean> completeResult = executor.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    return controller.completeRun();
+                });
+                Future<Boolean> triggerResult = executor.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    return controller.requestRun();
+                });
+
+                barrier.await(5, TimeUnit.SECONDS);
+                boolean followUpReservedByComplete = completeResult.get(5, TimeUnit.SECONDS);
+                boolean followUpReservedByTrigger = triggerResult.get(5, TimeUnit.SECONDS);
+
+                assertThat(followUpReservedByComplete)
+                        .as("iteration %s must reserve exactly one follow-up run", i)
+                        .isNotEqualTo(followUpReservedByTrigger);
+                assertThat(controller.completeRun()).isFalse();
+            }
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -1184,6 +1184,128 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
     }
 
+    @Test
+    public void automaticOffloadTriggersAreCoalescedWhileOffloadInProgress() throws Exception {
+        CompletableFuture<Void> slowOffload = new CompletableFuture<>();
+        CountDownLatch offloadRunning = new CountDownLatch(1);
+        AtomicInteger offloadPolicyCalls = new AtomicInteger();
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    offloadRunning.countDown();
+                    return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
+                }
+
+                @Override
+                public OffloadPoliciesImpl getOffloadPolicies() {
+                    offloadPolicyCalls.incrementAndGet();
+                    return super.getOffloadPolicies();
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setRetentionSizeInMB(10);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInBytes(0L);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+
+        for (int i = 0; i < 25; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        assertTrue(offloadRunning.await(5, TimeUnit.SECONDS));
+
+        int callsBeforeRepeatedTriggers = offloadPolicyCalls.get();
+        for (int i = 0; i < 20; i++) {
+            ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
+        }
+
+        Thread.sleep(300);
+        assertTrue(offloadPolicyCalls.get() < callsBeforeRepeatedTriggers + 5,
+                "Repeated automatic triggers should not create independent retry loops");
+
+        slowOffload.complete(null);
+
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 2);
+        List<Long> allLedgerIds = ledger.getLedgersInfoAsList().stream().map(LedgerInfo::getLedgerId).toList();
+        assertEquals(offloader.offloadedLedgers(), Set.of(allLedgerIds.get(0), allLedgerIds.get(1)));
+    }
+
+    @Test
+    public void automaticOffloadRunsAgainForCoalescedTrigger() throws Exception {
+        CompletableFuture<Void> slowOffload = new CompletableFuture<>();
+        CountDownLatch offloadRunning = new CountDownLatch(1);
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    offloadRunning.countDown();
+                    return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setRetentionSizeInMB(10);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInBytes(0L);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+
+        for (int i = 0; i < 11; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        assertTrue(offloadRunning.await(5, TimeUnit.SECONDS));
+
+        // The next ledger closes after the first automatic scan, so it depends on the coalesced rerun.
+        for (int i = 11; i < 21; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        assertEquals(offloader.offloadedLedgers().size(), 0);
+
+        slowOffload.complete(null);
+
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 2);
+        List<Long> allLedgerIds = ledger.getLedgersInfoAsList().stream().map(LedgerInfo::getLedgerId).toList();
+        assertEquals(offloader.offloadedLedgers(), Set.of(allLedgerIds.get(0), allLedgerIds.get(1)));
+    }
+
+    @Test
+    public void automaticOffloadWithoutThresholdDoesNotBlockLaterTriggers() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setRetentionSizeInMB(10);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInBytes(-1L);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+
+        for (int i = 0; i < 25; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
+        assertEquals(offloader.offloadedLedgers().size(), 0);
+
+        // A disabled automatic trigger must complete internally so a later enabled trigger can run.
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInBytes(0L);
+        ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
+
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 2);
+        List<Long> allLedgerIds = ledger.getLedgersInfoAsList().stream().map(LedgerInfo::getLedgerId).toList();
+        assertEquals(offloader.offloadedLedgers(), Set.of(allLedgerIds.get(0), allLedgerIds.get(1)));
+    }
+
     @DataProvider(name = "offloadAsSoonAsClosed")
     public Object[][] offloadAsSoonAsClosedProvider() {
         return new Object[][]{

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -1213,21 +1213,21 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
         config.setLedgerOffloader(offloader);
 
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
 
         for (int i = 0; i < 25; i++) {
             ledger.addEntry(buildEntry(10, "entry-" + i));
         }
         assertTrue(offloadRunning.await(5, TimeUnit.SECONDS));
 
+        // Repeated automatic triggers should stop at the controller and avoid another policy lookup.
         int callsBeforeRepeatedTriggers = offloadPolicyCalls.get();
         for (int i = 0; i < 20; i++) {
             ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
         }
 
-        Thread.sleep(300);
-        assertTrue(offloadPolicyCalls.get() < callsBeforeRepeatedTriggers + 5,
-                "Repeated automatic triggers should not create independent retry loops");
+        assertEquals(offloadPolicyCalls.get(), callsBeforeRepeatedTriggers);
 
         slowOffload.complete(null);
 
@@ -1258,7 +1258,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
         config.setLedgerOffloader(offloader);
 
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
 
         for (int i = 0; i < 11; i++) {
             ledger.addEntry(buildEntry(10, "entry-" + i));
@@ -1289,7 +1290,8 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(null);
         config.setLedgerOffloader(offloader);
 
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("my_test_ledger" + UUID.randomUUID(), config);
 
         for (int i = 0; i < 25; i++) {
             ledger.addEntry(buildEntry(10, "entry-" + i));
@@ -1297,7 +1299,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
         assertEquals(offloader.offloadedLedgers().size(), 0);
 
-        // A disabled automatic trigger must complete internally so a later enabled trigger can run.
+        // A disabled automatic trigger must complete internally so a later valid trigger can run.
         offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInBytes(0L);
         ledger.maybeOffloadInBackground(ManagedLedgerImpl.AUTOMATIC_OFFLOAD_TRIGGER);
 


### PR DESCRIPTION
### Related issue

Fixes #25859

### Motivation

  Automatic managed ledger offload can be triggered repeatedly while a previous offload is still running, for example around ledger rollover or topic load.

  Before this change, every automatic trigger could independently enter the offload path:

  1. read offload policies
  2. scan the managed ledger's ledger list
  3. try to acquire the offload mutex
  4. fail because another offload is already running
  5. schedule another retry after 100ms

  When offload is slow, or when a managed ledger has many ledgers, repeated automatic triggers can build up unnecessary scheduler/executor work. These retries do not improve the final offload
  result because only one offload can run at a time.

  ### Modifications

  This change coalesces automatic offload triggers in `ManagedLedgerImpl`.

  After this change:

  - there is at most one in-flight automatic offload
  - repeated automatic triggers during an in-flight offload are merged into one pending rerun
  - after the current automatic offload completes, one follow-up pass runs if any trigger arrived meanwhile
  - explicit/manual offload requests keep their existing `CompletableFuture<Position>` behavior
  - the automatic offload sentinel is renamed to make it clear that its `Position` value is not consumed
  - duplicate `getOffloadPolicies()` calls are avoided in the appendable offloader policy lookup path

  ### Impact

  The final automatic offload progression is preserved: if new ledgers become eligible while an offload is running, the follow-up pass still picks them up.

  The main benefit is reducing unnecessary work under slow offload or large-ledger workloads:

  - avoids repeated 100ms automatic offload retry loops
  - reduces redundant offload policy reads
  - reduces redundant ledger-list scans
  - lowers scheduler and executor pressure while offload is already in progress
  - keeps explicit/manual offload behavior unchanged

  In practice, repeated automatic triggers while one offload is running are reduced from many independent retry loops to one active run plus one pending rerun.

  ### Verifying this change

  - [x] Make sure that the change passes the CI checks.

  This change added tests and can be verified as follows:

  - Added a test that repeated automatic triggers during an in-flight offload do not create independent retry loops.
  - Added a test that a coalesced automatic trigger causes one follow-up offload pass.
  - Added a test that automatic offload state is released when offload thresholds are disabled, so later valid triggers can still run.

  Local verification:

  ```bash
  git diff --check
  ./gradlew :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.OffloadPrefixTest
  ./gradlew :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.OffloadLedgerDeleteTest
```
  ### Does this pull request potentially affect one of the following parts:

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment

  This only changes the internal scheduling behavior of automatic managed ledger offload. Public APIs, configs, metrics, explicit/manual offload behavior, and offload metadata semantics are
  unchanged.
