### PR TITLE
[improve][broker] Default managedLedgerMaxReadsInFlightSizeInMB to 15% of direct memory

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1473,13 +1473,16 @@ managedLedgerCursorMaxEntriesPerLedger=50000
 # Max time before triggering a rollover on a cursor ledger
 managedLedgerCursorRolloverTimeInSeconds=14400
 
-# Maximum amount of memory used hold data read from storage (or from the cache).
-# This mechanism prevents the broker to have too many concurrent
-# reads from storage and fall into Out of Memory errors in case
-# of multiple concurrent reads to multiple concurrent consumers.
-# Set 0 in order to disable the feature.
-#
-managedLedgerMaxReadsInFlightSizeInMB=0
+# Maximum buffer size in MB for bytes read from storage (or from the cache).
+# This is the memory retained by data read from storage (or cache) until it has been
+# delivered to the Consumer Netty channel. This provides backpressure for BookKeeper and
+# tiered storage reads, preventing the broker from having too many concurrent reads and
+# running into Out of Memory errors when there are multiple concurrent reads to multiple
+# concurrent consumers.
+# When left unset (empty), it defaults to 15% of available JVM direct memory.
+# Set to 0 to disable the feature.
+# Set to a value greater than 0 to use that many MB.
+managedLedgerMaxReadsInFlightSizeInMB=
 
 # Max number of "acknowledgment holes" that are going to be persistently stored.
 # When acknowledging out of order, a consumer will leave holes that are supposed

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1479,7 +1479,9 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # tiered storage reads, preventing the broker from having too many concurrent reads and
 # running into Out of Memory errors when there are multiple concurrent reads to multiple
 # concurrent consumers.
-# When left unset (empty), it defaults to 15% of available JVM direct memory.
+# When left unset (empty), it defaults to 15% of available JVM direct memory, but never below
+# dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a
+# single read.
 # Set to 0 to disable the feature.
 # Set to a value greater than 0 to use that many MB.
 managedLedgerMaxReadsInFlightSizeInMB=

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1479,9 +1479,9 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # tiered storage reads, preventing the broker from having too many concurrent reads and
 # running into Out of Memory errors when there are multiple concurrent reads to multiple
 # concurrent consumers.
-# When left unset (empty), it defaults to 15% of available JVM direct memory, but never below
-# dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a
-# single read.
+# When left unset (empty), it defaults to the greater of dispatcherMaxReadSizeBytes and 15% of available
+# JVM direct memory; dispatcherMaxReadSizeBytes is the minimum value so the limiter can never block the
+# completion of a single read.
 # Set to 0 to disable the feature.
 # Set to a value greater than 0 to use that many MB.
 managedLedgerMaxReadsInFlightSizeInMB=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -914,6 +914,17 @@ managedLedgerCacheEvictionExtendTTLOfRecentlyAccessed=true
 # The default value is 2 * managedLedgerCacheEvictionTimeThresholdMillis.
 managedLedgerContinueCachingAddedEntriesAfterLastActiveCursorLeavesMillis=
 
+# Maximum buffer size in MB for bytes read from storage (or from the cache).
+# This is the memory retained by data read from storage (or cache) until it has been
+# delivered to the Consumer Netty channel. This provides backpressure for BookKeeper and
+# tiered storage reads, preventing the broker from having too many concurrent reads and
+# running into Out of Memory errors when there are multiple concurrent reads to multiple
+# concurrent consumers.
+# When left unset (empty), it defaults to 15% of available JVM direct memory.
+# Set to 0 to disable the feature.
+# Set to a value greater than 0 to use that many MB.
+managedLedgerMaxReadsInFlightSizeInMB=
+
 # Configure the threshold (in number of entries) from where a cursor should be considered 'backlogged'
 # and thus should be set as inactive.
 # This has no effect when cacheEvictionByExpectedReadCount is enabled.

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -920,7 +920,9 @@ managedLedgerContinueCachingAddedEntriesAfterLastActiveCursorLeavesMillis=
 # tiered storage reads, preventing the broker from having too many concurrent reads and
 # running into Out of Memory errors when there are multiple concurrent reads to multiple
 # concurrent consumers.
-# When left unset (empty), it defaults to 15% of available JVM direct memory.
+# When left unset (empty), it defaults to 15% of available JVM direct memory, but never below
+# dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a
+# single read.
 # Set to 0 to disable the feature.
 # Set to a value greater than 0 to use that many MB.
 managedLedgerMaxReadsInFlightSizeInMB=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -920,9 +920,9 @@ managedLedgerContinueCachingAddedEntriesAfterLastActiveCursorLeavesMillis=
 # tiered storage reads, preventing the broker from having too many concurrent reads and
 # running into Out of Memory errors when there are multiple concurrent reads to multiple
 # concurrent consumers.
-# When left unset (empty), it defaults to 15% of available JVM direct memory, but never below
-# dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a
-# single read.
+# When left unset (empty), it defaults to the greater of dispatcherMaxReadSizeBytes and 15% of available
+# JVM direct memory; dispatcherMaxReadSizeBytes is the minimum value so the limiter can never block the
+# completion of a single read.
 # Set to 0 to disable the feature.
 # Set to a value greater than 0 to use that many MB.
 managedLedgerMaxReadsInFlightSizeInMB=

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2340,7 +2340,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " been delivered to the Consumer Netty channel. This provides backpressure for BookKeeper and tiered"
             + " storage reads, preventing the broker from having too many concurrent reads and running into Out of"
             + " Memory errors when there are multiple concurrent reads to multiple concurrent consumers.\n"
-            + "When left unset (empty), it defaults to 15% of available JVM direct memory.\n"
+            + "When left unset (empty), it defaults to 15% of available JVM direct memory, but never below"
+            + " dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a"
+            + " single read.\n"
             + "Set to 0 to disable the feature.\n"
             + "Set to a value greater than 0 to use that many MB.")
     private Long managedLedgerMaxReadsInFlightSizeInMB = null;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2340,9 +2340,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + " been delivered to the Consumer Netty channel. This provides backpressure for BookKeeper and tiered"
             + " storage reads, preventing the broker from having too many concurrent reads and running into Out of"
             + " Memory errors when there are multiple concurrent reads to multiple concurrent consumers.\n"
-            + "When left unset (empty), it defaults to 15% of available JVM direct memory, but never below"
-            + " dispatcherMaxReadBatchSize * maxMessageSize so the limiter can never block the completion of a"
-            + " single read.\n"
+            + "When left unset (empty), it defaults to the greater of dispatcherMaxReadSizeBytes and 15% of"
+            + " available JVM direct memory; dispatcherMaxReadSizeBytes is the minimum value so the limiter"
+            + " can never block the completion of a single read.\n"
             + "Set to 0 to disable the feature.\n"
             + "Set to a value greater than 0 to use that many MB.")
     private Long managedLedgerMaxReadsInFlightSizeInMB = null;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2335,10 +2335,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
             + "inserting in cache")
     private boolean managedLedgerCacheCopyEntries = false;
 
-    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum buffer size for bytes read from storage."
-            + " This is the memory retained by data read from storage (or cache) until it has been delivered to the"
-            + " Consumer Netty channel. Use O to disable")
-    private long managedLedgerMaxReadsInFlightSizeInMB = 0;
+    @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum buffer size in MB for bytes read from storage"
+            + " (or from the cache). This is the memory retained by data read from storage (or cache) until it has"
+            + " been delivered to the Consumer Netty channel. This provides backpressure for BookKeeper and tiered"
+            + " storage reads, preventing the broker from having too many concurrent reads and running into Out of"
+            + " Memory errors when there are multiple concurrent reads to multiple concurrent consumers.\n"
+            + "When left unset (empty), it defaults to 15% of available JVM direct memory.\n"
+            + "Set to 0 to disable the feature.\n"
+            + "Set to a value greater than 0 to use that many MB.")
+    private Long managedLedgerMaxReadsInFlightSizeInMB = null;
 
     @FieldContext(category = CATEGORY_STORAGE_ML, doc = "Maximum time to wait for acquiring permits for max reads in "
             + "flight when managedLedgerMaxReadsInFlightSizeInMB is set (>0) and the limit is reached.")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -94,8 +94,12 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         Long managedLedgerMaxReadsInFlightSizeInMB = conf.getManagedLedgerMaxReadsInFlightSizeInMB();
         final long managedLedgerMaxReadsInFlightSizeBytes;
         if (managedLedgerMaxReadsInFlightSizeInMB == null) {
-            // When unset, default to 15% of the available JVM direct memory.
-            managedLedgerMaxReadsInFlightSizeBytes = (long) (0.15d * DirectMemoryUtils.jvmMaxDirectMemory());
+            // When unset, default to 15% of the available JVM direct memory, but never below the size of a
+            // single full read (dispatcherMaxReadBatchSize entries of maxMessageSize bytes) so that the
+            // limiter can never block the completion of one read.
+            long fractionOfDirectMemory = (long) (0.15d * DirectMemoryUtils.jvmMaxDirectMemory());
+            long singleReadMaxSize = (long) conf.getDispatcherMaxReadBatchSize() * conf.getMaxMessageSize();
+            managedLedgerMaxReadsInFlightSizeBytes = Math.max(fractionOfDirectMemory, singleReadMaxSize);
         } else {
             // An explicit 0 disables the feature; an explicit value > 0 is used as-is.
             managedLedgerMaxReadsInFlightSizeBytes = managedLedgerMaxReadsInFlightSizeInMB * 1024L * 1024L;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.broker.storage.ManagedLedgerStorage;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.common.policies.data.EnsemblePlacementPolicyConfig;
 import org.apache.pulsar.common.stats.CacheMetricsCollector;
+import org.apache.pulsar.common.util.DirectMemoryUtils;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 
 @CustomLog
@@ -90,11 +91,20 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
             );
         }
         managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
-        long managedLedgerMaxReadsInFlightSizeBytes = conf.getManagedLedgerMaxReadsInFlightSizeInMB() * 1024L * 1024L;
+        Long managedLedgerMaxReadsInFlightSizeInMB = conf.getManagedLedgerMaxReadsInFlightSizeInMB();
+        final long managedLedgerMaxReadsInFlightSizeBytes;
+        if (managedLedgerMaxReadsInFlightSizeInMB == null) {
+            // When unset, default to 15% of the available JVM direct memory.
+            managedLedgerMaxReadsInFlightSizeBytes = (long) (0.15d * DirectMemoryUtils.jvmMaxDirectMemory());
+        } else {
+            // An explicit 0 disables the feature; an explicit value > 0 is used as-is.
+            managedLedgerMaxReadsInFlightSizeBytes = managedLedgerMaxReadsInFlightSizeInMB * 1024L * 1024L;
+        }
         if (managedLedgerMaxReadsInFlightSizeBytes > 0 && conf.getDispatcherMaxReadSizeBytes() > 0
                 && managedLedgerMaxReadsInFlightSizeBytes < conf.getDispatcherMaxReadSizeBytes()) {
             log.warn()
-                    .attr("managedLedgerMaxReadsInFlightSizeInMB", conf.getManagedLedgerMaxReadsInFlightSizeInMB())
+                    .attr("managedLedgerMaxReadsInFlightSizeInMB",
+                            managedLedgerMaxReadsInFlightSizeBytes / (1024L * 1024L))
                     .attr("dispatcherMaxReadSizeBytes", conf.getDispatcherMaxReadSizeBytes())
                     .attr("minManagedLedgerMaxReadsInFlightSizeInMB",
                             (conf.getDispatcherMaxReadSizeBytes() / (1024L * 1024L)) + 1)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/ManagedLedgerClientFactory.java
@@ -92,30 +92,33 @@ public class ManagedLedgerClientFactory implements ManagedLedgerStorage {
         }
         managedLedgerFactoryConfig.setCopyEntriesInCache(conf.isManagedLedgerCacheCopyEntries());
         Long managedLedgerMaxReadsInFlightSizeInMB = conf.getManagedLedgerMaxReadsInFlightSizeInMB();
+        // A single dispatcher read can retain up to dispatcherMaxReadSizeBytes bytes. The in-flight reads
+        // limit must be at least this size, otherwise the limiter can block the completion of a single read.
+        long dispatcherMaxReadSizeBytes = conf.getDispatcherMaxReadSizeBytes();
         final long managedLedgerMaxReadsInFlightSizeBytes;
         if (managedLedgerMaxReadsInFlightSizeInMB == null) {
-            // When unset, default to 15% of the available JVM direct memory, but never below the size of a
-            // single full read (dispatcherMaxReadBatchSize entries of maxMessageSize bytes) so that the
-            // limiter can never block the completion of one read.
+            // When unset, default to 15% of the available JVM direct memory, but never below the maximum
+            // size of a single read (dispatcherMaxReadSizeBytes) so that the limiter can never block the
+            // completion of one read.
             long fractionOfDirectMemory = (long) (0.15d * DirectMemoryUtils.jvmMaxDirectMemory());
-            long singleReadMaxSize = (long) conf.getDispatcherMaxReadBatchSize() * conf.getMaxMessageSize();
-            managedLedgerMaxReadsInFlightSizeBytes = Math.max(fractionOfDirectMemory, singleReadMaxSize);
+            managedLedgerMaxReadsInFlightSizeBytes = Math.max(fractionOfDirectMemory, dispatcherMaxReadSizeBytes);
         } else {
             // An explicit 0 disables the feature; an explicit value > 0 is used as-is.
             managedLedgerMaxReadsInFlightSizeBytes = managedLedgerMaxReadsInFlightSizeInMB * 1024L * 1024L;
-        }
-        if (managedLedgerMaxReadsInFlightSizeBytes > 0 && conf.getDispatcherMaxReadSizeBytes() > 0
-                && managedLedgerMaxReadsInFlightSizeBytes < conf.getDispatcherMaxReadSizeBytes()) {
-            log.warn()
-                    .attr("managedLedgerMaxReadsInFlightSizeInMB",
-                            managedLedgerMaxReadsInFlightSizeBytes / (1024L * 1024L))
-                    .attr("dispatcherMaxReadSizeBytes", conf.getDispatcherMaxReadSizeBytes())
-                    .attr("minManagedLedgerMaxReadsInFlightSizeInMB",
-                            (conf.getDispatcherMaxReadSizeBytes() / (1024L * 1024L)) + 1)
-                    .log("Invalid configuration:"
-                            + " managedLedgerMaxReadsInFlightSizeInMB in bytes"
-                            + " should be greater than"
-                            + " dispatcherMaxReadSizeBytes");
+            // Warn when the feature is enabled but manually configured below the size of a single read, since
+            // the limiter would then be unable to admit one read. Disabled (0) is ignored.
+            if (managedLedgerMaxReadsInFlightSizeBytes > 0 && dispatcherMaxReadSizeBytes > 0
+                    && managedLedgerMaxReadsInFlightSizeBytes < dispatcherMaxReadSizeBytes) {
+                log.warn()
+                        .attr("managedLedgerMaxReadsInFlightSizeInMB", managedLedgerMaxReadsInFlightSizeInMB)
+                        .attr("dispatcherMaxReadSizeBytes", dispatcherMaxReadSizeBytes)
+                        .attr("minManagedLedgerMaxReadsInFlightSizeInMB",
+                                (dispatcherMaxReadSizeBytes + (1024L * 1024L) - 1) / (1024L * 1024L))
+                        .log("Invalid configuration:"
+                                + " managedLedgerMaxReadsInFlightSizeInMB in bytes should be greater than or"
+                                + " equal to dispatcherMaxReadSizeBytes, otherwise the in-flight reads limiter"
+                                + " can block the completion of a single read.");
+            }
         }
         managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightSize(managedLedgerMaxReadsInFlightSizeBytes);
         managedLedgerFactoryConfig.setManagedLedgerMaxReadsInFlightPermitsAcquireTimeoutMillis(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionBrokerCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionBrokerCacheTest.java
@@ -100,7 +100,7 @@ public class KeySharedSubscriptionBrokerCacheTest extends ProducerConsumerBase {
         // Important: this is currently necessary to make use of cache for replay queue reads
         conf.setCacheEvictionByMarkDeletedPosition(true);
 
-        conf.setManagedLedgerMaxReadsInFlightSizeInMB(100);
+        conf.setManagedLedgerMaxReadsInFlightSizeInMB(100L);
         conf.setDispatcherRetryBackoffInitialTimeInMs(0);
         conf.setDispatcherRetryBackoffMaxTimeInMs(0);
         conf.setKeySharedUnblockingIntervalMs(0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionDisabledBrokerCacheTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionDisabledBrokerCacheTest.java
@@ -94,7 +94,7 @@ public class KeySharedSubscriptionDisabledBrokerCacheTest extends ProducerConsum
         this.conf.setUnblockStuckSubscriptionEnabled(false);
         this.conf.setSubscriptionKeySharedUseConsistentHashing(true);
         conf.setManagedLedgerCacheSizeMB(0);
-        conf.setManagedLedgerMaxReadsInFlightSizeInMB(0);
+        conf.setManagedLedgerMaxReadsInFlightSizeInMB(0L);
         conf.setDispatcherRetryBackoffInitialTimeInMs(0);
         conf.setDispatcherRetryBackoffMaxTimeInMs(0);
         conf.setKeySharedUnblockingIntervalMs(0);


### PR DESCRIPTION
### Motivation

`managedLedgerMaxReadsInFlightSizeInMB` controls the `InflightReadsLimiter`, which bounds the memory retained by data read from BookKeeper (or the cache) until it has been delivered to the consumer's Netty channel. It is the mechanism that provides [backpressure](https://github.com/apache/pulsar/blob/master/ARCHITECTURE.md#backpressure) for BookKeeper reads and tiered storage reads.

The current default is `0`, which **disables** the limiter. With no limit in place there is no backpressure on the read path: under many concurrent reads to many consumers — especially with large entries, catch-up reads, or tiered storage reads — the broker can accumulate unbounded read buffers and run into direct-memory OOM and broker stability issues.

The next release is the **Pulsar 5.0 LTS**, which makes it the right time to change this default. Shipping a sane, bounded default in an LTS gives operators safe out-of-the-box read backpressure instead of an unbounded read path. A conservative fraction of direct memory keeps the limiter coordinated with the existing `managedLedgerCacheSizeMB` default (20% of direct memory) and the broker's overall direct-memory budget.

### Modifications

- `managedLedgerMaxReadsInFlightSizeInMB` now defaults to **unset** (`null` in `ServiceConfiguration`, empty value in `conf/broker.conf` / `conf/standalone.conf`). When unset, the broker resolves the in-flight read limit to:

  ```
  managedLedgerMaxReadsInFlightSizeInBytes = max(0.15 * maxDirectMemoryInBytes, dispatcherMaxReadSizeBytes)
  ```

  - The `0.15 * maxDirectMemory` term provides the read-memory budget (15% of `DirectMemoryUtils.jvmMaxDirectMemory()`).
  - `dispatcherMaxReadSizeBytes` (the per-read byte limit, 5MB by default) is the **minimum**, guaranteeing the limit is always large enough to admit a single read so the limiter can never block the completion of one read (relevant on small-heap brokers where 15% of direct memory could otherwise be smaller than one read).
- An explicit `0` still **disables** the feature; an explicit value `> 0` is used as the buffer size in MB (unchanged semantics).
- When the feature is manually enabled (`> 0`) but configured below `dispatcherMaxReadSizeBytes`, the broker now logs a warning at startup (the disabled case is ignored), since the limiter would otherwise be too small to admit a single read.
- The field type changed from `long` to `Long` so the unset state can be represented; the resolution from the configured value to bytes is done in `ManagedLedgerClientFactory`. The only in-tree caller of the getter is updated accordingly.
- Documentation for the setting is made consistent across `ServiceConfiguration.java`, `conf/broker.conf` and `conf/standalone.conf`; `standalone.conf` gains the previously-missing entry.

### Verifying this change

This change is already covered by existing tests, such as the managed-ledger / Key_Shared broker cache tests (`KeySharedSubscriptionBrokerCacheTest`, `KeySharedSubscriptionDisabledBrokerCacheTest`), which exercise the limiter with explicit values. Those two tests are updated to pass `long` literals (`100L` / `0L`) to the now-`Long` setter. The default-resolution path (`null` → `max(15% direct memory, dispatcherMaxReadSizeBytes)`, `0` → disabled, `> 0` → MB with a warning when below `dispatcherMaxReadSizeBytes`) is covered by the broker startup wiring in `ManagedLedgerClientFactory`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] The default values of configurations
- [x] Anything that affects deployment

The default of `managedLedgerMaxReadsInFlightSizeInMB` changes from `0` (disabled) to unset = `max(15% of JVM direct memory, dispatcherMaxReadSizeBytes)`, enabling read backpressure by default. Operators who want the previous behavior can set `managedLedgerMaxReadsInFlightSizeInMB=0` explicitly. The `ServiceConfiguration` getter/setter type changes from `long` to `Long`.
