### PR TITLE
[fix][broker] Delete orphan cursor after failed subscribe

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1193,23 +1193,28 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 PersistentSubscription subscription = subscriptions.get(subscriptionName);
                 if (subscription == null) {
-                    PersistentSubscription newSubscription;
-                    try {
-                        newSubscription = createPersistentSubscription(subscriptionName, cursor, replicated,
-                                subscriptionProperties);
-                    } catch (Exception e) {
-                        deleteOpenedDurableCursor(cursor, subscriptionName, subscriptionFuture, e);
+                    subscription = subscriptions.computeIfAbsent(subscriptionName,
+                                  name -> createPersistentSubscription(subscriptionName, cursor,
+                                          replicated, subscriptionProperties));
+                } else {
+                    // if subscription exists, check if it's a non-durable subscription
+                    if (subscription.getCursor() != null && !subscription.getCursor().isDurable()) {
+                        ledger.asyncDeleteCursor(encodedSubscriptionName, new DeleteCursorCallback() {
+                            @Override
+                            public void deleteCursorComplete(Object ctx) {
+                            }
+
+                            @Override
+                            public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
+                                log.warn().attr("subscription", subscriptionName)
+                                        .exceptionMessage(exception)
+                                        .log("Failed to delete cursor for conflicts");
+                            }
+                        }, null);
+                        subscriptionFuture.completeExceptionally(
+                                new NotAllowedException("NonDurable subscription with the same name already exists."));
                         return;
                     }
-                    PersistentSubscription existingSubscription =
-                            subscriptions.putIfAbsent(subscriptionName, newSubscription);
-                    subscription = existingSubscription != null ? existingSubscription : newSubscription;
-                }
-                // If subscription exists, check if it's a non-durable subscription.
-                if (subscription.getCursor() != null && !subscription.getCursor().isDurable()) {
-                    deleteOpenedDurableCursor(cursor, subscriptionName, subscriptionFuture,
-                            new NotAllowedException("NonDurable subscription with the same name already exists."));
-                    return;
                 }
                 if (replicated != null && replicated && !subscription.isReplicated()) {
                     // Flip the subscription state
@@ -1238,31 +1243,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
         }, null);
         return subscriptionFuture;
-    }
-
-    private void deleteOpenedDurableCursor(ManagedCursor cursor, String subscriptionName,
-                                           CompletableFuture<Subscription> subscriptionFuture, Throwable cause) {
-        if (!cursor.isDurable()) {
-            subscriptionFuture.completeExceptionally(cause);
-            return;
-        }
-
-        ledger.asyncDeleteCursor(cursor.getName(), new DeleteCursorCallback() {
-            @Override
-            public void deleteCursorComplete(Object ctx) {
-                subscriptionFuture.completeExceptionally(cause);
-            }
-
-            @Override
-            public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                log.warn()
-                        .attr("subscription", subscriptionName)
-                        .attr("cursor", cursor.getName())
-                        .exceptionMessage(exception)
-                        .log("Failed to delete cursor after failed durable subscription creation");
-                subscriptionFuture.completeExceptionally(cause);
-            }
-        }, null);
     }
 
     private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1184,7 +1184,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
 
         Map<String, Long> properties = PersistentSubscription.getBaseCursorProperties(replicated);
