### PR TITLE
[fix][proxy] Avoid intermittent 502 when admin proxy follows a broker redirect for a request with a body

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/AdminProxyHandler.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.ProtocolHandlers;
 import org.eclipse.jetty.client.RedirectProtocolHandler;
 import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.ee10.proxy.ProxyServlet;
 import org.eclipse.jetty.http.HttpField;
@@ -120,12 +121,40 @@ class AdminProxyHandler extends ProxyServlet {
 
         ProtocolHandlers protocolHandlers = httpClient.getProtocolHandlers();
         if (protocolHandlers != null) {
-            protocolHandlers.put(new RedirectProtocolHandler(httpClient));
+            protocolHandlers.put(new NonAbortingRedirectProtocolHandler(httpClient));
         }
 
         httpClient.setIdleTimeout(config.getHttpProxyIdleTimeout());
 
         setTimeout(config.getHttpProxyTimeout());
+    }
+
+    /**
+     * A {@link RedirectProtocolHandler} that does not abort the in-flight request when a redirect
+     * response is received.
+     *
+     * <p>Jetty's default {@link RedirectProtocolHandler#onSuccess(Response)} aborts a request that
+     * still has a body to send when a redirect status is received, raising
+     * {@code HttpRequestException: "Aborting request after receiving a NNN response"}. When a broker
+     * returns a 307 (to redirect an admin request to the bundle-owner broker) before the proxy has
+     * finished streaming the request body, that abort can race ahead of the redirect continuation in
+     * {@link RedirectProtocolHandler#onComplete} and surface to the proxy as a spurious HTTP 502 Bad
+     * Gateway. The redirect itself is driven by {@code onComplete} from the response (its status and
+     * {@code Location} header) and does not depend on the abort, so skipping it lets the redirect
+     * always be followed on a fresh request (with the body replayed by
+     * {@link ReplayableProxyContentProvider}), which is the behavior this proxy needs.
+     */
+    static class NonAbortingRedirectProtocolHandler extends RedirectProtocolHandler {
+        NonAbortingRedirectProtocolHandler(HttpClient client) {
+            super(client);
+        }
+
+        @Override
+        public void onSuccess(Response response) {
+            // Intentionally do NOT abort the request here. The redirect is followed in onComplete();
+            // aborting the in-flight request only races a 502 to the proxy when the broker returns a
+            // redirect before the request body has finished sending.
+        }
     }
 
     // This class allows the request body to be replayed, the default implementation


### PR DESCRIPTION
### Motivation

`AdminProxyHandler` (the Pulsar admin proxy) follows broker HTTP `307` redirects internally: when the proxy forwards an admin request to a broker that does not own the topic's bundle, the broker responds with `307` and the proxy follows the redirect to the owner broker, replaying the request body.

Intermittently, admin requests **that carry a body** (e.g. `PUT createNonPartitionedTopic`, `POST setDelayedDeliveryPolicy`) fail through the proxy with **HTTP 502 Bad Gateway**. The failure is timing-dependent and surfaces as flakiness in `ProxyRedirectTest.testProxyHandlesReplayingContent`, more frequently on CPU-constrained environments such as CI runners. Requests **without** a body (`GET`) are unaffected.

Root cause: Jetty's `RedirectProtocolHandler.onSuccess(Response)` aborts the in-flight request with `HttpRequestException: "Aborting request after receiving a 307 response"` whenever the request still has a body to send (`request.getBody() != null`), in order to stop streaming the body:

```java
public void onSuccess(Response response) {
    // The request may still be sending content, stop it.
    Request request = response.getRequest();
    if (request.getBody() != null)
        request.abort(new HttpRequestException("Aborting request after receiving a %d response"
            .formatted(response.getStatus()), request));
}
```

When the broker returns the `307` **before the proxy has finished sending the request body**, that abort races ahead of the redirect continuation (`onComplete`) and is delivered to the proxy as the request failure. `AbstractProxyServlet.onProxyResponseFailure` then maps it (a non-`TimeoutException`) to **HTTP 502 Bad Gateway**. The cause is logged by Jetty only at `DEBUG`, which is why it is invisible in normal proxy logs.

### Modifications

- Add `NonAbortingRedirectProtocolHandler`, a `RedirectProtocolHandler` subclass whose `onSuccess` does not abort the in-flight request.
- Register it in `AdminProxyHandler#customizeHttpClient` in place of the stock `RedirectProtocolHandler`.

The redirect is still driven by `RedirectProtocolHandler#onComplete` from the response status and `Location` header, so redirects are followed exactly as before (the body is replayed by the existing `ReplayableProxyContentProvider`); only the abort that produced the spurious 502 is removed.

### Verifying this change

This change is already covered by existing tests, specifically `ProxyRedirectTest.testProxyHandlesReplayingContent`, which exercises the proxy redirect + request-body-replay path.

It was additionally validated against a reliable local reproduction: with the test's topic loop raised to 5000 and run in a single-CPU container, the 502 reproduced within ~1–3 minutes **before** this change, and passed **5/5** consecutive runs **after** it (with no regression to a `504`/idle-timeout path).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
