### PR TITLE
[fix][broker] Prevent dedup recovery race from allowing duplicate messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -187,7 +187,7 @@ public class MessageDeduplication {
                 }, null);
             }
 
-            if (status == Status.Enabled && !shouldBeEnabled) {
+            if ((status == Status.Enabled || status == Status.Failed) && !shouldBeEnabled) {
                 // Disabled deduping
                 CompletableFuture<Void> future = new CompletableFuture<>();
                 status = Status.Removing;
@@ -224,17 +224,25 @@ public class MessageDeduplication {
                         }, null);
 
                 return future;
-            } else if ((status == Status.Disabled || status == Status.Initialized) && shouldBeEnabled) {
+            } else if ((status == Status.Disabled || status == Status.Initialized || status == Status.Failed)
+                    && shouldBeEnabled) {
                 // Enable deduping
-                final var future = openCursor(managedLedger, PersistentTopic.DEDUPLICATION_CURSOR_NAME)
-                        .thenCompose(this::replayCursor);
-                future.exceptionally(e -> {
+                status = Status.Recovering;
+                final CompletableFuture<Void> future;
+                try {
+                    future = openCursor(managedLedger, PersistentTopic.DEDUPLICATION_CURSOR_NAME)
+                            .thenCompose(this::replayCursor);
+                } catch (Throwable e) {
                     status = Status.Failed;
                     log.error().exception(e).log("Failed to enable deduplication");
-                    future.completeExceptionally(e);
-                    return null;
+                    return CompletableFuture.failedFuture(e);
+                }
+                return future.whenComplete((__, e) -> {
+                    if (e != null) {
+                        status = Status.Failed;
+                        log.error().exception(e).log("Failed to enable deduplication");
+                    }
                 });
-                return future;
             } else {
                 // Nothing to do, we are in the correct state
                 return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -104,6 +104,7 @@ public class MessageDeduplication {
 
 
     private volatile Status status;
+    private CompletableFuture<Void> statusChangeFuture = CompletableFuture.completedFuture(null);
 
     // Map that contains the highest sequenceId that have been sent by each producers. The map will be updated before
     // the messages are persisted
@@ -159,7 +160,10 @@ public class MessageDeduplication {
     public CompletableFuture<Void> checkStatus() {
         boolean shouldBeEnabled = topic.isDeduplicationEnabled();
         synchronized (this) {
-            if (status == Status.Recovering || status == Status.Removing) {
+            if (status == Status.Recovering) {
+                return statusChangeFuture;
+            }
+            if (status == Status.Removing) {
                 // If there's already a transition happening, check later for status
                 pulsar.getExecutor().schedule(this::checkStatus, 1, TimeUnit.MINUTES);
                 return CompletableFuture.completedFuture(null);
@@ -187,7 +191,7 @@ public class MessageDeduplication {
                 }, null);
             }
 
-            if ((status == Status.Enabled || status == Status.Failed) && !shouldBeEnabled) {
+            if (status == Status.Enabled && !shouldBeEnabled) {
                 // Disabled deduping
                 CompletableFuture<Void> future = new CompletableFuture<>();
                 status = Status.Removing;
@@ -234,15 +238,17 @@ public class MessageDeduplication {
                             .thenCompose(this::replayCursor);
                 } catch (Throwable e) {
                     status = Status.Failed;
+                    statusChangeFuture = CompletableFuture.failedFuture(e);
                     log.error().exception(e).log("Failed to enable deduplication");
-                    return CompletableFuture.failedFuture(e);
+                    return statusChangeFuture;
                 }
-                return future.whenComplete((__, e) -> {
+                statusChangeFuture = future.whenComplete((__, e) -> {
                     if (e != null) {
                         status = Status.Failed;
                         log.error().exception(e).log("Failed to enable deduplication");
                     }
                 });
+                return statusChangeFuture;
             } else {
                 // Nothing to do, we are in the correct state
                 return CompletableFuture.completedFuture(null);
@@ -252,6 +258,11 @@ public class MessageDeduplication {
 
     private CompletableFuture<Void> replayCursor(ManagedCursor cursor) {
         managedCursor = cursor;
+        cursor.rewind();
+        snapshotCounter = 0;
+        highestSequencedPushed.clear();
+        highestSequencedPersisted.clear();
+        inactiveProducers.clear();
         // Load the sequence ids from the snapshot in the cursor properties
         managedCursor.getProperties().forEach((k, v) -> {
             producerRemoved(k);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
@@ -153,11 +153,12 @@ public class BrokerMessageDeduplicationTest {
         assertEquals(String.valueOf(deduplication.getStatus()), "Recovering");
 
         final var secondCheckStatus = deduplication.checkStatus();
-        assertTrue(secondCheckStatus.isDone());
+        assertFalse(secondCheckStatus.isDone());
         verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
 
         openCursorCallback.get().openCursorComplete(cursor, null);
         firstCheckStatus.get(3, TimeUnit.SECONDS);
+        secondCheckStatus.get(3, TimeUnit.SECONDS);
         assertEquals(String.valueOf(deduplication.getStatus()), "Enabled");
         verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
     }
@@ -169,7 +170,7 @@ public class BrokerMessageDeduplicationTest {
             ((AsyncCallbacks.OpenCursorCallback) invocation.getArgument(1)).openCursorComplete(cursor, null);
             return null;
         }).when(managedLedger).asyncOpenCursor(any(), any(), any());
-        doReturn(Map.of()).when(cursor).getProperties();
+        doReturn(Map.of("from-snapshot", 10L)).when(cursor).getProperties();
 
         final var hasMoreEntriesCalls = new AtomicInteger();
         doAnswer(invocation -> hasMoreEntriesCalls.getAndIncrement() == 0).when(cursor).hasMoreEntries();
@@ -186,8 +187,11 @@ public class BrokerMessageDeduplicationTest {
         }
         assertEquals(String.valueOf(deduplication.getStatus()), "Failed");
 
-        deduplication.checkStatus().get(3, TimeUnit.SECONDS);
+        final var retry = deduplication.checkStatus();
+        retry.get(3, TimeUnit.SECONDS);
         assertEquals(String.valueOf(deduplication.getStatus()), "Enabled");
+        assertEquals(deduplication.getLastPublishedSequenceId("from-snapshot"), 10L);
+        verify(cursor, times(2)).rewind();
         verify(managedLedger, times(2)).asyncOpenCursor(any(), any(), any());
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
@@ -25,7 +25,10 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
@@ -35,6 +38,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -129,5 +134,60 @@ public class BrokerMessageDeduplicationTest {
             assertTrue(e.getCause() instanceof RuntimeException);
             assertTrue(e.getMessage().contains("asyncReadEntries failed"));
         }
+        assertEquals(String.valueOf(deduplication.getStatus()), "Failed");
+    }
+
+    @Test
+    public void checkStatusDoesNotStartMultipleRecoveries() throws Exception {
+        final var cursor = mock(ManagedCursor.class);
+        final var openCursorCallback = new AtomicReference<AsyncCallbacks.OpenCursorCallback>();
+        doAnswer(invocation -> {
+            openCursorCallback.set(invocation.getArgument(1));
+            return null;
+        }).when(managedLedger).asyncOpenCursor(any(), any(), any());
+        doReturn(Map.of()).when(cursor).getProperties();
+        doReturn(false).when(cursor).hasMoreEntries();
+
+        final var firstCheckStatus = deduplication.checkStatus();
+        assertFalse(firstCheckStatus.isDone());
+        assertEquals(String.valueOf(deduplication.getStatus()), "Recovering");
+
+        final var secondCheckStatus = deduplication.checkStatus();
+        assertTrue(secondCheckStatus.isDone());
+        verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
+
+        openCursorCallback.get().openCursorComplete(cursor, null);
+        firstCheckStatus.get(3, TimeUnit.SECONDS);
+        assertEquals(String.valueOf(deduplication.getStatus()), "Enabled");
+        verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
+    }
+
+    @Test
+    public void checkStatusRetriesAfterFailedEnable() throws Exception {
+        final var cursor = mock(ManagedCursor.class);
+        doAnswer(invocation -> {
+            ((AsyncCallbacks.OpenCursorCallback) invocation.getArgument(1)).openCursorComplete(cursor, null);
+            return null;
+        }).when(managedLedger).asyncOpenCursor(any(), any(), any());
+        doReturn(Map.of()).when(cursor).getProperties();
+
+        final var hasMoreEntriesCalls = new AtomicInteger();
+        doAnswer(invocation -> hasMoreEntriesCalls.getAndIncrement() == 0).when(cursor).hasMoreEntries();
+        doAnswer(invocation -> {
+            throw new RuntimeException("asyncReadEntries failed");
+        }).when(cursor).asyncReadEntries(anyInt(), anyLong(), any(), any(), any());
+
+        try {
+            deduplication.checkStatus().get(3, TimeUnit.SECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof RuntimeException);
+            assertTrue(e.getMessage().contains("asyncReadEntries failed"));
+        }
+        assertEquals(String.valueOf(deduplication.getStatus()), "Failed");
+
+        deduplication.checkStatus().get(3, TimeUnit.SECONDS);
+        assertEquals(String.valueOf(deduplication.getStatus()), "Enabled");
+        verify(managedLedger, times(2)).asyncOpenCursor(any(), any(), any());
     }
 }


### PR DESCRIPTION
### Motivation

Fixes #25954.

Message deduplication recovery rebuilds the broker-side producer sequence state from the dedup cursor. When a topic is configured with deduplication, topic load must wait until this recovery is complete before the topic is exposed for writes.

The previous state machine had gaps around the recovery transition:

- Enabling deduplication could start cursor replay without first moving the status to `Recovering`.
- A concurrent `checkStatus()` that observed `Recovering` treated the recovery as complete instead of waiting for it.
- A failed enable moved deduplication to `Failed`, but a later check did not retry recovery when the topic policy still required deduplication.
- A retry could reuse local sequence state and cursor read progress left by a failed recovery attempt.

A common high-frequency case is topic load with existing topic-level policies. The topic load path can trigger dedup status checks from multiple flows before the first recovery replay completes:

| Time | Flow A: existing topic-level policy during load | Flow B: normal topic load chain | Dedup status / effect |
|------|--------------------------------------------------|----------------------------------|-----------------------|
| T1 | `initTopicPolicy()` loads existing topic policies | | `Initialized` or `Disabled` |
| T2 | `onUpdate()` applies topic policies and calls `checkDeduplicationStatus()` | | Dedup recovery replay starts |
| T3 | The replay is asynchronous and still rebuilding producer sequence state | | The topic is not safe to expose for writes yet |
| T4 | | `BrokerService` continues topic load and explicitly calls `checkDeduplicationStatus()` | A concurrent status check must wait for the same recovery |
| T5 | | If the second check treats recovery as complete, topic load can finish early | Producers can write while dedup state is incomplete |
| T6 | Producers retry previously published sequence IDs | | Missing or partial recovered sequence state can classify duplicates as new messages |

If recovery is retried after a transient failure, the retry must also rebuild from the correct cursor position and a clean local sequence state. Otherwise, the retry can eventually mark deduplication as `Enabled` with incomplete producer sequence maps.

### Modifications

- Move deduplication to `Recovering` before starting cursor replay.
- Track the in-progress recovery with a shared future.
- Make concurrent `checkStatus()` calls wait for the active `Recovering` transition.
- Allow `Failed` status to retry enabling when deduplication should be enabled.
- Rewind the dedup cursor and clear recovered sequence state before each recovery replay.
- Keep enable failures visible by leaving the status as `Failed`.
- Add tests for concurrent recovery waiting and clean retry after failed enable.

### Verifications

```bash
git diff --check
./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.BrokerMessageDeduplicationTest
```
