### PR TITLE
[improve][broker] Trim orphaned bucket snapshots when ledgers are deleted

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -641,6 +641,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         }
 
         long cutoffTime = getCutoffTime();
+        Long firstLiveLedgerId = firstActiveLedgerId();
 
         lastMutableBucket.moveScheduledMessageToSharedQueue(cutoffTime, sharedBucketPriorityQueue);
 
@@ -649,12 +650,15 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
         while (n > 0 && !sharedBucketPriorityQueue.isEmpty()) {
             long timestamp = sharedBucketPriorityQueue.peekN1();
+            long ledgerId = sharedBucketPriorityQueue.peekN2();
+            long entryId = sharedBucketPriorityQueue.peekN3();
+            if (firstLiveLedgerId != null && ledgerId < firstLiveLedgerId && !containsMessage(ledgerId, entryId)) {
+                sharedBucketPriorityQueue.pop();
+                continue;
+            }
             if (timestamp > cutoffTime) {
                 break;
             }
-
-            long ledgerId = sharedBucketPriorityQueue.peekN2();
-            long entryId = sharedBucketPriorityQueue.peekN3();
 
             SnapshotKey snapshotKey = new SnapshotKey(ledgerId, entryId);
 
@@ -773,16 +777,21 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         // Reuse trimFuture to block new triggers until the clear chain completes.
         CompletableFuture<Void> before = trimFuture != null && !trimFuture.isDone()
                 ? trimFuture : CompletableFuture.completedFuture(null);
-        trimFuture = before.thenCompose(__ -> {
-            synchronized (BucketDelayedDeliveryTracker.this) {
-                CompletableFuture<Void> future = cleanImmutableBuckets();
-                sharedBucketPriorityQueue.clear();
-                lastMutableBucket.clear();
-                snapshotSegmentLastIndexMap.clear();
-                numberDelayedMessages.set(0);
-                return future;
-            }
-        });
+        trimFuture = before
+                .exceptionally(t -> {
+                    log.warn().exception(t).log("Trim/merge buckets failed, but still clear");
+                    return null;
+                })
+                .thenCompose(__ -> {
+                    synchronized (BucketDelayedDeliveryTracker.this) {
+                        CompletableFuture<Void> future = cleanImmutableBuckets();
+                        sharedBucketPriorityQueue.clear();
+                        lastMutableBucket.clear();
+                        snapshotSegmentLastIndexMap.clear();
+                        numberDelayedMessages.set(0);
+                        return future;
+                    }
+                });
         return trimFuture;
     }
 
