### PR TITLE
[fix][txn] Fix X-Pulsar-txn-uncommitted header semantics and add X-Pulsar-txn-consumable for peek messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3324,10 +3324,16 @@ public class PersistentTopicsBase extends AdminResource {
             TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
             boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
             responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
+            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
+            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
+        } else {
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
-        boolean isTxnUncommitted = (entry.getPosition())
-                .compareTo(persistentTopic.getMaxReadPosition()) > 0;
-        responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
 
         // Decode if needed
         CompressionCodec codec = CompressionCodecProvider

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3308,10 +3308,10 @@ public class PersistentTopicsBase extends AdminResource {
             responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
             boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
             responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
+        boolean isTxnConsumable = entry.getPosition()
+                .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+        responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         if (metadata.hasHighestSequenceId()) {
             responseBuilder.header("X-Pulsar-highest-sequence-id", metadata.getHighestSequenceId());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3302,6 +3302,16 @@ public class PersistentTopicsBase extends AdminResource {
         if (metadata.hasTxnidMostBits()) {
             responseBuilder.header("X-Pulsar-txnid-most-bits", metadata.getTxnidMostBits());
         }
+        if (metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits()) {
+            TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
+            boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
+            responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
+            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
+            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
+        }
         if (metadata.hasHighestSequenceId()) {
             responseBuilder.header("X-Pulsar-highest-sequence-id", metadata.getHighestSequenceId());
         }
@@ -3319,20 +3329,6 @@ public class PersistentTopicsBase extends AdminResource {
         }
         if (metadata.hasNullPartitionKey()) {
             responseBuilder.header("X-Pulsar-null-partition-key", metadata.isNullPartitionKey());
-        }
-        if (metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits()) {
-            TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
-            boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
-            responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
-            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
-            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
-        } else {
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
 
         // Decode if needed

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3344,10 +3344,16 @@ public class PersistentTopicsBase extends AdminResource {
             TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
             boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
             responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
+            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
+            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
+        } else {
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
-        boolean isTxnUncommitted = (entry.getPosition())
-                .compareTo(persistentTopic.getMaxReadPosition()) > 0;
-        responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
 
         // Decode if needed
         CompressionCodec codec = CompressionCodecProvider

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3328,10 +3328,10 @@ public class PersistentTopicsBase extends AdminResource {
             responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
             boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
             responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
+        boolean isTxnConsumable = entry.getPosition()
+                .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+        responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         if (metadata.hasHighestSequenceId()) {
             responseBuilder.header("X-Pulsar-highest-sequence-id", metadata.getHighestSequenceId());
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3322,6 +3322,16 @@ public class PersistentTopicsBase extends AdminResource {
         if (metadata.hasTxnidMostBits()) {
             responseBuilder.header("X-Pulsar-txnid-most-bits", metadata.getTxnidMostBits());
         }
+        if (metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits()) {
+            TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
+            boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
+            responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
+            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
+            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
+            boolean isTxnConsumable = entry.getPosition()
+                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
+            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
+        }
         if (metadata.hasHighestSequenceId()) {
             responseBuilder.header("X-Pulsar-highest-sequence-id", metadata.getHighestSequenceId());
         }
@@ -3339,20 +3349,6 @@ public class PersistentTopicsBase extends AdminResource {
         }
         if (metadata.hasNullPartitionKey()) {
             responseBuilder.header("X-Pulsar-null-partition-key", metadata.isNullPartitionKey());
-        }
-        if (metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits()) {
-            TxnID txnID = new TxnID(metadata.getTxnidMostBits(), metadata.getTxnidLeastBits());
-            boolean isTxnAborted = persistentTopic.isTxnAborted(txnID, entry.getPosition());
-            responseBuilder.header("X-Pulsar-txn-aborted", isTxnAborted);
-            boolean isTxnUncommitted = persistentTopic.isTxnOngoing(txnID);
-            responseBuilder.header("X-Pulsar-txn-uncommitted", isTxnUncommitted);
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
-        } else {
-            boolean isTxnConsumable = entry.getPosition()
-                    .compareTo(persistentTopic.getMaxReadPosition()) <= 0;
-            responseBuilder.header("X-Pulsar-txn-consumable", isTxnConsumable);
         }
 
         // Decode if needed

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -5037,6 +5037,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return this.transactionBuffer.isTxnAborted(txnID, readPosition);
     }
 
+    public boolean isTxnOngoing(TxnID txnID) {
+        return this.transactionBuffer.isTxnOngoing(txnID);
+    }
+
     public TransactionInBufferStats getTransactionInBufferStats(TxnID txnID) {
         return this.transactionBuffer.getTransactionInBufferStats(txnID);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -4938,6 +4938,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return this.transactionBuffer.isTxnAborted(txnID, readPosition);
     }
 
+    public boolean isTxnOngoing(TxnID txnID) {
+        return this.transactionBuffer.isTxnOngoing(txnID);
+    }
+
     public TransactionInBufferStats getTransactionInBufferStats(TxnID txnID) {
         return this.transactionBuffer.getTransactionInBufferStats(txnID);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/TransactionBuffer.java
@@ -150,6 +150,14 @@ public interface TransactionBuffer {
     boolean isTxnAborted(TxnID txnID, Position readPosition);
 
     /**
+     * Check if the transaction is still ongoing (not committed and not aborted).
+     *
+     * @param txnID {@link TxnID} the transaction id.
+     * @return whether the txn is ongoing (uncommitted).
+     */
+    boolean isTxnOngoing(TxnID txnID);
+
+    /**
      * Sync max read position for normal publish.
      * @param position {@link Position} the position to sync.
      * @param isMarkerMessage whether the message is marker message.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/InMemTransactionBuffer.java
@@ -381,6 +381,16 @@ public class InMemTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
+    public boolean isTxnOngoing(TxnID txnID) {
+        TxnBuffer txnBuffer = buffers.get(txnID);
+        if (txnBuffer == null) {
+            return false;
+        }
+        TxnStatus status = txnBuffer.status();
+        return status == TxnStatus.OPEN || status == TxnStatus.COMMITTING || status == TxnStatus.ABORTING;
+    }
+
+    @Override
     public void syncMaxReadPositionForNormalPublish(Position position, boolean isMarkerMessage) {
         if (!isMarkerMessage) {
             updateLastDispatchablePosition(position);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/MetadataTransactionBuffer.java
@@ -661,6 +661,15 @@ public class MetadataTransactionBuffer implements TransactionBuffer {
     }
 
     @Override
+    public boolean isTxnOngoing(TxnID txnID) {
+        String key = TxnIds.toKey(txnID);
+        synchronized (lock) {
+            TxnEntry entry = txns.get(key);
+            return entry != null && entry.state == TxnState.OPEN;
+        }
+    }
+
+    @Override
     public void syncMaxReadPositionForNormalPublish(Position position, boolean isMarkerMessage) {
         if (isMarkerMessage) {
             return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -685,6 +685,11 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         return snapshotAbortedTxnProcessor.checkAbortedTransaction(txnID);
     }
 
+    @Override
+    public synchronized boolean isTxnOngoing(TxnID txnID) {
+        return ongoingTxns.containsKey(txnID);
+    }
+
     /**
      * Sync max read position for normal publish.
      * @param position {@link Position} the position to sync.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -702,6 +702,11 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
         return snapshotAbortedTxnProcessor.checkAbortedTransaction(txnID);
     }
 
+    @Override
+    public synchronized boolean isTxnOngoing(TxnID txnID) {
+        return ongoingTxns.containsKey(txnID);
+    }
+
     /**
      * Sync max read position for normal publish.
      * @param position {@link Position} the position to sync.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionBufferDisable.java
@@ -103,6 +103,11 @@ public class TransactionBufferDisable implements TransactionBuffer {
     }
 
     @Override
+    public boolean isTxnOngoing(TxnID txnID) {
+        return false;
+    }
+
+    @Override
     public void syncMaxReadPositionForNormalPublish(Position position, boolean isMarkerMessage) {
         if (!isMarkerMessage) {
             updateLastDispatchablePosition(position);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.pulsar.client.admin.internal.TopicsImpl.TXN_CONSUMABLE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -2015,10 +2016,11 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
 
         Message<byte[]> peekedMessage = admin.topics().peekMessages(topicName, "sub-peek", 1).get(0);
         assertEquals(new String(peekedMessage.getData()), "non-batch-message");
-        assertEquals(peekedMessage.getProperties().size(), 3);
+        assertEquals(peekedMessage.getProperties().size(), 4);
         assertEquals(peekedMessage.getProperties().get("key1"), "value1");
         assertEquals(peekedMessage.getProperties().get("KEY2"), "VALUE2");
         assertEquals(peekedMessage.getProperties().get("KeY3"), "VaLuE3");
+        assertEquals(peekedMessage.getProperties().get(TXN_CONSUMABLE), "true");
 
         admin.topics().truncate(topicName);
 
@@ -2053,10 +2055,11 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
             Message<byte[]> batchMessage = peekedMessages.get(i);
             assertEquals(new String(batchMessage.getData()), "batch-message-" + (i + 1));
             assertEquals(batchMessage.getProperties().size(),
-                    3 + 2 // 3 properties from the message + 2 properties from the batch
+                    3 + 2 + 1 // 3 properties from the message + 2 properties from the batch + 1 property from TNX
             );
             assertEquals(batchMessage.getProperties().get("X-Pulsar-num-batch-message"), "2");
             assertNotNull(batchMessage.getProperties().get("X-Pulsar-batch-size"));
+            assertEquals(peekedMessage.getProperties().get(TXN_CONSUMABLE), "true");
             assertEquals(batchMessage.getProperties().get("batch-key1"), "batch-value1");
             assertEquals(batchMessage.getProperties().get("BATCH-KEY2"), "BATCH-VALUE2");
             assertEquals(batchMessage.getProperties().get("BaTcH-kEy3"), "BaTcH-vAlUe3");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -936,6 +936,61 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testPeekMessageTxnHeaderAccuracy() throws Exception {
+        initTransaction(1);
+
+        final String topic = BrokerTestUtil.newUniqueName("persistent://public/default/peek_txn_header_accuracy");
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING).topic(topic).create();
+
+        // Start transaction T1, send a message, keep it uncommitted
+        Transaction txn1 = pulsarClient.newTransaction().build().get();
+        producer.newMessage(txn1).value("msg-uncommitted").send();
+
+        // Start transaction T2, send a message, commit it
+        Transaction txn2 = pulsarClient.newTransaction().build().get();
+        producer.newMessage(txn2).value("msg-committed").send();
+        txn2.commit().get();
+
+        // Peek all messages with READ_UNCOMMITTED to get both messages regardless of txn state
+        List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 10,
+                false, TransactionIsolationLevel.READ_UNCOMMITTED);
+
+        boolean foundUncommitted = false;
+        boolean foundCommitted = false;
+        for (Message<byte[]> peekMsg : peekMsgs) {
+            String value = new String(peekMsg.getValue());
+            if ("msg-uncommitted".equals(value)) {
+                foundUncommitted = true;
+                // T1 is ongoing, so X-Pulsar-txn-uncommitted should be true
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-uncommitted"), "true");
+                // Blocked by itself (uncommitted), so X-Pulsar-txn-consumable should be false
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "false");
+            } else if ("msg-committed".equals(value)) {
+                foundCommitted = true;
+                // T2 is committed, so X-Pulsar-txn-uncommitted should be false (not present in properties)
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
+                        "T2 is committed, X-Pulsar-txn-uncommitted should be false");
+                // Blocked by T1 before it, so X-Pulsar-txn-consumable should be false
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "false",
+                        "T2 is blocked by uncommitted T1 before it");
+            }
+        }
+        assertTrue(foundUncommitted, "Should have found the uncommitted message");
+        assertTrue(foundCommitted, "Should have found the committed message");
+
+        // Verify READ_COMMITTED filtering: both messages after an uncommitted txn should be filtered
+        List<Message<byte[]>> committedPeek = admin.topics().peekMessages(topic, "t-sub-2", 10,
+                false, TransactionIsolationLevel.READ_COMMITTED);
+        assertEquals(committedPeek.size(), 0,
+                "READ_COMMITTED should filter all messages after an uncommitted transaction");
+    }
+
+    @Test
     public void testPeekMessageForSkipTxnMarker() throws Exception {
         initTransaction(1);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/v3/AdminApiTransactionTest.java
@@ -946,12 +946,17 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         // Start transaction T1, send a message, keep it uncommitted
         Transaction txn1 = pulsarClient.newTransaction().build().get();
+        TxnID txnID1 = ((TransactionImpl) txn1).getTxnID();
         producer.newMessage(txn1).value("msg-uncommitted").send();
 
         // Start transaction T2, send a message, commit it
         Transaction txn2 = pulsarClient.newTransaction().build().get();
+        TxnID txnID2 = ((TransactionImpl) txn2).getTxnID();
         producer.newMessage(txn2).value("msg-committed").send();
         txn2.commit().get();
+
+        // Send a normal (non-transactional) message
+        producer.newMessage().value("msg-normal").send();
 
         // Peek all messages with READ_UNCOMMITTED to get both messages regardless of txn state
         List<Message<byte[]>> peekMsgs = admin.topics().peekMessages(topic, "t-sub", 10,
@@ -959,35 +964,143 @@ public class AdminApiTransactionTest extends MockedPulsarServiceBaseTest {
 
         boolean foundUncommitted = false;
         boolean foundCommitted = false;
+        boolean foundNormal = false;
         for (Message<byte[]> peekMsg : peekMsgs) {
             String value = new String(peekMsg.getValue());
+            MessageMetadata metadata = ((MessageImpl<?>) peekMsg).getMessageBuilder();
             if ("msg-uncommitted".equals(value)) {
                 foundUncommitted = true;
                 // T1 is ongoing, so X-Pulsar-txn-uncommitted should be true
                 assertTrue(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"));
                 assertEquals(peekMsg.getProperty("X-Pulsar-txn-uncommitted"), "true");
+                // T1 is not aborted
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "T1 is not aborted, X-Pulsar-txn-aborted should be false");
                 // Blocked by itself (uncommitted), so X-Pulsar-txn-consumable should be false
                 assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
                 assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "false");
+                // TxnID checks
+                assertTrue(metadata.hasTxnidMostBits());
+                assertEquals(metadata.getTxnidMostBits(), txnID1.getMostSigBits());
+                assertTrue(metadata.hasTxnidLeastBits());
+                assertEquals(metadata.getTxnidLeastBits(), txnID1.getLeastSigBits());
             } else if ("msg-committed".equals(value)) {
                 foundCommitted = true;
                 // T2 is committed, so X-Pulsar-txn-uncommitted should be false (not present in properties)
                 assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
                         "T2 is committed, X-Pulsar-txn-uncommitted should be false");
+                // T2 is not aborted
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "T2 is not aborted, X-Pulsar-txn-aborted should be false");
                 // Blocked by T1 before it, so X-Pulsar-txn-consumable should be false
                 assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
                 assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "false",
                         "T2 is blocked by uncommitted T1 before it");
+                // TxnID checks
+                assertTrue(metadata.hasTxnidMostBits());
+                assertEquals(metadata.getTxnidMostBits(), txnID2.getMostSigBits());
+                assertTrue(metadata.hasTxnidLeastBits());
+                assertEquals(metadata.getTxnidLeastBits(), txnID2.getLeastSigBits());
+            } else if ("msg-normal".equals(value)) {
+                foundNormal = true;
+                // Normal message has no txnid, so X-Pulsar-txn-uncommitted should not be set
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
+                        "Normal message should not have X-Pulsar-txn-uncommitted");
+                // Normal message has no txnid, so X-Pulsar-txn-aborted should not be set
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "Normal message should not have X-Pulsar-txn-aborted");
+                // Blocked by T1, so X-Pulsar-txn-consumable should be false
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "false",
+                        "Normal message is blocked by uncommitted T1");
+                // Normal message has no txnid
+                assertFalse(metadata.hasTxnidMostBits());
+                assertFalse(metadata.hasTxnidLeastBits());
             }
         }
         assertTrue(foundUncommitted, "Should have found the uncommitted message");
         assertTrue(foundCommitted, "Should have found the committed message");
+        assertTrue(foundNormal, "Should have found the normal message");
 
-        // Verify READ_COMMITTED filtering: both messages after an uncommitted txn should be filtered
+        // Verify READ_COMMITTED filtering: all messages after an uncommitted txn should be filtered
         List<Message<byte[]>> committedPeek = admin.topics().peekMessages(topic, "t-sub-2", 10,
                 false, TransactionIsolationLevel.READ_COMMITTED);
         assertEquals(committedPeek.size(), 0,
                 "READ_COMMITTED should filter all messages after an uncommitted transaction");
+
+        // Abort T1 and verify headers update correctly
+        txn1.abort().get();
+
+        List<Message<byte[]>> peekAfterAbort = admin.topics().peekMessages(topic, "t-sub-3", 10,
+                false, TransactionIsolationLevel.READ_UNCOMMITTED);
+
+        boolean foundAborted = false;
+        boolean foundCommittedAfterAbort = false;
+        boolean foundNormalAfterAbort = false;
+        for (Message<byte[]> peekMsg : peekAfterAbort) {
+            String value = new String(peekMsg.getValue());
+            MessageMetadata metadata = ((MessageImpl<?>) peekMsg).getMessageBuilder();
+            if ("msg-uncommitted".equals(value)) {
+                foundAborted = true;
+                // T1 is now aborted, so X-Pulsar-txn-aborted should be true
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "T1 is aborted, X-Pulsar-txn-aborted should be true");
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-aborted"), "true");
+                // T1 is no longer ongoing
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
+                        "T1 is aborted, X-Pulsar-txn-uncommitted should be false");
+                // maxReadPosition advanced past T1, so consumable should be true
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "true",
+                        "T1 is resolved, message should be consumable");
+                // TxnID unchanged
+                assertTrue(metadata.hasTxnidMostBits());
+                assertEquals(metadata.getTxnidMostBits(), txnID1.getMostSigBits());
+                assertTrue(metadata.hasTxnidLeastBits());
+                assertEquals(metadata.getTxnidLeastBits(), txnID1.getLeastSigBits());
+            } else if ("msg-committed".equals(value)) {
+                foundCommittedAfterAbort = true;
+                // T2 is still committed, not aborted
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
+                        "T2 is committed, X-Pulsar-txn-uncommitted should be false");
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "T2 is not aborted, X-Pulsar-txn-aborted should be false");
+                // maxReadPosition advanced past T1, so consumable should be true
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "true",
+                        "No open txn before T2, message should be consumable");
+                // TxnID unchanged
+                assertTrue(metadata.hasTxnidMostBits());
+                assertEquals(metadata.getTxnidMostBits(), txnID2.getMostSigBits());
+                assertTrue(metadata.hasTxnidLeastBits());
+                assertEquals(metadata.getTxnidLeastBits(), txnID2.getLeastSigBits());
+            } else if ("msg-normal".equals(value)) {
+                foundNormalAfterAbort = true;
+                // Normal message has no txnid, so no txn headers
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-uncommitted"),
+                        "Normal message should not have X-Pulsar-txn-uncommitted");
+                assertFalse(peekMsg.hasProperty("X-Pulsar-txn-aborted"),
+                        "Normal message should not have X-Pulsar-txn-aborted");
+                // No open txn before it, so consumable should be true
+                assertTrue(peekMsg.hasProperty("X-Pulsar-txn-consumable"));
+                assertEquals(peekMsg.getProperty("X-Pulsar-txn-consumable"), "true",
+                        "No open txn, normal message should be consumable");
+                // No txnid
+                assertFalse(metadata.hasTxnidMostBits());
+                assertFalse(metadata.hasTxnidLeastBits());
+            }
+        }
+        assertTrue(foundAborted, "Should have found the aborted message after abort");
+        assertTrue(foundCommittedAfterAbort, "Should have found the committed message after abort");
+        assertTrue(foundNormalAfterAbort, "Should have found the normal message after abort");
+
+        // READ_COMMITTED should show committed + normal message (aborted is filtered out)
+        List<Message<byte[]>> committedPeekAfterAbort = admin.topics().peekMessages(topic, "t-sub-4", 10,
+                false, TransactionIsolationLevel.READ_COMMITTED);
+        assertEquals(committedPeekAfterAbort.size(), 2,
+                "READ_COMMITTED should show committed and normal messages after abort");
+        assertEquals(new String(committedPeekAfterAbort.get(0).getValue()), "msg-committed");
+        assertEquals(new String(committedPeekAfterAbort.get(1).getValue()), "msg-normal");
     }
 
     @Test

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -138,6 +138,7 @@ public class TopicsImpl extends BaseResource implements Topics {
     private static final String ENCRYPTION_KEYS = "X-Pulsar-Base64-encryption-keys";
     public static final String TXN_ABORTED = "X-Pulsar-txn-aborted";
     public static final String TXN_UNCOMMITTED = "X-Pulsar-txn-uncommitted";
+    public static final String TXN_CONSUMABLE = "X-Pulsar-txn-consumable";
     // CHECKSTYLE.ON: MemberName
 
     public static final String PROPERTY_SHADOW_SOURCE_KEY = "PULSAR.SHADOW_SOURCE";
@@ -1338,6 +1339,15 @@ public class TopicsImpl extends BaseResource implements Topics {
             if (tmp != null && Boolean.parseBoolean(tmp.toString())) {
                 properties.put(TXN_UNCOMMITTED, tmp.toString());
                 if (transactionIsolationLevel == TransactionIsolationLevel.READ_COMMITTED) {
+                    return new ArrayList<>();
+                }
+            }
+
+            tmp = headers.getFirst(TXN_CONSUMABLE);
+            if (tmp != null) {
+                properties.put(TXN_CONSUMABLE, tmp.toString());
+                if (!Boolean.parseBoolean(tmp.toString())
+                        && transactionIsolationLevel == TransactionIsolationLevel.READ_COMMITTED) {
                     return new ArrayList<>();
                 }
             }


### PR DESCRIPTION
### Motivation

The `X-Pulsar-txn-uncommitted` response header returned by `peekNthMessage / peekMessages` REST APIs incorrectly indicates whether this specific entry's transaction is uncommitted. Currently it compares `entry.position > maxReadPosition`, which conflates two distinct concerns: the entry's own transaction state and the visibility of the entry (whether earlier uncommitted transactions block it).

Concretely, if transaction T1 is uncommitted and transaction T2 is committed, peeking T2's message still returns `X-Pulsar-txn-uncommitted: true` even though T2 itself is committed — the header is actually reporting that an earlier uncommitted transaction exists, not that this entry's transaction is uncommitted. This makes the header semantically misleading.

We need to:

- Correct `X-Pulsar-txn-uncommitted` to reflect this entry's own transaction state.
- Introduce a new header `X-Pulsar-txn-consumable` that reflects whether this entry can currently be consumed (i.e. no uncommitted transactions precede it).

### Modifications

- Correct the value of `X-Pulsar-txn-uncommitted`
- Added X-Pulsar-txn-consumable header based on `position <= maxReadPosition`. 


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment