### PR TITLE
[improve][meta] Upgrade Oxia client to 0.8.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -278,6 +278,7 @@ The Apache Software License, Version 2.0
     - io.swagger-swagger-annotations-1.6.2.jar
     - io.swagger-swagger-core-1.6.2.jar
     - io.swagger-swagger-models-1.6.2.jar
+ * slog -- io.github.merlimat.slog-slog-0.9.5.jar
  * DataSketches
     - com.yahoo.datasketches-memory-0.8.3.jar
     - com.yahoo.datasketches-sketches-core-0.8.3.jar
@@ -497,8 +498,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.github.oxia-db-oxia-client-api-0.7.4.jar
-    - io.github.oxia-db-oxia-client-0.7.4.jar
+    - io.github.oxia-db-oxia-client-api-0.8.0.jar
+    - io.github.oxia-db-oxia-client-0.8.0.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,8 @@ flexible messaging model and an intuitive client API.</description>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>
-    <oxia.version>0.7.4</oxia.version>
+    <oxia.version>0.8.0</oxia.version>
+    <oxia-testcontainers.version>0.7.4</oxia-testcontainers.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>
@@ -1306,7 +1307,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>io.github.oxia-db</groupId>
         <artifactId>oxia-testcontainers</artifactId>
-        <version>${oxia.version}</version>
+        <version>${oxia-testcontainers.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -32,7 +32,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.oxia.client.ClientConfig;
 import io.oxia.client.api.AsyncOxiaClient;
-import io.oxia.client.session.SessionFactory;
 import io.oxia.client.session.SessionManager;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -621,8 +620,7 @@ public class MetadataStoreTest extends BaseMetadataStoreTest {
         OxiaMetadataStore store = (OxiaMetadataStore) MetadataStoreFactory.create(oxia, config);
         var client = (AsyncOxiaClient) WhiteboxImpl.getInternalState(store, "client");
         var sessionManager = (SessionManager) WhiteboxImpl.getInternalState(client, "sessionManager");
-        var sessionFactory = (SessionFactory) WhiteboxImpl.getInternalState(sessionManager, "factory");
-        var clientConfig = (ClientConfig) WhiteboxImpl.getInternalState(sessionFactory, "config");
+        var clientConfig = (ClientConfig) WhiteboxImpl.getInternalState(sessionManager, "clientConfig");
         var sessionTimeout = clientConfig.sessionTimeout();
         assertEquals(sessionTimeout, Duration.ofSeconds(60));
     }


### PR DESCRIPTION
## Motivation
- Backport #25962 to branch-4.2.
- Keep the Oxia client on 0.8.0 while leaving oxia-testcontainers at 0.7.4 because 0.8.0 is not published for that artifact.

## Modifications
- Updated the Maven Oxia client version to 0.8.0 and split oxia-testcontainers to its own 0.7.4 property.
- Updated binary LICENSE entries for the Oxia 0.8.0 jars.
- Adjusted the Oxia config-file test reflection to read clientConfig from SessionManager.

## Testing
- mvn -pl pulsar-metadata -DskipTests dependency:tree -Dincludes=io.github.oxia-db,dev.failsafe
- mvn -pl pulsar-metadata -am -Pcore-modules,-main -DskipTests -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true -ntp package
- mvn -pl pulsar-metadata -am -Pcore-modules,-main -Dtest=MetadataStoreTest#testOxiaLoadConfigFromFile -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true -ntp test

Note: the targeted TestNG selector completed successfully but reported Tests run: 0, so the effective local validation is the reactor package/test-compile plus dependency and license-entry checks.