### PR TITLE
[fix][client] Don't pin broker-assigned redirect URL across reconnect retries

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -41,6 +41,8 @@ import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.ServerSocket;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -48,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -1127,5 +1130,44 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
                 .subscriptionName(sub).subscribe();
         consumer1.unsubscribe(true);
         assertFalse(consumer1.isConnected());
+    }
+
+    /**
+     * Regression test for https://github.com/apache/pulsar/issues/25997: a broker-assigned redirect
+     * ({@code CloseProducer}/{@code CloseConsumer} carrying an {@code assignedBrokerServiceUrl})
+     * pointing at a wrong or unreachable broker must be honored for the immediate reconnect attempt
+     * only. If that attempt fails, subsequent retries must fall back to topic lookup instead of
+     * staying pinned to the stale address.
+     */
+    @Test
+    public void testStaleBrokerRedirectFallsBackToLookup() throws Exception {
+        String topic = "persistent://my-property/my-ns/staleRedirectFallback";
+        @Cleanup
+        Producer<byte[]> producerInstance = pulsarClient.newProducer().topic(topic).create();
+        @Cleanup
+        Consumer<byte[]> consumerInstance = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("my-subscriber-name").subscribe();
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) producerInstance;
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) consumerInstance;
+
+        // An address with no listener behind it: dialing the redirect fails immediately.
+        URI unreachable;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            unreachable = URI.create("pulsar://127.0.0.1:" + socket.getLocalPort());
+        }
+
+        // Deliver the disconnect+redirect exactly as ClientCnx#handleCloseProducer and
+        // #handleCloseConsumer do for a broker unload notification.
+        producer.connectionClosed(producer.getClientCnx(), Optional.of(0L), Optional.of(unreachable));
+        consumer.connectionClosed(consumer.getClientCnx(), Optional.of(0L), Optional.of(unreachable));
+
+        // The redirect dial fails; the clients must recover by looking up the topic again.
+        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertEquals(producer.getState(), State.Ready);
+            assertEquals(consumer.getState(), State.Ready);
+        });
+
+        producer.send("msg".getBytes(UTF_8));
+        assertNotNull(consumer.receive(10, TimeUnit.SECONDS));
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -227,9 +227,15 @@ public class ConnectionHandler {
     public void connectionClosed(ClientCnx cnx, Optional<Long> initialConnectionDelayMs, Optional<URI> hostUrl) {
         lastConnectionClosedTimestamp = System.currentTimeMillis();
         duringConnect.set(false);
-        // Remember an explicit reconnect target so a later first-attempt failure (reconnectLater)
-        // re-dials the same broker rather than falling back to the service URL.
-        hostUrl.ifPresent(uri -> this.explicitHostURI = uri);
+        // Only handlers already pinned to an explicit host (v5 TC metadata-store discovery) update
+        // the pin here, so a later first-attempt failure (reconnectLater) re-dials the current
+        // leader rather than falling back to the service URL. For lookup-based handlers
+        // (producers/consumers), the broker-assigned redirect in hostUrl may be wrong or stale:
+        // it is honored for the immediate reconnect attempt below only, and retries after a
+        // failure go through a fresh topic lookup instead of staying pinned to it.
+        if (explicitHostURI != null) {
+            hostUrl.ifPresent(uri -> this.explicitHostURI = uri);
+        }
         state.client.getCnxPool().releaseConnection(cnx);
         if (CLIENT_CNX_UPDATER.compareAndSet(this, cnx, null)) {
             if (!state.changeToConnecting()) {


### PR DESCRIPTION
Fixes #25997

### Motivation

#25929 added an `explicitHostURI` pin to `ConnectionHandler` so the v5 transaction coordinator's metadata-store discovery re-dials the elected leader on retry instead of falling back to the service URL. The same change also persisted the broker-assigned redirect URL from `CommandCloseProducer`/`CommandCloseConsumer` unload notifications (PIP-307) into that pin: a producer/consumer that was redirected once stayed pinned to that address on every subsequent retry, never going through topic lookup again, and nothing ever cleared the field.

A redirect to a wrong or stale broker — e.g. a stepping-down `ExtensibleLoadManagerImpl` leader whose `closeInternalTopics()` redirects internal-topic clients to itself via the stale channel-table assignment — now wedged the client permanently with `ServiceUnitNotReadyException` instead of recovering via lookup on the next retry. This is the cause of the `ExtensibleLoadManagerImplTest.testRoleChange` flakiness on master. Before #25929 the redirect was honored for the immediate reconnect attempt only, so one failed attempt was followed by a lookup that found the new owner.

### Modifications

- `ConnectionHandler.connectionClosed()` updates the `explicitHostURI` pin only for handlers already in explicit-host mode, i.e. the TC metadata-store discovery, which entered it via `grabCnx(URI, boolean)`. The pin update is still needed there: `TransactionMetaStoreHandler.retargetLeader()` switches leaders by closing the channel and passing the new leader URI through `connectionClosed()`, and a failed first dial to the new leader must not retry against the old one.
- Lookup-based handlers (producers/consumers) never enter explicit-host mode, so the broker-assigned redirect is honored for the immediate reconnect attempt only; if that attempt fails, retries fall back to topic lookup, restoring the pre-#25929 behavior.
- Added a regression test that delivers a disconnect+redirect with an unreachable `assignedBrokerServiceUrl` to a live producer and consumer (exactly as `ClientCnx#handleCloseProducer`/`#handleCloseConsumer` do) and asserts both recover via lookup and can exchange a message.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `BrokerClientIntegrationTest.testStaleBrokerRedirectFallsBackToLookup` fails on master without the fix (the clients stay pinned to the unreachable address) and passes with it.
- `TransactionClientConnectTest` passes, covering the TC client connection path.
- `ExtensibleLoadManagerImplTest.testRoleChange` with `invocationCount = 20` passes 40/40 invocations with the fix (the test factory runs both `ServiceUnitStateChannel` implementations), vs. 1-2 failures per 20 on master per #25997.
