### PR TITLE
[fix][fn] Fix Go function incorrectly using nanoseconds for timestamp

### DIFF
--- a/pulsar-function-go/pf/stats.go
+++ b/pulsar-function-go/pf/stats.go
@@ -248,7 +248,7 @@ func getFirstMatch(
 
 func (stat *StatWithLabelValues) setLastInvocation() {
 	now := time.Now()
-	stat.statLastInvocation.Set(float64(now.UnixNano()))
+	stat.statLastInvocation.Set(float64(now.UnixMilli()))
 }
 
 func (stat *StatWithLabelValues) processTimeStart() {
@@ -272,7 +272,7 @@ func (stat *StatWithLabelValues) incrTotalUserExceptions(err error) {
 
 func (stat *StatWithLabelValues) addUserException(err error) {
 	now := time.Now()
-	ts := now.UnixNano()
+	ts := now.UnixMilli()
 	errorTS := LatestException{err, ts}
 	stat.latestUserException = append(stat.latestUserException, errorTS)
 	if len(stat.latestUserException) > 10 {
@@ -302,7 +302,7 @@ func (stat *StatWithLabelValues) incrTotalSysExceptions(exception error) {
 
 func (stat *StatWithLabelValues) addSysException(exception error) {
 	now := time.Now()
-	ts := now.UnixNano()
+	ts := now.UnixMilli()
 	errorTS := LatestException{exception, ts}
 	stat.latestSysException = append(stat.latestSysException, errorTS)
 	if len(stat.latestSysException) > 10 {


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->



<!-- or this PR is one task of an issue -->



<!-- If the PR belongs to a PIP, please add the PIP link here -->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Go function runtime recorded `last_invocation` and exception timestamps using `time.UnixNano()`.

### Modifications

<!-- Describe the modifications you've done. -->

- Change `setLastInvocation()`, `addUserException()`, and `addSysException()` in
  `pulsar-function-go/pf/stats.go` to use `UnixMilli()` instead of `UnixNano()`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment