### PR TITLE
[fix][client] Clean up unacked messages when unsubscribing a topic with ack timeout backoff

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1302,7 +1302,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     removeTopic(topicName);
                     if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker tracker) {
                         tracker.removeTopicMessages(topicName);
-                    }else if (unAckedMessageTracker instanceof UnAckedTopicMessageRedeliveryTracker tracker){
+                    } else if (unAckedMessageTracker instanceof UnAckedTopicMessageRedeliveryTracker tracker){
                         tracker.removeTopicMessages(topicName);
                     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -1300,8 +1300,10 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     });
 
                     removeTopic(topicName);
-                    if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker) {
-                        ((UnAckedTopicMessageTracker) unAckedMessageTracker).removeTopicMessages(topicName);
+                    if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker tracker) {
+                        tracker.removeTopicMessages(topicName);
+                    }else if (unAckedMessageTracker instanceof UnAckedTopicMessageRedeliveryTracker tracker){
+                        tracker.removeTopicMessages(topicName);
                     }
 
                     unsubscribeFuture.complete(null);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
@@ -44,7 +44,6 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
                 MessageId messageId = messageIdWrapper.getMessageId();
                 if (messageId instanceof TopicMessageId
                         && ((TopicMessageId) messageId).getOwnerTopic().contains(topicName)) {
-                    HashSet<UnackMessageIdWrapper> exist = redeliveryMessageIdPartitionMap.get(messageIdWrapper);
                     entry.getValue().remove(messageIdWrapper);
                     iterator.remove();
                     messageIdWrapper.recycle();
@@ -53,11 +52,11 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
             }
 
             Iterator<MessageId> iteratorAckTimeOut = ackTimeoutMessages.keySet().iterator();
-            while (iterator.hasNext()) {
+            while (iteratorAckTimeOut.hasNext()) {
                 MessageId messageId = iteratorAckTimeOut.next();
                 if (messageId instanceof TopicMessageId
                         && ((TopicMessageId) messageId).getOwnerTopic().contains(topicName)) {
-                    iterator.remove();
+                    iteratorAckTimeOut.remove();
                     removed++;
                 }
             }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTrackerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.testng.annotations.Test;
+
+public class UnAckedTopicMessageRedeliveryTrackerTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRemoveTopicMessages() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ConnectionPool connectionPool = mock(ConnectionPool.class);
+        when(client.instrumentProvider()).thenReturn(InstrumentProvider.NOOP);
+        when(client.getCnxPool()).thenReturn(connectionPool);
+        @Cleanup("stop")
+        Timer timer = new HashedWheelTimer(
+                new DefaultThreadFactory("pulsar-timer", Thread.currentThread().isDaemon()),
+                1, TimeUnit.MILLISECONDS);
+        when(client.timer()).thenReturn(timer);
+
+        ConsumerBase<byte[]> consumer = mock(ConsumerBase.class);
+        doNothing().when(consumer).onAckTimeoutSend(any());
+        doNothing().when(consumer).redeliverUnacknowledgedMessages(any());
+
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(1_000_000);
+        conf.setTickDurationMillis(100_000);
+        conf.setAckTimeoutRedeliveryBackoff(MultiplierRedeliveryBackoff.builder().build());
+
+        UnAckedTopicMessageRedeliveryTracker tracker =
+                new UnAckedTopicMessageRedeliveryTracker(client, consumer, conf);
+
+        String ownerTopic = "persistent://public/default/my-topic-partition-0";
+        TopicMessageIdImpl msgInPartition =
+                new TopicMessageIdImpl(ownerTopic, new MessageIdImpl(1L, 0L, -1));
+        TopicMessageIdImpl msgInAckTimeout =
+                new TopicMessageIdImpl(ownerTopic, new MessageIdImpl(2L, 0L, -1));
+
+        assertTrue(tracker.add(msgInPartition));
+        tracker.ackTimeoutMessages.put(msgInAckTimeout, System.currentTimeMillis() + 1_000_000L);
+        assertEquals(tracker.size(), 2);
+
+        assertEquals(tracker.removeTopicMessages("my-topic"), 2);
+        assertTrue(tracker.isEmpty());
+
+        tracker.close();
+    }
+
+}


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
When a multi-topic consumer unsubscribes from a single topic, the client should drop that topic's unacked messages from the ack-timeout tracker so they are not redelivered later.
`MultiTopicsConsumerImpl` already called `removeTopicMessages` for `UnAckedTopicMessageTracker`, but not for `UnAckedTopicMessageRedeliveryTracker`, which is used when `ackTimeoutRedeliveryBackoff` is configured . Unsubscribed topics could therefore leave stale entries in the redelivery partition map and in `ackTimeoutMessages`.
Additionally, `UnAckedTopicMessageRedeliveryTracker.removeTopicMessages` used the partition-map iterator when iterating `ackTimeoutMessages` (`iterator.hasNext()` / `iterator.remove()` instead of `iteratorAckTimeOut`), so ack-timeout entries were not removed correctly and internal tracker state could be corrupted.
### Modifications
- Call `removeTopicMessages` on `UnAckedTopicMessageRedeliveryTracker` when a topic is unsubscribed from a multi-topic consumer.
- Fix ack-timeout iteration in `UnAckedTopicMessageRedeliveryTracker.removeTopicMessages` to use `iteratorAckTimeOut`.
- Add `UnAckedTopicMessageRedeliveryTrackerTest` to verify `removeTopicMessages` clears both the partition map and ack-timeout map.
### Verifying this change
- [x] `./gradlew :pulsar-client-original:test --tests org.apache.pulsar.client.impl.UnAckedTopicMessageRedeliveryTrackerTest`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Matching PR in forked repository

PR in forked repository: https://github.com/Dream95/pulsar/pull/12