### PR TITLE
[improve][misc] Upgrade Netty to 4.1.134

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -293,26 +293,26 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.20.0.jar
     - org.apache.commons-commons-text-1.14.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.133.Final.jar
-    - io.netty-netty-codec-4.1.133.Final.jar
-    - io.netty-netty-codec-dns-4.1.133.Final.jar
-    - io.netty-netty-codec-http-4.1.133.Final.jar
-    - io.netty-netty-codec-http2-4.1.133.Final.jar
-    - io.netty-netty-codec-socks-4.1.133.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.133.Final.jar
-    - io.netty-netty-common-4.1.133.Final.jar
-    - io.netty-netty-handler-4.1.133.Final.jar
-    - io.netty-netty-handler-proxy-4.1.133.Final.jar
-    - io.netty-netty-resolver-4.1.133.Final.jar
-    - io.netty-netty-resolver-dns-4.1.133.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.133.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.133.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.133.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.133.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.133.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.133.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.133.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.133.Final.jar
+    - io.netty-netty-buffer-4.1.134.Final.jar
+    - io.netty-netty-codec-4.1.134.Final.jar
+    - io.netty-netty-codec-dns-4.1.134.Final.jar
+    - io.netty-netty-codec-http-4.1.134.Final.jar
+    - io.netty-netty-codec-http2-4.1.134.Final.jar
+    - io.netty-netty-codec-socks-4.1.134.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.134.Final.jar
+    - io.netty-netty-common-4.1.134.Final.jar
+    - io.netty-netty-handler-4.1.134.Final.jar
+    - io.netty-netty-handler-proxy-4.1.134.Final.jar
+    - io.netty-netty-resolver-4.1.134.Final.jar
+    - io.netty-netty-resolver-dns-4.1.134.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.134.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.134.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.134.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.134.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.134.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.134.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.134.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.134.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar
     - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -345,22 +345,22 @@ The Apache Software License, Version 2.0
     - commons-text-1.14.0.jar
     - commons-compress-1.28.0.jar
  * Netty
-    - netty-buffer-4.1.133.Final.jar
-    - netty-codec-4.1.133.Final.jar
-    - netty-codec-dns-4.1.133.Final.jar
-    - netty-codec-http-4.1.133.Final.jar
-    - netty-codec-socks-4.1.133.Final.jar
-    - netty-codec-haproxy-4.1.133.Final.jar
-    - netty-common-4.1.133.Final.jar
-    - netty-handler-4.1.133.Final.jar
-    - netty-handler-proxy-4.1.133.Final.jar
-    - netty-resolver-4.1.133.Final.jar
-    - netty-resolver-dns-4.1.133.Final.jar
-    - netty-transport-4.1.133.Final.jar
-    - netty-transport-classes-epoll-4.1.133.Final.jar
-    - netty-transport-native-epoll-4.1.133.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.133.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.133.Final.jar
+    - netty-buffer-4.1.134.Final.jar
+    - netty-codec-4.1.134.Final.jar
+    - netty-codec-dns-4.1.134.Final.jar
+    - netty-codec-http-4.1.134.Final.jar
+    - netty-codec-socks-4.1.134.Final.jar
+    - netty-codec-haproxy-4.1.134.Final.jar
+    - netty-common-4.1.134.Final.jar
+    - netty-handler-4.1.134.Final.jar
+    - netty-handler-proxy-4.1.134.Final.jar
+    - netty-resolver-4.1.134.Final.jar
+    - netty-resolver-dns-4.1.134.Final.jar
+    - netty-transport-4.1.134.Final.jar
+    - netty-transport-classes-epoll-4.1.134.Final.jar
+    - netty-transport-native-epoll-4.1.134.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.134.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.134.Final.jar
     - netty-tcnative-boringssl-static-2.0.77.Final.jar
     - netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar
     - netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar
@@ -371,9 +371,9 @@ The Apache Software License, Version 2.0
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.133.Final.jar
-    - netty-resolver-dns-native-macos-4.1.133.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.133.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.134.Final.jar
+    - netty-resolver-dns-native-macos-4.1.134.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.134.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ checkstyle = "13.3.0"
 # Major frameworks
 bookkeeper = "4.17.3"
 zookeeper = "3.9.5"
-netty = "4.1.133.Final"
+netty = "4.1.134.Final"
 netty-iouring = "0.0.26.Final"
 jetty = "12.1.9"
 jersey = "2.42"


### PR DESCRIPTION
### Motivation

Netty 4.1.134 contains some bug fixes and improvements.
* [Netty 4.1.134 release notes](https://netty.io/news/2026/05/20/4-1-134-Final.html)

### Changes

- upgrade Netty to 4.1.134