### PR TITLE
[improve][broker] Change bookkeeperClientSeparatedIoThreadsEnabled to True by default

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1112,8 +1112,8 @@ bookkeeperClientNumWorkerThreads=
 bookkeeperClientNumIoThreads=
 
 # Use separated IO threads for BookKeeper client
-# Default is false, which will use Pulsar IO threads
-bookkeeperClientSeparatedIoThreadsEnabled=false
+# Default is true, which will use dedicated BookKeeper IO threads
+bookkeeperClientSeparatedIoThreadsEnabled=true
 
 # Speculative reads are initiated if a read request doesn't complete within a certain time
 # Using a value of 0, is disabling the speculative reads

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -682,8 +682,8 @@ bookkeeperClientNumWorkerThreads=
 bookkeeperClientNumIoThreads=
 
 # Use separated IO threads for BookKeeper client
-# Default is false, which will use Pulsar IO threads
-bookkeeperClientSeparatedIoThreadsEnabled=false
+# Default is true, which will use dedicated BookKeeper IO threads
+bookkeeperClientSeparatedIoThreadsEnabled=true
 
 # Speculative reads are initiated if a read request doesn't complete within a certain time
 # Using a value of 0, is disabling the speculative reads

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2201,9 +2201,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
             category = CATEGORY_STORAGE_BK,
-            doc = "Use separated IO threads for BookKeeper client. Default is false, which will use Pulsar IO threads"
+            doc = "Use separated IO threads for BookKeeper client. Default is true, which will use dedicated "
+                    + "BookKeeper IO threads"
     )
-    private boolean bookkeeperClientSeparatedIoThreadsEnabled = false;
+    private boolean bookkeeperClientSeparatedIoThreadsEnabled = true;
 
     /**** --- Managed Ledger. --- ****/
     @FieldContext(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BookKeeperClientFactoryImplTest.java
@@ -312,11 +312,11 @@ public class BookKeeperClientFactoryImplTest {
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
         BookKeeper.Builder builder = factory.getBookKeeperBuilder(conf, eventLoopGroup,
                 mock(StatsLogger.class), mock(ClientConfiguration.class));
-        assertEquals(FieldUtils.readField(builder, "eventLoopGroup", true), eventLoopGroup);
-        conf.setBookkeeperClientSeparatedIoThreadsEnabled(true);
+        assertNull(FieldUtils.readField(builder, "eventLoopGroup", true));
+        conf.setBookkeeperClientSeparatedIoThreadsEnabled(false);
         builder = factory.getBookKeeperBuilder(conf, eventLoopGroup,
                 mock(StatsLogger.class), mock(ClientConfiguration.class));
-        assertNull(FieldUtils.readField(builder, "eventLoopGroup", true));
+        assertEquals(FieldUtils.readField(builder, "eventLoopGroup", true), eventLoopGroup);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -264,7 +264,7 @@ public class ServiceConfigurationTest {
         try (FileInputStream stream = new FileInputStream("../conf/broker.conf")) {
             final ServiceConfiguration fileConfig =
                     PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
-            assertFalse(fileConfig.isBookkeeperClientSeparatedIoThreadsEnabled());
+            assertTrue(fileConfig.isBookkeeperClientSeparatedIoThreadsEnabled());
             assertEquals(fileConfig.getBookkeeperClientNumIoThreads(), Runtime.getRuntime().availableProcessors() * 2);
         }
         String confFile = "bookkeeperClientNumIoThreads=1\n"


### PR DESCRIPTION
### Motivation

Apache Pulsar PR #16333 introduced `bookkeeperClientSeparatedIoThreadsEnabled` so the BookKeeper client can use a dedicated IO thread pool instead of sharing the broker's Pulsar `EventLoopGroup`. The upstream default remained `false` for backward compatibility.

In our deployment, sharing IO threads between the broker and the BookKeeper client can cause contention under storage-heavy workloads. Enabling separated IO threads by default isolates BookKeeper network I/O from broker I/O and better matches our production expectations.

### Modifications

- Set `bookkeeperClientSeparatedIoThreadsEnabled=true` in `conf/broker.conf` and `conf/standalone.conf`, and update related comments.
- Change the Java default in `ServiceConfiguration` from `false` to `true`, and update `@FieldContext` documentation.
- Update unit tests to reflect the new default:
  - `ServiceConfigurationTest#testBookKeeperClientIoThreads`
  - `BookKeeperClientFactoryImplTest#testBookKeeperIoThreadsConfiguration`

Operators who want the previous behavior can set:

```properties
bookkeeperClientSeparatedIoThreadsEnabled=false
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [x] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment 