### PR TITLE
[fix][client] Run the failover health probe off the Netty event-loop thread

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SameAuthParamsLookupAutoClusterFailoverTest.java
@@ -21,11 +21,11 @@ package org.apache.pulsar.broker;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.CA_CERT_FILE_PATH;
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.getTlsFileForClient;
 import static org.apache.pulsar.client.impl.SameAuthParamsLookupAutoClusterFailover.PulsarServiceState;
-import io.netty.channel.EventLoopGroup;
 import java.net.ServerSocket;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.broker.service.NetworkErrorTestBase;
 import org.apache.pulsar.broker.service.OneWayReplicatorTestBase;
@@ -99,7 +99,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
                 .tlsTrustCertsFilePath(CA_CERT_FILE_PATH);
         }
         final PulsarClient client = clientBuilder.build();
-        final EventLoopGroup executor = WhiteboxImpl.getInternalState(failover, "executor");
+        final ScheduledExecutorService executor = WhiteboxImpl.getInternalState(failover, "executor");
         final PulsarServiceState[] stateArray =
                 WhiteboxImpl.getInternalState(failover, "pulsarServiceStateArray");
 
@@ -160,7 +160,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
      * and producer/lookup operations are kept out of the polling loop so a slow message send does
      * not consume the convergence budget.
      */
-    private static void awaitStatesAndIndex(EventLoopGroup executor, PulsarServiceState[] stateArray,
+    private static void awaitStatesAndIndex(ScheduledExecutorService executor, PulsarServiceState[] stateArray,
                                             SameAuthParamsLookupAutoClusterFailover failover,
                                             int expectedIndex,
                                             PulsarServiceState... expectedStates) {
@@ -170,7 +170,7 @@ public class SameAuthParamsLookupAutoClusterFailoverTest extends OneWayReplicato
         });
     }
 
-    private static void assertStatesEqual(EventLoopGroup executor, PulsarServiceState[] stateArray,
+    private static void assertStatesEqual(ScheduledExecutorService executor, PulsarServiceState[] stateArray,
                                           PulsarServiceState... expected) throws Exception {
         CompletableFuture<PulsarServiceState[]> snapshot = new CompletableFuture<>();
         executor.submit(() -> snapshot.complete(stateArray.clone()));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -81,7 +81,10 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         this.pulsarClient = (PulsarClientImpl) client;
         this.executor = Executors.newSingleThreadScheduledExecutor(
                 new ExecutorProvider.ExtendedThreadFactory("broker-service-url-check"));
-        scheduledCheckTask = executor.scheduleAtFixedRate(() -> {
+        // Use fixed-delay (not fixed-rate) scheduling: a probe can block up to its timeout, and with a
+        // plain single-threaded scheduled executor fixed-rate runs would otherwise pile up back-to-back
+        // and monopolize the thread. Fixed-delay leaves a gap after each check completes.
+        scheduledCheckTask = executor.scheduleWithFixedDelay(() -> {
             try {
                 if (closed) {
                     return;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SameAuthParamsLookupAutoClusterFailover.java
@@ -19,10 +19,11 @@
 package org.apache.pulsar.client.impl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.ScheduledFuture;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -35,7 +36,6 @@ import org.apache.pulsar.client.api.ServiceUrlProvider;
 import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
-import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
 /**
  * A service URL provider that probes multiple Pulsar service URLs with the same authentication
@@ -50,7 +50,7 @@ import org.apache.pulsar.common.util.netty.EventLoopUtil;
 public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvider {
 
     private PulsarClientImpl pulsarClient;
-    private EventLoopGroup executor;
+    private ScheduledExecutorService executor;
     private volatile boolean closed;
     private ScheduledFuture<?> scheduledCheckTask;
     @Getter
@@ -79,7 +79,7 @@ public class SameAuthParamsLookupAutoClusterFailover implements ServiceUrlProvid
         }
         this.currentPulsarServiceIndex = 0;
         this.pulsarClient = (PulsarClientImpl) client;
-        this.executor = EventLoopUtil.newEventLoopGroup(1, false,
+        this.executor = Executors.newSingleThreadScheduledExecutor(
                 new ExecutorProvider.ExtendedThreadFactory("broker-service-url-check"));
         scheduledCheckTask = executor.scheduleAtFixedRate(() -> {
             try {


### PR DESCRIPTION
### Motivation

`SameAuthParamsLookupAutoClusterFailover` periodically probes broker health with a blocking `getLookup(url).getBroker(...).get(3, SECONDS)`. The periodic task was scheduled on a Netty `EventLoopGroup` (`EventLoopUtil.newEventLoopGroup(1, ...)`), so the blocking probe ran on a Netty **event-loop thread**.

### Modifications

Use a plain single-thread `ScheduledExecutorService` (`Executors.newSingleThreadScheduledExecutor`) for the periodic health check — matching the sibling `AutoClusterFailover` — so the blocking probe no longer occupies a Netty event-loop thread. `scheduleAtFixedRate` and `shutdownNow` are unchanged, and the executor is dedicated solely to this check.

### Verifying this change

Covered by existing `SameAuthParamsLookupAutoClusterFailoverTest` (4 tests) — passes.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
