### PR TITLE
[fix][test] Fix flaky ExtensibleLoadManagerImplTest by re-serving the channel topic in initializeState

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImplBaseTest.java
@@ -200,16 +200,24 @@ public abstract class ExtensibleLoadManagerImplBaseTest extends MockedPulsarServ
     protected void initializeState() throws PulsarAdminException, IllegalAccessException {
         // After a prior test churned leader election, the channel-topic bundle can be left
         // unserved ("not served by this instance"), making the unload's channel publish fail
-        // (HTTP 500) or hang server-side until the background monitor task (120s interval)
-        // reconciles the brokers' roles with the channel ownership. Drive monitor() eagerly to
-        // heal that state, bound each unload attempt (a synchronous unload() can block longer
-        // than the whole retry window), and fail loudly on exhaustion.
+        // (HTTP 500) or hang server-side. monitor() only self-heals when there is *no* channel
+        // owner; it does NOT heal the case where an owner is recorded but the bundle is not
+        // actually served, so the unload below can never publish. Force-serve the channel topic
+        // each attempt: an admin lookup re-assigns the pulsar/system bundle and getStats makes
+        // the owner load the topic (the lookup layer alone can claim an owner that refuses to
+        // serve). Bound each unload attempt and fail loudly on exhaustion.
+        boolean systemTopicChannel =
+                serviceUnitStateTableViewClassName.equals(ServiceUnitStateTableViewImpl.class.getName());
         Awaitility.await().atMost(120, TimeUnit.SECONDS)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .untilAsserted(() -> {
                     primaryLoadManager.monitor();
                     secondaryLoadManager.monitor();
+                    if (systemTopicChannel) {
+                        admin.lookups().lookupTopic(ServiceUnitStateTableViewImpl.TOPIC);
+                        admin.topics().getStats(ServiceUnitStateTableViewImpl.TOPIC);
+                    }
                     admin.namespaces().unloadAsync(defaultTestNamespace).get(15, TimeUnit.SECONDS);
                 });
         reset(primaryLoadManager, secondaryLoadManager);


### PR DESCRIPTION
### Motivation

The `Pulsar CI Flaky` suite has been failing frequently on `ExtensibleLoadManagerImplTest`, with a 2-minute timeout in the `initializeState` `@BeforeMethod` (example run: https://github.com/apache/pulsar/actions/runs/27144684649):

```
org.awaitility.core.ConditionTimeoutException: Assertion condition null within 2 minutes.
    at ...ExtensibleLoadManagerImplBaseTest.initializeState(ExtensibleLoadManagerImplBaseTest.java)
```

**Root cause.** Tests such as `testHandleNoChannelOwner` deliberately churn leader election by closing the `LeaderElectionService` on both brokers. This can leave the channel-topic bundle `pulsar/system/0x00000000_0xffffffff` (which hosts `loadbalancer-service-unit-state`) in an *owner-recorded-but-not-actually-served* state. Every channel operation then fails with `... not served by this instance ... Please redo the lookup`.

`initializeState` (reworked in #25946) drives `monitor()` and retries the namespace unload for 120s, but `monitor()` cannot heal this particular state: `ExtensibleLoadManagerImpl.handleNoChannelOwnerError` only restarts leader election when the channel reports *"no channel owner now"*. When an owner **is** recorded but refuses to serve, no such error is thrown, recovery never triggers, and the unload — which must publish to the channel topic — can never succeed. The 120s budget is exhausted and the `@BeforeMethod` fails, cascading to skipped tests.

### Modifications

In `ExtensibleLoadManagerImplBaseTest.initializeState`, force-serve the channel topic inside the existing retry loop, before the unload:

- `admin.lookups().lookupTopic(...)` re-assigns the `pulsar/system` bundle, and
- `admin.topics().getStats(...)` forces the recorded owner to actually load it (the lookup layer alone can claim an owner that refuses to serve).

This is the same sequence `awaitChannelOwnerStable()` already uses to stabilize after churn, but run on **every** retry attempt so the channel is re-served immediately before each unload — rather than only once in the churn test's `finally`, where the state can degrade again before the next `initializeState`. It is guarded to the `ServiceUnitStateTableViewImpl` (system-topic) variant, matching `awaitChannelOwnerStable`'s own guard; the metadata-store variant has no channel *topic* to serve.

This is a test-side mitigation. The durable fix is product-side — teaching `monitor()` / `handleNoChannelOwnerError` to detect *owner-recorded-but-unserved* and re-assign the bundle — and can follow separately.
