### PR TITLE
[fix][test] Drop racy concurrent-delete assertion in CompactionConcurrencyTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/CompactionConcurrencyTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/CompactionConcurrencyTest.java
@@ -68,15 +68,24 @@ public class CompactionConcurrencyTest extends SharedPulsarBaseTest {
             f2.set(admin.topics().deleteSubscriptionAsync(topicName, "__compaction"));
         }).start();
 
-        // Verify: at least one of the requests should fail (the other may succeed or also fail
-        // with "not found" if the in-memory metadata store processes them sequentially).
+        // Verify: both delete requests complete without deadlocking. With the in-memory
+        // metadata store the deletes can race in any way — both may succeed (the second as a
+        // no-op when the subscription is already gone), or one may fail with
+        // SubscriptionBusyException if the broker's concurrency guard catches the overlap.
+        // We just need to confirm the broker doesn't get stuck and the compaction
+        // subscription ends up removed.
         Awaitility.await().untilAsserted(() -> {
             assertTrue(f1.get() != null);
             assertTrue(f2.get() != null);
             assertTrue(f1.get().isDone());
             assertTrue(f2.get().isDone());
-            assertTrue(f1.get().isCompletedExceptionally() || f2.get().isCompletedExceptionally());
         });
+
+        // Verify the topic is in a healthy state: the compaction subscription is gone.
+        PersistentTopic persistentTopic =
+                (PersistentTopic) getTopic(topicName, false).get().get();
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(persistentTopic.getSubscription(Compactor.COMPACTION_SUBSCRIPTION) == null));
 
         // cleanup.
         producer.close();


### PR DESCRIPTION
### Motivation

`CompactionConcurrencyTest.testDisableCompactionConcurrently` fires two threads that both call `deleteSubscriptionAsync(\"__compaction\")` on the same topic and asserts that **at least one** of them fails:

```java
assertTrue(f1.get().isCompletedExceptionally() || f2.get().isCompletedExceptionally());
```

That assertion has been flaky since the test was migrated from `ProducerConsumerBase` to `SharedPulsarBaseTest` in #25381.

The original test relied on `MockZooKeeper.delay(...)` to inject a delay into the cursor delete operation. This forced the two calls to overlap inside `PersistentTopic#asyncDeleteCursorWithCleanCompactionLedger`'s `synchronized` block — the second one then hit the `disablingCompaction.compareAndSet(false, true) == false` branch and failed with `SubscriptionBusyException`.

`SharedPulsarBaseTest` uses an in-memory metadata store and there is no equivalent delay hook. The first delete can complete (and remove the subscription) before the second thread even reaches the broker. The second call then runs through `asyncDeleteCursorWithClearDelayedMessage`, sees `subscriptions.get(\"__compaction\") == null`, and returns success as a no-op:

```java
PersistentSubscription persistentSubscription = subscriptions.get(subscriptionName);
if (persistentSubscription == null) {
    log.warn().attr(...).log(\"Can't find subscription, skip delete cursor\");
    unsubscribeFuture.complete(null);
    return;
}
```

Both futures complete successfully — perfectly valid behavior — and the assertion fails.

Example failure: https://scans.gradle.com/s/2odpjlsucvuly/tests/task/:pulsar-broker:test/details/org.apache.pulsar.broker.service.persistent.CompactionConcurrencyTest/testDisableCompactionConcurrently/2/output

### Modifications

Drop the \"at least one fails\" assertion — the broker handles either outcome correctly (concurrent overlap → `SubscriptionBusyException`; sequential → no-op).

Keep the deadlock check (both futures complete in bounded time) and add a verification that the compaction subscription ends up removed, which is the actual invariant we care about.

### Verifying this change

This change is already covered by `CompactionConcurrencyTest.testDisableCompactionConcurrently`. Locally I ran 5 times with `--rerun-tasks`; all passed.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment