### PR TITLE
[fix][broker] Fix forced topic/namespace deletion hanging or failing when compaction is in progress

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1429,8 +1429,18 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 return;
             }
         }
-        // Unsubscribe compaction cursor and delete compacted ledger.
-        currentCompaction.thenCompose(__ -> {
+        // Unsubscribe compaction cursor and delete compacted ledger. Wait for any in-flight compaction to finish
+        // first, but don't let a compaction that completed exceptionally block the cursor deletion: the deletion
+        // would otherwise fail on every retry until the topic instance is reloaded (issue #24148). Note that a
+        // fenced topic makes the compactor's reader fail with an unrecoverable error, so a forced deletion
+        // terminates an in-flight compaction exceptionally rather than waiting for it to complete normally.
+        currentCompaction.exceptionally(compactionEx -> {
+            log.info()
+                    .attr("subscription", subscriptionName)
+                    .exceptionMessage(compactionEx)
+                    .log("Last compaction task failed, proceeding to delete the compaction cursor");
+            return null;
+        }).thenCompose(__ -> {
             asyncDeleteCursor(subscriptionName, unsubscribeFuture);
             return unsubscribeFuture;
         }).thenAccept(__ -> {
@@ -1452,15 +1462,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 disablingCompaction.compareAndSet(true, false);
             }
         }).exceptionally(ex -> {
-            if (currentCompaction.isCompletedExceptionally()) {
-                log.warn()
-                        .attr("subscription", subscriptionName)
-                        .log("Last compaction task failed");
-            } else {
-                log.warn()
-                        .attr("subscription", subscriptionName)
-                        .log("Failed to delete cursor task failed");
-            }
+            log.warn()
+                    .attr("subscription", subscriptionName)
+                    .exceptionMessage(ex)
+                    .log("Failed to delete the compaction cursor");
             // Reset the variable: disablingCompaction,
             disablingCompaction.compareAndSet(true, false);
             unsubscribeFuture.completeExceptionally(ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -230,6 +230,17 @@ public class RawReaderImpl implements RawReader {
             CompletableFuture<RawMessage> result = new CompletableFuture<>();
             pendingRawReceives.add(result);
             tryCompletePending();
+            // Once the consumer has reached a terminal state (for example it was closed after an
+            // unrecoverable error such as the topic or namespace being deleted), no further message
+            // will arrive and no close callback will run for receives enqueued from now on, so the
+            // future would never complete. Re-checking the state after enqueueing closes the race
+            // with a concurrent close() draining the queue, since close() drains only after moving to
+            // a terminal state. This matters for compaction: a never-completing read leaves the
+            // compaction future pending, which in turn blocks forced topic/namespace deletion.
+            State state = getState();
+            if (state == State.Closing || state == State.Closed || state == State.Failed) {
+                failPendingRawReceives();
+            }
             return result;
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -624,6 +624,25 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         admin.topics().delete(topic, false);
     }
 
+    @Test(timeOut = 30000)
+    public void testReadNextAsyncCompletesAfterConsumerClosed() throws Exception {
+        String topic = "persistent://my-property/my-ns/" + BrokerTestUtil.newUniqueName("reader");
+        admin.topics().createNonPartitionedTopic(topic);
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
+
+        // Put the reader's underlying consumer into a terminal state. In production this happens when a
+        // compaction's RawReader hits an unrecoverable error (e.g. the topic/namespace is being deleted).
+        reader.closeAsync().get(5, TimeUnit.SECONDS);
+
+        // A read issued once the consumer has reached a terminal state must complete instead of hanging
+        // forever: a never-completing read keeps the compaction future pending, which blocks forced
+        // topic/namespace deletion (issue #24148).
+        CompletableFuture<RawMessage> readFuture = reader.readNextAsync();
+        Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertTrue(readFuture.isDone()));
+        assertTrue(readFuture.isCompletedExceptionally());
+    }
+
     @Test(timeOut = 100000)
     public void testPauseAndResume() throws Exception {
         log.info("-- Starting testPauseAndResume test --");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -138,31 +138,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         conf.setForceDeleteNamespaceAllowed(true);
     }
 
-    @Test
-    public void testForcedNamespaceDeleteWithInflightCompaction() throws Exception {
-        String namespace = "my-tenant/my-ns-inflight-compaction";
-        admin.namespaces().createNamespace(namespace, Set.of(configClusterName));
-        final String topicName = newUniqueName("persistent://" + namespace + "/inflight-compaction");
-        admin.topics().createNonPartitionedTopic(topicName);
-        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
-            // dispatcherMaxReadBatchSize=1 makes the compactor read these one at a time, keeping the compaction
-            // in-flight for several seconds while the namespace is deleted
-            for (int i = 0; i < 2000; i++) {
-                producer.newMessage().key(String.valueOf(i)).value(String.valueOf(i)).send();
-            }
-        }
-        PersistentTopic persistentTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
-        persistentTopic.triggerCompactionWithCheckHasMoreMessages().join();
-        Awaitility.await().untilAsserted(() ->
-                assertEquals(persistentTopic.getSubscriptions().get(COMPACTION_SUBSCRIPTION).getConsumers().size(),
-                        1));
-
-        // Forced namespace deletion must succeed while the compaction is in-flight: fencing the topic terminates
-        // the compaction exceptionally, which must not fail the deletion of the compaction cursor (issue #24148)
-        deleteNamespaceWithRetry(namespace, true, admin);
-    }
-
     @BeforeClass
     @Override
     public void setup() throws Exception {
@@ -220,30 +195,6 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
     protected PublishingOrderCompactor getCompactor() {
         return compactor;
-    }
-
-    @Test
-    public void testForcedDeleteSucceedsAfterFailedCompaction() throws Exception {
-        String topicName = newUniqueName("persistent://my-tenant/my-ns/delete-after-failed-compaction");
-        admin.topics().createNonPartitionedTopic(topicName);
-        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
-            for (int i = 0; i < 10; i++) {
-                producer.newMessage().key("key" + (i % 2)).value("value-" + i).send();
-            }
-        }
-
-        // Fail the compaction after the phase-two seek
-        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek =
-                (reader, id) -> CompletableFuture.failedFuture(new RuntimeException("injected compaction failure"));
-        PersistentTopic persistentTopic =
-                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
-        persistentTopic.triggerCompaction();
-        Awaitility.await().untilAsserted(() ->
-                assertEquals(persistentTopic.compactionStatus().status, LongRunningProcessStatus.Status.ERROR));
-        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = RawReader::seekAsync;
-
-        // The failed compaction must not block the deletion of the compaction cursor
-        admin.topics().delete(topicName, true);
     }
 
     @Test
@@ -2563,6 +2514,55 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         // case where fencing the topic terminates the in-flight compaction exceptionally: the failed compaction
         // must not fail the deletion (issue #24148).
         deleteTopicFuture.get(15, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testForcedDeleteSucceedsAfterFailedCompaction() throws Exception {
+        String topicName = newUniqueName("persistent://my-tenant/my-ns/delete-after-failed-compaction");
+        admin.topics().createNonPartitionedTopic(topicName);
+        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
+            for (int i = 0; i < 10; i++) {
+                producer.newMessage().key("key" + (i % 2)).value("value-" + i).send();
+            }
+        }
+
+        // Fail the compaction after the phase-two seek
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek =
+                (reader, id) -> CompletableFuture.failedFuture(new RuntimeException("injected compaction failure"));
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        persistentTopic.triggerCompaction();
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.compactionStatus().status, LongRunningProcessStatus.Status.ERROR));
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = RawReader::seekAsync;
+
+        // The failed compaction must not block the deletion of the compaction cursor
+        admin.topics().delete(topicName, true);
+    }
+
+    @Test
+    public void testForcedNamespaceDeleteWithInflightCompaction() throws Exception {
+        String namespace = "my-tenant/my-ns-inflight-compaction";
+        admin.namespaces().createNamespace(namespace, Set.of(configClusterName));
+        final String topicName = newUniqueName("persistent://" + namespace + "/inflight-compaction");
+        admin.topics().createNonPartitionedTopic(topicName);
+        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
+            // dispatcherMaxReadBatchSize=1 makes the compactor read these one at a time, keeping the compaction
+            // in-flight for several seconds while the namespace is deleted
+            for (int i = 0; i < 2000; i++) {
+                producer.newMessage().key(String.valueOf(i)).value(String.valueOf(i)).send();
+            }
+        }
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        persistentTopic.triggerCompactionWithCheckHasMoreMessages().join();
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.getSubscriptions().get(COMPACTION_SUBSCRIPTION).getConsumers().size(),
+                        1));
+
+        // Forced namespace deletion must succeed while the compaction is in-flight: fencing the topic terminates
+        // the compaction exceptionally, which must not fail the deletion of the compaction cursor (issue #24148)
+        deleteNamespaceWithRetry(namespace, true, admin);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -135,6 +135,32 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
     protected void doInitConf() throws Exception {
         super.doInitConf();
         conf.setDispatcherMaxReadBatchSize(1);
+        conf.setForceDeleteNamespaceAllowed(true);
+    }
+
+    @Test
+    public void testForcedNamespaceDeleteWithInflightCompaction() throws Exception {
+        String namespace = "my-tenant/my-ns-inflight-compaction";
+        admin.namespaces().createNamespace(namespace, Set.of(configClusterName));
+        final String topicName = newUniqueName("persistent://" + namespace + "/inflight-compaction");
+        admin.topics().createNonPartitionedTopic(topicName);
+        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
+            // dispatcherMaxReadBatchSize=1 makes the compactor read these one at a time, keeping the compaction
+            // in-flight for several seconds while the namespace is deleted
+            for (int i = 0; i < 2000; i++) {
+                producer.newMessage().key(String.valueOf(i)).value(String.valueOf(i)).send();
+            }
+        }
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        persistentTopic.triggerCompactionWithCheckHasMoreMessages().join();
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.getSubscriptions().get(COMPACTION_SUBSCRIPTION).getConsumers().size(),
+                        1));
+
+        // Forced namespace deletion must succeed while the compaction is in-flight: fencing the topic terminates
+        // the compaction exceptionally, which must not fail the deletion of the compaction cursor (issue #24148)
+        deleteNamespaceWithRetry(namespace, true, admin);
     }
 
     @BeforeClass
@@ -194,6 +220,30 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
 
     protected PublishingOrderCompactor getCompactor() {
         return compactor;
+    }
+
+    @Test
+    public void testForcedDeleteSucceedsAfterFailedCompaction() throws Exception {
+        String topicName = newUniqueName("persistent://my-tenant/my-ns/delete-after-failed-compaction");
+        admin.topics().createNonPartitionedTopic(topicName);
+        try (Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topicName).create()) {
+            for (int i = 0; i < 10; i++) {
+                producer.newMessage().key("key" + (i % 2)).value("value-" + i).send();
+            }
+        }
+
+        // Fail the compaction after the phase-two seek
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek =
+                (reader, id) -> CompletableFuture.failedFuture(new RuntimeException("injected compaction failure"));
+        PersistentTopic persistentTopic =
+                (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).join().get();
+        persistentTopic.triggerCompaction();
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(persistentTopic.compactionStatus().status, LongRunningProcessStatus.Status.ERROR));
+        AbstractTwoPhaseCompactor.injectionPhaseTwoSeek = RawReader::seekAsync;
+
+        // The failed compaction must not block the deletion of the compaction cursor
+        admin.topics().delete(topicName, true);
     }
 
     @Test
@@ -2509,10 +2559,10 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
         Thread.sleep(3000);
         delayReadSignal.countDown();
 
