### PR TITLE
[improve][broker] Simplify listener config and support proxyless Admin API (complete PIP-61/PIP-95)

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -38,16 +38,22 @@ configurationMetadataSyncEventTopic=
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl
 configurationMetadataStoreUrl=
 
-# Broker data port
+# Port for the Pulsar binary protocol of the internal listener.
+# The same port number is used both for the local socket binding (with bindAddress) and for the
+# advertised URL (with advertisedAddress), so no entry in advertisedListeners or bindAddresses
+# is required for the internal listener.
 brokerServicePort=6650
 
-# Broker data port for TLS - By default TLS is disabled
+# Port for the Pulsar binary protocol TLS endpoint of the internal listener.
+# Used both for the local socket binding and the advertised URL. By default TLS is disabled.
 brokerServicePortTls=
 
-# Port to use to server HTTP request
+# Port for the HTTP admin/REST endpoint of the internal listener.
+# Used both for the local socket binding and the advertised URL.
 webServicePort=8080
 
-# Port to use to server HTTPS request - By default TLS is disabled
+# Port for the HTTPS admin/REST endpoint of the internal listener.
+# Used both for the local socket binding and the advertised URL. By default TLS is disabled.
 webServicePortTls=
 
 # Specify the tls protocols the broker's web service will use to negotiate during TLS handshake
@@ -62,27 +68,63 @@ webServiceTlsProtocols=
 # webServiceTlsCiphers=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 webServiceTlsCiphers=
 
-# Hostname or IP address the service binds on, default is 0.0.0.0.
+# Local network interface IP for the internal listener's port bindings.
+# Use a specific local IP to bind to a single interface, or 0.0.0.0 to bind on all interfaces.
 bindAddress=0.0.0.0
 
-# Extra bind addresses for the service: <listener_name>:<scheme>://<host>:<port>,[...]
+# Per-listener socket bindings.
+# The internal listener's bindings are derived automatically from bindAddress plus the port
+# properties (brokerServicePort / brokerServicePortTls / webServicePort / webServicePortTls)
+# and do not need to be repeated here.
+# PIP-95 smart listener selection routes a connection to the listener whose port it arrived on.
+# For the Pulsar binary protocol (pulsar / pulsar+ssl) this is optional — clients can also pass
+# an explicit listenerName. For the HTTP/HTTPS Admin API (http / https) it is the only routing
+# mechanism, so every HTTP/HTTPS advertised listener reachable from outside the cluster needs a
+# dedicated entry here on a unique port. This lets a layer-4 TCP load balancer serve the Admin
+# API directly per listener, without an HTTP reverse proxy.
+# Format: comma-separated <listener_name>:<scheme>://<ip>:<port> entries.
+# Supported schemes: pulsar, pulsar+ssl, http, https.
+# The <ip> part selects which local network interface the port binds to: use a specific local
+# IP, or 0.0.0.0 to bind on all interfaces. A local hostname is also accepted but not
+# recommended.
+# Each ip:port may be bound by exactly one (listener, scheme) pair. An entry that exactly
+# matches the auto-derived internal-listener binding is tolerated; assigning the same ip:port
+# to a different listener or scheme fails validation.
+# Port 0 (OS-assigned ephemeral port) is supported only for the internal listener.
 bindAddresses=
 
-# Hostname or IP address the service advertises to the outside world.
-# If not set, the value of InetAddress.getLocalHost().getCanonicalHostName() is used.
+# Hostname or IP advertised to clients for the internal listener.
+# Combined with the *Port properties it forms the internal listener's advertised URLs
+# (e.g. pulsar://<advertisedAddress>:<brokerServicePort>).
+# If not set, defaults to InetAddress.getLocalHost().getCanonicalHostName().
 advertisedAddress=
 
-# Used to specify multiple advertised listeners for the broker.
-# The value must format as <listener_name>:pulsar://<host>:<port>,
-# multiple listeners should separate with commas.
-# Do not use this configuration with advertisedAddress and brokerServicePort.
-# The Default value is absent means use advertisedAddress and brokerServicePort.
+# Declares additional advertised listeners — typically external listeners that complement the
+# internal one.
+# Format: comma-separated <listener_name>:<scheme>://<host>:<port> entries.
+# Supported schemes: pulsar, pulsar+ssl, http, https.
+# A listener name may be repeated to declare multiple schemes for the same listener.
+# The internal listener is auto-configured from advertisedAddress plus the *Port properties
+# (brokerServicePort / brokerServicePortTls / webServicePort / webServicePortTls) so it does
+# not need an entry here. URLs declared here under internalListenerName do override that
+# auto-configured listener, but this is not recommended because it can route cluster-internal
+# traffic through an external endpoint (for example, an external load balancer).
+# Legacy fallback: when internalListenerName is left blank, the first listener parsed from this
+# property is used as the internal listener (so in that case its entry here is required).
 # advertisedListeners=
 
-# Used to specify the internal listener name for the broker.
-# The listener name must contain in the advertisedListeners.
-# The Default value is absent, the broker uses the first listener as the internal listener.
-# internalListenerName=
+# Name of the listener used for cluster-internal broker-to-broker communication (lookup
+# redirects, admin forwarding to owner or leader broker). Defaults to "internal".
+# When set (the default), the internal listener is auto-configured from advertisedAddress plus
+# the *Port properties. The internal listener must advertise addresses reachable from other
+# brokers in the same cluster; avoid overriding its URLs in advertisedListeners to point at an
+# external load balancer because that would route cluster-internal traffic outside the cluster.
+# For external clients, declare a separate non-internal listener in advertisedListeners
+# instead. The default name "internal" also keeps the port-derived internal listener distinct
+# from any user-declared listener names.
+# Setting this to an empty string restores the legacy fallback: the first listener parsed from
+# advertisedListeners is used as the internal listener.
+internalListenerName=internal
 
 # Enable or disable the HAProxy protocol.
 # If true, the real IP addresses of consumers and producers can be obtained when getting topic statistics data.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -32,20 +32,59 @@ metadataStoreConfigPath=
 # The metadata store URL for the configuration data. If empty, we fall back to use metadataStoreUrl
 configurationMetadataStoreUrl=
 
+# Port for the Pulsar binary protocol of the internal listener.
+# The same port number is used both for the local socket binding (with bindAddress) and for the
+# advertised URL (with advertisedAddress), so no entry in advertisedListeners or bindAddresses
+# is required for the internal listener.
 brokerServicePort=6650
 
-# Port to use to server HTTP request
+# Port for the HTTP admin/REST endpoint of the internal listener.
+# Used both for the local socket binding and the advertised URL.
 webServicePort=8080
 
-# Hostname or IP address the service binds on, default is 0.0.0.0.
+# Local network interface IP for the internal listener's port bindings.
+# Use a specific local IP to bind to a single interface, or 0.0.0.0 to bind on all interfaces.
 bindAddress=0.0.0.0
 
-# Extra bind addresses for the service: <listener_name>:<scheme>://<host>:<port>,[...]
+# Per-listener socket bindings.
+# The internal listener's bindings are derived automatically from bindAddress plus the port
+# properties (brokerServicePort / brokerServicePortTls / webServicePort / webServicePortTls)
+# and do not need to be repeated here.
+# PIP-95 smart listener selection routes a connection to the listener whose port it arrived on.
+# For the Pulsar binary protocol (pulsar / pulsar+ssl) this is optional — clients can also pass
+# an explicit listenerName. For the HTTP/HTTPS Admin API (http / https) it is the only routing
+# mechanism, so every HTTP/HTTPS advertised listener reachable from outside the cluster needs a
+# dedicated entry here on a unique port. This lets a layer-4 TCP load balancer serve the Admin
+# API directly per listener, without an HTTP reverse proxy.
+# Format: comma-separated <listener_name>:<scheme>://<ip>:<port> entries.
+# Supported schemes: pulsar, pulsar+ssl, http, https.
+# The <ip> part selects which local network interface the port binds to: use a specific local
+# IP, or 0.0.0.0 to bind on all interfaces. A local hostname is also accepted but not
+# recommended.
+# Each ip:port may be bound by exactly one (listener, scheme) pair. An entry that exactly
+# matches the auto-derived internal-listener binding is tolerated; assigning the same ip:port
+# to a different listener or scheme fails validation.
+# Port 0 (OS-assigned ephemeral port) is supported only for the internal listener.
 bindAddresses=
 
-# Hostname or IP address the service advertises to the outside world.
-# If not set, the value of InetAddress.getLocalHost().getCanonicalHostName() is used.
+# Hostname or IP advertised to clients for the internal listener.
+# Combined with the *Port properties it forms the internal listener's advertised URLs
+# (e.g. pulsar://<advertisedAddress>:<brokerServicePort>).
+# If not set, defaults to InetAddress.getLocalHost().getCanonicalHostName().
 advertisedAddress=
+
+# Name of the listener used for cluster-internal broker-to-broker communication (lookup
+# redirects, admin forwarding to owner or leader broker). Defaults to "internal".
+# When set (the default), the internal listener is auto-configured from advertisedAddress plus
+# the *Port properties. The internal listener must advertise addresses reachable from other
+# brokers in the same cluster; avoid overriding its URLs in advertisedListeners to point at an
+# external load balancer because that would route cluster-internal traffic outside the cluster.
+# For external clients, declare a separate non-internal listener in advertisedListeners
+# instead. The default name "internal" also keeps the port-derived internal listener distinct
+# from any user-declared listener names.
+# Setting this to an empty string restores the legacy fallback: the first listener parsed from
+# advertisedListeners is used as the internal listener.
+internalListenerName=internal
 
 # Enable or disable the HAProxy protocol.
 # If true, the real IP addresses of consumers and producers can be obtained when getting topic statistics data.

--- a/pulsar-broker-common/build.gradle.kts
+++ b/pulsar-broker-common/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.slog)
     implementation(libs.guava)
     implementation(libs.commons.lang3)
+    implementation(libs.netty.common)
     implementation(libs.bookkeeper.server)
     implementation(libs.opentelemetry.api)
     implementation(libs.simpleclient)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -65,6 +65,12 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 @ToString
 public class ServiceConfiguration implements PulsarConfiguration {
 
+    /**
+     * Default name of the internal advertised listener used for broker-to-broker communication
+     * within a Pulsar cluster.
+     */
+    public static final String DEFAULT_INTERNAL_LISTENER_NAME = "internal";
+
     @Category
     private static final String CATEGORY_SERVER = "Server";
     @Category
@@ -169,26 +175,32 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving binary protobuf requests."
-            + " If set, defines a server binding for bindAddress:brokerServicePort."
-            + " The Default value is 6650."
+        doc = "Port for the Pulsar binary protocol of the internal listener."
+            + " The same port number is used both for the local socket binding (with `bindAddress`)"
+            + " and for the advertised URL (with `advertisedAddress`), so no entry in"
+            + " `advertisedListeners` or `bindAddresses` is required for the internal listener."
+            + " Default is 6650."
     )
 
     private Optional<Integer> brokerServicePort = Optional.of(6650);
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving TLS-secured binary protobuf requests."
-            + " If set, defines a server binding for bindAddress:brokerServicePortTls."
+        doc = "Port for the Pulsar binary protocol TLS endpoint of the internal listener."
+            + " Used both for the local socket binding and the advertised URL."
+            + " By default TLS is disabled."
     )
     private Optional<Integer> brokerServicePortTls = Optional.empty();
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving http requests"
+        doc = "Port for the HTTP admin/REST endpoint of the internal listener."
+            + " Used both for the local socket binding and the advertised URL."
     )
     private Optional<Integer> webServicePort = Optional.of(8080);
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "The port for serving https requests"
+        doc = "Port for the HTTPS admin/REST endpoint of the internal listener."
+            + " Used both for the local socket binding and the advertised URL."
+            + " By default TLS is disabled."
     )
     private Optional<Integer> webServicePortTls = Optional.empty();
 
@@ -214,38 +226,75 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "Hostname or IP address the service binds on"
+        doc = "Local network interface IP for the internal listener's port bindings."
+            + " Use a specific local IP to bind to a single interface, or `0.0.0.0` to bind on all"
+            + " interfaces. Default is `0.0.0.0`."
     )
     private String bindAddress = "0.0.0.0";
 
     @FieldContext(
         category = CATEGORY_SERVER,
-        doc = "Hostname or IP address the service advertises to the outside world."
-            + " If not set, the value of `InetAddress.getLocalHost().getCanonicalHostName()` is used."
+        doc = "Hostname or IP advertised to clients for the internal listener."
+            + " Combined with the *Port properties it forms the internal listener's advertised URLs"
+            + " (e.g. `pulsar://<advertisedAddress>:<brokerServicePort>`)."
+            + " If not set, defaults to `InetAddress.getLocalHost().getCanonicalHostName()`."
     )
     private String advertisedAddress;
 
     @FieldContext(category = CATEGORY_SERVER,
-            doc = "Used to specify multiple advertised listeners for the broker."
-                    + " The value must format as <listener_name>:pulsar://<host>:<port>,"
-                    + "multiple listeners should separate with commas."
-                    + "Do not use this configuration with advertisedAddress and brokerServicePort."
-                    + "The Default value is absent means use advertisedAddress and brokerServicePort.")
+            doc = "Declares additional advertised listeners — typically external listeners that"
+                    + " complement the internal one.\n"
+                    + " Format: comma-separated `<listener_name>:<scheme>://<host>:<port>` entries."
+                    + " Supported schemes: `pulsar`, `pulsar+ssl`, `http`, `https`."
+                    + " A listener name may be repeated to declare multiple schemes for the same listener.\n"
+                    + " The internal listener is auto-configured from `advertisedAddress` plus the *Port"
+                    + " properties (`brokerServicePort` / `brokerServicePortTls` / `webServicePort` /"
+                    + " `webServicePortTls`) so it does not need an entry here. URLs declared here under"
+                    + " `internalListenerName` do override that auto-configured listener, but this is"
+                    + " not recommended because it can route cluster-internal traffic through an external"
+                    + " endpoint (for example, an external load balancer).\n"
+                    + " Legacy fallback: when `internalListenerName` is left blank, the first listener"
+                    + " parsed from this property is used as the internal listener (so in that case its"
+                    + " entry here is required).")
     private String advertisedListeners;
 
     @FieldContext(category = CATEGORY_SERVER,
-            doc = "Used to specify the internal listener name for the broker."
-                    + "The listener name must contain in the advertisedListeners."
-                    + "The Default value is absent, the broker uses the first listener as the internal listener.")
-    private String internalListenerName;
+            doc = "Name of the listener used for cluster-internal broker-to-broker communication"
+                    + " (lookup redirects, admin forwarding to owner or leader broker). Defaults to"
+                    + " `internal`.\n"
+                    + " When set (the default), the internal listener is auto-configured from"
+                    + " `advertisedAddress` plus the *Port properties. The internal listener must"
+                    + " advertise addresses reachable from other brokers in the same cluster; avoid"
+                    + " overriding its URLs in `advertisedListeners` to point at an external load"
+                    + " balancer because that would route cluster-internal traffic outside the cluster."
+                    + " For external clients, declare a separate non-internal listener in"
+                    + " `advertisedListeners` instead. The default name `internal` also keeps the"
+                    + " port-derived internal listener distinct from any user-declared listener names.\n"
+                    + " Setting this to an empty string restores the legacy fallback: the first listener"
+                    + " parsed from `advertisedListeners` is used as the internal listener.")
+    private String internalListenerName = DEFAULT_INTERNAL_LISTENER_NAME;
 
     @FieldContext(category = CATEGORY_SERVER,
-            doc = "Used to specify additional bind addresses for the broker."
-                    + " The value must format as <listener_name>:<scheme>://<host>:<port>,"
-                    + " multiple bind addresses should be separated with commas."
-                    + " Associates each bind address with an advertised listener and protocol handler."
-                    + " Note that the brokerServicePort, brokerServicePortTls, webServicePort, and"
-                    + " webServicePortTls properties define additional bindings.")
+            doc = "Per-listener socket bindings.\n"
+                    + " The internal listener's bindings are derived automatically from `bindAddress`"
+                    + " plus the port properties (`brokerServicePort` / `brokerServicePortTls` /"
+                    + " `webServicePort` / `webServicePortTls`) and do not need to be repeated here.\n"
+                    + " PIP-95 smart listener selection routes a connection to the listener whose port"
+                    + " it arrived on. For the Pulsar binary protocol (`pulsar` / `pulsar+ssl`) this is"
+                    + " optional — clients can also pass an explicit `listenerName`. For the HTTP/HTTPS"
+                    + " Admin API (`http` / `https`) it is the only routing mechanism, so every"
+                    + " HTTP/HTTPS advertised listener reachable from outside the cluster needs a"
+                    + " dedicated entry here on a unique port. This lets a layer-4 TCP load balancer"
+                    + " serve the Admin API directly per listener, without an HTTP reverse proxy.\n"
+                    + " Format: comma-separated `<listener_name>:<scheme>://<ip>:<port>` entries."
+                    + " Supported schemes: `pulsar`, `pulsar+ssl`, `http`, `https`."
+                    + " The `<ip>` part selects which local network interface the port binds to:"
+                    + " use a specific local IP, or `0.0.0.0` to bind on all interfaces."
+                    + " A local hostname is also accepted but not recommended.\n"
+                    + " Each `ip:port` may be bound by exactly one (listener, scheme) pair. An entry"
+                    + " that exactly matches the auto-derived internal-listener binding is tolerated;"
+                    + " assigning the same `ip:port` to a different listener or scheme fails validation.\n"
+                    + " Port `0` (OS-assigned ephemeral port) is supported only for the internal listener.")
     private String bindAddresses;
 
     @FieldContext(category = CATEGORY_SERVER,
@@ -3033,6 +3082,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "Name of load manager to use"
     )
     private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl";
