### PR TITLE
[fix][broker] Avoid blocking the dispatcher close path on delayed-delivery tracker close

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -86,6 +86,16 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
      */
     void close();
 
+    /**
+     * Close the subscription tracker and release all resources, completing the returned future once the
+     * tracker has finished closing. Prefer this over {@link #close()} on asynchronous paths (e.g. inside a
+     * {@link CompletableFuture} continuation) so the caller is not blocked.
+     */
+    default CompletableFuture<Void> closeAsync() {
+        close();
+        return CompletableFuture.completedFuture(null);
+    }
+
     DelayedDeliveryTracker DISABLE = new DelayedDeliveryTracker() {
         @Override
         public boolean addMessage(long ledgerId, long entryId, long deliveryAt) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -758,17 +758,26 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     }
 
     @Override
-    public synchronized void close() {
-        super.close();
-        lastMutableBucket.close();
-        sharedBucketPriorityQueue.close();
-        try {
-            List<CompletableFuture<Long>> completableFutures = immutableBuckets.asMapOfRanges().values().stream()
+    public void close() {
+        // Block for AutoCloseable / synchronous callers; asynchronous callers should use closeAsync().
+        closeAsync().join();
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        List<CompletableFuture<Long>> completableFutures;
+        synchronized (this) {
+            super.close();
+            lastMutableBucket.close();
+            sharedBucketPriorityQueue.close();
+            completableFutures = immutableBuckets.asMapOfRanges().values().stream()
                     .map(bucket -> bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)).toList();
-            FutureUtil.waitForAll(completableFutures).get(AsyncOperationTimeoutSeconds, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            log.warn().exception(e).log("Failed wait to snapshot generate");
         }
+        return FutureUtil.waitForAll(completableFutures)
+                .exceptionally(e -> {
+                    log.warn().exception(e).log("Failed wait to snapshot generate");
+                    return null;
+                });
     }
 
     private CompletableFuture<Void> cleanImmutableBuckets() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -616,11 +616,13 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             this.delayedDeliveryTracker = Optional.empty();
         }
 
-        delayedDeliveryTracker.ifPresent(DelayedDeliveryTracker::close);
+        CompletableFuture<Void> closeTrackerFuture = delayedDeliveryTracker
+                .map(DelayedDeliveryTracker::closeAsync)
+                .orElseGet(() -> CompletableFuture.completedFuture(null));
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
 
-        return disconnectConsumers
-                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null);
+        return closeTrackerFuture.thenCompose(__ -> disconnectConsumers
+                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
@@ -528,11 +528,13 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             this.delayedDeliveryTracker = Optional.empty();
         }
 
-        delayedDeliveryTracker.ifPresent(DelayedDeliveryTracker::close);
+        CompletableFuture<Void> closeTrackerFuture = delayedDeliveryTracker
+                .map(DelayedDeliveryTracker::closeAsync)
+                .orElseGet(() -> CompletableFuture.completedFuture(null));
         dispatchRateLimiter.ifPresent(DispatchRateLimiter::close);
 
-        return disconnectConsumers
-                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null);
+        return closeTrackerFuture.thenCompose(__ -> disconnectConsumers
+                ? disconnectAllConsumers(false, assignedBrokerLookupData) : CompletableFuture.completedFuture(null));
     }
 
     @Override


### PR DESCRIPTION
### Motivation

`BucketDelayedDeliveryTracker.close()` blocks up to `AsyncOperationTimeoutSeconds` (60s) on `FutureUtil.waitForAll(snapshotCreateFutures).get(...)`, hidden behind the `void close()` of `DelayedDeliveryTracker`. It is invoked by `PersistentDispatcherMultipleConsumers.close()` (and the Classic variant) via `delayedDeliveryTracker.ifPresent(DelayedDeliveryTracker::close)`, which runs inside the topic/subscription close chain on a metadata / `CompletableFuture`-callback thread (e.g. the `ExtensibleLoadManager` `getAssignedBrokerLookupData(...).thenAccept(...)` continuation during unload). A pending snapshot generation could therefore stall that callback thread for up to 60s.

### Modifications

- Add `CompletableFuture<Void> closeAsync()` to the `DelayedDeliveryTracker` interface as a `default` that delegates to `close()`. Because the interface extends `AutoCloseable`, `close()` must stay `void`; the default keeps `InMemoryDelayedDeliveryTracker` and the `DISABLE` no-op working unchanged.
- `BucketDelayedDeliveryTracker` overrides `closeAsync()` to perform the cleanup (`super.close()` + the bucket queue closes) under its monitor and then return `waitForAll(snapshotCreateFutures)` (with `.exceptionally(...)` logging, as before) instead of blocking on `get(60s)`. Its `AutoCloseable` `close()` now delegates to `closeAsync().join()` for synchronous callers (try-with-resources, tests).
- `PersistentDispatcherMultipleConsumers` and its Classic variant chain `closeAsync()` into the returned close future, so the tracker still finishes closing **before** consumers are disconnected — but without blocking the callback thread.

### Verifying this change

This change is covered by existing tests, which pass: `BucketDelayedDeliveryTrackerTest`, `BucketDelayedDeliveryTrackerThreadSafetyTest`, `InMemoryDeliveryTrackerTest`, and `DelayedDeliveryTrackerFactoryTest`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
