### PR TITLE
[fix][client] Reset higher-index states on recovery in SameAuthParamsLookupAutoClusterFailover

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -267,6 +267,17 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         try {
             pulsarClient.updateServiceUrl(targetUrl);
             pulsarClient.reloadLookUp();
+            // When recovering to a higher-priority service, the check loop will only probe
+            // indices 0..targetIndex going forward. Any transient state (e.g., PreFail from
+            // a single timed-out probe) at higher indices would become stuck because those
+            // indices are no longer probed. Reset them so they start fresh if a future
+            // failover needs to consider them again.
+            if (targetIndex < currentPulsarServiceIndex) {
+                for (int i = targetIndex + 1; i < pulsarServiceStateArray.length; i++) {
+                    pulsarServiceStateArray[i] = PulsarServiceState.Healthy;
+                    checkCounterArray[i].setValue(0);
+                }
+            }
             currentPulsarServiceIndex = targetIndex;
         } catch (Exception e) {
             log.error().attr("logMsg", logMsg).exception(e).log("Failed to");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -168,6 +168,69 @@ public class SameAuthParamsLookupAutoClusterFailoverTest {
     }
 
     /**
+     * Reproduces the bug fixed by resetting state of higher-priority-than-target indices on
+     * recovery. The check loop only probes indices 0..currentPulsarServiceIndex, so if a
+     * higher index was left in a transient state (e.g., PreFail from a single timed-out
+     * probe) at the moment of recovery, it would stay there forever because no future probe
+     * ever visits it.
+     *
+     * <p>Scenario: failover 0 -> 2 (state[2]=Healthy). url1 recovers and is about to trigger
+     * recovery 2 -> 1. On the same check cycle that promotes state[1] to Healthy, url2 sees
+     * one transient probe failure that flips state[2] from Healthy to PreFail. The recovery
+     * fires (current 2 -> 1) and from that point on the loop only probes indices 0 and 1.
+     *
+     * <p>Without the fix, state[2] stays at PreFail forever. With the fix, state[2] is
+     * reset to Healthy when the recovery transition runs.
+     */
+    @Test(timeOut = 30000)
+    public void testRecoveryResetsHigherIndexStaleState() throws Exception {
+        // url0 down, url1 down, url2 up.
+        setLookupResult(URL0, false);
+        setLookupResult(URL1, false);
+        setLookupResult(URL2, true);
+
+        // Pre-set state[0]=Failed and trigger failover 0 -> 2.
+        runOnExecutor(() -> {
+            stateArray[0] = PulsarServiceState.Failed;
+            counterArray[0].setValue(0);
+        });
+        runCheckCycle();
+        runOnExecutor(() -> {
+            assertEquals(failover.getCurrentPulsarServiceIndex(), 2);
+            assertEquals(stateArray[1], PulsarServiceState.Failed);
+            assertEquals(stateArray[2], PulsarServiceState.Healthy);
+        });
+
+        // url1 becomes healthy; first check cycle moves state[1] Failed -> PreRecover.
+        setLookupResult(URL1, true);
+        runCheckCycle();
+        runOnExecutor(() -> {
+            assertEquals(failover.getCurrentPulsarServiceIndex(), 2);
+            assertEquals(stateArray[1], PulsarServiceState.PreRecover);
+            assertEquals(stateArray[2], PulsarServiceState.Healthy);
+        });
+
+        // On the cycle that completes recovery (state[1] PreRecover -> Healthy and triggers
+        // updateServiceUrl(1)), inject a single failed probe at url2 so state[2] flips
+        // Healthy -> PreFail just before the index transition.
+        setLookupResult(URL2, false);
+        runCheckCycle();
+
+        // After recovery to index 1:
+        //   - With the fix:    state[2] is reset to Healthy on the transition.
+        //   - Without the fix: state[2] is stuck at PreFail forever — the check loop now
+        //                      only iterates 0..1 and never visits index 2 again.
+        runOnExecutor(() -> {
+            assertEquals(failover.getCurrentPulsarServiceIndex(), 1);
+            assertEquals(stateArray[1], PulsarServiceState.Healthy);
+            assertEquals(stateArray[2], PulsarServiceState.Healthy,
+                    "state[2] should be reset to Healthy on recovery, not stuck at PreFail");
+            assertEquals(counterArray[2].intValue(), 0,
+                    "counter[2] should be reset to 0 on recovery");
+        });
+    }
+
+    /**
      * Verifies that recovery still works correctly for a service that was marked Failed
      * by findFailoverTo, once that service becomes available again.
      */


### PR DESCRIPTION
### Motivation

`SameAuthParamsLookupAutoClusterFailover` maintains a per-service-index state array (`Healthy`, `PreFail`, `Failed`, `PreRecover`) updated by a periodic check loop. The check loop only probes indices `0..currentPulsarServiceIndex`:

```java
private void checkPulsarServices() {
    for (int i = 0; i <= currentPulsarServiceIndex; i++) {
        ...
    }
}
```

When we recover to a higher-priority service (`currentPulsarServiceIndex` decreases), the loop stops probing the higher-indexed services. If any of those indices were in a transient state at the moment of recovery (e.g., `PreFail` from a single timed-out probe), they get stuck there because nothing ever probes them again to flip them back to `Healthy`.

This causes `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` to fail intermittently:

```
Caused by: java.lang.AssertionError: Arrays differ at element [2]: Healthy != PreFail expected [Healthy] but found [PreFail]
```

Concretely: while `currentPulsarServiceIndex` is 2 and the test is waiting for index 1 to recover, a single transient probe failure on pulsar2 transitions `state[2]: Healthy -> PreFail`. A subsequent successful probe at index 1 reaches `recoverThreshold` and triggers `updateServiceUrl(1)`, dropping `currentPulsarServiceIndex` to 1. From that point on the loop only probes indices 0 and 1, and `state[2]` stays at `PreFail` forever — the test's 3-minute await window never sees `state[2] == Healthy`.

Example failure: https://scans.gradle.com/s/7pttiiyo6yybc/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.SameAuthParamsLookupAutoClusterFailoverTest/testAutoClusterFailover%5B2%5D(true)/1/output

### Modifications

**Production fix** (`SameAuthParamsLookupAutoClusterFailover.java`): In `updateServiceUrl`, when recovering (target index < current index), reset state of indices above the new target to `Healthy` and zero their counters. The state of an unprobed index is not meaningful — resetting it ensures (a) a subsequent failover starts from a clean baseline if it needs to consider those services again, and (b) we don't leave stale transient state lying around.

**New deterministic test** (`SameAuthParamsLookupAutoClusterFailoverTest.testRecoveryResetsHigherIndexStaleState`): uses the existing mock-based harness in `pulsar-client` to drive a precise probe sequence that reproduces the bug:

1. Failover 0 → 2 (url0 down, url1 down, url2 up). State becomes `[Failed, Failed, Healthy]`.
2. url1 recovers; a check cycle transitions `state[1]: Failed → PreRecover`.
3. On the cycle that promotes `state[1]: PreRecover → Healthy` and triggers `updateServiceUrl(1)`, url2 sees one failed probe so `state[2]: Healthy → PreFail` right before the index drops to 1.

After the recovery transition the check loop only iterates `0..1`, so without the fix `state[2]` is stuck at `PreFail` forever. The test asserts `state[2] == Healthy` after the transition.

I verified the test fails with the exact expected message when the fix is reverted:

```
AssertionError: state[2] should be reset to Healthy on recovery, not stuck at PreFail expected [Healthy] but found [PreFail]
```

### Verifying this change

Covered by:

- The new deterministic unit test `SameAuthParamsLookupAutoClusterFailoverTest.testRecoveryResetsHigherIndexStaleState` in `pulsar-client` (fails without the fix, passes with it).
- The existing integration test `SameAuthParamsLookupAutoClusterFailoverTest.testAutoClusterFailover` in `pulsar-broker` (both TLS and non-TLS variants). Locally I ran it 3 times with `--rerun-tasks`; all passed in ~90s each.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment