### PR TITLE
[fix][test] Split and fix flaky SASL authentication first-stage auth cache tests

### DIFF
--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -68,7 +68,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.testng.collections.CollectionUtils;
 
 @CustomLog
 public class SaslAuthenticateTest extends ProducerConsumerBase {
@@ -307,53 +306,6 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         }
 
         log.info().attr("value", methodName).log("---- end");
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testSaslOnlyAuthFirstStage() throws Exception {
-        @Cleanup
-        AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
-        // The cache expiration time is set to 500ms. Residual auth info should be cleaned up
-        conf.setInflightSaslContextExpiryMs(500);
-        saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
-
-        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        doReturn("Init").when(servletRequest).getHeader("State");
-        // 10 clients only do one-stage verification, resulting in 10 auth info remaining in memory
-        for (int i = 0; i < 10; i++) {
-            AuthenticationDataProvider dataProvider =  authSasl.getAuthData("localhost");
-            AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
-            doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
-                    servletRequest).getHeader("SASL-Token");
-            doReturn(String.valueOf(i)).when(servletRequest).getHeader("SASL-Server-ID");
-            saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
-        }
-        Field field = AuthenticationProviderSasl.class.getDeclaredField("authStates");
-        field.setAccessible(true);
-        Cache<Long, AuthenticationState> cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
-        assertEquals(cache.asMap().size(), 10);
-        // Add more auth info into memory
-        for (int i = 0; i < 10; i++) {
-            AuthenticationDataProvider dataProvider =  authSasl.getAuthData("localhost");
-            AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
-            doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
-                    servletRequest).getHeader("SASL-Token");
-            doReturn(String.valueOf(10 + i)).when(servletRequest).getHeader("SASL-Server-ID");
-            saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
-        }
-        long start = System.currentTimeMillis();
-        while (true) {
-            if (System.currentTimeMillis() - start > 5000) {
-                fail();
-            }
-            cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
-            // Residual auth info should be cleaned up
-            if (CollectionUtils.hasElements(cache.asMap())) {
-                break;
-            }
-            Thread.sleep(5);
-        }
     }
 
     @Test

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.client.impl.auth.AuthenticationSasl;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.sasl.SaslConstants;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -353,6 +354,59 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
             }
             Thread.sleep(5);
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSaslOnlyAuthFirstStageKeepsInflightContextsBeforeExpiry() throws Exception {
+        @Cleanup
+        AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
+        conf.setInflightSaslContextExpiryMs(Integer.MAX_VALUE);
+        saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
+
+        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+        doReturn(SaslConstants.SASL_STATE_CLIENT_INIT).when(servletRequest).getHeader(SaslConstants.SASL_HEADER_STATE);
+        for (int i = 0; i < 10; i++) {
+            AuthenticationDataProvider dataProvider =  authSasl.getAuthData(localHostname);
+            AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+            doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
+                    servletRequest).getHeader(SaslConstants.SASL_AUTH_TOKEN);
+            doReturn(String.valueOf(i)).when(servletRequest).getHeader(SaslConstants.SASL_STATE_SERVER);
+            saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
+        }
+
+        Field field = AuthenticationProviderSasl.class.getDeclaredField("authStates");
+        field.setAccessible(true);
+        Cache<Long, AuthenticationState> cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
+        assertEquals(cache.asMap().size(), 10);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSaslOnlyAuthFirstStageExpiresResidualContexts() throws Exception {
+        @Cleanup
+        AuthenticationProviderSasl saslServer = new AuthenticationProviderSasl();
+        conf.setInflightSaslContextExpiryMs(50);
+        saslServer.initialize(AuthenticationProvider.Context.builder().config(conf).build());
+
+        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+        doReturn(SaslConstants.SASL_STATE_CLIENT_INIT).when(servletRequest).getHeader(SaslConstants.SASL_HEADER_STATE);
+        for (int i = 0; i < 10; i++) {
+            AuthenticationDataProvider dataProvider =  authSasl.getAuthData(localHostname);
+            AuthData initData1 = dataProvider.authenticate(AuthData.INIT_AUTH_DATA);
+            doReturn(Base64.getEncoder().encodeToString(initData1.getBytes())).when(
+                    servletRequest).getHeader(SaslConstants.SASL_AUTH_TOKEN);
+            doReturn(String.valueOf(i)).when(servletRequest).getHeader(SaslConstants.SASL_STATE_SERVER);
+            saslServer.authenticateHttpRequest(servletRequest, mock(HttpServletResponse.class));
+        }
+
+        Field field = AuthenticationProviderSasl.class.getDeclaredField("authStates");
+        field.setAccessible(true);
+        Cache<Long, AuthenticationState> cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
+        Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            cache.cleanUp();
+            assertEquals(cache.asMap().size(), 0);
+        });
     }
 
     @Test

--- a/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
+++ b/pulsar-broker-auth-sasl/src/test/java/org/apache/pulsar/broker/authentication/SaslAuthenticateTest.java
@@ -62,7 +62,6 @@ import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.sasl.SaslConstants;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.awaitility.Awaitility;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -220,7 +219,7 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         FileUtils.deleteQuietly(secretKeyFile);
-        Assert.assertFalse(secretKeyFile.exists());
+        assertFalse(secretKeyFile.exists());
         super.internalCleanup();
     }
 
@@ -355,9 +354,10 @@ public class SaslAuthenticateTest extends ProducerConsumerBase {
         Field field = AuthenticationProviderSasl.class.getDeclaredField("authStates");
         field.setAccessible(true);
         Cache<Long, AuthenticationState> cache = (Cache<Long, AuthenticationState>) field.get(saslServer);
-        Awaitility.await().atMost(3, TimeUnit.SECONDS).pollDelay(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
-            cache.cleanUp();
-            assertEquals(cache.asMap().size(), 0);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).pollDelay(100, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            for (int i = 0; i < 10; i++) {
+                assertNull(cache.getIfPresent(((long) i)));
+            }
         });
     }
 


### PR DESCRIPTION
Fixes apache/pulsar#24337

### Motivation

`SaslAuthenticateTest.testSaslOnlyAuthFirstStage` currently verifies two timing-sensitive behaviors in one test: that first-stage SASL authentication leaves inflight contexts in the cache, and that residual contexts are later expired. The exact cache-size assertion can become flaky when entries expire before the assertion is reached.

### Modifications

Added two focused tests for the separate behaviors:

- `testSaslOnlyAuthFirstStageKeepsInflightContextsBeforeExpiry` verifies that first-stage SASL authentication keeps inflight contexts when the expiry timeout is long enough.
- `testSaslOnlyAuthFirstStageExpiresResidualContexts` verifies that residual first-stage contexts expire and are removed after cleanup.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment