### PR TITLE
[fix][test] Fix flaky AdminApiTest.partitionedTopicsCursorReset

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -3101,7 +3101,13 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(receivedMessages.size(), 0);
 
         consumer.close();
-        admin.topics().deleteSubscription(topicName, "my-sub");
+        // consumer.close() returns when the close request is dispatched, but the broker may not
+        // have processed the disconnect yet, so deleteSubscription can still see active consumers
+        // and return HTTP 412. Retry until the broker has detected the disconnect.
+        final String topicNameFinal = topicName;
+        Awaitility.await()
+                .ignoreExceptionsInstanceOf(PulsarAdminException.PreconditionFailedException.class)
+                .untilAsserted(() -> admin.topics().deleteSubscription(topicNameFinal, "my-sub"));
         admin.topics().deletePartitionedTopic(topicName);
     }
 


### PR DESCRIPTION
### Motivation

`AdminApiTest.partitionedTopicsCursorReset` is flaky in CI. Recent example: [PR #25844 run 26175306430 job 77005757000](https://github.com/apache/pulsar/actions/runs/26175306430/job/77005757000).

```
Gradle suite > Gradle test > org.apache.pulsar.broker.admin.AdminApiTest > partitionedTopicsCursorReset[2](topic_+&*%{}() \$@#^%) FAILED
    org.apache.pulsar.client.admin.PulsarAdminException$PreconditionFailedException: Subscription has active connected consumers
        at org.apache.pulsar.broker.admin.AdminApiTest.partitionedTopicsCursorReset(AdminApiTest.java:3104)

        Caused by:
        javax.ws.rs.ClientErrorException: HTTP 412 {"reason":"Subscription has active connected consumers"}
```

`consumer.close()` returns once the close request has been dispatched to the broker, but the broker may not yet have processed the disconnect when the test immediately calls `admin.topics().deleteSubscription(...)`. The broker's precondition check still sees a connected consumer and returns HTTP 412.

### Modifications

Wrap the `deleteSubscription` call in `Awaitility.await().ignoreExceptionsInstanceOf(PreconditionFailedException.class).untilAsserted(...)` so the test retries the delete until the broker has detected the consumer disconnect.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *the modified `partitionedTopicsCursorReset` test itself*.