### PR TITLE
[improve][client] Handle synchronous failures in RetryUtil retry

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RetryUtilTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import org.apache.pulsar.client.util.RetryUtil;
@@ -58,6 +59,28 @@ public class RetryUtilTest {
         }, backoff, executor, callback);
         assertTrue(callback.get());
         assertEquals(atomicInteger.get(), 5);
+    }
+
+    @Test
+    public void testSyncFailureIsRetried() throws Exception {
+        @Cleanup("shutdownNow")
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        CompletableFuture<Boolean> callback = new CompletableFuture<>();
+        AtomicInteger atomicInteger = new AtomicInteger(0);
+        Backoff backoff = Backoff.builder()
+                .initialDelay(Duration.ofMillis(10))
+                .maxBackoff(Duration.ofMillis(10))
+                .mandatoryStop(Duration.ofMillis(1000))
+                .jitterPercent(0)
+                .build();
+        RetryUtil.retryAsynchronously(() -> {
+            if (atomicInteger.incrementAndGet() == 1) {
+                throw new RuntimeException("sync fail");
+            }
+            return CompletableFuture.completedFuture(true);
+        }, backoff, executor, callback);
+        assertTrue(callback.get(2, TimeUnit.SECONDS));
+        assertEquals(atomicInteger.get(), 2);
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/RetryUtil.java
@@ -44,7 +44,18 @@ public class RetryUtil {
     private static <T> void executeWithRetry(Supplier<CompletableFuture<T>> supplier, Backoff backoff,
                                              ScheduledExecutorService scheduledExecutorService,
                                              CompletableFuture<T> callback) {
-        supplier.get().whenComplete((result, e) -> {
+        CompletableFuture<T> future;
+        try {
+            future = supplier.get();
+        } catch (Throwable e) {
+            future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+        }
+        if (future == null) {
+            future = new CompletableFuture<>();
+            future.completeExceptionally(new NullPointerException("Retry supplier returned null future"));
+        }
+        future.whenComplete((result, e) -> {
             if (e != null) {
                 long next = backoff.next().toMillis();
                 boolean isMandatoryStop = backoff.isMandatoryStopMade();


### PR DESCRIPTION

### Motivation

`RetryUtil.retryAsynchronously` accepts a `Supplier<CompletableFuture<T>>` and retries when the returned future completes exceptionally. However, if the supplier throws before returning a future, the exception escapes from the executor task before `whenComplete` is registered.

In that case, the retry loop does not schedule another attempt and the caller-provided callback is never completed. A transient synchronous failure while building the async operation can therefore become a permanently pending callback.

### Modifications

- Wrap the supplier invocation in `RetryUtil` so synchronous exceptions are converted into an exceptionally completed future.
- Treat a `null` future from the supplier as an explicit failure instead of allowing an uncontrolled `NullPointerException`.
- Add a regression test that verifies a synchronous failure on the first attempt is retried and the callback completes successfully on the second attempt.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `RetryUtilTest.testSyncFailureIsRetried` to cover supplier exceptions thrown before a future is returned.
- Verified the new regression test:

```bash
./gradlew :pulsar-broker:test --tests org.apache.pulsar.client.impl.RetryUtilTest.testSyncFailureIsRetried -PtestGroups=utils -PtestRetryCount=0
```

- Verified the adjacent test class:

```bash
./gradlew :pulsar-broker:test --tests org.apache.pulsar.client.impl.RetryUtilTest -PtestGroups=utils -PtestRetryCount=0
```

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
