### PR TITLE
[fix][broker] Fix compacted read could be stuck forever or message loss due to cursor mark delete

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -58,6 +58,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.intercept.BrokerInterceptor;
 import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.data.BrokerLookupData;
+import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.AbstractSubscription;
 import org.apache.pulsar.broker.service.AnalyzeBacklogResult;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -471,6 +472,17 @@ public class PersistentSubscription extends AbstractSubscription {
                     .attr("position", position)
                     .log("Cumulative ack on");
             AckCallback callback = new AckCallback(previousMarkDeletePosition, future);
+            if (dispatcher instanceof AbstractDispatcherSingleActiveConsumer singleConsumerDispatcher) {
+                // For compacted consumer, we should ignore the position that does not exist in the managed ledger,
+                // otherwise, the `asyncMarkDelete` call could jump the read position to the active ledger, which will
+                // skip all entries present in the compacted ledger but not present in the managed ledger.
+                final var consumer = singleConsumerDispatcher.getActiveConsumer();
+                if (consumer != null
+                        && consumer.readCompacted()
+                        && cursor.getManagedLedger().getOptionalLedgerInfo(position.getLedgerId()).isEmpty()) {
+                    return CompletableFuture.completedFuture(null);
+                }
+            }
             cursor.asyncMarkDelete(position, mergeCursorProperties(properties),
                     callback, callback);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -477,9 +477,14 @@ public class PersistentSubscription extends AbstractSubscription {
                 // otherwise, the `asyncMarkDelete` call could jump the read position to the active ledger, which will
                 // skip all entries present in the compacted ledger but not present in the managed ledger.
                 final var consumer = singleConsumerDispatcher.getActiveConsumer();
+                final var ml = cursor.getManagedLedger();
                 if (consumer != null
                         && consumer.readCompacted()
-                        && cursor.getManagedLedger().getOptionalLedgerInfo(position.getLedgerId()).isEmpty()) {
+                        && ml.getOptionalLedgerInfo(position.getLedgerId()).isEmpty()) {
+                    if (ml.getFirstPosition() == null || position.getLedgerId() > ml.getFirstPosition().getLedgerId()) {
+                        log.warn("Received an ACK whose position is " + position + ", valid ledgers: "
+                                + ml.getLedgersInfo().keySet());
+                    }
                     return CompletableFuture.completedFuture(null);
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -480,6 +480,7 @@ public class PersistentSubscription extends AbstractSubscription {
                 final var ml = cursor.getManagedLedger();
                 if (consumer != null
                         && consumer.readCompacted()
+                        && !cursor.isDurable()
                         && ml.getOptionalLedgerInfo(position.getLedgerId()).isEmpty()) {
                     if (ml.getFirstPosition() == null || position.getLedgerId() > ml.getFirstPosition().getLedgerId()) {
                         log.warn("Received an ACK whose position is " + position + ", valid ledgers: "

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -2697,8 +2697,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
         triggerAndWaitCompaction(topic);
 
-        // Trigger the reconnection and trim the first ledger.
-        admin.namespaces().unload("my-tenant/my-ns");
         // Simulate the pending cumulative acknowledgment is flushed after the consumer is created
         // We don't need such interception if we can support controlling the acknowledgment flush for reader.
         final var firstTime = new AtomicBoolean(true);
@@ -2711,6 +2709,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
             }
         };
 
+        // Trigger the reconnection and trim the first ledger.
+        admin.namespaces().unload("my-tenant/my-ns");
         admin.lookups().lookupTopic(topic);
         final var persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topic, true).get()
                 .orElseThrow();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -70,12 +71,15 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.intercept.MockBrokerInterceptor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -87,6 +91,7 @@ import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -124,10 +129,12 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     protected ScheduledExecutorService compactionScheduler;
     protected BookKeeper bk;
     private PublishingOrderCompactor compactor;
+    private volatile java.util.function.Consumer<org.apache.pulsar.broker.service.Consumer> consumerCreated = __ -> {};
 
     @Override
     protected void doInitConf() throws Exception {
         super.doInitConf();
+        conf.setSystemTopicEnabled(false);
         conf.setDispatcherMaxReadBatchSize(1);
     }
 
@@ -135,6 +142,14 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     @Override
     public void setup() throws Exception {
         super.internalSetup();
+        pulsar.getBrokerService().setInterceptor(new MockBrokerInterceptor() {
+
+            @Override
+            public void consumerCreated(ServerCnx cnx, org.apache.pulsar.broker.service.Consumer consumer,
+                                        Map<String, String> metadata) {
+                consumerCreated.accept(consumer);
+            }
+        });
 
         admin.clusters().createCluster(configClusterName,
                 ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
@@ -2647,5 +2662,74 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         admin.topics().triggerCompaction(topic);
         Awaitility.await().untilAsserted(() -> assertEquals(
                 admin.topics().compactionStatus(topic).status, LongRunningProcessStatus.Status.SUCCESS));
+    }
+
+    @Test
+    public void testReceiveAckAfterReconnectionOnEmptyLedger() throws Exception {
+        final var topic = "persistent://my-tenant/my-ns/receive-ack-after-reconnection-on-empty-ledger";
+        try (final var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create()) {
+            for (int i = 0; i < 3; i++) {
+                producer.newMessage().key("key-" + i).value("value-" + i).send();
+            }
+        }
+        // Trigger the ledger rollover
+        var ml = (ManagedLedgerImpl) ((PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topic).get()
+                .orElseThrow()).getManagedLedger();
+        ml.getConfig().setMaxEntriesPerLedger(1);
+        ml.getConfig().setMaxSizePerLedgerMb(0);
+        ml.getConfig().setMinimumRolloverTime(0, TimeUnit.MILLISECONDS);
+        ml.rollCurrentLedgerIfFull();
+        Awaitility.await().untilAsserted(() -> assertEquals(ml.getLedgersInfo().size(), 2));
+
+        @Cleanup final var reader = pulsarClient.newReader(Schema.STRING).readCompacted(true).topic(topic)
+                .subscriptionName("reader")
+                .startMessageId(MessageId.earliest).create();
+
+        // Slow down the pre-fetching
+        pulsarTestContext.getMockBookKeeper().setDefaultReadEntriesDelayMillis(500);
+
+        // Receive 1 message so that the startMessageId will be reset to ledger_id:0 after reconnection
+        assertTrue(reader.hasMessageAvailable());
+        final var firstMsg = reader.readNext(3, TimeUnit.SECONDS);
+        assertNotNull(firstMsg);
+
+        triggerAndWaitCompaction(topic);
+
+        // Trigger the reconnection and trim the first ledger.
+        admin.namespaces().unload("my-tenant/my-ns");
+        // Simulate the pending cumulative acknowledgment is flushed after the consumer is created
+        // We don't need such interception if we can support controlling the acknowledgment flush for reader.
+        final var firstTime = new AtomicBoolean(true);
+        consumerCreated = serverConsumer -> {
+            final var subscription = serverConsumer.getSubscription();
+            if (subscription.getName().contains("reader") && firstTime.compareAndSet(true, false)) {
+                final var msgId = (MessageIdAdv) firstMsg.getMessageId();
+                subscription.acknowledgeMessageAsync(List.of(PositionFactory.create(msgId.getLedgerId(),
+                        msgId.getEntryId())), CommandAck.AckType.Cumulative, Map.of());
+            }
+        };
+
+        admin.lookups().lookupTopic(topic);
+        final var persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topic, true).get()
+                .orElseThrow();
+        final var trimFuture = new CompletableFuture<Void>();
+        persistentTopic.getManagedLedger().trimConsumedLedgersInBackground(trimFuture);
+        trimFuture.get();
+        assertEquals(persistentTopic.getManagedLedger().getLedgersInfo().size(), 1);
+
+        pulsarTestContext.getMockBookKeeper().setDefaultReadEntriesDelayMillis(1);
+
+        while (reader.hasMessageAvailable()) {
+            final var msg = reader.readNextAsync().get(3, TimeUnit.SECONDS);
+            log.info().attr("id", msg.getMessageId()).attr("key", msg.getKey())
+                    .attr("value", msg.getValue()).log("read");
+        }
+
+        final var serverConsumer = persistentTopic.getSubscription("reader").getDispatcher().getConsumers().get(0);
+        assertEquals(((MessageIdAdv) serverConsumer.getStartMessageId()).getEntryId(), 0L);
+
+        final var emptyLedgerId = persistentTopic.getManagedLedger().getLedgersInfo().lastEntry().getKey();
+        assertEquals(persistentTopic.getTopicCompactionService().getLastCompactedPosition().get(),
+                PositionFactory.create(emptyLedgerId, -1L));
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -178,6 +178,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         admin.namespaces().removeRetention("my-tenant/my-ns");
         AbstractTwoPhaseCompactor.injectionAfterSeekInPhaseTwo = () -> {};
         AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = RawReader::seekAsync;
+        consumerCreated = __ -> {};
+        pulsarTestContext.getMockBookKeeper().setDefaultReadEntriesDelayMillis(1);
     }
 
     protected long compact(String topic) throws ExecutionException, InterruptedException {
@@ -2664,8 +2666,8 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testReceiveAckAfterReconnectionOnEmptyLedger() throws Exception {
-        final var topic = "persistent://my-tenant/my-ns/receive-ack-after-reconnection-on-empty-ledger";
+    public void testReaderReadOnDeletedLedger() throws Exception {
+        final var topic = "persistent://my-tenant/my-ns/reader-read-on-deleted-ledger";
         try (final var producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create()) {
             for (int i = 0; i < 3; i++) {
                 producer.newMessage().key("key-" + i).value("value-" + i).send();
@@ -2680,8 +2682,9 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         ml.rollCurrentLedgerIfFull();
         Awaitility.await().untilAsserted(() -> assertEquals(ml.getLedgersInfo().size(), 2));
 
+        final var subName = "sub-" + System.currentTimeMillis();
         @Cleanup final var reader = pulsarClient.newReader(Schema.STRING).readCompacted(true).topic(topic)
-                .subscriptionName("reader")
+                .subscriptionName(subName)
                 .startMessageId(MessageId.earliest).create();
 
         // Slow down the pre-fetching
@@ -2701,7 +2704,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         final var firstTime = new AtomicBoolean(true);
         consumerCreated = serverConsumer -> {
             final var subscription = serverConsumer.getSubscription();
-            if (subscription.getName().contains("reader") && firstTime.compareAndSet(true, false)) {
+            if (subscription.getName().contains(subName) && firstTime.compareAndSet(true, false)) {
                 final var msgId = (MessageIdAdv) firstMsg.getMessageId();
                 subscription.acknowledgeMessageAsync(List.of(PositionFactory.create(msgId.getLedgerId(),
                         msgId.getEntryId())), CommandAck.AckType.Cumulative, Map.of());
@@ -2724,7 +2727,7 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
                     .attr("value", msg.getValue()).log("read");
         }
 
-        final var serverConsumer = persistentTopic.getSubscription("reader").getDispatcher().getConsumers().get(0);
+        final var serverConsumer = persistentTopic.getSubscription(subName).getDispatcher().getConsumers().get(0);
         assertEquals(((MessageIdAdv) serverConsumer.getStartMessageId()).getEntryId(), 0L);
 
         final var emptyLedgerId = persistentTopic.getManagedLedger().getLedgersInfo().lastEntry().getKey();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -134,7 +134,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void doInitConf() throws Exception {
         super.doInitConf();
-        conf.setSystemTopicEnabled(false);
         conf.setDispatcherMaxReadBatchSize(1);
     }
 


### PR DESCRIPTION
### Motivation

We observed the system topic reader encountered a typical bug case: `hasMessageAvailable()` returns true but `readNext()` is not able to read any message. It causes all topics in the same namespace fail to load.

After digging into details, I've figured out the cause for this incident. During the incident, there are two unload operations on bundles of the same namespace in short time:
1. The 1st bundle unloaded a user topic, then the topic loading triggered the read on `__change_events` topic
2. The system topic reader started to read from earliest, then it read a message from `broker-0`, the message id is `A:2` 
3. The 2nd bundle unloaded the `__change_events` topic from `broker-0` to `broker-1`
4. The system topic reader then reconnected to `broker-1`, with `A:2` as the start message id.

Then the reader was stuck. From the heap dump, I found the following important info from the dispatcher:

```yaml
isFirstRead: true
activeConsumer:
  msgOutCounter: 0
  messagePermits: 1000
  startMessageId: "A:2"
  msgOutCounter: 0
  messageAckCounter: 1
cursor:
  ledger:
    ledgers:
    - {"ledgerId":B,"entries":0}
    lastConfirmedEntry: "B:-1"
  entriesReadCount: 0
  readPosition: "B:0"
  waitingReadOp:
    entries: []
    readPosition: "B:0"
    nextReadPosition: "B:0"
```

As you can see, all entries are compacted (the original ledger id is `A`), the managed ledger was just empty with an empty ledger whose id is `B`.

From the logs, we can see the cursor's initial mark delete position and read position is different:

```
ackPos=A:1, readPos=A:2
```

But the `ackPos` is `A:2` in the heap dump, and `readPos` is `B:0`. I also checked the topic compaction context's cache and dumped the compacted ledger to verify there is even no `findStartPoint` call on the compacted ledger.

The root cause is:
1. When the reader received a message from `broker-0`, it stored the message ID `A:2` to `PersistentAcknowledgmentsGroupingTracker#lastCumulativeAck` via `acknowledgeCumulativeAsync`.
2. After 100ms (the default `acknowledgmentGroupTime`), the reader had already switched the connection to `broker-1`, then it flushed the ACK request to `broker-1`
3. `broker-1` received the ACK request and simply called `cursor.asyncMarkDelete(A:2)`.

https://github.com/apache/pulsar/blob/a045e4c279505fa842da0135c839c78c4cf6c3c4/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java#L474

The mark delete position was simply set to `A:2`:

https://github.com/apache/pulsar/blob/a045e4c279505fa842da0135c839c78c4cf6c3c4/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2216

However, the read position was advanced to **the next valid position** (`B:0`) in the managed ledger:

https://github.com/apache/pulsar/blob/a045e4c279505fa842da0135c839c78c4cf6c3c4/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L2225

while the compaction horizon is just `B:-1`, which is behind the new read position:

https://github.com/apache/pulsar/blob/a045e4c279505fa842da0135c839c78c4cf6c3c4/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicUtils.java#L55-L56

and the read operation went through the managed cursor directly and would be stuck forever.

### Modifications

When a subscription has a compacted consumer, if the acknowledged position's ledger id does not exist in the managed ledger, just do nothing. Otherwise, even if the next valid ledger has messages to read, the compacted entries could be skipped, which leads to message loss.

### Verifying this change

`testReceiveAckAfterReconnectionOnEmptyLedger` covers the case exactly.

### Others

Consumer does not have this issue, even if it's non-durable, because consumer's `startMessageId` is `null`, so in `asyncReadCompactedEntries`, in the first read, `readFromEarliest` is always true.