### PR TITLE
[fix][ci] Prevent Pull Request Labeler from canceling runs across PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# After updating these rules, update .github/workflows/labeler.yml to trigger when a file changes
+# in one of the defined paths.
+
 PIP:
   - changed-files:
       - any-glob-to-any-file: 'pip/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,10 +17,13 @@
 
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  pull_request_target:
+    # only run when a file in a path defined in .github/labeler.yml is changed
+    paths:
+      - 'pip/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Motivation

This PR addresses two problems with the **Pull Request Labeler** workflow
(`.github/workflows/labeler.yml`).

**1. Cross-PR run cancellation.** The workflow triggers on `pull_request_target`. For
`pull_request_target` events, `github.ref` resolves to the **base branch**
(`refs/heads/master`) rather than `refs/pull/<n>/merge` as it would for `pull_request` events.
The concurrency group was:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
```

so it evaluated to the same value — `Pull Request Labeler-refs/heads/master-pull_request_target` —
for **every** open PR targeting `master`. With `cancel-in-progress: true`, a labeler run for one
PR would cancel the in-progress run of an *unrelated* PR, producing errors like:

```
Canceling since a higher priority waiting request for
Pull Request Labeler-refs/heads/master-pull_request_target exists
```

**2. Unnecessary workflow runs.** The workflow ran on every PR, even though the only labeling
rule in `.github/labeler.yml` is the `PIP` label applied to changes under `pip/**`. The vast
majority of PRs touch no `pip/**` file, so the workflow started, did no useful work, and still
contended for the (shared) concurrency group above.

### Modifications

- **Fix cross-PR cancellation:** add the PR number (`github.event.number`) to the concurrency
  group so each PR gets its own group and a new run only cancels earlier runs of the **same** PR.
- **Avoid unnecessary runs (optimization):** restrict the trigger with a `paths` filter to
  changes under `pip/**`, matching the only labeling rule defined in `.github/labeler.yml`. The
  workflow now starts only when a PR actually changes a file it can label, so most PRs no longer
  spin up the labeler at all (and no longer contend for the concurrency group).
- Add a comment in `.github/labeler.yml` documenting the coupling between the rules file and the
  workflow's `paths` filter, so the two are kept in sync when labeling rules change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. It only modifies
GitHub Actions workflow configuration.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
