### PR TITLE
[fix][broker] Avoid blocking the PulsarAdmin callback thread on the post-unload load-report write

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -902,16 +902,18 @@ public class ClustersBase extends AdminResource {
             List<CompletableFuture<Void>> futures = clusterLocalNamespaces.stream()
                     .map(namespaceName -> adminClient.namespaces().unloadAsync(namespaceName))
                     .collect(Collectors.toList());
-            return FutureUtil.waitForAll(futures).thenAccept(__ -> {
+            return FutureUtil.waitForAll(futures).thenAcceptAsync(__ -> {
                 try {
-                    // write load info to load manager to make the load happens fast
+                    // Write the load report so the unloaded namespaces rebalance quickly. Run it on the
+                    // broker executor rather than the admin-client callback thread that completes the
+                    // unload futures, because writeLoadReportOnZookeeper blocks on a metadata-store write.
                     pulsar().getLoadManager().get().writeLoadReportOnZookeeper(true);
                 } catch (Exception e) {
                     log.warn()
                             .exception(e)
                             .log("Failed to writeLoadReportOnZookeeper.");
                 }
-            });
+            }, pulsar().getExecutor());
         });
     }
 


### PR DESCRIPTION
### Motivation

When a namespace isolation policy changes, `ClustersBase.filterAndUnloadMatchedNamespaceAsync` unloads the affected namespaces and then writes the load report so the cluster rebalances quickly. That write ran inside `FutureUtil.waitForAll(unloadAsync...).thenAccept(...)`, which executes on the thread that completes the `adminClient.namespaces().unloadAsync(...)` futures — a **PulsarAdmin async-HTTP-client callback thread**.

`LoadManager.writeLoadReportOnZookeeper(true)` blocks there: `ModularLoadManagerImpl.writeBrokerDataOnZooKeeper` does `lock.lock()` plus a metadata-store `updateValue(...).join()`. So a brief metadata write blocked the admin-client callback thread.

### Modifications

Run the load-report write via `thenAcceptAsync(..., pulsar().getExecutor())` so it executes on the broker executor (where short blocking metadata writes are routine) instead of the admin-client callback thread. The REST response still waits for the write (the chained future completes after it); the write remains best-effort (failure is logged and swallowed, as before).

### Verifying this change

Covered by `AdminApi2Test.testIsolationPolicyUnloadsNSWith*` (`AllScope`, `ChangedScope1`/`2`, `NoneScope`, `PrimaryChanged`, `ScopeMissing`; persistent + non-persistent) — 12/12 pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
