### PR TITLE
[improve][admin] PIP-482: Peek messages from topic subscription with messagePosition

### DIFF
--- a/pip/pip-482.md
+++ b/pip/pip-482.md
@@ -59,48 +59,46 @@ backlog pagination from any caller.
 
 ## API surface — `org.apache.pulsar.client.admin.Topics`
 
-The new method is the abstract, full-control entry point:
+The existing abstract entry point is left **unchanged** — it remains the head-of-backlog
+(`messagePosition = 1`) method that implementations must provide:
 
 ```java
-List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
+// Pre-existing abstract method — unchanged.
+List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
                                    boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
         throws PulsarAdminException;
-
-CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
-        String topic, String subName, int messagePosition, int numMessages,
-        boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
 ```
 
-All other overloads — including both pre-existing ones — become `default` methods that delegate
-to this primary method. This eliminates duplicated Javadoc across overloads and gives the
-interface a single source of truth for behavior.
-
-The full set of `default` overloads:
+The position-aware capability is added as a **new `default` overload** (not a new abstract
+method). Its default body preserves the existing behavior for `messagePosition == 1` by delegating
+to the abstract method, and throws `UnsupportedOperationException` for any other position. The
+in-tree `TopicsImpl` overrides it to honor an arbitrary position:
 
 ```java
-// 3-arg — pre-existing convenience method
-default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
+// New position-aware overload — a default method, so no implementor/mock is forced to change.
+default List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
+                                           boolean showServerMarker,
+                                           TransactionIsolationLevel transactionIsolationLevel)
         throws PulsarAdminException {
-    return peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+    if (messagePosition == 1) {
+        return peekMessages(topic, subName, numMessages, showServerMarker, transactionIsolationLevel);
+    }
+    throw new UnsupportedOperationException(
+            "This Topics implementation does not support peeking from a messagePosition other than 1");
 }
 
-// 4-arg — new user-facing convenience for pagination
+// New user-facing convenience for pagination — delegates to the position-aware default.
 default List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages)
         throws PulsarAdminException {
     return peekMessages(topic, subName, messagePosition, numMessages, false,
             TransactionIsolationLevel.READ_COMMITTED);
 }
-
-// 5-arg — pre-existing showServerMarker + isolation form; now delegates with messagePosition=1
-default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                           boolean showServerMarker,
-                                           TransactionIsolationLevel transactionIsolationLevel)
-        throws PulsarAdminException {
-    return peekMessages(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
-}
 ```
 
-Async variants mirror the same shape.
+The pre-existing 3-arg convenience method is unchanged and still delegates to the abstract method
+with `showServerMarker = false` and `READ_COMMITTED`. Async variants mirror the same shape (the
+async position-aware default fails the returned future with `UnsupportedOperationException` for a
+non-1 position).
 
 ## `messagePosition` semantics
 
@@ -121,8 +119,9 @@ which the Pulsar community prefers to keep distinct.
 The internal helper
 `TopicsImpl#peekMessagesAsync(String, String, int, List<Message<byte[]>>, CompletableFuture, int, boolean, TransactionIsolationLevel)`
 already takes the position as `int nthMessage`. The public overloads previously passed `1`
-unconditionally. The new abstract method passes the caller-supplied `messagePosition` instead.
-No change to the helper or to the REST call path is required.
+unconditionally. `TopicsImpl` now overrides the new position-aware `default` method to pass the
+caller-supplied `messagePosition` instead, and its pre-existing 5-arg method simply delegates with
+`messagePosition = 1`. No change to the helper or to the REST call path is required.
 
 # Backward & Forward Compatibility
 
@@ -132,22 +131,23 @@ All existing call sites and existing implementations of `Topics` continue to com
 
 ## Binary compatibility
 
-The pre-existing abstract method
-`peekMessages(String, String, int, boolean, TransactionIsolationLevel)` is changed to a `default`
-method. This is binary-compatible: classes that previously implemented the method by overriding
-it continue to work — their override still takes precedence over the new `default` body.
+No abstract method is added, removed, or changed. The pre-existing abstract method
+`peekMessages(String, String, int, boolean, TransactionIsolationLevel)` (and its async
+counterpart) is left exactly as-is, so every existing implementor and mock still satisfies the
+`Topics` interface with no recompilation.
 
-The new abstract method
-`peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)` is added to the
-interface. External classes implementing `Topics` directly will need to either:
-- override this new method to provide custom behavior, or
-- accept the default behavior by not overriding any peek methods.
+The position-aware method
+`peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)` is added as a
+`default` method. External classes implementing `Topics` directly therefore need no change:
+- they inherit the default, which honors `messagePosition = 1` (identical to the historical
+  head-of-backlog behavior) and throws `UnsupportedOperationException` for other positions; and
+- they may optionally override it to support arbitrary positions.
 
-`TopicsImpl` (the in-tree implementation of `Topics`) is updated to override the new abstract
-method. No other in-tree code requires changes.
+`TopicsImpl` (the in-tree implementation of `Topics`) overrides the new `default` method to support
+arbitrary positions. No other in-tree code requires changes.
 
-This follows the same compatibility pattern used when `showServerMarker` and
-`TransactionIsolationLevel` were added to the peek API.
+This is strictly additive — adding a `default` method to a public interface is both source- and
+binary-compatible.
 
 ## Behavioral compatibility
 

--- a/pip/pip-482.md
+++ b/pip/pip-482.md
@@ -1,0 +1,186 @@
+# PIP-482: Peek messages from topic subscription with messagePosition
+
+# Background knowledge
+
+A Pulsar subscription tracks which messages have been acknowledged. The set of unacknowledged
+messages on a subscription is the subscription **backlog**. The size of the backlog is the sum
+of the sizes (in bytes) of the unacknowledged messages.
+
+A topic may have many subscriptions.
+
+Messages on a subscription backlog can be inspected without being acknowledged. This operation
+is called **peeking** and is exposed via the Pulsar admin REST API and the Java admin client
+`org.apache.pulsar.client.admin.Topics.peekMessages(...)`.
+
+The underlying REST endpoint
+`/admin/v3/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{messagePosition}`
+already accepts an arbitrary message position. The current Java admin client API does not surface
+that parameter — every call hardcodes position `1`, so callers can only inspect the messages at
+the head of the backlog.
+
+# Motivation
+
+A common use case is paginated display of a subscription backlog in an admin UI: show messages
+1–10 on page 1, messages 11–20 on page 2, and so on. With the current Java admin client API,
+displaying page N requires fetching all `N * pageSize` messages from the head of the backlog and
+discarding the first `(N-1) * pageSize` of them. For large backlogs and large page indexes this
+is wasteful in bandwidth, memory, and time on both client and broker.
+
+The REST endpoint already supports the operation efficiently — the gap is purely in the Java
+admin client API surface.
+
+This PIP exposes the message position parameter on the Java admin client, enabling efficient
+backlog pagination from any caller.
+
+# Goals
+
+## In Scope
+
+- Add Java admin client `Topics` methods that accept a `messagePosition` parameter,
+  letting callers peek `numMessages` messages starting from `messagePosition` instead of from
+  position 1.
+- Preserve full source and behavioral compatibility with the existing `peekMessages` /
+  `peekMessagesAsync` overloads. Existing callers continue to compile and run with no change
+  in behavior.
+- Provide consistent overloads for the synchronous and asynchronous variants, with and without
+  the existing `showServerMarker` and `TransactionIsolationLevel` parameters.
+- Validate `messagePosition >= 1` at the client and surface a clear `IllegalArgumentException`
+  for invalid input.
+
+## Out of Scope
+
+- Server-side changes. The REST endpoint already supports this; no broker change is required.
+- Adding a `MessageId`-based peek API. That would be a separate, more invasive change and is
+  better discussed in its own PIP.
+- A builder-style `PeekOptions` parameter. Considered but rejected as out of scope for this
+  proposal (see "Alternatives Considered" below).
+
+# Design & Implementation Details
+
+## API surface — `org.apache.pulsar.client.admin.Topics`
+
+The new method is the abstract, full-control entry point:
+
+```java
+List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
+                                   boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
+        throws PulsarAdminException;
+
+CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+        String topic, String subName, int messagePosition, int numMessages,
+        boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
+```
+
+All other overloads — including both pre-existing ones — become `default` methods that delegate
+to this primary method. This eliminates duplicated Javadoc across overloads and gives the
+interface a single source of truth for behavior.
+
+The full set of `default` overloads:
+
+```java
+// 3-arg — pre-existing convenience method
+default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
+        throws PulsarAdminException {
+    return peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+}
+
+// 4-arg — new user-facing convenience for pagination
+default List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages)
+        throws PulsarAdminException {
+    return peekMessages(topic, subName, messagePosition, numMessages, false,
+            TransactionIsolationLevel.READ_COMMITTED);
+}
+
+// 5-arg — pre-existing showServerMarker + isolation form; now delegates with messagePosition=1
+default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+                                           boolean showServerMarker,
+                                           TransactionIsolationLevel transactionIsolationLevel)
+        throws PulsarAdminException {
+    return peekMessages(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+}
+```
+
+Async variants mirror the same shape.
+
+## `messagePosition` semantics
+
+- 1-indexed, matching the REST endpoint convention.
+  `messagePosition=1` returns the oldest unacknowledged message.
+  `messagePosition=N` returns the N-th unacknowledged message and onward.
+- Must be `>= 1`. `0` and negative values are rejected with `IllegalArgumentException` at the
+  client.
+- If `messagePosition` exceeds the size of the backlog, the returned list is empty (consistent
+  with the existing behavior when peeking past the tail).
+
+The parameter name `messagePosition` is used to match the existing internal `nthMessage`
+parameter and the REST endpoint path segment, and to avoid Kafka's "offset" terminology
+which the Pulsar community prefers to keep distinct.
+
+## Implementation
+
+The internal helper
+`TopicsImpl#peekMessagesAsync(String, String, int, List<Message<byte[]>>, CompletableFuture, int, boolean, TransactionIsolationLevel)`
+already takes the position as `int nthMessage`. The public overloads previously passed `1`
+unconditionally. The new abstract method passes the caller-supplied `messagePosition` instead.
+No change to the helper or to the REST call path is required.
+
+# Backward & Forward Compatibility
+
+## Source compatibility
+
+All existing call sites and existing implementations of `Topics` continue to compile unchanged.
+
+## Binary compatibility
+
+The pre-existing abstract method
+`peekMessages(String, String, int, boolean, TransactionIsolationLevel)` is changed to a `default`
+method. This is binary-compatible: classes that previously implemented the method by overriding
+it continue to work — their override still takes precedence over the new `default` body.
+
+The new abstract method
+`peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)` is added to the
+interface. External classes implementing `Topics` directly will need to either:
+- override this new method to provide custom behavior, or
+- accept the default behavior by not overriding any peek methods.
+
+`TopicsImpl` (the in-tree implementation of `Topics`) is updated to override the new abstract
+method. No other in-tree code requires changes.
+
+This follows the same compatibility pattern used when `showServerMarker` and
+`TransactionIsolationLevel` were added to the peek API.
+
+## Behavioral compatibility
+
+For every pre-existing overload, the behavior with default arguments is unchanged. Calls that
+omit `messagePosition` continue to peek from position 1.
+
+# Alternatives Considered
+
+## `MessageId`-based peek
+
+Allowing callers to peek starting from a specific `MessageId` would be more powerful (it would
+let UIs paginate by remembering the last-seen `MessageId` rather than a numeric position) and
+would compose more naturally with deduplication and replay. However:
+- The REST endpoint already supports position-based peeking; `MessageId`-based peeking would
+  require a server-side change.
+- Position-based pagination is the immediate request from Pulsar users and is fully implementable
+  client-side today.
+- A `MessageId`-based API can be added in a future PIP without conflicting with this one.
+
+## `PeekOptions` builder parameter
+
+A `PeekOptions` builder pattern (e.g. `topics.peek(PeekOptions.builder().topic(...).startAt(N)...)`)
+would be more extensible and self-documenting at the call site. However:
+- It would require renaming or duplicating every peek method, which is a larger and more invasive
+  API change.
+- It diverges from the parameter-list convention used by every other method in `Topics`.
+- It can be added later as a separate PIP without conflicting with the additions in this PIP.
+
+This PIP keeps the existing parameter-list convention and lets each variant be discoverable
+through method overloads, matching the rest of the `Topics` interface.
+
+# Links
+
+<!-- Updated after the dev@ discussion thread is opened. -->
+* Mailing List discussion thread: _to be filled after this PIP is sent to dev@_
+* Mailing List voting thread: _to be filled after the discussion completes_

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1009,6 +1009,52 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.topics().getList("prop-xyz/ns1"), new ArrayList<>());
     }
 
