### PR TITLE
[fix][test] Stabilize testSecondaryIsolationGroupsBookiesNegative() test

### DIFF
--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/bookie/rackawareness/IsolatedBookieEnsemblePlacementPolicyTest.java
@@ -590,6 +590,12 @@ public class IsolatedBookieEnsemblePlacementPolicyTest {
                 NullStatsLogger.INSTANCE, BookieSocketAddress.LEGACY_BOOKIEID_RESOLVER);
         isolationPolicy.onClusterChanged(writableBookies, readOnlyBookies);
 
+        // Wait for the async cache load triggered by initialize() to complete; otherwise the
+        // first newEnsemble call can race with an empty cachedRackConfiguration and skip isolation.
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertNotNull(isolationPolicy.getBookieMappingCache()
+                        .getIfCached(BookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH)));
+
         try {
             isolationPolicy
                     .newEnsemble(3, 3, 2, Collections.emptyMap(), new HashSet<>()).getResult();


### PR DESCRIPTION
### Motivation

`testSecondaryIsolationGroupsBookiesNegative()` is flaky because the test calls newEnsemble immediately after initializing IsolatedBookieEnsemblePlacementPolicy. The policy loads the bookie rack metadata cache asynchronously. If the first newEnsemble call races with the initial cache load, cachedRackConfiguration can still be empty and the isolation filtering is skipped, so the ensemble may be created successfully instead of throwing BKNotEnoughBookiesException.

The test is intended to verify the negative fallback path for secondary isolation groups: when the primary group does not have enough available bookies and the configured secondary group is absent from rack metadata, the policy must not fall back to default-group bookies, so creating an ensemble of size 3 should fail.

### Modifications

Add an Awaitility guard before calling newEnsemble so the test waits until the async bookie rack metadata cache load triggered by initialize() is visible. This matches the pattern used by nearby tests and keeps the production placement policy behavior unchanged.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment