### PR TITLE
[fix][build] Fix publishing public v5 client libraries to Maven repository

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -178,6 +178,9 @@ jobs:
       - name: Check binary licenses
         run: ./gradlew checkBinaryLicense --no-configuration-cache
 
+      - name: Check that project's public libraries can be published to a Maven repository
+        run: ./gradlew publishAllPublicationsToLocalDeployRepository
+
       - name: Upload Gradle reports
         uses: actions/upload-artifact@v4
         if: ${{ !success() }}

--- a/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/pulsar.publish-conventions.gradle.kts
@@ -22,6 +22,9 @@
 // the ASF Nexus release/snapshot repositories, and a local deploy repository
 // for testing.
 
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
 plugins {
     `maven-publish`
     signing
@@ -167,10 +170,11 @@ run {
 // Publish with one of:
 //   ./gradlew publishAllPublicationsToApacheSnapshotsRepository   (for -SNAPSHOT versions)
 //   ./gradlew publishAllPublicationsToApacheReleasesRepository    (for release versions)
-// Releases must be published with --no-parallel: when uploading to the Apache staging
-// repository, Nexus creates an implicit staging repository, and concurrent per-module uploads
-// can end up split across multiple implicitly-created staging repositories instead of being
-// collected into a single one.
+// Uploads to the Apache staging repository are serialized by the mavenPublishLock shared build
+// service (defined below) so they all land in a single Nexus staging repository: Nexus creates an
+// implicit staging repository on first upload, and concurrent per-module uploads could otherwise be
+// split across multiple implicitly-created staging repositories. Because the lock handles this,
+// --no-parallel is not required.
 // Credentials are resolved by Gradle at execution time from the apacheReleasesUsername /
 // apacheReleasesPassword and apacheSnapshotsUsername / apacheSnapshotsPassword Gradle properties
 // (the credentials(PasswordCredentials::class) form, which keeps the publish tasks
@@ -180,7 +184,7 @@ run {
 // builds; start the command line with a space to keep the password out of shell history:
 //    ORG_GRADLE_PROJECT_apacheReleasesUsername=$APACHE_USER \
 //    ORG_GRADLE_PROJECT_apacheReleasesPassword="<your ASF password>" \
-//    ./gradlew publishAllPublicationsToApacheReleasesRepository --no-parallel ...
+//    ./gradlew publishAllPublicationsToApacheReleasesRepository ...
 // The URLs can be overridden with the apacheReleasesRepoUrl / apacheSnapshotsRepoUrl Gradle
 // properties (e.g. a file:// URL for testing the publication layout).
 run {
@@ -242,6 +246,25 @@ run {
             }
         }
     }
+}
+
+// --- Serialize uploads to Maven repositories ---
+// Nexus creates an implicit staging repository on the first upload of a release, and concurrent
+// per-module uploads can end up split across multiple implicitly-created staging repositories
+// instead of being collected into a single one. A shared build service with maxParallelUsages = 1
+// ensures at most one PublishToMavenRepository upload runs at a time across the whole build, so the
+// rest of the build (compilation, jars, signing) can still run in parallel and --no-parallel is not
+// required.
+abstract class MavenPublishLock : BuildService<BuildServiceParameters.None>
+
+val mavenPublishLock = gradle.sharedServices.registerIfAbsent(
+    "mavenPublishLock", MavenPublishLock::class
+) {
+    maxParallelUsages = 1
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    usesService(mavenPublishLock)
 }
 
 // --- GPG signing ---

--- a/pulsar-client-api-v5/build.gradle.kts
+++ b/pulsar-client-api-v5/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {

--- a/pulsar-client-v5/build.gradle.kts
+++ b/pulsar-client-v5/build.gradle.kts
@@ -18,7 +18,7 @@
  */
 
 plugins {
-    id("pulsar.java-conventions")
+    id("pulsar.public-java-library-conventions")
 }
 
 dependencies {


### PR DESCRIPTION
### Motivation

The `pulsar-client-api-v5` and `pulsar-client-v5` modules are public client libraries, but they were configured with `pulsar.java-conventions`, which does not set up Maven publishing. Because the published `:pulsar-client-tools` module depends on them, publishing fails the published-dependency validation in `pulsar.public-java-library-conventions`:

```
Published module ':pulsar-client-tools' depends on unpublished projects:
  - implementation -> :pulsar-client-api-v5 (not published)
  - implementation -> :pulsar-client-v5 (not published)
```

This breaks publishing the public client libraries to the Maven repository during a release, and there was no CI coverage to catch this class of publishing problem before a release.

### Modifications

- Switch `pulsar-client-api-v5` and `pulsar-client-v5` from `pulsar.java-conventions` to `pulsar.public-java-library-conventions` so they are published to Maven repositories.
- Add a `mavenPublishLock` shared build service (`maxParallelUsages = 1`) wired into every `PublishToMavenRepository` task in `pulsar.publish-conventions`. This serializes uploads so release uploads to the Apache Nexus staging repository all land in a single implicitly-created staging repository, removing the need to pass `--no-parallel` for releases (the rest of the build still runs in parallel). The surrounding documentation comment is updated accordingly.
- Add a CI step that runs `./gradlew publishAllPublicationsToLocalDeployRepository` to verify that all publications can be published and to catch publishing regressions early.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a build/release configuration fix, verified manually as follows:

- Without the change, `./gradlew publishMavenPublicationToLocalDeployRepository` fails with the unpublished-projects error shown above.
- With the change, `./gradlew publishAllPublicationsToLocalDeployRepository` completes successfully and the v5 modules are published to the local deploy repository. The new CI step provides ongoing coverage.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment: the `pulsar-client-api-v5` and `pulsar-client-v5` artifacts are now published to the Maven repository (they were previously not published).
