### PR TITLE
[fix][test] Fix flaky PulsarFunctionTlsTest.testFunctionsCreation() test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/functions/worker/PulsarFunctionTlsTest.java
@@ -19,8 +19,6 @@
 package org.apache.pulsar.functions.worker;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
@@ -41,10 +39,10 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderTls;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.functions.FunctionConfig;
-import org.apache.pulsar.common.functions.WorkerInfo;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.ClassLoaderUtils;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -259,23 +257,16 @@ public class PulsarFunctionTlsTest {
 
             log.info().attr("function", functionName).log("Start test function");
 
-            int finalI = i;
-            // Wait for a leader to be ready and create the function.
-            // The createFunctionWithUrl call is included in the retry loop because a leadership
-            // transition can happen between the leader check and the actual API call, causing
-            // a 503 "Leader not yet ready" error.
             final PulsarAdmin createAdmin = pulsarAdmins[i];
-            Awaitility.await().atMost(1, TimeUnit.MINUTES).pollInterval(1, TimeUnit.SECONDS).untilAsserted(() -> {
-                final PulsarWorkerService workerService = ((PulsarWorkerService) fnWorkerServices[finalI]);
-                final LeaderService leaderService = workerService.getLeaderService();
-                assertNotNull(leaderService);
-                if (!leaderService.isLeader()) {
-                    final WorkerInfo workerInfo = workerService.getMembershipManager().getLeader();
-                    assertTrue(workerInfo != null
-                            && !workerInfo.getWorkerId().equals(workerService.getWorkerConfig().getWorkerId()));
-                }
-                createAdmin.functions().createFunctionWithUrl(functionConfig, jarFilePathUrl);
-            });
+            // During function-worker leadership election/switchover, the coordination topic can already point to
+            // the new leader while that worker is still finishing its leader initialization. In that short window
+            // the internal /functions/leader request returns a transient 503 "Leader not yet ready", so retry only
+            // that condition and let all other failures surface immediately.
+            Awaitility.await().atMost(1, TimeUnit.MINUTES)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .ignoreExceptionsMatching(PulsarFunctionTlsTest::isLeaderNotReady)
+                    .untilAsserted(() -> createAdmin.functions()
+                            .createFunctionWithUrl(functionConfig, jarFilePathUrl));
 
             // Function creation is not strongly consistent, so this test can fail with a get that is too eager and
             // does not have retries.
@@ -291,6 +282,14 @@ public class PulsarFunctionTlsTest {
             pulsarAdmins[i].functions().deleteFunction(config.getTenant(), config.getNamespace(), config.getName());
         }
     }
+
+    private static boolean isLeaderNotReady(Throwable e) {
+        return e instanceof PulsarAdminException
+                && ((PulsarAdminException) e).getStatusCode() == 503
+                && String.valueOf(((PulsarAdminException) e).getHttpError())
+                        .contains("Leader not yet ready");
+    }
+
     @SuppressWarnings("deprecation")
 
     protected static FunctionConfig createFunctionConfig(


### PR DESCRIPTION
### Motivation

`PulsarFunctionTlsTest.testFunctionsCreation` is flaky when the two function workers are in a leadership switchover window. The test can observe a worker/leader state that is already stale by the time the create-function request is internally forwarded to `/admin/v3/functions/leader/...`.

In that window, the coordination topic can already point to the new leader while the new leader is still finishing initialization. The forwarded request then fails with a transient `HTTP 503` response: `Leader not yet ready. Please retry again`.

Reproduction log snippet:

```text
2026-05-29T22:21:35,931 - INFO  - [assignment-tailer-thread:FunctionAssignmentTailer] - assignment tailer thread exiting {}
2026-05-29T22:21:35,931 - INFO  - [pulsar-external-listener-5215-1:FunctionAssignmentTailer] - Closing function assignment tailer {}
2026-05-29T22:21:35,932 - INFO  - [pulsar-external-listener-5215-1:FunctionMetaDataManager] - FunctionMetaDataManager becoming leader by creating exclusive producer {}
...
2026-05-29T22:21:36,011 - INFO  - [pulsar-web-5184-20:JettyRequestLogFactory] - HTTP request {bytesOut=53, clientAddr=127.0.0.1, clientPort=52607, durationMs=3, method=PUT, proto=HTTP/1.1, referer=null, status=503, uri=https://localhost:52588/admin/v3/functions/leader/my-tenant/my-ns/function-0, user=null, userAgent=Pulsar-Java-v5.0.0-M1-SNAPSHOT}
2026-05-29T22:21:36,012 - ERROR - [pulsar-web-5006-16:ComponentImpl] - Failed to update function on leader {error=Update Failed}
org.apache.pulsar.client.admin.PulsarAdminException$ServerSideErrorException: Leader not yet ready. Please retry again
        at org.apache.pulsar.client.admin.PulsarAdminException.wrap(PulsarAdminException.java:252)
        at org.apache.pulsar.client.admin.internal.BaseResource.sync(BaseResource.java:366)
        at org.apache.pulsar.client.admin.internal.FunctionsImpl.updateOnWorkerLeader(FunctionsImpl.java:706)
```

### Modifications

- Remove the test-side pre-check of the worker leader state before function creation.
- Retry `createFunctionWithUrl` only when the failure is a `PulsarAdminException` with status code `503` and `Leader not yet ready` in the HTTP error body.
- Keep all other admin failures visible immediately so TLS, auth, validation, or non-transient service errors are not hidden.

### Verifying this change

This change is already covered by existing tests:

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.functions.worker.PulsarFunctionTlsTest.testFunctionsCreation`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
