### PR TITLE
[improve][build] Upgrade SnakeYAML to 2.6

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -428,7 +428,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-jetty-websocket-jetty-client-12.1.10.jar
     - org.eclipse.jetty.websocket-jetty-websocket-jetty-common-12.1.10.jar
     - org.eclipse.jetty.websocket-jetty-websocket-jetty-server-12.1.10.jar
- * SnakeYaml -- org.yaml-snakeyaml-2.0.jar
+ * SnakeYaml -- org.yaml-snakeyaml-2.6.jar
  * RocksDB - org.rocksdb-rocksdbjni-9.9.3.jar
  * Google Error Prone Annotations - com.google.errorprone-error_prone_annotations-2.45.0.jar
  * Apache Thrift - org.apache.thrift-libthrift-0.23.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -418,7 +418,7 @@ The Apache Software License, Version 2.0
     - jetty-websocket-jetty-api-12.1.10.jar
     - jetty-websocket-jetty-client-12.1.10.jar
     - jetty-websocket-jetty-common-12.1.10.jar
- * SnakeYaml -- snakeyaml-2.0.jar
+ * SnakeYaml -- snakeyaml-2.6.jar
  * Google Error Prone Annotations - error_prone_annotations-2.45.0.jar
  * Javassist -- javassist-3.25.0-GA.jar
   * Apache Avro

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ bouncycastle-bc-fips = "2.0.1"
 # Serialization
 avro = "1.12.0"
 gson = "2.13.2"
-snakeyaml = "2.0"
+snakeyaml = "2.6"
 # Vert.x
 vertx = "4.5.28"
 # Networking / HTTP


### PR DESCRIPTION
### Motivation

SnakeYAML was pinned at `2.0`. This bumps it to the latest 2.x release (`2.6`) to
stay current and pick up the per-document size-limit handling, an emoji parsing
fix, and the performance/allocation improvements made across the 2.x line.

The entire 2.x line is binary and source compatible — the breaking changes (such
as safe-loading by default for CVE-2022-1471) happened in the 1.x → 2.0 jump — so
this is a maintenance refresh with no behavioral change. The parsing-limit
defaults (`codePointLimit` 3 MB, `nestingDepthLimit` 50, `maxAliasesForCollections`
50) are unchanged since before 2.0. No CVEs were fixed between 2.1 and 2.6, so this
is not a security fix.

SnakeYAML is a transitive dependency (via `jackson-dataformat-yaml`) that Pulsar
pins for convergence and shades into the client and function localrun jars. There
is no direct `org.yaml.snakeyaml` API usage in the codebase, so the change is
limited to the version pin and the bundled-jar references in the binary LICENSE
files. Jackson 2.21.x bundles SnakeYAML 2.5; forcing 2.6 (one patch ahead, with no
API or default-limit changes) is the convergence pin Pulsar already maintains.

### Modifications

- Bump `snakeyaml` `2.0` → `2.6` in the Gradle version catalog
  (`gradle/libs.versions.toml`).
- Update the bundled SnakeYAML jar version in the server and shell binary LICENSE
  files (`distribution/server/src/assemble/LICENSE.bin.txt`,
  `distribution/shell/src/assemble/LICENSE.bin.txt`).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial dependency-version bump without new test coverage. It was
verified locally as follows:

- `./gradlew :pulsar-common:dependencyInsight --dependency org.yaml:snakeyaml`
  confirms `org.yaml:snakeyaml` resolves to `2.6` (forced by the convergence
  constraint, winning over Jackson's bundled 2.5).
- The server and shell distribution tarballs bundle `org.yaml-snakeyaml-2.6.jar`
  and `snakeyaml-2.6.jar` respectively, matching the updated LICENSE pins.
- `./gradlew checkBinaryLicense` passes, validating the bundled jars against the
  binary LICENSE files.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
