### PR TITLE
[fix][build] Align protobuf proto-path and avroTools configs with the version platform

### DIFF
--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -197,6 +197,18 @@ protobuf {
     }
 }
 
+// Align the protobuf plugin's resolvable proto-path classpaths with the enforced version platform.
+// The protobuf-gradle-plugin creates `<sourceSet>ProtoPath` configurations that resolve the proto
+// closure of the project's dependencies. They are build-time only and never published, but the
+// GitHub dependency-submission resolves every resolvable configuration, and without the alignment
+// bucket these report transitive versions that diverge from the version catalog (e.g.
+// netty-codec-http2, commons-configuration2), which Dependabot then flags. Extending the
+// non-consumable `internalPlatform` bucket (see pulsar.java-conventions) keeps them consistent
+// with the catalog without affecting any published metadata.
+configurations.matching { it.name.endsWith("ProtoPath") }.configureEach {
+    extendsFrom(configurations["internalPlatform"])
+}
+
 // All main proto files now use lightproto. Only test protos use standard protobuf.
 sourceSets["main"].proto {
     exclude("TransactionPendingAck.proto")

--- a/pulsar-client/build.gradle.kts
+++ b/pulsar-client/build.gradle.kts
@@ -93,8 +93,22 @@ protobuf {
 // Only generate protobuf for test sources (no main protos)
 sourceSets["main"].proto { exclude("**/*") }
 
+// Align the protobuf plugin's resolvable proto-path classpaths with the enforced version platform.
+// These build-time-only `<sourceSet>ProtoPath` configurations are never published, but the GitHub
+// dependency-submission resolves every resolvable configuration and would otherwise report
+// transitive versions diverging from the version catalog (e.g. netty-codec-http2), which Dependabot
+// flags. See the matching comment in pulsar-broker/build.gradle.kts and pulsar.java-conventions.
+configurations.matching { it.name.endsWith("ProtoPath") }.configureEach {
+    extendsFrom(configurations["internalPlatform"])
+}
+
 // Generate Avro test classes from .avsc schema files
-val avroTools by configurations.creating
+val avroTools by configurations.creating {
+    // Align the avro-tools codegen classpath with the enforced version platform so its transitive
+    // dependencies (commons-*, jetty-util, ...) match the version catalog instead of avro-tools'
+    // own older transitives. Build-time only, never published.
+    extendsFrom(configurations["internalPlatform"])
+}
 dependencies {
     avroTools("org.apache.avro:avro-tools:${libs.versions.avro.get()}") {
         exclude(group = "org.eclipse.jetty", module = "jetty-server")


### PR DESCRIPTION
### Motivation

The enforced version-alignment platform (`:pulsar-dependencies`) is attached only to the build's main resolvable classpaths (`compileClasspath`, `runtimeClasspath`, the `test*` variants, `annotationProcessor*`) through the non-published `internalPlatform` bucket introduced to keep `enforcedPlatform` out of the published `apiElements`/`runtimeElements` metadata.

A few other resolvable configurations are not wired to that bucket and therefore get no catalog alignment:

- the protobuf-gradle-plugin's `compileProtoPath` / `testCompileProtoPath` configurations (in `pulsar-broker` and `pulsar-client-original`), and
- the `avroTools` codegen configuration (in `pulsar-client-original`).

Because the GitHub dependency-submission action resolves **every** resolvable configuration, these configurations contributed transitive versions that diverge from the version catalog into the submitted dependency graph, e.g.:

- `io.netty:netty-codec-http2:4.2.13.Final` instead of the catalog `4.2.15.Final`
- `org.apache.commons:commons-configuration2:2.12.0` instead of the catalog `2.15.1`
- `io.vertx:vertx-core:4.5.27` instead of `4.5.28`, and similar for grpc/opentelemetry/jetty/commons-* in the avro-tools closure.

Dependabot then raised alerts on these stale transitive versions. The published artifacts and the binary distribution were **not** affected — they build from the aligned `runtimeClasspath` — and an exhaustive scan of the local-deploy POMs and Gradle Module Metadata confirmed every catalog-managed reference there is already at its catalog version. This is purely about the build-time-only tool classpaths that feed the dependency-submission report.

### Modifications

- `pulsar-broker/build.gradle.kts` and `pulsar-client/build.gradle.kts`: wire the protobuf `*ProtoPath` configurations to the `internalPlatform` alignment bucket via `configurations.matching { it.name.endsWith("ProtoPath") }.configureEach { extendsFrom(configurations["internalPlatform"]) }`.
- `pulsar-client/build.gradle.kts`: make the `avroTools` configuration extend `internalPlatform`.

These configurations are resolvable, build-time only, and never published, so extending the non-consumable `internalPlatform` bucket aligns their resolution with the version catalog without adding anything to any published POM or Gradle Module Metadata.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a build-only change verified as follows:

- A Gradle audit confirmed that, before the change, `compileProtoPath`/`testCompileProtoPath` (broker + client) and `avroTools` (client) resolved catalog-managed artifacts to non-catalog versions; after the change a re-run of the same scan reports **zero** mismatches across all resolvable configurations.
- `:pulsar-broker:generateTestProto`, `:pulsar-client-original:generateTestProto` and `:pulsar-client-original:generateTestAvro` all run successfully after the change (proto/avro code generation is unaffected by the aligned versions).
- `:pulsar-broker:spotlessCheck` and `:pulsar-client-original:spotlessCheck` pass.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment