### PR TITLE
[fix][client] Match logical topic when removing unacked messages

### DIFF
--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TopicMessageId.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/TopicMessageId.java
@@ -41,6 +41,19 @@ public interface TopicMessageId extends MessageId {
      */
     String getOwnerTopic();
 
+    /**
+     * Checks if this message's owner topic and the given topic refer to the same base
+     * partitioned topic by comparing their base partitioned topic names.
+     *
+     * <p>For example, {@code persistent://public/default/my-topic-partition-0} matches
+     * {@code persistent://public/default/my-topic} or any other partition of that topic.
+     * Topics sharing only a name prefix (e.g., {@code my-topic} vs {@code my-topic-v2}) do not match.
+     *
+     * @param topicName a full topic name (non-partitioned, partitioned, or specific partition)
+     * @return {@code true} if both topics resolve to the same base partitioned topic name
+     */
+    boolean hasSameBasePartitionedTopic(String topicName);
+
     static TopicMessageId create(String topic, MessageId messageId) {
         if (messageId instanceof TopicMessageId) {
             return (TopicMessageId) messageId;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -23,6 +23,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.api.TraceableMessageId;
+import org.apache.pulsar.common.naming.TopicName;
 
 public class TopicMessageIdImpl implements MessageIdAdv, TopicMessageId, TraceableMessageId {
     private static final long serialVersionUID = 1L;
@@ -90,6 +91,12 @@ public class TopicMessageIdImpl implements MessageIdAdv, TopicMessageId, Traceab
     @Override
     public String getOwnerTopic() {
         return ownerTopic;
+    }
+
+    @Override
+    public boolean hasSameBasePartitionedTopic(String topicName) {
+        return TopicName.get(getOwnerTopic()).getPartitionedTopicName()
+                .equals(TopicName.get(topicName).getPartitionedTopicName());
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -36,10 +36,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.metrics.Counter;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.impl.metrics.Unit;
+import org.apache.pulsar.common.naming.TopicName;
 
 @CustomLog
 public class UnAckedMessageTracker implements Closeable {
@@ -303,5 +305,13 @@ public class UnAckedMessageTracker implements Closeable {
     @Override
     public void close() {
         stop();
+    }
+
+    protected static boolean messageBelongsToTopic(MessageId messageId, String topicName) {
+        if (!(messageId instanceof TopicMessageId topicMessageId)) {
+            return false;
+        }
+        return TopicName.get(topicMessageId.getOwnerTopic()).getPartitionedTopicName()
+                .equals(TopicName.get(topicName).getPartitionedTopicName());
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -36,12 +36,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.client.impl.metrics.Counter;
 import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
 import org.apache.pulsar.client.impl.metrics.Unit;
-import org.apache.pulsar.common.naming.TopicName;
 
 @CustomLog
 public class UnAckedMessageTracker implements Closeable {
@@ -305,13 +303,5 @@ public class UnAckedMessageTracker implements Closeable {
     @Override
     public void close() {
         stop();
-    }
-
-    protected static boolean messageBelongsToTopic(MessageId messageId, String topicName) {
-        if (!(messageId instanceof TopicMessageId topicMessageId)) {
-            return false;
-        }
-        return TopicName.get(topicMessageId.getOwnerTopic()).getPartitionedTopicName()
-                .equals(TopicName.get(topicName).getPartitionedTopicName());
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 
 public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedeliveryTracker {
@@ -41,7 +42,8 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
                 Entry<UnackMessageIdWrapper, HashSet<UnackMessageIdWrapper>> entry = iterator.next();
                 UnackMessageIdWrapper messageIdWrapper = entry.getKey();
                 MessageId messageId = messageIdWrapper.getMessageId();
-                if (messageBelongsToTopic(messageId, topicName)) {
+                if (messageId instanceof TopicMessageId topicMessageId
+                        && topicMessageId.hasSameBasePartitionedTopic(topicName)) {
                     entry.getValue().remove(messageIdWrapper);
                     iterator.remove();
                     messageIdWrapper.recycle();
@@ -52,7 +54,8 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
             Iterator<MessageId> iteratorAckTimeOut = ackTimeoutMessages.keySet().iterator();
             while (iteratorAckTimeOut.hasNext()) {
                 MessageId messageId = iteratorAckTimeOut.next();
-                if (messageBelongsToTopic(messageId, topicName)) {
+                if (messageId instanceof TopicMessageId topicMessageId
+                        && topicMessageId.hasSameBasePartitionedTopic(topicName)) {
                     iteratorAckTimeOut.remove();
                     removed++;
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTracker.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 
 public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedeliveryTracker {
@@ -42,8 +41,7 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
                 Entry<UnackMessageIdWrapper, HashSet<UnackMessageIdWrapper>> entry = iterator.next();
                 UnackMessageIdWrapper messageIdWrapper = entry.getKey();
                 MessageId messageId = messageIdWrapper.getMessageId();
-                if (messageId instanceof TopicMessageId
-                        && ((TopicMessageId) messageId).getOwnerTopic().contains(topicName)) {
+                if (messageBelongsToTopic(messageId, topicName)) {
                     entry.getValue().remove(messageIdWrapper);
                     iterator.remove();
                     messageIdWrapper.recycle();
@@ -54,8 +52,7 @@ public class UnAckedTopicMessageRedeliveryTracker extends UnAckedMessageRedelive
             Iterator<MessageId> iteratorAckTimeOut = ackTimeoutMessages.keySet().iterator();
             while (iteratorAckTimeOut.hasNext()) {
                 MessageId messageId = iteratorAckTimeOut.next();
-                if (messageId instanceof TopicMessageId
-                        && ((TopicMessageId) messageId).getOwnerTopic().contains(topicName)) {
+                if (messageBelongsToTopic(messageId, topicName)) {
                     iteratorAckTimeOut.remove();
                     removed++;
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 
 public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
@@ -40,8 +39,7 @@ public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
             while (iterator.hasNext()) {
                 Entry<MessageId, HashSet<MessageId>> entry = iterator.next();
                 MessageId messageId = entry.getKey();
-                if (messageId instanceof TopicMessageId
-                        && ((TopicMessageId) messageId).getOwnerTopic().contains(topicName)) {
+                if (messageBelongsToTopic(messageId, topicName)) {
                     entry.getValue().remove(messageId);
                     iterator.remove();
                     removed++;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.TopicMessageId;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 
 public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
@@ -39,7 +40,8 @@ public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
             while (iterator.hasNext()) {
                 Entry<MessageId, HashSet<MessageId>> entry = iterator.next();
                 MessageId messageId = entry.getKey();
-                if (messageBelongsToTopic(messageId, topicName)) {
+                if (messageId instanceof TopicMessageId topicMessageId
+                        && topicMessageId.hasSameBasePartitionedTopic(topicName)) {
                     entry.getValue().remove(messageId);
                     iterator.remove();
                     removed++;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/TopicMessageIdImplTest.java
@@ -19,8 +19,10 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 public class TopicMessageIdImplTest {
@@ -52,6 +54,21 @@ public class TopicMessageIdImplTest {
         assertEquals(topicMsgId1, msgId1);
         assertEquals(msgId1, topicMsgId1);
         assertNotEquals(topicMsgId1, topicMsgId2);
+    }
+
+    @Test
+    public void testHasSameBasePartitionedTopic() {
+        MessageIdImpl msgId = new MessageIdImpl(0, 0, 0);
+        TopicMessageIdImpl partitionMsgId = new TopicMessageIdImpl(
+                "persistent://public/default/my-topic-partition-0", msgId);
+        assertTrue(partitionMsgId.hasSameBasePartitionedTopic(
+                "persistent://public/default/my-topic-partition-1"));
+        assertTrue(partitionMsgId.hasSameBasePartitionedTopic(
+                "persistent://public/default/my-topic"));
+        assertFalse(partitionMsgId.hasSameBasePartitionedTopic(
+                "persistent://public/default/my-topic-v2"));
+        assertFalse(partitionMsgId.hasSameBasePartitionedTopic(
+                "persistent://public/default/my-topic-v2-partition-0"));
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/UnAckedTopicMessageRedeliveryTrackerTest.java
@@ -70,8 +70,46 @@ public class UnAckedTopicMessageRedeliveryTrackerTest {
         tracker.ackTimeoutMessages.put(msgInAckTimeout, System.currentTimeMillis() + 1_000_000L);
         assertEquals(tracker.size(), 2);
 
-        assertEquals(tracker.removeTopicMessages("my-topic"), 2);
+        assertEquals(tracker.removeTopicMessages("persistent://public/default/my-topic-partition-0"), 2);
         assertTrue(tracker.isEmpty());
+
+        tracker.close();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRemoveTopicMessagesDoesNotMatchPrefixTopic() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ConnectionPool connectionPool = mock(ConnectionPool.class);
+        when(client.instrumentProvider()).thenReturn(InstrumentProvider.NOOP);
+        when(client.getCnxPool()).thenReturn(connectionPool);
+        @Cleanup("stop")
+        Timer timer = new HashedWheelTimer(
+                new DefaultThreadFactory("pulsar-timer", Thread.currentThread().isDaemon()),
+                1, TimeUnit.MILLISECONDS);
+        when(client.timer()).thenReturn(timer);
+
+        ConsumerBase<byte[]> consumer = mock(ConsumerBase.class);
+        doNothing().when(consumer).onAckTimeoutSend(any());
+        doNothing().when(consumer).redeliverUnacknowledgedMessages(any());
+
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAckTimeoutMillis(1_000_000);
+        conf.setTickDurationMillis(100_000);
+        conf.setAckTimeoutRedeliveryBackoff(MultiplierRedeliveryBackoff.builder().build());
+
+        UnAckedTopicMessageRedeliveryTracker tracker =
+                new UnAckedTopicMessageRedeliveryTracker(client, consumer, conf);
+
+        String ownerTopic = "persistent://public/default/my-topic-v2-partition-0";
+        TopicMessageIdImpl msgInPartition =
+                new TopicMessageIdImpl(ownerTopic, new MessageIdImpl(1L, 0L, -1));
+
+        assertTrue(tracker.add(msgInPartition));
+        assertEquals(tracker.size(), 1);
+
+        assertEquals(tracker.removeTopicMessages("persistent://public/default/my-topic"), 0);
+        assertEquals(tracker.size(), 1);
 
         tracker.close();
     }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->



<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation
When a multi-topic consumer unsubscribes from a topic, it removes unacked messages that belong to the unsubscribed topic.
The previous matching logic used substring matching on `TopicMessageId#getOwnerTopic()`. This could incorrectly remove messages from topics with similar prefixes, such as matching `my-topic-v2` when unsubscribing `my-topic`.
### Modifications
- Normalize both the message owner topic and the target topic to their partitioned topic name before comparing them.
- Remove unacked messages for all partitions of the unsubscribed logical topic.
- Add test coverage to verify that similarly prefixed topics are not removed by mistake.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
`./gradlew :pulsar-client-original:test --tests org.apache.pulsar.client.impl.UnAckedTopicMessageRedeliveryTrackerTest`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment