### PR TITLE
[fix][client] Prevent client shutdown from leaking event loop threads when DNS resolver close fails

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -1071,11 +1071,21 @@ public class PulsarClientImpl implements PulsarClient {
             }
 
             if (addressResolver != null) {
-                addressResolver.close();
+                try {
+                    addressResolver.close();
+                } catch (Throwable t) {
+                    log.warn().exception(t).log("Failed to close addressResolver");
+                    throwable = t;
+                }
             }
 
             if (dnsResolverGroupLocalInstance != null) {
-                dnsResolverGroupLocalInstance.close();
+                try {
+                    dnsResolverGroupLocalInstance.close();
+                } catch (Throwable t) {
+                    log.warn().exception(t).log("Failed to close dnsResolverGroup");
+                    throwable = t;
+                }
             }
 
             try {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/PulsarClientImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +40,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
+import io.netty.resolver.AddressResolver;
 import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -180,6 +182,38 @@ public class PulsarClientImplTest {
         field.set(client, timer);
 
         client.shutdown();
+        verify(timer).stop();
+    }
+
+    @Test
+    public void testShutdownContinuesWhenAddressResolverCloseFails() throws Exception {
+        ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl("pulsar://localhost:6650");
+        PulsarClientImpl client = new PulsarClientImpl(conf);
+
+        // Simulate the Netty DNS resolver shutdown race where AddressResolver.close()
+        // throws "channel not registered to an event loop".
+        @SuppressWarnings("unchecked")
+        AddressResolver<InetSocketAddress> failingResolver = mock(AddressResolver.class);
+        doThrow(new IllegalStateException("channel not registered to an event loop"))
+                .when(failingResolver).close();
+        Field addressResolverField = PulsarClientImpl.class.getDeclaredField("addressResolver");
+        addressResolverField.setAccessible(true);
+        addressResolverField.set(client, failingResolver);
+
+        // Replace the timer with a mock so we can assert that shutdown still reaches the
+        // cleanup steps that run after the address resolver is closed.
+        HashedWheelTimer timer = mock(HashedWheelTimer.class);
+        Field timerField = PulsarClientImpl.class.getDeclaredField("timer");
+        timerField.setAccessible(true);
+        timerField.set(client, timer);
+
+        // shutdown() still surfaces the original failure, but it must not abort early:
+        // the remaining resources have to be released regardless. The key assertion is
+        // that timer.stop() (a step that runs after the resolver is closed) is reached.
+        assertThrows(IllegalStateException.class, client::shutdown);
+
+        verify(failingResolver).close();
         verify(timer).stop();
     }
 


### PR DESCRIPTION
### Motivation

`PulsarClientImpl.shutdown()` closes most resources defensively: each `close()` is wrapped in its own `try/catch` and the last failure is recorded in `throwable` so that shutdown always continues and releases the remaining resources. Two cleanup steps, however, are **not** guarded:

```java
if (addressResolver != null) {
    addressResolver.close();
}

if (dnsResolverGroupLocalInstance != null) {
    dnsResolverGroupLocalInstance.close();
}
```

These run *before* `shutdownEventLoopGroup()`, `closeCnxPool()`, `timer.stop()` and `shutdownExecutors()`. If `addressResolver.close()` throws, the exception propagates straight to the outer `catch`, and the remaining cleanup never runs — so the `EventLoopGroup`'s non-daemon threads (plus the connection pool, timer and executors) are leaked and the JVM never exits.

This is reachable in practice: when a DNS lookup is still in flight as the client shuts down, the Netty address resolver can throw `java.lang.IllegalStateException: channel not registered to an event loop` (a known Netty shutdown race). It reproduces consistently when upgrading Quarkus to `pulsar-client` 4.2.1 — the test JVM hangs and is eventually killed by the Surefire fork timeout (~20 minutes), with:

```
WARN  org.apache.pulsar.client.impl.PulsarClientImpl - Failed to shutdown Pulsar client: java.lang.IllegalStateException: channel not registered to an event loop
Exception in thread "pulsar-client-shutdown-thread" java.lang.IllegalStateException: channel not registered to an event loop
```

The DNS resolver group was introduced in #24784, and the unguarded close has been present since then (4.2.0 onward, including 4.2.1/4.2.2 and `master`).

### Modifications

Wrap `addressResolver.close()` and `dnsResolverGroupLocalInstance.close()` in `try/catch`, logging the failure and recording it in `throwable`, exactly like every other resource closed by `shutdown()`. This guarantees `shutdown()` always proceeds to release the event loop group, connection pool, timer and executors even if the DNS resolver fails to close, while still surfacing the original failure to the caller.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage. It restores the existing best-effort cleanup contract for two steps that were missing it; the surrounding steps already follow this pattern.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
