### PR TITLE
[fix][broker] Avoid blocking the bundle-throughput lookup on per-bundle metadata reads

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
@@ -138,8 +138,22 @@ public interface ModularLoadManager {
      *
      * @param bundle
      * @return bundle data
+     * @deprecated use {@link #getBundleDataOrDefaultAsync(String)} instead; this method blocks on
+     *     metadata-store reads and must not be called from async or event-loop threads.
      */
+    @Deprecated
     BundleData getBundleDataOrDefault(String bundle);
+
+    /**
+     * Asynchronously fetch bundle's load report data.
+     *
+     * @param bundle
+     * @return future of the bundle data
+     */
+    @SuppressWarnings("deprecation")
+    default CompletableFuture<BundleData> getBundleDataOrDefaultAsync(String bundle) {
+        return CompletableFuture.completedFuture(getBundleDataOrDefault(bundle));
+    }
 
     String setNamespaceBundleAffinity(String bundle, String broker);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -376,47 +376,56 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
     // Attempt to local the data for the given bundle in metadata store
     // If it cannot be found, return the default bundle data.
+    /**
+     * @deprecated use {@link #getBundleDataOrDefaultAsync(String)} instead.
+     */
+    @Deprecated
     @Override
     public BundleData getBundleDataOrDefault(final String bundle) {
-        BundleData bundleData = null;
-        try {
-            Optional<BundleData> optBundleData =
-                    pulsarResources.getLoadBalanceResources().getBundleDataResources().getBundleData(bundle).join();
-            if (optBundleData.isPresent()) {
-                return optBundleData.get();
-            }
+        return getBundleDataOrDefaultAsync(bundle).join();
+    }
 
-            Optional<ResourceQuota> optQuota = pulsarResources.getLoadBalanceResources().getQuotaResources()
-                    .getQuota(bundle).join();
-            if (optQuota.isPresent()) {
-                ResourceQuota quota = optQuota.get();
-                bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES);
-                // Initialize from existing resource quotas if new API ZNodes do not exist.
-                final TimeAverageMessageData shortTermData = bundleData.getShortTermData();
-                final TimeAverageMessageData longTermData = bundleData.getLongTermData();
+    @Override
+    public CompletableFuture<BundleData> getBundleDataOrDefaultAsync(final String bundle) {
+        return pulsarResources.getLoadBalanceResources().getBundleDataResources().getBundleData(bundle)
+                .thenCompose(optBundleData -> {
+                    if (optBundleData.isPresent()) {
+                        return CompletableFuture.completedFuture(optBundleData.get());
+                    }
+                    return pulsarResources.getLoadBalanceResources().getQuotaResources().getQuota(bundle)
+                            .thenApply(optQuota -> {
+                                if (optQuota.isEmpty()) {
+                                    return null;
+                                }
+                                ResourceQuota quota = optQuota.get();
+                                BundleData bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES);
+                                // Initialize from existing resource quotas if new API ZNodes do not exist.
+                                final TimeAverageMessageData shortTermData = bundleData.getShortTermData();
+                                final TimeAverageMessageData longTermData = bundleData.getLongTermData();
 
-                shortTermData.setMsgRateIn(quota.getMsgRateIn());
-                shortTermData.setMsgRateOut(quota.getMsgRateOut());
-                shortTermData.setMsgThroughputIn(quota.getBandwidthIn());
-                shortTermData.setMsgThroughputOut(quota.getBandwidthOut());
+                                shortTermData.setMsgRateIn(quota.getMsgRateIn());
+                                shortTermData.setMsgRateOut(quota.getMsgRateOut());
+                                shortTermData.setMsgThroughputIn(quota.getBandwidthIn());
+                                shortTermData.setMsgThroughputOut(quota.getBandwidthOut());
 
-                longTermData.setMsgRateIn(quota.getMsgRateIn());
-                longTermData.setMsgRateOut(quota.getMsgRateOut());
-                longTermData.setMsgThroughputIn(quota.getBandwidthIn());
-                longTermData.setMsgThroughputOut(quota.getBandwidthOut());
+                                longTermData.setMsgRateIn(quota.getMsgRateIn());
+                                longTermData.setMsgRateOut(quota.getMsgRateOut());
+                                longTermData.setMsgThroughputIn(quota.getBandwidthIn());
+                                longTermData.setMsgThroughputOut(quota.getBandwidthOut());
 
-                // Assume ample history.
-                shortTermData.setNumSamples(NUM_SHORT_SAMPLES);
-                longTermData.setNumSamples(NUM_LONG_SAMPLES);
-            }
-        } catch (Exception e) {
-            log.warn().attr("bundle", bundle).exceptionMessage(e)
-                    .log("Error when trying to find bundle on metadata store");
-        }
-        if (bundleData == null) {
-            bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES, defaultStats);
-        }
-        return bundleData;
+                                // Assume ample history.
+                                shortTermData.setNumSamples(NUM_SHORT_SAMPLES);
+                                longTermData.setNumSamples(NUM_LONG_SAMPLES);
+                                return bundleData;
+                            });
+                })
+                .exceptionally(e -> {
+                    log.warn().attr("bundle", bundle).exceptionMessage(e)
+                            .log("Error when trying to find bundle on metadata store");
+                    return null;
+                })
+                .thenApply(bundleData -> bundleData != null ? bundleData
+                        : new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES, defaultStats));
     }
 
     // Use the Pulsar client to acquire the namespace bundle stats.
@@ -556,7 +565,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
                 } else {
                     // Otherwise, attempt to find the bundle data on metadata store.
                     // If it cannot be found, use the latest stats as the first sample.
-                    BundleData currentBundleData = getBundleDataOrDefault(bundle);
+                    BundleData currentBundleData = getBundleDataOrDefaultAsync(bundle).join();
                     currentBundleData.update(stats);
                     bundleData.put(bundle, currentBundleData);
                 }
@@ -879,7 +888,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
 
     private void preallocateBundle(String bundle, String broker) {
         final BundleData data = loadData.getBundleData().computeIfAbsent(bundle,
-                key -> getBundleDataOrDefault(bundle));
+                key -> getBundleDataOrDefaultAsync(bundle).join());
         loadData.getBrokerData().get(broker).getPreallocatedBundleData().put(bundle, data);
         preallocatedBundleToBroker.put(bundle, broker);
 
@@ -893,7 +902,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager {
         synchronized (brokerCandidateCache) {
             final String bundle = serviceUnit.toString();
             final BundleData data = loadData.getBundleData().computeIfAbsent(bundle,
-                    key -> getBundleDataOrDefault(bundle));
+                    key -> getBundleDataOrDefaultAsync(bundle).join());
             brokerCandidateCache.clear();
             LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache,
                     getAvailableBrokers(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -57,6 +57,7 @@ import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.stats.CacheMetricsCollector;
 import org.apache.pulsar.common.util.Backoff;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.Notification;
 import org.apache.pulsar.policies.data.loadbalancer.BundleData;
 
@@ -242,19 +243,25 @@ public class NamespaceBundleFactory {
     public CompletableFuture<NamespaceBundle> getBundleWithHighestThroughputAsync(NamespaceName nsName) {
         LoadManager loadManager = pulsar.getLoadManager().get();
         if (loadManager instanceof ModularLoadManagerWrapper) {
-            return getBundlesAsync(nsName).thenApply(bundles -> {
-                double maxMsgThroughput = -1;
-                NamespaceBundle bundleWithHighestThroughput = null;
-                for (NamespaceBundle bundle : bundles.getBundles()) {
-                    BundleData bundleData = ((ModularLoadManagerWrapper) loadManager).getLoadManager()
-                            .getBundleDataOrDefault(bundle.toString());
-                    if (bundleData.getTopics() > 0
-                            && bundleData.getLongTermData().totalMsgThroughput() > maxMsgThroughput) {
-                        maxMsgThroughput = bundleData.getLongTermData().totalMsgThroughput();
-                        bundleWithHighestThroughput = bundle;
+            return getBundlesAsync(nsName).thenCompose(bundles -> {
+                List<NamespaceBundle> bundleList = bundles.getBundles();
+                List<CompletableFuture<BundleData>> bundleDataFutures = bundleList.stream()
+                        .map(bundle -> ((ModularLoadManagerWrapper) loadManager).getLoadManager()
+                                .getBundleDataOrDefaultAsync(bundle.toString()))
+                        .toList();
+                return FutureUtil.waitForAll(bundleDataFutures).thenApply(__ -> {
+                    double maxMsgThroughput = -1;
+                    NamespaceBundle bundleWithHighestThroughput = null;
+                    for (int i = 0; i < bundleList.size(); i++) {
+                        BundleData bundleData = bundleDataFutures.get(i).join();
+                        if (bundleData.getTopics() > 0
+                                && bundleData.getLongTermData().totalMsgThroughput() > maxMsgThroughput) {
+                            maxMsgThroughput = bundleData.getLongTermData().totalMsgThroughput();
+                            bundleWithHighestThroughput = bundleList.get(i);
+                        }
                     }
-                }
-                return bundleWithHighestThroughput;
+                    return bundleWithHighestThroughput;
+                });
             });
         }
         return getBundleWithHighestTopicsAsync(nsName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImplTest.java
@@ -1025,7 +1025,7 @@ public class ModularLoadManagerImplTest {
 
         // get the bundleData of the first bundle range.
         // The default value of the bundleData be the same as resourceQuota because the resourceQuota is present.
-        BundleData defaultBundleData = lm.getBundleDataOrDefault(namespaceBundle.toString());
+        BundleData defaultBundleData = lm.getBundleDataOrDefaultAsync(namespaceBundle.toString()).join();
 
         TimeAverageMessageData shortTermData = defaultBundleData.getShortTermData();
         TimeAverageMessageData longTermData = defaultBundleData.getLongTermData();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -703,7 +703,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         LoadManager loadManager = pulsar.getLoadManager().get();
         Awaitility.await().untilAsserted(() -> {
             BundleData targetBundleData = ((ModularLoadManagerWrapper) loadManager).getLoadManager()
-                    .getBundleDataOrDefault(namespace + "/" + bundle);
+                    .getBundleDataOrDefaultAsync(namespace + "/" + bundle).join();
             assertEquals(targetBundleData.getTopics(), 10);
         });
 


### PR DESCRIPTION
### Motivation

`ModularLoadManagerImpl.getBundleDataOrDefault(String)` reads bundle data (with a resource-quota fallback) from the metadata store, blocking on two `.join()` calls behind a plain `BundleData` return. Its clean signature hid that it blocks.

`NamespaceBundleFactory.getBundleWithHighestThroughputAsync()` called it **once per bundle** inside a `getBundlesAsync(...).thenApply(...)` continuation — so the continuation thread (which completes `getBundlesAsync`, a metadata-cache callback) blocked on a metadata read for every bundle in the namespace. This is reachable from the admin path (`NamespacesBase.findHotBundleAsync`).

### Modifications

- Add `ModularLoadManager.getBundleDataOrDefaultAsync(String)`, composing the two metadata reads asynchronously and returning the default `BundleData` on miss/error (preserving the exact logic of the blocking method). To stay backward compatible for custom `ModularLoadManager` implementations, it is a `default` method delegating to the existing sync method; `ModularLoadManagerImpl` overrides it with the real async implementation.
- **Deprecate** the blocking `getBundleDataOrDefault(String)`; it now delegates to `getBundleDataOrDefaultAsync(...).join()`. All internal callers (the load-data update loop, `preallocateBundle`, `selectBroker`) and the tests now use the async variant, so the deprecated method has no remaining callers except the interface's compat bridge.
- `NamespaceBundleFactory.getBundleWithHighestThroughputAsync()` now composes `getBundleDataOrDefaultAsync()` for all bundles (`thenCompose` + `waitForAll`) and selects the max-throughput bundle off the already-complete futures — no blocking on the continuation thread.

### Verifying this change

This change is covered by existing tests, which pass: `ModularLoadManagerImplTest.testBundleDataDefaultValue` and `NamespaceServiceTest.testSplitBundleWithHighestThroughput`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
