### PR TITLE
[fix][txn] PIP-473: prune terminal transactions from the metadata buffer cache

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBuffer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.transaction.buffer.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -434,6 +435,12 @@ public class MetadataTransactionBuffer implements TransactionBuffer {
                 // it (e.g. after an in-memory rebuild that lost the set).
                 abortedTxns.add(txnIdKey);
             }
+            // Drop the now-terminal entry so the cache stays bounded by the open-txn count rather
+            // than growing for the segment's lifetime. This is safe: recomputeMaxReadPositionLocked
+            // only consults OPEN entries, and isTxnAborted reads the separate abortedTxns set (an
+            // aborted txn stays there, a committed/unknown one correctly reads as visible). The
+            // positions needed for the durable side-effects below were already captured above.
+            txns.remove(txnIdKey);
         }
 
         // Persist aborted record if this is an abort.
@@ -701,6 +708,14 @@ public class MetadataTransactionBuffer implements TransactionBuffer {
                 }
             }
             return n;
+        }
+    }
+
+    /** Size of the in-memory per-txn cache; bounded by the open-txn count once terminals are pruned. */
+    @VisibleForTesting
+    int trackedTxnCount() {
+        synchronized (lock) {
+            return txns.size();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBufferTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBufferTest.java
@@ -158,6 +158,48 @@ public class MetadataTransactionBufferTest {
     }
 
     @Test
+    public void terminalTxns_prunedFromCache_visibilityUnchanged() throws Exception {
+        // Resolve many transactions (mixed commit/abort) and confirm the in-memory per-txn cache is
+        // pruned back to empty rather than growing for the segment's lifetime, while visibility stays
+        // correct: aborted txns remain filtered (via the durable aborted set) and committed/unknown
+        // txns remain visible.
+        MetadataTransactionBuffer tb = new MetadataTransactionBuffer(topic, txnStore);
+        tb.checkIfTBRecoverCompletely().get();
+
+        int n = 20;
+        TxnID lastAborted = null;
+        Position lastAbortedPos = null;
+        TxnID lastCommitted = null;
+        for (int i = 1; i <= n; i++) {
+            TxnID txnId = new TxnID(1, i);
+            createOpenHeader(txnId);
+            Position p = tb.appendBufferToTxn(txnId, 0, payload("v" + i)).get();
+            if (i % 2 == 0) {
+                commitTxn(txnId);
+                txnStore.publishSegmentEvent(SEGMENT, new TxnEvent(TxnIds.toKey(txnId), TxnState.COMMITTED)).get();
+                lastCommitted = txnId;
+            } else {
+                abortTxn(txnId);
+                txnStore.publishSegmentEvent(SEGMENT, new TxnEvent(TxnIds.toKey(txnId), TxnState.ABORTED)).get();
+                lastAborted = txnId;
+                lastAbortedPos = p;
+            }
+        }
+
+        // Once every txn is terminal, the cache holds nothing (no OPEN txns remain).
+        Awaitility.await().untilAsserted(() -> {
+            assertThat(tb.getOngoingTxnCount()).isZero();
+            assertThat(tb.trackedTxnCount()).isZero();
+        });
+
+        // Visibility correctness survives pruning.
+        assertThat(tb.isTxnAborted(lastAborted, lastAbortedPos)).isTrue();
+        assertThat(tb.isTxnAborted(lastCommitted, PositionFactory.create(1, 0))).isFalse();
+        assertThat(tb.getCommittedTxnCount()).isEqualTo(n / 2);
+        assertThat(tb.getAbortedTxnCount()).isEqualTo(n / 2);
+    }
+
+    @Test
     public void appendToCommittedTxn_failsTxnConflict() throws Exception {
         TxnID txnId = new TxnID(1, 1);
         // Pre-set header to COMMITTED — txn is terminal before any append.


### PR DESCRIPTION
### Motivation

`MetadataTransactionBuffer` kept an in-memory entry for **every** transaction it ever saw (committed and aborted alike) in its `txns` cache, and never removed them — so the map grew unbounded for the segment's lifetime. On long-lived segments with high transaction throughput this is a memory leak.

### Modifications

- `applyTerminalNow`: drop the entry from `txns` once the transaction is terminal, bounding the cache to the current open-transaction count. This is safe:
  - `recomputeMaxReadPositionLocked` only consults `OPEN` entries, so dropping terminal ones doesn't affect the max-read position;
  - `isTxnAborted` reads the **separate** `abortedTxns` set — an aborted txn stays filtered there, and a committed/unknown txn correctly reads as visible;
  - the positions needed for the durable side-effects (aborted record, watermark, op-record cleanup) are captured before the entry is removed.
- Add `trackedTxnCount()` (`@VisibleForTesting`) and a unit test asserting the cache is pruned back to empty after a mix of commits and aborts, while visibility stays correct (aborted filtered, committed visible).

`MetadataPendingAckStore.openTxns` is already pruned on terminal, and `/txn` headers are already GC'd by the coordinator's GC sweep, so this change targets the one remaining unbounded structure.

### Out of scope (follow-up)

The durable per-segment aborted records and the `abortedTxns` set grow only with **aborts** and are meant to be pruned on segment-ledger trim. That trim-driven GC needs a ledger-trim trigger that doesn't exist yet (`TransactionBuffer.purgeTxns` is declared but never invoked anywhere — the legacy buffer no-ops it too), so it's left as a follow-up.

### Verifying this change

- `MetadataTransactionBufferTest` — 13/13 (12 existing + the new `terminalTxns_prunedFromCache_visibilityUnchanged`).
- `V5TransactionTest` end-to-end commit/abort — passing.
- checkstyle clean.

### Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: no
- The schema: no
- The default values of configurations: no
- The threading model: no
- The binary protocol: no
- The REST endpoints: no
- The admin CLI options: no
- Anything that affects deployment: no
