### PR TITLE
[fix][broker] Prevent subscribe rate limit from stalling compaction and blocking forced deletion

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1010,8 +1010,15 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         new NamingException("Subscription with reserved subscription name attempted"));
             }
 
-            if (cnx.clientAddress() != null && cnx.clientAddress().toString().contains(":")
-                    && subscribeRateLimiter.isPresent()) {
+            // The subscribe rate limit must not apply to the broker-internal compaction subscription: the
+            // compactor's reader re-subscribes after the phase-two seek, and throttling that re-subscribe stalls
+            // the compaction, which in turn blocks forced topic/namespace deletion waiting on the in-flight
+            // compaction. System topics are exempt as well, consistent with the publish/dispatch rate limiters,
+            // since throttling broker-internal readers (e.g. on __change_events) can stall topic policy updates.
+            if (subscribeRateLimiter.isPresent()
+                    && !isSystemTopic()
+                    && !isCompactionSubscription(subscriptionName)
+                    && cnx.clientAddress() != null && cnx.clientAddress().toString().contains(":")) {
                 SubscribeRateLimiter.ConsumerIdentifier consumer = new SubscribeRateLimiter.ConsumerIdentifier(
                         cnx.clientAddress().toString().split(":")[0], consumerName, consumerId);
                 if (!subscribeRateLimiter.get().subscribeAvailable(consumer)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -110,6 +110,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscribeRate;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.protocol.Markers;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -194,6 +195,34 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
     protected PublishingOrderCompactor getCompactor() {
         return compactor;
+    }
+
+    @Test
+    public void testCompactionNotBlockedBySubscribeRateLimit() throws Exception {
+        String namespace = "my-tenant/my-ns";
+        String topic = "persistent://" + namespace + "/compaction-with-subscribe-rate-limit";
+
+        try (Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).enableBatching(false).create()) {
+            for (int i = 0; i < 10; i++) {
+                producer.newMessage().key("key" + (i % 2)).value(("my-message-" + i).getBytes()).send();
+            }
+        }
+
+        // Allow a single subscribe per consumer within a long period. The compactor's reader consumes the only
+        // token when it first subscribes, so the re-subscribe triggered by the phase-two seek would be throttled
+        // if the limit applied to the compaction subscription, stalling the compaction.
+        admin.namespaces().setSubscribeRate(namespace, new SubscribeRate(1, 3600));
+        Awaitility.await().untilAsserted(() -> {
+            PersistentTopic persistentTopic =
+                    (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic).get();
+            assertTrue(persistentTopic.getSubscribeRateLimiter().isPresent());
+        });
+
+        try {
+            compactor.compact(topic).get(30, TimeUnit.SECONDS);
+        } finally {
+            admin.namespaces().removeSubscribeRate(namespace);
+        }
     }
 
     @Test


### PR DESCRIPTION
Main Issue: #22736

Related: #24148

### Motivation

`MockedPulsarServiceBaseTest.deleteNamespaceWithRetry` times out sporadically in CI (#22736). Investigation of a recent occurrence ([TopicPoliciesTest.setupTestTopic in this run](https://github.com/apache/pulsar/actions/runs/27349826959/job/81141262202)) showed the following chain in the test-report logs:

1. A test sets a namespace-level `SubscribeRate` (1 subscribe per consumer per period).
2. A compaction of the namespace's `__change_events` topic starts. Phase two of the compaction seeks the `__compaction` subscription, which disconnects and re-subscribes the compactor's reader.
3. The re-subscribe is denied with `Subscribe limited by subscribe rate limit per consumer.` — the limiter's token bucket is per consumer identifier, and the reader's initial subscribe already consumed the only token. The reader retries in an exponential-backoff loop and the compaction stalls.
4. A subsequent forced namespace deletion blocks in `PersistentTopic.asyncDeleteCursorWithCleanCompactionLedger()`, which waits for the in-flight compaction to complete (the mechanism described in #24148), until the test times out.

This is not only a test problem: a user-configured subscribe rate (namespace, topic, or broker level) can stall compaction on any topic in production and consequently block forced topic/namespace deletion. Throttling broker-internal readers on system topics such as `__change_events` can also stall topic policy updates.

Note that this addresses one root cause of #22736 only; the underlying deletion-vs-compaction deadlock analyzed in #24148 (which can also be reached without any subscribe rate) is a separate issue and is not changed here.

### Modifications

- `PersistentTopic#internalSubscribe`: skip the subscribe rate limit check for the broker-internal `__compaction` subscription and for system topics. This is consistent with the existing system-topic exemptions for the publish and dispatch rate limiters (`SystemTopic#getBrokerPublishRateLimiter`, `AbstractTopic#updateTopicPolicyByNamespacePolicy`).
- Added `CompactionTest.testCompactionNotBlockedBySubscribeRateLimit`, which sets a `SubscribeRate(1, 3600)` on the namespace and verifies that a compaction completes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `CompactionTest.testCompactionNotBlockedBySubscribeRateLimit` reproduces the stall: without the fix, the compaction does not complete within 30 seconds (timed out deterministically); with the fix it completes immediately (verified locally with `invocationCount = 10`, 10/10 passes).
- `TopicPoliciesTest` subscribe-rate tests (`testGetSetSubscribeRate`, `testDisableSubscribeRate`, `testRemoveSubscribeRate`) still pass, confirming regular consumers remain throttled.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
