### PR TITLE
[fix][ml] Fix eviction trigger race that cleared the in-progress marker

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheManagerImpl.java
@@ -142,9 +142,9 @@ public class RangeEntryCacheManagerImpl implements EntryCacheManager {
             while (evictionCompletionFuture == null) {
                 evictionCompletionFuture = evictionInProgress.get();
                 if (evictionCompletionFuture == null) {
-                    evictionCompletionFuture = evictionInProgress.updateAndGet(
-                            currentValue -> currentValue == null ? new CompletableFuture<>() : null);
-                    if (evictionCompletionFuture != null) {
+                    CompletableFuture<Void> newEvictionFuture = new CompletableFuture<>();
+                    if (evictionInProgress.compareAndSet(null, newEvictionFuture)) {
+                        evictionCompletionFuture = newEvictionFuture;
                         triggerEvictionToMakeSpace(evictionCompletionFuture);
                     }
                 }


### PR DESCRIPTION
### Motivation

`RangeEntryCacheManagerImpl.triggerEvictionWhenNeeded()` uses `updateAndGet` with a lambda that returns `null` when another eviction is already in progress. Since `updateAndGet` stores the lambda's result, a thread losing the race overwrites the running eviction's in-progress marker with `null`. On its next loop iteration that thread installs its own future and submits a duplicate eviction task, while the first cycle's cleanup then clears the second cycle's marker.

With the cache sitting at the eviction trigger threshold and many managed-ledger threads inserting concurrently, this happens routinely: redundant tasks are queued on the single eviction executor (each re-checks the size, so the wasted work is bounded, but timer-driven eviction passes get delayed behind the no-op tasks), and the marker no longer reliably reflects whether an eviction is running.

### Modifications

Use `compareAndSet(null, newEvictionFuture)` so only the winning thread installs the in-progress marker; losing threads loop and pick up the owner's future via `get()`. The owner remains the only one clearing the marker in `triggerEvictionToMakeSpace`'s `finally` block.