### PR TITLE
[improve][misc] Upgrade Guava to 33.6.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -268,7 +268,7 @@ The Apache Software License, Version 2.0
     - com.google.code.gson-gson-2.13.2.jar
     - io.gsonfire-gson-fire-1.9.0.jar
  * Guava
-    - com.google.guava-guava-33.4.8-jre.jar
+    - com.google.guava-guava-33.6.0-jre.jar
     - com.google.guava-failureaccess-1.0.3.jar
     - com.google.guava-listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- com.google.j2objc-j2objc-annotations-1.3.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -329,7 +329,7 @@ The Apache Software License, Version 2.0
  * Gson
     - gson-2.13.2.jar
  * Guava
-    - guava-33.4.8-jre.jar
+    - guava-33.6.0-jre.jar
     - failureaccess-1.0.3.jar
     - listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
  * J2ObjC Annotations -- j2objc-annotations-1.3.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ j2objc-annotations = "1.3"
 opencensus = "0.28.0"
 opentelemetry-gcp-resources = "1.57.0-alpha"
 # Data structures / Utils
-guava = "33.4.8-jre"
+guava = "33.6.0-jre"
 caffeine = "3.2.4"
 jctools = "4.0.6"
 roaringbitmap = "1.6.9"


### PR DESCRIPTION
### Motivation

Upgrading Guava before Pulsar 5.0.0-M1
Release notes:
- https://github.com/google/guava/releases/tag/v33.5.0
- https://github.com/google/guava/releases/tag/v33.6.0

### Modifications

- Upgrade Guava to 33.6.0