### PR TITLE
[improve][build] Upgrade Athenz to 1.12.42

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,7 +97,7 @@ hdrHistogram = "2.1.9"
 perfmark = "0.26.0"
 # Auth
 jsonwebtoken = "0.13.0"
-athenz = "1.10.62"
+athenz = "1.12.42"
 jose4j = "0.9.6"
 nimbus-jose-jwt = "9.37.4"
 auth0-java-jwt = "4.5.2"


### PR DESCRIPTION
### Motivation

The Athenz client/server libraries (`com.yahoo.athenz`) used by the
`pulsar-client-auth-athenz` and `pulsar-broker-auth-athenz` authentication
plugins were pinned to **1.10.62**, which is several years old. Upgrading to
**1.12.42** picks up upstream bug fixes, dependency/security updates, and keeps
the integration on a maintained release line.

More importantly, this upgrade is a prerequisite for the **`javax.*` →
`jakarta.*` migration** ([PIP-472](https://github.com/apache/pulsar/blob/master/pip/pip-472.md)).
The old Athenz ZTS client (1.10.62) used Jersey and therefore dragged the
JAX-RS (`javax.ws.rs`) API onto the classpath transitively. JAX-RS is the
single largest migration surface in PIP-472 (~660 files), and a lingering
`javax.ws.rs` dependency pulled in by Athenz would be a conflicting problem for
the move to `jakarta.ws.rs`. Athenz **1.11.0** removed Jersey/JAX-RS from the
client in favor of Apache HttpClient5, so upgrading to 1.12.42 drops that
conflicting JAX-RS dependency — at which point it is no longer a blocker for the
PIP-472 implementation.

### Modifications

- Bump `athenz` in `gradle/libs.versions.toml` from `1.10.62` to `1.12.42`.
  This single version ref governs all four Athenz artifacts used by Pulsar:
  `athenz-zts-java-client`, `athenz-zpe-java-client`, `athenz-cert-refresher`
  and `athenz-auth-core`.

**No source changes are required.** Every Athenz API used by Pulsar keeps an
identical signature in 1.12.42. The breaking changes introduced in Athenz
**1.11.0** — the ZTS client is no longer shaded, Jersey/JAX-RS was replaced by
Apache HttpClient5, JDK 11+ is required, and `athenz-zts-java-client-core` plus
`ZTSClient.setProperty()`/`getClientBuilder()` were removed — do **not** affect
Pulsar: it uses none of the removed APIs/artifact and targets JDK 17/21.

**No LICENSE/NOTICE changes are required.** The Athenz auth modules are
standalone plugins and are not bundled in any Pulsar binary distribution
(server/shell), so the per-jar `LICENSE.bin.txt` accounting is unaffected by the
Athenz version change. The new transitive dependencies pulled in by 1.12.x
(e.g. Apache HttpClient5) are likewise not bundled.

> [!NOTE]
> The ZTS client's HTTP transport changed internally from Jersey to Apache
> HttpClient5 in the 1.11.x line. The public API is unchanged, but this is a
> behavior-surface change; the existing unit tests mock `ZTSClient`, so a full
> CI run (including any Athenz integration coverage) is the real end-to-end
> check.

### Verifying this change

This change is already covered by existing tests:

- `pulsar-client-auth-athenz` — `AuthenticationAthenzTest` (8/8 pass against 1.12.42)
- `pulsar-broker-auth-athenz` — `AuthenticationProviderAthenzTest` (4/4 pass against 1.12.42)

Both modules compile cleanly (`compileJava` + `compileTestJava`) and all 12 unit
tests pass locally against Athenz 1.12.42 with no deprecation/removal warnings.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
