### PR TITLE
[improve][meta] Upgrade Oxia client to 0.8.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -489,11 +489,13 @@ The Apache Software License, Version 2.0
     - io.dropwizard.metrics-metrics-core-4.1.12.1.jar
     - io.dropwizard.metrics-metrics-graphite-4.1.12.1.jar
     - io.dropwizard.metrics-metrics-jvm-4.1.12.1.jar
+  * Failsafe
+    - dev.failsafe-failsafe-3.3.2.jar
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.github.oxia-db-oxia-client-api-0.7.4.jar
-    - io.github.oxia-db-oxia-client-0.7.4.jar
+    - io.github.oxia-db-oxia-client-api-0.8.0.jar
+    - io.github.oxia-db-oxia-client-0.8.0.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,7 +142,8 @@ jakarta-validation = "3.0.2"
 javax-servlet = "3.1.0"
 jakarta-servlet = "6.0.0"
 # Oxia / etcd
-oxia = "0.7.4"
+oxia = "0.8.0"
+oxia-testcontainers = "0.7.4"
 # Build plugins
 lightproto = "0.7.3"
 errorprone = "2.45.0"
@@ -410,7 +411,7 @@ zt-zip = { module = "org.zeroturnaround:zt-zip", version.ref = "zt-zip" }
 ipaddress = { module = "com.github.seancfoley:ipaddress", version.ref = "ipaddress" }
 # Oxia / etcd
 oxia-client = { module = "io.github.oxia-db:oxia-client", version.ref = "oxia" }
-oxia-testcontainers = { module = "io.github.oxia-db:oxia-testcontainers", version.ref = "oxia" }
+oxia-testcontainers = { module = "io.github.oxia-db:oxia-testcontainers", version.ref = "oxia-testcontainers" }
 # Static analysis
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -223,9 +223,10 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
         try {
             client.rangeScan(firstKey, lastKey, new io.oxia.client.api.RangeScanConsumer() {
                 @Override
-                public void onNext(io.oxia.client.api.GetResult result) {
+                public boolean onNext(io.oxia.client.api.GetResult result) {
                     consumer.onNext(new GetResult(result.value(),
                             convertStat(result.key(), result.version())));
+                    return true;
                 }
 
                 @Override

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -32,7 +32,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.api.AsyncOxiaClient;
-import io.oxia.client.session.SessionFactory;
 import io.oxia.client.session.SessionManager;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -622,8 +621,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         OxiaMetadataStore store = (OxiaMetadataStore) MetadataStoreFactory.create(oxia, config);
         var client = (AsyncOxiaClient) WhiteboxImpl.getInternalState(store, "client");
         var sessionManager = (SessionManager) WhiteboxImpl.getInternalState(client, "sessionManager");
-        var sessionFactory = (SessionFactory) WhiteboxImpl.getInternalState(sessionManager, "factory");
-        var clientConfig = (ClientConfig) WhiteboxImpl.getInternalState(sessionFactory, "config");
+        var clientConfig = (ClientConfig) WhiteboxImpl.getInternalState(sessionManager, "clientConfig");
         var sessionTimeout = clientConfig.sessionTimeout();
         assertEquals(sessionTimeout, Duration.ofSeconds(60));
     }


### PR DESCRIPTION
## Motivation
- Upgrade the Oxia Java client used by Pulsar metadata store to the latest 0.8.0 release.
- Keep the Oxia testcontainers artifact on 0.7.4 because 0.8.0 is not published for that module on Maven Central.

## Modifications
- Bumped `io.github.oxia-db:oxia-client` to 0.8.0 in the Gradle version catalog.
- Split the Oxia testcontainers version so tests continue to resolve the currently published 0.7.4 artifact.
- Updated the binary LICENSE jar entries for the Oxia client artifacts and the new Failsafe runtime dependency.
- Adjusted the Oxia config-loading test to reflect the 0.8.0 client internals after `SessionFactory` was removed.
- Adapted the Oxia range-scan consumer to the 0.8.0 API where `onNext` returns whether scanning should continue.

## Testing
- `./gradlew :pulsar-metadata:compileJava --rerun-tasks`
- `./gradlew :pulsar-metadata:compileTestJava`
- `./gradlew :pulsar-metadata:test --tests org.apache.pulsar.metadata.MetadataStoreTest.testOxiaLoadConfigFromFile`
- `./gradlew :distribution:pulsar-server-distribution:checkBinaryLicense`