### PR TITLE
[improve][broker] PIP-468: auto-create scalable topics on lookup when policy allows

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -4002,13 +4002,35 @@ public class BrokerService implements Closeable {
             return CompletableFuture.completedFuture(false);
         }
 
-        // Segment topics (PIP-468 scalable topics) are explicitly created by the
-        // ScalableTopicController via the /admin/v2/segments endpoint. They must
-        // never be auto-created on connect — otherwise a producer/consumer racing
-        // a controller-driven delete (post-prune retention GC, force-delete) would
-        // silently re-create the topic with default schema and mask the deletion.
+        // Segment topics (PIP-468 scalable topics) are normally created explicitly by the
+        // ScalableTopicController, never blanket-auto-created on connect — a producer/consumer
+        // racing a controller-driven delete (post-prune retention GC, force-delete, or the
+        // sealed parent of a split/merge) must not silently resurrect a torn-down segment and
+        // mask the deletion. The one allowed exception is reconciliation: if the parent DAG
+        // still lists this segment as ACTIVE, its backing topic legitimately should exist, so
+        // a connect may (re)materialize it. This self-heals an active segment whose backing
+        // topic was never created or went missing (e.g. a createScalableTopic that wrote
+        // metadata then failed to materialize segments), without resurrecting sealed or pruned
+        // ones — those are marked sealed or absent from the layout, so the check below rejects
+        // them. (Narrow window: the controller terminates a split/merge parent's topic just
+        // before flipping its metadata to sealed, so a connect in that gap could briefly reopen
+        // it; the next layout update moves clients off it.)
         if (topicName.getDomain() == TopicDomain.segment) {
-            return CompletableFuture.completedFuture(false);
+            if (!pulsar.getConfiguration().isScalableTopicsEnabled()) {
+                return CompletableFuture.completedFuture(false);
+            }
+            ScalableTopicResources scalableResources =
+                    pulsar.getPulsarResources().getScalableTopicResources();
+            if (scalableResources == null) {
+                return CompletableFuture.completedFuture(false);
+            }
+            TopicName parent = SegmentTopicName.getParentTopicName(topicName);
+            long segmentId = SegmentTopicName.getSegmentId(topicName);
+            return scalableResources.getScalableTopicMetadataAsync(parent)
+                    .thenApply(optMd -> optMd
+                            .map(md -> md.getSegments().get(segmentId))
+                            .map(seg -> seg.isActive())
+                            .orElse(false));
         }
 
         // PIP-475: never auto-create a persistent:// topic that has been migrated to a

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
@@ -37,6 +37,8 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.scalable.HashRange;
 import org.apache.pulsar.common.scalable.SegmentInfo;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.metadata.api.NotificationType;
 
@@ -53,6 +55,10 @@ import org.apache.pulsar.metadata.api.NotificationType;
 public class DagWatchSession implements ScalableTopicResources.MetadataPathListener {
 
     private static final Logger LOG = Logger.get(DagWatchSession.class);
+
+    /** Initial segment count for an auto-created scalable topic. */
+    private static final int AUTO_CREATE_INITIAL_SEGMENTS = 1;
+
     private final Logger log;
 
     @Getter
@@ -132,8 +138,47 @@ public class DagWatchSession implements ScalableTopicResources.MetadataPathListe
                     if (topicName.getDomain() == TopicDomain.persistent) {
                         return buildSyntheticResponse();
                     }
+                    if (topicName.getDomain() == TopicDomain.topic) {
+                        return maybeAutoCreateAndBuildResponse();
+                    }
                     return CompletableFuture.failedFuture(
                             new IllegalStateException("Scalable topic not found: " + topicName));
+                });
+    }
+
+    /**
+     * A lookup for a {@code topic://...} scalable topic that doesn't exist yet. Auto-create it
+     * with a single initial segment — gated by the same broker/namespace auto-topic-creation
+     * policy as regular topics ({@link BrokerService#isAllowAutoTopicCreationAsync}) — then
+     * return its layout. If the policy disallows it, fail with the same not-found error as
+     * before so the client sees no behavioural change when auto-creation is off.
+     */
+    private CompletableFuture<ScalableTopicLayoutResponse> maybeAutoCreateAndBuildResponse() {
+        return brokerService.isAllowAutoTopicCreationAsync(scalableTopicName)
+                .thenCompose(allowed -> {
+                    if (!allowed) {
+                        return CompletableFuture.failedFuture(
+                                new IllegalStateException("Scalable topic not found: " + topicName));
+                    }
+                    return brokerService.getScalableTopicService()
+                            .createScalableTopic(scalableTopicName, AUTO_CREATE_INITIAL_SEGMENTS)
+                            // Tolerate a concurrent lookup that created it first; any other
+                            // failure propagates.
+                            .handle((v, ex) -> ex)
+                            .thenCompose(ex -> {
+                                if (ex != null && !(FutureUtil.unwrapCompletionException(ex)
+                                        instanceof MetadataStoreException.AlreadyExistsException)) {
+                                    return CompletableFuture.<ScalableTopicLayoutResponse>failedFuture(ex);
+                                }
+                                log.info().log("Auto-created scalable topic");
+                                return resources.getScalableTopicMetadataAsync(scalableTopicName, true)
+                                        .thenCompose(opt -> opt.isPresent()
+                                                ? buildResponse(opt.get())
+                                                : CompletableFuture.failedFuture(
+                                                        new IllegalStateException(
+                                                                "Scalable topic not found after "
+                                                                        + "auto-create: " + topicName)));
+                            });
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicService.java
@@ -146,12 +146,22 @@ public class ScalableTopicService {
         ScalableTopicMetadata metadata = ScalableTopicController.createInitialMetadata(
                 numInitialSegments, properties);
 
+        // Write the scalable metadata FIRST, then materialize the underlying segment topics.
+        // The metadata is the source of truth: its presence is what defines whether the topic
+        // "exists"; segment topics are derived state. Writing metadata first means a partial
+        // failure (a segment create throws, or the broker crashes mid-way) leaves no orphaned
+        // segment topics dangling without a parent — everything created is already referenced
+        // by valid metadata. An active segment whose backing topic is missing is
+        // (re)materialized on demand the first time a client connects to it — see the
+        // active-segment reconciliation in BrokerService.isAllowAutoTopicCreationAsync — so
+        // eager materialization here is a happy-path latency optimization, not a correctness
+        // requirement.
         return resources.createScalableTopicAsync(topic, metadata)
                 .thenCompose(__ -> {
-                    // Create underlying persistent topics for each initial segment
-                    List<CompletableFuture<Void>> segmentFutures = metadata.getSegments().values().stream()
-                            .map(segment -> createUnderlyingSegmentTopic(topic, segment))
-                            .toList();
+                    List<CompletableFuture<Void>> segmentFutures =
+                            metadata.getSegments().values().stream()
+                                    .map(segment -> createUnderlyingSegmentTopic(topic, segment))
+                                    .toList();
                     return FutureUtil.waitForAll(segmentFutures);
                 });
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
@@ -104,11 +104,15 @@ public class DagWatchSessionTest {
     // --- start() ---
 
     @Test
-    public void testStartFailsWhenTopicMetadataMissing() {
-        // topic://... input + no scalable metadata = TopicNotFound. Synthetic layouts
-        // are only produced for persistent://... input (regular topics).
+    public void testStartFailsWhenTopicMetadataMissingAndAutoCreateDisallowed() {
+        // topic://... input + no scalable metadata + auto-create disallowed by policy =
+        // TopicNotFound. (When auto-create is allowed the topic is created instead — covered
+        // end-to-end by V5ScalableTopicAutoCreateTest.) Synthetic layouts are only produced
+        // for persistent://... input (regular topics).
         when(resources.getScalableTopicMetadataAsync(TOPIC, true))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+        when(brokerService.isAllowAutoTopicCreationAsync(TOPIC))
+                .thenReturn(CompletableFuture.completedFuture(false));
 
         CompletableFuture<ScalableTopicLayoutResponse> future = session.start();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5ScalableTopicAutoCreateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5ScalableTopicAutoCreateTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api.v5;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import java.util.UUID;
+import lombok.Cleanup;
+import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
+import org.apache.pulsar.common.policies.data.ScalableTopicMetadata;
+import org.testng.annotations.Test;
+
+/**
+ * A V5 client looking up a {@code topic://...} scalable topic that doesn't exist yet should
+ * have it auto-created with a single initial segment — gated by the same broker/namespace
+ * auto-topic-creation policy as regular topics (PIP-468 / PIP-483). When the policy disallows
+ * it, the lookup fails as before.
+ */
+public class V5ScalableTopicAutoCreateTest extends V5ClientBaseTest {
+
+    private String freshTopic() {
+        return "topic://" + getNamespace() + "/autocreate-"
+                + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    @Test
+    public void testProducerAutoCreatesScalableTopicWithOneSegment() throws Exception {
+        String topic = freshTopic();
+
+        // No admin.createScalableTopic — the producer's lookup must create it.
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        assertNotNull(producer.newMessage().value("hello").send());
+
+        ScalableTopicMetadata md = admin.scalableTopics().getMetadata(topic);
+        assertNotNull(md, "scalable topic must have been auto-created");
+        assertEquals(md.getSegments().size(), 1, "auto-create uses a single initial segment");
+    }
+
+    @Test
+    public void testConsumerAutoCreatesScalableTopic() throws Exception {
+        String topic = freshTopic();
+
+        @Cleanup
+        QueueConsumer<String> consumer = v5Client.newQueueConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName("sub")
+                .subscribe();
+
+        ScalableTopicMetadata md = admin.scalableTopics().getMetadata(topic);
+        assertNotNull(md);
+        assertEquals(md.getSegments().size(), 1);
+    }
+
+    @Test
+    public void testNoAutoCreateWhenNamespaceDisallows() throws Exception {
+        // Turn auto-topic-creation off for this namespace; a lookup of a non-existent
+        // scalable topic must then fail instead of creating one.
+        admin.namespaces().setAutoTopicCreation(getNamespace(),
+                AutoTopicCreationOverride.builder().allowAutoTopicCreation(false).build());
+        try {
+            String topic = freshTopic();
+            // The lookup must surface a typed not-found, exactly as a non-existent regular
+            // topic does — not a generic PulsarClientException.
+            assertThrows(PulsarClientException.NotFoundException.class, () ->
+                    v5Client.newProducer(Schema.string()).topic(topic).create());
+        } finally {
+            admin.namespaces().removeAutoTopicCreation(getNamespace());
+        }
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5SegmentReconciliationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5SegmentReconciliationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api.v5;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.scalable.HashRange;
+import org.apache.pulsar.common.scalable.SegmentTopicName;
+import org.testng.annotations.Test;
+
+/**
+ * Coverage for the segment-topic auto-create reconciliation rule (PIP-468/483): a
+ * {@code segment://} topic may be auto-created on connect <b>only</b> when the parent DAG
+ * still lists that segment as ACTIVE. This is what lets an active segment whose backing topic
+ * is missing (e.g. a {@code createScalableTopic} that wrote metadata then failed to
+ * materialize segments) self-heal when a client connects — while still refusing to resurrect
+ * a sealed/pruned segment that a producer/consumer might be racing a delete on.
+ *
+ * <p>Exercised directly through {@code BrokerService.isAllowAutoTopicCreationAsync}, which is
+ * the gate every producer/consumer connect funnels through.
+ */
+public class V5SegmentReconciliationTest extends V5ClientBaseTest {
+
+    private boolean segmentAutoCreatable(String segmentTopic) throws Exception {
+        return getPulsar().getBrokerService().isAllowAutoTopicCreationAsync(segmentTopic).get();
+    }
+
+    private String segmentName(String parentTopic, HashRange range, long segmentId) {
+        return SegmentTopicName.fromParent(TopicName.get(parentTopic), range, segmentId).toString();
+    }
+
+    @Test
+    public void testActiveSegmentIsAutoCreatable() throws Exception {
+        String topic = newScalableTopic(1);
+        // The single initial segment covers the full hash range and is ACTIVE.
+        String seg0 = segmentName(topic, HashRange.of(0x0000, 0xFFFF), 0);
+        assertTrue(segmentAutoCreatable(seg0),
+                "an active segment in the DAG must be auto-creatable so a connect can "
+                        + "reconcile a missing backing topic");
+    }
+
+    @Test
+    public void testSealedSegmentIsNotAutoCreatable() throws Exception {
+        String topic = newScalableTopic(1);
+        String seg0 = segmentName(topic, HashRange.of(0x0000, 0xFFFF), 0);
+
+        // Split seals segment 0 (its range/id are unchanged; only its state flips to SEALED).
+        admin.scalableTopics().splitSegment(topic, 0);
+
+        assertFalse(segmentAutoCreatable(seg0),
+                "a sealed segment must NOT be auto-created — a connect racing its teardown "
+                        + "must not resurrect it");
+    }
+
+    @Test
+    public void testUnknownSegmentIsNotAutoCreatable() throws Exception {
+        String topic = newScalableTopic(1);
+        // A segment id that isn't in the DAG at all.
+        String ghost = segmentName(topic, HashRange.of(0x0000, 0xFFFF), 999);
+        assertFalse(segmentAutoCreatable(ghost),
+                "a segment id absent from the DAG must not be auto-created");
+    }
+
+    @Test
+    public void testSegmentUnderMissingParentIsNotAutoCreatable() throws Exception {
+        // Parent scalable topic was never created.
+        String missingParent = "topic://" + getNamespace() + "/never-created-"
+                + java.util.UUID.randomUUID().toString().substring(0, 8);
+        String seg0 = segmentName(missingParent, HashRange.of(0x0000, 0xFFFF), 0);
+        assertFalse(segmentAutoCreatable(seg0),
+                "a segment under a non-existent scalable topic must not be auto-created");
+    }
+}

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/DagWatchClient.java
@@ -190,9 +190,11 @@ final class DagWatchClient implements DagWatchSession, AutoCloseable {
         log.error().attr("error", error).attr("message", message)
                 .log("DAG watch session error");
         if (!initialLayoutFuture.isDone()) {
+            String detail = "Scalable topic lookup failed: " + error + " - " + message;
             initialLayoutFuture.completeExceptionally(
-                    new PulsarClientException(
-                            "Scalable topic lookup failed: " + error + " - " + message));
+                    error == ServerError.TopicNotFound
+                            ? new PulsarClientException.NotFoundException(detail)
+                            : new PulsarClientException(detail));
         }
         // After the initial layout has arrived, broker-side errors on this session
         // (e.g., metadata unavailable) are transient — a reconnect typically clears

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ProducerBuilderV5.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ProducerBuilderV5.java
@@ -55,10 +55,14 @@ final class ProducerBuilderV5<T> implements ProducerBuilder<T> {
         try {
             return createAsync().join();
         } catch (java.util.concurrent.CompletionException e) {
-            if (e.getCause() instanceof PulsarClientException pce) {
+            Throwable cause = e.getCause();
+            if (cause instanceof PulsarClientException pce) {
                 throw pce;
             }
-            throw new PulsarClientException(e.getCause());
+            if (cause instanceof org.apache.pulsar.client.api.PulsarClientException.NotFoundException) {
+                throw new PulsarClientException.NotFoundException(cause.getMessage());
+            }
+            throw new PulsarClientException(cause);
         }
     }
 


### PR DESCRIPTION
### Motivation

PIP-468 scalable topics (`topic://` domain) could not be auto-created on
client lookup the way regular topics are — a producer/consumer connecting to a
not-yet-existing scalable topic always failed, even when the broker, namespace,
and topic policies would happily auto-create a regular topic. Operators had to
pre-create every scalable topic out of band.

This makes scalable-topic lookup honor the same auto-topic-creation policy as
regular topics, materializing a single initial segment, while preserving the
PIP-483 safety guarantees around segment lifecycle.

### Modifications

- **Auto-create on lookup (`DagWatchSession`)**: a `topic://` lookup with no
  existing metadata now calls `BrokerService.isAllowAutoTopicCreationAsync`
  (the same gate regular topics funnel through). When allowed, it creates the
  scalable topic with one initial segment; when disallowed, it fails with the
  same not-found error as before, so behavior is unchanged when auto-creation
  is off. A concurrent lookup that creates it first is tolerated
  (`AlreadyExistsException`).

- **Metadata-first creation (`ScalableTopicService.createScalableTopic`)**:
  writes the scalable-topic metadata *before* materializing the underlying
  segment topics. Metadata is the source of truth and segment topics are
  derived state, so a partial failure cannot leave an orphaned segment topic
  that no parent references.

- **Read-side segment reconciliation (`BrokerService.isAllowAutoTopicCreationAsync`)**:
  a `segment://` topic may now be auto-created on connect **only** when the
  parent DAG still lists that segment as ACTIVE. This self-heals an active
  segment whose backing topic is missing (e.g. metadata written but segment
  materialization failed) when a client connects, while preserving the PIP-483
  anti-resurrection guarantee — sealed/pruned/unknown segments, and segments
  under a missing parent, stay non-creatable so a connect cannot race a delete
  and resurrect a gone segment.

- **Typed not-found in the V5 client**: a scalable-topic lookup that fails with
  `TopicNotFound` now surfaces a typed `PulsarClientException.NotFoundException`
  (via `DagWatchClient` + `ProducerBuilderV5`) instead of a generic
  `PulsarClientException`, matching how a non-existent regular topic behaves.

### Verifying this change

- `V5ScalableTopicAutoCreateTest` — producer and consumer auto-create a
  single-segment scalable topic when policy allows; lookup throws
  `NotFoundException` when the namespace disallows auto-creation.
- `V5SegmentReconciliationTest` — active segment is auto-creatable;
  sealed/unknown/missing-parent segments are not.
