### PR TITLE
[fix][test] PIP-473: deflake TransactionCoordinatorV5Test.sweepTimeouts_abortsExpiredOpenTxnAndFansOut

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/v5/TransactionCoordinatorV5Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/coordinator/v5/TransactionCoordinatorV5Test.java
@@ -281,9 +281,14 @@ public class TransactionCoordinatorV5Test {
 
         List<String> received = new ArrayList<>();
         try (var sub = txnStore.subscribeSegmentEvents(segment, received::add)) {
-            tc.sweepTimeouts().get();
-            var header = txnStore.getHeader(txnIdKey).get().orElseThrow();
-            assertThat(header.value().getState()).isEqualTo(TxnState.ABORTED);
+            // newTransaction and the first sweep can land in the same millisecond on a fast machine,
+            // leaving the 1ms-timeout txn not-yet-expired. The sweep is idempotent, so retry it until
+            // the deadline has elapsed and the txn is aborted.
+            Awaitility.await().untilAsserted(() -> {
+                tc.sweepTimeouts().get();
+                var header = txnStore.getHeader(txnIdKey).get().orElseThrow();
+                assertThat(header.value().getState()).isEqualTo(TxnState.ABORTED);
+            });
             // Fan-out fires for the participant.
             Awaitility.await().untilAsserted(() -> assertThat(received).isNotEmpty());
         }


### PR DESCRIPTION
### Motivation

`sweepTimeouts_abortsExpiredOpenTxnAndFansOut` opens a transaction with a **1 ms** timeout and then immediately runs the timeout sweep once. The expiry check is `deadline (createdAt + 1ms) <= now`, so when `newTransaction` and the sweep land in the same millisecond (common on fast CI), the transaction is not yet expired and stays `OPEN`, failing the assertion intermittently (observed as `expected: ABORTED but was: OPEN`).

### Modifications

- Retry the (idempotent) sweep via `Awaitility` until the header is `ABORTED`, removing the dependence on the sub-millisecond gap between creating the transaction and running the sweep.

### Verifying this change

Test-only. `TransactionCoordinatorV5Test` 22/22 locally.

### Does this pull request potentially affect one of the following parts:

- Anything that affects deployment: no (test-only)

Assisted-by: Claude Code