@@ -847,14 +856,11 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
      * to avoid wasted work when storage is unavailable.
      */
     private synchronized CompletableFuture<Void> asyncTrimImmutableBuckets() {
-        ManagedLedger ledger = context.getCursor().getManagedLedger();
-        if (ledger == null || ledger.getLedgersInfo().isEmpty()) {
-            return CompletableFuture.completedFuture(null);
-        }
-        Long firstLedgerId = ledger.getLedgersInfo().firstKey();
+        Long firstLedgerId = firstActiveLedgerId();
         if (null == firstLedgerId) {
             return CompletableFuture.completedFuture(null);
         }
+        ManagedLedger ledger = context.getCursor().getManagedLedger();
 
         Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets = immutableBuckets.asMapOfRanges().entrySet().stream()
                 .filter(e -> e.getKey().upperEndpoint() < firstLedgerId)
@@ -875,23 +881,28 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private CompletableFuture<Void> deleteBucketSnapshot(String ledgerName,
                                                           Range<Long> range, ImmutableBucket bucket) {
-        synchronized (this) {
-            immutableBuckets.remove(range);
-            numberDelayedMessages.addAndGet(-bucket.getNumberBucketDelayedMessages());
-        }
         return bucket.asyncDeleteBucketSnapshot(stats)
                 .handle((__, t) -> {
                     if (t != null) {
                         log.warn().attr("LedgerName", ledgerName)
                                 .attr("BucketKey", bucket.bucketKey())
                                 .log("Failed to delete bucket snapshot");
-                        synchronized (this) {
-                            immutableBuckets.put(range, bucket);
-                            numberDelayedMessages.addAndGet(bucket.getNumberBucketDelayedMessages());
-                        }
                         throw new CompletionException(t);
+                    }
+                    synchronized (this) {
+                        snapshotSegmentLastIndexMap.entrySet().removeIf(entry -> entry.getValue() == bucket);
+                        immutableBuckets.remove(range);
+                        numberDelayedMessages.addAndGet(-bucket.getNumberBucketDelayedMessages());
                     }
                     return null;
                 });
+    }
+
+    private Long firstActiveLedgerId() {
+        ManagedLedger ledger = context.getCursor().getManagedLedger();
+        if (ledger == null || ledger.getLedgersInfo().isEmpty()) {
+            return null;
+        }
+        return ledger.getLedgersInfo().firstKey();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -39,6 +39,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +49,7 @@ import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.commons.collections4.CollectionUtils;
@@ -114,6 +116,8 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     private final BucketDelayedMessageIndexStats stats;
 
     private CompletableFuture<Void> pendingLoad = null;
+
+    private volatile CompletableFuture<Void> trimFuture;
 
     public BucketDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher,
                                         Timer timer, long tickTimeMillis,
@@ -409,8 +413,15 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             afterCreateImmutableBucket(immutableBucketDelayedIndexPair, createStartTime);
             lastMutableBucket.resetLastMutableBucketRange();
 
-            if (maxNumBuckets > 0 && immutableBuckets.asMapOfRanges().size() > maxNumBuckets) {
-                asyncMergeBucketSnapshot();
+            if (maxNumBuckets > 0 && immutableBuckets.asMapOfRanges().size() > maxNumBuckets
+                    && (trimFuture == null || trimFuture.isDone())) {
+                trimFuture = asyncTrimImmutableBuckets()
+                        .thenCompose(ignore -> asyncMergeBucketSnapshot())
+                        .whenComplete((ignore, t) -> {
+                            if (t != null) {
+                                log.warn().exception(t).log("Failed to trim or merge bucket snapshots");
+                            }
+                        });
             }
         }
 
@@ -473,6 +484,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private synchronized CompletableFuture<Void> asyncMergeBucketSnapshot() {
         List<ImmutableBucket> immutableBucketList = immutableBuckets.asMapOfRanges().values().stream().toList();
+        if (maxNumBuckets <= 0 || immutableBucketList.size() <= maxNumBuckets) {
+            return CompletableFuture.completedFuture(null);
+        }
+
         List<ImmutableBucket> toBeMergeImmutableBuckets = selectMergedBuckets(immutableBucketList, MAX_MERGE_NUM);
 
         if (toBeMergeImmutableBuckets.isEmpty()) {
@@ -754,12 +769,21 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     @Override
     public synchronized CompletableFuture<Void> clear() {
-        CompletableFuture<Void> future = cleanImmutableBuckets();
-        sharedBucketPriorityQueue.clear();
-        lastMutableBucket.clear();
-        snapshotSegmentLastIndexMap.clear();
-        numberDelayedMessages.set(0);
-        return future;
+        // Wait for any in-flight trim+merge to settle, then clear.
+        // Reuse trimFuture to block new triggers until the clear chain completes.
+        CompletableFuture<Void> before = trimFuture != null && !trimFuture.isDone()
+                ? trimFuture : CompletableFuture.completedFuture(null);
+        trimFuture = before.thenCompose(__ -> {
+            synchronized (BucketDelayedDeliveryTracker.this) {
+                CompletableFuture<Void> future = cleanImmutableBuckets();
+                sharedBucketPriorityQueue.clear();
+                lastMutableBucket.clear();
+                snapshotSegmentLastIndexMap.clear();
+                numberDelayedMessages.set(0);
+                return future;
+            }
+        });
+        return trimFuture;
     }
 
     @Override
@@ -815,5 +839,59 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         });
         stats.recordBucketSnapshotSizeBytes(totalSnapshotLength.longValue());
         return stats.genTopicMetricMap();
+    }
+
+    /**
+     * Delete orphaned bucket snapshots whose ledger range lies entirely before the earliest
+     * surviving ledger. Buckets are deleted sequentially; the chain stops on first failure
+     * to avoid wasted work when storage is unavailable.
+     */
+    private synchronized CompletableFuture<Void> asyncTrimImmutableBuckets() {
+        ManagedLedger ledger = context.getCursor().getManagedLedger();
+        if (ledger == null || ledger.getLedgersInfo().isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        Long firstLedgerId = ledger.getLedgersInfo().firstKey();
+        if (null == firstLedgerId) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets = immutableBuckets.asMapOfRanges().entrySet().stream()
+                .filter(e -> e.getKey().upperEndpoint() < firstLedgerId)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (toBeDeletedBuckets.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        String ledgerName = ledger.getName();
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+        for (Map.Entry<Range<Long>, ImmutableBucket> entry : toBeDeletedBuckets.entrySet()) {
+            chain = chain.thenCompose(__ ->
+                    deleteBucketSnapshot(ledgerName, entry.getKey(), entry.getValue()));
+        }
+        return chain;
+    }
+
+    private CompletableFuture<Void> deleteBucketSnapshot(String ledgerName,
+                                                          Range<Long> range, ImmutableBucket bucket) {
+        synchronized (this) {
+            immutableBuckets.remove(range);
+            numberDelayedMessages.addAndGet(-bucket.getNumberBucketDelayedMessages());
+        }
+        return bucket.asyncDeleteBucketSnapshot(stats)
+                .handle((__, t) -> {
+                    if (t != null) {
+                        log.warn().attr("LedgerName", ledgerName)
+                                .attr("BucketKey", bucket.bucketKey())
+                                .log("Failed to delete bucket snapshot");
+                        synchronized (this) {
+                            immutableBuckets.put(range, bucket);
+                            numberDelayedMessages.addAndGet(bucket.getNumberBucketDelayedMessages());
+                        }
+                        throw new CompletionException(t);
+                    }
+                    return null;
+                });
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -652,8 +652,11 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             long timestamp = sharedBucketPriorityQueue.peekN1();
             long ledgerId = sharedBucketPriorityQueue.peekN2();
             long entryId = sharedBucketPriorityQueue.peekN3();
-            if (firstLiveLedgerId != null && ledgerId < firstLiveLedgerId && !containsMessage(ledgerId, entryId)) {
+            if (firstLiveLedgerId != null && ledgerId < firstLiveLedgerId) {
                 sharedBucketPriorityQueue.pop();
+                if (removeIndexBit(ledgerId, entryId)) {
+                    numberDelayedMessages.decrementAndGet();
+                }
                 continue;
             }
             if (timestamp > cutoffTime) {
@@ -862,9 +865,8 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         }
         ManagedLedger ledger = context.getCursor().getManagedLedger();
 
-        Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets = immutableBuckets.asMapOfRanges().entrySet().stream()
-                .filter(e -> e.getKey().upperEndpoint() < firstLedgerId)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets =
+                new HashMap<>(immutableBuckets.subRangeMap(Range.lessThan(firstLedgerId)).asMapOfRanges());
 
         if (toBeDeletedBuckets.isEmpty()) {
             return CompletableFuture.completedFuture(null);
@@ -899,10 +901,8 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     }
 
     private Long firstActiveLedgerId() {
-        ManagedLedger ledger = context.getCursor().getManagedLedger();
-        if (ledger == null || ledger.getLedgersInfo().isEmpty()) {
-            return null;
-        }
-        return ledger.getLedgersInfo().firstKey();
+        ManagedCursor cursor = context.getCursor();
+        Position mdp = cursor.getMarkDeletedPosition();
+        return mdp == null ? null : mdp.getLedgerId();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -40,6 +40,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -475,10 +476,13 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
     private static class TrackerWithStorage {
         final BucketDelayedDeliveryTracker tracker;
         final MockBucketSnapshotStorage storage;
+        final AtomicLong clockTime;
 
-        TrackerWithStorage(BucketDelayedDeliveryTracker tracker, MockBucketSnapshotStorage storage) {
+        TrackerWithStorage(BucketDelayedDeliveryTracker tracker, MockBucketSnapshotStorage storage,
+                           AtomicLong clockTime) {
             this.tracker = tracker;
             this.storage = storage;
+            this.clockTime = clockTime;
         }
 
         void close() throws Exception {
@@ -487,9 +491,27 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
     }
 
+    private static class BlockingDeleteStorage extends MockBucketSnapshotStorage {
+        final CompletableFuture<Void> firstDeleteFuture = new CompletableFuture<>();
+        final AtomicLong deleteCalls = new AtomicLong();
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            if (deleteCalls.incrementAndGet() <= 4) {
+                return firstDeleteFuture;
+            }
+            return super.deleteBucketSnapshot(bucketId);
+        }
+    }
+
     private TrackerWithStorage createTrackerWithMockLedger(long firstLedgerId, int maxNumBuckets)
             throws Exception {
-        MockBucketSnapshotStorage storage = new MockBucketSnapshotStorage();
+        return createTrackerWithMockLedger(firstLedgerId, maxNumBuckets, new MockBucketSnapshotStorage());
+    }
+
+    private TrackerWithStorage createTrackerWithMockLedger(long firstLedgerId, int maxNumBuckets,
+                                                          MockBucketSnapshotStorage storage)
+            throws Exception {
         storage.start();
 
         ManagedLedger mockLedger = mock(ManagedLedger.class);
@@ -515,14 +537,16 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
         BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(disp, mock(Timer.class),
                 100000, mockClock, true, storage, 5, TimeUnit.MILLISECONDS.toMillis(10), -1, maxNumBuckets);
-        return new TrackerWithStorage(tracker, storage);
+        return new TrackerWithStorage(tracker, storage, mockClockTime);
     }
 
     @Test
     public void testTrimRemovesOrphanedBuckets() throws Exception {
-        TrackerWithStorage ts = createTrackerWithMockLedger(50L, 5);
+        long firstLedgerId = 31L;
+        int messageCount = 36;
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5);
 
-        for (int i = 1; i <= 31; i++) {
+        for (int i = 1; i <= messageCount; i++) {
             ts.tracker.addMessage(i, i, i * 10);
         }
         Awaitility.await().untilAsserted(() ->
@@ -534,28 +558,74 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                 "Bucket count " + bucketCount + " should be <= maxNumBuckets=5 after trim+merge");
 
         ts.tracker.getImmutableBuckets().asMapOfRanges().forEach((range, bucket) ->
-                assertTrue(range.lowerEndpoint() >= 50L,
-                        "Remaining bucket range " + range + " should be >= 50"));
+                assertTrue(range.lowerEndpoint() >= firstLedgerId,
+                        "Remaining bucket range " + range + " should be >= " + firstLedgerId));
+
+        long messagesAfterTrim = ts.tracker.getNumberOfDelayedMessages();
+        ts.clockTime.set(messageCount * 10);
+        NavigableSet<Position> scheduledMessages = ts.tracker.getScheduledMessages(1);
+        assertTrue(scheduledMessages.stream().noneMatch(position -> position.getLedgerId() < firstLedgerId),
+                "Trimmed ledgers should not be returned from the loaded shared queue");
+        assertEquals(ts.tracker.getNumberOfDelayedMessages(), messagesAfterTrim - scheduledMessages.size());
 
         ts.close();
     }
 
     @Test
     public void testTrimHandlesDeleteFailure() throws Exception {
-        TrackerWithStorage ts = createTrackerWithMockLedger(50L, 5);
+        long firstLedgerId = 50L;
+        int messageCount = 31;
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5);
 
-        ts.storage.injectDeleteException(
-                new BucketSnapshotPersistenceException("Delete failed"));
+        for (int i = 0; i < 4; i++) {
+            ts.storage.injectDeleteException(
+                    new BucketSnapshotPersistenceException("Delete failed"));
+        }
 
-        for (int i = 1; i <= 31; i++) {
+        for (int i = 1; i <= messageCount; i++) {
             ts.tracker.addMessage(i, i, i * 10);
         }
         Awaitility.await().untilAsserted(() ->
                 Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
                         .noneMatch(x -> x.merging)));
 
-        assertTrue(ts.storage.deleteExceptionQueue.isEmpty(),
-                "Delete exception should have been consumed");
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(ts.storage.deleteExceptionQueue.isEmpty(),
+                        "Delete exception should have been consumed"));
+
+        long messagesBeforeSchedule = ts.tracker.getNumberOfDelayedMessages();
+        ts.clockTime.set(messageCount * 10);
+        Awaitility.await().untilAsserted(() -> {
+            NavigableSet<Position> scheduledMessages = ts.tracker.getScheduledMessages(1);
+            assertEquals(scheduledMessages.size(), 1);
+            assertTrue(scheduledMessages.first().getLedgerId() < firstLedgerId);
+            assertEquals(ts.tracker.getNumberOfDelayedMessages(), messagesBeforeSchedule - 1);
+        });
+
+        ts.close();
+    }
+
+    @Test
+    public void testClearRunsAfterInFlightTrimFailure() throws Exception {
+        long firstLedgerId = 50L;
+        int messageCount = 31;
+        BlockingDeleteStorage storage = new BlockingDeleteStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5, storage);
+
+        for (int i = 1; i <= messageCount; i++) {
+            ts.tracker.addMessage(i, i, i * 10);
+        }
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(storage.deleteCalls.get() > 0, "Trim delete should be in flight"));
+
+        CompletableFuture<Void> clearFuture = ts.tracker.clear();
+        storage.firstDeleteFuture.completeExceptionally(new BucketSnapshotPersistenceException("Delete failed"));
+
+        clearFuture.get(1, TimeUnit.MINUTES);
+        assertEquals(ts.tracker.getNumberOfDelayedMessages(), 0);
+        assertEquals(ts.tracker.getImmutableBuckets().asMapOfRanges().size(), 0);
+        assertEquals(ts.tracker.getLastMutableBucket().size(), 0);
+        assertEquals(ts.tracker.getSharedBucketPriorityQueue().size(), 0);
 
         ts.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -45,8 +45,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo.LedgerInfo;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.pulsar.broker.delayed.AbstractDeliveryTrackerTest;
 import org.apache.pulsar.broker.delayed.MockBucketSnapshotStorage;
@@ -468,5 +470,138 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
       assertEquals(tracker.getSharedBucketPriorityQueue().size(), 0);
 
       tracker.close();
+    }
+
+    private static class TrackerWithStorage {
+        final BucketDelayedDeliveryTracker tracker;
+        final MockBucketSnapshotStorage storage;
+
+        TrackerWithStorage(BucketDelayedDeliveryTracker tracker, MockBucketSnapshotStorage storage) {
+            this.tracker = tracker;
+            this.storage = storage;
+        }
+
+        void close() throws Exception {
+            tracker.close();
+            storage.close();
+        }
+    }
+
+    private TrackerWithStorage createTrackerWithMockLedger(long firstLedgerId, int maxNumBuckets)
+            throws Exception {
+        MockBucketSnapshotStorage storage = new MockBucketSnapshotStorage();
+        storage.start();
+
+        ManagedLedger mockLedger = mock(ManagedLedger.class);
+        NavigableMap<Long, LedgerInfo> ledgerInfo = new TreeMap<>();
+        ledgerInfo.put(firstLedgerId, mock(LedgerInfo.class));
+        when(mockLedger.getLedgersInfo()).thenReturn(ledgerInfo);
+        when(mockLedger.getName()).thenReturn("test-ledger");
+
+        ManagedCursor mockCursor = new MockManagedCursor("test-cursor") {
+            @Override
+            public ManagedLedger getManagedLedger() {
+                return mockLedger;
+            }
+        };
+
+        AbstractPersistentDispatcherMultipleConsumers disp =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock mockClock = mock(Clock.class);
+        AtomicLong mockClockTime = new AtomicLong();
+        when(mockClock.millis()).then(x -> mockClockTime.get());
+        doReturn(mockCursor).when(disp).getCursor();
+        doReturn("persistent://public/default/testDelay" + " / " + mockCursor.getName()).when(disp).getName();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(disp, mock(Timer.class),
+                100000, mockClock, true, storage, 5, TimeUnit.MILLISECONDS.toMillis(10), -1, maxNumBuckets);
+        return new TrackerWithStorage(tracker, storage);
+    }
+
+    @Test
+    public void testTrimRemovesOrphanedBuckets() throws Exception {
+        TrackerWithStorage ts = createTrackerWithMockLedger(50L, 5);
+
+        for (int i = 1; i <= 31; i++) {
+            ts.tracker.addMessage(i, i, i * 10);
+        }
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging)));
+
+        int bucketCount = ts.tracker.getImmutableBuckets().asMapOfRanges().size();
+        assertTrue(bucketCount <= 5,
+                "Bucket count " + bucketCount + " should be <= maxNumBuckets=5 after trim+merge");
+
+        ts.tracker.getImmutableBuckets().asMapOfRanges().forEach((range, bucket) ->
+                assertTrue(range.lowerEndpoint() >= 50L,
+                        "Remaining bucket range " + range + " should be >= 50"));
+
+        ts.close();
+    }
+
+    @Test
+    public void testTrimHandlesDeleteFailure() throws Exception {
+        TrackerWithStorage ts = createTrackerWithMockLedger(50L, 5);
+
+        ts.storage.injectDeleteException(
+                new BucketSnapshotPersistenceException("Delete failed"));
+
+        for (int i = 1; i <= 31; i++) {
+            ts.tracker.addMessage(i, i, i * 10);
+        }
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging)));
+
+        assertTrue(ts.storage.deleteExceptionQueue.isEmpty(),
+                "Delete exception should have been consumed");
+
+        ts.close();
+    }
+
+    @Test
+    public void testTrimWithNoOrphanedBuckets() throws Exception {
+        TrackerWithStorage ts = createTrackerWithMockLedger(0L, 5);
+
+        for (int i = 1; i <= 31; i++) {
+            ts.tracker.addMessage(i, i, i * 10);
+        }
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging)));
+
+        int bucketCount = ts.tracker.getImmutableBuckets().asMapOfRanges().size();
+        assertTrue(bucketCount <= 5,
+                "Bucket count " + bucketCount + " should be <= maxNumBuckets=5");
+        assertTrue(bucketCount > 0, "Should have at least one bucket after merge");
+
+        ts.close();
+    }
+
+    @Test
+    public void testMergeEarlyReturnWhenWithinLimit() throws Exception {
+        TrackerWithStorage ts = createTrackerWithMockLedger(0L, 50);
+
+        for (int i = 1; i <= 30; i++) {
+            ts.tracker.addMessage(i, i, i * 10);
+        }
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging)));
+
+        int bucketCount = ts.tracker.getImmutableBuckets().asMapOfRanges().size();
+        assertTrue(bucketCount < 50,
+                "Bucket count " + bucketCount + " should be well below maxNumBuckets=50");
+
+        long msgsBefore = ts.tracker.getNumberOfDelayedMessages();
+        ts.tracker.addMessage(200, 200, 200 * 10);
+        Awaitility.await().untilAsserted(() ->
+                Assert.assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging)));
+
+        assertEquals(ts.tracker.getNumberOfDelayedMessages(), msgsBefore + 1);
+
+        ts.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -525,6 +525,11 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
             public ManagedLedger getManagedLedger() {
                 return mockLedger;
             }
+
+            @Override
+            public Position getMarkDeletedPosition() {
+                return PositionFactory.create(firstLedgerId, -1);
+            }
         };
 
         AbstractPersistentDispatcherMultipleConsumers disp =
@@ -577,6 +582,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         int messageCount = 31;
         TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5);
 
+        // MaxRetryTimes=3 means the first trim delete attempt plus 3 retries = 4 exceptions consumed.
         for (int i = 0; i < 4; i++) {
             ts.storage.injectDeleteException(
                     new BucketSnapshotPersistenceException("Delete failed"));
@@ -593,14 +599,16 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                 assertTrue(ts.storage.deleteExceptionQueue.isEmpty(),
                         "Delete exception should have been consumed"));
 
-        long messagesBeforeSchedule = ts.tracker.getNumberOfDelayedMessages();
-        ts.clockTime.set(messageCount * 10);
-        Awaitility.await().untilAsserted(() -> {
-            NavigableSet<Position> scheduledMessages = ts.tracker.getScheduledMessages(1);
-            assertEquals(scheduledMessages.size(), 1);
-            assertTrue(scheduledMessages.first().getLedgerId() < firstLedgerId);
-            assertEquals(ts.tracker.getNumberOfDelayedMessages(), messagesBeforeSchedule - 1);
-        });
+        // Trim failed on the first orphaned bucket; the sequential chain stopped, so all
+        // 6 orphaned buckets remain in immutableBuckets.
+        assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().size() > 0,
+                "Orphaned buckets should remain when trim delete fails");
+        ts.tracker.getImmutableBuckets().asMapOfRanges().forEach((range, bucket) ->
+                assertTrue(range.upperEndpoint() < firstLedgerId,
+                        "Remaining bucket " + range + " should be an orphaned bucket"));
+
+        // numberDelayedMessages is unchanged because failed deletes do not decrement the count.
+        assertEquals(ts.tracker.getNumberOfDelayedMessages(), messageCount);
 
         ts.close();
     }


