### PR TITLE
[fix][ci] Use CodeQL build-mode: none to avoid intermittent build-cache failures

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,9 +30,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
-env:
-  JDK_DISTRIBUTION: corretto
-
 jobs:
   analyze:
     # only run on push and schedule in apache/pulsar repo
@@ -52,29 +49,19 @@ jobs:
         language: [ 'java-kotlin' ]
 
     steps:
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: ${{ env.JDK_DISTRIBUTION }}
-          java-version: 21
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Gradle
-        uses: ./.github/actions/setup-gradle
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-          cache-read-only: true
-
       # Initializes the CodeQL tools for scanning.
+      # Use build-mode: none so CodeQL extracts the source directly instead of
+      # tracing a Gradle build. A traced build fails intermittently because the
+      # Gradle build cache restores compileJava/compileKotlin FROM-CACHE, so no
+      # compiler runs and CodeQL sees no source ("could not process any of it").
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-
-      - name: Build Java code
-        run: ./gradlew assemble
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -836,7 +836,6 @@ jobs:
       contents: read
       security-events: write
     env:
-      CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       CODEQL_LANGUAGE: java-kotlin
     steps:
       - name: checkout
@@ -853,24 +852,15 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: ${{ env.JDK_DISTRIBUTION }}
-          java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
-
-      - name: Setup Gradle
-        uses: ./.github/actions/setup-gradle
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-
+      # Use build-mode: none so CodeQL extracts the source directly instead of
+      # tracing a Gradle build. A traced build fails intermittently because the
+      # Gradle build cache restores compileJava/compileKotlin FROM-CACHE, so no
+      # compiler runs and CodeQL sees no source ("could not process any of it").
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ env.CODEQL_LANGUAGE }}
-
-      - name: Build Java code
-        run: ./gradlew assemble
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Motivation

The `CodeQL` workflow fails intermittently with:

> CodeQL detected code written in Java/Kotlin but could not process any of it.

(the [no-source-code-seen-during-build](https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build) error). These failures block PRs from merging — e.g. https://github.com/apache/pulsar/actions/runs/26842303893

**Root cause:** CodeQL's traced Java/Kotlin extraction works by observing the compiler (`javac`/`kotlinc`) as the build runs. But the project enables the Gradle build cache (`org.gradle.caching=true`) plus the shared Develocity remote build cache. When the cache is warm, every `compileJava`/`compileKotlin` task is restored `FROM-CACHE` and the compiler never actually executes, so CodeQL extracts zero source and `codeql database finalize` aborts.

This is why the failures are intermittent, and it correlates directly with the Analyze job duration:

| Outcome | Analyze job duration | What happened |
|---|---|---|
| ❌ failure | ~1.5 min | every `compileJava` restored `FROM-CACHE` → compiler never ran → no source seen |
| ✅ success | 8–17 min | cache missed → compilation actually ran → CodeQL traced it |

### Modifications

Switch the CodeQL job to buildless extraction with `build-mode: none`, so CodeQL extracts the source directly and no longer depends on the Gradle build executing:

- Set `build-mode: none` on the `Initialize CodeQL` step.
- Remove the now-unnecessary `Build Java code` (`./gradlew assemble`), `Setup Gradle`, and `Set up JDK` steps (and the orphaned `JDK_DISTRIBUTION` env), leaving the canonical `checkout → init → analyze` flow.

This makes the workflow immune to Gradle build-cache state and faster (no compilation), while remaining within the standard CodeQL security query suite.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. The CodeQL workflow runs on `push` to `master` and on schedule; it can also be validated on demand via `workflow_dispatch`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
