### PR TITLE
[fix][broker] Apply dedup disable after recovery

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -161,6 +161,9 @@ public class MessageDeduplication {
         boolean shouldBeEnabled = topic.isDeduplicationEnabled();
         synchronized (this) {
             if (status == Status.Recovering) {
+                if (!shouldBeEnabled) {
+                    return statusChangeFuture.handle((__, e) -> null).thenCompose(__ -> checkStatus());
+                }
                 return statusChangeFuture;
             }
             if (status == Status.Removing) {
@@ -191,7 +194,7 @@ public class MessageDeduplication {
                 }, null);
             }
 
-            if (status == Status.Enabled && !shouldBeEnabled) {
+            if ((status == Status.Enabled || status == Status.Failed) && !shouldBeEnabled) {
                 // Disabled deduping
                 CompletableFuture<Void> future = new CompletableFuture<>();
                 status = Status.Removing;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/BrokerMessageDeduplicationTest.java
@@ -56,6 +56,7 @@ import org.testng.annotations.Test;
 public class BrokerMessageDeduplicationTest {
 
     private ManagedLedger managedLedger;
+    private PersistentTopic topic;
     private MessageDeduplication deduplication;
     private ScheduledExecutorService executor;
 
@@ -68,9 +69,9 @@ public class BrokerMessageDeduplicationTest {
         executor = Executors.newScheduledThreadPool(1, new ExecutorProvider.ExtendedThreadFactory("pulsar"));
         doReturn(executor).when(pulsarService).getExecutor();
         managedLedger = mock(ManagedLedger.class);
-        final var mockTopic = mock(PersistentTopic.class);
-        doReturn(true).when(mockTopic).isDeduplicationEnabled();
-        deduplication = spy(new MessageDeduplication(pulsarService, mockTopic, managedLedger));
+        topic = mock(PersistentTopic.class);
+        doReturn(true).when(topic).isDeduplicationEnabled();
+        deduplication = spy(new MessageDeduplication(pulsarService, topic, managedLedger));
         doReturn(true).when(deduplication).isEnabled();
     }
 
@@ -161,6 +162,83 @@ public class BrokerMessageDeduplicationTest {
         secondCheckStatus.get(3, TimeUnit.SECONDS);
         assertEquals(String.valueOf(deduplication.getStatus()), "Enabled");
         verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
+    }
+
+    @Test
+    public void checkStatusDisablesAfterRecoveryCompletesWhenPolicyChanges() throws Exception {
+        final var cursor = mock(ManagedCursor.class);
+        final var shouldEnableDeduplication = new AtomicReference<>(true);
+        final var openCursorCallback = new AtomicReference<AsyncCallbacks.OpenCursorCallback>();
+        doAnswer(invocation -> shouldEnableDeduplication.get()).when(topic).isDeduplicationEnabled();
+        doAnswer(invocation -> {
+            openCursorCallback.set(invocation.getArgument(1));
+            return null;
+        }).when(managedLedger).asyncOpenCursor(any(), any(), any());
+        doAnswer(invocation -> {
+            ((AsyncCallbacks.DeleteCursorCallback) invocation.getArgument(1)).deleteCursorComplete(null);
+            return null;
+        }).when(managedLedger).asyncDeleteCursor(any(), any(), any());
+        doReturn(Map.of("from-snapshot", 10L)).when(cursor).getProperties();
+        doReturn(false).when(cursor).hasMoreEntries();
+
+        final var enableFuture = deduplication.checkStatus();
+        assertFalse(enableFuture.isDone());
+        assertEquals(String.valueOf(deduplication.getStatus()), "Recovering");
+
+        shouldEnableDeduplication.set(false);
+        final var disableFuture = deduplication.checkStatus();
+        assertFalse(disableFuture.isDone());
+        verify(managedLedger, times(1)).asyncOpenCursor(any(), any(), any());
+
+        openCursorCallback.get().openCursorComplete(cursor, null);
+        enableFuture.get(3, TimeUnit.SECONDS);
+        disableFuture.get(3, TimeUnit.SECONDS);
+
+        assertEquals(String.valueOf(deduplication.getStatus()), "Disabled");
+        assertEquals(deduplication.getLastPublishedSequenceId("from-snapshot"), -1L);
+        verify(managedLedger, times(1)).asyncDeleteCursor(any(), any(), any());
+    }
+
+    @Test
+    public void checkStatusDisablesAfterRecoveryFailsWhenPolicyChanges() throws Exception {
+        final var cursor = mock(ManagedCursor.class);
+        final var shouldEnableDeduplication = new AtomicReference<>(true);
+        final var openCursorCallback = new AtomicReference<AsyncCallbacks.OpenCursorCallback>();
+        doAnswer(invocation -> shouldEnableDeduplication.get()).when(topic).isDeduplicationEnabled();
+        doAnswer(invocation -> {
+            openCursorCallback.set(invocation.getArgument(1));
+            return null;
+        }).when(managedLedger).asyncOpenCursor(any(), any(), any());
+        doAnswer(invocation -> {
+            ((AsyncCallbacks.DeleteCursorCallback) invocation.getArgument(1)).deleteCursorComplete(null);
+            return null;
+        }).when(managedLedger).asyncDeleteCursor(any(), any(), any());
+        doReturn(Map.of()).when(cursor).getProperties();
+        doReturn(true).when(cursor).hasMoreEntries();
+        doAnswer(invocation -> {
+            throw new RuntimeException("asyncReadEntries failed");
+        }).when(cursor).asyncReadEntries(anyInt(), anyLong(), any(), any(), any());
+
+        final var enableFuture = deduplication.checkStatus();
+        assertFalse(enableFuture.isDone());
+        assertEquals(String.valueOf(deduplication.getStatus()), "Recovering");
+
+        shouldEnableDeduplication.set(false);
+        final var disableFuture = deduplication.checkStatus();
+        assertFalse(disableFuture.isDone());
+
+        openCursorCallback.get().openCursorComplete(cursor, null);
+        try {
+            enableFuture.get(3, TimeUnit.SECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof RuntimeException);
+            assertTrue(e.getMessage().contains("asyncReadEntries failed"));
+        }
+        disableFuture.get(3, TimeUnit.SECONDS);
+
+        assertEquals(String.valueOf(deduplication.getStatus()), "Disabled");
+        verify(managedLedger, times(1)).asyncDeleteCursor(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Message deduplication recovery now returns the active recovery future when another `checkStatus()` call observes `Recovering`. However, if the topic policy changes to disable deduplication while recovery is still in progress, the second check only waits for the recovery future and does not apply the new disabled target state.

As a result, recovery can complete as `Enabled`, leaving deduplication active until another status check happens.

### Modifications

- Re-check deduplication status after an in-progress recovery completes when the desired policy has changed to disabled.
- Allow disabled policy handling to clean up from `Failed` status as well as `Enabled`.
- Add broker deduplication state-machine tests for policy changes during successful and failed recovery.

### Verifying this change

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.BrokerMessageDeduplicationTest --rerun-tasks`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment