### PR TITLE
[fix][build] Fix stage-release.sh for the Gradle build

### DIFF
--- a/src/stage-release.sh
+++ b/src/stage-release.sh
@@ -30,19 +30,24 @@ DEST_PATH="$(cd "$DEST_PATH" && pwd)"
 
 pushd $(dirname "$0")
 PULSAR_PATH=$(git rev-parse --show-toplevel)
-VERSION=`./get-project-version.py`
+VERSION=$(./get-pulsar-version.sh)
 popd
 
-pushd "$(dirname "$0")/.."
+# Source release: archive the committed tree (HEAD). git archive includes every
+# tracked file, which covers the Gradle wrapper, build-logic, settings.gradle.kts,
+# gradle.properties and all module build files needed to build Pulsar from source.
+pushd "$PULSAR_PATH"
 git archive --format=tar.gz --output="$DEST_PATH/apache-pulsar-$VERSION-src.tar.gz" --prefix="apache-pulsar-$VERSION-src/" HEAD
 popd
 
-cp $PULSAR_PATH/distribution/server/target/apache-pulsar-$VERSION-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/offloaders/target/apache-pulsar-offloaders-$VERSION-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-bin.tar.gz $DEST_PATH
-cp $PULSAR_PATH/distribution/shell/target/apache-pulsar-shell-$VERSION-bin.zip $DEST_PATH
+# Binary distributions are produced by the Gradle build under build/distributions
+# (e.g. ./gradlew assemble, or the individual *DistTar / *DistZip tasks).
+cp $PULSAR_PATH/distribution/server/build/distributions/apache-pulsar-$VERSION-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/offloaders/build/distributions/apache-pulsar-offloaders-$VERSION-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/build/distributions/apache-pulsar-shell-$VERSION-bin.tar.gz $DEST_PATH
+cp $PULSAR_PATH/distribution/shell/build/distributions/apache-pulsar-shell-$VERSION-bin.zip $DEST_PATH
 
-cp -r $PULSAR_PATH/distribution/io/target/apache-pulsar-io-connectors-$VERSION-bin $DEST_PATH/connectors
+# Note: IO connectors are no longer staged here — pulsar-connectors is released separately.
 
 # Sign all files
 cd $DEST_PATH


### PR DESCRIPTION
### Motivation

The release staging script `src/stage-release.sh` was left pointing at the Maven layout after the build migrated to Gradle, so it no longer works:

- it called `./get-project-version.py`, which was removed during the migration;
- it copied the binary distributions from `distribution/*/target/`, but Gradle writes them to `distribution/*/build/distributions/`;
- it copied an IO connectors distribution that the Gradle build no longer produces.

### Modifications

- Read the version from `gradle.properties` via `get-pulsar-version.sh`.
- Copy the server, offloaders and shell binary distributions from the Gradle output directory `build/distributions` instead of the Maven `target`.
- Drop the IO connectors copy; `pulsar-connectors` is released separately.

The source release is left unchanged: it is still produced by `git archive` of `HEAD`. Because `.gitattributes` declares no `export-ignore`, the archive contains every tracked file, which already covers everything needed to build from source (the Gradle wrapper and `gradle-wrapper.jar`, `build-logic`, `settings.gradle.kts`, `gradle.properties`, the version catalog and all module build files). No `.gitignore`/`.gitattributes` changes are required.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is build/release tooling and is not covered by automated tests. It was verified manually:

- `src/get-pulsar-version.sh` returns the expected version from `gradle.properties`.
- The generated source tarball (`git archive` of `HEAD`) was extracted and the Gradle build configured from the extract alone with `./gradlew help --offline`, confirming the source release is self-contained.
- The binary distribution paths match the `Tar`/`Zip` task outputs in `distribution/{server,offloaders,shell}/build.gradle.kts` (`build/distributions/apache-pulsar[-offloaders|-shell]-$VERSION-bin.{tar.gz,zip}`).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment