### PR TITLE
[improve][misc] Make Protobuf v4 the default

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -258,8 +258,8 @@ jobs:
             group: CLIENT
           - name: Pulsar Metadata
             group: METADATA
-          - name: Protobuf v4
-            group: PROTOBUFV4
+          - name: Protobuf v3
+            group: PROTOBUFV3
 
     steps:
       - name: checkout

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -586,8 +586,8 @@ MIT License
     - com.auth0-jwks-rsa-0.23.1.jar
 Protocol Buffers License
  * Protocol Buffers
-   - com.google.protobuf-protobuf-java-3.25.5.jar -- ../licenses/LICENSE-protobuf.txt
-   - com.google.protobuf-protobuf-java-util-3.25.5.jar -- ../licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-4.35.0.jar -- ../licenses/LICENSE-protobuf.txt
+   - com.google.protobuf-protobuf-java-util-4.35.0.jar -- ../licenses/LICENSE-protobuf.txt
 
 CDDL-1.1 -- ../licenses/LICENSE-CDDL-1.1.txt
  * Java Servlet API

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ jetty = "12.1.10"
 jersey = "3.1.10"
 jackson = "2.21.3"
 jackson-annotations = "2.21"
-protobuf = "3.25.5"
+protobuf = "4.35.0"
 grpc = "1.75.0"
 slf4j = "2.0.17"
 slog = "0.9.7"
@@ -473,7 +473,7 @@ datasketches-java = { module = "org.apache.datasketches:datasketches-java", vers
 [plugins]
 lightproto = { id = "io.streamnative.lightproto", version.ref = "lightproto" }
 nar = "io.github.merlimat.nar:0.1.3"
-protobuf = "com.google.protobuf:0.9.6"
+protobuf = "com.google.protobuf:0.10.0"
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 rat = "org.nosphere.apache.rat:0.8.1"
 spotless = "com.diffplug.spotless:8.4.0"

--- a/pulsar-build/run_unit_group_gradle.sh
+++ b/pulsar-build/run_unit_group_gradle.sh
@@ -157,16 +157,16 @@ function test_group_pulsar_io() {
     :pulsar-io:pulsar-io-batch-discovery-triggerers:test
 }
 
-function test_group_protobufv4() {
-  # Rebuild and test with protobuf v4 (overriding the default v3 version)
+function test_group_protobufv3() {
+  # Rebuild and test with protobuf v3 (overriding the default v4 version)
   gradle_test \
-    -PprotobufVersion=4.31.1 \
+    -PprotobufVersion=3.25.5 \
     :pulsar-client-original:test \
     --tests "org.apache.pulsar.client.api.ProtobufSchemaApiSignatureTest" \
     --tests "org.apache.pulsar.client.impl.schema.ProtobufSchemaTest" \
     --tests "org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaTest"
   gradle_test \
-    -PprotobufVersion=4.31.1 \
+    -PprotobufVersion=3.25.5 \
     :pulsar-functions:pulsar-functions-instance:test \
     --tests "org.apache.pulsar.functions.source.TopicSchemaTest" \
     --tests "org.apache.pulsar.functions.instance.JavaInstanceRunnableTest"

--- a/pulsar-functions/utils/build.gradle.kts
+++ b/pulsar-functions/utils/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(libs.protobuf.java.util)
     implementation(libs.byte.buddy)
     implementation(libs.zt.zip)
+    implementation(libs.guava)
 
     testImplementation(libs.wiremock)
     testImplementation(libs.json)


### PR DESCRIPTION
### Motivation

Protobuf switched from v3 to v4 after 3.25.x (the following version was 4.26.0). Since there will be no longer any updates to Protobuf 3.x, it will be necessary to switch to v4 as the default to get further updates to Protobuf.

### Modifications

- Update protobuf to 4.35.0 (latest released)
- Switch the previous v4 test to test Protobuf v3 (3.25.5) for backwards compatibility with Protobuf v3