### PR TITLE
[improve][build] Disable test retry when running tests in IntelliJ

### DIFF
--- a/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts
@@ -171,7 +171,9 @@ tasks.withType<Test>().configureEach {
     maxParallelForks = 4
     val failFastValue = providers.gradleProperty("testFailFast").getOrElse("true").toBoolean()
     failFast = failFastValue
-    systemProperty("testRetryCount", providers.gradleProperty("testRetryCount").getOrElse("1"))
+    val ideaActive = providers.systemProperty("idea.active").map { it.toBoolean() }.getOrElse(false)
+    val defaultTestRetryCount = if (ideaActive) "0" else "1"
+    systemProperty("testRetryCount", providers.gradleProperty("testRetryCount").getOrElse(defaultTestRetryCount))
     systemProperty("testFailFast", failFastValue.toString())
     jvmArgs(
         "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED",

--- a/tests/integration/build.gradle.kts
+++ b/tests/integration/build.gradle.kts
@@ -98,7 +98,9 @@ val integrationTest by tasks.registering(Test::class) {
 
     val failFastValue = providers.gradleProperty("testFailFast").getOrElse("true").toBoolean()
     failFast = failFastValue
-    systemProperty("testRetryCount", providers.gradleProperty("testRetryCount").getOrElse("1"))
+    val ideaActive = providers.systemProperty("idea.active").map { it.toBoolean() }.getOrElse(false)
+    val defaultTestRetryCount = if (ideaActive) "0" else "1"
+    systemProperty("testRetryCount", providers.gradleProperty("testRetryCount").getOrElse(defaultTestRetryCount))
     systemProperty("testFailFast", failFastValue.toString())
 
     systemProperty("currentVersion", project.version.toString())


### PR DESCRIPTION
### Motivation

When running tests in IntelliJ, the current Gradle configuration re-runs failed tests via the `testRetryCount` system property (default `1`). This is undesirable when running tests manually in the IDE: a developer triggering a single test expects to see its actual failure, not a retried run that obscures the original error or flakiness.

IntelliJ delegates test execution to Gradle, and it can be detected at build configuration time via the `idea.active` system property that IntelliJ sets when invoking Gradle.

### Modifications

- `build-logic/conventions/src/main/kotlin/pulsar.java-conventions.gradle.kts`: when `idea.active=true`, default `testRetryCount` to `0` instead of `1`. An explicit `-PtestRetryCount=...` Gradle property still takes precedence.
- `tests/integration/build.gradle.kts`: same change applied to the `integrationTest` task.

CLI / CI behavior is unchanged because `idea.active` is not set there.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment