### PR TITLE
[fix][fn] Fix Go function runtime to continue after user exceptions and add neg-ack tests

### DIFF
--- a/pulsar-function-go/pf/instance.go
+++ b/pulsar-function-go/pf/instance.go
@@ -164,7 +164,6 @@ CLOSE:
 		case cm := <-channel:
 			msgInput := cm.Message
 			atMostOnce := gi.context.instanceConf.funcDetails.ProcessingGuarantees == pb.ProcessingGuarantees_ATMOST_ONCE
-			atLeastOnce := gi.context.instanceConf.funcDetails.ProcessingGuarantees == pb.ProcessingGuarantees_ATLEAST_ONCE
 			autoAck := gi.context.instanceConf.funcDetails.AutoAck //nolint:staticcheck
 			if autoAck && atMostOnce {
 				gi.ackInputMessage(msgInput)
@@ -177,12 +176,8 @@ CLOSE:
 
 			output, err := gi.handlerMsg(msgInput)
 			if err != nil {
-				log.Errorf("handler message error:%v", err)
-				if autoAck && atLeastOnce {
-					gi.nackInputMessage(msgInput)
-				}
-				gi.stats.incrTotalUserExceptions(err)
-				return err
+				gi.handleUserError(msgInput, err)
+				continue
 			}
 
 			gi.stats.processTimeEnd()
@@ -391,6 +386,29 @@ func (gi *goInstance) setupConsumer() (chan pulsar.ConsumerMessage, error) {
 	return channel, nil
 }
 
+func (gi *goInstance) shouldNackInputOnFailure() bool {
+	guarantee := gi.context.instanceConf.funcDetails.ProcessingGuarantees
+	return guarantee == pb.ProcessingGuarantees_ATLEAST_ONCE ||
+		guarantee == pb.ProcessingGuarantees_MANUAL
+}
+
+func (gi *goInstance) handleUserError(msgInput pulsar.Message, err error) {
+	log.Errorf("handler message error:%v", err)
+	if gi.shouldNackInputOnFailure() {
+		gi.nackInputMessage(msgInput)
+	}
+	gi.stats.incrTotalUserExceptions(err)
+	gi.stats.processTimeEnd()
+}
+
+func (gi *goInstance) handlePublishError(msgInput pulsar.Message, err error) {
+	if gi.context.instanceConf.funcDetails.ProcessingGuarantees == pb.ProcessingGuarantees_ATLEAST_ONCE {
+		gi.nackInputMessage(msgInput)
+	}
+	gi.stats.incrTotalSysExceptions(err)
+	log.Errorf("failed to publish output message: %v", err)
+}
+
 func (gi *goInstance) handlerMsg(input pulsar.Message) (output []byte, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -420,11 +438,8 @@ func (gi *goInstance) processResult(msgInput pulsar.Message, output []byte) {
 				// semantics, ensure we nack so someone else can get it, in case we are the only handler. Then mark
 				// exception and fail out.
 				if err != nil {
-					if autoAck && atLeastOnce {
-						gi.nackInputMessage(msgInput)
-					}
-					gi.stats.incrTotalSysExceptions(err)
-					log.Fatal(err)
+					gi.handlePublishError(msgInput, err)
+					return
 				}
 				// Otherwise the message succeeded. If the SDK is entrusted with responding and we are using
 				// atLeastOnce delivery semantics, ack the message.
@@ -437,7 +452,7 @@ func (gi *goInstance) processResult(msgInput pulsar.Message, output []byte) {
 		return
 	}
 
-	// No output from the function or no output topic. Ack if we need to and mark the success before rturning.
+	// No output from the function or no output topic. Ack if we need to and mark the success before returning.
 	if autoAck && atLeastOnce {
 		gi.ackInputMessage(msgInput)
 	}

--- a/pulsar-function-go/pf/instance_test.go
+++ b/pulsar-function-go/pf/instance_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	pb "github.com/apache/pulsar/pulsar-function-go/pb"
 )
 
 func testProcessSpawnerHealthCheckTimer(
@@ -114,4 +116,34 @@ func Test_goInstance_handlerMsg(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "output", string(output))
 	assert.Equal(t, message, fc.record)
+}
+
+func newTestGoInstance(guarantee pb.ProcessingGuarantees) *goInstance {
+	return &goInstance{
+		context: &FunctionContext{
+			instanceConf: &instanceConf{
+				funcDetails: pb.FunctionDetails{
+					ProcessingGuarantees: guarantee,
+				},
+			},
+		},
+	}
+}
+
+func TestShouldNackInputOnFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		guarantee pb.ProcessingGuarantees
+		want      bool
+	}{
+		{"atLeastOnce", pb.ProcessingGuarantees_ATLEAST_ONCE, true},
+		{"manual", pb.ProcessingGuarantees_MANUAL, true},
+		{"atMostOnce", pb.ProcessingGuarantees_ATMOST_ONCE, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := newTestGoInstance(tt.guarantee)
+			assert.Equal(t, tt.want, instance.shouldNackInputOnFailure())
+		})
+	}
 }

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -24,6 +24,7 @@ ARG GOLANG_IMAGE
 FROM $GOLANG_IMAGE as pulsar-function-go
 
 COPY target/pulsar-function-go/ /go/src/github.com/apache/pulsar/pulsar-function-go
