### PR TITLE
[improve][build] Switch default JDK to 25 for 5.0.0-M2

### DIFF
--- a/.github/workflows/pulsar-ci-flaky.yaml
+++ b/.github/workflows/pulsar-ci-flaky.yaml
@@ -25,9 +25,9 @@ on:
       - branch-*
       - pulsar-*
   schedule:
-    # scheduled job with JDK 21
-    - cron: '0 12 * * *'
     # scheduled job with JDK 25
+    - cron: '0 12 * * *'
+    # scheduled job with JDK 21
     # if cron expression is changed, make sure to update the expression in jdk_major_version step in preconditions job
     - cron: '0 6 * * *'
   workflow_dispatch:
@@ -42,9 +42,9 @@ on:
         required: true
         type: choice
         options:
-          - '21'
           - '25'
-        default: '21'
+          - '21'
+        default: '25'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
         required: true
@@ -104,13 +104,13 @@ jobs:
       - name: Select JDK major version
         id: jdk_major_version
         run: |
-          # use JDK 25 for the scheduled build with cron expression '0 6 * * *'
+          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
           if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
-            echo "jdk_major_version=25" >> $GITHUB_OUTPUT
+            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # use JDK 21 for build unless overridden with workflow_dispatch input
-          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '21'}}" >> $GITHUB_OUTPUT
+          # use JDK 25 for build unless overridden with workflow_dispatch input
+          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '25'}}" >> $GITHUB_OUTPUT
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -25,9 +25,9 @@ on:
       - branch-*
       - pulsar-*
   schedule:
-    # scheduled job with JDK 21
-    - cron: '0 12 * * *'
     # scheduled job with JDK 25
+    - cron: '0 12 * * *'
+    # scheduled job with JDK 21
     # if cron expression is changed, make sure to update the expression in jdk_major_version step in preconditions job
     - cron: '0 6 * * *'
   workflow_dispatch:
@@ -37,9 +37,9 @@ on:
         required: true
         type: choice
         options:
-          - '21'
           - '25'
-        default: '21'
+          - '21'
+        default: '25'
       trace_test_resource_cleanup:
         description: 'Collect thread & heap information before exiting a test JVM. When set to "on", thread dump and heap histogram will be collected. When set to "full", a heap dump will also be collected.'
         required: true
@@ -97,13 +97,13 @@ jobs:
       - name: Select JDK major version
         id: jdk_major_version
         run: |
-          # use JDK 25 for the scheduled build with cron expression '0 6 * * *'
+          # use JDK 21 for the scheduled build with cron expression '0 6 * * *'
           if [[ "${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * *' && 'true' || 'false' }}" == "true" ]]; then
-            echo "jdk_major_version=25" >> $GITHUB_OUTPUT
+            echo "jdk_major_version=21" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # use JDK 21 for build unless overridden with workflow_dispatch input
-          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '21'}}" >> $GITHUB_OUTPUT
+          # use JDK 25 for build unless overridden with workflow_dispatch input
+          echo "jdk_major_version=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.jdk_major_version || '25'}}" >> $GITHUB_OUTPUT
 
       - name: checkout
         if: ${{ github.event_name == 'pull_request' }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 #
 [versions]
 # Docker
-docker-jdk = "21"
+docker-jdk = "25"
 pulsar-client-python = "3.12.0"
 # Code quality
 checkstyle = "13.3.0"


### PR DESCRIPTION
### Motivation

Making **JDK 25 the default** was agreed on the dev@ mailing list:
<https://lists.apache.org/thread/3zclb8cq0dt95c8f1lh83qxyyj11m8pq>

As part of the release planning, `4.3.0` was renamed to `5.0.0-M1`:
<https://lists.apache.org/thread/1hyrcq11jbczdkmqqw07h5qq6fyfxoj7>

`5.0.0-M1` ships with **Java 21** as the default and is being released from the
already-cut `branch-5.0-M1`. The switch to **Java 25** lands in `5.0.0-M2`, which
is the `master` development line now that the M1 release branch exists. This change
therefore targets `master` only; `branch-5.0-M1` keeps Java 21 as its default.

### Modifications

- **`gradle/libs.versions.toml`**: `docker-jdk` `21` → `25`, so the official Pulsar
  Docker image is built on JDK 25 by default.
- **`.github/workflows/pulsar-ci.yaml`** and **`.github/workflows/pulsar-ci-flaky.yaml`**
  — make JDK 25 the primary JDK and keep JDK 21 as the secondary scheduled run (swap):
  - `workflow_dispatch` `jdk_major_version` input: default `21` → `25` (options reordered `25`, `21`).
  - *Select JDK major version* step: the default fallback (pull requests, pushes, and the
    `0 12 * * *` scheduled run) is now JDK 25; the special-cased `0 6 * * *` scheduled run
    now uses JDK 21.
  - Updated the schedule comments to match the new mapping.
- **Left unchanged on purpose**: the `runtime_jdk: 17 / 21 / 25` shade-run and Native Image
  matrix entries — those exercise specific runtime JDKs regardless of the primary build JDK,
  so they are not part of the swap.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial build/CI configuration change without dedicated test coverage; it is
exercised by the CI workflows themselves, which now build and test on JDK 25 by default.

### Does this pull request potentially affect one of the following parts:

- [x] Anything that affects deployment

The official Pulsar Docker image is now built on JDK 25 by default (`docker-jdk = "25"`).
This applies to the `master` / `5.0.0-M2` line only; the `5.0.0-M1` release (`branch-5.0-M1`)
continues to default to Java 21.
