### PR TITLE
[fix] functions: Run worker leader-election off the consumer event-listener thread

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/LeaderService.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pulsar.functions.worker;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.Consumer;
@@ -43,6 +48,11 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
     private final WorkerConfig workerConfig;
     private final PulsarClient pulsarClient;
     private volatile boolean isLeader = false;
+    // The consumer event listener callbacks (becameActive/becameInactive) run the blocking
+    // leader-election routines on this dedicated single-threaded executor so that the Pulsar client's
+    // shared consumer-listener thread is not blocked. The single thread also preserves event ordering.
+    private final ExecutorService executor =
+            Executors.newSingleThreadExecutor(new DefaultThreadFactory("function-worker-leader"));
 
     static final String COORDINATION_TOPIC_SUBSCRIPTION = "participants";
 
@@ -90,6 +100,12 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
 
     @Override
     public void becameActive(Consumer<?> consumer, int partitionId) {
+        // Run the (blocking) become-leader routine on a dedicated executor so the consumer
+        // event-listener thread, which is shared with the Pulsar client, is not blocked.
+        executor.execute(() -> becameActiveInternal(consumer, partitionId));
+    }
+
+    private void becameActiveInternal(Consumer<?> consumer, int partitionId) {
         synchronized (this) {
             if (isLeader) {
                 return;
@@ -151,7 +167,11 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
     }
 
     @Override
-    public synchronized void becameInactive(Consumer<?> consumer, int partitionId) {
+    public void becameInactive(Consumer<?> consumer, int partitionId) {
+        executor.execute(() -> becameInactiveInternal(consumer, partitionId));
+    }
+
+    private synchronized void becameInactiveInternal(Consumer<?> consumer, int partitionId) {
         if (isLeader) {
             log.info().attr("worker", consumerName).log("Worker lost the leadership.");
             isLeader = false;
@@ -180,10 +200,16 @@ public class LeaderService implements AutoCloseable, ConsumerEventListener {
         return isLeader;
     }
 
+    @VisibleForTesting
+    void joinPendingEventTasks() throws InterruptedException, ExecutionException {
+        executor.submit(() -> { }).get();
+    }
+
     @Override
     public void close() throws PulsarClientException {
         if (consumer != null) {
             consumer.close();
         }
+        executor.shutdown();
     }
 }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/LeaderServiceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/LeaderServiceTest.java
@@ -138,6 +138,7 @@ public class LeaderServiceTest {
         verify(mockClient, times(1)).newConsumer();
 
         listenerHolder.get().becameActive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertTrue(leaderService.isLeader());
 
         verify(functionMetadataManager, times(1)).getIsInitialized();
@@ -153,6 +154,7 @@ public class LeaderServiceTest {
         verify(schedulerManager, times((1))).initialize(any());
 
         listenerHolder.get().becameInactive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertFalse(leaderService.isLeader());
 
         verify(functionAssignmentTailer, times(1)).startFromMessage(messageId);
@@ -168,6 +170,7 @@ public class LeaderServiceTest {
         verify(mockClient, times(1)).newConsumer();
 
         listenerHolder.get().becameActive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertTrue(leaderService.isLeader());
 
         verify(functionMetadataManager, times(1)).acquireExclusiveWrite(any());
@@ -179,6 +182,7 @@ public class LeaderServiceTest {
         verify(schedulerManager, times((1))).initialize(any());
 
         listenerHolder.get().becameInactive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertFalse(leaderService.isLeader());
 
         verify(functionAssignmentTailer, times(1)).start();
@@ -198,6 +202,7 @@ public class LeaderServiceTest {
         when(schedulerManager.acquireExclusiveWrite(any())).thenThrow(new WorkerUtils.NotLeaderAnymore());
 
         listenerHolder.get().becameActive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         // should have failed to become leader
         assertFalse(leaderService.isLeader());
 
@@ -214,6 +219,7 @@ public class LeaderServiceTest {
         verify(schedulerManager, times((0))).initialize(any());
 
         listenerHolder.get().becameInactive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertFalse(leaderService.isLeader());
 
         verify(functionAssignmentTailer, times(0)).startFromMessage(messageId);
@@ -234,6 +240,7 @@ public class LeaderServiceTest {
         when(functionMetadataManager.acquireExclusiveWrite(any())).thenThrow(new WorkerUtils.NotLeaderAnymore());
 
         listenerHolder.get().becameActive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         // should have failed to become leader
         assertFalse(leaderService.isLeader());
 
@@ -250,6 +257,7 @@ public class LeaderServiceTest {
         verify(schedulerManager, times((0))).initialize(any());
 
         listenerHolder.get().becameInactive(mockConsumer, 0);
+        leaderService.joinPendingEventTasks();
         assertFalse(leaderService.isLeader());
 
         verify(functionAssignmentTailer, times(0)).startFromMessage(messageId);


### PR DESCRIPTION
### Motivation

`LeaderService` implements `ConsumerEventListener` for the failover-subscription leader election. Its `becameActive` / `becameInactive` callbacks ran the full **blocking** leader-election routine inline:

- `functionMetaDataManager` / `functionRuntimeManager` `getIsInitialized().get()` (unbounded),
- `schedulerManager` / `functionMetaDataManager` `acquireExclusiveWrite(...)` — a retry loop doing `createAsync().get(10s)` + `Thread.sleep` *while still leader*,
- `functionAssignmentTailer.triggerReadToTheEndAndExit().get()`,
- and on `becameInactive`, `schedulerManager.close()` (which blocks on `schedulerLock` for an in-flight schedule).

These callbacks are dispatched by the Pulsar client on its **shared consumer-listener executor** (`ConsumerImpl.activeConsumerChanged` → `externalPinnedExecutor`), so this potentially-unbounded leader handshake blocked a thread shared by all consumers/readers on that client — including the worker's own tailers.

### Modifications

Run `becameActive` / `becameInactive` on a dedicated single-threaded executor and return from the listener callbacks immediately. The single thread preserves the `becameActive` → `becameInactive` ordering. The callback bodies are unchanged, moved into `becameActiveInternal` / `becameInactiveInternal`. `close()` shuts the executor down. A `@VisibleForTesting joinPendingEventTasks()` barrier keeps `LeaderServiceTest` deterministic.

### Verifying this change

Covered by the existing `LeaderServiceTest` (updated to await the offloaded tasks via the barrier) — 4/4 pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