-        // Verify: topic deletion is successfully executed.
-        Awaitility.await().atMost(15, TimeUnit.SECONDS).untilAsserted(() -> {
-            assertTrue(deleteTopicFuture.isDone());
-        });
+        // Verify: topic deletion is successfully executed. Asserting success (not just completion) covers the
+        // case where fencing the topic terminates the in-flight compaction exceptionally: the failed compaction
+        // must not fail the deletion (issue #24148).
+        deleteTopicFuture.get(15, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
Fixes #24148
Related: #22736

### Motivation

#### Symptom (who is affected)

On a topic that uses compaction, a **forced deletion can hang forever or fail on every retry**:

- `admin.topics().delete(topic, true)` never completes (or keeps failing), and
- `admin.namespaces().deleteNamespace(ns, true)` never completes — it cascades into deleting the namespace's topics, and the always-compacted `__change_events` system topic (plus any user topic with a compaction threshold) hits the same problem.

This is the long-standing issue reported in #24148 and the flakiness in #22736 (e.g. `deleteNamespaceWithRetry` timing out). In production it shows up as a force-delete that hangs, or that fails on every attempt until the topic is unloaded/reloaded or the broker restarts.

The trigger is a compaction that is running when the forced deletion fences the topic. Forcing deletion is expected to abort the in-flight compaction and then delete the topic; instead, the deletion gets stuck on the compaction.

#### Root causes

Two independent bugs can each wedge a forced deletion. They sit at different stages of the same flow, so depending on timing you hit one or the other.

1. **A failed/aborted compaction permanently poisons the compaction-cursor deletion.** When the deletion fences the topic, the compaction aborts and `currentCompaction` completes *exceptionally* (the reader-close behavior from #24366). But `asyncDeleteCursorWithCleanCompactionLedger()` chained the cursor deletion with `currentCompaction.thenCompose(...)`, so an exceptional completion **skipped** the cursor deletion and failed the unsubscribe instead. That failed `currentCompaction` future is never reset (a new compaction can't start while the topic is deleting), so **every subsequent delete attempt fails immediately** until the topic instance is reloaded.

2. **The compaction's reader can hang, so `currentCompaction` never completes at all.** The compactor reads the topic through an internal `RawReader`. When the forced deletion makes that reader hit an unrecoverable error and close, a `readNextAsync()` issued by the compactor at just the wrong instant was enqueued **after** the consumer's close had already drained its pending-receive queue — leaving that read future uncompleted forever. `currentCompaction` then never completes, and the cursor deletion that waits on it blocks the entire forced deletion indefinitely.

#### What about unloads?

Unloading a topic does **not** itself hang — unload does not wait on `currentCompaction`. However, an unload/fence of a compacting topic is one of the events that can leave a compaction's reader in the hung state of cause 2 (the compaction reader is configured to treat "service not ready" as unrecoverable). The user-visible deadlock is on **forced deletion**, but the cause-2 fix applies no matter what drove the reader to close — a delete, a namespace delete, or an unload.

### Modifications

1. **`PersistentTopic.asyncDeleteCursorWithCleanCompactionLedger()`** — proceed with the compaction-cursor deletion once `currentCompaction` has *finished*, whether it completed normally or exceptionally (only an in-flight compaction is awaited). Fixes cause 1.
2. **`RawReaderImpl.RawConsumerImpl.receiveRawAsync()`** — after enqueuing a pending receive, re-check the consumer state and fail the pending raw receives if the consumer is in a terminal state (`Closing`/`Closed`/`Failed`). This completes the read future deterministically once the consumer is terminal, regardless of why it closed. Fixes cause 2. Re-checking *after* the enqueue is what closes the race: every close path moves the consumer to a terminal state before it drains the pending-receive queue, so the recheck either observes the terminal state (and self-drains) or is ordered before the close's drain (which then covers it).
3. Strengthened **`testConcurrentCompactionAndTopicDelete`** to assert the deletion actually **succeeded** (`deleteTopicFuture.get(...)`), instead of only asserting it completed (which is also true when it fails).
4. Added regression tests:
   - `CompactionTest.testForcedDeleteSucceedsAfterFailedCompaction` — forced topic deletion after a deterministically failed compaction (cause 1).
   - `CompactionTest.testForcedNamespaceDeleteWithInflightCompaction` — end-to-end forced namespace deletion with an in-flight compaction (#24148 reproduction).
   - `RawReaderTest.testReadNextAsyncCompletesAfterConsumerClosed` — a read issued once the consumer is terminal must complete rather than hang (cause 2).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Each of `RawReaderTest.testReadNextAsyncCompletesAfterConsumerClosed`, `CompactionTest.testForcedDeleteSucceedsAfterFailedCompaction`, and the strengthened `testConcurrentCompactionAndTopicDelete` was verified **red without** its corresponding fix and **green with** it.
- `CompactionTest.testForcedNamespaceDeleteWithInflightCompaction` and the full `CompactionTest` / `RawReaderTest` suites pass locally.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