+    @Test
+    public void peekMessagesPaginatesFromMessagePosition() throws Exception {
+        final String topic = "persistent://prop-xyz/ns1/peek-paginate";
+        final String subName = "peek-sub";
+
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(pulsar.getWebServiceAddress())
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        // Create the subscription so the published messages form a tracked backlog.
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer()
+                .topic(topic).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Exclusive).subscribe();
+
+        publishMessagesOnPersistentTopic(topic, 10);
+
+        // Page 1: positions 1..5 -> message-0 .. message-4 (head of backlog).
+        List<Message<byte[]>> page1 = admin.topics().peekMessages(topic, subName, 1, 5);
+        assertEquals(page1.size(), 5);
+        for (int i = 0; i < 5; i++) {
+            assertEquals(page1.get(i).getData(), ("message-" + i).getBytes());
+        }
+
+        // Page 2: starting at messagePosition 6 -> message-5 .. message-9. The point of PIP-482 is
+        // that this peeks directly from position 6 instead of re-reading and discarding page 1.
+        List<Message<byte[]>> page2 = admin.topics().peekMessages(topic, subName, 6, 5);
+        assertEquals(page2.size(), 5);
+        for (int i = 0; i < 5; i++) {
+            assertEquals(page2.get(i).getData(), ("message-" + (i + 5)).getBytes());
+        }
+
+        // Page 2 must contain none of page 1's messages.
+        Set<String> page1Bodies = new HashSet<>();
+        for (Message<byte[]> m : page1) {
+            page1Bodies.add(new String(m.getData()));
+        }
+        for (Message<byte[]> m : page2) {
+            String body = new String(m.getData());
+            assertFalse(page1Bodies.contains(body), "page 2 re-read a page 1 message: " + body);
+        }
+
+        admin.topics().skipAllMessages(topic, subName);
+    }
+
     @SuppressWarnings("deprecation")
     @Test(dataProvider = "topicName")
     public void testSkipHoleMessages(String topicName) throws Exception {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1641,9 +1641,6 @@ public interface Topics {
     /**
      * Peek messages from a topic subscription.
      *
-     * <p>Equivalent to {@link #peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)
-     * peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED)}.
-     *
      * @param topic
      *            topic name
      * @param subName
@@ -1660,8 +1657,36 @@ public interface Topics {
      */
     default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        return peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+        return peekMessages(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
     }
+
+    /**
+     * Peek messages from a topic subscription.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param numMessages
+     *            Number of messages
+     * @param showServerMarker
+     *            Enables the display of internal server write markers
+     * @param transactionIsolationLevel
+     *            Sets the isolation level for peeking messages within transactions.
+     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows peeking all messages,
+     *                                 even transactional messages which have been aborted.
+     * @return
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic or subscription does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException;
 
     /**
      * Peek {@code numMessages} messages from a topic subscription, starting from {@code messagePosition}.
@@ -1700,8 +1725,15 @@ public interface Topics {
     }
 
     /**
-     * Peek messages from a topic subscription, with full control over starting position and
-     * transaction isolation.
+     * Peek messages from a topic subscription, starting from {@code messagePosition}, with full
+     * control over transaction isolation.
+     *
+     * <p>This is an additive overload of
+     * {@link #peekMessages(String, String, int, boolean, TransactionIsolationLevel)}; callers that
+     * pass {@code messagePosition == 1} get the same head-of-backlog behavior. The default
+     * implementation supports {@code messagePosition == 1} only and throws
+     * {@link UnsupportedOperationException} for any other position; the Pulsar admin client
+     * overrides it to support arbitrary positions.
      *
      * @param topic
      *            topic name
@@ -1726,13 +1758,34 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
-                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
-            throws PulsarAdminException;
+    default List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
+                                               boolean showServerMarker,
+                                               TransactionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException {
+        if (messagePosition == 1) {
+            return peekMessages(topic, subName, numMessages, showServerMarker, transactionIsolationLevel);
+        }
+        throw new UnsupportedOperationException(
+                "This Topics implementation does not support peeking from a messagePosition other than 1");
+    }
 
     /**
-     * Peek messages from a topic subscription. Backward-compatible overload that uses
-     * {@code messagePosition=1}.
+     * Peek messages from a topic subscription asynchronously.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param numMessages
+     *            Number of messages
+     * @return a future that can be used to track when the messages are returned
+     */
+    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
+        return peekMessagesAsync(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    /**
+     * Peek messages from a topic subscription asynchronously.
      *
      * @param topic
      *            topic name
@@ -1747,41 +1800,11 @@ public interface Topics {
      *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
      *            - 'READ_UNCOMMITTED' allows peeking all messages,
      *                                 even transactional messages which have been aborted.
-     * @return
-     * @throws NotAuthorizedException
-     *             Don't have admin permission
-     * @throws NotFoundException
-     *             Topic or subscription does not exist
-     * @throws PulsarAdminException
-     *             Unexpected error
-     */
-    default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                               boolean showServerMarker,
-                                               TransactionIsolationLevel transactionIsolationLevel)
-            throws PulsarAdminException {
-        return peekMessages(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
-    }
-
-    /**
-     * Peek messages from a topic subscription asynchronously.
-     *
-     * <p>Equivalent to
-     * {@link #peekMessagesAsync(String, String, int, int, boolean, TransactionIsolationLevel)
-     * peekMessagesAsync(topic, subName, 1, numMessages, false,
-     * TransactionIsolationLevel.READ_COMMITTED)}.
-     *
-     * @param topic
-     *            topic name
-     * @param subName
-     *            Subscription name
-     * @param numMessages
-     *            Number of messages
      * @return a future that can be used to track when the messages are returned
      */
-    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        return peekMessagesAsync(topic, subName, 1, numMessages,
-                false, TransactionIsolationLevel.READ_COMMITTED);
-    }
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int numMessages,
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
 
     /**
      * Peek {@code numMessages} messages from a topic subscription asynchronously, starting from
@@ -1805,8 +1828,15 @@ public interface Topics {
     }
 
     /**
-     * Peek messages from a topic subscription asynchronously, with full control over starting
-     * position and transaction isolation.
+     * Peek messages from a topic subscription asynchronously, starting from {@code messagePosition},
+     * with full control over transaction isolation.
+     *
+     * <p>This is an additive overload of
+     * {@link #peekMessagesAsync(String, String, int, boolean, TransactionIsolationLevel)}; callers
+     * that pass {@code messagePosition == 1} get the same head-of-backlog behavior. The default
+     * implementation supports {@code messagePosition == 1} only and fails the returned future with
+     * {@link UnsupportedOperationException} for any other position; the Pulsar admin client
+     * overrides it to support arbitrary positions.
      *
      * @param topic
      *            topic name
@@ -1825,33 +1855,16 @@ public interface Topics {
      *                                 even transactional messages which have been aborted.
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
-            String topic, String subName, int messagePosition, int numMessages,
-            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
-
-    /**
-     * Peek messages from a topic subscription asynchronously. Backward-compatible overload that
-     * uses {@code messagePosition=1}.
-     *
-     * @param topic
-     *            topic name
-     * @param subName
-     *            Subscription name
-     * @param numMessages
-     *            Number of messages
-     * @param showServerMarker
-     *            Enables the display of internal server write markers
-     * @param transactionIsolationLevel
-     *            Sets the isolation level for peeking messages within transactions.
-     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
-     *            - 'READ_UNCOMMITTED' allows peeking all messages,
-     *                                 even transactional messages which have been aborted.
-     * @return a future that can be used to track when the messages are returned
-     */
     default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
-            String topic, String subName, int numMessages,
+            String topic, String subName, int messagePosition, int numMessages,
             boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
-        return peekMessagesAsync(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+        if (messagePosition == 1) {
+            return peekMessagesAsync(topic, subName, numMessages, showServerMarker, transactionIsolationLevel);
+        }
+        CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<>();
+        future.completeExceptionally(new UnsupportedOperationException(
+                "This Topics implementation does not support peeking from a messagePosition other than 1"));
+        return future;
     }
 
     /**

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1641,6 +1641,9 @@ public interface Topics {
     /**
      * Peek messages from a topic subscription.
      *
+     * <p>Equivalent to {@link #peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)
+     * peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED)}.
+     *
      * @param topic
      *            topic name
      * @param subName
@@ -1657,11 +1660,79 @@ public interface Topics {
      */
     default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages)
             throws PulsarAdminException {
-        return peekMessages(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+        return peekMessages(topic, subName, 1, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     /**
-     * Peek messages from a topic subscription.
+     * Peek {@code numMessages} messages from a topic subscription, starting from {@code messagePosition}.
+     *
+     * <p>Use this overload to paginate through a subscription backlog without fetching all
+     * preceding messages. For example, to display the 91st–100th unacknowledged messages in a UI,
+     * call this method with {@code messagePosition=91, numMessages=10}.
+     *
+     * <p>Equivalent to {@link #peekMessages(String, String, int, int, boolean, TransactionIsolationLevel)
+     * peekMessages(topic, subName, messagePosition, numMessages, false,
+     * TransactionIsolationLevel.READ_COMMITTED)}.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param messagePosition
+     *            1-indexed position to start peeking from. Position {@code 1} returns the
+     *            oldest unacknowledged message; position {@code N} returns the N-th unacknowledged
+     *            message and onward. Must be {@code >= 1}.
+     * @param numMessages
+     *            Number of messages to peek. Must be {@code > 0}. Fewer messages may be returned
+     *            if the subscription backlog has fewer remaining messages from {@code messagePosition}.
+     * @return up to {@code numMessages} messages starting at {@code messagePosition}
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic or subscription does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    default List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages)
+            throws PulsarAdminException {
+        return peekMessages(topic, subName, messagePosition, numMessages,
+                false, TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    /**
+     * Peek messages from a topic subscription, with full control over starting position and
+     * transaction isolation.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param messagePosition
+     *            1-indexed position to start peeking from. Must be {@code >= 1}.
+     * @param numMessages
+     *            Number of messages to peek. Must be {@code > 0}.
+     * @param showServerMarker
+     *            Enables the display of internal server write markers
+     * @param transactionIsolationLevel
+     *            Sets the isolation level for peeking messages within transactions.
+     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows peeking all messages,
+     *                                 even transactional messages which have been aborted.
+     * @return up to {@code numMessages} messages starting at {@code messagePosition}
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic or subscription does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
+                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException;
+
+    /**
+     * Peek messages from a topic subscription. Backward-compatible overload that uses
+     * {@code messagePosition=1}.
      *
      * @param topic
      *            topic name
@@ -1684,12 +1755,20 @@ public interface Topics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
-                                       boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel)
-            throws PulsarAdminException;
+    default List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+                                               boolean showServerMarker,
+                                               TransactionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException {
+        return peekMessages(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+    }
 
     /**
      * Peek messages from a topic subscription asynchronously.
+     *
+     * <p>Equivalent to
+     * {@link #peekMessagesAsync(String, String, int, int, boolean, TransactionIsolationLevel)
+     * peekMessagesAsync(topic, subName, 1, numMessages, false,
+     * TransactionIsolationLevel.READ_COMMITTED)}.
      *
      * @param topic
      *            topic name
@@ -1700,11 +1779,59 @@ public interface Topics {
      * @return a future that can be used to track when the messages are returned
      */
     default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages) {
-        return peekMessagesAsync(topic, subName, numMessages, false, TransactionIsolationLevel.READ_COMMITTED);
+        return peekMessagesAsync(topic, subName, 1, numMessages,
+                false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     /**
-     * Peek messages from a topic subscription asynchronously.
+     * Peek {@code numMessages} messages from a topic subscription asynchronously, starting from
+     * {@code messagePosition}.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param messagePosition
+     *            1-indexed position to start peeking from. Must be {@code >= 1}.
+     * @param numMessages
+     *            Number of messages
+     * @return a future that completes with up to {@code numMessages} messages starting at
+     *         {@code messagePosition}
+     */
+    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int messagePosition, int numMessages) {
+        return peekMessagesAsync(topic, subName, messagePosition, numMessages,
+                false, TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    /**
+     * Peek messages from a topic subscription asynchronously, with full control over starting
+     * position and transaction isolation.
+     *
+     * @param topic
+     *            topic name
+     * @param subName
+     *            Subscription name
+     * @param messagePosition
+     *            1-indexed position to start peeking from. Must be {@code >= 1}.
+     * @param numMessages
+     *            Number of messages
+     * @param showServerMarker
+     *            Enables the display of internal server write markers
+     * @param transactionIsolationLevel
+     *            Sets the isolation level for peeking messages within transactions.
+     *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
+     *            - 'READ_UNCOMMITTED' allows peeking all messages,
+     *                                 even transactional messages which have been aborted.
+     * @return a future that can be used to track when the messages are returned
+     */
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int messagePosition, int numMessages,
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
+
+    /**
+     * Peek messages from a topic subscription asynchronously. Backward-compatible overload that
+     * uses {@code messagePosition=1}.
      *
      * @param topic
      *            topic name
@@ -1714,16 +1841,18 @@ public interface Topics {
      *            Number of messages
      * @param showServerMarker
      *            Enables the display of internal server write markers
-      @param transactionIsolationLevel
+     * @param transactionIsolationLevel
      *            Sets the isolation level for peeking messages within transactions.
      *            - 'READ_COMMITTED' allows peeking only committed transactional messages.
      *            - 'READ_UNCOMMITTED' allows peeking all messages,
      *                                 even transactional messages which have been aborted.
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+    default CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
             String topic, String subName, int numMessages,
-            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel);
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
+        return peekMessagesAsync(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+    }
 
     /**
      * Get a message by its messageId via a topic subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -912,6 +912,21 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+                                              boolean showServerMarker,
+                                              TransactionIsolationLevel transactionIsolationLevel)
+            throws PulsarAdminException {
+        return peekMessages(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+    }
+
+    @Override
+    public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
+            String topic, String subName, int numMessages,
+            boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
+        return peekMessagesAsync(topic, subName, 1, numMessages, showServerMarker, transactionIsolationLevel);
+    }
+
+    @Override
     public List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
                                               boolean showServerMarker,
                                               TransactionIsolationLevel transactionIsolationLevel)

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -912,21 +912,23 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
-    public List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages,
+    public List<Message<byte[]>> peekMessages(String topic, String subName, int messagePosition, int numMessages,
                                               boolean showServerMarker,
                                               TransactionIsolationLevel transactionIsolationLevel)
             throws PulsarAdminException {
-        return sync(() -> peekMessagesAsync(topic, subName, numMessages, showServerMarker, transactionIsolationLevel));
+        return sync(() -> peekMessagesAsync(topic, subName, messagePosition, numMessages,
+                showServerMarker, transactionIsolationLevel));
     }
 
     @Override
     public CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(
-            String topic, String subName, int numMessages,
+            String topic, String subName, int messagePosition, int numMessages,
             boolean showServerMarker, TransactionIsolationLevel transactionIsolationLevel) {
-        checkArgument(numMessages > 0);
+        checkArgument(numMessages > 0, "numMessages must be > 0");
+        checkArgument(messagePosition >= 1, "messagePosition must be >= 1");
         CompletableFuture<List<Message<byte[]>>> future = new CompletableFuture<List<Message<byte[]>>>();
         peekMessagesAsync(topic, subName, numMessages, new ArrayList<>(),
-                future, 1, showServerMarker, transactionIsolationLevel);
+                future, messagePosition, showServerMarker, transactionIsolationLevel);
         return future;
     }
 

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/TopicsInterfaceDefaultsTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/TopicsInterfaceDefaultsTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.TransactionIsolationLevel;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests verifying that the default-method overloads of
+ * {@link Topics#peekMessages} and {@link Topics#peekMessagesAsync} delegate correctly to the
+ * primary abstract method
+ * {@code peekMessages(topic, sub, messagePosition, numMessages, showServerMarker, isolation)}.
+ *
+ * <p>Uses Mockito with {@code CALLS_REAL_METHODS} so the interface defaults run for real while
+ * the primary abstract method is stubbed.
+ *
+ * <p>Tests added for PIP-332.
+ */
+public class TopicsInterfaceDefaultsTest {
+
+    private Topics mockTopicsWithStubbedPrimary() {
+        Topics topics = mock(Topics.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        // Stub the sync primary
+        try {
+            doReturn(Collections.<Message<byte[]>>emptyList())
+                    .when(topics)
+                    .peekMessages(anyString(), anyString(), anyInt(), anyInt(),
+                            anyBoolean(), any(TransactionIsolationLevel.class));
+        } catch (Exception ignored) {
+            // checked exception declared on the method; no real call here
+        }
+        // Stub the async primary
+        doReturn(CompletableFuture.completedFuture(Collections.<Message<byte[]>>emptyList()))
+                .when(topics)
+                .peekMessagesAsync(anyString(), anyString(), anyInt(), anyInt(),
+                        anyBoolean(), any(TransactionIsolationLevel.class));
+        return topics;
+    }
+
+    @Test
+    public void threeArgPeekDelegatesWithMessagePositionOne() throws Exception {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessages("topic", "sub", 10);
+        verify(topics).peekMessages("topic", "sub", 1, 10, false,
+                TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    @Test
+    public void fourArgPeekDelegatesWithSuppliedPosition() throws Exception {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessages("topic", "sub", 91, 10);
+        verify(topics).peekMessages("topic", "sub", 91, 10, false,
+                TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    @Test
+    public void fiveArgPeekDelegatesWithMessagePositionOne() throws Exception {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessages("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
+        verify(topics).peekMessages("topic", "sub", 1, 10, true,
+                TransactionIsolationLevel.READ_UNCOMMITTED);
+    }
+
+    @Test
+    public void threeArgPeekAsyncDelegatesWithMessagePositionOne() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        CompletableFuture<List<Message<byte[]>>> fut = topics.peekMessagesAsync("topic", "sub", 10);
+        verify(topics).peekMessagesAsync("topic", "sub", 1, 10, false,
+                TransactionIsolationLevel.READ_COMMITTED);
+        // Smoke: the stub completes with an empty list
+        fut.join();
+    }
+
+    @Test
+    public void fourArgPeekAsyncDelegatesWithSuppliedPosition() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessagesAsync("topic", "sub", 91, 10);
+        verify(topics).peekMessagesAsync("topic", "sub", 91, 10, false,
+                TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    @Test
+    public void fiveArgPeekAsyncDelegatesWithMessagePositionOne() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessagesAsync("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
+        verify(topics).peekMessagesAsync("topic", "sub", 1, 10, true,
+                TransactionIsolationLevel.READ_UNCOMMITTED);
+    }
+}

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/TopicsInterfaceDefaultsTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/TopicsInterfaceDefaultsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,7 +27,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
-
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -36,84 +37,116 @@ import org.apache.pulsar.client.api.TransactionIsolationLevel;
 import org.testng.annotations.Test;
 
 /**
- * Unit tests verifying that the default-method overloads of
- * {@link Topics#peekMessages} and {@link Topics#peekMessagesAsync} delegate correctly to the
- * primary abstract method
- * {@code peekMessages(topic, sub, messagePosition, numMessages, showServerMarker, isolation)}.
+ * Unit tests verifying the default-method overloads of {@link Topics#peekMessages} and
+ * {@link Topics#peekMessagesAsync}.
+ *
+ * <p>The pre-existing primary abstract method
+ * {@code peekMessages(topic, sub, numMessages, showServerMarker, isolation)} is left unchanged, so
+ * these tests stub it and assert that:
+ * <ul>
+ *   <li>the simple overloads delegate to it with {@code showServerMarker=false} and
+ *       {@code READ_COMMITTED};</li>
+ *   <li>the position-aware overloads (added in PIP-482) delegate to it when
+ *       {@code messagePosition == 1}, preserving head-of-backlog behavior; and</li>
+ *   <li>the position-aware default fails with {@link UnsupportedOperationException} for any other
+ *       position (the Pulsar admin client overrides it to support arbitrary positions).</li>
+ * </ul>
  *
  * <p>Uses Mockito with {@code CALLS_REAL_METHODS} so the interface defaults run for real while
  * the primary abstract method is stubbed.
  *
- * <p>Tests added for PIP-332.
+ * <p>Tests added for PIP-482.
  */
 public class TopicsInterfaceDefaultsTest {
 
     private Topics mockTopicsWithStubbedPrimary() {
         Topics topics = mock(Topics.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        // Stub the sync primary
+        // Stub the sync primary abstract method
         try {
             doReturn(Collections.<Message<byte[]>>emptyList())
                     .when(topics)
-                    .peekMessages(anyString(), anyString(), anyInt(), anyInt(),
+                    .peekMessages(anyString(), anyString(), anyInt(),
                             anyBoolean(), any(TransactionIsolationLevel.class));
         } catch (Exception ignored) {
             // checked exception declared on the method; no real call here
         }
-        // Stub the async primary
+        // Stub the async primary abstract method
         doReturn(CompletableFuture.completedFuture(Collections.<Message<byte[]>>emptyList()))
                 .when(topics)
-                .peekMessagesAsync(anyString(), anyString(), anyInt(), anyInt(),
+                .peekMessagesAsync(anyString(), anyString(), anyInt(),
                         anyBoolean(), any(TransactionIsolationLevel.class));
         return topics;
     }
 
     @Test
-    public void threeArgPeekDelegatesWithMessagePositionOne() throws Exception {
+    public void threeArgPeekDelegatesToPrimary() throws Exception {
         Topics topics = mockTopicsWithStubbedPrimary();
         topics.peekMessages("topic", "sub", 10);
-        verify(topics).peekMessages("topic", "sub", 1, 10, false,
-                TransactionIsolationLevel.READ_COMMITTED);
+        verify(topics).peekMessages("topic", "sub", 10, false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     @Test
-    public void fourArgPeekDelegatesWithSuppliedPosition() throws Exception {
+    public void fourArgPeekWithPositionOneDelegatesToPrimary() throws Exception {
         Topics topics = mockTopicsWithStubbedPrimary();
-        topics.peekMessages("topic", "sub", 91, 10);
-        verify(topics).peekMessages("topic", "sub", 91, 10, false,
-                TransactionIsolationLevel.READ_COMMITTED);
+        topics.peekMessages("topic", "sub", 1, 10);
+        verify(topics).peekMessages("topic", "sub", 10, false, TransactionIsolationLevel.READ_COMMITTED);
     }
 
     @Test
-    public void fiveArgPeekDelegatesWithMessagePositionOne() throws Exception {
+    public void sixArgPeekWithPositionOneDelegatesToPrimary() throws Exception {
         Topics topics = mockTopicsWithStubbedPrimary();
-        topics.peekMessages("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
-        verify(topics).peekMessages("topic", "sub", 1, 10, true,
-                TransactionIsolationLevel.READ_UNCOMMITTED);
+        topics.peekMessages("topic", "sub", 1, 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
+        verify(topics).peekMessages("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
     }
 
     @Test
-    public void threeArgPeekAsyncDelegatesWithMessagePositionOne() {
+    public void sixArgPeekWithNonOnePositionThrowsByDefault() {
         Topics topics = mockTopicsWithStubbedPrimary();
-        CompletableFuture<List<Message<byte[]>>> fut = topics.peekMessagesAsync("topic", "sub", 10);
-        verify(topics).peekMessagesAsync("topic", "sub", 1, 10, false,
-                TransactionIsolationLevel.READ_COMMITTED);
-        // Smoke: the stub completes with an empty list
-        fut.join();
+        assertThrows(UnsupportedOperationException.class,
+                () -> topics.peekMessages("topic", "sub", 91, 10, false,
+                        TransactionIsolationLevel.READ_COMMITTED));
     }
 
     @Test
-    public void fourArgPeekAsyncDelegatesWithSuppliedPosition() {
+    public void fourArgPeekWithNonOnePositionThrowsByDefault() {
         Topics topics = mockTopicsWithStubbedPrimary();
-        topics.peekMessagesAsync("topic", "sub", 91, 10);
-        verify(topics).peekMessagesAsync("topic", "sub", 91, 10, false,
-                TransactionIsolationLevel.READ_COMMITTED);
+        assertThrows(UnsupportedOperationException.class,
+                () -> topics.peekMessages("topic", "sub", 91, 10));
     }
 
     @Test
-    public void fiveArgPeekAsyncDelegatesWithMessagePositionOne() {
+    public void threeArgPeekAsyncDelegatesToPrimary() {
         Topics topics = mockTopicsWithStubbedPrimary();
-        topics.peekMessagesAsync("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
-        verify(topics).peekMessagesAsync("topic", "sub", 1, 10, true,
-                TransactionIsolationLevel.READ_UNCOMMITTED);
+        topics.peekMessagesAsync("topic", "sub", 10).join();
+        verify(topics).peekMessagesAsync("topic", "sub", 10, false, TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    @Test
+    public void fourArgPeekAsyncWithPositionOneDelegatesToPrimary() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessagesAsync("topic", "sub", 1, 10).join();
+        verify(topics).peekMessagesAsync("topic", "sub", 10, false, TransactionIsolationLevel.READ_COMMITTED);
+    }
+
+    @Test
+    public void sixArgPeekAsyncWithPositionOneDelegatesToPrimary() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        topics.peekMessagesAsync("topic", "sub", 1, 10, true, TransactionIsolationLevel.READ_UNCOMMITTED).join();
+        verify(topics).peekMessagesAsync("topic", "sub", 10, true, TransactionIsolationLevel.READ_UNCOMMITTED);
+    }
+
+    @Test
+    public void sixArgPeekAsyncWithNonOnePositionFailsByDefault() {
+        Topics topics = mockTopicsWithStubbedPrimary();
+        CompletableFuture<List<Message<byte[]>>> future = topics.peekMessagesAsync(
+                "topic", "sub", 91, 10, false, TransactionIsolationLevel.READ_COMMITTED);
+        assertTrue(future.isCompletedExceptionally());
+        assertThrows(UnsupportedOperationException.class, () -> {
+            try {
+                future.join();
+            } catch (java.util.concurrent.CompletionException e) {
+                throw e.getCause();
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation

Adds a `messagePosition` parameter to the Java admin client `Topics.peekMessages` /
`peekMessagesAsync` API, enabling efficient pagination through a subscription backlog without
fetching all preceding messages.

The underlying REST endpoint
`/admin/v3/persistent/{tenant}/{namespace}/{topic}/subscription/{subName}/position/{N}`
already accepts an arbitrary message position. The Java admin client has historically
hardcoded `1`, so callers could only inspect the head of the backlog. The most common use
case affected by this gap is UI pagination — to display the 91st–100th messages on a backlog
page, a caller has to fetch and discard the first 90.

PIP-482 surfaces the existing server capability at the Java client level.

### Modifications

- **`pip/pip-482.md` (new)** — formal proposal document with motivation, full API surface,
  alternatives considered (`MessageId`-based, `PeekOptions` builder), and binary-compatibility
  analysis.
- **`pulsar-client-admin-api/.../Topics.java`** — adds the primary abstract method
  `peekMessages(topic, subName, messagePosition, numMessages, showServerMarker, isolation)`
  and its async variant. All pre-existing peek overloads become `default` methods that
  delegate to it, giving the interface a single source of Javadoc.
- **`pulsar-client-admin/.../internal/TopicsImpl.java`** — implements the new primary abstract
  method. The internal recursive helper already took the position as `nthMessage` — the change
  is to pass the caller-supplied `messagePosition` instead of hardcoded `1`. Adds
  `checkArgument(messagePosition >= 1)` for client-side validation.
- **`pulsar-client-admin/.../TopicsInterfaceDefaultsTest.java` (new)** — unit tests covering
  delegation of all six `peekMessages` / `peekMessagesAsync` overloads to the primary abstract
  method, with expected `messagePosition` and parameter forwarding asserted via Mockito
  `CALLS_REAL_METHODS`.

### Verifying this change

- [x] Builds locally:
      `./gradlew :pulsar-client-admin-api:compileJava :pulsar-client-admin-original:compileJava :pulsar-client-admin-original:compileTestJava`
- [x] Unit tests pass:
      `./gradlew :pulsar-client-admin-original:test --tests "org.apache.pulsar.client.admin.TopicsInterfaceDefaultsTest"`
      → 6 tests, 0 failures, 0 errors
- [ ] Manual integration test against a local broker: produce 100 messages, peek with
      `messagePosition=91, numMessages=10`, verify the returned messages match positions 91–100.
      _(Reviewer note: I will add a broker integration test in a follow-up if requested. The
      change is fundamentally a client-side surface change — the REST endpoint already supports
      arbitrary positions and is exercised by existing broker tests.)_

**Note on test location:** The new unit test lives in `pulsar-client-admin/src/test/` (not
`pulsar-client-admin-api/src/test/`) because the latter has no existing test infrastructure
configured. The test still covers the `Topics` interface defaults (from the api module) — it
runs in the admin module's test classpath where Mockito and TestNG are wired up via the
convention plugin (`pulsar.public-java-library-conventions`).

### Does this pull request potentially affect one of the following parts:

If the box was checked, please highlight the changes:

- [ ] Dependencies (add or upgrade a dependency)
- [x] **The public API** — see PIP-482 for the full surface change and compatibility analysis.
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The change extends the public Java admin client API with one new abstract method per sync/async
variant and four new default-method overloads. All pre-existing call sites remain source- and
behavior-compatible. See PIP-482 "Backward & Forward Compatibility" for full analysis.

### Documentation

- [x] `doc-required`
  Documentation update will follow as a separate PR to `apache/pulsar-site` once this lands.
- [ ] `doc-not-needed`
- [ ] `doc`
- [ ] `doc-complete`

### Matching PR in forked repository

PR in forked repository: _to be filled after the fork branch is pushed_
