### PR TITLE
[fix][ml] Prevent terminated managed ledger from transitioning back to writable state

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1706,7 +1706,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     @Override
     public synchronized void createComplete(int rc, final LedgerHandle lh, Object ctx) {
-        if (STATE_UPDATER.get(this) == State.Closed) {
+        State state = STATE_UPDATER.get(this);
+        if (state == State.Terminated) {
+            if (lh != null) {
+                log.warn().attr("rc", rc)
+                        .attr("ledgerId", lh != null ? lh.getId() : -1)
+                        .attr("state", state)
+                        .log("Ledger create completed after the managed ledger is terminated,"
+                                + " so just close this ledger handle");
+                lh.closeAsync();
+            }
+            clearPendingAddEntries(new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
+            return;
+        } else if (state == State.Closed) {
             if (lh != null) {
                 log.warn().attr("rc", rc)
                         .attr("ledgerId", lh != null ? lh.getId() : -1)
@@ -1749,8 +1761,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     synchronized (ManagedLedgerImpl.this) {
                         try {
                             State state = STATE_UPDATER.get(ManagedLedgerImpl.this);
-                            if (state == State.Closed || state.isFenced()) {
-                                log.debug().log("skip ledger update after create complete ledger is closed or fenced");
+                            if (state == State.Closed || state == State.Terminated || state.isFenced()) {
+                                log.debug().attr("state", state)
+                                        .log("skip ledger update after create complete ledger is not writable");
                                 lh.closeAsync().exceptionally(e -> {
                                     if (e != null) {
                                         log.error()
@@ -1760,6 +1773,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                     }
                                     return null;
                                 });
+                                if (state == State.Terminated) {
+                                    clearPendingAddEntries(new ManagedLedgerTerminatedException(
+                                            "Managed ledger was already terminated"));
+                                }
                             } else {
                                 LedgerHandle originalCurrentLedger = currentLedger;
                                 ledgers.put(lh.getId(), newLedger);
@@ -1861,6 +1878,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     protected synchronized void updateLedgersIdsComplete(@Nullable LedgerHandle originalCurrentLedger) {
+        State state = STATE_UPDATER.get(this);
+        if (state == State.Terminated) {
+            log.debug().attr("state", state)
+                    .attr("pendingAddEntries", pendingAddEntries.size())
+                    .log("Skip completing ledger switch because managed ledger is terminated");
+            clearPendingAddEntries(new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
+            return;
+        }
         STATE_UPDATER.set(this, State.LedgerOpened);
         // Delete original "currentLedger" if it has been removed from "ledgers".
         if (originalCurrentLedger != null && !ledgers.containsKey(originalCurrentLedger.getId())){
@@ -1996,7 +2021,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     boolean isNeededCreateNewLedgerAfterCloseLedger() {
         final State state = STATE_UPDATER.get(this);
-        if (state != State.CreatingLedger && state != State.LedgerOpened) {
+        if (state != State.CreatingLedger && state != State.LedgerOpened && state != State.Terminated) {
             return true;
         }
         return false;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1523,7 +1523,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         log.info("Terminating managed ledger");
+        State previousState = state;
         state = State.Terminated;
+        clearPendingAddEntriesAfterTerminate(previousState,
+                new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
 
         LedgerHandle lh = currentLedger;
         log.debug().attr("ledgerId", lh.getId()).log("Closing current writing ledger");
@@ -1706,6 +1709,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     @Override
     public synchronized void createComplete(int rc, final LedgerHandle lh, Object ctx) {
+        log.debug().attr("rc", rc).attr("ledgerId", lh != null ? lh.getId() : -1).log("createComplete");
+
+        // The create callback carries a future used by the timeout checker. Complete it before any terminal-state
+        // return; otherwise a late callback after terminate/close can leave the timeout task and create-op metric
+        // unbalanced. A true return means this callback is stale because the future was already completed, and the
+        // helper has already deleted the late-created ledger if needed.
+        if (checkAndCompleteLedgerOpTask(rc, lh, ctx)) {
+            return;
+        }
+
+        mbean.endDataLedgerCreateOp();
         State state = STATE_UPDATER.get(this);
         if (state == State.Terminated) {
             if (lh != null) {
@@ -1713,8 +1727,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                         .attr("ledgerId", lh != null ? lh.getId() : -1)
                         .attr("state", state)
                         .log("Ledger create completed after the managed ledger is terminated,"
-                                + " so just close this ledger handle");
-                lh.closeAsync();
+                                + " so close and delete this ledger handle");
+                closeAndDeleteCreatedLedger(lh);
             }
             clearPendingAddEntries(new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
             return;
@@ -1728,14 +1742,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             }
             return;
         }
-
-        log.debug().attr("rc", rc).attr("ledgerId", lh != null ? lh.getId() : -1).log("createComplete");
-
-        if (checkAndCompleteLedgerOpTask(rc, lh, ctx)) {
-            return;
-        }
-
-        mbean.endDataLedgerCreateOp();
         if (rc != BKException.Code.OK) {
             log.error().attr("rc", rc).attr("message", BKException.getMessage(rc)).log("Error creating ledger");
             ManagedLedgerException status = createManagedLedgerException(rc);
@@ -1764,6 +1770,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                             if (state == State.Closed || state == State.Terminated || state.isFenced()) {
                                 log.debug().attr("state", state)
                                         .log("skip ledger update after create complete ledger is not writable");
+                                // TODO: if this path is hit after the new ledger was already written into metadata,
+                                // delete the unused ledger together with removing it from the metadata.
                                 lh.closeAsync().exceptionally(e -> {
                                     if (e != null) {
                                         log.error()
@@ -1852,6 +1860,23 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         log.debug().attr("version", ledgersStat).log("Updating ledgers ids with new ledger");
         ManagedLedgerInfo mlInfo = getManagedLedgerInfo(newLedger);
         store.asyncUpdateLedgerIds(name, mlInfo, ledgersStat, callback);
+    }
+
+    private void closeAndDeleteCreatedLedger(LedgerHandle lh) {
+        long ledgerId = lh.getId();
+        lh.closeAsync().whenComplete((ignore, closeException) -> {
+            if (closeException != null) {
+                log.warn().attr("ledgerId", ledgerId)
+                        .attr("error", closeException.getMessage())
+                        .log("Failed to close late-created ledger before deletion");
+            }
+            asyncDeleteLedger(ledgerId, DEFAULT_LEDGER_DELETE_RETRIES).exceptionally(deleteException -> {
+                log.warn().attr("ledgerId", ledgerId)
+                        .attr("error", deleteException.getMessage())
+                        .log("Failed to delete late-created ledger");
+                return null;
+            });
+        });
     }
 
     @VisibleForTesting
@@ -2102,6 +2127,41 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         OpAddEntry op;
         while ((op = pendingAddEntries.poll()) != null) {
             op.failed(e);
+        }
+    }
+
+    synchronized boolean failAddIfTerminated(OpAddEntry op) {
+        if (STATE_UPDATER.get(this) != State.Terminated) {
+            return false;
+        }
+
+        // This is only for a failed add callback that arrives after terminate has taken ownership of the ledger.
+        // terminate closes the current ledger at the current BK LAC; any outstanding add drained by
+        // LedgerHandle.close() is outside the terminated position. If this callback falls through to the normal
+        // write-failure path, ledgerClosed() will return in Terminated state without completing this add, leaving the
+        // client callback hanging. Fail it explicitly instead.
+        pendingAddEntries.remove(op);
+        op.failed(new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
+        return true;
+    }
+
+    synchronized void clearPendingAddEntriesAfterTerminate(State previousState, ManagedLedgerException e) {
+        // In these states, there is no current-ledger write path left. Every pending op is waiting for a future ledger
+        // or a replay onto that future ledger, which terminate must not create.
+        if (previousState == State.CreatingLedger || previousState == State.ClosedLedger
+                || previousState == State.WriteFailed) {
+            clearPendingAddEntries(e);
+            return;
+        }
+
+        // In LedgerOpened/ClosingLedger, this queue can also contain writes already sent to the current ledger.
+        // Those writes are decided by the BK callback path: they either complete before close advances LAC, or
+        // LedgerHandle.close() drains them and OpAddEntry.handleAddFailure completes them as terminated. Only fail
+        // entries that have not been initiated yet, since they are only waiting for a future ledger.
+        for (OpAddEntry op : pendingAddEntries) {
+            if (op.getState() == OpAddEntry.State.OPEN && pendingAddEntries.remove(op)) {
+                op.failed(e);
+            }
         }
     }
 
@@ -4663,8 +4723,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     /**
-     * check if ledger-op task is already completed by timeout-task. If completed then delete the created ledger
-     * @return
+     * Complete the ledger-create future used by the timeout checker.
+     *
+     * @return true when this callback is stale because another callback or the timeout task already completed the
+     *         future. In that case the caller must stop processing this callback. If a ledger was created by the stale
+     *         callback, this method schedules it for deletion.
      */
     @SuppressWarnings("unchecked")
     protected boolean checkAndCompleteLedgerOpTask(int rc, LedgerHandle lh, Object ctx) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -366,6 +366,9 @@ public class OpAddEntry implements AddCallback, CloseCallback, Runnable, Managed
         finalMl.mbean.recordAddEntryError();
 
         finalMl.getExecutor().execute(() -> {
+            if (finalMl.failAddIfTerminated(this)) {
+                return;
+            }
             // Force the creation of a new ledger. Doing it in a background thread to avoid acquiring ML lock
             // from a BK callback.
             // If we received a "MetadataVersionException" or a "LedgerFencedException", we should tell the ML that

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
@@ -29,10 +29,14 @@ import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
@@ -72,6 +76,9 @@ public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
 
     @Test(timeOut = 30000)
     public void terminateDuringLedgerSwitchKeepsTerminatedState() throws Exception {
+        // Regression for terminate racing with a ledger rollover. The new ledger create callback is held until after
+        // terminate wins. The late create callback must not reopen the managed ledger, and the late-created ledger
+        // must be closed/deleted because terminate will not use a future ledger for pending writes.
         BookKeeper spyBookKeeper = spy(bkc);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         initManagedLedgerConfig(config);
@@ -127,10 +134,17 @@ public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
             assertEquals(lastPosition, p0);
             assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
 
-            createCallback.get().createComplete(BKException.Code.OK, createdLedger.get(), createCtx.get());
             assertTrue(addFailed.await(5, TimeUnit.SECONDS));
             assertTrue(addSuccess.get() == null);
             assertTrue(addFailure.get() instanceof ManagedLedgerTerminatedException);
+            assertEquals(ledger.pendingAddEntries.size(), 0);
+
+            long lateCreatedLedgerId = createdLedger.get().getId();
+            assertTrue(bkc.getLedgers().contains(lateCreatedLedgerId));
+            createCallback.get().createComplete(BKException.Code.OK, createdLedger.get(), createCtx.get());
+            assertTrue(((CompletableFuture<?>) createCtx.get()).isDone());
+            assertEquals(ledger.mbean.getPendingBookieOpsStats().dataLedgerCreateOp, 0);
+            Awaitility.await().untilAsserted(() -> assertFalse(bkc.getLedgers().contains(lateCreatedLedgerId)));
             assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
 
             try {
@@ -152,6 +166,145 @@ public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
         } finally {
             localFactory.shutdown();
         }
+    }
+
+    @Test(timeOut = 30000)
+    public void terminatePositionIncludesAddAlreadyAckedByBookKeeper() throws Exception {
+        // BK has already acked the add and advanced LAC, but the ML client callback is still queued behind the
+        // managed-ledger executor. terminate must use the BK LAC as its boundary, so the terminated position still
+        // includes this add even though the client callback is delivered after terminate() returns.
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("terminate_includes_acked_add");
+        LedgerHandle originalLedger = ledger.currentLedger;
+        LedgerHandle spyLedger = spy(originalLedger);
+        long ledgerId = originalLedger.getId();
+
+        CountDownLatch addIssued = new CountDownLatch(1);
+        CountDownLatch executorBlocked = new CountDownLatch(1);
+        CountDownLatch releaseExecutor = new CountDownLatch(1);
+        CountDownLatch addCompleted = new CountDownLatch(1);
+        AtomicLong lac = new AtomicLong(-1);
+        AtomicReference<AddCallback> bkAddCallback = new AtomicReference<>();
+        AtomicReference<Object> bkAddCtx = new AtomicReference<>();
+        AtomicReference<Position> addSuccess = new AtomicReference<>();
+        AtomicReference<ManagedLedgerException> addFailure = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            bkAddCallback.set(invocation.getArgument(1));
+            bkAddCtx.set(invocation.getArgument(2));
+            addIssued.countDown();
+            return null;
+        }).when(spyLedger).asyncAddEntry(any(ByteBuf.class), any(AddCallback.class), any());
+        doAnswer(invocation -> lac.get()).when(spyLedger).getLastAddConfirmed();
+        doAnswer(invocation -> {
+            CloseCallback closeCallback = invocation.getArgument(0);
+            Object closeCtx = invocation.getArgument(1);
+            closeCallback.closeComplete(BKException.Code.OK, spyLedger, closeCtx);
+            return null;
+        }).when(spyLedger).asyncClose(any(CloseCallback.class), any());
+
+        ledger.currentLedger = spyLedger;
+
+        ledger.asyncAddEntry("entry-0".getBytes(), new AddEntryCallback() {
+            @Override
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                addSuccess.set(position);
+                addCompleted.countDown();
+            }
+
+            @Override
+            public void addFailed(ManagedLedgerException exception, Object ctx) {
+                addFailure.set(exception);
+                addCompleted.countDown();
+            }
+        }, null);
+
+        assertTrue(addIssued.await(5, TimeUnit.SECONDS));
+        ledger.getExecutor().execute(() -> {
+            executorBlocked.countDown();
+            try {
+                releaseExecutor.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(executorBlocked.await(5, TimeUnit.SECONDS));
+
+        lac.set(0);
+        bkAddCallback.get().addComplete(BKException.Code.OK, spyLedger, 0, bkAddCtx.get());
+
+        try {
+            Position terminatedPosition = ledger.terminate();
+            assertEquals(terminatedPosition, PositionFactory.create(ledgerId, 0));
+            assertFalse(addCompleted.await(100, TimeUnit.MILLISECONDS));
+        } finally {
+            releaseExecutor.countDown();
+        }
+
+        assertTrue(addCompleted.await(5, TimeUnit.SECONDS));
+        assertEquals(addSuccess.get(), PositionFactory.create(ledgerId, 0));
+        assertTrue(addFailure.get() == null);
+        assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
+    }
+
+    @Test(timeOut = 30000)
+    public void terminateFailsInflightAddDrainedByLedgerClose() throws Exception {
+        // BK close drains outstanding adds that have not reached LAC. Those entries are outside the terminated
+        // position, so ML must fail their callbacks as terminated instead of entering the normal write-failure path,
+        // which would return from ledgerClosed() in Terminated state and leave the add callback hanging.
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("terminate_inflight_add_close");
+        LedgerHandle originalLedger = ledger.currentLedger;
+        LedgerHandle spyLedger = spy(originalLedger);
+        long ledgerId = originalLedger.getId();
+
+        CountDownLatch addIssued = new CountDownLatch(1);
+        AtomicReference<AddCallback> bkAddCallback = new AtomicReference<>();
+        AtomicReference<Object> bkAddCtx = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            bkAddCallback.set(invocation.getArgument(1));
+            bkAddCtx.set(invocation.getArgument(2));
+            addIssued.countDown();
+            return null;
+        }).when(spyLedger).asyncAddEntry(any(ByteBuf.class), any(AddCallback.class), any());
+
+        doAnswer(invocation -> {
+            CloseCallback closeCallback = invocation.getArgument(0);
+            Object closeCtx = invocation.getArgument(1);
+            bkAddCallback.get().addComplete(BKException.Code.LedgerClosedException, spyLedger, -1, bkAddCtx.get());
+            closeCallback.closeComplete(BKException.Code.OK, spyLedger, closeCtx);
+            return null;
+        }).when(spyLedger).asyncClose(any(CloseCallback.class), any());
+
+        ledger.currentLedger = spyLedger;
+
+        CountDownLatch addFailed = new CountDownLatch(1);
+        AtomicReference<ManagedLedgerException> addFailure = new AtomicReference<>();
+        AtomicReference<Position> addSuccess = new AtomicReference<>();
+        ledger.asyncAddEntry("entry-0".getBytes(), new AddEntryCallback() {
+            @Override
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                addSuccess.set(position);
+                addFailed.countDown();
+            }
+
+            @Override
+            public void addFailed(ManagedLedgerException exception, Object ctx) {
+                addFailure.set(exception);
+                addFailed.countDown();
+            }
+        }, null);
+
+        assertTrue(addIssued.await(5, TimeUnit.SECONDS));
+        Awaitility.await().untilAsserted(() -> assertEquals(ledger.pendingAddEntries.size(), 1));
+
+        Position lastPosition = ledger.terminate();
+
+        assertEquals(lastPosition, PositionFactory.create(ledgerId, -1));
+        assertTrue(addFailed.await(5, TimeUnit.SECONDS));
+        assertTrue(addSuccess.get() == null);
+        assertTrue(addFailure.get() instanceof ManagedLedgerTerminatedException);
+        Awaitility.await().untilAsserted(() -> assertEquals(ledger.pendingAddEntries.size(), 0));
+        assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
     }
 
     @Test(timeOut = 20000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTerminationTest.java
@@ -18,20 +18,37 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import io.netty.buffer.ByteBuf;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.bookkeeper.client.AsyncCallback.CreateCallback;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.NoMoreEntriesToReadException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
@@ -51,6 +68,102 @@ public class ManagedLedgerTerminationTest extends MockedBookKeeperTestCase {
         } catch (ManagedLedgerTerminatedException e) {
             // Expected
         }
+    }
+
+    @Test(timeOut = 30000)
+    public void terminateDuringLedgerSwitchKeepsTerminatedState() throws Exception {
+        BookKeeper spyBookKeeper = spy(bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        initManagedLedgerConfig(config);
+        config.setMaxEntriesPerLedger(1);
+
+        AtomicBoolean holdNextCreate = new AtomicBoolean(false);
+        CountDownLatch createRequested = new CountDownLatch(1);
+        AtomicReference<CreateCallback> createCallback = new AtomicReference<>();
+        AtomicReference<Object> createCtx = new AtomicReference<>();
+        AtomicReference<LedgerHandle> createdLedger = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            if (holdNextCreate.compareAndSet(true, false)) {
+                LedgerHandle lh = bkc.createLedger(invocation.getArgument(0), invocation.getArgument(1),
+                        invocation.getArgument(2), invocation.getArgument(3), invocation.getArgument(4));
+                createdLedger.set(lh);
+                createCallback.set(invocation.getArgument(5));
+                createCtx.set(invocation.getArgument(6));
+                createRequested.countDown();
+                return null;
+            }
+            return invocation.callRealMethod();
+        }).when(spyBookKeeper).asyncCreateLedger(anyInt(), anyInt(), anyInt(), any(), any(), any(), any(), any());
+
+        ManagedLedgerFactoryImpl localFactory = new ManagedLedgerFactoryImpl(metadataStore, spyBookKeeper);
+        try {
+            ManagedLedgerImpl ledger = (ManagedLedgerImpl) localFactory.open("terminate_during_ledger_switch", config);
+            holdNextCreate.set(true);
+
+            Position p0 = ledger.addEntry("entry-0".getBytes());
+            assertTrue(createRequested.await(5, TimeUnit.SECONDS));
+            assertEquals(ledger.getState(), ManagedLedgerImpl.State.CreatingLedger);
+
+            CountDownLatch addFailed = new CountDownLatch(1);
+            AtomicReference<ManagedLedgerException> addFailure = new AtomicReference<>();
+            AtomicReference<Position> addSuccess = new AtomicReference<>();
+            ledger.asyncAddEntry("entry-1".getBytes(), new AddEntryCallback() {
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    addSuccess.set(position);
+                    addFailed.countDown();
+                }
+
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                    addFailure.set(exception);
+                    addFailed.countDown();
+                }
+            }, null);
+            Awaitility.await().untilAsserted(() -> assertEquals(ledger.pendingAddEntries.size(), 1));
+
+            Position lastPosition = ledger.terminate();
+            assertEquals(lastPosition, p0);
+            assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
+
+            createCallback.get().createComplete(BKException.Code.OK, createdLedger.get(), createCtx.get());
+            assertTrue(addFailed.await(5, TimeUnit.SECONDS));
+            assertTrue(addSuccess.get() == null);
+            assertTrue(addFailure.get() instanceof ManagedLedgerTerminatedException);
+            assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
+
+            try {
+                ledger.addEntry("entry-2".getBytes());
+                fail("Should have thrown exception");
+            } catch (ManagedLedgerTerminatedException e) {
+                // Expected
+            }
+
+            ledger.close();
+            ManagedLedger reopened = localFactory.open("terminate_during_ledger_switch", config);
+            assertTrue(reopened.isTerminated());
+            try {
+                reopened.addEntry("entry-3".getBytes());
+                fail("Should have thrown exception");
+            } catch (ManagedLedgerTerminatedException e) {
+                // Expected
+            }
+        } finally {
+            localFactory.shutdown();
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void ledgerSwitchCompletionDoesNotReopenTerminatedLedger() throws Exception {
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("terminate_state_not_overwritten");
+        ledger.addEntry("entry-0".getBytes());
+
+        // Regression for a ledger-switch completion callback arriving after terminate().
+        ManagedLedgerImpl.STATE_UPDATER.set(ledger, ManagedLedgerImpl.State.Terminated);
+        ledger.updateLedgersIdsComplete(null);
+
+        assertEquals(ledger.getState(), ManagedLedgerImpl.State.Terminated);
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
### Related issue

Fixes #25858

### Motivation

  `ManagedLedger.terminate()` seals the managed ledger at the current BookKeeper committed boundary. After termination, no new entries should be accepted, and the managed ledger must not
  become writable again.

  The key invariant is:

  > Any add operation that is acknowledged successfully to the caller must have a position less than or equal to the final `terminatedPosition`.

  `terminate()` does not wait for every submitted add to succeed. It closes the current BookKeeper ledger and uses the ledger's final LAC as the `terminatedPosition`.

  Therefore:

  - adds already acknowledged by BookKeeper and included in LAC may still complete successfully, even if the ManagedLedger callback is delivered after `terminate()`;
  - adds that have not reached LAC, including queued writes waiting for a future ledger, must fail with `ManagedLedgerTerminatedException`;
  - termination must not create or switch to another ledger to replay pending writes.

  There is a race between `terminate()` and ledger rollover:

  1. An add fills the current ledger and triggers rollover.
  2. The managed ledger moves into `ClosingLedger` / `CreatingLedger`.
  3. `terminate()` runs before the rollover create/switch callback finishes and marks the managed ledger as `Terminated`.
  4. The delayed `createComplete()` or `updateLedgersIdsComplete()` callback resumes the old rollover flow.
  5. The callback can set the state back to `LedgerOpened`, making a terminated managed ledger writable again.

  This breaks the terminate semantics. It can also leave pending writes handled as normal rollover writes instead of terminated writes, or leave in-flight add callbacks hanging when
  BookKeeper close drains writes that were not included in the final LAC.

  ### Modifications

  This change keeps `Terminated` as the final write state after `terminate()` takes ownership.

  The implementation follows one invariant:

  > Any add that completes successfully to the caller must be included in the final `terminatedPosition`.

  To keep that invariant, this PR handles each race path explicitly:

  - **Queued adds that have not been sent to BookKeeper**
    - When `terminate()` takes ownership, these adds are failed with `ManagedLedgerTerminatedException`.
    - They are only waiting for a future ledger, and terminate must not create or switch to another ledger to replay them.

  - **In-flight adds already sent to BookKeeper**
    - These adds are not failed immediately.
    - BookKeeper decides whether they are inside the final LAC:
      - if BookKeeper has acked the add and advanced LAC, the add may still complete successfully;
      - if BookKeeper close drains the add before it reaches LAC, the add is failed as terminated.
    - This preserves the rule that successful add positions are covered by `terminatedPosition`.

  - **Failed add callbacks after terminate**
    - Added `failAddIfTerminated()` for failed add callbacks that arrive after terminate has taken ownership.
    - Without this, a drained add would enter the normal write-failure path. In `Terminated` state, `ledgerClosed()` returns without replaying or failing the add, leaving the client callback
  hanging.

  - **Late ledger create callbacks**
    - `createComplete()` now completes the ledger-create future before terminal-state checks.
    - This keeps the timeout checker and pending create-op metric balanced even if the create callback arrives after terminate.
    - If the late callback created a ledger after termination, the ledger is closed and deleted because terminated ledgers cannot use a future ledger for pending writes.

  - **Late ledger switch callbacks**
    - `updateLedgersIdsComplete()` now returns when the managed ledger is already `Terminated`.
    - This prevents a delayed rollover callback from setting the state back to `LedgerOpened`.

  - **Replacement ledger creation after close**
    - The close path no longer creates a replacement ledger when the state is already `Terminated`.
    - Terminate closes the current ledger to seal the committed prefix; it must not continue the rollover flow by creating another writable ledger.

  This does not change the public API, protocol, schema, or metric names. It only fixes the behavior of existing state transitions and balances the existing pending ledger-create metric in
  the late-callback path.

  ### Verifying this change

  - [x] Make sure that the change passes the CI checks.

  This change added tests and can be verified as follows:

  - `terminateDuringLedgerSwitchKeepsTerminatedState`
    - Simulates a delayed BookKeeper ledger create callback returning after `terminate()`.
    - Verifies the managed ledger stays `Terminated`.
    - Verifies queued pending writes fail with `ManagedLedgerTerminatedException`.
    - Verifies the late-created ledger is deleted.
    - Verifies the ledger-create future is completed and the pending create-op metric is balanced.
    - Verifies reopening the managed ledger still observes the terminated state.

  - `terminatePositionIncludesAddAlreadyAckedByBookKeeper`
    - Simulates BookKeeper already acking an add and advancing LAC, while the ManagedLedger client callback is delayed.
    - Verifies `terminate()` returns a `terminatedPosition` that includes the acknowledged add.
    - Verifies the delayed client callback can still complete successfully with a position inside the terminated range.

  - `terminateFailsInflightAddDrainedByLedgerClose`
    - Simulates BookKeeper close draining an outstanding add that has not reached LAC.
    - Verifies the add fails with `ManagedLedgerTerminatedException`.
    - Verifies the pending add queue is cleared.
    - Verifies the callback does not hang.

  - `ledgerSwitchCompletionDoesNotReopenTerminatedLedger`
    - Verifies a late ledger-switch completion cannot move the state from `Terminated` back to `LedgerOpened`.

  Local verification:

  ./gradlew :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.ManagedLedgerTerminationTest
  ./gradlew :managed-ledger:checkstyleMain :managed-ledger:checkstyleTest

  ### Does this pull request potentially affect one of the following parts:

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment
