### PR TITLE
[improve][build] Remove kotlin-stdlib override; upgrade okhttp3 5.3.2 and okio 3.17.0

### DIFF
--- a/distribution/server/build.gradle.kts
+++ b/distribution/server/build.gradle.kts
@@ -29,10 +29,8 @@ tasks.named("jar") { enabled = false }
 
 val bookkeeperVersion: String = libs.versions.bookkeeper.get()
 val zookeeperVersion: String = libs.versions.zookeeper.get()
-val kotlinStdlibVersion: String = libs.versions.kotlin.stdlib.get()
 val nettyTcnativeVersion: String = libs.versions.netty.tcnative.get()
 val audienceAnnotationsVersion: String = libs.versions.audience.annotations.get()
-val jetbrainsAnnotationsVersion: String = libs.versions.jetbrains.annotations.get()
 
 // Configuration for collecting runtime dependencies
 val distLib by configurations.creating {
@@ -167,11 +165,6 @@ dependencies {
     distLib("org.apache.bookkeeper:native-io:${bookkeeperVersion}") {
         artifact { type = "jar" }
     }
-
-    // Kotlin stdlib and JetBrains annotations (Maven includes these transitively)
-    distLib("org.jetbrains.kotlin:kotlin-stdlib:${kotlinStdlibVersion}")
-    distLib("org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinStdlibVersion}")
-    distLib("org.jetbrains:annotations:${jetbrainsAnnotationsVersion}")
 
     // zookeeper-jute (transitive of zookeeper, but zookeeper itself is excluded)
     distLib("org.apache.zookeeper:zookeeper-jute:${zookeeperVersion}")

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -434,14 +434,13 @@ The Apache Software License, Version 2.0
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar
  * OkHttp3
-     - com.squareup.okhttp3-logging-interceptor-5.3.1.jar
-     - com.squareup.okhttp3-okhttp-jvm-5.3.1.jar
+     - com.squareup.okhttp3-logging-interceptor-5.3.2.jar
+     - com.squareup.okhttp3-okhttp-jvm-5.3.2.jar
  * Okio
-     - com.squareup.okio-okio-jvm-3.16.3.jar
+     - com.squareup.okio-okio-jvm-3.17.0.jar
  * Javassist -- org.javassist-javassist-3.25.0-GA.jar
  * Kotlin Standard Lib
-     - org.jetbrains.kotlin-kotlin-stdlib-1.8.20.jar
-     - org.jetbrains.kotlin-kotlin-stdlib-common-1.8.20.jar
+     - org.jetbrains.kotlin-kotlin-stdlib-2.2.21.jar
      - org.jetbrains-annotations-13.0.jar
  * gRPC
     - io.grpc-grpc-all-1.75.0.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,8 +69,8 @@ vertx = "4.5.27"
 # Networking / HTTP
 asynchttpclient = "2.15.0"
 conscrypt = "2.5.2"
-okhttp3 = "5.3.1"
-okio = "3.16.3"
+okhttp3 = "5.3.2"
+okio = "3.17.0"
 netty-tcnative = "2.0.77.Final"
 httpcomponents-httpclient = "4.5.13"
 httpcomponents-httpcore = "4.4.15"
@@ -108,9 +108,7 @@ jline3 = "3.21.0"
 jline2 = "2.14.6"
 javassist = "3.25.0-GA"
 rocksdb = "7.9.2"
-kotlin-stdlib = "1.8.20"
 audience-annotations = "0.12.0"
-jetbrains-annotations = "13.0"
 # Misc
 curator = "5.7.1"
 reflections = "0.10.2"
@@ -353,7 +351,6 @@ opencensus-contrib-http-util = { module = "io.opencensus:opencensus-contrib-http
 httpcomponents-httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpcomponents-httpclient" }
 httpcomponents-httpcore = { module = "org.apache.httpcomponents:httpcore", version.ref = "httpcomponents-httpcore" }
 jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation" }
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 ant = { module = "org.apache.ant:ant", version.ref = "ant" }
 guice = { module = "com.google.inject:guice", version.ref = "guice" }


### PR DESCRIPTION
Closes #25763

### Motivation

The explicit `kotlin-stdlib` version override was added in PR #13065 to mitigate [CVE-2020-29582](https://nvd.nist.gov/vuln/detail/CVE-2020-29582), which only affects Kotlin `< 1.4.21`. With the recent upgrade to `okhttp3` 5.x and `okio` 3.x, the transitive `kotlin-stdlib` is already on a modern major (2.x), so the override is no longer necessary. Worse, pinning to `1.8.20` was downgrading a transitive resolution that would naturally land on `2.2.21`, and `1.8.20` is itself out of support.

While here, this also resolves a transitive version split: `opentelemetry-exporter-sender-okhttp:1.62.0` was bringing in `okhttp:5.3.2`, but the `okhttp-bom:5.3.1` constraint forced it back down to `5.3.1`. Aligning the BOM to `5.3.2` removes the mismatch.

`org.jetbrains:annotations` is no longer pinned in the catalog either — it now resolves naturally to `13.0` as requested by `kotlin-stdlib` 2.2.21 (not forced).

### Modifications

* `gradle/libs.versions.toml`
  * `okhttp3`: `5.3.1` → `5.3.2`
  * `okio`: `3.16.3` → `3.17.0`
  * Remove `kotlin-stdlib = "1.8.20"` version and catalog entry — resolves transitively to `2.2.21` via okio/okhttp.
  * Remove `jetbrains-annotations = "13.0"` — was unused outside the explicit dist declaration; resolves naturally to `13.0` via `kotlin-stdlib`.
* `distribution/server/build.gradle.kts`
  * Remove explicit `distLib` entries for `kotlin-stdlib`, `kotlin-stdlib-common`, and `org.jetbrains:annotations`. These now flow in transitively. (`kotlin-stdlib-common` is no longer published as a separate JVM artifact in Kotlin 2.x — it is bundled into `kotlin-stdlib`.)
* `distribution/server/src/assemble/LICENSE.bin.txt`
  * Update version numbers for `okhttp3-*`, `okio-jvm`, and `kotlin-stdlib`.
  * Drop the `kotlin-stdlib-common` entry (no longer in the distribution).

Affected transitive consumers verified compatible:
- `io.kubernetes:client-java:23.0.0` (Pulsar Functions kubernetes runtime)
- `io.opentelemetry:opentelemetry-exporter-sender-okhttp:1.62.0`
- `pulsar-broker-auth-oidc` (direct usage)
- Tests in `pulsar-broker` and `pulsar-proxy`

The contents of the built `apache-pulsar-*-bin.tar.gz` were inspected to confirm the new versions land in `lib/`:

```
lib/com.squareup.okhttp3-logging-interceptor-5.3.2.jar
lib/com.squareup.okhttp3-okhttp-jvm-5.3.2.jar
lib/com.squareup.okio-okio-jvm-3.17.0.jar
lib/org.jetbrains.kotlin-kotlin-stdlib-2.2.21.jar
lib/org.jetbrains-annotations-13.0.jar
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

Local verification performed:
- `./gradlew :distribution:pulsar-server-distribution:checkBinaryLicense` — passes
- `./gradlew :distribution:pulsar-shell-distribution:checkBinaryLicense` — passes
- `./gradlew spotlessCheck` — passes
- Inspected resolved dependency tree to confirm `kotlin-stdlib` is no longer forced to `1.8.20` and that `okhttp3`/`okio` resolve to the aligned versions.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [x] `no-need-doc`