+
+    @FieldContext(
+            dynamic = true,
+            category = CATEGORY_LOAD_BALANCER,
+            doc = "When load manager migration is enabled, the broker will redirect requests to another broker if the "
+                    + "load manager on the current broker is not using the load manager of the latest service "
+                    + "lookup data available in the metadata store."
+    )
+    private boolean loadManagerMigrationEnabled = false;
 
     @FieldContext(category = CATEGORY_LOAD_BALANCER, doc = "Name of topic bundle assignment strategy to use")
     private String topicBundleAssignmentStrategy =

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfigurationUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import io.netty.util.NetUtil;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -61,7 +62,7 @@ public class ServiceConfigurationUtils {
     public static String getAppliedAdvertisedAddress(ServiceConfiguration configuration,
                                                      boolean ignoreAdvertisedListener) {
         Map<String, AdvertisedListener> result = MultipleListenerValidator
-                .validateAndAnalysisAdvertisedListener(configuration);
+                .validateAndUpdateAdvertisedListeners(configuration);
 
         String advertisedAddress = configuration.getAdvertisedAddress();
         if (advertisedAddress != null) {
@@ -70,9 +71,14 @@ public class ServiceConfigurationUtils {
 
         AdvertisedListener advertisedListener = result.get(configuration.getInternalListenerName());
         if (advertisedListener != null && !ignoreAdvertisedListener) {
-            String address = advertisedListener.getBrokerServiceUrl().getHost();
-            if (address != null) {
-                return address;
+            // The listener may have been synthesized from a subset of the legacy ports, so any of
+            // the four URLs may be null. Pick the first non-null URL to derive the host.
+            URI url = firstNonNullUri(advertisedListener.getBrokerServiceUrl(),
+                    advertisedListener.getBrokerServiceUrlTls(),
+                    advertisedListener.getBrokerHttpUrl(),
+                    advertisedListener.getBrokerHttpsUrl());
+            if (url != null && url.getHost() != null) {
+                return url.getHost();
             }
         }
 
@@ -85,7 +91,7 @@ public class ServiceConfigurationUtils {
      */
     public static AdvertisedListener getInternalListener(ServiceConfiguration config, String protocol) {
         Map<String, AdvertisedListener> result = MultipleListenerValidator
-                .validateAndAnalysisAdvertisedListener(config);
+                .validateAndUpdateAdvertisedListeners(config);
         AdvertisedListener internal = result.get(config.getInternalListenerName());
         if (internal == null || !internal.hasUriForProtocol(protocol)) {
             // Search for an advertised listener for same protocol
@@ -109,8 +115,35 @@ public class ServiceConfigurationUtils {
         return internal;
     }
 
-    private static URI createUriOrNull(String scheme, String hostname, Optional<Integer> port) {
-        return port.map(p -> URI.create(String.format("%s://%s:%d", scheme, hostname, p))).orElse(null);
+    private static URI createUriOrNull(String scheme, String ipOrHost, Optional<Integer> port) {
+        return port.map(p -> URI.create(String.format("%s://%s:%d", scheme, formatHost(ipOrHost), p))).orElse(null);
+    }
+
+    /**
+     * Wrap bare IPv6 literals in square brackets so they parse correctly as the host component of a
+     * URL. IPv4 addresses and hostnames are returned unchanged, as is an IPv6 literal that is
+     * already bracketed.
+     */
+    static String formatHost(String ipOrHost) {
+        if (ipOrHost == null || ipOrHost.isEmpty()) {
+            return ipOrHost;
+        }
+        if (ipOrHost.startsWith("[") && ipOrHost.endsWith("]")) {
+            return ipOrHost;
+        }
+        if (NetUtil.isValidIpV6Address(ipOrHost)) {
+            return "[" + ipOrHost + "]";
+        }
+        return ipOrHost;
+    }
+
+    private static URI firstNonNullUri(URI... uris) {
+        for (URI uri : uris) {
+            if (uri != null) {
+                return uri;
+            }
+        }
+        return null;
     }
 
     /**
@@ -120,19 +153,19 @@ public class ServiceConfigurationUtils {
         return ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
     }
 
-    public static String brokerUrl(String host, int port) {
-        return String.format("pulsar://%s:%d", host, port);
+    public static String brokerUrl(String ipOrHost, int port) {
+        return String.format("pulsar://%s:%d", formatHost(ipOrHost), port);
     }
 
-    public static String brokerUrlTls(String host, int port) {
-        return String.format("pulsar+ssl://%s:%d", host, port);
+    public static String brokerUrlTls(String ipOrHost, int port) {
+        return String.format("pulsar+ssl://%s:%d", formatHost(ipOrHost), port);
     }
 
-    public static String webServiceUrl(String host, int port) {
-        return String.format("http://%s:%d", host, port);
+    public static String webServiceUrl(String ipOrHost, int port) {
+        return String.format("http://%s:%d", formatHost(ipOrHost), port);
     }
 
-    public static String webServiceUrlTls(String host, int port) {
-        return String.format("https://%s:%d", host, port);
+    public static String webServiceUrlTls(String ipOrHost, int port) {
+        return String.format("https://%s:%d", formatHost(ipOrHost), port);
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/BindAddressValidator.java
@@ -22,7 +22,10 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -35,21 +38,37 @@ import org.apache.pulsar.common.configuration.BindAddress;
  */
 public class BindAddressValidator {
 
-    private static final Pattern BIND_ADDRESSES_PATTERN = Pattern.compile("(?<name>\\w+):(?<url>.+)$");
+    private static final Pattern BIND_ADDRESSES_PATTERN = Pattern.compile("(?<name>[^:]+):(?<url>.+)$");
 
     /**
      * Validate the configuration of `bindAddresses`.
-     * @param config the pulsar broker configure.
+     *
+     * <p>Bindings derived from the legacy port properties (`brokerServicePort`, `brokerServicePortTls`,
+     * `webServicePort`, `webServicePortTls`) are associated with the listener identified by
+     * `internalListenerName` and merged with the entries declared in `bindAddresses`. Exact duplicates
+     * (same `listener:scheme://ip:port`) are tolerated. Two failure modes are rejected:
+     * <ol>
+     *   <li>the same {@code scheme://ip:port} mapped to different listener names, and
+     *   <li>the same {@code ip:port} mapped to two different protocol schemes — because a TCP socket
+     *       can only be bound by one process, an IP+port can carry at most one scheme.
+     * </ol>
+     *
+     * @param config the pulsar broker configuration.
      * @param schemes a filter on the schemes of the bind addresses, or null to not apply a filter.
      * @return a list of bind addresses.
      */
     public static List<BindAddress> validateBindAddresses(ServiceConfiguration config, Collection<String> schemes) {
-        // migrate the existing configuration properties
-        List<BindAddress> addresses = migrateBindAddresses(config);
+        String internalListenerName = StringUtils.defaultIfBlank(config.getInternalListenerName(),
+                ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
 
-        // parse the list of additional bind addresses
-        Arrays
-                .stream(StringUtils.split(StringUtils.defaultString(config.getBindAddresses()), ","))
+        // migrate the legacy port-based configuration to bind addresses tagged with the internal listener name
+        List<BindAddress> addresses = migrateBindAddresses(config, internalListenerName);
+
+        // parse the list of additional bind addresses; trim whitespace around the comma-separated
+        // entries so configurations split across multiple lines or padded for readability are accepted
+        Arrays.stream(StringUtils.split(StringUtils.defaultString(config.getBindAddresses()), ","))
+                .map(StringUtils::trim)
+                .filter(StringUtils::isNotEmpty)
                 .map(s -> {
                     Matcher m = BIND_ADDRESSES_PATTERN.matcher(s);
                     if (!m.matches()) {
@@ -57,7 +76,11 @@ public class BindAddressValidator {
                     }
                     return m;
                 })
-                .map(m -> new BindAddress(m.group("name"), URI.create(m.group("url"))))
+                .map(m -> {
+                    String name = StringUtils.trim(m.group("name"));
+                    MultipleListenerValidator.validateListenerName(name);
+                    return new BindAddress(name, URI.create(StringUtils.trim(m.group("url"))));
+                })
                 .forEach(addresses::add);
 
         // apply the filter
@@ -65,33 +88,70 @@ public class BindAddressValidator {
             addresses.removeIf(a -> !schemes.contains(a.getAddress().getScheme()));
         }
 
-        return addresses;
+        // Deduplicate by full URI (scheme + ip + port). Tolerate exact duplicates (same URI and
+        // same listener name) so that a user's bindAddresses entry that matches a migrated binding
+        // is accepted; reject same URI assigned to different listener names.
+        Map<URI, BindAddress> uniqueBindAddresses = new LinkedHashMap<>();
+        for (BindAddress addr : addresses) {
+            BindAddress existing = uniqueBindAddresses.get(addr.getAddress());
+            if (existing == null) {
+                uniqueBindAddresses.put(addr.getAddress(), addr);
+            } else if (Objects.equals(existing.getListenerName(), addr.getListenerName())) {
+                // exact duplicate, tolerate
+                continue;
+            } else {
+                throw new IllegalArgumentException("bindAddresses: conflicting listener names for "
+                        + addr.getAddress() + ": `" + existing.getListenerName() + "` and `"
+                        + addr.getListenerName() + "`");
+            }
+        }
+
+        // ip:port uniqueness across protocol schemes. A TCP socket can only be bound by one
+        // listener+scheme combination, so two bindings that share host:port but differ in scheme
+        // (e.g. pulsar://0.0.0.0:8080 and http://0.0.0.0:8080) cannot both be active. Port 0 is
+        // skipped because it means "OS-assigned ephemeral port" — the kernel will hand out a unique
+        // port to each socket, so two port-0 entries with the same IP cannot actually collide.
+        Map<String, BindAddress> uniqueIpPort = new LinkedHashMap<>();
+        for (BindAddress addr : uniqueBindAddresses.values()) {
+            if (addr.getAddress().getPort() == 0) {
+                continue;
+            }
+            String ipPort = MultipleListenerValidator.formatHostPort(addr.getAddress());
+            BindAddress prior = uniqueIpPort.putIfAbsent(ipPort, addr);
+            if (prior != null) {
+                throw new IllegalArgumentException("bindAddresses: ip:port `" + ipPort
+                        + "` is bound by two schemes: `" + prior.getListenerName() + ":"
+                        + prior.getAddress().getScheme() + "` and `" + addr.getListenerName() + ":"
+                        + addr.getAddress().getScheme() + "`; an ip:port can carry only one scheme");
+            }
+        }
+
+        return new ArrayList<>(uniqueBindAddresses.values());
     }
 
     /**
-     * Generates bind addresses based on legacy configuration properties.
+     * Generates bind addresses based on legacy configuration properties. The synthesized bindings are
+     * tagged with the {@code internalListenerName} so that {@link MultipleListenerValidator} and
+     * downstream code can correlate them with the internal advertised listener.
      */
-    private static List<BindAddress> migrateBindAddresses(ServiceConfiguration config) {
-        List<BindAddress> addresses = new ArrayList<>(2);
+    private static List<BindAddress> migrateBindAddresses(ServiceConfiguration config, String internalListenerName) {
+        List<BindAddress> addresses = new ArrayList<>(4);
+        String bindAddress = config.getBindAddress();
         if (config.getBrokerServicePort().isPresent()) {
-            addresses.add(new BindAddress(null, URI.create(
-                    ServiceConfigurationUtils.brokerUrl(config.getBindAddress(),
-                            config.getBrokerServicePort().get()))));
+            addresses.add(new BindAddress(internalListenerName,
+                    URI.create(ServiceConfigurationUtils.brokerUrl(bindAddress, config.getBrokerServicePort().get()))));
         }
         if (config.getBrokerServicePortTls().isPresent()) {
-            addresses.add(new BindAddress(null, URI.create(
-                    ServiceConfigurationUtils.brokerUrlTls(config.getBindAddress(),
-                            config.getBrokerServicePortTls().get()))));
+            addresses.add(new BindAddress(internalListenerName, URI.create(
+                    ServiceConfigurationUtils.brokerUrlTls(bindAddress, config.getBrokerServicePortTls().get()))));
         }
         if (config.getWebServicePort().isPresent()) {
-            addresses.add(new BindAddress(null, URI.create(
-                    ServiceConfigurationUtils.webServiceUrl(config.getBindAddress(),
-                            config.getWebServicePort().get()))));
+            addresses.add(new BindAddress(internalListenerName, URI.create(
+                    ServiceConfigurationUtils.webServiceUrl(bindAddress, config.getWebServicePort().get()))));
         }
         if (config.getWebServicePortTls().isPresent()) {
-            addresses.add(new BindAddress(null, URI.create(
-                    ServiceConfigurationUtils.webServiceUrlTls(config.getBindAddress(),
-                            config.getWebServicePortTls().get()))));
+            addresses.add(new BindAddress(internalListenerName, URI.create(
+                    ServiceConfigurationUtils.webServiceUrlTls(bindAddress, config.getWebServicePortTls().get()))));
         }
         return addresses;
     }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -18,17 +18,18 @@
  */
 package org.apache.pulsar.broker.validator;
 
+import io.netty.util.NetUtil;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 
 /**
@@ -36,47 +37,155 @@ import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
  */
 public final class MultipleListenerValidator {
 
+    /** Allowed listener-name characters: ASCII letters, digits, underscore, hyphen. */
+    private static final Pattern LISTENER_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+
     /**
-     * Validate the configuration of `advertisedListeners`, `internalListenerName`.
-     * 1. `advertisedListeners` consists of a comma-separated list of endpoints.
-     * 2. Each endpoint consists of a listener name and an associated address (`listener:scheme://host:port`).
-     * 3. A listener name may be repeated to define both a non-TLS and a TLS endpoint.
-     * 4. Duplicate definitions are disallowed.
-     * 5. If `internalListenerName` is absent, set it to the first listener defined in `advertisedListeners`.
-     * @param config the pulsar broker configure.
-     * @return
+     * Format the host:port part of a URI for use as a uniqueness key and in error messages, wrapping
+     * IPv6 literals in brackets so that the colon separator is unambiguous. {@link URI#getHost()} may
+     * or may not include the brackets depending on the JDK, so they are stripped before the
+     * {@link NetUtil#isValidIpV6Address} check.
      */
-    public static Map<String, AdvertisedListener> validateAndAnalysisAdvertisedListener(ServiceConfiguration config) {
-        if (StringUtils.isBlank(config.getAdvertisedListeners())) {
-            return Collections.emptyMap();
+    static String formatHostPort(URI uri) {
+        String host = uri.getHost();
+        if (host == null) {
+            return host + ":" + uri.getPort();
         }
-        Optional<String> firstListenerName = Optional.empty();
+        String unbracketed = host.startsWith("[") && host.endsWith("]")
+                ? host.substring(1, host.length() - 1) : host;
+        if (NetUtil.isValidIpV6Address(unbracketed)) {
+            return "[" + unbracketed + "]:" + uri.getPort();
+        }
+        return host + ":" + uri.getPort();
+    }
+
+    /**
+     * Validate a listener name. Listener names must be non-blank and contain only ASCII letters,
+     * digits, underscore, and hyphen so they are safe to embed in URLs without encoding.
+     *
+     * @throws IllegalArgumentException if the name is null, blank, or contains disallowed characters.
+     */
+    public static void validateListenerName(String name) {
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("listener name must not be blank");
+        }
+        if (!LISTENER_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("listener name `" + name + "` must contain only ASCII"
+                    + " letters, digits, underscore, or hyphen");
+        }
+    }
+
+    /**
+     * Validate `advertisedListeners` and `internalListenerName`, returning the parsed listener map.
+     * <p>
+     * This method mutates the supplied {@link ServiceConfiguration}: when {@code internalListenerName}
+     * is blank, it is written back with the resolved fallback value (the first parsed listener if any,
+     * otherwise {@value ServiceConfiguration#DEFAULT_INTERNAL_LISTENER_NAME}) so that subsequent reads
+     * from the config see the effective value.
+     * <ol>
+     * <li>`advertisedListeners` is a comma-separated list of endpoints in the form
+     *     `listener:scheme://host:port`. Supported schemes are `pulsar`, `pulsar+ssl`, `http`, and `https`.
+     * <li>A listener name may be repeated to define multiple endpoints (e.g. binary and HTTPS) for the
+     *     same listener; duplicate definitions for the same scheme are rejected.
+     * <li>`internalListenerName` identifies the listener used for cluster-internal broker-to-broker
+     *     communication. It defaults to {@value ServiceConfiguration#DEFAULT_INTERNAL_LISTENER_NAME}.
+     *     An internal listener entry is synthesized from the legacy `brokerServicePort`,
+     *     `brokerServicePortTls`, `webServicePort`, and `webServicePortTls` properties; any URLs the
+     *     user has explicitly declared for the internal listener in `advertisedListeners` take
+     *     precedence and the legacy-port URLs only fill in the unspecified slots. This allows the
+     *     internal listener to override individual URLs (e.g. a custom TLS hostname) while still
+     *     benefiting from auto-population for the rest.
+     * </ol>
+     * @param config the pulsar broker configuration; updated in place when
+     *               {@code internalListenerName} is blank.
+     * @return the parsed and validated advertised listeners, keyed by listener name.
+     */
+    public static Map<String, AdvertisedListener> validateAndUpdateAdvertisedListeners(ServiceConfiguration config) {
+        Map<String, AdvertisedListener> result = parseAdvertisedListeners(config);
+
+        // Resolve `internalListenerName` if the user left it blank (null, empty, or whitespace).
+        // For backward compatibility, prefer the first entry parsed from `advertisedListeners`;
+        // otherwise fall back to the constant default ("internal"). The field's own default is
+        // also "internal", so this branch is normally taken only when the user explicitly set the
+        // property to an empty string.
+        if (StringUtils.isBlank(config.getInternalListenerName())) {
+            String fallback = result.isEmpty()
+                    ? ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME
+                    : result.keySet().iterator().next();
+            config.setInternalListenerName(fallback);
+        }
+        String internalListenerName = config.getInternalListenerName();
+
+        // Merge the legacy-port-derived internal listener URLs into any explicit configuration.
+        // Explicit URLs in `advertisedListeners` take precedence; the legacy-port URLs fill in the
+        // unspecified slots so that broker-to-broker communication keeps working without forcing the
+        // user to redeclare every URL when they only want to override one.
+        AdvertisedListener fromLegacyPorts = buildInternalListenerFromLegacyPorts(config);
+        if (fromLegacyPorts != null) {
+            AdvertisedListener explicit = result.get(internalListenerName);
+            result.put(internalListenerName, mergeListeners(explicit, fromLegacyPorts));
+        }
+
+        if (!result.isEmpty() && !result.containsKey(internalListenerName)) {
+            throw new IllegalArgumentException("the `advertisedListeners` configuration does not contain "
+                    + "an entry for the internal listener `" + internalListenerName + "`, and the legacy "
+                    + "port properties are not configured so an internal listener cannot be synthesized");
+        }
+
+        return result;
+    }
+
+    /**
+     * Merges two {@link AdvertisedListener} entries. URLs from {@code override} take precedence; URLs
+     * from {@code fallback} only fill in the slots that {@code override} leaves null. Either argument
+     * may be null.
+     */
+    private static AdvertisedListener mergeListeners(AdvertisedListener override, AdvertisedListener fallback) {
+        if (override == null) {
+            return fallback;
+        }
+        if (fallback == null) {
+            return override;
+        }
+        return AdvertisedListener.builder()
+                .brokerServiceUrl(override.getBrokerServiceUrl() != null
+                        ? override.getBrokerServiceUrl() : fallback.getBrokerServiceUrl())
+                .brokerServiceUrlTls(override.getBrokerServiceUrlTls() != null
+                        ? override.getBrokerServiceUrlTls() : fallback.getBrokerServiceUrlTls())
+                .brokerHttpUrl(override.getBrokerHttpUrl() != null
+                        ? override.getBrokerHttpUrl() : fallback.getBrokerHttpUrl())
+                .brokerHttpsUrl(override.getBrokerHttpsUrl() != null
+                        ? override.getBrokerHttpsUrl() : fallback.getBrokerHttpsUrl())
+                .build();
+    }
+
+    private static Map<String, AdvertisedListener> parseAdvertisedListeners(ServiceConfiguration config) {
+        if (StringUtils.isBlank(config.getAdvertisedListeners())) {
+            return new LinkedHashMap<>();
+        }
         Map<String, List<String>> listeners = new LinkedHashMap<>();
-        for (final String str : StringUtils.split(config.getAdvertisedListeners(), ",")) {
+        // Trim whitespace around comma-separated entries so configurations split across multiple
+        // lines or padded for readability are accepted, and skip empties.
+        for (final String raw : StringUtils.split(config.getAdvertisedListeners(), ",")) {
+            String str = StringUtils.trim(raw);
+            if (StringUtils.isEmpty(str)) {
+                continue;
+            }
             int index = str.indexOf(":");
             if (index <= 0) {
                 throw new IllegalArgumentException("the configure entry `advertisedListeners` is invalid. because "
                         + str + " do not contain listener name");
             }
             String listenerName = StringUtils.trim(str.substring(0, index));
-            if (!firstListenerName.isPresent()) {
-                firstListenerName = Optional.of(listenerName);
-            }
+            validateListenerName(listenerName);
             String value = StringUtils.trim(str.substring(index + 1));
             listeners.computeIfAbsent(listenerName, k -> new ArrayList<>(2));
             listeners.get(listenerName).add(value);
         }
-        if (StringUtils.isBlank(config.getInternalListenerName())) {
-            config.setInternalListenerName(firstListenerName.get());
-        }
-        if (!listeners.containsKey(config.getInternalListenerName())) {
-            throw new IllegalArgumentException("the `advertisedListeners` configure do not contain "
-                    + "`internalListenerName` entry");
-        }
         final Map<String, AdvertisedListener> result = new LinkedHashMap<>();
         final Map<String, Set<String>> reverseMappings = new LinkedHashMap<>();
         for (final Map.Entry<String, List<String>> entry : listeners.entrySet()) {
-            if (entry.getValue().size() > 2) {
+            if (entry.getValue().size() > 4) {
                 throw new IllegalArgumentException("there are redundant configure for listener `" + entry.getKey()
                         + "`");
             }
@@ -114,7 +223,7 @@ public final class MultipleListenerValidator {
                         }
                     }
 
-                    String hostPort = String.format("%s:%d", uri.getHost(), uri.getPort());
+                    String hostPort = formatHostPort(uri);
                     Set<String> sets = reverseMappings.computeIfAbsent(hostPort, k -> new TreeSet<>());
                     sets.add(entry.getKey());
                     if (sets.size() > 1) {
@@ -136,4 +245,35 @@ public final class MultipleListenerValidator {
         return result;
     }
 
+    /**
+     * Synthesize an {@link AdvertisedListener} for the internal listener from the legacy port
+     * configuration (`brokerServicePort`, `brokerServicePortTls`, `webServicePort`,
+     * `webServicePortTls`). Returns {@code null} if no binary port and no web port is set; the caller
+     * is then responsible for raising an error if the internal listener is still missing after
+     * parsing `advertisedListeners`.
+     */
+    private static AdvertisedListener buildInternalListenerFromLegacyPorts(ServiceConfiguration config) {
+        boolean hasBinaryPort = config.getBrokerServicePort().isPresent()
+                || config.getBrokerServicePortTls().isPresent();
+        boolean hasWebPort = config.getWebServicePort().isPresent()
+                || config.getWebServicePortTls().isPresent();
+        if (!hasBinaryPort && !hasWebPort) {
+            return null;
+        }
+        String host = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
+        return AdvertisedListener.builder()
+                .brokerServiceUrl(config.getBrokerServicePort()
+                        .map(port -> URI.create(ServiceConfigurationUtils.brokerUrl(host, port))).orElse(null))
+                .brokerServiceUrlTls(config.getBrokerServicePortTls()
+                        .map(port -> URI.create(ServiceConfigurationUtils.brokerUrlTls(host, port))).orElse(null))
+                .brokerHttpUrl(config.getWebServicePort()
+                        .map(port -> URI.create(ServiceConfigurationUtils.webServiceUrl(host, port))).orElse(null))
+                .brokerHttpsUrl(config.getWebServicePortTls()
+                        .map(port -> URI.create(ServiceConfigurationUtils.webServiceUrlTls(host, port))).orElse(null))
+                .build();
+    }
+
+    // Prevent instantiation
+    private MultipleListenerValidator() {
+    }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -49,7 +49,7 @@ public final class MultipleListenerValidator {
     static String formatHostPort(URI uri) {
         String host = uri.getHost();
         if (host == null) {
-            return host + ":" + uri.getPort();
+            throw new IllegalArgumentException("host must not be null")
         }
         String unbracketed = host.startsWith("[") && host.endsWith("]")
                 ? host.substring(1, host.length() - 1) : host;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/validator/MultipleListenerValidator.java
@@ -49,7 +49,7 @@ public final class MultipleListenerValidator {
     static String formatHostPort(URI uri) {
         String host = uri.getHost();
         if (host == null) {
-            throw new IllegalArgumentException("host must not be null")
+            throw new IllegalArgumentException("host must not be null");
         }
         String unbracketed = host.startsWith("[") && host.endsWith("]")
                 ? host.substring(1, host.length() - 1) : host;

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/ServiceConfigurationUtilsTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/ServiceConfigurationUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import static org.testng.Assert.assertEquals;
+import java.net.URI;
+import org.testng.annotations.Test;
+
+public class ServiceConfigurationUtilsTest {
+
+    @Test
+    public void testBrokerUrlWithHostname() {
+        assertEquals(ServiceConfigurationUtils.brokerUrl("broker-1.example.com", 6650),
+                "pulsar://broker-1.example.com:6650");
+    }
+
+    @Test
+    public void testBrokerUrlWithIpv4() {
+        assertEquals(ServiceConfigurationUtils.brokerUrl("10.0.0.1", 6650), "pulsar://10.0.0.1:6650");
+    }
+
+    @Test
+    public void testBrokerUrlWithIpv6Bare() {
+        // A bare IPv6 literal must be wrapped in brackets so the resulting URL parses correctly.
+        String url = ServiceConfigurationUtils.brokerUrl("::1", 6650);
+        assertEquals(url, "pulsar://[::1]:6650");
+        URI parsed = URI.create(url);
+        assertEquals(parsed.getPort(), 6650);
+    }
+
+    @Test
+    public void testBrokerUrlTlsWithIpv6Bare() {
+        String url = ServiceConfigurationUtils.brokerUrlTls("fe80::1", 6651);
+        assertEquals(url, "pulsar+ssl://[fe80::1]:6651");
+        assertEquals(URI.create(url).getPort(), 6651);
+    }
+
+    @Test
+    public void testWebServiceUrlWithIpv6Bare() {
+        String url = ServiceConfigurationUtils.webServiceUrl("2001:db8::1", 8080);
+        assertEquals(url, "http://[2001:db8::1]:8080");
+        assertEquals(URI.create(url).getPort(), 8080);
+    }
+
+    @Test
+    public void testWebServiceUrlTlsWithIpv6Bare() {
+        String url = ServiceConfigurationUtils.webServiceUrlTls("2001:db8::1", 8443);
+        assertEquals(url, "https://[2001:db8::1]:8443");
+        assertEquals(URI.create(url).getPort(), 8443);
+    }
+
+    @Test
+    public void testIpv6AlreadyBracketedIsNotDoubleWrapped() {
+        // If the caller passed a pre-bracketed IPv6 literal, leave it as-is rather than producing
+        // `pulsar://[[::1]]:6650`.
+        String url = ServiceConfigurationUtils.brokerUrl("[::1]", 6650);
+        assertEquals(url, "pulsar://[::1]:6650");
+        assertEquals(URI.create(url).getPort(), 6650);
+    }
+
+    @Test
+    public void testIpv4InUrlIsNotBracketed() {
+        // IPv4 addresses must not be bracketed.
+        String url = ServiceConfigurationUtils.webServiceUrl("0.0.0.0", 8080);
+        assertEquals(url, "http://0.0.0.0:8080");
+    }
+}

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/BindAddressValidatorTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.broker.validator;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -58,9 +60,9 @@ public class BindAddressValidatorTest {
         ServiceConfiguration config = newEmptyConfiguration();
         config.setBindAddresses("internal:pulsar://0.0.0.0:6650,internal:pulsar+ssl://0.0.0.0:6651");
         List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
+        assertEquals(addresses, Arrays.asList(
                 new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651"))), addresses);
+                new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651"))));
     }
 
     @Test
@@ -68,9 +70,9 @@ public class BindAddressValidatorTest {
         ServiceConfiguration config = newEmptyConfiguration();
         config.setBindAddresses("internal:pulsar://0.0.0.0:6650,external:pulsar+ssl://0.0.0.0:6651");
         List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
+        assertEquals(addresses, Arrays.asList(
                 new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651"))), addresses);
+                new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651"))));
     }
 
     @Test
@@ -82,20 +84,20 @@ public class BindAddressValidatorTest {
         config.setWebServicePortTls(Optional.of(443));
         config.setBindAddress("0.0.0.0");
         List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
-                new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")),
-                new BindAddress(null, URI.create("http://0.0.0.0:8080")),
-                new BindAddress(null, URI.create("https://0.0.0.0:443"))), addresses);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651")),
+                new BindAddress("internal", URI.create("http://0.0.0.0:8080")),
+                new BindAddress("internal", URI.create("https://0.0.0.0:443"))));
     }
 
     @Test
     public void testMigrationWithDefaults() {
         ServiceConfiguration config = new ServiceConfiguration();
         List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
-                new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress(null, URI.create("http://0.0.0.0:8080"))), addresses);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("internal", URI.create("http://0.0.0.0:8080"))));
     }
 
     @Test
@@ -104,9 +106,9 @@ public class BindAddressValidatorTest {
         config.setBrokerServicePort(Optional.of(6650));
         config.setBindAddresses("extra:pulsar://0.0.0.0:6652");
         List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
-                new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652"))), addresses);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652"))));
     }
 
     @Test
@@ -118,20 +120,141 @@ public class BindAddressValidatorTest {
 
         List<BindAddress> addresses;
         addresses = BindAddressValidator.validateBindAddresses(config, null);
-        assertEquals(Arrays.asList(
-                new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")),
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651")),
                 new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652")),
-                new BindAddress("extra", URI.create("http://0.0.0.0:8080"))), addresses);
+                new BindAddress("extra", URI.create("http://0.0.0.0:8080"))));
 
         addresses = BindAddressValidator.validateBindAddresses(config, Arrays.asList("pulsar", "pulsar+ssl"));
-        assertEquals(Arrays.asList(
-                new BindAddress(null, URI.create("pulsar://0.0.0.0:6650")),
-                new BindAddress(null, URI.create("pulsar+ssl://0.0.0.0:6651")),
-                new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652"))), addresses);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("internal", URI.create("pulsar+ssl://0.0.0.0:6651")),
+                new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652"))));
 
         addresses = BindAddressValidator.validateBindAddresses(config, Collections.singletonList("http"));
-        assertEquals(Collections.singletonList(
-                new BindAddress("extra", URI.create("http://0.0.0.0:8080"))), addresses);
+        assertEquals(addresses, Collections.singletonList(
+                new BindAddress("extra", URI.create("http://0.0.0.0:8080"))));
+    }
+
+    @Test
+    public void testMigrationUsesConfiguredInternalListenerName() {
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setInternalListenerName("region1");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("region1", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("region1", URI.create("http://0.0.0.0:8080"))));
+    }
+
+    @Test
+    public void testDuplicateMatchingMigratedBindingIsTolerated() {
+        // User explicitly re-declares the migrated binding under the same listener name; this must
+        // be accepted without throwing.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Collections.singletonList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650"))));
+    }
+
+    @Test
+    public void testDuplicateConflictFailsWithError() {
+        // The migrated binding uses the internal listener name, but the user re-declares the same
+        // URI under a different listener name. This is a conflict and must be rejected.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBindAddresses("external:pulsar://0.0.0.0:6650");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> BindAddressValidator.validateBindAddresses(config, null));
+        assertTrue(e.getMessage().contains("conflicting listener names"),
+                "expected conflict message but got: " + e.getMessage());
+    }
+
+    @Test
+    public void testDuplicateBindAddressesEntriesAreTolerated() {
+        // Two identical entries in bindAddresses should not cause a failure.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBindAddresses("extra:pulsar://0.0.0.0:6652,extra:pulsar://0.0.0.0:6652");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Collections.singletonList(
+                new BindAddress("extra", URI.create("pulsar://0.0.0.0:6652"))));
+    }
+
+    @Test
+    public void testSameIpPortDifferentSchemeSameListenerFails() {
+        // Same ip:port with two different schemes (even for the same listener) cannot both be bound.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBindAddresses("internal:pulsar://0.0.0.0:8080,internal:http://0.0.0.0:8080");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> BindAddressValidator.validateBindAddresses(config, null));
+        assertTrue(e.getMessage().contains("0.0.0.0:8080"),
+                "expected ip:port in message but got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("only one scheme"),
+                "expected scheme-collision wording but got: " + e.getMessage());
+    }
+
+    @Test
+    public void testSameIpPortDifferentSchemeDifferentListenerFails() {
+        // Same ip:port with two different schemes and two different listener names also fails for
+        // the same reason: an ip:port can only be bound by one (listener, scheme).
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBindAddresses("internal:pulsar://0.0.0.0:8080,external:http://0.0.0.0:8080");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> BindAddressValidator.validateBindAddresses(config, null));
+        assertTrue(e.getMessage().contains("0.0.0.0:8080"),
+                "expected ip:port in message but got: " + e.getMessage());
+    }
+
+    @Test
+    public void testDynamicPortZeroIsSkippedFromIpPortUniqueness() {
+        // Port 0 means "OS-assigned ephemeral port", so two port-0 bindings with the same IP cannot
+        // actually collide — each socket gets a different kernel-assigned port. The ip:port
+        // uniqueness check therefore skips port-0 entries.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBindAddresses("internal:pulsar://0.0.0.0:0,internal:http://0.0.0.0:0");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:0")),
+                new BindAddress("internal", URI.create("http://0.0.0.0:0"))));
+    }
+
+    @Test
+    public void testLegacyMigrationIpPortCollisionFails() {
+        // brokerServicePort and webServicePort collide on the same ip:port: the migrated bindings
+        // would produce pulsar://0.0.0.0:8080 and http://0.0.0.0:8080, which cannot coexist.
+        ServiceConfiguration config = newEmptyConfiguration();
+        config.setBrokerServicePort(Optional.of(8080));
+        config.setWebServicePort(Optional.of(8080));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> BindAddressValidator.validateBindAddresses(config, null));
+        assertTrue(e.getMessage().contains("0.0.0.0:8080"),
+                "expected ip:port in message but got: " + e.getMessage());
+    }
+
+    @Test
+    public void testWhitespaceBetweenEntriesIsTrimmed() {
+        ServiceConfiguration config = newEmptyConfiguration();
+        // Spaces, newlines, and tabs around the comma separators and around the entries themselves
+        // must all be tolerated and trimmed.
+        config.setBindAddresses("  internal:pulsar://0.0.0.0:6650 ,\n\texternal:pulsar+ssl://0.0.0.0:6651  ");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651"))));
+    }
+
+    @Test
+    public void testEmptyEntriesAreSkipped() {
+        ServiceConfiguration config = newEmptyConfiguration();
+        // A trailing comma or an extra comma in the middle should be ignored, not flagged as malformed.
+        config.setBindAddresses("internal:pulsar://0.0.0.0:6650, ,external:pulsar+ssl://0.0.0.0:6651,");
+        List<BindAddress> addresses = BindAddressValidator.validateBindAddresses(config, null);
+        assertEquals(addresses, Arrays.asList(
+                new BindAddress("internal", URI.create("pulsar://0.0.0.0:6650")),
+                new BindAddress("external", URI.create("pulsar+ssl://0.0.0.0:6651"))));
     }
 }

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/broker/validator/MultipleListenerValidatorTest.java
@@ -18,11 +18,18 @@
  */
 package org.apache.pulsar.broker.validator;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import java.net.InetAddress;
+import java.net.URI;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.testng.annotations.Test;
 
 /**
@@ -34,7 +41,8 @@ public class MultipleListenerValidatorTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testGetAppliedAdvertised() throws Exception {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setBrokerServicePort(Optional.of(6650));
         config.setBrokerServicePortTls(Optional.of(6651));
         config.setAdvertisedListeners("internal:pulsar://192.0.0.1:6660, internal:pulsar+ssl://192.0.0.1:6651");
         config.setInternalListenerName("internal");
@@ -43,7 +51,7 @@ public class MultipleListenerValidatorTest {
         assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, true),
                 InetAddress.getLocalHost().getCanonicalHostName());
 
-        config = new ServiceConfiguration();
+        config = newConfigWithNoPorts();
         config.setBrokerServicePortTls(Optional.of(6651));
         config.setAdvertisedAddress("192.0.0.2");
         assertEquals(ServiceConfigurationUtils.getAppliedAdvertisedAddress(config, false),
@@ -60,59 +68,265 @@ public class MultipleListenerValidatorTest {
 
     @Test
     public void testListenerDefaulting() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName(null);
         config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660, internal:pulsar+ssl://127.0.0.1:6651");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
         assertEquals("internal", config.getInternalListenerName());
+    }
+
+    @Test
+    public void testBlankInternalListenerNameFallsBackToFirstAdvertisedListener() {
+        // Backwards compatibility: if the user explicitly leaves `internalListenerName` blank but
+        // configures `advertisedListeners` with custom names, the first listener parsed from
+        // `advertisedListeners` is used as the internal listener — the previous Pulsar behavior.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("");
+        config.setAdvertisedListeners(
+                "region1:pulsar://region1.example.com:6650,region2:pulsar://region2.example.com:6650");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        // `region1` is the first declared, so it becomes the internal listener.
+        assertEquals(config.getInternalListenerName(), "region1");
+        // Both region entries are preserved in the result map.
+        assertEquals(listeners.size(), 2);
+        assertNotNull(listeners.get("region1"));
+        assertNotNull(listeners.get("region2"));
+    }
+
+    @Test
+    public void testBlankInternalListenerNameFallsBackToDefaultWhenNoAdvertisedListeners() {
+        // When both `internalListenerName` and `advertisedListeners` are blank, the validator falls
+        // back to the constant default `"internal"`.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(config.getInternalListenerName(), ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
+        assertNotNull(listeners.get(ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME),
+                "the legacy-port-synthesized internal listener should be present");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMalformedListener() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
         config.setAdvertisedListeners(":pulsar://127.0.0.1:6660");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testListenerDuplicate_1() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
         config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660, internal:pulsar+ssl://127.0.0.1:6651,"
                 + " internal:pulsar://192.168.1.11:6660, internal:pulsar+ssl://192.168.1.11:6651");
         config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testListenerDuplicate_2() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
         config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660," + " internal:pulsar://192.168.1.11:6660");
         config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testListenerDuplicate_3() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
         config.setAdvertisedListeners(" internal:pulsar+ssl://127.0.0.1:6661,"
                 + " internal:pulsar+ssl://192.168.1.11:6661");
         config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testDifferentListenerWithSameHostPort() {
-        ServiceConfiguration config = new ServiceConfiguration();
+        ServiceConfiguration config = newConfigWithNoPorts();
         config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660," + " external:pulsar://127.0.0.1:6660");
         config.setInternalListenerName("internal");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testWithoutListenerNameInAdvertisedListeners() {
+    @Test
+    public void testInternalListenerSynthesizedFromLegacyPorts() {
+        // No advertisedListeners configured, only legacy ports. The internal listener is synthesized.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        AdvertisedListener internal = listeners.get(ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
+        assertNotNull(internal, "expected an `internal` listener to be synthesized from legacy ports");
+        assertEquals(internal.getBrokerServiceUrl(), URI.create("pulsar://broker-1.example.com:6650"));
+        assertEquals(internal.getBrokerHttpUrl(), URI.create("http://broker-1.example.com:8080"));
+        assertNull(internal.getBrokerServiceUrlTls());
+        assertNull(internal.getBrokerHttpsUrl());
+    }
+
+    @Test
+    public void testInternalListenerSynthesizedWithAllPorts() {
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setWebServicePort(Optional.of(8080));
+        config.setWebServicePortTls(Optional.of(8443));
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        AdvertisedListener internal = listeners.get(ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
+        assertNotNull(internal);
+        assertEquals(internal.getBrokerServiceUrl(), URI.create("pulsar://broker-1.example.com:6650"));
+        assertEquals(internal.getBrokerServiceUrlTls(), URI.create("pulsar+ssl://broker-1.example.com:6651"));
+        assertEquals(internal.getBrokerHttpUrl(), URI.create("http://broker-1.example.com:8080"));
+        assertEquals(internal.getBrokerHttpsUrl(), URI.create("https://broker-1.example.com:8443"));
+    }
+
+    @Test
+    public void testInternalListenerAutoAddedWhenAdvertisedListenersDoesNotContainIt() {
+        // User configures advertisedListeners with their own listener name but does not declare the
+        // internal listener. The validator must auto-add it from the legacy ports.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        config.setAdvertisedListeners("region1:pulsar://region1.example.com:6660,"
+                + "region1:pulsar+ssl://region1.example.com:6661");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(listeners.size(), 2);
+        AdvertisedListener region1 = listeners.get("region1");
+        assertNotNull(region1);
+        assertEquals(region1.getBrokerServiceUrl(), URI.create("pulsar://region1.example.com:6660"));
+        AdvertisedListener internal = listeners.get("internal");
+        assertNotNull(internal, "internal listener should have been auto-added from legacy ports");
+        assertEquals(internal.getBrokerServiceUrl(), URI.create("pulsar://broker-1.example.com:6650"));
+        assertEquals(internal.getBrokerHttpUrl(), URI.create("http://broker-1.example.com:8080"));
+    }
+
+    @Test
+    public void testExplicitInternalListenerUrlsTakePrecedenceOverLegacyPorts() {
+        // When the user explicitly declares URLs for the internal listener in advertisedListeners, those
+        // URLs take precedence over the legacy-port-derived values. The legacy values still fill in any
+        // URL slots the user did not declare.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        config.setAdvertisedListeners("internal:pulsar://explicit.example.com:6660,"
+                + "internal:http://explicit.example.com:8888");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(listeners.size(), 1);
+        AdvertisedListener internal = listeners.get("internal");
+        assertNotNull(internal);
+        // Both URLs were declared explicitly: the user-provided values win over the legacy ports.
+        assertEquals(internal.getBrokerServiceUrl(), URI.create("pulsar://explicit.example.com:6660"));
+        assertEquals(internal.getBrokerHttpUrl(), URI.create("http://explicit.example.com:8888"));
+        // The user did not declare TLS variants and the legacy TLS ports are unset.
+        assertNull(internal.getBrokerServiceUrlTls());
+        assertNull(internal.getBrokerHttpsUrl());
+    }
+
+    @Test
+    public void testPartialInternalListenerOverrideMergesWithLegacyPorts() {
+        // The user overrides only one URL (the binary endpoint) for the internal listener. The remaining
+        // URLs must be filled in from the legacy-port configuration so the listener is complete.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setBrokerServicePortTls(Optional.of(6651));
+        config.setWebServicePort(Optional.of(8080));
+        config.setWebServicePortTls(Optional.of(8443));
+        config.setAdvertisedListeners("internal:pulsar://override.example.com:6660");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        AdvertisedListener internal = listeners.get("internal");
+        assertNotNull(internal);
+        // Overridden by the explicit advertisedListeners entry:
+        assertEquals(internal.getBrokerServiceUrl(), URI.create("pulsar://override.example.com:6660"));
+        // Filled in from the legacy ports:
+        assertEquals(internal.getBrokerServiceUrlTls(), URI.create("pulsar+ssl://broker-1.example.com:6651"));
+        assertEquals(internal.getBrokerHttpUrl(), URI.create("http://broker-1.example.com:8080"));
+        assertEquals(internal.getBrokerHttpsUrl(), URI.create("https://broker-1.example.com:8443"));
+    }
+
+    @Test
+    public void testInternalListenerNameCustomizable() {
+        // The internal listener name is configurable; the validator must look for the configured name.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("region1");
+        config.setAdvertisedAddress("broker-1.example.com");
+        config.setBrokerServicePort(Optional.of(6650));
+        config.setWebServicePort(Optional.of(8080));
+        config.setAdvertisedListeners("region1:pulsar://region1.example.com:6660,"
+                + "region1:http://region1.example.com:8888");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(listeners.size(), 1);
+        AdvertisedListener region1 = listeners.get("region1");
+        assertNotNull(region1);
+        assertEquals(region1.getBrokerServiceUrl(), URI.create("pulsar://region1.example.com:6660"));
+    }
+
+    @Test
+    public void testFailureWhenNoInternalListenerAvailable() {
+        // Custom internal listener name + no matching entry in advertisedListeners + no ports for the
+        // legacy fallback => validation must fail with a clear message.
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("region1");
+        config.setAdvertisedListeners("region2:pulsar://region2.example.com:6660");
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config));
+        assertTrue(e.getMessage().contains("region1"), "expected error to mention the listener name: "
+                + e.getMessage());
+    }
+
+    @Test
+    public void testInternalListenerNameDefaultsToInternalConstant() {
         ServiceConfiguration config = new ServiceConfiguration();
-        config.setAdvertisedListeners(" internal:pulsar://127.0.0.1:6660, internal:pulsar+ssl://127.0.0.1:6651");
-        config.setInternalListenerName("external");
-        MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        assertEquals(config.getInternalListenerName(), ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
     }
 
+    @Test
+    public void testWhitespaceBetweenEntriesIsTrimmed() {
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("internal");
+        // Spaces, newlines, and tabs around the comma separators and around the entries themselves
+        // must all be tolerated and trimmed.
+        config.setAdvertisedListeners(
+                "  internal:pulsar://broker-1:6650 ,\n\texternal:pulsar://broker-1.public:6650  ");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(listeners.size(), 2);
+        assertEquals(listeners.get("internal").getBrokerServiceUrl(), URI.create("pulsar://broker-1:6650"));
+        assertEquals(listeners.get("external").getBrokerServiceUrl(),
+                URI.create("pulsar://broker-1.public:6650"));
+    }
+
+    @Test
+    public void testEmptyEntriesAreSkipped() {
+        ServiceConfiguration config = newConfigWithNoPorts();
+        config.setInternalListenerName("internal");
+        // A trailing comma or an extra comma in the middle should be ignored.
+        config.setAdvertisedListeners("internal:pulsar://broker-1:6650, ,external:pulsar://broker-1.public:6650,");
+        Map<String, AdvertisedListener> listeners =
+                MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
+        assertEquals(listeners.size(), 2);
+        assertEquals(listeners.get("internal").getBrokerServiceUrl(), URI.create("pulsar://broker-1:6650"));
+        assertEquals(listeners.get("external").getBrokerServiceUrl(),
+                URI.create("pulsar://broker-1.public:6650"));
+    }
+
+    private ServiceConfiguration newConfigWithNoPorts() {
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setBrokerServicePort(Optional.empty());
+        config.setBrokerServicePortTls(Optional.empty());
+        config.setWebServicePort(Optional.empty());
+        config.setWebServicePortTls(Optional.empty());
+        return config;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -39,6 +39,7 @@ import java.net.MalformedURLException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,6 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -134,9 +136,11 @@ import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
 import org.apache.pulsar.broker.transaction.buffer.impl.TransactionBufferClientImpl;
 import org.apache.pulsar.broker.transaction.pendingack.TransactionPendingAckStoreProvider;
 import org.apache.pulsar.broker.transaction.pendingack.impl.MLPendingAckStoreProvider;
+import org.apache.pulsar.broker.validator.BindAddressValidator;
 import org.apache.pulsar.broker.validator.MultipleListenerValidator;
 import org.apache.pulsar.broker.validator.TransactionBatchedWriteValidator;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.broker.web.RestProducerContext;
 import org.apache.pulsar.broker.web.WebService;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServlet;
 import org.apache.pulsar.broker.web.plugin.servlet.AdditionalServletWithClassLoader;
@@ -289,6 +293,8 @@ public class PulsarService implements AutoCloseable, ShutdownService {
 
     private BrokerInterceptor brokerInterceptor;
     private AdditionalServlets brokerAdditionalServlets;
+    @Getter
+    private final RestProducerContext restProducerContext = new RestProducerContext();
 
     // packages management service
     private PackagesManagement packagesManagement = null;
@@ -362,7 +368,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
         this.openTelemetry = new PulsarBrokerOpenTelemetry(config, openTelemetrySdkBuilderCustomizer);
 
         // validate `advertisedAddress`, `advertisedListeners`, `internalListenerName`
-        this.advertisedListeners = MultipleListenerValidator.validateAndAnalysisAdvertisedListener(config);
+        this.advertisedListeners = MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
 
         // the advertised address is defined as the host component of the broker's canonical name.
         this.advertisedAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(config.getAdvertisedAddress());
@@ -854,8 +860,11 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                 throw new PulsarServerException("Cannot start the service once it was stopped");
             }
 
-            if (config.getWebServicePort().isEmpty() && config.getWebServicePortTls().isEmpty()) {
-                throw new IllegalArgumentException("webServicePort/webServicePortTls must be present");
+            if (config.getWebServicePort().isEmpty()
+                    && config.getWebServicePortTls().isEmpty()
+                    && BindAddressValidator.validateBindAddresses(config, Arrays.asList("http", "https")).isEmpty()) {
+                throw new IllegalArgumentException(
+                        "webServicePort/webServicePortTls or http/https bindAddresses must be present");
             }
 
             if (config.isAuthorizationEnabled() && !config.isAuthenticationEnabled()) {
@@ -923,6 +932,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             managedLedgerStorage = newManagedLedgerStorage();
 
             this.brokerService = newBrokerService(this);
+            this.brokerService.addTopicEventListener(restProducerContext);
 
             // Start load management service (even if load balancing is disabled)
             this.loadManager.set(LoadManager.create(this));
@@ -962,13 +972,16 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             this.addWebServerHandlers(webService, metricsServlet, this.config);
             this.webService.start();
 
-            // Refresh addresses and update configuration, since the port might have been dynamically assigned
-            if (config.getBrokerServicePort().equals(Optional.of(0))) {
-                config.setBrokerServicePort(brokerService.getListenPort());
-            }
-            if (config.getBrokerServicePortTls().equals(Optional.of(0))) {
-                config.setBrokerServicePortTls(brokerService.getListenPortTls());
-            }
+            // Refresh addresses and update configuration based on the actual bound ports. This is
+            // necessary both for dynamic ports (`Optional.of(0)`) and for the case where the broker
+            // is configured only via `bindAddresses` (legacy port properties left as
+            // `Optional.empty()`), so that downstream code — in particular
+            // MultipleListenerValidator.validateAndUpdateAdvertisedListeners — can synthesize the
+            // internal advertised listener from the now-known ports.
+            brokerService.getListenPort().ifPresent(port -> config.setBrokerServicePort(Optional.of(port)));
+            brokerService.getListenPortTls().ifPresent(port -> config.setBrokerServicePortTls(Optional.of(port)));
+            // Recompute the cached advertised listener map now that the bound ports are known.
+            this.advertisedListeners = MultipleListenerValidator.validateAndUpdateAdvertisedListeners(config);
             this.webServiceAddress = webAddress(config);
             this.webServiceAddressTls = webAddressTls(config);
             this.brokerServiceUrl = brokerUrl(config);
@@ -1531,6 +1544,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
             List<CompletableFuture<Optional<Topic>>> persistentTopics = new ArrayList<>();
             long topicLoadStart = System.nanoTime();
 
+            AtomicInteger failedCount = new AtomicInteger(0);
             for (String topic : getNamespaceService().getListOfPersistentTopics(nsName)
                     .get(config.getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS)) {
                 try {
@@ -1538,7 +1552,10 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                     if (bundle.includes(topicName) && !isTransactionInternalName(topicName)) {
                         CompletableFuture<Optional<Topic>> future = brokerService.getTopicIfExists(topic);
                         if (future != null) {
-                            persistentTopics.add(future);
+                            persistentTopics.add(future.exceptionally(e -> {
+                                failedCount.incrementAndGet();
+                                return Optional.empty();
+                            }));
                         }
                     }
                 } catch (Throwable t) {
@@ -1555,6 +1572,7 @@ public class PulsarService implements AutoCloseable, ShutdownService {
                             .count();
                     log.info()
                             .attr("numTopicsLoaded", numTopicsLoaded)
+                            .attr("failedCount", failedCount.get())
                             .attr("bundle", bundle)
                             .attr("timeTakenSeconds", topicLoadTimeSeconds)
                             .log("Loaded topics on bundle");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.loadbalance.LeaderBroker;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import org.apache.pulsar.broker.service.Subscription;
@@ -1424,31 +1425,17 @@ public abstract class NamespacesBase extends AdminResource {
         }
         LeaderBroker leaderBroker = pulsar().getLeaderElectionService().getCurrentLeader().get();
         String leaderBrokerId = leaderBroker.getBrokerId();
+        LookupOptions lookupOptions = LookupOptions.builder()
+                .webServiceAdvertisedListenerName(getWebServiceListenerName()).build();
         return pulsar().getNamespaceService()
-                .createLookupResult(leaderBrokerId, false, null)
+                .createLookupResult(leaderBrokerId, false, lookupOptions)
                 .thenCompose(lookupResult -> {
-                    String redirectUrl = isRequestHttps() ? lookupResult.getLookupData().getHttpUrlTls()
-                            : lookupResult.getLookupData().getHttpUrl();
-                    if (redirectUrl == null) {
-                        log.error("Redirected broker's service url is not configured");
-                        return FutureUtil.failedFuture(new RestException(Response.Status.PRECONDITION_FAILED,
-                                "Redirected broker's service url is not configured."));
-                    }
-
-                    try {
-                        URL url = new URL(redirectUrl);
-                        URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(url.getHost())
-                                .port(url.getPort())
-                                .replaceQueryParam("authoritative",
-                                        false).build();
-                        // Redirect
-                            log.debug().attr("leader", redirect).log("Redirecting the request call to leader -");
-                                                return FutureUtil.failedFuture((
-                                new WebApplicationException(Response.temporaryRedirect(redirect).build())));
-                    } catch (MalformedURLException exception) {
-                        log.error().attr("malformed", redirectUrl).log("The redirect url is malformed -");
-                        return FutureUtil.failedFuture(new RestException(exception));
-                    }
+                    URI redirectUri = lookupResult.toRedirectUri(uri.getRequestUri());
+                    log.debug()
+                            .attr("leaderBrokerId", leaderBrokerId)
+                            .attr("redirectUri", redirectUri).log("Redirecting the request call to leader broker");
+                    return FutureUtil.failedFuture(
+                            new WebApplicationException(Response.temporaryRedirect(redirectUri).build()));
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -60,7 +60,7 @@ public class NoopLoadManager implements LoadManager {
         brokerId = pulsar.getBrokerId();
         localResourceUnit = new SimpleResourceUnit(brokerId, new PulsarResourceDescription());
 
-        LocalBrokerData localData = new LocalBrokerData(pulsar.getWebServiceAddress(),
+        LocalBrokerData localData = new LocalBrokerData(pulsar.getBrokerId(), pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(),
                 pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
         localData.setProtocols(pulsar.getProtocolDataToAdvertise());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/BrokerRegistryImpl.java
@@ -89,6 +89,7 @@ public class BrokerRegistryImpl implements BrokerRegistry {
         this.listeners = new ArrayList<>();
         this.brokerIdKeyPath = keyPath(pulsar.getBrokerId());
         this.brokerLookupData = new BrokerLookupData(
+                pulsar.getBrokerId(),
                 pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(),
                 pulsar.getBrokerServiceUrl(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupData.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.data;
 
-import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -31,7 +30,8 @@ import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 /**
  * Defines the information required to broker lookup.
  */
-public record BrokerLookupData (String webServiceUrl,
+public record BrokerLookupData (String brokerId,
+                                String webServiceUrl,
                                 String webServiceUrlTls,
                                 String pulsarServiceUrl,
                                 String pulsarServiceUrlTls,
@@ -43,6 +43,11 @@ public record BrokerLookupData (String webServiceUrl,
                                 long startTimestamp,
                                 String brokerVersion,
                                 Map<String, String> properties) implements ServiceLookupData {
+    @Override
+    public String getBrokerId() {
+        return this.brokerId;
+    }
+
     @Override
     public String getWebServiceUrl() {
         return this.webServiceUrl();
@@ -84,24 +89,20 @@ public record BrokerLookupData (String webServiceUrl,
     }
 
     public LookupResult toLookupResult(LookupOptions options) throws PulsarServerException {
-        if (options.hasAdvertisedListenerName()) {
-            AdvertisedListener listener = advertisedListeners.get(options.getAdvertisedListenerName());
-            if (listener == null) {
-                throw new PulsarServerException("the broker do not have "
-                        + options.getAdvertisedListenerName() + " listener");
-            }
-            URI url = listener.getBrokerServiceUrl();
-            URI urlTls = listener.getBrokerServiceUrlTls();
-            return new LookupResult(webServiceUrl, webServiceUrlTls,
-                    url == null ? null : url.toString(),
-                    urlTls == null ? null : urlTls.toString(), LookupResult.Type.BrokerUrl, false);
+        if (options.hasAdvertisedListenerName()
+                && !advertisedListeners.containsKey(options.getAdvertisedListenerName())) {
+            throw new PulsarServerException("the broker do not have "
+                    + options.getAdvertisedListenerName() + " listener");
         }
-        return new LookupResult(webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
-                LookupResult.Type.BrokerUrl, false);
+        return LookupResult.create(this, options);
+    }
+
+    public LookupResult toLoadManagerMigrationLookupResult(LookupOptions options) {
+        return LookupResult.create(this, options, false);
     }
 
     public NamespaceEphemeralData toNamespaceEphemeralData() {
-        return new NamespaceEphemeralData(pulsarServiceUrl, pulsarServiceUrlTls, webServiceUrl, webServiceUrlTls,
-                false, advertisedListeners);
+        return new NamespaceEphemeralData(brokerId, pulsarServiceUrl, pulsarServiceUrlTls, webServiceUrl,
+                webServiceUrlTls, false, advertisedListeners);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerForLoadManagerMigration.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerForLoadManagerMigration.java
@@ -34,24 +34,31 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
 import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.LockManager;
-import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 
+/**
+ * RedirectManagerForLoadManagerMigration checks if the current load manager class name is the same as the latest
+ * service lookup data.
+ * If not, it will redirect to a random broker with the same load manager class name.
+ * The name of this class is misleading since it doesn't manage all redirects.
+ */
 @CustomLog
-public class RedirectManager {
+public class RedirectManagerForLoadManagerMigration {
     private final PulsarService pulsar;
 
     private final LockManager<BrokerLookupData> brokerLookupDataLockManager;
 
 
-    public RedirectManager(PulsarService pulsar) {
+    public RedirectManagerForLoadManagerMigration(PulsarService pulsar) {
         this.pulsar = pulsar;
         this.brokerLookupDataLockManager = pulsar.getCoordinationService().getLockManager(BrokerLookupData.class);
     }
 
     @VisibleForTesting
-    public RedirectManager(PulsarService pulsar, LockManager<BrokerLookupData> brokerLookupDataLockManager) {
+    public RedirectManagerForLoadManagerMigration(PulsarService pulsar,
+                                                  LockManager<BrokerLookupData> brokerLookupDataLockManager) {
         this.pulsar = pulsar;
         this.brokerLookupDataLockManager = brokerLookupDataLockManager;
     }
@@ -75,7 +82,19 @@ public class RedirectManager {
         });
     }
 
-    public CompletableFuture<Optional<LookupResult>> findRedirectLookupResultAsync() {
+    /**
+     * Redirect the request to another broker if the load balancer on the current broker is using the load manager
+     * of the latest service lookup data available in the metadata store.
+     *
+     * @param options lookup options
+     * @return lookup result
+     */
+    public CompletableFuture<Optional<LookupResult>> redirectIfLoadBalancerOnBrokerIsNotExpected(
+            LookupOptions options) {
+        if (!pulsar.getConfiguration().isLoadManagerMigrationEnabled()) {
+            // no-op when load manager migration is disabled.
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
         String currentLMClassName = pulsar.getConfiguration().getLoadManagerClassName();
         boolean debug = ExtensibleLoadManagerImpl.debug(pulsar.getConfiguration(), log);
         return getAvailableBrokerLookupDataAsync().thenApply(lookupDataMap -> {
@@ -84,7 +103,7 @@ public class RedirectManager {
                 log.warn(errorMsg);
                 throw new IllegalStateException(errorMsg);
             }
-            AtomicReference<ServiceLookupData> latestServiceLookupData = new AtomicReference<>();
+            AtomicReference<BrokerLookupData> latestServiceLookupData = new AtomicReference<>();
             AtomicLong lastStartTimestamp = new AtomicLong(0L);
             lookupDataMap.forEach((key, value) -> {
                 if (lastStartTimestamp.get() <= value.getStartTimestamp()) {
@@ -106,7 +125,7 @@ public class RedirectManager {
                 return Optional.empty();
             }
             var serviceLookupDataObj = latestServiceLookupData.get();
-            var candidateBrokers = new ArrayList<ServiceLookupData>();
+            var candidateBrokers = new ArrayList<BrokerLookupData>();
             lookupDataMap.forEach((key, value) -> {
                 if (Objects.equals(value.getLoadManagerClassName(), serviceLookupDataObj.getLoadManagerClassName())) {
                     candidateBrokers.add(value);
@@ -114,12 +133,7 @@ public class RedirectManager {
             });
             var selectedBroker = candidateBrokers.get((int) (Math.random() * candidateBrokers.size()));
 
-            return Optional.of(new LookupResult(selectedBroker.getWebServiceUrl(),
-                    selectedBroker.getWebServiceUrlTls(),
-                    selectedBroker.getPulsarServiceUrl(),
-                    selectedBroker.getPulsarServiceUrlTls(),
-                    true));
+            return Optional.of(selectedBroker.toLoadManagerMigrationLookupResult(options));
         });
     }
-
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -993,15 +993,17 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
             // At this point, the ports will be updated with the real port number that the server was assigned
             Map<String, String> protocolData = pulsar.getProtocolDataToAdvertise();
 
-            lastData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
-                    pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
+            lastData = new LocalBrokerData(pulsar.getBrokerId(), pulsar.getWebServiceAddress(),
+                    pulsar.getWebServiceAddressTls(), pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(),
+                    pulsar.getAdvertisedListeners());
             lastData.setProtocols(protocolData);
             // configure broker-topic mode
             lastData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
             lastData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
 
-            localData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
-                    pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(), pulsar.getAdvertisedListeners());
+            localData = new LocalBrokerData(pulsar.getBrokerId(), pulsar.getWebServiceAddress(),
+                    pulsar.getWebServiceAddressTls(), pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls(),
+                    pulsar.getAdvertisedListeners());
             localData.setProtocols(protocolData);
             localData.setBrokerVersionString(pulsar.getBrokerVersion());
             // configure broker-topic mode

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/LookupResult.java
@@ -18,8 +18,24 @@
  */
 package org.apache.pulsar.broker.lookup;
 
+import static org.apache.pulsar.broker.lookup.v2.TopicLookup.LISTENERNAME_PARAM;
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import lombok.Builder;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 
 /**
  * Represent a lookup result.
@@ -29,42 +45,173 @@ import org.apache.pulsar.common.lookup.data.LookupData;
  */
 public class LookupResult {
     public enum Type {
-        BrokerUrl, RedirectUrl
+        BrokerUrl, RedirectUrl, LoadManagerMigrationUrl
     }
 
     private final Type type;
-    private final LookupData lookupData;
     private final boolean authoritativeRedirect;
+    @Getter
+    private final String brokerServiceListenerName;
+    @Getter
+    private final String webServiceListenerName;
+    private final LookupData lookupData;
 
-    public LookupResult(NamespaceEphemeralData namespaceEphemeralData) {
-        this.type = Type.BrokerUrl;
-        this.authoritativeRedirect = false;
-        this.lookupData = new LookupData(namespaceEphemeralData.getNativeUrl(),
-                namespaceEphemeralData.getNativeUrlTls(), namespaceEphemeralData.getHttpUrl(),
-                namespaceEphemeralData.getHttpUrlTls());
-    }
-
-    public LookupResult(String httpUrl, String httpUrlTls, String brokerServiceUrl, String brokerServiceUrlTls,
-            boolean authoritativeRedirect) {
-        this.type = Type.RedirectUrl; // type = redirect => as current broker is
-                                      // not owner and prepares LookupResult
-                                      // with other broker's urls
+    @Builder
+    private LookupResult(String brokerId, String httpUrl, String httpUrlTls, String brokerServiceUrl,
+                         String brokerServiceUrlTls, Type type, boolean authoritativeRedirect,
+                         String brokerServiceListenerName, String webServiceListenerName) {
+        this.type = Objects.requireNonNull(type);
         this.authoritativeRedirect = authoritativeRedirect;
-        this.lookupData = new LookupData(brokerServiceUrl, brokerServiceUrlTls, httpUrl, httpUrlTls);
+        this.brokerServiceListenerName = brokerServiceListenerName;
+        this.webServiceListenerName = webServiceListenerName;
+        this.lookupData = new LookupData(brokerId, brokerServiceUrl, brokerServiceUrlTls, httpUrl, httpUrlTls);
     }
 
-    public LookupResult(String httpUrl, String httpUrlTls, String nativeUrl, String nativeUrlTls, Type type,
-            boolean authoritativeRedirect) {
-        this.type = type;
-        this.authoritativeRedirect = authoritativeRedirect;
-        this.lookupData = new LookupData(nativeUrl, nativeUrlTls, httpUrl, httpUrlTls);
+    public static LookupResult create(BrokerLookupData selectedBroker, LookupOptions options,
+                                      boolean authoritativeRedirect) {
+        return internalCreate(selectedBroker, options, Type.RedirectUrl, authoritativeRedirect);
     }
 
-    public LookupResult(NamespaceEphemeralData namespaceEphemeralData, String nativeUrl, String nativeUrlTls) {
-        this.type = Type.BrokerUrl;
-        this.authoritativeRedirect = false;
-        this.lookupData = new LookupData(nativeUrl, nativeUrlTls, namespaceEphemeralData.getHttpUrl(),
-                namespaceEphemeralData.getHttpUrlTls());
+    public static LookupResult createLoadManagerMigrationLookupResult(BrokerLookupData selectedBroker,
+                                                                      LookupOptions options) {
+        return internalCreate(selectedBroker, options, Type.LoadManagerMigrationUrl, false);
+    }
+
+    public static LookupResult create(BrokerLookupData selectedBroker, LookupOptions options) {
+        return internalCreate(selectedBroker, options, Type.BrokerUrl, false);
+    }
+
+    private static LookupResult internalCreate(BrokerLookupData selectedBroker, LookupOptions options,
+                                               Type type, boolean authoritativeRedirect) {
+        return internalCreate(options, type, authoritativeRedirect, selectedBroker.getBrokerId(),
+                selectedBroker.getWebServiceUrl(), selectedBroker.getWebServiceUrlTls(),
+                selectedBroker.getPulsarServiceUrl(), selectedBroker.getPulsarServiceUrlTls(),
+                selectedBroker.advertisedListeners());
+    }
+
+    public static LookupResult create(LocalBrokerData selectedBroker, LookupOptions options,
+                                      boolean authoritativeRedirect) {
+        return internalCreate(selectedBroker, options, Type.RedirectUrl, authoritativeRedirect);
+    }
+
+    public static LookupResult create(LocalBrokerData selectedBroker, LookupOptions options) {
+        return internalCreate(selectedBroker, options, Type.BrokerUrl, false);
+    }
+
+    private static LookupResult internalCreate(LocalBrokerData selectedBroker, LookupOptions options,
+                                               Type type, boolean authoritativeRedirect) {
+        return internalCreate(options, type, authoritativeRedirect, selectedBroker.getBrokerId(),
+                selectedBroker.getWebServiceUrl(), selectedBroker.getWebServiceUrlTls(),
+                selectedBroker.getPulsarServiceUrl(), selectedBroker.getPulsarServiceUrlTls(),
+                selectedBroker.getAdvertisedListeners());
+    }
+
+    public static LookupResult create(NamespaceEphemeralData nsData, LookupOptions options) {
+        return internalCreate(nsData, options, Type.BrokerUrl, false);
+    }
+
+    public static LookupResult create(NamespaceEphemeralData nsData, LookupOptions options,
+                                      boolean authoritativeRedirect) {
+        return internalCreate(nsData, options, Type.RedirectUrl, authoritativeRedirect);
+    }
+
+    private static LookupResult internalCreate(NamespaceEphemeralData nsData, LookupOptions options, Type type,
+                                               boolean authoritativeRedirect) {
+        return internalCreate(options, type, authoritativeRedirect, nsData.getBrokerId(), nsData.getHttpUrl(),
+                nsData.getHttpUrlTls(), nsData.getNativeUrl(), nsData.getNativeUrlTls(),
+                nsData.getAdvertisedListeners());
+    }
+
+    private static LookupResult internalCreate(LookupOptions options, Type type,
+                                               boolean authoritativeRedirect, String brokerId, String webServiceUrl,
+                                               String webServiceUrlTls, String pulsarServiceUrl,
+                                               String pulsarServiceUrlTls,
+                                               Map<String, AdvertisedListener> advertisedListeners) {
+        UrlOverride urls = new UrlOverride(webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls);
+
+        AdvertisedListener brokerListener = lookupListener(options, advertisedListeners,
+                LookupOptions::hasAdvertisedListenerName, LookupOptions::getAdvertisedListenerName);
+        if (brokerListener != null) {
+            urls.brokerServiceListenerName = options.getAdvertisedListenerName();
+            urls.applyBrokerServiceOverride(brokerListener);
+        }
+
+        AdvertisedListener webListener = lookupListener(options, advertisedListeners,
+                LookupOptions::hasWebServiceAdvertisedListenerName,
+                LookupOptions::getWebServiceAdvertisedListenerName);
+        if (webListener != null) {
+            urls.webServiceListenerName = options.getWebServiceAdvertisedListenerName();
+            urls.applyWebServiceOverride(webListener);
+            // default the brokerServiceListenerName to the webServiceAdvertisedListenerName if the
+            // listener also configures broker service URLs and no separate advertisedListenerName was given
+            if (urls.brokerServiceListenerName == null
+                    && (webListener.getBrokerServiceUrl() != null || webListener.getBrokerServiceUrlTls() != null)) {
+                urls.brokerServiceListenerName = options.getWebServiceAdvertisedListenerName();
+                urls.applyBrokerServiceOverride(webListener);
+            }
+        }
+
+        // for backwards compatibility, derive the brokerId from webServiceUrl or webServiceUrlTls by
+        // parsing the URL and taking host:port. This is a transient state that may occur during a
+        // rolling upgrade when older brokers in the cluster do not yet publish a brokerId in their
+        // ephemeral data; once all brokers have been upgraded, the brokerId field is always populated.
+        if (brokerId == null && (webServiceUrl != null || webServiceUrlTls != null)) {
+            URI url = URI.create(webServiceUrl != null ? webServiceUrl : webServiceUrlTls);
+            if (url.getHost() != null && url.getPort() != -1) {
+                brokerId = url.getHost() + ":" + url.getPort();
+            }
+        }
+
+        return builder()
+                .type(type)
+                .brokerId(brokerId)
+                .httpUrl(urls.httpUrl)
+                .httpUrlTls(urls.httpUrlTls)
+                .brokerServiceUrl(urls.brokerServiceUrl)
+                .brokerServiceUrlTls(urls.brokerServiceUrlTls)
+                .authoritativeRedirect(authoritativeRedirect)
+                .brokerServiceListenerName(urls.brokerServiceListenerName)
+                .webServiceListenerName(urls.webServiceListenerName)
+                .build();
+    }
+
+    private static AdvertisedListener lookupListener(LookupOptions options,
+                                                     Map<String, AdvertisedListener> advertisedListeners,
+                                                     Predicate<LookupOptions> hasName,
+                                                     Function<LookupOptions, String> getName) {
+        if (options == null || !hasName.test(options)) {
+            return null;
+        }
+        return advertisedListeners.get(getName.apply(options));
+    }
+
+    /** Mutable URL-set used while resolving listener-specific overrides for a LookupResult. */
+    private static final class UrlOverride {
+        String httpUrl;
+        String httpUrlTls;
+        String brokerServiceUrl;
+        String brokerServiceUrlTls;
+        String brokerServiceListenerName;
+        String webServiceListenerName;
+
+        UrlOverride(String httpUrl, String httpUrlTls, String brokerServiceUrl, String brokerServiceUrlTls) {
+            this.httpUrl = httpUrl;
+            this.httpUrlTls = httpUrlTls;
+            this.brokerServiceUrl = brokerServiceUrl;
+            this.brokerServiceUrlTls = brokerServiceUrlTls;
+        }
+
+        void applyBrokerServiceOverride(AdvertisedListener listener) {
+            brokerServiceUrl = listener.getBrokerServiceUrl() != null
+                    ? listener.getBrokerServiceUrl().toString() : null;
+            brokerServiceUrlTls = listener.getBrokerServiceUrlTls() != null
+                    ? listener.getBrokerServiceUrlTls().toString() : null;
+        }
+
+        void applyWebServiceOverride(AdvertisedListener listener) {
+            httpUrl = listener.getBrokerHttpUrl() != null ? listener.getBrokerHttpUrl().toString() : null;
+            httpUrlTls = listener.getBrokerHttpsUrl() != null ? listener.getBrokerHttpsUrl().toString() : null;
+        }
     }
 
     public boolean isBrokerUrl() {
@@ -72,7 +219,11 @@ public class LookupResult {
     }
 
     public boolean isRedirect() {
-        return type == Type.RedirectUrl;
+        return type == Type.RedirectUrl || type == Type.LoadManagerMigrationUrl;
+    }
+
+    public boolean isLoadManagerMigration() {
+        return type == Type.LoadManagerMigrationUrl;
     }
 
     public boolean isAuthoritativeRedirect() {
@@ -83,9 +234,94 @@ public class LookupResult {
         return lookupData;
     }
 
-    @Override
-    public String toString() {
-        return "LookupResult [type=" + type + ", lookupData=" + lookupData + "]";
+    /**
+     * Creates a redirect URI by replacing the host, port and scheme of the given request URI with the
+     * web service URL of this lookup result. The original path and query parameters are preserved.
+     * The {@code authoritative} query parameter is set from this lookup result's
+     * {@link #isAuthoritativeRedirect()} value when the result is a redirect, and removed otherwise.
+     *
+     * @param requestUri the incoming request URI (its scheme decides whether the HTTP or HTTPS
+     *                   broker URL is used as the redirect target)
+     * @return the redirect URI
+     */
+    public URI toRedirectUri(URI requestUri) {
+        return toRedirectUriInternal(requestUri, this.authoritativeRedirect, false);
     }
 
+    /**
+     * Same as {@link #toRedirectUri(URI)} but overrides the {@code authoritative} query parameter
+     * with the supplied value (e.g. when the current broker is the leader and must mark the
+     * redirect as authoritative regardless of what the lookup result carried).
+     */
+    public URI toRedirectUri(URI requestUri, boolean authoritativeRedirectOverride) {
+        return toRedirectUriInternal(requestUri, authoritativeRedirectOverride, false);
+    }
+
+    /**
+     * Same as {@link #toRedirectUri(URI)} but specialised for topic-lookup redirects: when this
+     * {@code LookupResult} has a resolved {@code brokerServiceListenerName} it is always written to
+     * the {@code listenerName} query parameter on the redirect URI. This handles the case where the
+     * original lookup request carried the listener name in a header rather than as a query
+     * parameter — the header does not survive an HTTP redirect, so the parameter form must be
+     * propagated to the next broker. Other (non-lookup) redirect paths use {@link #toRedirectUri}
+     * and leave the parameter alone.
+     */
+    public URI toLookupRedirectUri(URI requestUri) {
+        return toRedirectUriInternal(requestUri, this.authoritativeRedirect, true);
+    }
+
+    private URI toRedirectUriInternal(URI requestUri, boolean authoritativeRedirect,
+                                      boolean injectListenerNameQueryParam) {
+        boolean requireHttps = "https".equalsIgnoreCase(requestUri.getScheme());
+        String webServiceUrl = requireHttps ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
+        if (webServiceUrl == null) {
+            // Preserve the legacy 412 error semantics when the redirect target broker has no URL
+            // configured for the requested scheme.
+            String scheme = requireHttps ? "https" : "http";
+            StringBuilder entity = new StringBuilder()
+                    .append("No ").append(scheme).append(" URL configured for broker ")
+                    .append(lookupData.getBrokerId());
+            if (StringUtils.isNotBlank(webServiceListenerName)) {
+                entity.append(" on web service listener `").append(webServiceListenerName).append("`");
+            } else if (StringUtils.isNotBlank(brokerServiceListenerName)) {
+                entity.append(" on listener `").append(brokerServiceListenerName).append("`");
+            }
+            throw new WebApplicationException(Response.status(Response.Status.PRECONDITION_FAILED)
+                    .entity(entity.toString())
+                    .build());
+        }
+        URI webServiceUri = URI.create(webServiceUrl);
+        UriBuilder uriBuilder =
+                UriBuilder.fromUri(requestUri) // use the path and query parameters from the request URI
+                        .scheme(webServiceUri.getScheme()) // use the schema from the lookup result
+                        .host(webServiceUri.getHost())  // use the host from the lookup result
+                        .port(webServiceUri.getPort()); // use the port from the lookup result
+        if (isRedirect()) {
+            // pass the authoritative parameter only when the type is redirect
+            uriBuilder.replaceQueryParam("authoritative", authoritativeRedirect);
+        } else {
+            // remove the parameter when the type is not redirect
+            uriBuilder.replaceQueryParam("authoritative");
+        }
+        // Only set the listenerName query parameter on topic-lookup redirects. The original lookup
+        // request can carry it either as a query parameter or as a header; the latter does not
+        // survive an HTTP redirect, so the resolved listener name must be reinjected as a query
+        // parameter so the next broker sees it. Other redirect paths (admin endpoints) do not
+        // understand `listenerName` as a parameter, so for those we leave the request URI alone.
+        if (injectListenerNameQueryParam && StringUtils.isNotBlank(brokerServiceListenerName)) {
+            uriBuilder.replaceQueryParam(LISTENERNAME_PARAM, brokerServiceListenerName);
+        }
+        return uriBuilder.build();
+    }
+
+    @Override
+    public String toString() {
+        return "LookupResult{"
+                + "type=" + type
+                + ", lookupData=" + lookupData
+                + ", authoritativeRedirect=" + authoritativeRedirect
+                + ", brokerServiceListenerName='" + brokerServiceListenerName + '\''
+                + ", webServiceListenerName='" + webServiceListenerName + '\''
+                + '}';
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookupBase.java
@@ -23,10 +23,10 @@ import static org.apache.pulsar.common.protocol.Commands.newLookupResponse;
 import io.netty.buffer.ByteBuf;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -60,8 +60,10 @@ public class TopicLookupBase extends PulsarWebResource {
 
     protected CompletableFuture<LookupData> internalLookupTopicAsync(final TopicName topicName, boolean authoritative,
                                                                      String listenerName) {
-        if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
-            log.warn().attr("topic", topicName).log("No broker was found available for topic");
+        Semaphore lookupRequestSemaphore = pulsar().getBrokerService().getLookupRequestSemaphore();
+        if (!lookupRequestSemaphore.tryAcquire()) {
+            log.warn().attr("topic", topicName)
+                    .log("Cannot acquire lookup request semaphore, rejecting lookup request");
             return FutureUtil.failedFuture(new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
         }
         return validateGlobalNamespaceOwnershipAsync(topicName.getNamespaceObject())
@@ -89,13 +91,13 @@ public class TopicLookupBase extends PulsarWebResource {
                         throw new RestException(Response.Status.NOT_FOUND,
                                 String.format("Topic not found %s", topicName.toString()));
                     }
+                    LookupOptions lookupOptions = LookupOptions.builder()
+                            .advertisedListenerName(listenerName)
+                            .webServiceAdvertisedListenerName(getWebServiceListenerName())
+                            .authoritative(authoritative)
+                            .build();
                     CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                            .getBrokerServiceUrlAsync(topicName,
-                                    LookupOptions.builder()
-                                            .advertisedListenerName(listenerName)
-                                            .authoritative(authoritative)
-                                            .loadTopicsInBundle(false)
-                                            .build());
+                            .getBrokerServiceUrlAsync(topicName, lookupOptions);
 
                     return lookupFuture.thenApply(optionalResult -> {
                         if (optionalResult == null || !optionalResult.isPresent()) {
@@ -103,52 +105,43 @@ public class TopicLookupBase extends PulsarWebResource {
                             throw new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE);
                         }
 
-                        LookupResult result = optionalResult.get();
+                        LookupResult lookupResult = optionalResult.get();
+
+                        if (lookupResult.isLoadManagerMigration()) {
+                            URI redirectUri = lookupResult.toLookupRedirectUri(uri.getRequestUri());
+                            log.debug().log("Redirecting to a broker with the expected load manager.");
+                            throw new WebApplicationException(Response.temporaryRedirect(redirectUri).build());
+                        }
+
                         // We have found either a broker that owns the topic, or a broker to
                         // which we should redirect the client to
-                        if (result.isRedirect()) {
-                            boolean newAuthoritative = result.isAuthoritativeRedirect();
-                            URI redirect;
-                            try {
-                                String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
-                                        : result.getLookupData().getHttpUrl();
-                                if (redirectUrl == null) {
-                                    log.error("Redirected cluster's service url is not configured");
-                                    throw new RestException(Response.Status.PRECONDITION_FAILED,
-                                            "Redirected cluster's service url is not configured.");
-                                }
-                                String lookupPath = LOOKUP_PATH;
-                                String path = String.format("%s%s%s?authoritative=%s",
-                                        redirectUrl, lookupPath, topicName.getLookupName(), newAuthoritative);
-                                path = listenerName == null ? path : path + "&listenerName=" + listenerName;
-                                redirect = new URI(path);
-                            } catch (URISyntaxException e) {
-                                log.error()
-                                        .attr("topic", topicName)
-                                        .exception(e)
-                                        .log("Error in preparing redirect url");
-                                throw new RestException(Response.Status.PRECONDITION_FAILED, e.getMessage());
+                        if (lookupResult.isRedirect()) {
+                            URI requestUri = uri.getRequestUri();
+                            if (!requestUri.getPath().startsWith(LOOKUP_PATH)) {
+                                throw new UnsupportedOperationException(
+                                        "This implementation expects that the requestUri is a topic lookup.");
                             }
-                                log.debug()
-                                        .attr("topic", topicName)
-                                        .attr("redirect", redirect)
-                                        .log("Redirect lookup for topic");
-                                throw new WebApplicationException(
-                                        Response.temporaryRedirect(redirect).build());
+                            URI redirectUri = lookupResult.toLookupRedirectUri(requestUri);
+                            log.debug()
+                                    .attr("topic", topicName)
+                                    .attr("redirectUri", redirectUri)
+                                    .log("Redirect lookup for topic");
+                            throw new WebApplicationException(Response.temporaryRedirect(redirectUri).build());
                         } else {
                             // Found broker owning the topic
-                                log.debug()
-                                        .attr("topic", topicName)
-                                        .attr("broker", result.getLookupData())
-                                        .log("Lookup succeeded for topic - broker");
-                                                        pulsar().getBrokerService().getLookupRequestSemaphore()
-                                                                .release();
-                            return result.getLookupData();
+                            log.debug()
+                                    .attr("topic", topicName)
+                                    .attr("broker", lookupResult.getLookupData())
+                                    .log("Lookup succeeded for topic - broker");
+                            return lookupResult.getLookupData();
                         }
                     });
-                }).exceptionally(ex -> {
-                    pulsar().getBrokerService().getLookupRequestSemaphore().release();
-                    throw FutureUtil.wrapToCompletionException(ex);
+                }).handle((lookupData, throwable) -> {
+                    lookupRequestSemaphore.release();
+                    if (throwable != null) {
+                        throw FutureUtil.wrapToCompletionException(throwable);
+                    }
+                    return lookupData;
                 });
     }
 
@@ -276,21 +269,22 @@ public class TopicLookupBase extends PulsarWebResource {
                         .properties(properties)
                         .build();
                 pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topicName, options)
-                        .thenAccept(lookupResult -> {
-                                LOG.debug()
-                                        .attr("toString", topicName.toString())
-                                        .attr("result", lookupResult)
-                                        .log("Lookup result");
-                                                        if (!lookupResult.isPresent()) {
+                        .thenAccept(optLookupResult -> {
+                            LOG.debug()
+                                    .attr("toString", topicName.toString())
+                                    .attr("result", optLookupResult)
+                                    .log("Lookup result");
+                            if (!optLookupResult.isPresent()) {
                                 lookupfuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady,
                                         "No broker was available to own " + topicName, requestId));
                                 return;
                             }
 
-                            LookupData lookupData = lookupResult.get().getLookupData();
+                            LookupResult lookupResult = optLookupResult.get();
+                            LookupData lookupData = lookupResult.getLookupData();
                             printWarnLogIfLookupResUnexpected(topicName, lookupData, options, pulsarService);
-                            if (lookupResult.get().isRedirect()) {
-                                boolean newAuthoritative = lookupResult.get().isAuthoritativeRedirect();
+                            if (lookupResult.isRedirect()) {
+                                boolean newAuthoritative = lookupResult.isAuthoritativeRedirect();
                                 lookupfuture.complete(
                                         newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),
                                                 newAuthoritative, LookupType.Redirect, requestId, false));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/v2/TopicLookup.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.common.naming.TopicName;
 public class TopicLookup extends TopicLookupBase {
 
     static final String LISTENERNAME_HEADER = "X-Pulsar-ListenerName";
+    public static final String LISTENERNAME_PARAM = "listenerName";
 
     @GET
     @Path("{topic-domain}/{tenant}/{namespace}/{topic}")
@@ -58,7 +59,7 @@ public class TopicLookup extends TopicLookupBase {
             @PathParam("topic-domain") String topicDomain, @PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace, @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
-            @QueryParam("listenerName") String listenerName,
+            @QueryParam(LISTENERNAME_PARAM) String listenerName,
             @HeaderParam(LISTENERNAME_HEADER) String listenerNameHeader) {
         TopicName topicName = getTopicName(topicDomain, tenant, namespace, encodedTopic);
         if (StringUtils.isEmpty(listenerName) && StringUtils.isNotEmpty(listenerNameHeader)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/LookupOptions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/LookupOptions.java
@@ -41,14 +41,13 @@ public class LookupOptions {
      */
     private final boolean loadTopicsInBundle;
 
-    /**
-     * The lookup request was made through HTTPs.
-     */
-    private final boolean requestHttps;
-
+    private final String webServiceAdvertisedListenerName;
     private final String advertisedListenerName;
     private final Map<String, String> properties;
 
+    public boolean hasWebServiceAdvertisedListenerName() {
+        return StringUtils.isNotBlank(webServiceAdvertisedListenerName);
+    }
     public boolean hasAdvertisedListenerName() {
         return StringUtils.isNotBlank(advertisedListenerName);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceEphemeralData.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.jspecify.annotations.NonNull;
@@ -29,6 +30,12 @@ import org.jspecify.annotations.NonNull;
 @Data
 @NoArgsConstructor
 public class NamespaceEphemeralData {
+    // The brokerId field was added later. During a rolling upgrade, entries written by older brokers may not
+    // contain it (LookupResult derives it from the URL host:port in that case). Exclude it from equals/hashCode
+    // so that consumers of this object do not see spurious "changed" notifications when the same logical owner
+    // transitions from a missing brokerId to a populated one.
+    @EqualsAndHashCode.Exclude
+    private String brokerId;
     private String nativeUrl;
     private String nativeUrlTls;
     private String httpUrl;
@@ -36,13 +43,15 @@ public class NamespaceEphemeralData {
     private boolean disabled;
     private Map<String, AdvertisedListener> advertisedListeners;
 
-    public NamespaceEphemeralData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls,
-            boolean disabled) {
-        this(brokerUrl, brokerUrlTls, httpUrl, httpUrlTls, disabled, null);
+    public NamespaceEphemeralData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl,
+                                  String httpUrlTls, boolean disabled) {
+        this(brokerId, brokerUrl, brokerUrlTls, httpUrl, httpUrlTls, disabled, null);
     }
 
-    public NamespaceEphemeralData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls,
-                                  boolean disabled, Map<String, AdvertisedListener> advertisedListeners) {
+    public NamespaceEphemeralData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl,
+                                  String httpUrlTls, boolean disabled,
+                                  Map<String, AdvertisedListener> advertisedListeners) {
+        this.brokerId = brokerId;
         this.nativeUrl = brokerUrl;
         this.nativeUrlTls = brokerUrlTls;
         this.httpUrl = httpUrl;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -30,8 +30,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.prometheus.client.Counter;
-import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -66,7 +64,7 @@ import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
-import org.apache.pulsar.broker.loadbalance.extensions.manager.RedirectManager;
+import org.apache.pulsar.broker.loadbalance.extensions.manager.RedirectManagerForLoadManagerMigration;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
@@ -111,7 +109,6 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
-import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.jspecify.annotations.Nullable;
 
@@ -149,7 +146,7 @@ public class NamespaceService implements AutoCloseable {
 
     private final List<NamespaceBundleSplitListener> bundleSplitListeners;
 
-    private final RedirectManager redirectManager;
+    private final RedirectManagerForLoadManagerMigration redirectManagerForLoadManagerMigration;
 
     public static final String LOOKUP_REQUEST_DURATION_METRIC_NAME = "pulsar.broker.request.topic.lookup.duration";
 
@@ -199,7 +196,7 @@ public class NamespaceService implements AutoCloseable {
         this.bundleOwnershipListeners = new CopyOnWriteArrayList<>();
         this.bundleSplitListeners = new CopyOnWriteArrayList<>();
         this.localBrokerDataCache = pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
-        this.redirectManager = new RedirectManager(pulsar);
+        this.redirectManagerForLoadManagerMigration = new RedirectManagerForLoadManagerMigration(pulsar);
 
         this.lookupLatencyHistogram = pulsar.getOpenTelemetry().getMeter()
                 .histogramBuilder(LOOKUP_REQUEST_DURATION_METRIC_NAME)
@@ -220,7 +217,8 @@ public class NamespaceService implements AutoCloseable {
         CompletableFuture<Optional<LookupResult>> future = getBundleAsync(topic)
                 .thenCompose(bundle -> {
                     // Do redirection if the cluster is in rollback or deploying.
-                    return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
+                    return redirectIfLoadBalancerOnBrokerIsNotExpected(bundle, options).thenCompose(
+                            optResult -> {
                         if (optResult.isPresent()) {
                             log.info()
                                     .attr("brokerId", pulsar.getBrokerId())
@@ -265,11 +263,12 @@ public class NamespaceService implements AutoCloseable {
         return future;
     }
 
-    private CompletableFuture<Optional<LookupResult>> findRedirectLookupResultAsync(ServiceUnitId bundle) {
+    private CompletableFuture<Optional<LookupResult>> redirectIfLoadBalancerOnBrokerIsNotExpected(
+            ServiceUnitId bundle, LookupOptions options) {
         if (isSLAOrHeartbeatNamespace(bundle.getNamespaceObject().toString())) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        return redirectManager.findRedirectLookupResultAsync();
+        return redirectManagerForLoadManagerMigration.redirectIfLoadBalancerOnBrokerIsNotExpected(options);
     }
 
     public CompletableFuture<NamespaceBundle> getBundleAsync(TopicName topic) {
@@ -303,84 +302,63 @@ public class NamespaceService implements AutoCloseable {
      * <p>
      * If the service unit is not owned, return a CompletableFuture with empty optional.
      */
-    public CompletableFuture<Optional<URL>> getWebServiceUrlAsync(ServiceUnitId suName, LookupOptions options) {
+    public CompletableFuture<Optional<LookupResult>> getLookupResultForWebRequestAsync(ServiceUnitId suName,
+                                                                                       LookupOptions options) {
         if (suName instanceof TopicName name) {
-                log.debug()
-                        .attr("topic", name)
-                        .attr("options", options)
-                        .log("Getting web service URL of topic: - options");
-                        return getBundleAsync(name)
+            log.debug()
+                    .attr("topic", name)
+                    .attr("options", options)
+                    .log("Getting web service URL of topic: - options");
+            return getBundleAsync(name)
                     .thenCompose(namespaceBundle ->
-                            internalGetWebServiceUrl(name, namespaceBundle, options));
+                            internalGetLookupResultForWebRequestAsync(name, namespaceBundle, options));
         }
 
         if (suName instanceof NamespaceName namespaceName) {
             return getFullBundleAsync(namespaceName)
                     .thenCompose(namespaceBundle ->
-                            internalGetWebServiceUrl(null, namespaceBundle, options));
+                            internalGetLookupResultForWebRequestAsync(null, namespaceBundle, options));
         }
 
         if (suName instanceof NamespaceBundle namespaceBundle) {
-            return internalGetWebServiceUrl(null, namespaceBundle, options);
+            return internalGetLookupResultForWebRequestAsync(null, namespaceBundle, options);
         }
 
         throw new IllegalArgumentException("Unrecognized class of NamespaceBundle: " + suName.getClass().getName());
     }
 
     /**
-     * Return the URL of the broker who's owning a particular service unit.
-     * <p>
-     * If the service unit is not owned, return an empty optional
+     * Return the LookupResult of the broker that owns a particular service unit.
+     *
+     * <p>The returned LookupResult will not necessarily point to the broker that currently owns the service unit.
+     * When the cluster contains multiple brokers with different load manager implementations (e.g. during a
+     * load-manager migration), the LookupResult may point to a broker running the expected load manager, so the
+     * caller redirects the request to a broker that can handle it.
+     *
+     * <p>If the service unit is not owned, return an empty optional.
      */
-    public Optional<URL> getWebServiceUrl(ServiceUnitId suName, LookupOptions options) throws Exception {
-        return getWebServiceUrlAsync(suName, options)
+    public Optional<LookupResult> getLookupResultForWebRequest(ServiceUnitId suName, LookupOptions options)
+            throws Exception {
+        return getLookupResultForWebRequestAsync(suName, options)
                 .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), SECONDS);
     }
 
-    private CompletableFuture<Optional<URL>> internalGetWebServiceUrl(@Nullable ServiceUnitId topic,
-                                                                      NamespaceBundle bundle,
-                                                                      LookupOptions options) {
-        return findRedirectLookupResultAsync(bundle).thenCompose(optResult -> {
+    private CompletableFuture<Optional<LookupResult>> internalGetLookupResultForWebRequestAsync(
+            @Nullable ServiceUnitId topic, NamespaceBundle bundle, LookupOptions options) {
+        return redirectIfLoadBalancerOnBrokerIsNotExpected(bundle, options).thenCompose(optResult -> {
             if (optResult.isPresent()) {
                 log.info()
                         .attr("brokerId", pulsar.getBrokerId())
                         .attr("redirect", optResult.get())
                         .attr("topic", topic)
                         .log("Redirect lookup request");
-                try {
-                    LookupData lookupData = optResult.get().getLookupData();
-                    final String redirectUrl = options.isRequestHttps()
-                            ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
-                    return CompletableFuture.completedFuture(Optional.of(new URL(redirectUrl)));
-                } catch (Exception e) {
-                    // just log the exception, nothing else to do
-                    log.warn()
-                            .exception(e)
-                            .log("internalGetWebServiceUrl");
-                }
-                return CompletableFuture.completedFuture(Optional.empty());
+                return CompletableFuture.completedFuture(optResult);
             }
             CompletableFuture<Optional<LookupResult>> future =
                     ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)
                     ? loadManager.get().findBrokerServiceUrl(Optional.ofNullable(topic), bundle, options) :
                     findBrokerServiceUrl(bundle, options);
-
-            return future.thenApply(lookupResult -> {
-                if (lookupResult.isPresent()) {
-                    try {
-                        LookupData lookupData = lookupResult.get().getLookupData();
-                        final String redirectUrl = options.isRequestHttps()
-                                ? lookupData.getHttpUrlTls() : lookupData.getHttpUrl();
-                        return Optional.of(new URL(redirectUrl));
-                    } catch (Exception e) {
-                        // just log the exception, nothing else to do
-                        log.warn()
-                                .exception(e)
-                                .log("internalGetWebServiceUrl");
-                    }
-                }
-                return Optional.empty();
-            });
+            return future;
         });
     }
 
@@ -472,11 +450,11 @@ public class NamespaceService implements AutoCloseable {
      */
     private CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
             NamespaceBundle bundle, LookupOptions options) {
-            log.debug()
-                    .attr("bundle", bundle)
-                    .attr("options", options)
-                    .log("findBrokerServiceUrl");
-                Map<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
+        log.debug()
+                .attr("bundle", bundle)
+                .attr("options", options)
+                .log("findBrokerServiceUrl");
+        Map<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
         if (options.isAuthoritative()) {
             targetMap = findingBundlesAuthoritative;
         } else {
@@ -502,31 +480,13 @@ public class NamespaceService implements AutoCloseable {
                     future.completeExceptionally(
                             new IllegalStateException(String.format("Namespace bundle %s is being unloaded", bundle)));
                 } else {
-                        log.debug().attr("bundle", bundle).attr("owner", nsData)
-                                .log("Namespace bundle already owned");
-                                        // find the target
-                    if (options.hasAdvertisedListenerName()) {
-                        AdvertisedListener listener =
-                                nsData.get().getAdvertisedListeners().get(options.getAdvertisedListenerName());
-                        if (listener == null) {
-                            future.completeExceptionally(
-                                    new PulsarServerException("the broker do not have "
-                                            + options.getAdvertisedListenerName() + " listener"));
-                        } else {
-                            URI url = listener.getBrokerServiceUrl();
-                            URI urlTls = listener.getBrokerServiceUrlTls();
-                            future.complete(Optional.of(new LookupResult(nsData.get(),
-                                    url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString())));
-                        }
-                    } else {
-                        future.complete(Optional.of(new LookupResult(nsData.get())));
-                    }
+                    log.debug().attr("bundle", bundle).attr("owner", nsData)
+                            .log("Namespace bundle already owned");
+                    resolveBrokerServiceLookupResult(options, nsData.get(), future);
                 }
             }).exceptionally(exception -> {
                 log.warn()
                         .attr("bundle", bundle)
-
                         .exception(exception)
                         .log("Failed to check owner for bundle");
                 future.completeExceptionally(exception);
@@ -567,6 +527,35 @@ public class NamespaceService implements AutoCloseable {
             });
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    // package-private for tests
+    static void resolveBrokerServiceLookupResult(LookupOptions options, NamespaceEphemeralData nsData,
+                                                 CompletableFuture<Optional<LookupResult>> future) {
+        LookupResult result = LookupResult.create(nsData, options);
+
+        // fail the lookup if advertised listener name is provided and does not match
+        if (options.hasAdvertisedListenerName()
+                && !Objects.equals(result.getBrokerServiceListenerName(), options.getAdvertisedListenerName())) {
+            future.completeExceptionally(
+                    new PulsarServerException("The broker '" + result.getLookupData().getBrokerId() + "' does not "
+                            + "have '" + options.getAdvertisedListenerName() + "' listener configured."));
+            return;
+        }
+
+        // Tolerate a missing web service listener on the target broker — during a rolling cluster
+        // upgrade, older brokers may not have published the listener yet. Fall back to the default
+        // web service URL (the broker's primary HTTP/HTTPS) in that case; toRedirectUri picks it up
+        // because httpUrl/httpUrlTls were left at the broker's defaults by LookupResult.create.
+        if (options.hasWebServiceAdvertisedListenerName()
+                && !Objects.equals(result.getWebServiceListenerName(), options.getWebServiceAdvertisedListenerName())) {
+            log.warn()
+                    .attr("brokerId", result.getLookupData().getBrokerId())
+                    .attr("webServiceListenerName", options.getWebServiceAdvertisedListenerName())
+                    .log("Target broker has no matching web service listener; redirecting to its default URL.");
+        }
+
+        future.complete(Optional.of(result));
     }
 
     private void searchForCandidateBroker(NamespaceBundle bundle,
@@ -642,7 +631,6 @@ public class NamespaceService implements AutoCloseable {
         } catch (Exception e) {
             log.warn()
                     .attr("acquire", bundle)
-
                     .exception(e)
                     .log("Error when searching for candidate broker to acquire");
             lookupFuture.completeExceptionally(e);
@@ -666,25 +654,8 @@ public class NamespaceService implements AutoCloseable {
                             // Schedule the task to preload topics
                             pulsar.loadNamespaceTopics(bundle);
                         }
-                        // find the target
-                        if (options.hasAdvertisedListenerName()) {
-                            AdvertisedListener listener =
-                                    ownerInfo.getAdvertisedListeners().get(options.getAdvertisedListenerName());
-                            if (listener == null) {
-                                lookupFuture.completeExceptionally(
-                                        new PulsarServerException("the broker do not have "
-                                                + options.getAdvertisedListenerName() + " listener"));
-                            } else {
-                                URI url = listener.getBrokerServiceUrl();
-                                URI urlTls = listener.getBrokerServiceUrlTls();
-                                lookupFuture.complete(Optional.of(
-                                        new LookupResult(ownerInfo,
-                                                url == null ? null : url.toString(),
-                                                urlTls == null ? null : urlTls.toString())));
-                            }
-                        } else {
-                            lookupFuture.complete(Optional.of(new LookupResult(ownerInfo)));
-                        }
+
+                        resolveBrokerServiceLookupResult(options, ownerInfo, lookupFuture);
                     }
                 }).exceptionally(exception -> {
                     log.warn()
@@ -698,18 +669,17 @@ public class NamespaceService implements AutoCloseable {
 
             } else {
                 // Load managed decider some other broker should try to acquire ownership
-                    log.debug()
-                            .attr("broker", candidateBroker)
-                            .attr("bundle", bundle)
-                            .log("Redirecting to broker to acquire ownership of bundle");
-                                // Now setting the redirect url
-                createLookupResult(candidateBroker, authoritativeRedirect, options.getAdvertisedListenerName())
+                log.debug()
+                        .attr("broker", candidateBroker)
+                        .attr("bundle", bundle)
+                        .log("Redirecting to broker to acquire ownership of bundle");
+                // Now setting the redirect url
+                createLookupResult(candidateBroker, authoritativeRedirect, options)
                         .thenAccept(lookupResult -> lookupFuture.complete(Optional.of(lookupResult)))
                         .exceptionally(ex -> {
                             lookupFuture.completeExceptionally(ex);
                             return null;
                         });
-
             }
         } catch (Exception e) {
             log.warn()
@@ -721,7 +691,7 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<LookupResult> createLookupResult(String candidateBroker, boolean authoritativeRedirect,
-                                                                 final String advertisedListenerName) {
+                                                                 LookupOptions options) {
 
         CompletableFuture<LookupResult> lookupFuture = new CompletableFuture<>();
         try {
@@ -730,25 +700,9 @@ public class NamespaceService implements AutoCloseable {
 
             localBrokerDataCache.get(path).thenAccept(reportData -> {
                 if (reportData.isPresent()) {
-                    LocalBrokerData lookupData = reportData.get();
-                    if (StringUtils.isNotBlank(advertisedListenerName)) {
-                        AdvertisedListener listener = lookupData.getAdvertisedListeners().get(advertisedListenerName);
-                        if (listener == null) {
-                            lookupFuture.completeExceptionally(
-                                    new PulsarServerException(
-                                            "the broker do not have " + advertisedListenerName + " listener"));
-                        } else {
-                            URI url = listener.getBrokerServiceUrl();
-                            URI urlTls = listener.getBrokerServiceUrlTls();
-                            lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                    lookupData.getWebServiceUrlTls(), url == null ? null : url.toString(),
-                                    urlTls == null ? null : urlTls.toString(), authoritativeRedirect));
-                        }
-                    } else {
-                        lookupFuture.complete(new LookupResult(lookupData.getWebServiceUrl(),
-                                lookupData.getWebServiceUrlTls(), lookupData.getPulsarServiceUrl(),
-                                lookupData.getPulsarServiceUrlTls(), authoritativeRedirect));
-                    }
+                    LookupResult lookupResult =
+                            LookupResult.create(reportData.get(), options, authoritativeRedirect);
+                    lookupFuture.complete(lookupResult);
                 } else {
                     lookupFuture.completeExceptionally(new MetadataStoreException.NotFoundException(path));
                 }
@@ -788,7 +742,7 @@ public class NamespaceService implements AutoCloseable {
      * Helper function to encapsulate the logic to invoke between old and new load manager.
      *
      * @param serviceUnit the service unit
-     * @return the least loaded broker addresses
+     * @return the least loaded brokerId
      * @throws Exception if an error occurs
      */
     private Optional<String> getLeastLoadedFromLoadManager(ServiceUnitId serviceUnit) throws Exception {
@@ -798,12 +752,12 @@ public class NamespaceService implements AutoCloseable {
             return Optional.empty();
         }
 
-        String lookupAddress = leastLoadedBroker.get().getResourceId();
-            log.debug()
-                    .attr("brokerId", pulsar.getBrokerId())
-                    .attr("address", lookupAddress)
-                    .log("redirecting to the least loaded broker, lookup address");
-                return Optional.of(lookupAddress);
+        String leastLoadedBrokerId = leastLoadedBroker.get().getResourceId();
+        log.debug()
+                .attr("brokerId", pulsar.getBrokerId())
+                .attr("leastLoadedBrokerId", leastLoadedBrokerId)
+                .log("redirecting to the least loaded broker");
+        return Optional.of(leastLoadedBrokerId);
     }
 
     public CompletableFuture<Void> unloadNamespaceBundle(NamespaceBundle bundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -117,10 +117,10 @@ public class OwnershipCache {
         // At this moment, the variables "webServiceAddress" and "webServiceAddressTls" and so on have not been
         // initialized, so we will get an empty "selfOwnerInfo" and an empty "selfOwnerInfoDisabled" here.
         // But do not worry, these two fields will be set by the method "refreshSelfOwnerInfo" soon.
-        this.selfOwnerInfo = new NamespaceEphemeralData(ownerBrokerUrl, ownerBrokerUrlTls,
+        this.selfOwnerInfo = new NamespaceEphemeralData(null, ownerBrokerUrl, ownerBrokerUrlTls,
                 pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
                 false, pulsar.getAdvertisedListeners());
-        this.selfOwnerInfoDisabled = new NamespaceEphemeralData(ownerBrokerUrl, ownerBrokerUrlTls,
+        this.selfOwnerInfoDisabled = new NamespaceEphemeralData(null, ownerBrokerUrl, ownerBrokerUrlTls,
                 pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
                 true, pulsar.getAdvertisedListeners());
         this.lockManager = pulsar.getCoordinationService().getLockManager(NamespaceEphemeralData.class);
@@ -349,10 +349,10 @@ public class OwnershipCache {
     }
 
     public synchronized boolean refreshSelfOwnerInfo() {
-        this.selfOwnerInfo = new NamespaceEphemeralData(pulsar.getBrokerServiceUrl(),
+        this.selfOwnerInfo = new NamespaceEphemeralData(pulsar.getBrokerId(), pulsar.getBrokerServiceUrl(),
                 pulsar.getBrokerServiceUrlTls(), pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(), false, pulsar.getAdvertisedListeners());
-        this.selfOwnerInfoDisabled = new NamespaceEphemeralData(pulsar.getBrokerServiceUrl(),
+        this.selfOwnerInfoDisabled = new NamespaceEphemeralData(pulsar.getBrokerId(), pulsar.getBrokerServiceUrl(),
                 pulsar.getBrokerServiceUrlTls(), pulsar.getWebServiceAddress(),
                 pulsar.getWebServiceAddressTls(), true, pulsar.getAdvertisedListeners());
         return selfOwnerInfo.getNativeUrl() != null || selfOwnerInfo.getNativeUrlTls() != null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/rest/TopicsBase.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -33,20 +32,18 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
@@ -55,7 +52,6 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.admin.impl.PersistentTopicsBase;
 import org.apache.pulsar.broker.authentication.AuthenticationParameters;
@@ -66,6 +62,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.schema.SchemaRegistry;
 import org.apache.pulsar.broker.service.schema.exceptions.SchemaException;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.broker.web.RestProducerContext;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
@@ -83,6 +80,7 @@ import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericAvroWriter;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonRecord;
 import org.apache.pulsar.client.impl.schema.generic.GenericJsonWriter;
+import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.naming.TopicName;
@@ -106,15 +104,18 @@ import org.apache.pulsar.websocket.data.ProducerMessages;
  * Contains methods used by REST api to producer/consumer/read messages to/from pulsar topics.
  */
 public class TopicsBase extends PersistentTopicsBase {
-
     private static String defaultProducerName = "RestProducer";
+
+    protected RestProducerContext restProducerContext() {
+        return pulsar().getRestProducerContext();
+    }
 
     // Publish message to a topic, can be partitioned or non-partitioned
     protected void publishMessages(AsyncResponse asyncResponse, ProducerMessages request, boolean authoritative) {
         String topic = topicName.getPartitionedTopicName();
         try {
-            if (pulsar().getBrokerService().getOwningTopics().containsKey(topic)
-                    || !findOwnerBrokerForTopic(authoritative, asyncResponse)) {
+            if (restProducerContext().isTopicOwned(topic)
+                    || !findOwnerBrokerForTopic(topicName, authoritative, asyncResponse)) {
                 // If we've done look up or or after look up this broker owns some of the partitions
                 // then proceed to publish message else asyncResponse will be complete by look up.
                 addOrGetSchemaForTopic(getSchemaData(request.getKeySchema(), request.getValueSchema()),
@@ -122,8 +123,7 @@ public class TopicsBase extends PersistentTopicsBase {
                         .thenAccept(schemaMeta -> {
                             // Both schema version and schema data are necessary.
                             if (schemaMeta.getLeft() != null && schemaMeta.getRight() != null) {
-                                final var partitionIndexes = pulsar().getBrokerService().getOwningTopics()
-                                        .getOrDefault(topic, Set.of()).stream().toList();
+                                final var partitionIndexes = restProducerContext().getPartitionIndexes(topic);
                                 internalPublishMessages(topicName, request, partitionIndexes, asyncResponse,
                                         AutoConsumeSchema.getSchema(schemaMeta.getLeft().toSchemaInfo()),
                                         schemaMeta.getRight());
@@ -132,12 +132,12 @@ public class TopicsBase extends PersistentTopicsBase {
                                         "Fail to add or retrieve schema."));
                             }
                         }).exceptionally(e -> {
-                        log.debug().exceptionMessage(e).log("Fail to publish message");
-                                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
-                                                "Fail to publish message:"
-                            + e.getMessage()));
-                    return null;
-                });
+                            log.debug().exceptionMessage(e).log("Fail to publish message");
+                            asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
+                                    "Fail to publish message:"
+                                            + e.getMessage()));
+                            return null;
+                        });
             }
         } catch (Exception e) {
             asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Fail to publish message: "
@@ -155,10 +155,8 @@ public class TopicsBase extends PersistentTopicsBase {
         String topic = topicName.getPartitionedTopicName();
         try {
             // If broker owns the partition then proceed to publish message, else do look up.
-            if ((pulsar().getBrokerService().getOwningTopics().containsKey(topic)
-                    && pulsar().getBrokerService().getOwningTopics().get(topic)
-                    .contains(partition))
-                    || !findOwnerBrokerForTopic(authoritative, asyncResponse)) {
+            if (restProducerContext().containsTopicPartition(topic, partition)
+                    || !findOwnerBrokerForTopic(topicName.getPartition(partition), authoritative, asyncResponse)) {
                 addOrGetSchemaForTopic(getSchemaData(request.getKeySchema(), request.getValueSchema()),
                         request.getSchemaVersion() == -1 ? null : new LongSchemaVersion(request.getSchemaVersion()))
                         .thenAccept(schemaMeta -> {
@@ -190,11 +188,11 @@ public class TopicsBase extends PersistentTopicsBase {
 
     private void internalPublishMessagesToPartition(TopicName topicName, ProducerMessages request,
                                                   int partition, AsyncResponse asyncResponse,
-                                                  Schema schema, SchemaVersion schemaVersion) {
+                                                  Schema<?> schema, SchemaVersion schemaVersion) {
         try {
-            String producerName = (null == request.getProducerName() || request.getProducerName().isEmpty())
+            String producerName = null == request.getProducerName() || request.getProducerName().isEmpty()
                     ? defaultProducerName : request.getProducerName();
-            List<Message> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
+            List<Message<?>> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
             List<CompletableFuture<Position>> publishResults = new ArrayList<>();
             List<ProducerAck> produceMessageResults = new ArrayList<>();
             for (int index = 0; index < messages.size(); index++) {
@@ -226,25 +224,25 @@ public class TopicsBase extends PersistentTopicsBase {
 
     private void internalPublishMessages(TopicName topicName, ProducerMessages request,
                                                      List<Integer> partitionIndexes,
-                                                     AsyncResponse asyncResponse, Schema schema,
+                                                     AsyncResponse asyncResponse, Schema<?> schema,
                                                      SchemaVersion schemaVersion) {
-        if (partitionIndexes.size() < 1) {
+        if (partitionIndexes.isEmpty()) {
             asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
                     new BrokerServiceException.TopicNotFoundException("Topic not owned by current broker.")));
         }
         try {
-            String producerName = (null == request.getProducerName() || request.getProducerName().isEmpty())
+            String producerName = null == request.getProducerName() || request.getProducerName().isEmpty()
                     ? defaultProducerName : request.getProducerName();
-            List<Message> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
+            List<Message<?>> messages = buildMessage(request, schema, producerName, topicName, schemaVersion);
             List<CompletableFuture<Position>> publishResults = new ArrayList<>();
             List<ProducerAck> produceMessageResults = new ArrayList<>();
             // Try to publish messages to all partitions this broker owns in round robin mode.
             for (int index = 0; index < messages.size(); index++) {
                 ProducerAck produceMessageResult = new ProducerAck();
-                produceMessageResult.setMessageId(partitionIndexes.get(index % (int) partitionIndexes.size()) + "");
+                produceMessageResult.setMessageId(partitionIndexes.get(index % partitionIndexes.size()) + "");
                 produceMessageResults.add(produceMessageResult);
                 publishResults.add(publishSingleMessageToPartition(topicName.getPartition(partitionIndexes
-                                .get(index % (int) partitionIndexes.size())).toString(),
+                                .get(index % partitionIndexes.size())).toString(),
                         messages.get(index)));
             }
             FutureUtil.waitForAll(publishResults).thenRun(() -> {
@@ -267,18 +265,15 @@ public class TopicsBase extends PersistentTopicsBase {
         }
     }
 
-    private CompletableFuture<Position> publishSingleMessageToPartition(String topic, Message message) {
+    private CompletableFuture<Position> publishSingleMessageToPartition(String topic, Message<?> message) {
         CompletableFuture<Position> publishResult = new CompletableFuture<>();
         pulsar().getBrokerService().getTopic(topic, false)
-        .thenAccept(t -> {
+                .thenAccept(t -> {
             // TODO: Check message backlog and fail if backlog too large.
-            if (!t.isPresent()) {
+            if (t.isEmpty()) {
                 // Topic not found, and remove from owning partition list.
                 publishResult.completeExceptionally(new BrokerServiceException.TopicNotFoundException("Topic not "
                         + "owned by current broker."));
-                TopicName topicName = TopicName.get(topic);
-                pulsar().getBrokerService().getOwningTopics().get(topicName.getPartitionedTopicName())
-                        .remove(topicName.getPartitionIndex());
             } else {
                 try {
                     ByteBuf headersAndPayload = messageToByteBuf(message);
@@ -313,21 +308,17 @@ public class TopicsBase extends PersistentTopicsBase {
                         Integer.parseInt(produceMessageResults.get(index).getMessageId()));
                 produceMessageResults.get(index).setMessageId(messageId.toString());
             } catch (Exception e) {
-                    log.debug()
-                            .attr("publish", index)
-                            .attr("topic", topicName)
-                            .log("Fail publish message with rest produce message request for topic");
-                                if (e instanceof BrokerServiceException.TopicNotFoundException) {
-                    // Topic ownership might changed, force to look up again.
-                    pulsar().getBrokerService().getOwningTopics().remove(topicName.getPartitionedTopicName());
-                }
+                log.debug()
+                        .attr("publish", index)
+                        .attr("topic", topicName)
+                        .log("Fail publish message with rest produce message request for topic");
                 extractException(e, produceMessageResults.get(index));
             }
         }
     }
 
     // Return error code depends on exception we got indicating if client should retry with same broker.
-    private void extractException(Exception e, ProducerAck produceMessageResult) {
+    private static void extractException(Exception e, ProducerAck produceMessageResult) {
         if (!(e instanceof BrokerServiceException.TopicFencedException && e instanceof ManagedLedgerException)) {
             produceMessageResult.setErrorCode(2);
         } else {
@@ -338,147 +329,90 @@ public class TopicsBase extends PersistentTopicsBase {
 
     // Look up topic owner for given topic. Return if asyncResponse has been completed
     // which indicating redirect or exception.
-    private boolean findOwnerBrokerForTopic(boolean authoritative, AsyncResponse asyncResponse) {
+    private boolean findOwnerBrokerForTopic(TopicName topicName, boolean authoritative, AsyncResponse asyncResponse) {
         PartitionedTopicMetadata metadata = internalGetPartitionedMetadata(authoritative, false);
-        List<String> redirectAddresses = Collections.synchronizedList(new ArrayList<>());
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        List<CompletableFuture<Void>> lookupFutures = new ArrayList<>();
+        List<CompletableFuture<Optional<LookupResult>>> lookupFutures = new ArrayList<>();
         if (!topicName.isPartitioned() && metadata.partitions > 0) {
             // Partitioned topic with multiple partitions, need to do look up for each partition.
             for (int index = 0; index < metadata.partitions; index++) {
-                lookupFutures.add(lookUpBrokerForTopic(topicName.getPartition(index),
-                        authoritative, redirectAddresses));
+                lookupFutures.add(lookUpBrokerForTopic(topicName.getPartition(index), authoritative)
+                        .exceptionally(e -> Optional.empty()));
             }
         } else {
             // Non-partitioned topic or specific topic partition.
-            lookupFutures.add(lookUpBrokerForTopic(topicName, authoritative, redirectAddresses));
+            lookupFutures.add(lookUpBrokerForTopic(topicName, authoritative)
+                    .exceptionally(e -> Optional.empty()));
         }
 
-        FutureUtil.waitForAll(lookupFutures)
-        .thenRun(() -> {
-            processLookUpResult(redirectAddresses, asyncResponse, future);
-        }).exceptionally(e -> {
-            processLookUpResult(redirectAddresses, asyncResponse, future);
-            return null;
-        });
         try {
-            return future.get();
+            FutureUtil.waitForAll(lookupFutures).get();
+            Map<String, List<LookupResult>> resultsByBrokerId =
+                lookupFutures.stream()
+                    .map(CompletableFuture::join)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.groupingBy(result -> result.getLookupData().getBrokerId()));
+
+            // if any partition is served by this broker, then return false so that producing happens on this broker.
+            if (resultsByBrokerId.containsKey(pulsar().getBrokerId())) {
+                return false;
+            }
+
+            // redirect to broker with most number of partitions
+            List<LookupResult> lookupResults = resultsByBrokerId.entrySet().stream()
+                    .max(Comparator.comparingInt(entry -> entry.getValue().size()))
+                    .map(Map.Entry::getValue)
+                    .orElse(null);
+            if (lookupResults != null) {
+                LookupResult lookupResult = lookupResults.get(0);
+                URI redirectUri = lookupResult.toRedirectUri(uri.getRequestUri());
+                asyncResponse.resume(Response.temporaryRedirect(redirectUri).build());
+                return true;
+            }
         } catch (Exception e) {
-                log.debug()
-                        .attr("topic", topicName.toString())
-                        .log("Fail to lookup topic for rest produce message request for topic .");
-                        if (!asyncResponse.isDone()) {
+            log.debug()
+                    .attr("topic", topicName.toString())
+                    .log("Fail to lookup topic for rest produce message request for topic .");
+            if (!asyncResponse.isDone()) {
                 asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR, "Internal error: "
                         + e.getMessage()));
             }
             return true;
         }
-    }
-
-    private void processLookUpResult(List<String> redirectAddresses,  AsyncResponse asyncResponse,
-                                     CompletableFuture<Boolean> future) {
-        // Current broker doesn't own the topic or any partition of the topic, redirect client to a broker
-        // that own partition of the topic or know who own partition of the topic.
-        if (!pulsar().getBrokerService().getOwningTopics().containsKey(topicName.getPartitionedTopicName())) {
-            if (redirectAddresses.isEmpty()) {
-                // No broker to redirect, means look up for some partitions failed,
-                // client should retry with other brokers.
-                asyncResponse.resume(new RestException(Status.NOT_FOUND, "Can't find owner of given topic."));
-                future.complete(true);
-            } else {
-                // Redirect client to other broker owns the topic or know which broker own the topic.
-                try {
-                        log.debug()
-                                .attr("topic", topicName)
-                                .attr("from", pulsar().getWebServiceAddress())
-                                .attr("to", redirectAddresses.get(0))
-                                .log("Redirect rest produce request");
-                                        URL redirectAddress = new URL(redirectAddresses.get(0));
-                    URI redirectURI = UriBuilder.fromUri(uri.getRequestUri())
-                            .host(redirectAddress.getHost())
-                            .port(redirectAddress.getPort())
-                            .build();
-                    asyncResponse.resume(Response.temporaryRedirect(redirectURI).build());
-                    future.complete(true);
-                } catch (Exception e) {
-                        log.error()
-                                .attr("topic", topicName)
-
-                                .exception(e)
-                                .log("Error in preparing redirect url with rest produce message request for topic");
-                                        asyncResponse.resume(new RestException(Status.INTERNAL_SERVER_ERROR,
-                            "Fail to redirect client request."));
-                    future.complete(true);
-                }
-            }
-        } else {
-            future.complete(false);
-        }
+        return false;
     }
 
     // Look up topic owner for non-partitioned topic or single topic partition.
-    private CompletableFuture<Void> lookUpBrokerForTopic(TopicName partitionedTopicName,
-                                                         boolean authoritative, List<String> redirectAddresses) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
-                log.debug("Too many concurrent lookup request.");
-                        future.completeExceptionally(new BrokerServiceException.TooManyRequestsException("Too many "
+    private CompletableFuture<Optional<LookupResult>> lookUpBrokerForTopic(TopicName partitionedTopicName,
+                                                                           boolean authoritative) {
+        Semaphore lookupRequestSemaphore = pulsar().getBrokerService().getLookupRequestSemaphore();
+        if (!lookupRequestSemaphore.tryAcquire()) {
+            log.debug("Too many concurrent lookup request.");
+            return FutureUtil.failedFuture(new BrokerServiceException.TooManyRequestsException("Too many "
                     + "concurrent lookup request"));
-            return future;
         }
+
+        LookupOptions lookupOptions = LookupOptions.builder()
+                .webServiceAdvertisedListenerName(getWebServiceListenerName())
+                .authoritative(authoritative)
+                .build();
         CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService()
-                .getBrokerServiceUrlAsync(partitionedTopicName,
-                        LookupOptions.builder().authoritative(authoritative).loadTopicsInBundle(false).build());
+                .getBrokerServiceUrlAsync(partitionedTopicName, lookupOptions);
 
-        lookupFuture.thenAccept(optionalResult -> {
-            if (optionalResult == null || !optionalResult.isPresent()) {
-                    log.debug()
-                            .attr("topic", partitionedTopicName)
-                            .log("Fail to lookup topic for rest produce message request for topic .");
-                                completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
-                return;
-            }
-
-            LookupResult result = optionalResult.get();
-            String httpUrl = result.getLookupData().getHttpUrl();
-            String httpUrlTls = result.getLookupData().getHttpUrlTls();
-            if ((StringUtils.isNotBlank(httpUrl) && httpUrl.equals(pulsar().getWebServiceAddress()))
-                    || (StringUtils.isNotBlank(httpUrlTls) && httpUrlTls.equals(pulsar().getWebServiceAddressTls()))) {
-                // Current broker owns the topic, add to owning topic.
-                    log.debug()
-                            .attr("topic", partitionedTopicName)
-                            .attr("broker", result.getLookupData())
-                            .log("Complete topic look up for rest produce message request for topic , current broker"
-                                    + " is owner broker");
-                                pulsar().getBrokerService().getOwningTopics().computeIfAbsent(partitionedTopicName
-                                .getPartitionedTopicName(),
-                        __ -> ConcurrentHashMap.newKeySet())
-                        .add(partitionedTopicName.getPartitionIndex());
-                completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
-            } else {
-                // Current broker doesn't own the topic or doesn't know who own the topic.
-                    log.debug()
-                            .attr("topic", partitionedTopicName)
-                            .attr("broker", result.getLookupData())
-                            .log("Complete topic look up for rest produce message request for topic , current broker"
-                                    + " is not owner broker");
-                                if (result.isRedirect()) {
-                    // Redirect lookup.
-                    completeLookup(Pair.of(Arrays.asList(httpUrl, httpUrlTls), false), redirectAddresses, future);
-                } else {
-                    // Found owner for topic.
-                    completeLookup(Pair.of(Arrays.asList(httpUrl, httpUrlTls), true), redirectAddresses, future);
-                }
-            }
-        }).exceptionally(exception -> {
-                log.debug()
-                        .attr("topic", partitionedTopicName)
-                        .exceptionMessage(exception)
-                        .log("Fail to lookup broker with rest produce message request for topic");
-                        completeLookup(Pair.of(Collections.emptyList(), false), redirectAddresses, future);
-            return null;
+        // release semaphore when lookup is complete
+        lookupFuture.whenComplete((result, exception) -> {
+            lookupRequestSemaphore.release();
         });
-        return future;
+
+        // Register the topic eagerly when this broker is the owner so that subsequent steps see it
+        // in RestProducerContext without racing the asynchronous TopicEvent.LOAD listener notification.
+        return lookupFuture.thenApply(optResult -> {
+            if (optResult.isPresent()
+                    && pulsar().getBrokerId().equals(optResult.get().getLookupData().getBrokerId())) {
+                restProducerContext().addTopic(partitionedTopicName.toString());
+            }
+            return optResult;
+        });
     }
 
     private CompletableFuture<Pair<SchemaData, SchemaVersion>> addOrGetSchemaForTopic(SchemaData schemaData,
@@ -524,15 +458,15 @@ public class TopicsBase extends PersistentTopicsBase {
     private CompletableFuture<SchemaVersion> addSchema(SchemaData schemaData) {
         // Only need to add to first partition the broker owns since the schema id in schema registry are
         // same for all partitions which is the partitionedTopicName
-        List<Integer> partitions = pulsar().getBrokerService().getOwningTopics()
-                .get(topicName.getPartitionedTopicName()).stream().toList();
+        String topic1 = topicName.getPartitionedTopicName();
+        List<Integer> partitions = restProducerContext().getPartitionIndexes(topic1);
         CompletableFuture<SchemaVersion> result = new CompletableFuture<>();
         for (int index = 0; index < partitions.size(); index++) {
             CompletableFuture<SchemaVersion> future = new CompletableFuture<>();
             String topicPartitionName = topicName.getPartition(partitions.get(index)).toString();
             pulsar().getBrokerService().getTopic(topicPartitionName, false)
             .thenAccept(topic -> {
-                if (!topic.isPresent()) {
+                if (topic.isEmpty()) {
                     future.completeExceptionally(new BrokerServiceException.TopicNotFoundException(
                             "Topic " + topicPartitionName + " not found"));
                 } else {
@@ -567,7 +501,7 @@ public class TopicsBase extends PersistentTopicsBase {
     // Build schemaData from passed in schema string.
     private SchemaData getSchemaData(String keySchema, String valueSchema) {
         try {
-            SchemaInfoImpl valueSchemaInfo = (valueSchema == null || valueSchema.isEmpty())
+            SchemaInfoImpl valueSchemaInfo = valueSchema == null || valueSchema.isEmpty()
                     ? (SchemaInfoImpl) StringSchema.utf8().getSchemaInfo() :
                     SCHEMA_INFO_READER.readValue(valueSchema);
             if (null == valueSchemaInfo.getName()) {
@@ -613,10 +547,10 @@ public class TopicsBase extends PersistentTopicsBase {
     }
 
     // Convert message to ByteBuf
-    public ByteBuf messageToByteBuf(Message message) {
+    public ByteBuf messageToByteBuf(Message<?> message) {
         checkArgument(message instanceof MessageImpl, "Message must be type of MessageImpl.");
 
-        MessageImpl msg = (MessageImpl) message;
+        MessageImpl<?> msg = (MessageImpl<?>) message;
         MessageMetadata messageMetadata = msg.getMessageBuilder();
         ByteBuf payload = msg.getDataBuffer();
         messageMetadata.setCompression(CompressionCodecProvider.convertToWireProtocol(CompressionType.NONE));
@@ -626,11 +560,10 @@ public class TopicsBase extends PersistentTopicsBase {
     }
 
     // Build pulsar message from REST request.
-    @SuppressWarnings("unchecked")
-    private List<Message> buildMessage(ProducerMessages producerMessages, Schema schema,
+    private List<Message<?>> buildMessage(ProducerMessages producerMessages, Schema<?> schema,
                                        String producerName, TopicName topicName, SchemaVersion schemaVersion) {
         List<ProducerMessage> messages;
-        List<Message> pulsarMessages = new ArrayList<>();
+        List<Message<?>> pulsarMessages = new ArrayList<>();
 
         messages = producerMessages.getMessages();
         for (ProducerMessage message : messages) {
@@ -645,8 +578,7 @@ public class TopicsBase extends PersistentTopicsBase {
 
             if (null != message.getProperties()) {
                 messageMetadata.addAllProperties(message.getProperties().entrySet().stream().map(entry -> {
-                    org.apache.pulsar.common.api.proto.KeyValue keyValue =
-                            new org.apache.pulsar.common.api.proto.KeyValue();
+                    KeyValue keyValue = new KeyValue();
                     keyValue.setKey(entry.getKey());
                     keyValue.setValue(entry.getValue());
                     return keyValue;
@@ -655,10 +587,10 @@ public class TopicsBase extends PersistentTopicsBase {
             if (null != message.getKey()) {
                 // If has key schema, encode partition key, else use plain text.
                 if (schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
-                    KeyValueSchemaImpl kvSchema = (KeyValueSchemaImpl) schema;
+                    KeyValueSchemaImpl<?, ?> kvSchema = (KeyValueSchemaImpl<?, ?>) schema;
                     messageMetadata.setPartitionKey(
-                            Base64.getEncoder().encodeToString(encodeWithSchema(message.getKey(),
-                                    kvSchema.getKeySchema())));
+                            Base64.getEncoder()
+                                    .encodeToString(encodeWithSchema(message.getKey(), kvSchema.getKeySchema())));
                     messageMetadata.setPartitionKeyB64Encoded(true);
                 } else {
                     messageMetadata.setPartitionKey(message.getKey());
@@ -678,9 +610,10 @@ public class TopicsBase extends PersistentTopicsBase {
                 messageMetadata.setDeliverAtTime(messageMetadata.getEventTime() + message.getDeliverAfterMs());
             }
             if (schema.getSchemaInfo().getType() == SchemaType.KEY_VALUE) {
-                KeyValueSchemaImpl kvSchema = (KeyValueSchemaImpl) schema;
+                KeyValueSchemaImpl<?, ?> kvSchema = (KeyValueSchemaImpl<?, ?>) schema;
                 pulsarMessages.add(MessageImpl.create(messageMetadata,
-                        ByteBuffer.wrap(encodeWithSchema(message.getPayload(), kvSchema.getValueSchema())),
+                        ByteBuffer.wrap(
+                                encodeWithSchema(message.getPayload(), kvSchema.getValueSchema())),
                         schema, topicName.toString()));
             } else {
                 pulsarMessages.add(MessageImpl.create(messageMetadata,
@@ -694,7 +627,8 @@ public class TopicsBase extends PersistentTopicsBase {
 
     // Encode message with corresponding schema, do necessary conversion before encoding
     @SuppressWarnings("unchecked")
-    private byte[] encodeWithSchema(String input, Schema schema) {
+    private byte[] encodeWithSchema(String input, Schema<?> schemaParam) {
+        Schema<Object> schema = (Schema<Object>) schemaParam;
         try {
             switch (schema.getSchemaInfo().getType()) {
                 case INT8:
@@ -734,9 +668,10 @@ public class TopicsBase extends PersistentTopicsBase {
                     return jsonWriter.write(new GenericJsonRecord(null, null,
                           ObjectMapperFactory.getMapper().reader().readTree(input), schema.getSchemaInfo()));
                 case AVRO:
-                    AvroBaseStructSchema avroSchema = ((AvroBaseStructSchema) schema);
+                    AvroBaseStructSchema<?> avroSchema = (AvroBaseStructSchema<?>) schema;
                     Decoder decoder = DecoderFactory.get().jsonDecoder(avroSchema.getAvroSchema(), input);
-                    DatumReader<GenericData.Record> reader = new GenericDatumReader(avroSchema.getAvroSchema());
+                    DatumReader<GenericData.Record> reader =
+                            new GenericDatumReader<GenericData.Record>(avroSchema.getAvroSchema());
                     GenericRecord genericRecord = reader.read(null, decoder);
                     GenericAvroWriter avroWriter = new GenericAvroWriter(avroSchema.getAvroSchema());
                     return avroWriter.write(new GenericAvroRecord(null,
@@ -747,31 +682,12 @@ public class TopicsBase extends PersistentTopicsBase {
                     throw new PulsarClientException.InvalidMessageException("");
             }
         } catch (Exception e) {
-                log.debug()
-                        .attr("value", input)
-                        .attr("schema", new String(schema.getSchemaInfo().getSchema()))
-                        .log("Fail to encode value with schema for rest produce request");
-                        return new byte[0];
+            log.debug()
+                    .attr("value", input)
+                    .attr("schema", new String(schema.getSchemaInfo().getSchema()))
+                    .log("Fail to encode value with schema for rest produce request");
+            return new byte[0];
         }
-    }
-
-    // Release lookup semaphore and add result to redirectAddresses if current broker doesn't own the topic.
-    private synchronized void completeLookup(Pair<List<String>, Boolean> result, List<String> redirectAddresses,
-                                              CompletableFuture<Void> future) {
-        pulsar().getBrokerService().getLookupRequestSemaphore().release();
-        // Left is lookup result of secure/insecure address if lookup succeed, Right is address is the owner's address
-        // or it's a address to redirect lookup.
-        if (!result.getLeft().isEmpty()) {
-            if (result.getRight()) {
-                // If address is for owner of topic partition, add to head and it'll have higher priority
-                // compare to broker for look redirect.
-                redirectAddresses.add(0, isRequestHttps() ? result.getLeft().get(1) : result.getLeft().get(0));
-            } else {
-                redirectAddresses.add(redirectAddresses.size(), isRequestHttps()
-                        ? result.getLeft().get(1) : result.getLeft().get(0));
-            }
-        }
-        future.complete(null);
     }
 
     public void validateProducePermission() throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -231,9 +231,6 @@ public class BrokerService implements Closeable {
     // Multi-layer topics map:
     // Namespace --> Bundle --> topicName --> topic
     private final Map<String, Map<String, Map<String, Topic>>> multiLayerTopicsMap = new ConcurrentHashMap<>();
-    // Keep track of topics and partitions served by this broker for fast lookup.
-    @Getter
-    private final Map<String, Set<Integer>> owningTopics = new ConcurrentHashMap<>();
     private long numberOfNamespaceBundles = 0;
 
     private final EventLoopGroup acceptorGroup;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
@@ -47,6 +48,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
@@ -57,6 +59,7 @@ import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.resources.BookieResources;
@@ -127,6 +130,7 @@ public abstract class PulsarWebResource {
     @Context
     protected ServletContext servletContext;
 
+    @Setter(onMethod_ = @VisibleForTesting)
     @Context
     protected HttpServletRequest httpRequest;
 
@@ -178,6 +182,13 @@ public abstract class PulsarWebResource {
 
     public boolean isRequestHttps() {
         return "https".equalsIgnoreCase(httpRequest.getScheme());
+    }
+
+    public String getWebServiceListenerName() {
+        if (httpRequest == null) {
+            return null;
+        }
+        return (String) httpRequest.getAttribute(WebService.ATTRIBUTE_LISTENER_NAME);
     }
 
     public static boolean isClientAuthenticated(String appId) {
@@ -646,10 +657,11 @@ public abstract class PulsarWebResource {
                     }
                     LookupOptions options = LookupOptions.builder()
                         .authoritative(false)
-                        .requestHttps(isRequestHttps())
+                        .webServiceAdvertisedListenerName(getWebServiceListenerName())
                         .readOnly(true)
-                        .loadTopicsInBundle(false).build();
-                    return nsService.getWebServiceUrlAsync(nsBundle, options).thenApply(Optional::isPresent);
+                        .build();
+                    return nsService.getLookupResultForWebRequestAsync(nsBundle, options)
+                            .thenApply(Optional::isPresent);
                 });
     }
 
@@ -661,90 +673,30 @@ public abstract class PulsarWebResource {
                         .thenApply(__ -> nsBundle));
     }
 
-    public void validateBundleOwnership(NamespaceBundle bundle, boolean authoritative, boolean readOnly)
-            throws Exception {
-        NamespaceService nsService = pulsar().getNamespaceService();
-
-        try {
-            // Call getWebServiceUrl() to acquire or redirect the request
-            // Get web service URL of owning broker.
-            // 1: If namespace is assigned to this broker, continue
-            // 2: If namespace is assigned to another broker, redirect to the webservice URL of another broker
-            // authoritative flag is ignored
-            // 3: If namespace is unassigned and readOnly is true, return 412
-            // 4: If namespace is unassigned and readOnly is false:
-            // - If authoritative is false and this broker is not leader, forward to leader
-            // - If authoritative is false and this broker is leader, determine owner and forward w/ authoritative=true
-            // - If authoritative is true, own the namespace and continue
-            LookupOptions options = LookupOptions.builder()
-                    .authoritative(authoritative)
-                    .requestHttps(isRequestHttps())
-                    .readOnly(readOnly)
-                    .loadTopicsInBundle(false).build();
-            Optional<URL> webUrl = nsService.getWebServiceUrl(bundle, options);
-            // Ensure we get a url
-            if (webUrl.isEmpty()) {
-                log.warn("Unable to get web service url");
-                throw new RestException(Status.PRECONDITION_FAILED,
-                        "Failed to find ownership for ServiceUnit:" + bundle.toString());
-            }
-
-            if (!nsService.isServiceUnitOwned(bundle)) {
-                boolean newAuthoritative = this.isLeaderBroker();
-                // Replace the host and port of the current request and redirect
-                URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(webUrl.get().getHost())
-                        .port(webUrl.get().getPort()).replaceQueryParam("authoritative", newAuthoritative).build();
-
-                log.debug().attr("bundle", bundle).log("is not a service unit owned");
-
-                // Redirect
-                log.debug().attr("redirect", redirect).log("Redirecting the rest call");
-                throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
-            }
-        } catch (TimeoutException te) {
-            String msg = String.format("Finding owner for ServiceUnit %s timed out", bundle);
-            log.error().exception(te).log(msg);
-            throw new RestException(Status.INTERNAL_SERVER_ERROR, msg);
-        } catch (IllegalArgumentException iae) {
-            // namespace format is not valid
-            log.debug().attr("serviceUnit", bundle).exception(iae).log("Failed to find owner for ServiceUnit");
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "ServiceUnit format is not expected. ServiceUnit " + bundle);
-        } catch (IllegalStateException ise) {
-            log.debug().attr("serviceUnit", bundle).exception(ise).log("Failed to find owner for ServiceUnit");
-            throw new RestException(Status.PRECONDITION_FAILED, "ServiceUnit bundle is actived. ServiceUnit " + bundle);
-        } catch (NullPointerException e) {
-            log.warn("Unable to get web service url");
-            throw new RestException(Status.PRECONDITION_FAILED, "Failed to find ownership for ServiceUnit:" + bundle);
-        }
-    }
-
     public CompletableFuture<Void> validateBundleOwnershipAsync(NamespaceBundle bundle, boolean authoritative,
                                                                 boolean readOnly) {
         NamespaceService nsService = pulsar().getNamespaceService();
         LookupOptions options = LookupOptions.builder()
                 .authoritative(authoritative)
-                .requestHttps(isRequestHttps())
+                .webServiceAdvertisedListenerName(getWebServiceListenerName())
                 .readOnly(readOnly)
-                .loadTopicsInBundle(false).build();
-        return nsService.getWebServiceUrlAsync(bundle, options)
-                .thenCompose(webUrl -> {
-                    if (webUrl.isEmpty()) {
+                .build();
+        return nsService.getLookupResultForWebRequestAsync(bundle, options)
+                .thenCompose(optLookupResult -> {
+                    if (optLookupResult.isEmpty()) {
                         log.warn("Unable to get web service url");
                         throw new RestException(Status.PRECONDITION_FAILED,
                                 "Failed to find ownership for ServiceUnit:" + bundle.toString());
                     }
+                    LookupResult lookupResult = optLookupResult.get();
                     return nsService.isServiceUnitOwnedAsync(bundle)
                             .thenAccept(owned -> {
                                 if (!owned) {
                                     boolean newAuthoritative = this.isLeaderBroker();
-                                    // Replace the host and port of the current request and redirect
-                                    UriBuilder uriBuilder = UriBuilder.fromUri(uri.getRequestUri())
-                                            .host(webUrl.get().getHost())
-                                            .port(webUrl.get().getPort())
-                                            .replaceQueryParam("authoritative", newAuthoritative);
+                                    UriBuilder uriBuilder = UriBuilder.fromUri(
+                                            lookupResult.toRedirectUri(uri.getRequestUri(), newAuthoritative));
                                     if (!ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
-                                        uriBuilder.replaceQueryParam("destinationBroker", (Object[]) null);
+                                        uriBuilder.replaceQueryParam("destinationBroker");
                                     }
                                     URI redirect = uriBuilder.build();
                                     log.debug().attr("bundle", bundle).log("is not a service unit owned");
@@ -773,32 +725,26 @@ public abstract class PulsarWebResource {
 
         LookupOptions options = LookupOptions.builder()
                 .authoritative(authoritative)
-                .requestHttps(isRequestHttps())
+                .webServiceAdvertisedListenerName(getWebServiceListenerName())
                 .readOnly(false)
-                .loadTopicsInBundle(false)
                 .build();
 
-        return nsService.getWebServiceUrlAsync(topicName, options)
-                .thenApply(webUrl ->
-                        webUrl.orElseThrow(() -> {
+        return nsService.getLookupResultForWebRequestAsync(topicName, options)
+                .thenApply(optLookupResult ->
+                        optLookupResult.orElseThrow(() -> {
                             log.info("Unable to get web service url");
                             throw new RestException(Status.PRECONDITION_FAILED,
                                     "Failed to find ownership for topic:" + topicName);
                         })
-                ).thenCompose(webUrl -> nsService.isServiceUnitOwnedAsync(topicName)
-                        .thenApply(isTopicOwned -> Pair.of(webUrl, isTopicOwned))
+                ).thenCompose(lookupResult -> nsService.isServiceUnitOwnedAsync(topicName)
+                        .thenApply(isTopicOwned -> Pair.of(lookupResult, isTopicOwned))
                 ).thenAccept(pair -> {
-                    URL webUrl = pair.getLeft();
+                    LookupResult lookupResult = pair.getLeft();
                     boolean isTopicOwned = pair.getRight();
 
                     if (!isTopicOwned) {
                         boolean newAuthoritative = isLeaderBroker(pulsar());
-                        // Replace the host and port of the current request and redirect
-                        URI redirect = UriBuilder.fromUri(uri.getRequestUri())
-                                .host(webUrl.getHost())
-                                .port(webUrl.getPort())
-                                .replaceQueryParam("authoritative", newAuthoritative)
-                                .build();
+                        URI redirect = lookupResult.toRedirectUri(uri.getRequestUri(), newAuthoritative);
                         // Redirect
                         log.debug()
                                 .attr("redirect", redirect)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestProducerContext.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestProducerContext.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.web;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pulsar.broker.service.TopicEventsListener;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * Per-broker cache of topic partitions that this broker currently owns for the REST producer flow.
+ *
+ * <p>Used by {@link org.apache.pulsar.broker.rest.TopicsBase} to back the REST API for producing messages to
+ * Pulsar topics. When a REST publish request arrives, {@code TopicsBase} consults this context to decide whether
+ * the local broker already owns (some partitions of) the target topic. If it does, the publish proceeds directly
+ * against the in-process topic instance; otherwise a namespace lookup is performed and the request is redirected
+ * to the owning broker. After a successful lookup that resolves to this broker, {@code TopicsBase} eagerly
+ * registers the topic via {@link #addTopic(String)} so that subsequent publishes do not race the asynchronous
+ * {@link TopicEvent#LOAD} listener notification.
+ *
+ * <p>Ownership is tracked as a map from partitioned-topic name to the set of partition indexes owned locally.
+ * Entries are removed when a topic is unloaded: this class implements {@link TopicEventsListener} and reacts to
+ * {@link TopicEvent#UNLOAD} events.
+ */
+public class RestProducerContext implements TopicEventsListener {
+    private final Map<String, Set<Integer>> owningTopics = new ConcurrentHashMap<>();
+
+    public boolean isTopicOwned(String topic) {
+        return owningTopics.containsKey(topic);
+    }
+
+    @Override
+    public void handleEvent(String topicName, TopicEvent event, EventStage stage, Throwable t) {
+        // remove topic from owning topics when it's unloaded
+        if (event == TopicEvent.UNLOAD && stage == EventStage.SUCCESS) {
+            addOrRemoveTopic(topicName, true);
+        }
+    }
+
+    public void addTopic(String topicName) {
+        addOrRemoveTopic(topicName, false);
+    }
+
+    private void addOrRemoveTopic(String topicName, boolean remove) {
+        TopicName topic = TopicName.get(topicName);
+        owningTopics.compute(topic.getPartitionedTopicName(), (k, partitionSet) -> {
+            if (remove) {
+                if (partitionSet != null) {
+                    partitionSet.remove(topic.getPartitionIndex());
+                }
+            } else {
+                if (partitionSet == null) {
+                    partitionSet = ConcurrentHashMap.newKeySet();
+                }
+                partitionSet.add(topic.getPartitionIndex());
+            }
+            return partitionSet == null || partitionSet.isEmpty() ? null : partitionSet;
+        });
+    }
+
+    public boolean containsTopicPartition(String topic, int partition) {
+        return owningTopics.getOrDefault(topic, Set.of()).contains(partition);
+    }
+
+    public List<Integer> getPartitionIndexes(String topic) {
+        return owningTopics.getOrDefault(topic, Set.of()).stream().toList();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pulsar.broker.web;
 
+import static org.eclipse.jetty.ee8.nested.Request.getBaseRequest;
 import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,11 +42,14 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 import lombok.CustomLog;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.intercept.BrokerInterceptors;
+import org.apache.pulsar.broker.validator.BindAddressValidator;
+import org.apache.pulsar.common.configuration.BindAddress;
 import org.apache.pulsar.common.util.PulsarSslConfiguration;
 import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.apache.pulsar.jetty.metrics.JettyStatisticsCollector;
@@ -56,6 +63,7 @@ import org.eclipse.jetty.ee8.websocket.server.JettyWebSocketServlet;
 import org.eclipse.jetty.ee8.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -86,6 +94,7 @@ public class WebService implements AutoCloseable {
     private static final String MATCH_ALL = "/*";
 
     public static final String ATTRIBUTE_PULSAR_NAME = "pulsar";
+    public static final String ATTRIBUTE_LISTENER_NAME = "listenerName";
     public static final String HANDLER_CACHE_CONTROL = "max-age=3600";
 
     private final PulsarService pulsar;
@@ -129,9 +138,13 @@ public class WebService implements AutoCloseable {
             server.addBean(new NetworkConnectionLimit(config.getMaxHttpServerConnections(), server));
         }
         server.setStopTimeout(config.getBrokerShutdownTimeoutMs());
-        List<ServerConnector> connectors = new ArrayList<>();
 
-        Optional<Integer> port = config.getWebServicePort();
+        List<BindAddress> bindAddresses = BindAddressValidator.validateBindAddresses(config,
+                Arrays.asList("http", "https"));
+        String internalListenerName = config.getInternalListenerName();
+        boolean tlsRequired = bindAddresses.stream()
+                .anyMatch(a -> "https".equalsIgnoreCase(a.getAddress().getScheme()));
+
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setUriCompliance(UriCompliance.LEGACY);
         if (config.isWebServiceTrustXForwardedFor()) {
@@ -139,23 +152,16 @@ public class WebService implements AutoCloseable {
         }
         httpConfig.setRequestHeaderSize(pulsar.getConfig().getHttpMaxRequestHeaderSize());
         httpConfig.setIdleTimeout(pulsar.getConfig().getHttpServerIdleTimeout());
-        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
-        if (port.isPresent()) {
-            List<ConnectionFactory> connectionFactories = new ArrayList<>();
-            if (config.isWebServiceHaProxyProtocolEnabled()) {
-                connectionFactories.add(new ProxyConnectionFactory());
-            }
-            connectionFactories.add(httpConnectionFactory);
-            httpConnector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
-            httpConnector.setPort(port.get());
-            httpConnector.setHost(pulsar.getBindAddress());
-            connectors.add(httpConnector);
-        } else {
-            httpConnector = null;
+        if (tlsRequired) {
+            // org.eclipse.jetty.server.AbstractConnectionFactory.getFactories contains similar logic
+            // this is needed for TLS authentication
+            // disable SNI host check for backwards compatibility with Jetty 9.x
+            httpConfig.addCustomizer(new SecureRequestCustomizer(false));
         }
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
 
-        Optional<Integer> tlsPort = config.getWebServicePortTls();
-        if (tlsPort.isPresent()) {
+        SslContextFactory.Server sslCtxFactory = null;
+        if (tlsRequired) {
             try {
                 PulsarSslConfiguration sslConfiguration = buildSslConfiguration(config);
                 this.sslFactory = (PulsarSslFactory) Class.forName(config.getSslFactoryPlugin())
@@ -169,42 +175,60 @@ public class WebService implements AutoCloseable {
                                     config.getTlsCertRefreshCheckDurationSec(),
                                     TimeUnit.SECONDS);
                 }
-                SslContextFactory.Server sslCtxFactory =
-                        JettySslContextFactory.createSslContextFactory(config.getWebServiceTlsProvider(),
-                                this.sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
-                                config.getTlsCiphers(), config.getTlsProtocols());
-                List<ConnectionFactory> connectionFactories = new ArrayList<>();
-                if (config.isWebServiceHaProxyProtocolEnabled()) {
-                    connectionFactories.add(new ProxyConnectionFactory());
-                }
-                connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
-                connectionFactories.add(httpConnectionFactory);
-                // org.eclipse.jetty.server.AbstractConnectionFactory.getFactories contains similar logic
-                // this is needed for TLS authentication
-                if (httpConfig.getCustomizer(SecureRequestCustomizer.class) == null) {
-                    // disable SNI host check for backwards compatibility with Jetty 9.x
-                    boolean sniHostCheck = false;
-                    httpConfig.addCustomizer(new SecureRequestCustomizer(sniHostCheck));
-                }
-                httpsConnector = new ServerConnector(server, connectionFactories.toArray(new ConnectionFactory[0]));
-                httpsConnector.setPort(tlsPort.get());
-                httpsConnector.setHost(pulsar.getBindAddress());
-                connectors.add(httpsConnector);
+                sslCtxFactory = JettySslContextFactory.createSslContextFactory(config.getWebServiceTlsProvider(),
+                        this.sslFactory, config.isTlsRequireTrustedClientCertOnConnect(),
+                        config.getTlsCiphers(), config.getTlsProtocols());
             } catch (Exception e) {
                 throw new PulsarServerException(e);
             }
-        } else {
-            httpsConnector = null;
         }
+
+        List<ServerConnector> connectors = new ArrayList<>();
+        ServerConnector primaryHttpConnector = null;
+        ServerConnector primaryHttpsConnector = null;
+        // Connector to BindAddress mapping is used to resolve the listener name for the request
+        // in AddListenerAttributeFilter, which adds a listenerName attribute to the request
+        Map<Connector, BindAddress> connectorToBindAddress = new HashMap<>();
+        for (BindAddress bindAddress : bindAddresses) {
+            URI address = bindAddress.getAddress();
+            boolean isTls = "https".equalsIgnoreCase(address.getScheme());
+            List<ConnectionFactory> connectionFactories = new ArrayList<>();
+            if (config.isWebServiceHaProxyProtocolEnabled()) {
+                connectionFactories.add(new ProxyConnectionFactory());
+            }
+            if (isTls) {
+                connectionFactories.add(new SslConnectionFactory(sslCtxFactory, httpConnectionFactory.getProtocol()));
+            }
+            connectionFactories.add(httpConnectionFactory);
+            ServerConnector connector = new ServerConnector(server,
+                    connectionFactories.toArray(new ConnectionFactory[0]));
+            connector.setPort(address.getPort());
+            connector.setHost(StringUtils.defaultIfBlank(address.getHost(), pulsar.getBindAddress()));
+            connectorToBindAddress.put(connector, bindAddress);
+            connectors.add(connector);
+
+            // identify the primary connector. Note that the legacy bindings appear first and have no listener.
+            if (StringUtils.isBlank(bindAddress.getListenerName())
+                    || StringUtils.equalsIgnoreCase(bindAddress.getListenerName(), internalListenerName)) {
+                if (!isTls && primaryHttpConnector == null) {
+                    primaryHttpConnector = connector;
+                }
+                if (isTls && primaryHttpsConnector == null) {
+                    primaryHttpsConnector = connector;
+                }
+            }
+        }
+        this.httpConnector = primaryHttpConnector;
+        this.httpsConnector = primaryHttpsConnector;
 
         // Limit number of concurrent HTTP connections to avoid getting out of file descriptors
         connectors.forEach(c -> {
             c.setAcceptQueueSize(config.getHttpServerAcceptQueueSize());
             c.setIdleTimeout(pulsar.getConfig().getHttpServerIdleTimeout());
         });
-        server.setConnectors(connectors.toArray(new ServerConnector[connectors.size()]));
+        server.setConnectors(connectors.toArray(new ServerConnector[0]));
 
-        filterInitializer = new FilterInitializer(pulsar);
+        filterInitializer = new FilterInitializer(pulsar, connectorToBindAddress);
         // Whether to reject requests with unknown attributes.
         sharedUnknownPropertyHandler.setSkipUnknownProperty(!config.isHttpRequestsFailOnUnknownPropertiesEnabled());
     }
@@ -245,7 +269,8 @@ public class WebService implements AutoCloseable {
     private static class FilterInitializer {
         private final List<FilterHolder> filterHolders = new ArrayList<>();
         private final FilterHolder authenticationFilterHolder;
-        FilterInitializer(PulsarService pulsarService) {
+
+        FilterInitializer(PulsarService pulsarService, Map<Connector, BindAddress> connectorToBindAddress) {
             ServiceConfiguration config = pulsarService.getConfiguration();
 
             if (config.isHttpRequestsLimitEnabled()) {
@@ -257,6 +282,8 @@ public class WebService implements AutoCloseable {
             // wait until the PulsarService is ready to serve incoming requests
             filterHolders.add(
                     new FilterHolder(new WaitUntilPulsarServiceIsReadyForIncomingRequestsFilter(pulsarService)));
+            // add listenerName attribute to the request
+            filterHolders.add(new FilterHolder(new AddListenerAttributeFilter(connectorToBindAddress)));
 
             boolean brokerInterceptorEnabled = pulsarService.getBrokerInterceptor() != null;
             if (brokerInterceptorEnabled) {
@@ -344,6 +371,36 @@ public class WebService implements AutoCloseable {
             public void destroy() {
 
             }
+        }
+    }
+
+    // Parses the internal listener name from the connector name and sets it as a request attribute
+    private static class AddListenerAttributeFilter implements Filter {
+        private final Map<Connector, BindAddress> connectorToBindAddress;
+
+        public AddListenerAttributeFilter(Map<Connector, BindAddress> connectorToBindAddress) {
+            this.connectorToBindAddress = connectorToBindAddress;
+        }
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            Connector connector = getBaseRequest(request).getHttpChannel().getConnector();
+            BindAddress bindAddress = connectorToBindAddress.get(connector);
+            if (bindAddress != null) {
+                request.setAttribute(ATTRIBUTE_LISTENER_NAME, bindAddress.getListenerName());
+            }
+            chain.doFilter(request, response);
+        }
+
+        @Override
+        public void destroy() {
+
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundle.java
@@ -30,7 +30,7 @@ public class NamespaceBundle implements ServiceUnitId, Comparable<NamespaceBundl
     private final NamespaceBundleFactory factory;
     // Issue#596: remove this once we remove broker persistent/non-persistent mode configuration
     // it is used by load-manager while considering bundle ownership
-    private boolean hasNonPersistentTopic = false;
+    private volatile boolean hasNonPersistentTopic = false;
     private final String key;
     private final String bundleRange;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.broker.admin;
 
 import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -38,7 +37,6 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,6 +76,7 @@ import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.admin.v2.Namespaces;
 import org.apache.pulsar.broker.admin.v2.PersistentTopics;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -739,8 +738,11 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(uri).when(uriInfo).getRequestUri();
 
         // setup to redirect to another broker in the same cluster
-        doReturn(Optional.of(new URL("http://otherhost" + ":" + 8080))).when(nsSvc)
-                .getWebServiceUrl(Mockito.argThat(new ArgumentMatcher<NamespaceName>() {
+        doReturn(Optional.of(LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl("http://otherhost:8080")
+                .build())).when(nsSvc)
+                .getLookupResultForWebRequest(Mockito.argThat(new ArgumentMatcher<NamespaceName>() {
                     @Override
                     public boolean matches(NamespaceName nsname) {
                         return nsname.equals(NamespacesTest.this.testGlobalNamespaces.get(0));
@@ -784,10 +786,13 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
                 new byte[0], null, null);
 
         // setup ownership to localhost
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         LookupOptions options = LookupOptions.builder().authoritative(false)
-                .readOnly(false).requestHttps(false).build();
-        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
+                .readOnly(false).build();
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getLookupResultForWebRequest(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
 
         response = mock(AsyncResponse.class);
@@ -817,7 +822,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         testNs = this.testGlobalNamespaces.get(0);
         // setup ownership to localhost
-        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getLookupResultForWebRequest(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testNs.getTenant(),
@@ -828,7 +833,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         testNs = this.testLocalNamespaces.get(0);
         // setup ownership to localhost
-        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getLookupResultForWebRequest(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testNs.getTenant(),
@@ -845,7 +850,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         testNs = this.testLocalNamespaces.get(1);
         // setup ownership to localhost
-        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, options);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getLookupResultForWebRequest(testNs, options);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testNs.getTenant(),
@@ -863,7 +868,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         uriField.set(namespaces, uriInfo);
         doReturn(URI.create(pulsar.getWebServiceAddress() + "/dummy/uri")).when(uriInfo).getRequestUri();
 
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-delete-namespace-with-bundles";
         List<String> boundaries = List.of("0x00000000", "0x80000000", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()
@@ -878,7 +886,8 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(namespacesAdmin).when(admin).namespaces();
 
         doReturn(CompletableFuture.completedFuture(Optional.of(localWebServiceUrl))).when(nsSvc)
-                .getWebServiceUrlAsync(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)),
+                .getLookupResultForWebRequestAsync(
+                        Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)),
                         Mockito.any());
         doReturn(CompletableFuture.completedFuture(false)).when(nsSvc)
                 .isServiceUnitOwnedAsync(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)));
@@ -902,16 +911,16 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         assertEquals(captor.getValue().getResponse().getStatus(), Status.TEMPORARY_REDIRECT.getStatusCode());
         NamespaceBundles nsBundles = nsSvc.getNamespaceBundleFactory().getBundles(testNs, bundleData);
         doReturn(CompletableFuture.completedFuture(Optional.empty())).when(nsSvc)
-                .getWebServiceUrlAsync(any(NamespaceBundle.class), any(LookupOptions.class));
+                .getLookupResultForWebRequestAsync(any(NamespaceBundle.class), any(LookupOptions.class));
         response = mock(AsyncResponse.class);
         namespaces.deleteNamespace(response, testTenant, bundledNsLocal, false, false);
         verify(response, timeout(5000).times(1)).resume(captor.capture());
         assertEquals(captor.getValue().getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         // make one bundle owned
         LookupOptions optionsHttps = LookupOptions.builder().authoritative(false)
-                .requestHttps(true).readOnly(false).build();
+                .readOnly(false).build();
         doReturn(CompletableFuture.completedFuture(Optional.of(localWebServiceUrl))).when(nsSvc)
-                .getWebServiceUrlAsync(nsBundles.getBundles().get(0), optionsHttps);
+                .getLookupResultForWebRequestAsync(nsBundles.getBundles().get(0), optionsHttps);
         doReturn(CompletableFuture.completedFuture(true)).when(nsSvc)
                 .isServiceUnitOwnedAsync(nsBundles.getBundles().get(0));
         doReturn(CompletableFuture.completedFuture(null)).when(namespacesAdmin).deleteNamespaceBundleAsync(
@@ -924,7 +933,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         assertEquals(captor.getValue().getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         response = mock(AsyncResponse.class);
         doReturn(CompletableFuture.completedFuture(Optional.of(localWebServiceUrl))).when(nsSvc)
-                .getWebServiceUrlAsync(any(NamespaceBundle.class), any(LookupOptions.class));
+                .getLookupResultForWebRequestAsync(any(NamespaceBundle.class), any(LookupOptions.class));
         for (NamespaceBundle bundle : nsBundles.getBundles()) {
             doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).isServiceUnitOwnedAsync(bundle);
         }
@@ -940,13 +949,13 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testUnloadNamespaces() throws Exception {
         final NamespaceName testNs = this.testLocalNamespaces.get(1);
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc)
-                .getWebServiceUrl(Mockito.argThat(ns -> ns.equals(testNs)), Mockito.any());
+                .getLookupResultForWebRequest(Mockito.argThat(ns -> ns.equals(testNs)), Mockito.any());
         doReturn(true).when(nsSvc).isServiceUnitOwned(Mockito.argThat(ns -> ns.equals(testNs)));
-
-        NamespaceBundle bundle = nsSvc.getNamespaceBundleFactory().getFullBundle(testNs);
-        doNothing().when(namespaces).validateBundleOwnership(bundle, false, true);
 
         // The namespace unload should succeed on all the bundles
         AsyncResponse response = mock(AsyncResponse.class);
@@ -962,7 +971,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testSplitBundles() throws Exception {
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-bundled-namespace-1";
         List<String> boundaries = List.of("0x00000000", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()
@@ -1007,7 +1019,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testSplitBundleWithUnDividedRange() throws Exception {
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-bundled-namespace-1";
         List<String> boundaries = List.of("0x00000000", "0x08375b1a", "0x08375b1b", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()
@@ -1038,7 +1053,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testUnloadNamespaceWithBundles() throws Exception {
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-bundled-namespace-1";
         List<String> boundaries = List.of("0x00000000", "0x80000000", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()
@@ -1049,7 +1067,8 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         final NamespaceName testNs = NamespaceName.get(this.testTenant, bundledNsLocal);
 
         doReturn(CompletableFuture.completedFuture(Optional.of(localWebServiceUrl))).when(nsSvc)
-                .getWebServiceUrlAsync(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)),
+                .getLookupResultForWebRequestAsync(
+                        Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)),
                         Mockito.any());
         doReturn(true).when(nsSvc)
                 .isServiceUnitOwned(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(testNs)));
@@ -1058,9 +1077,9 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         NamespaceBundle testBundle = nsBundles.getBundles().get(0);
         // make one bundle owned
         LookupOptions optionsHttps = LookupOptions.builder().authoritative(false)
-                .requestHttps(true).readOnly(false).build();
+                .readOnly(false).build();
         doReturn(CompletableFuture.completedFuture(Optional.of(localWebServiceUrl)))
-                .when(nsSvc).getWebServiceUrlAsync(testBundle, optionsHttps);
+                .when(nsSvc).getLookupResultForWebRequestAsync(testBundle, optionsHttps);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testBundle);
         doReturn(CompletableFuture.completedFuture(null)).when(nsSvc).unloadNamespaceBundle(testBundle);
         AsyncResponse response = mock(AsyncResponse.class);
@@ -1115,7 +1134,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @Test
     public void testRetention() throws Exception {
         try {
-            URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+            LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
             String bundledNsLocal = "test-bundled-namespace-1";
             List<String> boundaries = List.of("0x00000000", "0xffffffff");
             BundlesData bundleData = BundlesData.builder()
@@ -1205,7 +1227,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testValidateTopicOwnership() throws Exception {
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-bundled-namespace-1";
         List<String> boundaries = List.of("0x00000000", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()
@@ -1598,9 +1623,9 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().deleteNamespace(namespace);
     }
 
-    private void mockWebUrl(URL localWebServiceUrl, NamespaceName namespace) throws Exception {
+    private void mockWebUrl(LookupResult localWebServiceUrl, NamespaceName namespace) throws Exception {
         doReturn(Optional.of(localWebServiceUrl)).when(nsSvc)
-                .getWebServiceUrl(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(namespace)),
+                .getLookupResultForWebRequest(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(namespace)),
                         Mockito.any());
         doReturn(true).when(nsSvc)
                 .isServiceUnitOwned(Mockito.argThat(bundle -> bundle.getNamespaceObject().equals(namespace)));
@@ -2059,7 +2084,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         int initBundleCount = 4;
         BundlesData data = BundlesData.builder().numBundles(initBundleCount).build();
         admin.namespaces().createNamespace(namespace, data);
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         final NamespaceName testNs = NamespaceName.get(namespace);
         mockWebUrl(localWebServiceUrl, testNs);
         for (int i = 0; i < 10; i++) {
@@ -2620,7 +2648,10 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testBundleValidationAfterSplit() throws Exception {
-        URL localWebServiceUrl = new URL(pulsar.getSafeWebServiceAddress());
+        LookupResult localWebServiceUrl = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(pulsar.getSafeWebServiceAddress())
+                .build();
         String bundledNsLocal = "test-bundle-validation-after-split";
         List<String> boundaries = List.of("0x00000000", "0xffffffff");
         BundlesData bundleData = BundlesData.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicsTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -114,9 +115,13 @@ public class TopicsTest extends MockedPulsarServiceBaseTest {
         super.internalSetup();
         topics = spy(new Topics());
         topics.setPulsar(pulsar);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        doReturn("http").when(request).getScheme();
+        topics.setHttpRequest(request);
         doReturn(TopicDomain.persistent.value()).when(topics).domain();
         doReturn("test-app").when(topics).clientAppId();
         doReturn(mock(AuthenticationDataHttps.class)).when(topics).clientAuthData();
+        doReturn(null).when(topics).getWebServiceListenerName();
         admin.clusters().createCluster(testLocalCluster, new ClusterDataImpl());
         admin.tenants().createTenant(testTenant, new TenantInfoImpl(Set.of("role1", "role2"),
                 Set.of(testLocalCluster)));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -189,7 +189,7 @@ public abstract class MockedPulsarServiceBaseTest extends TestRetrySupport {
         return resolveLookupUrl(usePulsarBinaryProtocol).toString();
     }
 
-    private URI resolveLookupUrl(boolean usePulsarBinaryProtocol) {
+    protected URI resolveLookupUrl(boolean usePulsarBinaryProtocol) {
         if (usePulsarBinaryProtocol) {
             return URI.create(pulsar.getBrokerServiceUrl());
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AdvertisedListenersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AdvertisedListenersTest.java
@@ -73,10 +73,13 @@ public class AdvertisedListenersTest extends MultiBrokerBaseTest {
 
         // Use invalid domain name as identifier and instead make sure the advertised listeners work as intended
         conf.setAdvertisedAddress(advertisedAddress);
+        // let it be detected from advertised listeners
+        conf.setInternalListenerName(null);
+        // set advertised listeners
         conf.setAdvertisedListeners(
                 "public:pulsar://localhost:" + pulsarPort
-                        + ",public_http:http://localhost:" + httpPort
-                        + ",public_https:https://localhost:" + httpsPort);
+                        + ",public:http://localhost:" + httpPort
+                        + ",public:https://localhost:" + httpsPort);
         conf.setBrokerServicePort(Optional.of(pulsarPort));
         conf.setWebServicePort(Optional.of(httpPort));
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplTest.java
@@ -53,7 +53,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -197,10 +196,10 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         assertTrue(lookupResult.isPresent());
         assertEquals(lookupResult.get().getLookupData().getHttpUrl(), brokerLookupData.get().getWebServiceUrl());
 
-        Optional<URL> webServiceUrl = pulsar2.getNamespaceService()
-                .getWebServiceUrl(bundle, LookupOptions.builder().requestHttps(false).build());
+        Optional<LookupResult> webServiceUrl = pulsar2.getNamespaceService()
+                .getLookupResultForWebRequest(bundle, LookupOptions.builder().build());
         assertTrue(webServiceUrl.isPresent());
-        assertEquals(webServiceUrl.get().toString(), brokerLookupData.get().getWebServiceUrl());
+        assertEquals(webServiceUrl.get().getLookupData().getHttpUrl(), brokerLookupData.get().getWebServiceUrl());
     }
 
     // Test that the load manager will use round-robin assignment
@@ -248,30 +247,25 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
         admin.topics().createPartitionedTopic(topicName.toString(), 1);
 
         // Test LookupOptions.readOnly = true when the bundle is not owned by any broker.
-        Optional<URL> webServiceUrlReadOnlyTrue = pulsar1.getNamespaceService()
-                .getWebServiceUrl(bundle, LookupOptions.builder().readOnly(true).requestHttps(false).build());
+        Optional<LookupResult> webServiceUrlReadOnlyTrue = pulsar1.getNamespaceService()
+                .getLookupResultForWebRequest(bundle, LookupOptions.builder().readOnly(true).build());
         assertTrue(webServiceUrlReadOnlyTrue.isEmpty());
 
         // Test LookupOptions.readOnly = false and the bundle assign to some broker.
-        Optional<URL> webServiceUrlReadOnlyFalse = pulsar1.getNamespaceService()
-                .getWebServiceUrl(bundle, LookupOptions.builder().readOnly(false).requestHttps(false).build());
+        Optional<LookupResult> webServiceUrlReadOnlyFalse = pulsar1.getNamespaceService()
+                .getLookupResultForWebRequest(bundle, LookupOptions.builder().readOnly(false).build());
         assertTrue(webServiceUrlReadOnlyFalse.isPresent());
-
-        // Test LookupOptions.requestHttps = true
-        Optional<URL> webServiceUrlHttps = pulsar2.getNamespaceService()
-                .getWebServiceUrl(bundle, LookupOptions.builder().requestHttps(true).build());
-        assertTrue(webServiceUrlHttps.isPresent());
-        assertTrue(webServiceUrlHttps.get().toString().startsWith("https"));
 
         // TODO: Support LookupOptions.loadTopicsInBundle = true
 
-        // Test LookupOptions.advertisedListenerName = internal but the broker do not have internal listener.
+        // Test LookupOptions.advertisedListenerName = otherlistener but the broker does not have it.
         try {
             pulsar2.getNamespaceService()
-                    .getWebServiceUrl(bundle, LookupOptions.builder().advertisedListenerName("internal").build());
+                    .getLookupResultForWebRequest(bundle,
+                            LookupOptions.builder().advertisedListenerName("otherlistener").build());
             fail();
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("the broker do not have internal listener"));
+            assertTrue(e.getMessage().contains("the broker do not have otherlistener listener"));
         }
     }
 
@@ -1142,12 +1136,21 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
 
     @Test(priority = 200)
     public void testDeployAndRollbackLoadManager() throws Exception {
+        // The migration redirect (RedirectManagerForLoadManagerMigration) is gated by
+        // loadManagerMigrationEnabled; enable it on the existing brokers so they redirect
+        // requests to the newly added broker that uses a different load manager.
+        boolean prevMigration1 = pulsar1.getConfiguration().isLoadManagerMigrationEnabled();
+        boolean prevMigration2 = pulsar2.getConfiguration().isLoadManagerMigrationEnabled();
+        pulsar1.getConfiguration().setLoadManagerMigrationEnabled(true);
+        pulsar2.getConfiguration().setLoadManagerMigrationEnabled(true);
+        try {
         // Test rollback to modular load manager.
         ServiceConfiguration defaultConf = getDefaultConf();
         defaultConf.setAllowAutoTopicCreation(true);
         defaultConf.setForceDeleteNamespaceAllowed(true);
         defaultConf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
         defaultConf.setLoadBalancerSheddingEnabled(false);
+        defaultConf.setLoadManagerMigrationEnabled(true);
         try (var additionalPulsarTestContext = createAdditionalPulsarTestContext(defaultConf)) {
             // start pulsar3 with old load manager
             @Cleanup
@@ -1168,23 +1171,24 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
 
             LookupOptions options = LookupOptions.builder()
                     .authoritative(false)
-                    .requestHttps(false)
                     .readOnly(false)
-                    .loadTopicsInBundle(false).build();
-            Optional<URL> webServiceUrl1 =
-                    pulsar1.getNamespaceService().getWebServiceUrl(bundle, options);
+                    .build();
+            Optional<LookupResult> webServiceUrl1 =
+                    pulsar1.getNamespaceService().getLookupResultForWebRequest(bundle, options);
             assertTrue(webServiceUrl1.isPresent());
-            assertEquals(webServiceUrl1.get().toString(), pulsar3.getWebServiceAddress());
+            assertEquals(webServiceUrl1.get().getLookupData().getHttpUrl(), pulsar3.getWebServiceAddress());
 
-            Optional<URL> webServiceUrl2 =
-                    pulsar2.getNamespaceService().getWebServiceUrl(bundle, options);
+            Optional<LookupResult> webServiceUrl2 =
+                    pulsar2.getNamespaceService().getLookupResultForWebRequest(bundle, options);
             assertTrue(webServiceUrl2.isPresent());
-            assertEquals(webServiceUrl2.get().toString(), webServiceUrl1.get().toString());
+            assertEquals(webServiceUrl2.get().getLookupData().getHttpUrl(),
+                    webServiceUrl1.get().getLookupData().getHttpUrl());
 
-            Optional<URL> webServiceUrl3 =
-                    pulsar3.getNamespaceService().getWebServiceUrl(bundle, options);
+            Optional<LookupResult> webServiceUrl3 =
+                    pulsar3.getNamespaceService().getLookupResultForWebRequest(bundle, options);
             assertTrue(webServiceUrl3.isPresent());
-            assertEquals(webServiceUrl3.get().toString(), webServiceUrl1.get().toString());
+            assertEquals(webServiceUrl3.get().getLookupData().getHttpUrl(),
+                    webServiceUrl1.get().getLookupData().getHttpUrl());
 
             List<PulsarService> pulsarServices = List.of(pulsar1, pulsar2, pulsar3);
             for (PulsarService pulsarService : pulsarServices) {
@@ -1207,6 +1211,7 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
             conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
             conf.setLoadBalancerLoadSheddingStrategy(TransferShedder.class.getName());
             conf.setLoadManagerServiceUnitStateTableViewClassName(serviceUnitStateTableViewClassName);
+            conf.setLoadManagerMigrationEnabled(true);
             try (var additionPulsarTestContext = createAdditionalPulsarTestContext(conf)) {
                 @Cleanup
                 var pulsar4 = additionPulsarTestContext.getPulsarService();
@@ -1229,26 +1234,28 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                         pulsar4.getWebServiceAddress());
 
                 webServiceUrl1 =
-                        pulsar1.getNamespaceService().getWebServiceUrl(bundle, options);
+                        pulsar1.getNamespaceService().getLookupResultForWebRequest(bundle, options);
                 assertTrue(webServiceUrl1.isPresent());
-                assertTrue(availableWebUrlCandidates.contains(webServiceUrl1.get().toString()));
+                assertTrue(availableWebUrlCandidates.contains(webServiceUrl1.get().getLookupData().getHttpUrl()));
 
                 webServiceUrl2 =
-                        pulsar2.getNamespaceService().getWebServiceUrl(bundle, options);
+                        pulsar2.getNamespaceService().getLookupResultForWebRequest(bundle, options);
                 assertTrue(webServiceUrl2.isPresent());
-                assertEquals(webServiceUrl2.get().toString(), webServiceUrl1.get().toString());
+                assertEquals(webServiceUrl2.get().getLookupData().getHttpUrl(),
+                        webServiceUrl1.get().getLookupData().getHttpUrl());
 
                 // The pulsar3 will redirect to pulsar4
                 webServiceUrl3 =
-                        pulsar3.getNamespaceService().getWebServiceUrl(bundle, options);
+                        pulsar3.getNamespaceService().getLookupResultForWebRequest(bundle, options);
                 assertTrue(webServiceUrl3.isPresent());
                 // It will redirect to pulsar4
-                assertTrue(availableWebUrlCandidates.contains(webServiceUrl3.get().toString()));
+                assertTrue(availableWebUrlCandidates.contains(webServiceUrl3.get().getLookupData().getHttpUrl()));
 
                 var webServiceUrl4 =
-                        pulsar4.getNamespaceService().getWebServiceUrl(bundle, options);
+                        pulsar4.getNamespaceService().getLookupResultForWebRequest(bundle, options);
                 assertTrue(webServiceUrl4.isPresent());
-                assertEquals(webServiceUrl4.get().toString(), webServiceUrl1.get().toString());
+                assertEquals(webServiceUrl4.get().getLookupData().getHttpUrl(),
+                        webServiceUrl1.get().getLookupData().getHttpUrl());
 
                 pulsarServices = List.of(pulsar1, pulsar2, pulsar3, pulsar4);
                 for (PulsarService pulsarService : pulsarServices) {
@@ -1333,6 +1340,10 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
                 assertEquals(consumer.receive().getValue(), "t3");
             }
         }
+        } finally {
+            pulsar1.getConfiguration().setLoadManagerMigrationEnabled(prevMigration1);
+            pulsar2.getConfiguration().setLoadManagerMigrationEnabled(prevMigration2);
+        }
     }
 
     @Test(priority = 200)
@@ -1347,13 +1358,13 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
 
         LookupOptions options = LookupOptions.builder()
                 .authoritative(false)
-                .requestHttps(false)
                 .readOnly(false)
-                .loadTopicsInBundle(false).build();
+                .build();
 
         String ownershipBefore = pulsar1.getAdminClient().lookups().lookupTopic(topic);
         assertEquals(pulsar2.getAdminClient().lookups().lookupTopic(topic), ownershipBefore);
-        Optional<URL> webUrlBefore = pulsar1.getNamespaceService().getWebServiceUrl(bundle, options);
+        Optional<LookupResult> webUrlBefore =
+                pulsar1.getNamespaceService().getLookupResultForWebRequest(bundle, options);
         assertTrue(webUrlBefore.isPresent());
 
         // === Phase 1: enable the syncer and verify it activates on the leader only ===
@@ -1397,9 +1408,11 @@ public class ExtensibleLoadManagerImplTest extends ExtensibleLoadManagerImplBase
             // All three brokers (across both impls) must agree on topic ownership.
             assertEquals(pulsar2.getAdminClient().lookups().lookupTopic(topic), ownershipBefore);
             assertEquals(pulsar3.getAdminClient().lookups().lookupTopic(topic), ownershipBefore);
-            Optional<URL> webUrlPulsar3 = pulsar3.getNamespaceService().getWebServiceUrl(bundle, options);
+            Optional<LookupResult> webUrlPulsar3 =
+                    pulsar3.getNamespaceService().getLookupResultForWebRequest(bundle, options);
             assertTrue(webUrlPulsar3.isPresent());
-            assertEquals(webUrlPulsar3.get().toString(), webUrlBefore.get().toString());
+            assertEquals(webUrlPulsar3.get().getLookupData().getHttpUrl(),
+                    webUrlBefore.get().getLookupData().getHttpUrl());
 
             // SLA monitor and heartbeat lookups must agree across impls in every direction.
             List<PulsarService> brokers = List.of(pulsar1, pulsar2, pulsar3);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/data/BrokerLookupDataTest.java
@@ -39,6 +39,7 @@ public class BrokerLookupDataTest {
 
     @Test
     public void testConstructors() throws PulsarServerException, URISyntaxException {
+        String brokerId = "localhost:8080";
         String webServiceUrl = "http://localhost:8080";
         String webServiceUrlTls = "https://localhoss:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
@@ -55,7 +56,7 @@ public class BrokerLookupDataTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        BrokerLookupData lookupData = new BrokerLookupData(
+        BrokerLookupData lookupData = new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 ExtensibleLoadManagerImpl.class.getName(), System.currentTimeMillis(), "3.0",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerFilterTestBase.java
@@ -124,6 +124,7 @@ public class BrokerFilterTestBase {
     }
 
     public BrokerLookupData getLookupData(String version, String loadManagerClassName) {
+        String brokerId = "localhost:8080";
         String webServiceUrl = "http://localhost:8080";
         String webServiceUrlTls = "https://localhoss:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
@@ -132,7 +133,7 @@ public class BrokerFilterTestBase {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 loadManagerClassName, -1, version, Collections.emptyMap());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/filter/BrokerIsolationPoliciesFilterTest.java
@@ -205,6 +205,7 @@ public class BrokerIsolationPoliciesFilterTest {
 
     public BrokerLookupData getLookupData(boolean persistentTopicsEnabled,
                                           boolean nonPersistentTopicsEnabled) {
+        String brokerId = "localhost:8080";
         String webServiceUrl = "http://localhost:8080";
         String webServiceUrlTls = "https://localhoss:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
@@ -213,7 +214,7 @@ public class BrokerIsolationPoliciesFilterTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
                 persistentTopicsEnabled, nonPersistentTopicsEnabled,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerForLoadManagerMigrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/manager/RedirectManagerForLoadManagerMigrationTest.java
@@ -40,19 +40,21 @@ import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
 import org.testng.annotations.Test;
 
 /**
- * Unit test {@link RedirectManager}.
+ * Unit test {@link RedirectManagerForLoadManagerMigration}.
  */
-public class RedirectManagerTest {
+public class RedirectManagerForLoadManagerMigrationTest {
 
     @Test
-    public void testFindRedirectLookupResultAsync() throws ExecutionException, InterruptedException {
+    public void testRedirectIfLoadBalancerOnBrokerIsNotExpected() throws ExecutionException, InterruptedException {
         PulsarService pulsar = mock(PulsarService.class);
         ServiceConfiguration configuration = new ServiceConfiguration();
         when(pulsar.getConfiguration()).thenReturn(configuration);
-        RedirectManager redirectManager = spy(new RedirectManager(pulsar, null));
+        RedirectManagerForLoadManagerMigration
+                redirectManagerForLoadManagerMigration = spy(new RedirectManagerForLoadManagerMigration(pulsar, null));
 
         configuration.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
         configuration.setLoadBalancerDebugModeEnabled(true);
+        configuration.setLoadManagerMigrationEnabled(true);
 
         // Test 1: No load manager class name found.
         doReturn(CompletableFuture.completedFuture(
@@ -60,10 +62,11 @@ public class RedirectManagerTest {
                     put("broker-1", getLookupData("broker-1", null, 10));
                     put("broker-2", getLookupData("broker-2", ModularLoadManagerImpl.class.getName(), 1));
                 }}
-        )).when(redirectManager).getAvailableBrokerLookupDataAsync();
+        )).when(redirectManagerForLoadManagerMigration).getAvailableBrokerLookupDataAsync();
 
         // Should redirect to broker-1, since broker-1 has the latest load manager, even though the class name is null.
-        Optional<LookupResult> lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        Optional<LookupResult> lookupResult =
+                redirectManagerForLoadManagerMigration.redirectIfLoadBalancerOnBrokerIsNotExpected(null).get();
         assertTrue(lookupResult.isPresent());
         assertTrue(lookupResult.get().getLookupData().getBrokerUrl().contains("broker-1"));
 
@@ -73,9 +76,9 @@ public class RedirectManagerTest {
                     put("broker-1", getLookupData("broker-1", ExtensibleLoadManagerImpl.class.getName(), 10));
                     put("broker-2", getLookupData("broker-2", ModularLoadManagerImpl.class.getName(), 1));
                 }}
-        )).when(redirectManager).getAvailableBrokerLookupDataAsync();
+        )).when(redirectManagerForLoadManagerMigration).getAvailableBrokerLookupDataAsync();
 
-        lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        lookupResult = redirectManagerForLoadManagerMigration.redirectIfLoadBalancerOnBrokerIsNotExpected(null).get();
         assertTrue(lookupResult.isPresent());
         assertTrue(lookupResult.get().getLookupData().getBrokerUrl().contains("broker-1"));
 
@@ -86,14 +89,15 @@ public class RedirectManagerTest {
                     put("broker-1", getLookupData("broker-1", ExtensibleLoadManagerImpl.class.getName(), 10));
                     put("broker-2", getLookupData("broker-2", ModularLoadManagerImpl.class.getName(), 100));
                 }}
-        )).when(redirectManager).getAvailableBrokerLookupDataAsync();
+        )).when(redirectManagerForLoadManagerMigration).getAvailableBrokerLookupDataAsync();
 
-        lookupResult = redirectManager.findRedirectLookupResultAsync().get();
+        lookupResult = redirectManagerForLoadManagerMigration.redirectIfLoadBalancerOnBrokerIsNotExpected(null).get();
         assertFalse(lookupResult.isPresent());
     }
 
 
     public BrokerLookupData getLookupData(String broker, String loadManagerClassName, long startTimeStamp) {
+        String brokerId = "broker:8080";
         String webServiceUrl = "http://" + broker + ":8080";
         String webServiceUrlTls = "https://" + broker + ":8081";
         String pulsarServiceUrl = "pulsar://" + broker + ":6650";
@@ -102,7 +106,7 @@ public class RedirectManagerTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols, true, true,
                 loadManagerClassName, startTimeStamp, "3.0.0", Collections.emptyMap());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/scheduler/TransferShedderTest.java
@@ -711,6 +711,7 @@ public class TransferShedderTest {
     }
 
     public BrokerLookupData getLookupData() {
+        String brokerId = "localhost:8080";
         String webServiceUrl = "http://localhost:8080";
         String webServiceUrlTls = "https://localhoss:8081";
         String pulsarServiceUrl = "pulsar://localhost:6650";
@@ -719,7 +720,7 @@ public class TransferShedderTest {
         Map<String, String> protocols = new HashMap<>(){{
             put("kafka", "9092");
         }};
-        return new BrokerLookupData(
+        return new BrokerLookupData(brokerId,
                 webServiceUrl, webServiceUrlTls, pulsarServiceUrl,
                 pulsarServiceUrlTls, advertisedListeners, protocols,
                 true, true,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/LookupResultTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/LookupResultTest.java
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.lookup;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.namespace.LookupOptions;
+import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class LookupResultTest {
+
+    private static final String BROKER_ID = "broker-1:8080";
+    private static final String WEB_URL = "http://broker-1:8080";
+    private static final String WEB_URL_TLS = "https://broker-1:8443";
+    private static final String PULSAR_URL = "pulsar://broker-1:6650";
+    private static final String PULSAR_URL_TLS = "pulsar+ssl://broker-1:6651";
+
+    private static final String LISTENER_NAME = "internal";
+    private static final String LISTENER_PULSAR_URL = "pulsar://gateway:7000";
+    private static final String LISTENER_PULSAR_URL_TLS = "pulsar+ssl://gateway:7001";
+    private static final String LISTENER_HTTP_URL = "http://gateway:8000";
+    private static final String LISTENER_HTTP_URL_TLS = "https://gateway:8001";
+
+    private static Map<String, AdvertisedListener> singleListener() {
+        Map<String, AdvertisedListener> map = new HashMap<>();
+        map.put(LISTENER_NAME, AdvertisedListener.builder()
+                .brokerServiceUrl(URI.create(LISTENER_PULSAR_URL))
+                .brokerServiceUrlTls(URI.create(LISTENER_PULSAR_URL_TLS))
+                .brokerHttpUrl(URI.create(LISTENER_HTTP_URL))
+                .brokerHttpsUrl(URI.create(LISTENER_HTTP_URL_TLS))
+                .build());
+        return map;
+    }
+
+    private static BrokerLookupData newBrokerLookupData(Map<String, AdvertisedListener> listeners) {
+        return new BrokerLookupData(BROKER_ID, WEB_URL, WEB_URL_TLS, PULSAR_URL, PULSAR_URL_TLS,
+                listeners, Collections.emptyMap(), true, true,
+                "ModularLoadManager", 0L, "3.0", Collections.emptyMap());
+    }
+
+    @Test
+    public void testTypeBrokerUrl() {
+        LookupResult result = LookupResult.builder().type(LookupResult.Type.BrokerUrl).build();
+        assertTrue(result.isBrokerUrl());
+        assertFalse(result.isRedirect());
+        assertFalse(result.isLoadManagerMigration());
+    }
+
+    @Test
+    public void testTypeRedirectUrl() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .authoritativeRedirect(true)
+                .build();
+        assertFalse(result.isBrokerUrl());
+        assertTrue(result.isRedirect());
+        assertFalse(result.isLoadManagerMigration());
+        assertTrue(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testTypeLoadManagerMigrationUrl() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.LoadManagerMigrationUrl)
+                .build();
+        assertFalse(result.isBrokerUrl());
+        assertTrue(result.isRedirect());
+        assertTrue(result.isLoadManagerMigration());
+        assertFalse(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testTypeIsRequiredByBuilder() {
+        assertThrows(NullPointerException.class, () -> LookupResult.builder().build());
+    }
+
+    @Test
+    public void testCreateFromBrokerLookupDataWithoutOptions() {
+        LookupResult result = LookupResult.create(newBrokerLookupData(Collections.emptyMap()), null);
+        assertTrue(result.isBrokerUrl());
+        assertFalse(result.isRedirect());
+        assertEquals(result.getLookupData().getBrokerId(), BROKER_ID);
+        assertEquals(result.getLookupData().getHttpUrl(), WEB_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), WEB_URL_TLS);
+        assertEquals(result.getLookupData().getBrokerUrl(), PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), PULSAR_URL_TLS);
+        assertNull(result.getBrokerServiceListenerName());
+        assertNull(result.getWebServiceListenerName());
+    }
+
+    @Test
+    public void testCreateAsRedirectFromBrokerLookupData() {
+        LookupResult result = LookupResult.create(newBrokerLookupData(Collections.emptyMap()),
+                LookupOptions.builder().build(), true);
+        assertTrue(result.isRedirect());
+        assertFalse(result.isLoadManagerMigration());
+        assertTrue(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testCreateLoadManagerMigrationLookupResult() {
+        LookupResult result = LookupResult.createLoadManagerMigrationLookupResult(
+                newBrokerLookupData(Collections.emptyMap()), LookupOptions.builder().build());
+        assertTrue(result.isRedirect());
+        assertTrue(result.isLoadManagerMigration());
+        assertFalse(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testCreateWithAdvertisedListenerOverridesBrokerServiceUrls() {
+        BrokerLookupData lookupData = newBrokerLookupData(singleListener());
+        LookupOptions options = LookupOptions.builder().advertisedListenerName(LISTENER_NAME).build();
+
+        LookupResult result = LookupResult.create(lookupData, options);
+
+        assertEquals(result.getBrokerServiceListenerName(), LISTENER_NAME);
+        assertNull(result.getWebServiceListenerName());
+        assertEquals(result.getLookupData().getBrokerUrl(), LISTENER_PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), LISTENER_PULSAR_URL_TLS);
+        // web URLs are untouched when only advertisedListenerName is set
+        assertEquals(result.getLookupData().getHttpUrl(), WEB_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), WEB_URL_TLS);
+    }
+
+    @Test
+    public void testCreateWithUnknownAdvertisedListenerLeavesUrlsUnchanged() {
+        BrokerLookupData lookupData = newBrokerLookupData(singleListener());
+        LookupOptions options = LookupOptions.builder().advertisedListenerName("does-not-exist").build();
+
+        LookupResult result = LookupResult.create(lookupData, options);
+
+        assertNull(result.getBrokerServiceListenerName());
+        assertNull(result.getWebServiceListenerName());
+        assertEquals(result.getLookupData().getBrokerUrl(), PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), PULSAR_URL_TLS);
+        assertEquals(result.getLookupData().getHttpUrl(), WEB_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), WEB_URL_TLS);
+    }
+
+    @Test
+    public void testCreateWithWebServiceAdvertisedListenerOverridesHttpUrls() {
+        BrokerLookupData lookupData = newBrokerLookupData(singleListener());
+        LookupOptions options = LookupOptions.builder()
+                .webServiceAdvertisedListenerName(LISTENER_NAME)
+                .build();
+
+        LookupResult result = LookupResult.create(lookupData, options);
+
+        assertEquals(result.getWebServiceListenerName(), LISTENER_NAME);
+        // Since the listener has broker service URLs configured, brokerServiceListenerName
+        // defaults to the same listener name (per LookupResult contract).
+        assertEquals(result.getBrokerServiceListenerName(), LISTENER_NAME);
+        assertEquals(result.getLookupData().getHttpUrl(), LISTENER_HTTP_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), LISTENER_HTTP_URL_TLS);
+        assertEquals(result.getLookupData().getBrokerUrl(), LISTENER_PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), LISTENER_PULSAR_URL_TLS);
+    }
+
+    @Test
+    public void testCreateWithWebServiceListenerWithoutBrokerServiceUrls() {
+        Map<String, AdvertisedListener> listeners = new HashMap<>();
+        listeners.put(LISTENER_NAME, AdvertisedListener.builder()
+                .brokerHttpUrl(URI.create(LISTENER_HTTP_URL))
+                .brokerHttpsUrl(URI.create(LISTENER_HTTP_URL_TLS))
+                .build());
+        BrokerLookupData lookupData = newBrokerLookupData(listeners);
+        LookupOptions options = LookupOptions.builder()
+                .webServiceAdvertisedListenerName(LISTENER_NAME)
+                .build();
+
+        LookupResult result = LookupResult.create(lookupData, options);
+
+        assertEquals(result.getWebServiceListenerName(), LISTENER_NAME);
+        // No broker service URLs on the listener — broker URLs stay on the broker's defaults
+        // and brokerServiceListenerName is not overridden.
+        assertNull(result.getBrokerServiceListenerName());
+        assertEquals(result.getLookupData().getBrokerUrl(), PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), PULSAR_URL_TLS);
+        assertEquals(result.getLookupData().getHttpUrl(), LISTENER_HTTP_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), LISTENER_HTTP_URL_TLS);
+    }
+
+    @Test
+    public void testCreateWithBothListenerNamesIndependently() {
+        Map<String, AdvertisedListener> listeners = new HashMap<>();
+        listeners.put("broker-listener", AdvertisedListener.builder()
+                .brokerServiceUrl(URI.create("pulsar://broker-listener:7000"))
+                .build());
+        listeners.put("web-listener", AdvertisedListener.builder()
+                .brokerHttpUrl(URI.create("http://web-listener:8000"))
+                .build());
+        BrokerLookupData lookupData = newBrokerLookupData(listeners);
+        LookupOptions options = LookupOptions.builder()
+                .advertisedListenerName("broker-listener")
+                .webServiceAdvertisedListenerName("web-listener")
+                .build();
+
+        LookupResult result = LookupResult.create(lookupData, options);
+
+        assertEquals(result.getBrokerServiceListenerName(), "broker-listener");
+        assertEquals(result.getWebServiceListenerName(), "web-listener");
+        assertEquals(result.getLookupData().getBrokerUrl(), "pulsar://broker-listener:7000");
+        assertNull(result.getLookupData().getBrokerUrlTls());
+        assertEquals(result.getLookupData().getHttpUrl(), "http://web-listener:8000");
+        assertNull(result.getLookupData().getHttpUrlTls());
+    }
+
+    @Test
+    public void testCreateFromLocalBrokerData() {
+        LocalBrokerData data = new LocalBrokerData(BROKER_ID, WEB_URL, WEB_URL_TLS, PULSAR_URL, PULSAR_URL_TLS,
+                singleListener());
+
+        LookupResult result = LookupResult.create(data, LookupOptions.builder()
+                .advertisedListenerName(LISTENER_NAME).build());
+        assertTrue(result.isBrokerUrl());
+        assertEquals(result.getLookupData().getBrokerId(), BROKER_ID);
+        assertEquals(result.getBrokerServiceListenerName(), LISTENER_NAME);
+        assertEquals(result.getLookupData().getBrokerUrl(), LISTENER_PULSAR_URL);
+    }
+
+    @Test
+    public void testCreateAsRedirectFromLocalBrokerData() {
+        LocalBrokerData data = new LocalBrokerData(BROKER_ID, WEB_URL, WEB_URL_TLS, PULSAR_URL, PULSAR_URL_TLS);
+
+        LookupResult result = LookupResult.create(data, LookupOptions.builder().build(), true);
+        assertTrue(result.isRedirect());
+        assertTrue(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testCreateFromNamespaceEphemeralData() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData(BROKER_ID, PULSAR_URL, PULSAR_URL_TLS,
+                WEB_URL, WEB_URL_TLS, false, singleListener());
+
+        LookupResult result = LookupResult.create(nsData, LookupOptions.builder().build());
+        assertTrue(result.isBrokerUrl());
+        assertEquals(result.getLookupData().getBrokerId(), BROKER_ID);
+        assertEquals(result.getLookupData().getBrokerUrl(), PULSAR_URL);
+        assertEquals(result.getLookupData().getBrokerUrlTls(), PULSAR_URL_TLS);
+        assertEquals(result.getLookupData().getHttpUrl(), WEB_URL);
+        assertEquals(result.getLookupData().getHttpUrlTls(), WEB_URL_TLS);
+    }
+
+    @Test
+    public void testCreateAsRedirectFromNamespaceEphemeralData() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData(BROKER_ID, PULSAR_URL, PULSAR_URL_TLS,
+                WEB_URL, WEB_URL_TLS, false);
+        LookupResult result = LookupResult.create(nsData, LookupOptions.builder().build(), true);
+        assertTrue(result.isRedirect());
+        assertTrue(result.isAuthoritativeRedirect());
+    }
+
+    @Test
+    public void testBackwardCompatibleBrokerIdDerivationFromWebServiceUrl() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData(null, PULSAR_URL, PULSAR_URL_TLS,
+                WEB_URL, WEB_URL_TLS, false);
+        LookupResult result = LookupResult.create(nsData, LookupOptions.builder().build());
+        assertEquals(result.getLookupData().getBrokerId(), "broker-1:8080");
+    }
+
+    @Test
+    public void testBackwardCompatibleBrokerIdDerivationFromWebServiceUrlTls() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData(null, PULSAR_URL, PULSAR_URL_TLS,
+                null, WEB_URL_TLS, false);
+        LookupResult result = LookupResult.create(nsData, LookupOptions.builder().build());
+        assertEquals(result.getLookupData().getBrokerId(), "broker-1:8443");
+    }
+
+    @Test
+    public void testBackwardCompatibleBrokerIdRemainsNullWhenNoWebUrls() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData(null, PULSAR_URL, PULSAR_URL_TLS,
+                null, null, false);
+        LookupResult result = LookupResult.create(nsData, LookupOptions.builder().build());
+        assertNull(result.getLookupData().getBrokerId());
+    }
+
+    @Test
+    public void testToRedirectUriUsesLookupHostAndPortPreservesPath() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .httpUrlTls(WEB_URL_TLS)
+                .authoritativeRedirect(true)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin/v2/persistent/public/default/topic?x=1");
+
+        URI redirect = result.toRedirectUri(request);
+
+        assertEquals(redirect.getScheme(), "http");
+        assertEquals(redirect.getHost(), "broker-1");
+        assertEquals(redirect.getPort(), 8080);
+        assertEquals(redirect.getPath(), "/admin/v2/persistent/public/default/topic");
+        assertTrue(redirect.getQuery().contains("x=1"));
+        // authoritative parameter is taken from the LookupResult, not from the request URI
+        assertTrue(redirect.getQuery().contains("authoritative=true"));
+    }
+
+    @Test
+    public void testToRedirectUriUsesAuthoritativeFromLookupResultNotRequest() {
+        // The redirect should reflect the LookupResult's authoritativeRedirect flag, even when
+        // the incoming request URI carried a different authoritative value.
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .authoritativeRedirect(true)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin?authoritative=false");
+
+        URI redirect = result.toRedirectUri(request);
+
+        assertTrue(redirect.getQuery().contains("authoritative=true"));
+    }
+
+    @Test
+    public void testToRedirectUriHttpsUsesTlsHostAndPort() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .httpUrlTls(WEB_URL_TLS)
+                .build();
+
+        URI request = URI.create("https://original-host:1234/admin/v2/topic");
+
+        URI redirect = result.toRedirectUri(request);
+
+        assertEquals(redirect.getScheme(), "https");
+        assertEquals(redirect.getHost(), "broker-1");
+        assertEquals(redirect.getPort(), 8443);
+    }
+
+    @Test
+    public void testToRedirectUriHttpsRequiresTlsUrl() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .brokerId(BROKER_ID)
+                .httpUrl(WEB_URL)
+                .build();
+
+        URI request = URI.create("https://original-host:1234/admin");
+
+        WebApplicationException e = expectThrows(WebApplicationException.class, () -> result.toRedirectUri(request));
+        assertEquals(e.getResponse().getStatus(), Response.Status.PRECONDITION_FAILED.getStatusCode());
+    }
+
+    @Test
+    public void testToRedirectUriRemovesAuthoritativeWhenBrokerUrlType() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.BrokerUrl)
+                .httpUrl(WEB_URL)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin?authoritative=true&keep=me");
+
+        URI redirect = result.toRedirectUri(request);
+
+        String query = redirect.getQuery();
+        assertNotNull(query);
+        assertFalse(query.contains("authoritative"));
+        assertTrue(query.contains("keep=me"));
+    }
+
+    @Test
+    public void testToRedirectUriPassesAuthoritativeWhenLoadManagerMigration() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.LoadManagerMigrationUrl)
+                .httpUrl(WEB_URL)
+                .authoritativeRedirect(true)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin");
+
+        URI redirect = result.toRedirectUri(request);
+
+        assertTrue(redirect.getQuery().contains("authoritative=true"));
+    }
+
+    @Test
+    public void testToRedirectUriWithExplicitAuthoritativeOverride() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .authoritativeRedirect(true)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin");
+
+        // explicit override wins over the LookupResult's authoritativeRedirect
+        URI redirect = result.toRedirectUri(request, false);
+
+        assertTrue(redirect.getQuery().contains("authoritative=false"));
+    }
+
+    @Test
+    public void testToRedirectUriPreservesExistingQueryParameters() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin?listenerName=internal&other=1");
+
+        URI redirect = result.toRedirectUri(request);
+
+        String query = redirect.getQuery();
+        assertNotNull(query);
+        assertTrue(query.contains("listenerName=internal"));
+        assertTrue(query.contains("other=1"));
+    }
+
+    @Test
+    public void testToLookupRedirectUriInjectsListenerNameWhenResolved() {
+        // Topic-lookup case: the original request may carry the listener name in a header that the
+        // redirect does not preserve. toLookupRedirectUri must inject it as a query parameter so the
+        // next broker sees it.
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .brokerServiceListenerName("external")
+                .build();
+
+        URI request = URI.create("http://original-host:1234/lookup/v2/topic/persistent/p/d/t");
+
+        URI redirect = result.toLookupRedirectUri(request);
+
+        String query = redirect.getQuery();
+        assertNotNull(query);
+        assertTrue(query.contains("listenerName=external"), "query=" + query);
+    }
+
+    @Test
+    public void testToRedirectUriDoesNotInjectListenerNameForAdminPaths() {
+        // Admin redirects do not understand the listenerName query parameter — even if the
+        // LookupResult has a resolved brokerServiceListenerName, toRedirectUri must leave the
+        // request's query string alone.
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .brokerServiceListenerName("external")
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin/v2/persistent/p/d/t");
+
+        URI redirect = result.toRedirectUri(request);
+
+        String query = redirect.getQuery();
+        // no listenerName query param added
+        if (query != null) {
+            assertFalse(query.contains("listenerName"), "query=" + query);
+        }
+    }
+
+    @Test
+    public void testToRedirectUriPreservesExistingListenerNameForAdminPaths() {
+        // If the original admin request already carries listenerName in the query string, leave it
+        // there rather than dropping it.
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(WEB_URL)
+                .brokerServiceListenerName("external")
+                .build();
+
+        URI request = URI.create("http://original-host:1234/admin?listenerName=fromClient");
+
+        URI redirect = result.toRedirectUri(request);
+
+        String query = redirect.getQuery();
+        assertNotNull(query);
+        assertTrue(query.contains("listenerName=fromClient"), "query=" + query);
+    }
+
+    @Test
+    public void testToStringIncludesAllFields() {
+        LookupResult result = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .brokerId(BROKER_ID)
+                .httpUrl(WEB_URL)
+                .authoritativeRedirect(true)
+                .brokerServiceListenerName("broker-listener")
+                .webServiceListenerName("web-listener")
+                .build();
+
+        String s = result.toString();
+        assertTrue(s.contains("type=RedirectUrl"));
+        assertTrue(s.contains("authoritativeRedirect=true"));
+        assertTrue(s.contains("brokerServiceListenerName='broker-listener'"));
+        assertTrue(s.contains("webServiceListenerName='web-listener'"));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceListenerResolutionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceListenerResolutionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link NamespaceService#resolveBrokerServiceLookupResult}.
+ */
+@Test(groups = "broker")
+public class NamespaceServiceListenerResolutionTest {
+
+    @Test
+    public void testFailsOnBrokerServiceListenerMismatch() {
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData("broker-1:8080",
+                "pulsar://broker-1:6650", null, "http://broker-1:8080", null, false,
+                new HashMap<>());
+        LookupOptions options = LookupOptions.builder().advertisedListenerName("missing").build();
+        CompletableFuture<Optional<LookupResult>> future = new CompletableFuture<>();
+        NamespaceService.resolveBrokerServiceLookupResult(options, nsData, future);
+        assertTrue(future.isCompletedExceptionally());
+        Throwable cause = expectThrows(Exception.class, future::get).getCause();
+        assertTrue(cause instanceof PulsarServerException, "unexpected cause: " + cause);
+        assertTrue(cause.getMessage().contains("'missing' listener"), "unexpected message: " + cause.getMessage());
+    }
+
+    @Test
+    public void testFallsBackOnWebServiceListenerMismatch() throws Exception {
+        // During rolling upgrades, the target broker may not publish the listener yet. The lookup
+        // must not fail; instead, the redirect target falls back to the broker's default URLs.
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData("broker-1:8080",
+                "pulsar://broker-1:6650", null, "http://broker-1:8080", null, false,
+                new HashMap<>());
+        LookupOptions options = LookupOptions.builder().webServiceAdvertisedListenerName("missing").build();
+        CompletableFuture<Optional<LookupResult>> future = new CompletableFuture<>();
+        NamespaceService.resolveBrokerServiceLookupResult(options, nsData, future);
+        LookupResult result = future.get().orElseThrow();
+        assertNull(result.getWebServiceListenerName());
+        assertEquals(result.getLookupData().getHttpUrl(), "http://broker-1:8080");
+    }
+
+    @Test
+    public void testSucceedsWhenListenersMatch() throws Exception {
+        Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
+        advertisedListeners.put("listener-a", AdvertisedListener.builder()
+                .brokerServiceUrl(new URI("pulsar://gateway:6650"))
+                .brokerHttpUrl(new URI("http://gateway:8080"))
+                .build());
+        NamespaceEphemeralData nsData = new NamespaceEphemeralData("broker-1:8080",
+                "pulsar://broker-1:6650", null, "http://broker-1:8080", null, false,
+                advertisedListeners);
+        LookupOptions options = LookupOptions.builder()
+                .advertisedListenerName("listener-a")
+                .webServiceAdvertisedListenerName("listener-a")
+                .build();
+        CompletableFuture<Optional<LookupResult>> future = new CompletableFuture<>();
+        NamespaceService.resolveBrokerServiceLookupResult(options, nsData, future);
+        LookupResult result = future.get().orElseThrow();
+        assertEquals(result.getBrokerServiceListenerName(), "listener-a");
+        assertEquals(result.getWebServiceListenerName(), "listener-a");
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -375,7 +375,10 @@ public class NamespaceServiceTest extends BrokerTestBase {
         final String candidateBroker2 = "localhost:3000";
         String broker2Url = "pulsar://localhost:6660";
         LoadReport lr = new LoadReport("http://" + candidateBroker1, null, broker1Url, null);
-        LocalBrokerData ld = new LocalBrokerData("http://" + candidateBroker2, null, broker2Url, null);
+        lr.setName(candidateBroker1);
+        LocalBrokerData ld =
+                new LocalBrokerData(candidateBroker2, "http://" + candidateBroker2, null, broker2Url, null);
+
         String path1 = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker1);
         String path2 = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker2);
 
@@ -412,7 +415,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         Map<String, AdvertisedListener> advertisedListeners = new HashMap<>();
         advertisedListeners.put(listener, AdvertisedListener.builder()
                 .brokerServiceUrl(new URI(listenerUrl)).brokerServiceUrlTls(new URI(listenerUrlTls)).build());
-        LocalBrokerData ld = new LocalBrokerData("http://" + candidateBroker,
+        LocalBrokerData ld = new LocalBrokerData(candidateBroker, "http://" + candidateBroker,
                 null, brokerUrl, null, advertisedListeners);
         String path = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, candidateBroker);
 
@@ -423,8 +426,9 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
         LookupResult noListener = pulsar.getNamespaceService()
                 .createLookupResult(candidateBroker, false, null).get();
+        LookupOptions options = LookupOptions.builder().advertisedListenerName(listener).build();
         LookupResult withListener = pulsar.getNamespaceService()
-                .createLookupResult(candidateBroker, false, listener).get();
+                .createLookupResult(candidateBroker, false, options).get();
 
         Assert.assertEquals(noListener.getLookupData().getBrokerUrl(), brokerUrl);
         Assert.assertEquals(withListener.getLookupData().getBrokerUrl(), listenerUrl);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/OwnershipCacheTest.java
@@ -170,7 +170,7 @@ public class OwnershipCacheTest {
                 MetadataStoreConfig.builder().sessionTimeoutMillis(5000).build());
         otherStore.put(ServiceUnitUtils.path(testFullBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("otherhost:8881", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -205,7 +205,7 @@ public class OwnershipCacheTest {
                 MetadataStoreConfig.builder().sessionTimeoutMillis(5000).build());
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("otherhost:8881", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -256,7 +256,7 @@ public class OwnershipCacheTest {
         // case 2: someone else owns the namespace
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("otherhost:8881", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://localhost:8080",
                                 "https://localhost:4443", false)),
@@ -312,7 +312,7 @@ public class OwnershipCacheTest {
         // case 2: someone else owns the namespace
         otherStore.put(ServiceUnitUtils.path(testBundle),
                 ObjectMapperFactory.getMapper().writer().writeValueAsBytes(
-                        new NamespaceEphemeralData("pulsar://otherhost:8881",
+                        new NamespaceEphemeralData("otherhost:8881", "pulsar://otherhost:8881",
                                 "pulsar://otherhost:8884",
                                 "http://otherhost:8080",
                                 "https://otherhost:4443", false)),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/TopicOwnerTest.java
@@ -146,12 +146,14 @@ public class TopicOwnerTest {
             if (pulsarService == null) {
                 return (CompletableFuture<Optional<LookupResult>>) invocation.callRealMethod();
             }
-            LookupResult lookupResult = new LookupResult(
-                    pulsarService.getWebServiceAddress(),
-                    pulsarService.getWebServiceAddressTls(),
-                    pulsarService.getBrokerServiceUrl(),
-                    pulsarService.getBrokerServiceUrlTls(),
-                    true);
+            LookupResult lookupResult = LookupResult.builder()
+                    .type(LookupResult.Type.RedirectUrl)
+                    .httpUrl(pulsarService.getWebServiceAddress())
+                    .httpUrlTls(pulsarService.getWebServiceAddressTls())
+                    .brokerServiceUrl(pulsarService.getBrokerServiceUrl())
+                    .brokerServiceUrlTls(pulsarService.getBrokerServiceUrlTls())
+                    .authoritativeRedirect(true)
+                    .build();
             return CompletableFuture.completedFuture(Optional.of(lookupResult));
         };
         doAnswer(answer).when(spyLeaderNamespaceService).getBrokerServiceUrlAsync(any(TopicName.class),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/DynamicBindAddressesIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/DynamicBindAddressesIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Integration test for configuring the broker entirely through {@code bindAddresses} with dynamic
+ * ports (port {@code 0}). Verifies that:
+ * <ul>
+ *   <li>None of the legacy {@code brokerServicePort}/{@code webServicePort} (and TLS variants)
+ *       need to be set when {@code bindAddresses} supplies {@code pulsar://} and {@code http://}
+ *       entries under the internal listener;</li>
+ *   <li>after the broker binds, the actual bound ports are reflected back into the configuration
+ *       and the internal advertised listener is synthesized with the real ports;</li>
+ *   <li>{@code advertisedAddress} defaults to the local hostname when left blank;</li>
+ *   <li>{@code PulsarAdmin} and {@code PulsarClient} can talk to the broker via the resolved
+ *       service URLs.</li>
+ * </ul>
+ *
+ * <p>This exercises the post-bind dependency: only after the Netty/Jetty servers have bound is
+ * the dynamic port known, and only then can the advertised listener map be populated.
+ */
+@Test(groups = "broker")
+public class DynamicBindAddressesIntegrationTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        // Provision the standard `public/default` namespace that the admin/client tests below use.
+        // This cannot be done from inside the constructor flow because the admin client only becomes
+        // reachable after the dynamic web port has been bound and surfaced into the configuration.
+        admin.clusters().createCluster(conf.getClusterName(),
+                ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
+        admin.tenants().createTenant("public",
+                TenantInfo.builder()
+                        .allowedClusters(Set.of(conf.getClusterName()))
+                        .build());
+        admin.namespaces().createNamespace("public/default");
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        // Clear every legacy port property — the broker must come up purely from `bindAddresses`.
+        conf.setBrokerServicePort(Optional.empty());
+        conf.setBrokerServicePortTls(Optional.empty());
+        conf.setWebServicePort(Optional.empty());
+        conf.setWebServicePortTls(Optional.empty());
+        // Bind to all interfaces on a dynamically assigned port for both schemes, tagged with the
+        // internal listener so the connectors are selected as the primary ones for broker-to-broker
+        // communication.
+        conf.setBindAddresses("internal:pulsar://0.0.0.0:0,internal:http://0.0.0.0:0");
+        // Force `advertisedAddress` to be blank so we exercise the hostname-fallback path.
+        conf.setAdvertisedAddress(null);
+        // No explicit `advertisedListeners` either; the internal listener must be synthesized from
+        // the dynamically bound ports.
+        conf.setAdvertisedListeners(null);
+    }
+
+    @Test
+    public void testRuntimeListenerSynthesizedFromDynamicBindAddresses() {
+        ServiceConfiguration runtimeConf = pulsar.getConfiguration();
+
+        // After binding, the legacy port properties must reflect the actual dynamic ports.
+        assertTrue(runtimeConf.getBrokerServicePort().isPresent(),
+                "brokerServicePort should be populated from the bound port");
+        assertTrue(runtimeConf.getWebServicePort().isPresent(),
+                "webServicePort should be populated from the bound port");
+        int boundPulsarPort = runtimeConf.getBrokerServicePort().get();
+        int boundWebPort = runtimeConf.getWebServicePort().get();
+        assertFalse(boundPulsarPort == 0, "the dynamic pulsar port must not still be 0");
+        assertFalse(boundWebPort == 0, "the dynamic web port must not still be 0");
+        // TLS variants stay empty because no TLS binding was declared.
+        assertFalse(runtimeConf.getBrokerServicePortTls().isPresent());
+        assertFalse(runtimeConf.getWebServicePortTls().isPresent());
+
+        // The advertised address must default to the local hostname.
+        String expectedHost;
+        try {
+            expectedHost = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (Exception e) {
+            throw new AssertionError("unable to resolve canonical local hostname for the test", e);
+        }
+
+        // The internal listener must now exist in the cached map with both URLs populated.
+        Map<String, AdvertisedListener> listeners = pulsar.getAdvertisedListeners();
+        assertNotNull(listeners, "advertised listener map must not be null");
+        AdvertisedListener internal = listeners.get(ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
+        assertNotNull(internal,
+                "the `internal` listener must have been synthesized after binding, but the map was: "
+                        + listeners);
+        assertEquals(internal.getBrokerServiceUrl(),
+                URI.create("pulsar://" + expectedHost + ":" + boundPulsarPort));
+        assertEquals(internal.getBrokerHttpUrl(),
+                URI.create("http://" + expectedHost + ":" + boundWebPort));
+
+        // The top-level service URLs must agree with the listener.
+        assertEquals(pulsar.getBrokerServiceUrl(), "pulsar://" + expectedHost + ":" + boundPulsarPort);
+        assertEquals(pulsar.getWebServiceAddress(), "http://" + expectedHost + ":" + boundWebPort);
+
+        // The broker id is derived from the (post-bind) advertised address and web port.
+        String brokerId = pulsar.getBrokerId();
+        assertNotNull(brokerId, "brokerId must be initialized after start()");
+        assertEquals(brokerId, expectedHost + ":" + boundWebPort);
+    }
+
+    @Test
+    public void testPulsarAdminCanCreateTopicOverDynamicBindAddress() throws Exception {
+        String namespace = "public/default";
+        String topic = "persistent://" + namespace + "/dynamic-bind-admin-" + UUID.randomUUID();
+
+        // The `admin` field is built against the runtime web URL by MockedPulsarServiceBaseTest;
+        // exercise it with a real round-trip to confirm the URL is reachable.
+        try (PulsarAdmin localAdmin = PulsarAdmin.builder()
+                .serviceHttpUrl(pulsar.getWebServiceAddress())
+                .build()) {
+            localAdmin.topics().createNonPartitionedTopic(topic);
+            assertTrue(localAdmin.topics().getList(namespace).contains(topic),
+                    "topic should be listed under its namespace after creation");
+        }
+    }
+
+    @Test
+    public void testPulsarClientProduceConsumeOverDynamicBindAddress() throws Exception {
+        String topic = "persistent://public/default/dynamic-bind-pubsub-" + UUID.randomUUID();
+        String subscription = "test-sub";
+        String payload = "hello-dynamic-bind";
+
+        try (PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getBrokerServiceUrl())
+                .build()) {
+            try (Consumer<String> consumer = client.newConsumer(Schema.STRING)
+                    .topic(topic)
+                    .subscriptionName(subscription)
+                    .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                    .subscribe();
+                 Producer<String> producer = client.newProducer(Schema.STRING)
+                         .topic(topic)
+                         .create()) {
+                producer.send(payload);
+                Message<String> received = consumer.receive(10, TimeUnit.SECONDS);
+                assertNotNull(received, "consumer must receive the message produced over the dynamic port");
+                assertEquals(received.getValue(), payload);
+                consumer.acknowledge(received);
+            }
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/MultipleInternalBindAddressesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/web/MultipleInternalBindAddressesTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.web;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Optional;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies behavior when the internal listener has more than one bind address for the same protocol
+ * scheme. In that case the broker accepts every binding but uses the first declared one (per scheme)
+ * as the primary, which is what drives {@code pulsar.getBrokerServiceUrl()},
+ * {@code pulsar.getWebServiceAddress()}, and the synthesized internal advertised listener.
+ */
+@Test(groups = "broker")
+public class MultipleInternalBindAddressesTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        // Drive everything off `bindAddresses` so the validator/binder cannot reach back to legacy
+        // ports to find a "default" primary.
+        conf.setBrokerServicePort(Optional.empty());
+        conf.setBrokerServicePortTls(Optional.empty());
+        conf.setWebServicePort(Optional.empty());
+        conf.setWebServicePortTls(Optional.empty());
+        // Two pulsar bindings and two http bindings for the internal listener, on different IPs so
+        // the ip:port uniqueness check is satisfied (each combination is unique). Both use port 0
+        // so the OS assigns distinct dynamic ports.
+        conf.setBindAddresses(
+                "internal:pulsar://0.0.0.0:0,"
+                        + "internal:pulsar://127.0.0.1:0,"
+                        + "internal:http://0.0.0.0:0,"
+                        + "internal:http://127.0.0.1:0");
+        // Hostname-fallback path for the advertised address.
+        conf.setAdvertisedAddress(null);
+        conf.setAdvertisedListeners(null);
+    }
+
+    @Test
+    public void testFirstInternalBindingPerSchemeBecomesPrimary() throws Exception {
+        ServiceConfiguration runtimeConf = pulsar.getConfiguration();
+
+        // The primary listen ports are surfaced via the dedicated methods. By contract, these come
+        // from the FIRST binding (per scheme) that matches the internal listener.
+        int primaryPulsarPort = pulsar.getBrokerListenPort().orElseThrow();
+        int primaryWebPort = pulsar.getWebService().getListenPortHTTP().orElseThrow();
+        assertTrue(primaryPulsarPort > 0, "primary pulsar port must be a real OS-assigned port");
+        assertTrue(primaryWebPort > 0, "primary web port must be a real OS-assigned port");
+        assertTrue(primaryPulsarPort != primaryWebPort,
+                "pulsar and web primaries must have been assigned distinct ports");
+
+        // After binding, the configuration's legacy ports must reflect the primary binding's ports
+        // (not the additional bindings' ports), which is what downstream synthesis depends on.
+        assertEquals(runtimeConf.getBrokerServicePort(), Optional.of(primaryPulsarPort));
+        assertEquals(runtimeConf.getWebServicePort(), Optional.of(primaryWebPort));
+
+        // The bindAddresses config string still records all the original entries the user declared,
+        // proving the multi-binding configuration was accepted up-front.
+        String declared = runtimeConf.getBindAddresses();
+        assertNotNull(declared);
+        assertEquals(countOccurrences(declared, "internal:pulsar://"), 2,
+                "two internal:pulsar:// bindings should be in the declared config: " + declared);
+        assertEquals(countOccurrences(declared, "internal:http://"), 2,
+                "two internal:http:// bindings should be in the declared config: " + declared);
+
+        // pulsar.getBrokerServiceUrl() / pulsar.getWebServiceAddress() must use the primary ports
+        // (not any of the additional bindings' ports).
+        String expectedHost = InetAddress.getLocalHost().getCanonicalHostName();
+        assertEquals(pulsar.getBrokerServiceUrl(), "pulsar://" + expectedHost + ":" + primaryPulsarPort);
+        assertEquals(pulsar.getWebServiceAddress(), "http://" + expectedHost + ":" + primaryWebPort);
+
+        // The synthesized internal advertised listener must agree with the same primary ports.
+        AdvertisedListener internal =
+                pulsar.getAdvertisedListeners().get(ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME);
+        assertNotNull(internal,
+                "the `internal` listener must have been synthesized after binding, but the map was: "
+                        + pulsar.getAdvertisedListeners());
+        assertEquals(internal.getBrokerServiceUrl(),
+                URI.create("pulsar://" + expectedHost + ":" + primaryPulsarPort));
+        assertEquals(internal.getBrokerHttpUrl(),
+                URI.create("http://" + expectedHost + ":" + primaryWebPort));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = haystack.indexOf(needle, index)) != -1) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -307,7 +307,7 @@ public class MockBrokerService {
             startMockBrokerService();
             log.info().attr("serviceOn", getBrokerAddress()).log("Started mock Pulsar service on");
 
-            lookupData = new LookupData(getBrokerAddress(), null,
+            lookupData = new LookupData(getBrokerId(), getBrokerAddress(), null,
                     getHttpAddress(), null);
         } catch (Exception e) {
             log.error().exception(e).log("Error starting mock service");
@@ -439,6 +439,10 @@ public class MockBrokerService {
 
     public void resetHandleCloseConsumer() {
         handleCloseConsumer = null;
+    }
+
+    public String getBrokerId() {
+        return String.format("localhost:%d", server.getURI().getPort());
     }
 
     public String getHttpAddress() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/PulsarMultiListenersWithInternalListenerNameTest.java
@@ -29,15 +29,17 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
@@ -60,20 +62,33 @@ import org.testng.annotations.Test;
 
 @Test(groups = "broker-api")
 public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPulsarServiceBaseTest {
-    private final boolean withInternalListener;
+    private final boolean withLegacyListeners;
     private ExecutorService executorService;
     private InetSocketAddress brokerAddress;
     private InetSocketAddress brokerSslAddress;
+    private InetSocketAddress webServiceAddress;
     private EventLoopGroup eventExecutors;
 
     public PulsarMultiListenersWithInternalListenerNameTest() {
         this(true);
     }
 
-    protected PulsarMultiListenersWithInternalListenerNameTest(boolean withInternalListener) {
-        this.withInternalListener = withInternalListener;
-        // enable port forwarding from the configured advertised port to the dynamic listening port
-        this.enableBrokerGateway = true;
+    protected PulsarMultiListenersWithInternalListenerNameTest(boolean withLegacyListeners) {
+        this.withLegacyListeners = withLegacyListeners;
+        this.isTcpLookup = true;
+    }
+
+    @Override
+    protected URI resolveLookupUrl(boolean usePulsarBinaryProtocol) {
+        if (usePulsarBinaryProtocol) {
+            if (withLegacyListeners) {
+                return URI.create(pulsar.getBrokerServiceUrl());
+            } else {
+                return URI.create("pulsar://" + brokerAddress.getHostString() + ":" + brokerAddress.getPort());
+            }
+        } else {
+            throw new IllegalStateException("Not supported in this test");
+        }
     }
 
     @BeforeMethod(alwaysRun = true)
@@ -81,36 +96,71 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     protected void setup() throws Exception {
         this.executorService = Executors.newFixedThreadPool(1);
         this.eventExecutors = new NioEventLoopGroup();
-        this.isTcpLookup = true;
-        String host = InetAddress.getLocalHost().getHostAddress();
-        Pair<Integer, Integer> freePorts = getFreePorts();
-        int brokerPort = freePorts.getLeft();
-        brokerAddress = InetSocketAddress.createUnresolved(host, brokerPort);
-        int brokerPortSsl = freePorts.getRight();
-        brokerSslAddress = InetSocketAddress.createUnresolved(host, brokerPortSsl);
+        InetAddress host = InetAddress.getLocalHost();
+        String hostAddress = host.getHostAddress();
+        List<Integer> freePorts = getFreePorts(host, 3);
+        brokerAddress = InetSocketAddress.createUnresolved(hostAddress, freePorts.get(0));
+        brokerSslAddress = InetSocketAddress.createUnresolved(hostAddress, freePorts.get(1));
+        webServiceAddress = InetSocketAddress.createUnresolved(hostAddress, freePorts.get(2));
         super.internalSetup();
-    }
-
-    private static Pair<Integer, Integer> getFreePorts() {
-        try (ServerSocket serverSocket = new ServerSocket(); ServerSocket serverSocket2 = new ServerSocket()) {
-            serverSocket.setReuseAddress(true);
-            serverSocket.bind(new InetSocketAddress(0));
-            serverSocket2.setReuseAddress(true);
-            serverSocket2.bind(new InetSocketAddress(0));
-            return Pair.of(serverSocket.getLocalPort(), serverSocket2.getLocalPort());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 
     protected void doInitConf() throws Exception {
         super.doInitConf();
+        if (!withLegacyListeners) {
+            conf.setBrokerServicePort(Optional.empty());
+            conf.setWebServicePort(Optional.empty());
+        }
         this.conf.setClusterName("localhost");
-        this.conf.setAdvertisedListeners(String.format("internal:pulsar://%s:%s,internal:pulsar+ssl://%s:%s",
-                brokerAddress.getHostString(), brokerAddress.getPort(),
-                brokerSslAddress.getHostString(), brokerSslAddress.getPort()));
-        if (withInternalListener) {
-            this.conf.setInternalListenerName("internal");
+        this.conf.setAdvertisedListeners(
+                String.format("internal:pulsar://%s:%s,internal:pulsar+ssl://%s:%s,internal:http://%s:%s",
+                        brokerAddress.getHostString(), brokerAddress.getPort(), brokerSslAddress.getHostString(),
+                        brokerSslAddress.getPort(), webServiceAddress.getHostString(), webServiceAddress.getPort()));
+        String bindAll = "0.0.0.0";
+        this.conf.setBindAddresses(
+                String.format("internal:pulsar://%s:%s,internal:pulsar+ssl://%s:%s,internal:http://%s:%s",
+                        bindAll, brokerAddress.getPort(),
+                        bindAll, brokerSslAddress.getPort(),
+                        bindAll, webServiceAddress.getPort()));
+        conf.setTlsEnabledWithKeyStore(true);
+        conf.setTlsKeyStoreType(KEYSTORE_TYPE);
+        conf.setTlsKeyStore(BROKER_KEYSTORE_FILE_PATH);
+        conf.setTlsKeyStorePassword(BROKER_KEYSTORE_PW);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        GracefulExecutorServicesShutdown.initiate()
+                .timeout(Duration.ZERO)
+                .shutdown(executorService)
+                .handle().get();
+        EventLoopUtil.shutdownGracefully(eventExecutors).get();
+        super.internalCleanup();
+    }
+
+    private static List<Integer> getFreePorts(InetAddress host, int numberOfPorts) {
+        List<ServerSocket> sockets = new ArrayList<>(numberOfPorts);
+        try {
+            List<Integer> ports = new ArrayList<>(numberOfPorts);
+            for (int i = 0; i < numberOfPorts; i++) {
+                ServerSocket socket = new ServerSocket();
+                sockets.add(socket);
+                socket.setReuseAddress(true);
+                socket.bind(new InetSocketAddress(host, 0));
+                ports.add(socket.getLocalPort());
+            }
+            return List.copyOf(ports);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            for (ServerSocket socket : sockets) {
+                try {
+                    socket.close();
+                } catch (IOException ignored) {
+                    // ignore
+                }
+            }
         }
     }
 
@@ -118,6 +168,7 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
     protected void customizeNewPulsarClientBuilder(ClientBuilder clientBuilder) {
         clientBuilder.listenerName("internal");
     }
+
     @Test
     public void testFindBrokerWithListenerName() throws Exception {
         admin.clusters().createCluster("localhost", ClusterData.builder()
@@ -181,14 +232,20 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
                 new DefaultNameResolver(ImmediateEventExecutor.INSTANCE));
         NamespaceService namespaceService = pulsar.getNamespaceService();
 
-        LookupResult lookupResult = new LookupResult(pulsar.getWebServiceAddress(), null,
-                pulsar.getBrokerServiceUrl(), null, true);
+        LookupResult lookupResult = LookupResult.builder()
+                .type(LookupResult.Type.RedirectUrl)
+                .httpUrl(pulsar.getWebServiceAddress())
+                .brokerServiceUrl(pulsar.getBrokerServiceUrl())
+                .authoritativeRedirect(true)
+                .build();
         Optional<LookupResult> optional = Optional.of(lookupResult);
         InetSocketAddress address = InetSocketAddress.createUnresolved("192.168.0.1", 8080);
-        NamespaceEphemeralData namespaceEphemeralData =
-                new NamespaceEphemeralData("pulsar://" + address.getHostName() + ":" + address.getPort(),
-                null, "http://192.168.0.1:8081", null, false);
-        LookupResult lookupResult2 = new LookupResult(namespaceEphemeralData);
+        NamespaceEphemeralData namespaceEphemeralData = new NamespaceEphemeralData("192.168.0.1:8081",
+                "pulsar://" + address.getHostName() + ":" + address.getPort(), null,
+                "http://192.168.0.1:8081", null, false);
+        // The redirect target serves the second lookup as a final broker URL response so that
+        // HttpLookupService terminates the redirect chain at the broker that owns the topic.
+        LookupResult lookupResult2 = LookupResult.create(namespaceEphemeralData, null);
         Optional<LookupResult> optional2 = Optional.of(lookupResult2);
         doReturn(CompletableFuture.completedFuture(optional), CompletableFuture.completedFuture(optional2))
                 .when(namespaceService).getBrokerServiceUrlAsync(any(), any());
@@ -198,17 +255,5 @@ public class PulsarMultiListenersWithInternalListenerNameTest extends MockedPuls
         Assert.assertEquals(result.getLogicalAddress(), address);
         Assert.assertEquals(result.getPhysicalAddress(), address);
         Assert.assertEquals(result.isUseProxy(), false);
-    }
-
-    @AfterMethod(alwaysRun = true)
-    @Override
-    protected void cleanup() throws Exception {
-        pulsar.close();
-        GracefulExecutorServicesShutdown.initiate()
-                .timeout(Duration.ZERO)
-                .shutdown(executorService)
-                .handle().get();
-        EventLoopUtil.shutdownGracefully(eventExecutors).get();
-        super.internalCleanup();
     }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/policies/data/loadbalancer/ServiceLookupData.java
@@ -25,6 +25,8 @@ import java.util.Optional;
  * For backwards compatibility purposes.
  */
 public interface ServiceLookupData {
+    String getBrokerId();
+
     String getWebServiceUrl();
 
     String getWebServiceUrlTls();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/data/LookupData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/lookup/data/LookupData.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
  * This class encapsulates lookup data.
  */
 public class LookupData {
+    private String brokerId;
     private String brokerUrl;
     private String brokerUrlTls;
     private String httpUrl; // Web service HTTP address
@@ -33,12 +34,17 @@ public class LookupData {
     public LookupData() {
     }
 
-    public LookupData(String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls) {
+    public LookupData(String brokerId, String brokerUrl, String brokerUrlTls, String httpUrl, String httpUrlTls) {
+        this.brokerId = brokerId;
         this.brokerUrl = brokerUrl;
         this.brokerUrlTls = brokerUrlTls;
         this.httpUrl = httpUrl;
         this.httpUrlTls = httpUrlTls;
         this.nativeUrl = brokerUrl;
+    }
+
+    public String getBrokerId() {
+        return brokerId;
     }
 
     public String getBrokerUrl() {
@@ -82,7 +88,7 @@ public class LookupData {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("brokerUrl", brokerUrl).add("brokerUrlTls", brokerUrlTls)
-                .add("httpUrl", httpUrl).add("httpUrlTls", httpUrlTls).toString();
+        return MoreObjects.toStringHelper(this).add("brokerId", brokerId).add("brokerUrl", brokerUrl)
+                .add("brokerUrlTls", brokerUrlTls).add("httpUrl", httpUrl).add("httpUrlTls", httpUrlTls).toString();
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LoadReport.java
@@ -126,6 +126,11 @@ public class LoadReport implements LoadManagerReport {
         this.name = brokerName;
     }
 
+    @JsonIgnore
+    public String getBrokerId() {
+        return name;
+    }
+
     public SystemResourceUsage getSystemResourceUsage() {
         return systemResourceUsage;
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/policies/data/loadbalancer/LocalBrokerData.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @JsonIgnoreProperties(value = {"bundleStats"})
 @JsonDeserialize(as = LocalBrokerData.class)
 public class LocalBrokerData implements LoadManagerReport {
-
+    private final String brokerId;
     // URLs to satisfy contract of ServiceLookupData (used by NamespaceService).
     private final String webServiceUrl;
     private final String webServiceUrlTls;
@@ -96,20 +96,22 @@ public class LocalBrokerData implements LoadManagerReport {
 
     // For JSON only.
     public LocalBrokerData() {
-        this(null, null, null, null);
+        this(null, null, null, null, null);
     }
 
     /**
      * Broker data constructor which takes in four URLs to satisfy the contract of ServiceLookupData.
      */
-    public LocalBrokerData(final String webServiceUrl, final String webServiceUrlTls, final String pulsarServiceUrl,
-            final String pulsarServiceUrlTls) {
-        this(webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
+    public LocalBrokerData(final String brokerId, final String webServiceUrl, final String webServiceUrlTls,
+                           final String pulsarServiceUrl, final String pulsarServiceUrlTls) {
+        this(brokerId, webServiceUrl, webServiceUrlTls, pulsarServiceUrl, pulsarServiceUrlTls,
                 Collections.unmodifiableMap(Collections.emptyMap()));
     }
 
-    public LocalBrokerData(final String webServiceUrl, final String webServiceUrlTls, final String pulsarServiceUrl,
-                           final String pulsarServiceUrlTls, Map<String, AdvertisedListener> advertisedListeners) {
+    public LocalBrokerData(final String brokerId, final String webServiceUrl, final String webServiceUrlTls,
+                           final String pulsarServiceUrl, final String pulsarServiceUrlTls,
+                           Map<String, AdvertisedListener> advertisedListeners) {
+        this.brokerId = brokerId;
         this.webServiceUrl = webServiceUrl;
         this.webServiceUrlTls = webServiceUrlTls;
         this.pulsarServiceUrl = pulsarServiceUrl;
@@ -460,6 +462,11 @@ public class LocalBrokerData implements LoadManagerReport {
     @Override
     public String getBrokerVersionString() {
         return brokerVersionString;
+    }
+
+    @Override
+    public String getBrokerId() {
+        return brokerId;
     }
 
     @Override

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/lookup/data/LookupDataTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/lookup/data/LookupDataTest.java
@@ -35,8 +35,8 @@ public class LookupDataTest {
 
     @Test
     public void withConstructor() {
-        LookupData data = new LookupData("pulsar://localhost:8888", "pulsar://localhost:8884", "http://localhost:8080",
-                                         "http://localhost:8081");
+        LookupData data = new LookupData(null, "pulsar://localhost:8888", "pulsar://localhost:8884",
+                "http://localhost:8080", "http://localhost:8081");
         assertEquals(data.getBrokerUrl(), "pulsar://localhost:8888");
         assertEquals(data.getHttpUrl(), "http://localhost:8080");
     }
@@ -44,8 +44,8 @@ public class LookupDataTest {
     @SuppressWarnings("unchecked")
     @Test
     public void serializeToJsonTest() throws Exception {
-        LookupData data = new LookupData("pulsar://localhost:8888", "pulsar://localhost:8884", "http://localhost:8080",
-                                         "http://localhost:8081");
+        LookupData data = new LookupData(null, "pulsar://localhost:8888", "pulsar://localhost:8884",
+                "http://localhost:8080", "http://localhost:8081");
         ObjectMapper mapper = ObjectMapperFactory.getMapper().getObjectMapper();
         String json = mapper.writeValueAsString(data);
 
@@ -109,7 +109,7 @@ public class LookupDataTest {
     }
 
     private LocalBrokerData getModularLoadManagerLoadReport(String brokerUrl, ResourceUsage bandwidthIn) {
-        LocalBrokerData report = new LocalBrokerData(brokerUrl, null, null, null);
+        LocalBrokerData report = new LocalBrokerData(null, brokerUrl, null, null, null);
         report.setBandwidthIn(bandwidthIn);
         return report;
     }


### PR DESCRIPTION
### Motivation

[PIP-61: Advertised multiple addresses](https://github.com/apache/pulsar/blob/master/pip/pip-61.md) and [PIP-95: Smart Listener Selection with Multiple Bind Addresses](https://github.com/apache/pulsar/blob/master/pip/pip-95.md) are not fully implemented for the broker webservice (HTTP/HTTPS). Support for `bindAddresses` was completely missing on the webservice side, and Admin API redirects between brokers did not preserve the listener the request originally arrived on. This PR closes both gaps and, while doing so, simplifies the configuration model. It has two main goals:

**Goal 1 — Simpler configuration: the internal listener does not have to be declared in `advertisedListeners` or `bindAddresses`.**

- The `*Port` properties (`brokerServicePort` / `brokerServicePortTls` / `webServicePort` / `webServicePortTls`) now serve a dual role: the same port number is used both for the local socket bind port **and** for the advertised port of the internal listener, with `advertisedAddress` supplying the hostname. Setting just the `*Port` properties is therefore enough to fully configure the internal listener — no entry in `advertisedListeners` or `bindAddresses` is required for it.
- Adding an external listener no longer forces re-declaring the internal one: `advertisedListeners` (and `bindAddresses`, when PIP-95 is used) only needs entries for the additional listeners.
- `internalListenerName` defaults to `internal`. This default is chosen so that the auto-configured port-derived internal listener cannot accidentally collide with any user-declared listener name. Overriding the internal listener's URLs in `advertisedListeners` is discouraged because pointing them at an external load balancer would route cluster-internal traffic outside the cluster.
- The previous "use the first advertised listener as the internal one" rule was brittle, but is preserved as a backwards-compat fallback: leaving `internalListenerName` blank still uses the first entry in `advertisedListeners` as the internal listener.

**Goal 2 — PIP-95 smart listener selection for the HTTP/HTTPS Admin API, enabling a proxyless deployment.**

This was one of the original PIP-61 goals that the existing code only delivered for the Pulsar binary protocol; the Admin API was missing. Before this PR, the broker had no way to know which advertised listener a given Admin API request belonged to, so admin redirects had to send clients back through a single Admin URL — typically requiring an HTTP reverse proxy in front of the brokers to multiplex Admin API calls per listener.

With this PR, PIP-95 smart listener selection is extended to HTTP/HTTPS:
- Each HTTP/HTTPS advertised listener is bound to a unique port via `bindAddresses`.
- The broker identifies the listener from the destination port the request arrived on.
- Admin API redirect responses (lookup redirects, admin forwarding to the owner or leader broker) preserve that listener name and route the client to the matching listener on the target broker.

This enables a **fully proxyless deployment**: a layer-4 (TCP/IP) load balancer in front of the brokers can forward both the Pulsar binary protocol and the HTTP/HTTPS Admin API directly to the listener-specific `ip:port` configured in `bindAddresses`, with no HTTP reverse proxy needed.

**Goal 3 — Foundation for per-listener authentication and authorization plugins.**

This PR does not change any auth plugin behavior, but it puts the necessary plumbing in place: after this PR, every incoming connection on both the broker service and the web service has its listener identity resolved from the destination port (the PIP-95 "smart listener" feature, now extended to HTTP/HTTPS as well). With the listener identity available on each request, follow-up work can restrict authentication or authorization plugins to specific listeners.

A motivating example is the static JWT token that brokers use for internal broker-to-broker communication. Today such a token has to be accepted by every listener, so leaking it gives an attacker direct access from any externally-reachable endpoint. Once auth plugins can be scoped per listener, the static JWT can be limited to the internal listener only — a leaked internal token then becomes useless without direct network access to the cluster-internal listener's `ip:port`, while external clients continue to authenticate via OAuth (or similar) on the external listeners.

Additional notable behavior changes:

- Both the Pulsar binary protocol (`pulsar` & `pulsar+ssl`) and the web API (`http` & `https`) can now share the same listener name; the previous restriction is removed. For HTTP broker lookups, the binary-protocol listener name defaults to the webservice listener name when there is a matching `pulsar` / `pulsar+ssl` entry under the same listener.

### Modifications

Main change — webservice listener support:

- Add bindAddresses + advertisedListeners (http/https) support to the broker webservice (`WebService`, `BindAddressValidator`, `MultipleListenerValidator`).
- Per-request listener tracking: an `AddListenerAttributeFilter` records the listener name on the servlet request, and `PulsarWebResource#getWebServiceListenerName()` exposes it to admin handlers so redirects preserve the listener.
- Centralize redirect-URI construction in `LookupResult#toRedirectUri(...)` to remove duplicated host/port/scheme-swap logic from `NamespacesBase`, `PulsarWebResource`, `TopicLookupBase`, and `TopicsBase`. The redirect URI carries the correct `authoritative` flag and listener query param. Listener URL overrides are applied through a small `UrlOverride` helper so the broker- and web-service paths read as a sequence of small steps rather than nested branches.
- Topic-lookup redirects use a dedicated `LookupResult#toLookupRedirectUri(URI)` method that always injects the resolved listener name as a `listenerName` query parameter. This is the case where the original request may have carried the listener via the `X-Pulsar-Listener-Name` header (headers do not survive HTTP redirects, so the parameter form must be propagated). Other (admin) redirect paths use `toRedirectUri` and leave the request's query string alone, since admin endpoints do not understand `listenerName`.
- The 412 entity emitted when the target broker has no URL for the request scheme now mentions the resolved listener name to aid debugging.
- `LookupOptions` gains `webServiceAdvertisedListenerName` and drops the `requestHttps` boolean (the scheme is now derived per-request from the incoming `requestUri`).
- Plumb `brokerId` through `LookupData` / `ServiceLookupData` / `LocalBrokerData` / `NamespaceEphemeralData` and use broker-id equality for ownership checks rather than URL string comparison.
- For rolling-upgrade safety, a missing web-service listener on the target broker does not fail the lookup; the redirect falls back to the broker's default URL. A missing broker-service listener still fails the lookup as before.

Configuration — defaults, migration, and validation:

- Default `internalListenerName` to `internal` and add the public constant `ServiceConfiguration.DEFAULT_INTERNAL_LISTENER_NAME`.
- Backwards-compat fallback: if the user explicitly sets `internalListenerName=` (blank) and `advertisedListeners` is non-empty, the validator uses the first listener parsed from `advertisedListeners` as the internal listener — matching the pre-PR behavior. Only when both are blank does the validator fall back to the constant default `internal`.
- `MultipleListenerValidator` (the new `validateAndUpdateAdvertisedListeners` entry point — renamed from `validateAndAnalysisAdvertisedListener` so the name reflects that it also writes back the resolved `internalListenerName`) now synthesizes the internal advertised listener from the *Port properties (`brokerServicePort` / `brokerServicePortTls` / `webServicePort` / `webServicePortTls`), using `advertisedAddress` as the host. Each *Port value is reused as both the local socket bind port and the advertised port for the internal listener. Any URLs the user declares explicitly under the internal listener in `advertisedListeners` override the corresponding port-derived URLs (the rest still fill in from the *Port properties), but doing so is discouraged because it can route cluster-internal traffic via whatever external endpoint is advertised.
  - *Goal*: Setting just `advertisedAddress` and the *Port properties is enough to configure the internal listener; an additional external listener can be added to `advertisedListeners` without touching the internal listener at all.
- `BindAddressValidator` migrations are now tagged with `internalListenerName` (was `null`). Validation tolerates exact duplicates (`listener:scheme://ip:port`), rejects the same URI assigned to different listener names, and rejects the same `ip:port` being used by two different schemes (a TCP socket can host only one scheme). Port `0` is exempt from the ip:port cross-scheme check because the OS assigns distinct ephemeral ports per socket; port `0` is documented as supported only for the internal listener.
  - Routing model per scheme: for the Pulsar binary protocol (`pulsar` / `pulsar+ssl`), `bindAddresses` is optional — clients may pass an explicit `listenerName` and connect to any binary-protocol port the broker exposes. For the HTTP/HTTPS Admin API (`http` / `https`), `bindAddresses` is the only routing mechanism, because the broker identifies the listener from the destination port the request arrived on; any HTTP/HTTPS advertised listener that should be reachable from outside the cluster therefore needs a dedicated entry in `bindAddresses` on a unique port.
- Consistent listener-name validation between `advertisedListeners` and `bindAddresses`: listener names must match `[A-Za-z0-9_-]+` (no whitespace, no characters that would need URL-encoding). Both validators delegate to a single shared `validateListenerName` helper.
- Whitespace handling: comma-separated entries in both `advertisedListeners` and `bindAddresses` are trimmed end-to-end, and empty entries (extra/trailing commas, blank-only segments from configurations split across multiple lines) are skipped.
- IPv6 support: bare IPv6 literals are wrapped in square brackets when embedded in URLs. The four URL builders in `ServiceConfigurationUtils` (`brokerUrl` / `brokerUrlTls` / `webServiceUrl` / `webServiceUrlTls`) rename their `host` parameter to `ipOrHost` and apply the formatter — `io.netty.util.NetUtil.isValidIpV6Address` decides whether to bracket. The same helper is used for ip:port uniqueness keys and error messages in `MultipleListenerValidator` and `BindAddressValidator`, so `[::1]:6650` is unambiguous in both validation and reporting.
- `PulsarService.start()`: after the Netty/Jetty servers bind, unconditionally sync `brokerServicePort` / `brokerServicePortTls` from the actually bound channels (was only refreshing the `Optional.of(0)` case), then re-compute the cached `advertisedListeners` map so it reflects the dynamic ports. This makes a `bindAddresses=...:0`-only configuration fully supported.
- `ServiceConfigurationUtils.getAppliedAdvertisedAddress`: tolerate a synthesized internal listener that only has a subset of the four URLs populated (e.g. only HTTPS); pick the first non-null URL to derive the host.
- Rewrite the documentation for the eight listener-related properties in `ServiceConfiguration` and mirror it in `conf/broker.conf` and `conf/standalone.conf`. Each `*Port` property explicitly says it serves as both the bind port and the advertised port of the internal listener. `advertisedListeners` is reframed so its primary purpose comes first (declaring additional, typically external, listeners); the auto-configured internal listener and the discouraged-override caveat come after, and the legacy fallback (blank `internalListenerName` ⇒ first listener parsed here becomes the internal one) is called out in its own paragraph. `internalListenerName` is described in terms of cluster-internal traffic, with the Kubernetes external-listener guidance. The `bindAddresses` documentation calls out that port `0` is supported only for the internal listener. The six shared property comment blocks are byte-identical between `broker.conf` and `standalone.conf`.

Bundled changes (not strictly required for the webservice listener support, but related to the same redirect/lookup code paths touched by this PR — split-out PRs would only churn the same files):

- Move REST-producer topic ownership tracking out of `BrokerService.owningTopics` into a dedicated `RestProducerContext`. Eagerly registers ownership after a successful lookup to close a race against the asynchronous `TopicEvent.LOAD` listener notification.
- `PulsarService#loadNamespaceTopics`: add a `failedCount` counter so partial topic-load failures surface in the log line instead of silently being lost.
- `NamespaceBundle#hasNonPersistentTopic`: make `volatile` to fix a concurrency hazard observed in the surrounding code.
- Rename `RedirectManager` → `RedirectManagerForLoadManagerMigration` (and its method `findRedirectLookupResultAsync` → `redirectIfLoadBalancerOnBrokerIsNotExpected`). The previous name suggested the class managed *all* lookup redirects, which it does not. Its only responsibility is the load-manager-migration path: when `loadManagerMigrationEnabled` is set, it compares the broker's current `loadManagerClassName` against the latest entry in the service lookup data and, if they differ, redirects to a random broker running the expected load manager. The new name + Javadoc make the narrow scope (and the `loadManagerMigrationEnabled` gate) explicit so future readers don't mistake it for a general redirect facility.

### Verifying this change

This change added tests and can be verified as follows:

- `LookupResultTest` — unit coverage for `LookupResult.create(...)` factories, redirect URI building, and the backward-compatible `brokerId` derivation from `webServiceUrl` / `webServiceUrlTls` host:port. Includes cases for `toLookupRedirectUri` injecting the `listenerName` query parameter on topic-lookup redirects, `toRedirectUri` leaving the query string alone on admin redirects (including when the original request already carried `listenerName`), and the listener-aware 412 entity.
- `MultipleListenerValidatorTest` — defaulting, custom internal listener name, port synthesis (binary, web, both, partial), merge semantics with explicit URLs, failure paths, whitespace trimming around comma-separated entries, and empty-entry skipping.
- `BindAddressValidatorTest` — migrated-binding listener naming, duplicate tolerance, listener-name conflict, ip:port cross-scheme conflict, port-0 exemption from the ip:port check, legacy-migration ip:port collision, whitespace trimming, and empty-entry skipping.
- `ServiceConfigurationUtilsTest` — hostname, IPv4, bare IPv6, and pre-bracketed IPv6 for each of the four URL builders; asserts the resulting strings round-trip through `URI.create(...)` with the expected port.
- `NamespaceServiceListenerResolutionTest` — `NamespaceService.resolveBrokerServiceLookupResult` behavior: broker-service listener mismatch fails the lookup, web-service listener mismatch falls back to the default URL (rolling-upgrade safety), and a fully matching listener succeeds for both.
- `DynamicBindAddressesIntegrationTest` — end-to-end test that boots a broker purely from `bindAddresses=internal:pulsar://0.0.0.0:0,internal:http://0.0.0.0:0`, asserts that the runtime ports flow back into the configuration and the advertised listener, that the hostname fallback is used when `advertisedAddress` is null, that `pulsar.getBrokerId()` is populated, and that `PulsarAdmin` and `PulsarClient` can create a topic / produce / consume over the dynamic ports.
- `MultipleInternalBindAddressesTest` — confirms that when the internal listener carries multiple bindings for the same scheme, the first one becomes the primary and that `pulsar.getBrokerServiceUrl()`, `pulsar.getWebServiceAddress()`, and the synthesized internal advertised listener all reflect that primary.
- `PulsarMultiListenersWithInternalListenerNameTest` — extended end-to-end coverage for the webservice listener routing.
- `RedirectManagerForLoadManagerMigrationTest` (renamed) — coverage for the load-manager-migration redirect path.
- Existing integration / namespace / topic-owner tests adjusted for the new lookup API.

### Does this pull request potentially affect one of the following parts:

- [x] The public API
- [x] The REST endpoints
- [x] The threading model
- [x] The default values of configurations
- [x] Anything that affects deployment

### Documentation

- [x] `doc-not-needed`
