### PR TITLE
[improve][broker] Improve dispatch performance by summing entry bytes with a loop

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/AbstractPersistentDispatcherMultipleConsumers.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.AbstractDispatcherMultipleConsumers;
@@ -64,4 +66,12 @@ public abstract class AbstractPersistentDispatcherMultipleConsumers extends Abst
     public abstract Map<String, TopicMetricBean> getBucketDelayedIndexStats();
 
     public abstract boolean isClassic();
+
+    static long getTotalBytesSize(List<Entry> entries) {
+        long totalBytesSize = 0;
+        for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {
+            totalBytesSize += entries.get(i).getLength();
+        }
+        return totalBytesSize;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -702,7 +702,7 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                 .attr("consumerCount", consumerList.size())
                 .log("Distributing messages to consumers");
 
-        long totalBytesSize = entries.stream().mapToLong(Entry::getLength).sum();
+        long totalBytesSize = getTotalBytesSize(entries);
         updatePendingBytesToDispatch(totalBytesSize);
 
         // dispatch messages to a separate thread, but still in order for this subscription

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
@@ -614,7 +614,7 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                 .attr("consumerCount", consumerList.size())
                 .log("Distributing messages to consumers");
 
-        long size = entries.stream().mapToLong(Entry::getLength).sum();
+        long size = getTotalBytesSize(entries);
         updatePendingBytesToDispatch(size);
 
         // dispatch messages to a separate thread, but still in order for this subscription

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherTotalBytesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherTotalBytesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import static org.testng.Assert.assertEquals;
+import java.util.ArrayList;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class PersistentDispatcherTotalBytesTest {
+
+    @DataProvider(name = "entryCounts")
+    public Object[][] entryCounts() {
+        return new Object[][] {
+                {0},
+                {1},
+                {32},
+                {1024}
+        };
+    }
+
+    @Test(dataProvider = "entryCounts")
+    public void testGetTotalBytesSize(int entryCount) {
+        EntriesAndExpectedSize entries = entriesWithVaryingPayloadSizes(entryCount);
+        try {
+            assertEquals(AbstractPersistentDispatcherMultipleConsumers.getTotalBytesSize(entries.entries),
+                    entries.expectedSize);
+        } finally {
+            entries.release();
+        }
+    }
+
+    private static EntriesAndExpectedSize entriesWithVaryingPayloadSizes(int entryCount) {
+        EntriesAndExpectedSize entries = new EntriesAndExpectedSize(entryCount);
+        for (int i = 0; i < entryCount; i++) {
+            int payloadSize = payloadSize(i);
+            entries.entries.add(EntryImpl.create(1, i, new byte[payloadSize]));
+            entries.expectedSize += payloadSize;
+        }
+        return entries;
+    }
+
+    private static int payloadSize(int index) {
+        return index % 97 == 0 ? 4096 : 1 + ((index * 31) & 1023);
+    }
+
+    private static final class EntriesAndExpectedSize {
+        private final ArrayList<Entry> entries;
+        private long expectedSize;
+
+        private EntriesAndExpectedSize(int entryCount) {
+            this.entries = new ArrayList<>(entryCount);
+        }
+
+        private void release() {
+            entries.forEach(Entry::release);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

The shared-subscription dispatch path sums entry bytes for every read batch. The existing implementation uses a stream pipeline, which adds avoidable allocation and dispatch overhead on this hot path.

### Modifications

Replace the stream-based byte summation in both multiple-consumer dispatchers with a simple indexed loop.

### Performance

This improves the dispatch hot path by reducing per-read-batch CPU work and eliminating stream pipeline allocation.

JMH data gathered locally using `DispatcherDispatchPathBenchmark.(streamTotalBytes|loopTotalBytes)`, with `-p entriesCount=32,256,1000 -wi 2 -i 5 -w 1s -r 1s -f 1 -bm avgt -tu ns -prof gc`:

| entriesCount | streamTotalBytes | loopTotalBytes | improvement | allocation |
| ---: | ---: | ---: | ---: | ---: |
| 32 | 112.4 ns/op | 40.3 ns/op | 64.1% | 256 B/op -> ~0 |
| 256 | 407.3 ns/op | 253.7 ns/op | 37.7% | 256 B/op -> ~0 |
| 1000 | 1886.0 ns/op | 1565.8 ns/op | 17.0% | 256 B/op -> ~0 |

### Verification

- Added `PersistentDispatcherTotalBytesTest` coverage for empty, single-entry, and large 1024-entry batches with varying real `EntryImpl` payload sizes.
- `./gradlew :pulsar-broker:compileJava :pulsar-broker:checkstyleMain --max-workers=1`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.service.persistent.PersistentDispatcherTotalBytesTest --max-workers=1 -PtestRetryCount=0`
- `./gradlew :pulsar-broker:checkstyleTest --max-workers=1`
