### PR TITLE
[fix][broker] Fail fast for load balancer misconfigurations instead of falling back to SimpleLoadManagerImpl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -150,35 +150,31 @@ public interface LoadManager {
     void initialize(PulsarService pulsar);
 
     static LoadManager create(final PulsarService pulsar) {
-        try {
-            final ServiceConfiguration conf = pulsar.getConfiguration();
+        final ServiceConfiguration conf = pulsar.getConfiguration();
 
-            String loadManagerClassName = conf.getLoadManagerClassName();
-            if (StringUtils.isBlank(loadManagerClassName)) {
-                loadManagerClassName = SimpleLoadManagerImpl.class.getName();
-            }
-
-            // Assume there is a constructor with one argument of PulsarService.
-            final Object loadManagerInstance = Reflections.createInstance(loadManagerClassName,
-                    Thread.currentThread().getContextClassLoader());
-            if (loadManagerInstance instanceof LoadManager casted) {
-                casted.initialize(pulsar);
-                return casted;
-            } else if (loadManagerInstance instanceof ModularLoadManager modularLoadManager) {
-                final LoadManager casted = new ModularLoadManagerWrapper(modularLoadManager);
-                casted.initialize(pulsar);
-                return casted;
-            } else if (loadManagerInstance instanceof ExtensibleLoadManager) {
-                final LoadManager casted =
-                        new ExtensibleLoadManagerWrapper((ExtensibleLoadManagerImpl) loadManagerInstance);
-                casted.initialize(pulsar);
-                return casted;
-            }
-        } catch (Exception e) {
-            LOG.warn().exception(e).log("Error when trying to create load manager");
+        String loadManagerClassName = conf.getLoadManagerClassName();
+        if (StringUtils.isBlank(loadManagerClassName)) {
+            loadManagerClassName = SimpleLoadManagerImpl.class.getName();
         }
-        // If we failed to create a load manager, default to SimpleLoadManagerImpl.
-        return new SimpleLoadManagerImpl(pulsar);
+
+        // Assume there is a constructor with one argument of PulsarService.
+        final Object loadManagerInstance = Reflections.createInstance(loadManagerClassName,
+                Thread.currentThread().getContextClassLoader());
+        if (loadManagerInstance instanceof LoadManager casted) {
+            casted.initialize(pulsar);
+            return casted;
+        } else if (loadManagerInstance instanceof ModularLoadManager modularLoadManager) {
+            final LoadManager casted = new ModularLoadManagerWrapper(modularLoadManager);
+            casted.initialize(pulsar);
+            return casted;
+        } else if (loadManagerInstance instanceof ExtensibleLoadManager) {
+            final LoadManager casted =
+                    new ExtensibleLoadManagerWrapper((ExtensibleLoadManagerImpl) loadManagerInstance);
+            casted.initialize(pulsar);
+            return casted;
+        } else {
+            throw new IllegalArgumentException(loadManagerClassName + " is not a supported LoadManager");
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation

We observed production issues due to the following misconfigurations:

```
loadBalancerLoadSheddingStrategy=org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder
loadBalancerLoadPlacementStrategy=org.apache.pulsar.broker.loadbalance.impl.AvgShedder
```

Logs:

```
2026-06-15T07:27:18,079+0000 [main] WARN  org.apache.pulsar.broker.loadbalance.LoadManager - Error when trying to create load manager:
  java.lang.IllegalArgumentException: The load shedding strategy: org.apache.pulsar.broker.loadbalance.impl.ThresholdShedder can't work with the placement strategy: org.apache.pulsar.broker.loadbalance.impl.AvgShedder
```

This did not fail fast, instead, it created a `SimpleLoadManagerImpl` object as a load balance. This early implementation has many issues and its functionality is hardly tested, for example, it might not work well with multiple listeners specified like `the broker do not have gw listener`.

IMO, we should remove this outdated implementation in future, but for now, I think we should fail fast for misconfigurations rather than falling back to this implementation.