### PR TITLE
[fix][broker] Prevent backlog quota cursor updates during topic close

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -195,18 +196,20 @@ public class BacklogQuotaManager {
                     break;
                 }
                 beforeBacklogQuotaCursorMutation(persistentTopic);
-                if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                if (!runCursorMutationIfTopicNotClosingOrDeleting(persistentTopic, () -> {
+                    // Skip messages on the slowest consumer
+                    log.debug()
+                            .attr("topic", persistentTopic.getName())
+                            .attr("messagesToSkip", messagesToSkip)
+                            .attr("consumer", slowestConsumer.getName())
+                            .attr("entriesInBacklog", entriesInBacklog)
+                            .log("Skipping messages on slowest consumer having backlog entries");
+                    slowestConsumer.skipEntries(messagesToSkip, IndividualDeletedEntries.Include);
+                    markDeletePositionMoveForward(persistentTopic, slowestConsumer);
+                    return null;
+                })) {
                     break;
                 }
-                // Skip messages on the slowest consumer
-                log.debug()
-                        .attr("topic", persistentTopic.getName())
-                        .attr("messagesToSkip", messagesToSkip)
-                        .attr("consumer", slowestConsumer.getName())
-                        .attr("entriesInBacklog", entriesInBacklog)
-                        .log("Skipping messages on slowest consumer having backlog entries");
-                slowestConsumer.skipEntries(messagesToSkip, IndividualDeletedEntries.Include);
-                markDeletePositionMoveForward(persistentTopic, slowestConsumer);
             } catch (Exception e) {
                 log.error()
                         .attr("topic", persistentTopic.getName())
@@ -270,11 +273,13 @@ public class BacklogQuotaManager {
                         long ledgerId = mLedger.getLedgersInfo().ceilingKey(oldestPosition.getLedgerId() + 1);
                         Position nextPosition = PositionFactory.create(ledgerId, -1);
                         beforeBacklogQuotaCursorMutation(persistentTopic);
-                        if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                        if (!runCursorMutationIfTopicNotClosingOrDeleting(persistentTopic, () -> {
+                            slowestConsumer.markDelete(nextPosition);
+                            markDeletePositionMoveForward(persistentTopic, slowestConsumer);
+                            return null;
+                        })) {
                             break;
                         }
-                        slowestConsumer.markDelete(nextPosition);
-                        markDeletePositionMoveForward(persistentTopic, slowestConsumer);
                         continue;
                     }
                     // Timestamp only > 0 if ledger has been closed
@@ -285,11 +290,13 @@ public class BacklogQuotaManager {
                         Position nextPosition = PositionFactory.create(ledgerId, -1);
                         if (!nextPosition.equals(oldestPosition)) {
                             beforeBacklogQuotaCursorMutation(persistentTopic);
-                            if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                            if (!runCursorMutationIfTopicNotClosingOrDeleting(persistentTopic, () -> {
+                                slowestConsumer.markDelete(nextPosition);
+                                markDeletePositionMoveForward(persistentTopic, slowestConsumer);
+                                return null;
+                            })) {
                                 break;
                             }
-                            slowestConsumer.markDelete(nextPosition);
-                            markDeletePositionMoveForward(persistentTopic, slowestConsumer);
                             continue;
                         }
                     }
@@ -381,16 +388,16 @@ public class BacklogQuotaManager {
         // No-op.
     }
 
-    private boolean shouldStopEvictionOnTopicClose(PersistentTopic persistentTopic) {
-        if (persistentTopic.isClosingOrDeleting()) {
+    private boolean runCursorMutationIfTopicNotClosingOrDeleting(PersistentTopic persistentTopic,
+                                                                 Callable<Void> mutation) throws Exception {
+        boolean didRun = persistentTopic.runWithTopicCloseReadLock(mutation);
+        if (!didRun) {
             log.debug()
                     .attr("topic", persistentTopic.getName())
                     .log("Stopping backlog-quota eviction because topic is closing or deleting");
-            return true;
         }
-        return false;
+        return didRun;
     }
-
 
     /**
      * Compute the target value after backlog eviction.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -95,10 +95,8 @@ public class BacklogQuotaManager {
     public void handleExceededBacklogQuota(PersistentTopic persistentTopic, BacklogQuotaType backlogQuotaType,
                                            boolean preciseTimeBasedBacklogQuotaCheck) {
         if (persistentTopic.isFenced() || persistentTopic.isClosingOrDeleting()) {
-            // Skip eviction work on a topic that is being torn down or transiently fenced.
-            // Mutating cursors here (skipEntries / markDeletePosition) contends with the
-            // delete path and can keep namespace force-delete from completing in time;
-            // the entries are about to be discarded anyway.
+            // Skip quota handling on a topic that is temporarily unavailable or being torn down.
+            // For close/delete, mutating cursors here can contend with the teardown path.
             log.debug()
                     .attr("topic", persistentTopic.getName())
                     .attr("backlogQuotaType", backlogQuotaType)
@@ -196,6 +194,10 @@ public class BacklogQuotaManager {
                     log.debug().attr("slowestConsumer", slowestConsumer).log("no messages to skip for");
                     break;
                 }
+                beforeBacklogQuotaCursorMutation(persistentTopic);
+                if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                    break;
+                }
                 // Skip messages on the slowest consumer
                 log.debug()
                         .attr("topic", persistentTopic.getName())
@@ -267,6 +269,10 @@ public class BacklogQuotaManager {
                     if (ledgerInfo == null) {
                         long ledgerId = mLedger.getLedgersInfo().ceilingKey(oldestPosition.getLedgerId() + 1);
                         Position nextPosition = PositionFactory.create(ledgerId, -1);
+                        beforeBacklogQuotaCursorMutation(persistentTopic);
+                        if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                            break;
+                        }
                         slowestConsumer.markDelete(nextPosition);
                         markDeletePositionMoveForward(persistentTopic, slowestConsumer);
                         continue;
@@ -278,6 +284,10 @@ public class BacklogQuotaManager {
                         long ledgerId = mLedger.getLedgersInfo().ceilingKey(oldestPosition.getLedgerId() + 1);
                         Position nextPosition = PositionFactory.create(ledgerId, -1);
                         if (!nextPosition.equals(oldestPosition)) {
+                            beforeBacklogQuotaCursorMutation(persistentTopic);
+                            if (shouldStopEvictionOnTopicClose(persistentTopic)) {
+                                break;
+                            }
                             slowestConsumer.markDelete(nextPosition);
                             markDeletePositionMoveForward(persistentTopic, slowestConsumer);
                             continue;
@@ -364,6 +374,21 @@ public class BacklogQuotaManager {
         if (subscription != null && subscription.getDispatcher() != null) {
             subscription.getDispatcher().markDeletePositionMoveForward();
         }
+    }
+
+    @VisibleForTesting
+    protected void beforeBacklogQuotaCursorMutation(PersistentTopic persistentTopic) {
+        // No-op.
+    }
+
+    private boolean shouldStopEvictionOnTopicClose(PersistentTopic persistentTopic) {
+        if (persistentTopic.isClosingOrDeleting()) {
+            log.debug()
+                    .attr("topic", persistentTopic.getName())
+                    .log("Stopping backlog-quota eviction because topic is closing or deleting");
+            return true;
+        }
+        return false;
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -23,6 +23,7 @@ import io.github.merlimat.slog.Logger;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -91,6 +92,11 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         // check to avoid test failures
         return this.cursor.getManagedLedger() != null
                 && this.cursor.getManagedLedger().getConfig().isAutoSkipNonRecoverableData();
+    }
+
+    @VisibleForTesting
+    public boolean isExpirationCheckInProgress() {
+        return expirationCheckInProgress == TRUE;
     }
 
     @Override
@@ -244,15 +250,45 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
             log.info()
                     .attr("position", position)
                     .log("Expiring all messages until position");
-            Position prevMarkDeletePos = cursor.getMarkDeletedPosition();
-            cursor.asyncMarkDelete(position, null, markDeleteCallback, cursor.getNumberOfEntriesInBacklog(false));
-            if (!Objects.equals(cursor.getMarkDeletedPosition(), prevMarkDeletePos) && subscription != null) {
-                subscription.updateLastMarkDeleteAdvancedTimestamp();
+            beforeCursorMarkDelete(position);
+            if (!runCursorMarkDeleteIfTopicNotClosingOrDeleting(position, () -> {
+                Position prevMarkDeletePos = cursor.getMarkDeletedPosition();
+                cursor.asyncMarkDelete(position, null, markDeleteCallback, cursor.getNumberOfEntriesInBacklog(false));
+                if (!Objects.equals(cursor.getMarkDeletedPosition(), prevMarkDeletePos) && subscription != null) {
+                    subscription.updateLastMarkDeleteAdvancedTimestamp();
+                }
+                return null;
+            })) {
+                expirationCheckInProgress = FALSE;
+                updateRates();
             }
         } else {
             log.debug("No messages to expire");
             expirationCheckInProgress = FALSE;
             updateRates();
+        }
+    }
+
+    @VisibleForTesting
+    protected void beforeCursorMarkDelete(Position position) {
+        // No-op.
+    }
+
+    private boolean runCursorMarkDeleteIfTopicNotClosingOrDeleting(Position position, Callable<Void> markDelete) {
+        try {
+            boolean didRun = topic.runWithTopicCloseReadLock(markDelete);
+            if (!didRun) {
+                log.debug()
+                        .attr("position", position)
+                        .log("Skipping message expiry mark-delete because topic is closing or deleting");
+            }
+            return didRun;
+        } catch (Exception e) {
+            log.warn()
+                    .attr("position", position)
+                    .exception(e)
+                    .log("Message expiry failed - mark delete failed");
+            return false;
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -1747,6 +1748,26 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     @Override
     public CompletableFuture<Void> close(boolean closeWithoutWaitingClientDisconnect) {
         return close(true, closeWithoutWaitingClientDisconnect);
+    }
+
+    /**
+     * Executes an action while holding the read side of the topic close/delete lock.
+     * Topic close and delete acquire the write side before setting {@link #isClosingOrDeleting}, so they cannot start
+     * between the state check and the action.
+     *
+     * @return true if the action ran, or false if close/delete had already started
+     */
+    public boolean runWithTopicCloseReadLock(Callable<Void> action) throws Exception {
+        lock.readLock().lock();
+        try {
+            if (isClosingOrDeleting) {
+                return false;
+            }
+            action.call();
+            return true;
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     private enum CloseTypes {

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorMockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorMockTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -52,7 +53,7 @@ public class PersistentMessageExpiryMonitorMockTest {
     private BrokerService mockBrokerService;
 
     @BeforeMethod
-    public void setup() {
+    public void setup() throws Exception {
         mockTopic = mock(PersistentTopic.class);
         mockCursor = mock(ManagedCursor.class);
         mockManagedLedger = mock(ManagedLedger.class);
@@ -66,6 +67,11 @@ public class PersistentMessageExpiryMonitorMockTest {
         ServiceConfiguration config = new ServiceConfiguration();
         when(mockBrokerService.pulsar()).thenReturn(mockPulsarService);
         when(mockPulsarService.getConfig()).thenReturn(config);
+        doAnswer(invocation -> {
+            Callable<Void> action = invocation.getArgument(0);
+            action.call();
+            return true;
+        }).when(mockTopic).runWithTopicCloseReadLock(any());
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/bookkeeper/mledger/impl/PersistentMessageExpiryMonitorTest.java
@@ -27,6 +27,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -34,6 +35,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor;
+import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -197,5 +199,71 @@ public class PersistentMessageExpiryMonitorTest extends ProducerConsumerBase {
         // cleanup.
         producer.close();
         admin.topics().delete(topicName);
+    }
+
+    @Test
+    void testExpireMessagesRaceWithTopicCloseDoesNotMarkDelete() throws Exception {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://public/default/tp-closing-expiry");
+        final String subName = "closing-expiry-sub";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, subName, MessageId.earliest);
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create();
+        for (int i = 0; i < 3; i++) {
+            producer.send("message-" + i);
+        }
+        producer.close();
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        PersistentSubscription subscription = topic.getSubscription(subName);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) subscription.getCursor();
+        Position markDeleteBeforeExpiry = cursor.getMarkDeletedPosition();
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+        BlockingPersistentMessageExpiryMonitor monitor =
+                new BlockingPersistentMessageExpiryMonitor(topic, subName, cursor, subscription);
+        CompletableFuture<Boolean> expireFuture = CompletableFuture.supplyAsync(() -> monitor.expireMessages(1));
+        monitor.awaitBeforeCursorMarkDelete();
+
+        CompletableFuture<Void> closeFuture = topic.close(false);
+        Awaitility.await().untilAsserted(() -> Assert.assertTrue(topic.isClosingOrDeleting()));
+        monitor.allowCursorMarkDelete();
+
+        Assert.assertTrue(expireFuture.get(30, TimeUnit.SECONDS));
+        Awaitility.await().untilAsserted(() -> Assert.assertFalse(monitor.isExpirationCheckInProgress()));
+        assertEquals(cursor.getMarkDeletedPosition(), markDeleteBeforeExpiry);
+        closeFuture.get(30, TimeUnit.SECONDS);
+    }
+
+    private static class BlockingPersistentMessageExpiryMonitor extends PersistentMessageExpiryMonitor {
+        private final CountDownLatch beforeCursorMarkDelete = new CountDownLatch(1);
+        private final CountDownLatch continueCursorMarkDelete = new CountDownLatch(1);
+        private final AtomicBoolean blocked = new AtomicBoolean();
+
+        BlockingPersistentMessageExpiryMonitor(PersistentTopic topic, String subscriptionName, ManagedCursorImpl cursor,
+                                               PersistentSubscription subscription) {
+            super(topic, subscriptionName, cursor, subscription);
+        }
+
+        @Override
+        protected void beforeCursorMarkDelete(Position position) {
+            if (!blocked.compareAndSet(false, true)) {
+                return;
+            }
+            beforeCursorMarkDelete.countDown();
+            try {
+                Assert.assertTrue(continueCursorMarkDelete.await(30, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        void awaitBeforeCursorMarkDelete() throws InterruptedException {
+            Assert.assertTrue(beforeCursorMarkDelete.await(30, TimeUnit.SECONDS));
+        }
+
+        void allowCursorMarkDelete() {
+            continueCursorMarkDelete.countDown();
+        }
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -2223,6 +2224,139 @@ public class BacklogQuotaManagerTest {
         assertThat(pendingAcks).isNotNull();
         assertThat(pendingAcks.size()).isEqualTo(expected);
         assertThat(consumer.getUnackedMessages()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testSizeBacklogEvictionRaceWithTopicCloseDoesNotSkipEntries() throws Exception {
+        final int msgSize = 1024;
+        final int quotaSizeLimit = 10 * 1024;
+        final int numMsgs = 20;
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(adminUrl.toString())
+                .build();
+        final String topicName =
+                BrokerTestUtil.newUniqueName("persistent://prop/ns-quota/topic-closing-size");
+        final String subName = "closing-size-sub";
+
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscribe();
+        @Cleanup
+        Producer<byte[]> producer = createProducer(client, topicName);
+        byte[] content = new byte[msgSize];
+        for (int i = 0; i < numMsgs; i++) {
+            producer.send(content);
+            consumer.receive();
+        }
+        PersistentTopic topic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+        PersistentSubscription sub = topic.getSubscription(subName);
+        Position markDeleteBeforeEviction = sub.getCursor().getMarkDeletedPosition();
+        admin.namespaces().setBacklogQuota("prop/ns-quota",
+                BacklogQuota.builder()
+                        .limitSize(quotaSizeLimit)
+                        .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
+                        .build());
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(topic.getBacklogQuota(destination_storage).getLimitSize(), quotaSizeLimit));
+
+        BlockingBacklogQuotaManager backlogQuotaManager = new BlockingBacklogQuotaManager(pulsar);
+        CompletableFuture<Void> evictionFuture = CompletableFuture.runAsync(
+                () -> backlogQuotaManager.handleExceededBacklogQuota(topic, destination_storage, false));
+        backlogQuotaManager.awaitBeforeMutation();
+        CompletableFuture<Void> closeFuture = topic.close(false);
+        Awaitility.await().untilAsserted(() -> assertTrue(topic.isClosingOrDeleting()));
+        backlogQuotaManager.allowMutationPointToContinue();
+        evictionFuture.get(30, SECONDS);
+
+        assertEquals(sub.getCursor().getMarkDeletedPosition(), markDeleteBeforeEviction);
+        closeFuture.get(30, SECONDS);
+    }
+
+    @Test
+    public void testTimeBacklogEvictionRaceWithTopicCloseDoesNotMarkDelete() throws Exception {
+        final int numMsgs = 14;
+        @Cleanup
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl(adminUrl.toString())
+                .build();
+        final String topicName =
+                BrokerTestUtil.newUniqueName("persistent://prop/ns-quota/topic-closing-time");
+        final String subName = "closing-time-sub";
+
+        @Cleanup
+        Consumer<byte[]> consumer = client.newConsumer()
+                .topic(topicName)
+                .subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Key_Shared)
+                .subscribe();
+        @Cleanup
+        Producer<byte[]> producer = createProducer(client, topicName);
+        byte[] content = new byte[1024];
+        for (int i = 0; i < numMsgs; i++) {
+            producer.send(content);
+            consumer.receive();
+        }
+        PersistentTopic topic =
+                (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+        PersistentSubscription sub = topic.getSubscription(subName);
+        Position markDeleteBeforeEviction = sub.getCursor().getMarkDeletedPosition();
+        Thread.sleep(SECONDS.toMillis(2));
+        admin.namespaces().setBacklogQuota("prop/ns-quota",
+                BacklogQuota.builder()
+                        .limitTime(1)
+                        .retentionPolicy(BacklogQuota.RetentionPolicy.consumer_backlog_eviction)
+                        .build(), message_age);
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(topic.getBacklogQuota(message_age).getLimitTime(), 1));
+
+        BlockingBacklogQuotaManager backlogQuotaManager = new BlockingBacklogQuotaManager(pulsar);
+        CompletableFuture<Void> evictionFuture = CompletableFuture.runAsync(
+                () -> backlogQuotaManager.handleExceededBacklogQuota(topic, message_age, false));
+        backlogQuotaManager.awaitBeforeMutation();
+        CompletableFuture<Void> closeFuture = topic.close(false);
+        Awaitility.await().untilAsserted(() -> assertTrue(topic.isClosingOrDeleting()));
+        backlogQuotaManager.allowMutationPointToContinue();
+        evictionFuture.get(30, SECONDS);
+
+        assertEquals(sub.getCursor().getMarkDeletedPosition(), markDeleteBeforeEviction);
+        closeFuture.get(30, SECONDS);
+    }
+
+    private static class BlockingBacklogQuotaManager extends BacklogQuotaManager {
+        private final CountDownLatch beforeMutation = new CountDownLatch(1);
+        private final CountDownLatch continueMutation = new CountDownLatch(1);
+        private final AtomicBoolean blocked = new AtomicBoolean();
+
+        BlockingBacklogQuotaManager(PulsarService pulsar) {
+            super(pulsar);
+        }
+
+        @Override
+        protected void beforeBacklogQuotaCursorMutation(PersistentTopic persistentTopic) {
+            if (!blocked.compareAndSet(false, true)) {
+                return;
+            }
+            beforeMutation.countDown();
+            try {
+                assertTrue(continueMutation.await(30, SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        void awaitBeforeMutation() throws InterruptedException {
+            assertTrue(beforeMutation.await(30, SECONDS));
+        }
+
+        void allowMutationPointToContinue() {
+            continueMutation.countDown();
+        }
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -692,6 +693,11 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         doReturn(pulsarService).when(brokerService).pulsar();
         ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
         doReturn(serviceConfiguration).when(pulsarService).getConfig();
+        doAnswer(invocation -> {
+            Callable<Void> action = invocation.getArgument(0);
+            action.call();
+            return true;
+        }).when(mock).runWithTopicCloseReadLock(any());
         return mock;
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Follow-up to #25684

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

`BacklogQuotaManager` already skips backlog quota handling when a topic is fenced or closing/deleting. However, checking the topic state only before entering the eviction path is not enough: a topic can begin close/delete after backlog quota eviction has started but before eviction mutates the slowest cursor.

This can let backlog quota eviction call `skipEntries` or `markDelete` while the topic teardown path is starting, which is the race this PR is intended to harden.

### Modifications

- Keep the existing entry guard for fenced or closing/deleting topics.
- Add a topic close/delete read-lock helper in `PersistentTopic`.
- Run direct backlog quota cursor mutations under that read lock, after checking `isClosingOrDeleting()`.
- Apply the guarded mutation path to size-based eviction before `ManagedCursor#skipEntries`.
- Apply the guarded mutation path to non-precise time-based eviction before `ManagedCursor#markDelete`.
- Keep the pending-ack cleanup hook after cursor advancement by continuing to call `markDeletePositionMoveForward()` inside the guarded mutation.
- Add real broker/topic race tests that start topic close after backlog quota eviction reaches the cursor mutation point and verify the cursor mark-delete position does not move.

### Verifying this change

This change added tests and can be verified as follows:

- Added `BacklogQuotaManagerTest.testSizeBacklogEvictionRaceWithTopicCloseDoesNotSkipEntries`
- Added `BacklogQuotaManagerTest.testTimeBacklogEvictionRaceWithTopicCloseDoesNotMarkDelete`

Verified locally with:

```bash
./gradlew :pulsar-broker:test --rerun-tasks --tests "org.apache.pulsar.broker.service.BacklogQuotaManagerTest.testSizeBacklogEvictionRaceWithTopicCloseDoesNotSkipEntries" --tests "org.apache.pulsar.broker.service.BacklogQuotaManagerTest.testTimeBacklogEvictionRaceWithTopicCloseDoesNotMarkDelete"
./gradlew :pulsar-broker:spotlessCheck :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest
git diff --check
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment