### PR TITLE
[fix][fn] Fix orphan exclusive producer on creation timeout in WorkerUtils.createExclusiveProducerWithRetry

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerUtils.java
@@ -30,8 +30,8 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
@@ -59,6 +59,7 @@ import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.functions.WorkerInfo;
 import org.apache.pulsar.common.policies.data.FunctionInstanceStatsDataImpl;
 import org.apache.pulsar.common.policies.data.FunctionInstanceStatsImpl;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.functions.proto.MetricsData;
 import org.apache.pulsar.functions.runtime.Runtime;
 import org.apache.pulsar.functions.runtime.RuntimeSpawner;
@@ -413,13 +414,17 @@ public final class WorkerUtils {
             int tries = 0;
             do {
                 try {
-                    return client.newProducer().topic(topic)
+                    CompletableFuture<Producer<byte[]>> producerFuture = client.newProducer().topic(topic)
                             .accessMode(ProducerAccessMode.Exclusive)
                             .enableBatching(false)
                             .blockIfQueueFull(true)
                             .compressionType(CompressionType.LZ4)
                             .producerName(producerName)
-                            .createAsync().get(10, TimeUnit.SECONDS);
+                            .createAsync();
+                    return FutureUtil.getAndCleanupOnInterrupt(producerFuture, Producer::closeAsync);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw e;
                 } catch (Exception e) {
                     log.info().attr("topic", topic).exception(e)
                             .log("Encountered exception while creating exclusive producer");

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/WorkerUtilsTest.java
@@ -18,26 +18,33 @@
  */
 package org.apache.pulsar.functions.worker;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import lombok.Cleanup;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.CompressionType;
@@ -108,6 +115,68 @@ public class WorkerUtilsTest {
         } catch (WorkerUtils.NotLeaderAnymore notLeaderAnymore) {
 
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateExclusiveProducerWithRetryClosesProducerOnInterrupt() throws Exception {
+        Producer<byte[]> producer = mock(Producer.class);
+        when(producer.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+
+        // producer creation stays pending until the test completes it explicitly
+        CompletableFuture<Producer<byte[]>> producerFuture = new CompletableFuture<>();
+        CountDownLatch createAsyncCalled = new CountDownLatch(1);
+
+        ProducerBuilder<byte[]> builder = mock(ProducerBuilder.class);
+        when(builder.topic(anyString())).thenReturn(builder);
+        when(builder.producerName(anyString())).thenReturn(builder);
+        when(builder.enableBatching(anyBoolean())).thenReturn(builder);
+        when(builder.blockIfQueueFull(anyBoolean())).thenReturn(builder);
+        when(builder.compressionType(any(CompressionType.class))).thenReturn(builder);
+        when(builder.accessMode(any())).thenReturn(builder);
+        when(builder.createAsync()).thenAnswer(invocation -> {
+            createAsyncCalled.countDown();
+            return producerFuture;
+        });
+
+        PulsarClient pulsarClient = mock(PulsarClient.class);
+        when(pulsarClient.newProducer()).thenReturn(builder);
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        AtomicBoolean interruptStatusPreserved = new AtomicBoolean();
+        @Cleanup("interrupt")
+        Thread caller = new Thread(() -> {
+            try {
+                WorkerUtils.createExclusiveProducerWithRetry(pulsarClient, "test-topic", "test-producer",
+                        () -> true, 0);
+            } catch (Throwable t) {
+                thrown.set(t);
+                interruptStatusPreserved.set(Thread.currentThread().isInterrupted());
+            }
+        });
+        caller.setDaemon(true);
+        caller.start();
+        assertTrue(createAsyncCalled.await(10, TimeUnit.SECONDS));
+
+        // interrupt the caller while it is waiting for the producer to be created
+        caller.interrupt();
+        caller.join(TimeUnit.SECONDS.toMillis(10));
+        assertThat(caller.isAlive())
+                .as("Interrupt should abort the retry loop instead of retrying")
+                .isFalse();
+
+        assertThat(thrown.get())
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(InterruptedException.class);
+        assertThat(interruptStatusPreserved)
+                .as("Interrupt status should be restored")
+                .isTrue();
+
+        // when the pending creation completes after the interrupt, the producer must be closed so that
+        // the exclusive producer doesn't leak
+        verify(producer, never()).closeAsync();
+        producerFuture.complete(producer);
+        verify(producer, times(1)).closeAsync();
     }
 
     @Test


### PR DESCRIPTION
Fixes #25936

### Motivation

`WorkerUtils.createExclusiveProducerWithRetry` bounded the exclusive producer creation with `createAsync().get(10, TimeUnit.SECONDS)` inside a retry loop. When `get()` threw `TimeoutException`, the catch block logged and retried, abandoning the in-flight `CompletableFuture<Producer>`. The underlying producer state machine kept running on the client IO thread, and when the creation eventually succeeded, the producer registered with the broker as an orphan: no caller held a reference to it, so it was never closed.

The orphan held the topic's exclusive producer access, so every subsequent retry was rejected — locking up leader election in the function worker, since the elected leader could not acquire the exclusive producer it needs on the internal topics and remained stuck retrying. The orphan was never reaped: the client never sends `CloseProducer` for it (no reference exists to invoke `close()`), the TCP connection stays alive because it is shared with other producers/consumers on the same `PulsarClient`, and the functions internal topics are created with deduplication disabled, so the broker's inactivity-based producer reaper does not apply.

In addition, the generic `catch (Exception e)` swallowed `InterruptedException`, so the retry loop kept running with the interrupt status cleared and abandoned the in-flight creation the same way. This is the `WorkerUtils` counterpart of the client-side interrupt fix in #24539.

### Modifications

- Remove the 10-second timeout on the `.get` call: `.get(10, TimeUnit.SECONDS)` is effectively replaced with `.get()`, since the Pulsar client already bounds producer creation with the client's `operationTimeout` (applied via the lookup timeout, which defaults to `operationTimeout`) and completes the future exceptionally instead of abandoning it. This eliminates the `TimeoutException` path that orphaned in-flight producer creations.
- Wait for the creation with `FutureUtil.getAndCleanupOnInterrupt(producerFuture, Producer::closeAsync)` (the helper introduced in #24539) so that an interrupt registers a cleanup that closes the producer if the pending creation completes later.
- Handle `InterruptedException` explicitly: restore the interrupt status and propagate it, aborting the retry loop instead of retrying.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added `WorkerUtilsTest.testCreateExclusiveProducerWithRetryClosesProducerOnInterrupt` verifying that an interrupt aborts the retry loop instead of retrying, restores the interrupt status, and closes the producer once the pending creation completes after the interrupt.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
