### PR TITLE
[fix][broker] Avoid blocking the metrics thread on the pending-ack managed ledger

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TransactionAggregator.java
@@ -65,10 +65,15 @@ public class TransactionAggregator {
                                     if (!isEventSystemTopic(TopicName.get(subscription.getTopic().getName()))
                                             && subscription instanceof PersistentSubscription
                                             && ((PersistentSubscription) subscription).checkIfPendingAckStoreInit()) {
+                                        // Use getNow() rather than get() so a not-yet-resolved managed
+                                        // ledger cannot block (and exhaust) the metrics thread pool; the
+                                        // stats are simply skipped for this scrape and picked up later.
                                         ManagedLedger managedLedger = ((PersistentSubscription) subscription)
-                                                .getPendingAckManageLedger().get();
-                                        generateManageLedgerStats(managedLedger,
-                                                stream, cluster, namespace, name, subscription.getName());
+                                                .getPendingAckManageLedger().getNow(null);
+                                        if (managedLedger != null) {
+                                            generateManageLedgerStats(managedLedger,
+                                                    stream, cluster, namespace, name, subscription.getName());
+                                        }
                                     }
                                 } catch (Exception e) {
                                     log.warn()


### PR DESCRIPTION
### Motivation

`TransactionAggregator.generate` (per-subscription transaction metrics) read the pending-ack store's managed ledger with `((PersistentSubscription) subscription).getPendingAckManageLedger().get()` — an **un-timed** `CompletableFuture.get()` running on the prometheus-stats executor (a bounded, 4-thread pool).

The guard `checkIfPendingAckStoreInit()` only verifies `pendingAckStoreFuture.isDone()`; `getStoreManageLedger()` then composes `pendingAckStoreFuture.thenCompose(store -> store.getManagedLedger())`, so the *managed-ledger* future can still be resolving. A stuck future blocks that metrics thread, and enough of them exhaust the pool — hanging all metric scraping.

### Modifications

Use `getNow(null)` instead of `get()`: if the managed ledger is already resolved it is used exactly as before; if not, this subscription's pending-ack-store stats are skipped for the current scrape and picked up on the next one. A future that completed exceptionally still throws into the existing `catch` (unchanged).

### Verifying this change

Covered by existing tests, which pass: `TransactionMetricsTest.testManagedLedgerMetrics` (ledger ready → stats present) and `testManagedLedgerMetricsWhenPendingAckNotInit` (store not initialized → skipped).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
