### PR TITLE
[improve][fn] Avoid gRPC timeout when getting status of a dead process runtime

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/process/ProcessRuntime.java
@@ -241,6 +241,15 @@ class ProcessRuntime implements Runtime {
             retval.completeExceptionally(new RuntimeException("Not alive"));
             return retval;
         }
+        if (!isAlive()){
+            FunctionStatus status = new FunctionStatus();
+            status.setRunning(false);
+            if (deathException != null && deathException.getMessage() != null) {
+                status.setFailureException(deathException.getMessage());
+            }
+            retval.complete(status);
+            return retval;
+        }
         stub.withDeadlineAfter(GRPC_TIMEOUT_SECS, TimeUnit.SECONDS)
                 .getFunctionStatus(new Empty(), new StreamObserver<>() {
             @Override


### PR DESCRIPTION
### Motivation

In process runtime mode,  When the child process had exited, the stub could still be non-null, so the call continued through gRPC getFunctionStatus and could block until the 5-second deadline expired.

﻿Aligned ProcessRuntime.getFunctionStatus() with ThreadRuntime.getFunctionStatus() by checking !isAlive() before invoking gRPC.

### Modifications

- In `ProcessRuntime.getFunctionStatus()`, if `!isAlive()`, complete immediately with `running=false` and populate `failureException` from the stored `deathException` when available, without invoking gRPC.


### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment