### PR TITLE
[improve][broker] Improve no-filter dispatch performance by skipping filter calls

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractBaseDispatcher.java
@@ -135,6 +135,7 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
         int filteredMessageCount = 0;
         int filteredEntryCount = 0;
         long filteredBytesCount = 0;
+        final boolean hasFilter = this.hasFilter;
         List<Position> entriesToFiltered = hasFilter ? new ArrayList<>() : null;
         List<Position> entriesToRedeliver = hasFilter ? new ArrayList<>() : null;
         for (int i = 0, entriesSize = entries.size(); i < entriesSize; i++) {
@@ -161,29 +162,27 @@ public abstract class AbstractBaseDispatcher extends EntryFilterSupport implemen
                 this.filterProcessedMsgs.add(entryMsgCnt);
             }
 
-            EntryFilter.FilterResult filterResult = runFiltersForEntry(entry, msgMetadata, consumer);
-            if (filterResult == EntryFilter.FilterResult.REJECT) {
-                entriesToFiltered.add(entry.getPosition());
-                entries.set(i, null);
-                // FilterResult will be always `ACCEPTED` when there is No Filter
-                // dont need to judge whether `hasFilter` is true or not.
-                this.filterRejectedMsgs.add(entryMsgCnt);
-                filteredEntryCount++;
-                filteredMessageCount += entryMsgCnt;
-                filteredBytesCount += metadataAndPayload.readableBytes();
-                entry.release();
-                continue;
-            } else if (filterResult == EntryFilter.FilterResult.RESCHEDULE) {
-                entriesToRedeliver.add(entry.getPosition());
-                entries.set(i, null);
-                // FilterResult will be always `ACCEPTED` when there is No Filter
-                // dont need to judge whether `hasFilter` is true or not.
-                this.filterRescheduledMsgs.add(entryMsgCnt);
-                filteredEntryCount++;
-                filteredMessageCount += entryMsgCnt;
-                filteredBytesCount += metadataAndPayload.readableBytes();
-                entry.release();
-                continue;
+            if (hasFilter) {
+                EntryFilter.FilterResult filterResult = runFiltersForEntry(entry, msgMetadata, consumer);
+                if (filterResult == EntryFilter.FilterResult.REJECT) {
+                    entriesToFiltered.add(entry.getPosition());
+                    entries.set(i, null);
+                    this.filterRejectedMsgs.add(entryMsgCnt);
+                    filteredEntryCount++;
+                    filteredMessageCount += entryMsgCnt;
+                    filteredBytesCount += metadataAndPayload.readableBytes();
+                    entry.release();
+                    continue;
+                } else if (filterResult == EntryFilter.FilterResult.RESCHEDULE) {
+                    entriesToRedeliver.add(entry.getPosition());
+                    entries.set(i, null);
+                    this.filterRescheduledMsgs.add(entryMsgCnt);
+                    filteredEntryCount++;
+                    filteredMessageCount += entryMsgCnt;
+                    filteredBytesCount += metadataAndPayload.readableBytes();
+                    entry.release();
+                    continue;
+                }
             }
             if (msgMetadata != null && msgMetadata.hasTxnidMostBits()
                     && msgMetadata.hasTxnidLeastBits()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AbstractBaseDispatcherTest.java
@@ -56,6 +56,8 @@ import org.testng.annotations.Test;
 @Test(groups = "broker")
 public class AbstractBaseDispatcherTest {
 
+    private static final int MANY_ENTRIES_COUNT = 512;
+
     private AbstractBaseDispatcherTestHelper helper;
 
     private ServiceConfiguration svcConfig;
@@ -82,6 +84,29 @@ public class AbstractBaseDispatcherTest {
         assertEquals(size, 0);
     }
 
+    @Test
+    public void testFilterEntriesForConsumerSkipsFilterWhenNoFiltersConfigured() {
+        EntriesAndExpectedMetadata entries = createEntriesWithVaryingBatchSizes(MANY_ENTRIES_COUNT);
+
+        SendMessageInfo sendMessageInfo = SendMessageInfo.getThreadLocal();
+        EntryBatchSizes batchSizes = EntryBatchSizes.get(entries.entries.size());
+        try {
+            int size = this.helper.filterEntriesForConsumer(entries.entries, batchSizes, sendMessageInfo,
+                    null, null, false, null);
+
+            assertEquals(size, MANY_ENTRIES_COUNT);
+            assertEquals(this.helper.getFilterInvocationCount(), 0);
+            assertEquals(sendMessageInfo.getTotalMessages(), entries.expectedMessages);
+            assertEquals(sendMessageInfo.getTotalBytes(), entries.expectedBytes);
+            assertEquals(sendMessageInfo.getTotalChunkedMessages(), 0);
+            for (int i = 0; i < MANY_ENTRIES_COUNT; i++) {
+                assertEquals(batchSizes.getBatchSize(i), batchSizeForEntry(i));
+            }
+        } finally {
+            entries.release();
+            batchSizes.recyle();
+        }
+    }
 
     @Test
     public void testFilterEntriesForConsumerOfEntryFilter() throws Exception {
@@ -192,6 +217,53 @@ public class AbstractBaseDispatcherTest {
                 Unpooled.copiedBuffer(message.getBytes(UTF_8)));
     }
 
+    private ByteBuf createBatchMessage(String message, int sequenceId, int batchSize) {
+        MessageMetadata messageMetadata = new MessageMetadata()
+                .setSequenceId(sequenceId)
+                .setProducerName("testProducer")
+                .setPartitionKeyB64Encoded(false)
+                .setPublishTime(System.currentTimeMillis())
+                .setNumMessagesInBatch(batchSize);
+        return serializeMetadataAndPayload(Commands.ChecksumType.Crc32c, messageMetadata,
+                Unpooled.copiedBuffer(message.getBytes(UTF_8)));
+    }
+
+    private EntriesAndExpectedMetadata createEntriesWithVaryingBatchSizes(int entryCount) {
+        EntriesAndExpectedMetadata entries = new EntriesAndExpectedMetadata(entryCount);
+        for (int i = 0; i < entryCount; i++) {
+            int batchSize = batchSizeForEntry(i);
+            ByteBuf message = createBatchMessage(messagePayload(i), i, batchSize);
+            Entry entry = EntryImpl.create(1, i, message);
+            message.release();
+            entries.entries.add(entry);
+            entries.expectedMessages += batchSize;
+            entries.expectedBytes += entry.getLength();
+        }
+        return entries;
+    }
+
+    private static int batchSizeForEntry(int index) {
+        return 1 + (index % 10);
+    }
+
+    private static String messagePayload(int index) {
+        return "message-" + index + "-" + "x".repeat(1 + (index % 128));
+    }
+
+    private static final class EntriesAndExpectedMetadata {
+        private final List<Entry> entries;
+        private int expectedMessages;
+        private long expectedBytes;
+
+        private EntriesAndExpectedMetadata(int entryCount) {
+            this.entries = new ArrayList<>(entryCount);
+        }
+
+        private void release() {
+            entries.forEach(Entry::release);
+        }
+    }
+
     private ByteBuf createTnxMessage(String message, int sequenceId) {
         MessageMetadata messageMetadata = new MessageMetadata()
                 .setSequenceId(sequenceId)
@@ -231,6 +303,7 @@ public class AbstractBaseDispatcherTest {
     private static class AbstractBaseDispatcherTestHelper extends AbstractBaseDispatcher {
 
         private final Optional<DispatchRateLimiter> dispatchRateLimiter;
+        private int filterInvocationCount;
 
         protected AbstractBaseDispatcherTestHelper(Subscription subscription,
                                                    ServiceConfiguration serviceConfig,
@@ -242,6 +315,17 @@ public class AbstractBaseDispatcherTest {
         @Override
         public Optional<DispatchRateLimiter> getRateLimiter() {
             return dispatchRateLimiter;
+        }
+
+        @Override
+        public EntryFilter.FilterResult runFiltersForEntry(Entry entry, MessageMetadata msgMetadata,
+                                                           Consumer consumer) {
+            filterInvocationCount++;
+            return super.runFiltersForEntry(entry, msgMetadata, consumer);
+        }
+
+        int getFilterInvocationCount() {
+            return filterInvocationCount;
         }
 
         @Override


### PR DESCRIPTION
### Motivation

`AbstractBaseDispatcher#filterEntriesForConsumer` is on the dispatch hot path. When no entry filters are configured, `runFiltersForEntry` only returns `ACCEPT`, so calling it once per entry is avoidable work.

### Modifications

- Cache the dispatcher filter state in a local variable for the batch.
- Skip `runFiltersForEntry` when no entry filters are configured.

### Scope

This intentionally leaves the filtered/redelivery list allocation and ack-set handling unchanged. Those are separate optimizations and are kept out of this PR to make the review focused on the no-filter fast path only.

### Performance

This improves no-filter dispatch performance by removing one no-op filter call and the REJECT/RESCHEDULE checks per entry when no filters are configured. Allocation remains effectively unchanged; this is a CPU-path optimization.

JMH data gathered locally using a local-only `DispatcherDispatchPathBenchmark.(noFilterRunFiltersPerEntry|noFilterFastPath)` benchmark, with `-p entriesCount=32,256,1000 -p batchSize=1,10 -wi 2 -i 5 -w 1s -r 1s -f 1 -bm avgt -tu ns -prof gc`:

| batchSize | entriesCount | old path | fast path | improvement |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 32 | 44.8 ns/op | 28.0 ns/op | 37.6% |
| 1 | 256 | 329.1 ns/op | 186.1 ns/op | 43.4% |
| 1 | 1000 | 3151.4 ns/op | 1603.3 ns/op | 49.1% |
| 10 | 32 | 52.4 ns/op | 31.2 ns/op | 40.4% |
| 10 | 256 | 361.7 ns/op | 182.9 ns/op | 49.4% |
| 10 | 1000 | 2658.4 ns/op | 1593.4 ns/op | 40.1% |

### Verification

- Added `AbstractBaseDispatcherTest` coverage for a 512-entry no-filter dispatch batch with varying payload sizes and batch sizes.
- `./gradlew :pulsar-broker:compileJava :pulsar-broker:checkstyleMain --max-workers=1`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.service.AbstractBaseDispatcherTest --max-workers=1 -PtestRetryCount=0`
- `./gradlew :pulsar-broker:checkstyleTest --max-workers=1`
