### PR TITLE
[fix][sec] Upgrade commons-configuration2 to 2.15.0 to address CVE-2026-45205

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -289,7 +289,7 @@ The Apache Software License, Version 2.0
     - commons-logging-commons-logging-1.3.5.jar
     - org.apache.commons-commons-collections4-4.5.0.jar
     - org.apache.commons-commons-compress-1.28.0.jar
-    - org.apache.commons-commons-configuration2-2.12.0.jar
+    - org.apache.commons-commons-configuration2-2.15.0.jar
     - org.apache.commons-commons-lang3-3.20.0.jar
     - org.apache.commons-commons-text-1.14.0.jar
  * Netty

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ commons-text = "1.14.0"
 commons-math3 = "3.6.1"
 commons-logging = "1.3.5"
 commons-beanutils = "1.11.0"
-commons-configuration2 = "2.12.0"
+commons-configuration2 = "2.15.0"
 # BouncyCastle
 bouncycastle = "1.84"
 bouncycastle-bcpkix-fips = "2.0.11"


### PR DESCRIPTION
### Motivation

Upgrade `commons-configuration2` from 2.12.0 to 2.15.0 to address [CVE-2026-45205](https://nvd.nist.gov/vuln/detail/CVE-2026-45205), a medium-severity vulnerability affecting versions prior to 2.15.0.

The upgrade is a routine dependency bump within the 2.x line and is API-compatible.

### Modifications

- Bump `commons-configuration2` from `2.12.0` to `2.15.0` in `gradle/libs.versions.toml`.
- Update the bundled artifact name in `distribution/server/src/assemble/LICENSE.bin.txt`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Upgrades the `commons-configuration2` dependency. API-compatible patch within the 2.x line.

### Documentation

- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`