-        ledger.asyncOpenCursor(Codec.encode(subscriptionName), initialPosition, properties, subscriptionProperties,
+        String encodedSubscriptionName = Codec.encode(subscriptionName);
+        ledger.asyncOpenCursor(encodedSubscriptionName, initialPosition, properties, subscriptionProperties,
                 new OpenCursorCallback() {
             @Override
             public void openCursorComplete(ManagedCursor cursor, Object ctx) {
@@ -1192,16 +1193,23 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                 PersistentSubscription subscription = subscriptions.get(subscriptionName);
                 if (subscription == null) {
-                    subscription = subscriptions.computeIfAbsent(subscriptionName,
-                                  name -> createPersistentSubscription(subscriptionName, cursor,
-                                          replicated, subscriptionProperties));
-                } else {
-                    // if subscription exists, check if it's a non-durable subscription
-                    if (subscription.getCursor() != null && !subscription.getCursor().isDurable()) {
-                        subscriptionFuture.completeExceptionally(
-                                new NotAllowedException("NonDurable subscription with the same name already exists."));
+                    PersistentSubscription newSubscription;
+                    try {
+                        newSubscription = createPersistentSubscription(subscriptionName, cursor, replicated,
+                                subscriptionProperties);
+                    } catch (Exception e) {
+                        deleteOpenedDurableCursor(cursor, subscriptionName, subscriptionFuture, e);
                         return;
                     }
+                    PersistentSubscription existingSubscription =
+                            subscriptions.putIfAbsent(subscriptionName, newSubscription);
+                    subscription = existingSubscription != null ? existingSubscription : newSubscription;
+                }
+                // If subscription exists, check if it's a non-durable subscription.
+                if (subscription.getCursor() != null && !subscription.getCursor().isDurable()) {
+                    deleteOpenedDurableCursor(cursor, subscriptionName, subscriptionFuture,
+                            new NotAllowedException("NonDurable subscription with the same name already exists."));
+                    return;
                 }
                 if (replicated != null && replicated && !subscription.isReplicated()) {
                     // Flip the subscription state
@@ -1230,6 +1238,31 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             }
         }, null);
         return subscriptionFuture;
+    }
+
+    private void deleteOpenedDurableCursor(ManagedCursor cursor, String subscriptionName,
+                                           CompletableFuture<Subscription> subscriptionFuture, Throwable cause) {
+        if (!cursor.isDurable()) {
+            subscriptionFuture.completeExceptionally(cause);
+            return;
+        }
+
+        ledger.asyncDeleteCursor(cursor.getName(), new DeleteCursorCallback() {
+            @Override
+            public void deleteCursorComplete(Object ctx) {
+                subscriptionFuture.completeExceptionally(cause);
+            }
+
+            @Override
+            public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
+                log.warn()
+                        .attr("subscription", subscriptionName)
+                        .attr("cursor", cursor.getName())
+                        .exceptionMessage(exception)
+                        .log("Failed to delete cursor after failed durable subscription creation");
+                subscriptionFuture.completeExceptionally(cause);
+            }
+        }, null);
     }
 
     private CompletableFuture<? extends Subscription> getNonDurableSubscription(String subscriptionName,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
@@ -650,6 +651,55 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             // Expected
             assertTrue(ee.getCause() instanceof BrokerServiceException.NamingException);
         }
+    }
+
+    @Test
+    public void testFailedDurableSubscribeDeletesOpenedCursor() throws Exception {
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+        topic.initialize().join();
+
+        String subscriptionName = "sub/with/slash";
+        String encodedSubscriptionName = Codec.encode(subscriptionName);
+        ManagedCursor nonDurableCursor = mock(ManagedCursor.class);
+        doReturn(false).when(nonDurableCursor).isDurable();
+        doReturn(subscriptionName).when(nonDurableCursor).getName();
+        doReturn(ledgerMock).when(nonDurableCursor).getManagedLedger();
+        PersistentSubscription nonDurableSubscription =
+                new PersistentSubscription(topic, subscriptionName, nonDurableCursor, false);
+        topic.getSubscriptions().put(subscriptionName, nonDurableSubscription);
+
+        ManagedCursor durableCursor = mock(ManagedCursor.class);
+        doReturn(true).when(durableCursor).isDurable();
+        doReturn(encodedSubscriptionName).when(durableCursor).getName();
+        doAnswer(invocationOnMock -> {
+            ((OpenCursorCallback) invocationOnMock.getArguments()[4]).openCursorComplete(durableCursor, null);
+            return null;
+        }).when(ledgerMock).asyncOpenCursor(eq(encodedSubscriptionName), any(InitialPosition.class), anyMap(),
+                anyMap(), any(OpenCursorCallback.class), any());
+        doAnswer(invocationOnMock -> {
+            ((DeleteCursorCallback) invocationOnMock.getArguments()[1]).deleteCursorComplete(null);
+            return null;
+        }).when(ledgerMock).asyncDeleteCursor(eq(encodedSubscriptionName), any(DeleteCursorCallback.class), any());
+
+        SubscriptionOption option = SubscriptionOption.builder().cnx(serverCnx)
+                .subscriptionName(subscriptionName).consumerId(1).subType(SubType.Exclusive)
+                .priorityLevel(0).consumerName("consumer-name").isDurable(true).startMessageId(null)
+                .metadata(Collections.emptyMap()).readCompacted(false)
+                .initialPosition(InitialPosition.Latest).subscriptionProperties(Optional.empty())
+                .startMessageRollbackDurationSec(0).replicatedSubscriptionStateArg(false).keySharedMeta(null)
+                .build();
+
+        Future<Consumer> subscribeFuture = topic.subscribe(option);
+        try {
+            subscribeFuture.get(1, TimeUnit.SECONDS);
+            fail("should fail with exception");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof BrokerServiceException.NotAllowedException);
+        }
+
+        verify(ledgerMock).asyncDeleteCursor(eq(encodedSubscriptionName), any(DeleteCursorCallback.class), any());
+        assertSame(topic.getSubscription(subscriptionName), nonDurableSubscription);
+        assertSame(topic.getSubscription(subscriptionName).getCursor(), nonDurableCursor);
     }
 
     private SubscriptionOption getSubscriptionOption(CommandSubscribe cmd) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
