### PR TITLE
[feat][fn] Add message decoding failure handling

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,6 +52,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -561,10 +563,32 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
         // check record is valid
         if (record == null) {
             throw new IllegalArgumentException("The record returned by the source cannot be null");
-        } else if (record.getValue() == null) {
-            throw new IllegalArgumentException("The value in the record returned by the source cannot be null");
+        }
+        // Eagerly access the value here so a malformed/poison message surfaces with enough
+        // context (message id, topic, key, schema version) to be located and skipped, instead
+        // of bubbling up as an opaque crash that names no message.
+        try {
+            if (record.getValue() == null) {
+                throw new IllegalArgumentException("The value in the record returned by the source cannot be null");
+            }
+        } catch (Exception e) {
+            logInputValueDecodeFailure(record, e);
+            throw e;
         }
         return record;
+    }
+
+    private void logInputValueDecodeFailure(Record<?> record, Exception e) {
+        log.warn()
+                .attr("topic", record.getTopicName().orElse(null))
+                .attr("messageId", record.getMessage().map(m -> String.valueOf(m.getMessageId())).orElse(null))
+                .attr("partitionKey", record.getKey().orElse(null))
+                .attr("schemaVersion", record.getMessage()
+                        .map(Message::getSchemaVersion)
+                        .map(sv -> HexFormat.of().formatHex(sv))
+                        .orElse(null))
+                .exception(e)
+                .log("Failed to decode the value of the input message; the message cannot be processed");
     }
 
     /**

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/JavaInstanceRunnableTest.java
@@ -27,12 +27,14 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.protobuf.Any;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -41,8 +43,11 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -537,6 +542,64 @@ public class JavaInstanceRunnableTest {
                     Assert.assertFalse(fnThread.isAlive());
                     Assert.assertFalse((boolean) getPrivateField(javaInstanceRunnable, "isInitialized"));
                 });
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testReadInputLogsAndRethrowsOnValueDecodeFailure() throws Exception {
+        SchemaSerializationException decodeError = new SchemaSerializationException("boom");
+
+        // Case 1: full message coordinates present -> the original decode exception is rethrown unchanged.
+        Record<?> record = mock(Record.class);
+        when(record.getValue()).thenThrow(decodeError);
+        when(record.getTopicName()).thenReturn(Optional.of("persistent://t/n/topic-partition-0"));
+        when(record.getKey()).thenReturn(Optional.of("eyJpZCI6NjU2MzY0Nn0="));
+        Message<?> message = mock(Message.class);
+        when(message.getMessageId()).thenReturn(new MessageIdImpl(232155494L, 7641L, 0));
+        when(message.getSchemaVersion()).thenReturn(new byte[]{0, 0, 0, 0, 0, 0, 0, 1});
+        when(record.getMessage()).thenReturn((Optional) Optional.of(message));
+
+        JavaInstanceRunnable runnable = createRunnable((String) null);
+        setPrivateSource(runnable, record);
+        InvocationTargetException ite =
+                Assert.expectThrows(InvocationTargetException.class, () -> invokeReadInput(runnable));
+        Assert.assertSame(ite.getCause(), decodeError);
+
+        // Case 2: missing coordinates (empty message, no topic/key) must not NPE and still rethrows.
+        Record<?> record2 = mock(Record.class);
+        when(record2.getValue()).thenThrow(decodeError);
+        when(record2.getTopicName()).thenReturn(Optional.empty());
+        when(record2.getKey()).thenReturn(Optional.empty());
+        when(record2.getMessage()).thenReturn(Optional.empty());
+
+        JavaInstanceRunnable runnable2 = createRunnable((String) null);
+        setPrivateSource(runnable2, record2);
+        InvocationTargetException ite2 =
+                Assert.expectThrows(InvocationTargetException.class, () -> invokeReadInput(runnable2));
+        Assert.assertSame(ite2.getCause(), decodeError);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void setPrivateSource(JavaInstanceRunnable runnable, Record<?> record) throws Exception {
+        Source<?> source = mock(Source.class);
+        when(source.read()).thenReturn((Record) record);
+        Field field = JavaInstanceRunnable.class.getDeclaredField("source");
+        field.setAccessible(true);
+        field.set(runnable, source);
+        field.setAccessible(false);
+    }
+
+    private void invokeReadInput(JavaInstanceRunnable runnable) throws Exception {
+        Method method = JavaInstanceRunnable.class.getDeclaredMethod("readInput");
+        method.setAccessible(true);
+        // readInput()'s finally block resets the context classloader; preserve and restore the
+        // test thread's classloader so it is not left null for subsequent tests.
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        try {
+            method.invoke(runnable);
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes/closes an issue — use "Fixes #xyz" or, equivalently, "Closes #xyz", -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Show error message metadata when function failed to consume the messages.

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment