### PR TITLE
[improve][client] In cases where there is a risk of message loss, adjust the log level to error

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -350,10 +350,15 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
 
     protected void completePendingReceive(CompletableFuture<Message<T>> receivedFuture, Message<T> message) {
         getInternalExecutor(message).execute(() -> {
-            if (!receivedFuture.complete(message)) {
-                log.warn().attr("cancelled", receivedFuture.isCancelled())
-                        .attr("message", message)
-                        .log("Race condition detected, receive future was already completed and message was dropped");
+            if (!receivedFuture.complete(message) && getState() != State.Closing && getState() != State.Closed) {
+                log.error().attr("cancelled", receivedFuture.isCancelled())
+                    .attr("message", message)
+                    .log("Race condition detected, receive future was already completed and message was dropped."
+                        + " In other words, the message was dropped internally, the client-side will encounter a"
+                        + " crucial issue: this message will never be consumed until the consumer is restarted or"
+                        + " the topic is unloaded. Under normal circumstances, this won't happen. It only occurs when"
+                        + " user itself has completed the completable future object returned by"
+                        + " \"consumer.receiveAsync()\"");
             }
         });
     }
@@ -1118,9 +1123,13 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
     protected void completePendingBatchReceive(CompletableFuture<Messages<T>> future, Messages<T> messages) {
         if (!future.complete(messages)) {
             log.warn().attr("cancelled", future.isCancelled())
-                    .attr("messages", messages)
-                    .log("Race condition detected, batch receive future was"
-                            + " already completed and messages were dropped");
+                .attr("messages", messages)
+                .log("Race condition detected, receive future was already completed and message was dropped."
+                    + " In other words, the message was dropped internally, the client-side will encounter a"
+                    + " crucial issue: these message will never be consumed until the consumer is restarted or"
+                    + " the topic is unloaded. Under normal circumstances, this won't happen. It only occurs when"
+                    + " user itself has completed the completable future object returned by"
+                    + " \"consumer.batchReceiveAsync()\"");
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1723,7 +1723,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (getState() != State.Closing && getState() != State.Closed) {
                 log.error().attr("message", message)
                     .attr("pendingReceives-size", pendingReceives.size())
-                    .log(" If you received this log, it means that you encountered a bug: a message was"
+                    .log("If you received this log, it means that you encountered a bug: a message was"
                         + " dropped internally, the client-side will encounter a crucial issue: this message will"
                         + " never be consumed until the consumer is restarted or the topic is unloaded.");
             }
@@ -1735,7 +1735,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (receivedFuture == null) {
             if (getState() != State.Closing && getState() != State.Closed) {
                 log.error().attr("message", message)
-                    .log("pendingReceives pulled out a null conpletableFuture object. If you received this log,"
+                    .log("The pendingReceives pulled out a null conpletableFuture object. If you received this log,"
                         + " it means that you encountered a bug: a message was"
                         + " dropped internally, the client-side will encounter a crucial issue: this message will never"
                         + " be consumed until the consumer is restarted or the topic is unloaded.");

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1720,12 +1720,26 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
      */
     void notifyPendingReceivedCallback(final Message<T> message, Exception exception) {
         if (pendingReceives.isEmpty()) {
+            if (getState() != State.Closing && getState() != State.Closed) {
+                log.error().attr("message", message)
+                    .attr("pendingReceives-size", pendingReceives.size())
+                    .log(" If you received this log, it means that you encountered a bug: a message was"
+                        + " dropped internally, the client-side will encounter a crucial issue: this message will"
+                        + " never be consumed until the consumer is restarted or the topic is unloaded.");
+            }
             return;
         }
 
         // fetch receivedCallback from queue
         final CompletableFuture<Message<T>> receivedFuture = nextPendingReceive();
         if (receivedFuture == null) {
+            if (getState() != State.Closing && getState() != State.Closed) {
+                log.error().attr("message", message)
+                    .log("pendingReceives pulled out a null conpletableFuture object. If you received this log,"
+                        + " it means that you encountered a bug: a message was"
+                        + " dropped internally, the client-side will encounter a crucial issue: this message will never"
+                        + " be consumed until the consumer is restarted or the topic is unloaded.");
+            }
             return;
         }
 


### PR DESCRIPTION
### Motivation & Modifications

**Background**: When calling `consumer.receiveAsync()`, the client will maintain a pending completable future that is used to trace the receive messages request. The client will trigger the pending future when the next message comes in.

**Issue**: The client ignores some unexpected cases, which may lose messages.

**modifications**: print error log if the code runs to an unexpected case

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment