### PR TITLE
[improve][broker] Add cache metrics for ledger offloader reads

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStats.java
@@ -44,6 +44,12 @@ public interface LedgerOffloaderStats extends AutoCloseable {
 
     void recordReadOffloadBytes(String topic, long size);
 
+    default void recordReadOffloadCacheHit(String topic, long size) {
+    }
+
+    default void recordReadOffloadCacheMiss(String topic, long size) {
+    }
+
     void recordReadOffloadIndexLatency(String topic, long latency, TimeUnit unit);
 
     void recordReadOffloadDataLatency(String topic, long latency, TimeUnit unit);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloaderStatsDisable.java
@@ -59,6 +59,16 @@ public class LedgerOffloaderStatsDisable implements LedgerOffloaderStats {
     }
 
     @Override
+    public void recordReadOffloadCacheHit(String topic, long size) {
+
+    }
+
+    @Override
+    public void recordReadOffloadCacheMiss(String topic, long size) {
+
+    }
+
+    @Override
     public void recordReadOffloadIndexLatency(String topic, long latency, TimeUnit unit) {
 
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LedgerOffloaderStatsImpl.java
@@ -44,6 +44,8 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
     private static final String STATUS = "status";
     private static final String SUCCEED = "succeed";
     private static final String FAILED = "failed";
+    private static final String HIT = "hit";
+    private static final String MISS = "miss";
 
     private final boolean exposeTopicLevelMetrics;
     private final int interval;
@@ -58,13 +60,15 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
     private final Gauge readOffloadRate;
     private final Summary readOffloadIndexLatency;
     private final Summary readOffloadDataLatency;
+    private final Counter readOffloadCacheOps;
+    private final Counter readOffloadCacheBytes;
 
     private final Map<String, Long> topicAccess;
     private final Map<String, Pair<LongAdder, LongAdder>> offloadAndReadOffloadBytesMap;
 
     final AtomicBoolean closed = new AtomicBoolean(false);
 
-     private LedgerOffloaderStatsImpl(boolean exposeTopicLevelMetrics,
+    private LedgerOffloaderStatsImpl(boolean exposeTopicLevelMetrics,
                                      ScheduledExecutorService scheduler, int interval) {
         this.interval = interval;
         this.exposeTopicLevelMetrics = exposeTopicLevelMetrics;
@@ -116,6 +120,13 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
                 ? new String[]{NAMESPACE_LABEL, TOPIC_LABEL, STATUS} : new String[]{NAMESPACE_LABEL, STATUS};
         this.deleteOffloadOps = Counter.build("brk_ledgeroffloader_delete_offload_ops", "-")
                 .labelNames(deleteOpsLabels).create().register();
+
+        String[] cacheLabels = exposeTopicLevelMetrics
+                ? new String[]{NAMESPACE_LABEL, TOPIC_LABEL, STATUS} : new String[]{NAMESPACE_LABEL, STATUS};
+        this.readOffloadCacheOps = Counter.build("brk_ledgeroffloader_read_offload_cache_ops", "-")
+                .labelNames(cacheLabels).create().register();
+        this.readOffloadCacheBytes = Counter.build("brk_ledgeroffloader_read_offload_cache_bytes", "-")
+                .labelNames(cacheLabels).create().register();
     }
 
 
@@ -174,6 +185,23 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
         pair.getRight().add(size);
         String[] labelValues = this.labelValues(topic);
         this.readOffloadBytes.labels(labelValues).inc(size);
+        this.addOrUpdateTopicAccess(topic);
+    }
+
+    @Override
+    public void recordReadOffloadCacheHit(String topic, long size) {
+        recordReadOffloadCacheOperation(topic, size, HIT);
+    }
+
+    @Override
+    public void recordReadOffloadCacheMiss(String topic, long size) {
+        recordReadOffloadCacheOperation(topic, size, MISS);
+    }
+
+    private void recordReadOffloadCacheOperation(String topic, long size, String status) {
+        String[] labelValues = this.labelValues(topic, status);
+        this.readOffloadCacheOps.labels(labelValues).inc();
+        this.readOffloadCacheBytes.labels(labelValues).inc(size);
         this.addOrUpdateTopicAccess(topic);
     }
 
@@ -252,6 +280,12 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
                 this.deleteOffloadOps.remove(labelValues);
                 labelValues = this.labelValues(topic, FAILED);
                 this.deleteOffloadOps.remove(labelValues);
+                labelValues = this.labelValues(topic, HIT);
+                this.readOffloadCacheOps.remove(labelValues);
+                this.readOffloadCacheBytes.remove(labelValues);
+                labelValues = this.labelValues(topic, MISS);
+                this.readOffloadCacheOps.remove(labelValues);
+                this.readOffloadCacheBytes.remove(labelValues);
 
                 return true;
             }
@@ -288,6 +322,8 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadIndexLatency);
             CollectorRegistry.defaultRegistry.unregister(this.readOffloadDataLatency);
             CollectorRegistry.defaultRegistry.unregister(this.deleteOffloadOps);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadCacheOps);