+COPY go-examples/exceptionFunc/ /go/src/github.com/apache/pulsar/pulsar-function-go/examples/exceptionFunc/
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go && go install ./...
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/pf && go install
 RUN cd /go/src/github.com/apache/pulsar/pulsar-function-go/examples && go install ./...

--- a/tests/docker-images/latest-version-image/go-examples/exceptionFunc/exceptionFunc.go
+++ b/tests/docker-images/latest-version-image/go-examples/exceptionFunc/exceptionFunc.go
@@ -1,0 +1,41 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/apache/pulsar/pulsar-function-go/pf"
+)
+
+var i int
+
+func HandleException(ctx context.Context, in []byte) ([]byte, error) {
+	i++
+	if i%10 == 0 {
+		return nil, errors.New("test")
+	}
+	return []byte(string(in) + "!"), nil
+}
+
+func main() {
+	pf.Start(HandleException)
+}

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -410,6 +410,10 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
             submitFunction(
                     runtime, inputTopicName, outputTopicName, functionName, EXCEPTION_FUNCTION_PYTHON_FILE,
                     EXCEPTION_PYTHON_CLASS, schema, null);
+        } else if (runtime == Runtime.GO) {
+            submitFunction(
+                    runtime, inputTopicName, outputTopicName, functionName, EXCEPTION_GO_FILE,
+                    null, schema, null);
         } else {
             submitFunction(
                     runtime, inputTopicName, outputTopicName, functionName, null, EXCEPTION_JAVA_CLASS, schema, null);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTestBase.java
@@ -78,6 +78,7 @@ public abstract class PulsarFunctionsTestBase extends PulsarTestSuite {
 
     public static final String EXCLAMATION_GO_FILE = "exclamationFunc";
     public static final String PUBLISH_FUNCTION_GO_FILE = "exclamationFunc";
+    public static final String EXCEPTION_GO_FILE = "exceptionFunc";
 
     public static final String LOGGING_JAVA_CLASS =
             "org.apache.pulsar.functions.api.examples.LoggingFunction";

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/go/PulsarFunctionsGoTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/go/PulsarFunctionsGoTest.java
@@ -39,4 +39,9 @@ public abstract class PulsarFunctionsGoTest extends PulsarFunctionsTest {
         testExclamationFunction(Runtime.GO, false, false, true, false);
     }
 
+    @Test(groups = {"go_function", "function"})
+    public void testGoFunctionNegAck() throws Exception {
+        testFunctionNegAck(Runtime.GO);
+    }
+
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->



<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Go function runtime currently exits the processing loop when user code returns an error, which causes behavior inconsistency with Java/Python runtimes and prevents expected retry/negative-ack flow in failure scenarios.
This PR aligns Go runtime behavior for user-function failures and adds integration coverage for Go neg-ack semantics.

This PR aligns Go runtime behavior for user-function failures and adds integration coverage for Go neg-ack semantics.

### Modifications

<!-- Describe the modifications you've done. -->

- In `pulsar-function-go/pf/instance.go`:
  - Refactored error handling into helper methods (`handleUserError`, `handlePublishError`).
  - Changed user-function error path from returning error (exit loop) to continuing message processing.
  - Added `shouldNackInputOnFailure()` and enabled `nack` for `ATLEAST_ONCE` and `MANUAL` on user-function failures.
  - Kept publish-error handling with system exception metrics and appropriate ack/nack behavior.
- In `pulsar-function-go/pf/instance_test.go`:
  - Added Go exception function example: `tests/docker-images/latest-version-image/go-examples/exceptionFunc/exceptionFunc.go`.
  - Updated Docker image build to include the new Go example artifact.
  - Added `testGoFunctionNegAck` in Go integration test suite.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

~~~ shell
./gradlew :tests:integration:integrationTest \
  -PintegrationTestSuiteFile=pulsar-process.xml \
  -PtestGroups=go_function
~~~

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Matching PR in forked repository

PR in forked repository: https://github.com/Dream95/pulsar/pull/10