### PR TITLE
[fix][ml] Reset messageMetadataInitialized when recycling RangeCacheEntryWrapper

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeCacheEntryWrapper.java
@@ -191,6 +191,7 @@ class RangeCacheEntryWrapper {
         size = 0;
         timestampNanos = 0;
         requeueCount = 0;
+        messageMetadataInitialized = false;
         accessed = false;
         recyclerHandle.recycle(this);
     }


### PR DESCRIPTION
### Motivation

`RangeCacheEntryWrapper.recycle()` resets all wrapper fields except `messageMetadataInitialized`. Once a wrapper has served a cache hit (which sets the flag in `getValueInternal`), every entry later stored in that recycled wrapper instance inherits `messageMetadataInitialized=true`, so `getValueInternal()` skips the lazy `EntryImpl.initializeMessageMetadataIfNeeded()` call.

After recycler warm-up, cache hits return entries whose message metadata was never parsed, and each dispatcher falls back to `Commands.peekAndCopyMessageMetadata` — a full metadata parse plus a `MessageMetadata` copy per entry per subscription. This silently defeats the parse-once-per-cached-entry optimization, with the cost multiplied by subscription fan-out.

### Modifications

Reset `messageMetadataInitialized` in `recycle()`, matching the reset of the other wrapper fields. `recycle()` is the wrapper's only return-to-pool path, so this fully restores the intended lazy-init behavior.