### PR TITLE
[fix][ci] Fix CodeQL job which is currently broken

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,6 +30,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
+env:
+  JDK_DISTRIBUTION: corretto
+
 jobs:
   analyze:
     # only run on push and schedule in apache/pulsar repo
@@ -49,14 +52,33 @@ jobs:
         language: [ 'java-kotlin' ]
 
     steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+          java-version: 21
+
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: true
+
+      - name: Configure Gradle for CodeQL
+        run: |
+          cat >> gradle.properties <<'EOF'
+          
+          org.gradle.configuration-cache=false
+          org.gradle.configureondemand=false
+          org.gradle.parallel=false
+          org.gradle.caching=false
+          org.gradle.daemon=false
+          EOF
+
       # Initializes the CodeQL tools for scanning.
-      # Use build-mode: none so CodeQL extracts the source directly instead of
-      # tracing a Gradle build. A traced build fails intermittently because the
-      # Gradle build cache restores compileJava/compileKotlin FROM-CACHE, so no
-      # compiler runs and CodeQL sees no source ("could not process any of it").
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -836,6 +836,7 @@ jobs:
       contents: read
       security-events: write
     env:
+      CI_JDK_MAJOR_VERSION: ${{ needs.preconditions.outputs.jdk_major_version }}
       CODEQL_LANGUAGE: java-kotlin
     steps:
       - name: checkout
@@ -852,10 +853,29 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      # Use build-mode: none so CodeQL extracts the source directly instead of
-      # tracing a Gradle build. A traced build fails intermittently because the
-      # Gradle build cache restores compileJava/compileKotlin FROM-CACHE, so no
-      # compiler runs and CodeQL sees no source ("could not process any of it").
+      - name: Set up JDK ${{ env.CI_JDK_MAJOR_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+          java-version: ${{ env.CI_JDK_MAJOR_VERSION }}
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-read-only: true
+
+      - name: Configure Gradle for CodeQL
+        run: |
+          cat >> gradle.properties <<'EOF'
+          
+          org.gradle.configuration-cache=false
+          org.gradle.configureondemand=false
+          org.gradle.parallel=false
+          org.gradle.caching=false
+          org.gradle.daemon=false
+          EOF
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
### Motivation

The CodeQL job invokes the Gradle build although buildmode is set to `none`. The CodeQL build job currently fails since it pick Java 17 for the Gradle builds. This fails since Pulsar build requires Java 21/25.

### Modifications

- Restore workflow job steps to setup JDK 21/25 and Gradle
- Disable configuration cache, build cache and daemon for Gradle invocations