### PR DESCRIPTION
### Motivation

  When a topic's managed ledger trims old ledgers (via retention or compaction), the immutable bucket snapshots in BucketDelayedDeliveryTracker that cover those deleted ledger ranges become orphaned — their underlying message data no longer exists, yet they:

  1. Continue to occupy storage as bucket snapshots.
  2. Count against the maxNumBuckets limit, potentially triggering unnecessary and expensive merge operations.

  Prior to this change, the tracker only merged buckets when the count exceeded the limit; it never cleaned up buckets whose ledger range had been fully trimmed. This change introduces a trim step that runs before merge, deleting orphaned buckets and decrementing the delayed-message counter accordingly.

### Modifications

  Source (BucketDelayedDeliveryTracker.java)

  - Added trimFuture: A volatile CompletableFuture<Void> that represents the currently in-flight trim/merge/clear operation. It acts as both a gate (preventing concurrent trim chains) and a synchronization point for clear().
  - Added asyncTrimImmutableBuckets(): Scans the managed ledger's surviving ledger range. Buckets whose upperEndpoint falls entirely before the earliest surviving ledger are selected for deletion — these are orphaned and safe to remove.
  - Added deleteBucketSnapshot(): Removes a single bucket from immutableBuckets, asynchronously deletes its snapshot, and re-adds the bucket on failure (rolling back the message count). Failures propagate via CompletionException to stop the sequential deletion chain, avoiding wasted attempts when storage is unavailable.
  - Changed the merge trigger in addMessage(): Before merging, the tracker now runs asyncTrimImmutableBuckets() first. The trimFuture gate ensures only one trim/merge chain is in-flight at a time.
  - Added early-return to asyncMergeBucketSnapshot(): If the bucket count is already within the limit, merge returns immediately without scanning for merge candidates.
  - Rewrote clear(): Instead of immediately clearing state (which could race with an in-flight trim's failure callback), clear() now chains itself after any pending trimFuture. It also sets trimFuture to the clear chain, blocking new trim triggers until the clear completes.

  Test (BucketDelayedDeliveryTrackerTest.java)

  Added 4 tests using a helper that injects a mocked ManagedLedger:

  | Test | Scenario |
  | -- | -- |
  | testTrimRemovesOrphanedBuckets | Buckets covering ledgers below firstLedgerId are removed, remaining ones have ranges ≥ firstLedgerId |
  | testTrimHandlesDeleteFailure | Injected delete exception is consumed, tracker remains operational |
  | testTrimWithNoOrphanedBuckets | With firstLedgerId=0, trim is a no-op, merge runs normally |
  | testMergeEarlyReturnWhenWithinLimit | With maxNumBuckets far above actual count, merge returns early without compaction |

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment