### PR TITLE
[improve][client] Clean up unacked message tracker when topics are removed in multi-topic consumers

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -982,6 +982,14 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
     }
 
+    protected void removeTopicMessagesFromUnackedTracker(String topicName) {
+        if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker tracker) {
+            tracker.removeTopicMessages(topicName);
+        } else if (unAckedMessageTracker instanceof UnAckedTopicMessageRedeliveryTracker tracker) {
+            tracker.removeTopicMessages(topicName);
+        }
+    }
+
     /***
      * Subscribe one more given topic.
      * @param topicName topic name without the partition suffix.
@@ -1300,11 +1308,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     });
 
                     removeTopic(topicName);
-                    if (unAckedMessageTracker instanceof UnAckedTopicMessageTracker tracker) {
-                        tracker.removeTopicMessages(topicName);
-                    } else if (unAckedMessageTracker instanceof UnAckedTopicMessageRedeliveryTracker tracker){
-                        tracker.removeTopicMessages(topicName);
-                    }
+                    removeTopicMessagesFromUnackedTracker(topicName);
 
                     unsubscribeFuture.complete(null);
                     log.info().attr("topic", topicName)
@@ -1431,7 +1435,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                     }
                 }
 
-                return FutureUtil.waitForAll(futures);
+                return FutureUtil.waitForAll(futures)
+                        .thenRun(() -> removeTopicMessagesFromUnackedTracker(topicName));
             } else if (oldPartitionNumber < currentPartitionNumber) {
                 allTopicPartitionsNumber.addAndGet(currentPartitionNumber - oldPartitionNumber);
                 partitionedTopics.put(topicName, currentPartitionNumber);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -367,6 +367,7 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                             removedPartitionedTopicsForLog.add(String.format("%s with %s partitions",
                                     groupedTopicRemoved, partitions));
                             partitionedTopics.remove(groupedTopicRemoved, partitions);
+                            removeTopicMessagesFromUnackedTracker(groupedTopicRemoved);
                         }
                     }
                 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImplTest.java
@@ -37,6 +37,7 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -267,6 +268,56 @@ public class MultiTopicsConsumerImplTest {
         // getPartitionedTopicMetadata should have been called only the first time, for each of the 3 topics,
         // but not anymore since the topics are not partitioned.
         verify(clientMock, times(3)).getPartitionedTopicMetadata(any(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnTopicsExtendedRemovedTopicCleansUnackedMessages() {
+        String topicName = "persistent://public/default/deleted-topic";
+        String topicPartition0 = topicName + "-partition-0";
+        String topicPartition1 = topicName + "-partition-1";
+        String otherTopicPartition = "persistent://public/default/other-topic-partition-0";
+
+        ConsumerConfigurationData<byte[]> consumerConfData = new ConsumerConfigurationData<>();
+        consumerConfData.setSubscriptionName("subscriptionName");
+        consumerConfData.setAutoUpdatePartitions(true);
+        consumerConfData.setAutoUpdatePartitionsIntervalSeconds(60);
+        consumerConfData.setAckTimeoutMillis(1000);
+
+        MultiTopicsConsumerImpl<byte[]> impl = createMultiTopicsConsumer(consumerConfData);
+
+        impl.partitionedTopics.put(topicName, 2);
+        impl.allTopicPartitionsNumber.set(2);
+
+        ConsumerImpl<byte[]> partitionConsumer0 = (ConsumerImpl<byte[]>) mock(ConsumerImpl.class);
+        ConsumerImpl<byte[]> partitionConsumer1 = (ConsumerImpl<byte[]>) mock(ConsumerImpl.class);
+        when(partitionConsumer0.getTopic()).thenReturn(topicPartition0);
+        when(partitionConsumer1.getTopic()).thenReturn(topicPartition1);
+        when(partitionConsumer0.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        when(partitionConsumer1.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        impl.consumers.put(topicPartition0, partitionConsumer0);
+        impl.consumers.put(topicPartition1, partitionConsumer1);
+
+        TopicMessageIdImpl removedTopicMessageId = new TopicMessageIdImpl(topicPartition0, new MessageIdImpl(1, 1, 0));
+        TopicMessageIdImpl otherTopicMessageId =
+                new TopicMessageIdImpl(otherTopicPartition, new MessageIdImpl(2, 2, 0));
+        impl.getUnAckedMessageTracker().add(removedTopicMessageId);
+        impl.getUnAckedMessageTracker().add(otherTopicMessageId);
+        assertEquals(impl.getUnAckedMessageTracker().size(), 2);
+
+        when(impl.client.getPartitionsForTopic(topicName, false)).thenReturn(CompletableFuture.completedFuture(
+                Collections.emptyList()));
+
+        PartitionsChangedListener listener = impl.topicsPartitionChangedListener;
+        listener.onTopicsExtended(Collections.singleton(topicName)).join();
+
+        assertTrue(impl.getConsumers().isEmpty());
+        assertEquals(impl.partitionedTopics.get(topicName), Integer.valueOf(0));
+        assertEquals(impl.allTopicPartitionsNumber.get(), 0);
+        assertEquals(impl.getUnAckedMessageTracker().size(), 1);
+        assertTrue(impl.getUnAckedMessageTracker().remove(otherTopicMessageId));
+        verify(partitionConsumer0).closeAsync();
+        verify(partitionConsumer1).closeAsync();
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImplTest.java
@@ -310,6 +310,47 @@ public class PatternMultiTopicsConsumerImplTest {
         assertThat(invocationCount.get()).isEqualTo(5);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOnTopicsRemovedCleansUnackedMessagesForRemovedPartitionedTopic() {
+        String partitionedTopic = "persistent://tenant/namespace/deleted-topic";
+        String partition0 = partitionedTopic + "-partition-0";
+        String partition1 = partitionedTopic + "-partition-1";
+        String otherTopicPartition = "persistent://tenant/namespace/other-topic-partition-0";
+        TopicsPattern topicsPattern =
+                TopicsPatternFactory.create("persistent://tenant/namespace/.*", TopicsPattern.RegexImplementation.JDK);
+        ConsumerConfigurationData<byte[]> consumerConfData = createConsumerConfigurationData();
+        consumerConfData.setAckTimeoutMillis(1000);
+
+        PatternMultiTopicsConsumerImpl<byte[]> consumer =
+                createPatternMultiTopicsConsumer(consumerConfData, topicsPattern);
+
+        consumer.partitionedTopics.put(partitionedTopic, 2);
+
+        ConsumerImpl<byte[]> partitionConsumer0 = (ConsumerImpl<byte[]>) mock(ConsumerImpl.class);
+        ConsumerImpl<byte[]> partitionConsumer1 = (ConsumerImpl<byte[]>) mock(ConsumerImpl.class);
+        when(partitionConsumer0.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        when(partitionConsumer1.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+        consumer.consumers.put(partition0, partitionConsumer0);
+        consumer.consumers.put(partition1, partitionConsumer1);
+
+        TopicMessageIdImpl removedTopicMessageId = new TopicMessageIdImpl(partition0, new MessageIdImpl(1, 1, 0));
+        TopicMessageIdImpl otherTopicMessageId =
+                new TopicMessageIdImpl(otherTopicPartition, new MessageIdImpl(2, 2, 0));
+        consumer.getUnAckedMessageTracker().add(removedTopicMessageId);
+        consumer.getUnAckedMessageTracker().add(otherTopicMessageId);
+        assertThat(consumer.getUnAckedMessageTracker().size()).isEqualTo(2);
+
+        consumer.topicsChangeListener.onTopicsRemoved(Arrays.asList(partition0, partition1)).join();
+
+        assertThat(consumer.partitionedTopics.containsKey(partitionedTopic)).isFalse();
+        assertThat(consumer.consumers).doesNotContainKeys(partition0, partition1);
+        assertThat(consumer.getUnAckedMessageTracker().size()).isEqualTo(1);
+        assertThat(consumer.getUnAckedMessageTracker().remove(otherTopicMessageId)).isTrue();
+        verify(partitionConsumer0).closeAsync();
+        verify(partitionConsumer1).closeAsync();
+    }
+
     private static void runTimerTasks(Deque<TimerTask> tasks) throws Exception {
         // first drain the queue to a list to avoid an infinite loop
         List<TimerTask> taskList = new ArrayList<>();


### PR DESCRIPTION


<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Follow-up to [#25921]. That PR fixed incorrect unacked-message removal on explicit unsubscribe by comparing base partitioned topic names instead of substring matching. This change extends the same cleanup to other paths where a multi-topic or pattern consumer drops a topic without calling unsubscribe, so timed-out unacked entries are not left behind.

In production, topics can also disappear from a consumer when:

* Partition metadata shrinks — onTopicsExtended closes partition consumers when a partitioned topic is deleted or loses partitions (autoUpdatePartitions).
* Pattern subscription — PatternMultiTopicsConsumerImpl removes a grouped partitioned topic after all its partition consumers are gone.

Those paths closed partition consumers but did not clear matching entries from the unacked tracker. 

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

* Extract removeTopicMessagesFromUnackedTracker(String topicName) in MultiTopicsConsumerImpl and reuse it from unsubscribeAsync .
* After partition consumers are closed in onTopicsExtended when partition count goes to zero, call removeTopicMessagesFromUnackedTracker for the logical topic name.
* In PatternMultiTopicsConsumerImpl, when all partitions of a grouped topic are removed, call the same helper before dropping the topic from partitionedTopics.


<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*



This change added tests and can be verified as follows:

~~~sh
./gradlew :pulsar-client-original:test --tests "org.apache.pulsar.client.impl.MultiTopicsConsumerImplTest.testOnTopicsExtendedRemovedTopicCleansUnackedMessages"
./gradlew :pulsar-client-original:test --tests "org.apache.pulsar.client.impl.PatternMultiTopicsConsumerImplTest#testOnTopicsRemovedCleansUnackedMessagesForRemovedPartitionedTopic"
~~~

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Matching PR in forked repository

PR in forked repository: https://github.com/Dream95/pulsar/pull/13