+            CollectorRegistry.defaultRegistry.unregister(this.readOffloadCacheBytes);
             instance = null;
         }
     }
@@ -344,6 +380,18 @@ public final class LedgerOffloaderStatsImpl implements LedgerOffloaderStats, Run
             totalBytes += this.offloadAndReadOffloadBytesMap.get(key).getRight().sum();
         }
         return totalBytes;
+    }
+
+    @VisibleForTesting
+    public long getReadOffloadCacheOps(String topic, boolean hit) {
+        String[] labels = this.labelValues(topic, hit ? HIT : MISS);
+        return (long) this.readOffloadCacheOps.labels(labels).get();
+    }
+
+    @VisibleForTesting
+    public long getReadOffloadCacheBytes(String topic, boolean hit) {
+        String[] labels = this.labelValues(topic, hit ? HIT : MISS);
+        return (long) this.readOffloadCacheBytes.labels(labels).get();
     }
 
     @VisibleForTesting

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/LedgerOffloaderMetricsTest.java
@@ -135,4 +135,22 @@ public class LedgerOffloaderMetricsTest extends BrokerTestBase {
         }
     }
 
+    @Test
+    public void testReadOffloadCacheMetrics() throws Exception {
+        conf.setExposeTopicLevelMetricsInPrometheus(true);
+        super.baseSetup();
+
+        String topicName = "persistent://prop/ns-abc1/testMetrics" + UUID.randomUUID();
+
+        LedgerOffloaderStatsImpl offloaderStats = (LedgerOffloaderStatsImpl) pulsar.getOffloaderStats();
+        offloaderStats.recordReadOffloadCacheHit(topicName, 10);
+        offloaderStats.recordReadOffloadCacheMiss(topicName, 20);
+        offloaderStats.recordReadOffloadCacheMiss(topicName, 30);
+
+        assertEquals(offloaderStats.getReadOffloadCacheOps(topicName, true), 1);
+        assertEquals(offloaderStats.getReadOffloadCacheBytes(topicName, true), 10);
+        assertEquals(offloaderStats.getReadOffloadCacheOps(topicName, false), 2);
+        assertEquals(offloaderStats.getReadOffloadCacheBytes(topicName, false), 50);
+    }
+
 }


### PR DESCRIPTION
### Motivation

Ledger offloader implementations can keep their own read caches, but Pulsar currently does not expose hit/miss metrics through `LedgerOffloaderStats`. This makes it hard to diagnose tiered-storage read performance and cache sizing issues from broker metrics.

### Modifications

- Add `recordReadOffloadCacheHit` and `recordReadOffloadCacheMiss` to `LedgerOffloaderStats`.
- Add Prometheus counters for ledger offloader read cache operations and bytes.
- Use the same namespace/topic label behavior as the existing ledger offloader metrics, plus `status=hit|miss`.
- Add broker test coverage for the new cache metrics.

### Verifying this change

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.stats.LedgerOffloaderMetricsTest.testReadOffloadCacheMetrics :managed-ledger:checkstyleMain :pulsar-broker:checkstyleTest`