@@ -651,55 +650,6 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
             // Expected
             assertTrue(ee.getCause() instanceof BrokerServiceException.NamingException);
         }
-    }
-
-    @Test
-    public void testFailedDurableSubscribeDeletesOpenedCursor() throws Exception {
-        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
-        topic.initialize().join();
-
-        String subscriptionName = "sub/with/slash";
-        String encodedSubscriptionName = Codec.encode(subscriptionName);
-        ManagedCursor nonDurableCursor = mock(ManagedCursor.class);
-        doReturn(false).when(nonDurableCursor).isDurable();
-        doReturn(subscriptionName).when(nonDurableCursor).getName();
-        doReturn(ledgerMock).when(nonDurableCursor).getManagedLedger();
-        PersistentSubscription nonDurableSubscription =
-                new PersistentSubscription(topic, subscriptionName, nonDurableCursor, false);
-        topic.getSubscriptions().put(subscriptionName, nonDurableSubscription);
-
-        ManagedCursor durableCursor = mock(ManagedCursor.class);
-        doReturn(true).when(durableCursor).isDurable();
-        doReturn(encodedSubscriptionName).when(durableCursor).getName();
-        doAnswer(invocationOnMock -> {
-            ((OpenCursorCallback) invocationOnMock.getArguments()[4]).openCursorComplete(durableCursor, null);
-            return null;
-        }).when(ledgerMock).asyncOpenCursor(eq(encodedSubscriptionName), any(InitialPosition.class), anyMap(),
-                anyMap(), any(OpenCursorCallback.class), any());
-        doAnswer(invocationOnMock -> {
-            ((DeleteCursorCallback) invocationOnMock.getArguments()[1]).deleteCursorComplete(null);
-            return null;
-        }).when(ledgerMock).asyncDeleteCursor(eq(encodedSubscriptionName), any(DeleteCursorCallback.class), any());
-
-        SubscriptionOption option = SubscriptionOption.builder().cnx(serverCnx)
-                .subscriptionName(subscriptionName).consumerId(1).subType(SubType.Exclusive)
-                .priorityLevel(0).consumerName("consumer-name").isDurable(true).startMessageId(null)
-                .metadata(Collections.emptyMap()).readCompacted(false)
-                .initialPosition(InitialPosition.Latest).subscriptionProperties(Optional.empty())
-                .startMessageRollbackDurationSec(0).replicatedSubscriptionStateArg(false).keySharedMeta(null)
-                .build();
-
-        Future<Consumer> subscribeFuture = topic.subscribe(option);
-        try {
-            subscribeFuture.get(1, TimeUnit.SECONDS);
-            fail("should fail with exception");
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof BrokerServiceException.NotAllowedException);
-        }
-
-        verify(ledgerMock).asyncDeleteCursor(eq(encodedSubscriptionName), any(DeleteCursorCallback.class), any());
-        assertSame(topic.getSubscription(subscriptionName), nonDurableSubscription);
-        assertSame(topic.getSubscription(subscriptionName).getCursor(), nonDurableCursor);
     }
 
     private SubscriptionOption getSubscriptionOption(CommandSubscribe cmd) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonDurableSubscriptionTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -192,8 +193,10 @@ public class NonDurableSubscriptionTest extends ProducerConsumerBase {
                     .startMessageIdInclusive()
                     .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
                     .subscribe();
+            Assert.fail("should fail since non-durable subscription already exist.");
         } catch (PulsarClientException.NotAllowedException exception) {
-            //ignore
+            final var cursors = admin.topics().getInternalStats(topicName).getCursors().keySet();
+            Assert.assertEquals(cursors, Set.of("mix-subscription"), "cursors: " + cursors);
         }
     }
 


### PR DESCRIPTION
### Motivation

When a durable subscription fails due to an existing non-durable subscription, the durable cursor will still be created but not deleted, this could cause the durable cursor unexpectedly recovered after the topic is loaded again.

### Modifications

Delete the cursor in this case. Improve `testSameSubscriptionNameForDurableAndNonDurableSubscription` to avoid the regression.