### PR TITLE
[fix][broker] Avoid attaching a consumer to a migrated non-persistent topic on subscribe

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -346,47 +346,59 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
                     false, cnx, cnx.getAuthRole(), metadata, readCompacted, keySharedMeta, MessageId.latest,
                     DEFAULT_CONSUMER_EPOCH, schemaType);
-            if (isMigrated()) {
-                getMigratedClusterUrlAsync().thenAccept(consumer::topicMigrated);
-            }
-
-            addConsumerToSubscription(subscription, consumer).thenRun(() -> {
-                if (!cnx.isActive()) {
-                    try {
-                        consumer.close();
-                    } catch (BrokerServiceException e) {
-                        if (e instanceof ConsumerBusyException) {
-                            log.warn()
-                                    .attr("subscription", subscriptionName)
-                                    .attr("consumerId", consumerId)
-                                    .attr("consumerName", consumerName)
-                                    .log("Consumer already connected");
-                        } else if (e instanceof SubscriptionBusyException) {
-                            log.warn()
-                                    .attr("subscription", subscriptionName)
-                                    .exceptionMessage(e)
-                                    .log("Failed to subscribe");
-                        }
-
-                        decrementUsageCount();
-                        future.completeExceptionally(e);
-                        return;
-                    }
-                    log.debug()
-                            .attr("subscription", subscriptionName)
-                            .attr("consumerName", consumer.consumerName())
-                            .attr("usageCount", currentUsageCount())
-                            .log("Subscribe failed");
-                    future.completeExceptionally(
-                            new BrokerServiceException.ConnectionClosedException(
-                                    "Connection was closed while the opening the cursor "));
-                } else {
+            consumer.checkAndApplyTopicMigrationAsync().thenCompose(migrated -> {
+                if (migrated) {
+                    // The topic is migrated: checkAndApplyTopicMigrationAsync() has already sent the
+                    // TopicMigrated redirect and disconnected the consumer (which also released the usage
+                    // count taken by handleConsumerAdded above). Skip addConsumerToSubscription so the consumer
+                    // is never attached to the subscription on the old cluster. Sequencing the migration check
+                    // through thenCompose (instead of the previous fire-and-forget thenAccept that raced with
+                    // addConsumerToSubscription) is what guarantees the consumer is not added once migrated.
                     log.info()
                             .attr("subscription", subscriptionName)
                             .attr("consumerId", consumerId)
-                            .log("Created new subscription");
+                            .log("Skipped subscription on migrated topic; consumer was redirected");
                     future.complete(consumer);
+                    return CompletableFuture.<Void>completedFuture(null);
                 }
+                return addConsumerToSubscription(subscription, consumer).thenRun(() -> {
+                    if (!cnx.isActive()) {
+                        try {
+                            consumer.close();
+                        } catch (BrokerServiceException e) {
+                            if (e instanceof ConsumerBusyException) {
+                                log.warn()
+                                        .attr("subscription", subscriptionName)
+                                        .attr("consumerId", consumerId)
+                                        .attr("consumerName", consumerName)
+                                        .log("Consumer already connected");
+                            } else if (e instanceof SubscriptionBusyException) {
+                                log.warn()
+                                        .attr("subscription", subscriptionName)
+                                        .exceptionMessage(e)
+                                        .log("Failed to subscribe");
+                            }
+
+                            decrementUsageCount();
+                            future.completeExceptionally(e);
+                            return;
+                        }
+                        log.debug()
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerName", consumer.consumerName())
+                                .attr("usageCount", currentUsageCount())
+                                .log("Subscribe failed");
+                        future.completeExceptionally(
+                                new BrokerServiceException.ConnectionClosedException(
+                                        "Connection was closed while the opening the cursor "));
+                    } else {
+                        log.info()
+                                .attr("subscription", subscriptionName)
+                                .attr("consumerId", consumerId)
+                                .log("Created new subscription");
+                        future.complete(consumer);
+                    }
+                });
             }).exceptionally(e -> {
                 Throwable throwable = e.getCause();
                 if (throwable instanceof ConsumerBusyException) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -30,7 +31,9 @@ import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.broker.service.PulsarCommandSender;
 import org.apache.pulsar.broker.service.SubscriptionOption;
+import org.apache.pulsar.broker.service.TransportCnx;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -39,7 +42,9 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
@@ -125,6 +130,90 @@ public class NonPersistentTopicTest extends BrokerTestBase {
         assertEquals(admin.topics().getPartitionedTopicMetadata(topicName).partitions, 4);
     }
 
+
+    /**
+     * Regression test for the migration-redirect race in {@code NonPersistentTopic.internalSubscribe}
+     * (introduced by PR #26051, which turned a blocking, ordered migration redirect into a fire-and-forget
+     * async one). When the topic is migrated, the migration check must complete <i>before</i>
+     * {@code addConsumerToSubscription}, and the consumer must NOT be attached to the subscription on the
+     * old cluster. The previous code ran {@code getMigratedClusterUrlAsync().thenAccept(consumer::topicMigrated)}
+     * concurrently with {@code addConsumerToSubscription}, so the consumer could be added before the redirect
+     * and disconnect ran. The fix sequences the check through {@link org.apache.pulsar.broker.service.Consumer
+     * #checkAndApplyTopicMigrationAsync()} and skips the add when migrated.
+     */
+    @Test
+    public void testSubscribeOnMigratedTopicSkipsAddingConsumer() throws Exception {
+        final String topicName = "non-persistent://prop/ns-abc/migration-race-" + UUID.randomUUID();
+        final String subName = "migration-sub";
+
+        // Materialize the real topic on the broker and acquire namespace-bundle ownership via a client lookup.
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        NonPersistentTopic realTopic =
+                (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+
+        // Mark the local cluster as migrated so AbstractTopic.getMigratedClusterUrlAsync() (used by
+        // Consumer.checkAndApplyTopicMigrationAsync()) resolves to a present migrated-cluster URL.
+        ClusterUrl migratedUrl = new ClusterUrl("http://migrated:8080", "https://migrated:8443",
+                "pulsar://migrated:6650", "pulsar+ssl://migrated:6651");
+        admin.clusters().updateClusterMigration(conf.getClusterName(), true, migratedUrl);
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() ->
+                AbstractTopic.getMigratedClusterUrlAsync(pulsar, topicName).get().isPresent());
+
+        // Spy the topic and force isMigrated() so the subscription is considered migrated.
+        NonPersistentTopic spyTopic = Mockito.spy(realTopic);
+        Mockito.doReturn(true).when(spyTopic).isMigrated();
+
+        // Pre-install a spy subscription so we can assert addConsumer is never invoked when migrated.
+        NonPersistentSubscription spySubscription =
+                Mockito.spy(new NonPersistentSubscription(spyTopic, subName, Collections.emptyMap()));
+        spyTopic.getSubscriptions().put(subName, spySubscription);
+
+        // An active transport connection that records the migration redirect.
+        PulsarCommandSender commandSender = Mockito.mock(PulsarCommandSender.class);
+        TransportCnx cnx = Mockito.mock(TransportCnx.class);
+        Mockito.doReturn(true).when(cnx).isActive();
+        Mockito.doReturn(true).when(cnx).isBatchMessageCompatibleVersion();
+        Mockito.doReturn("test-role").when(cnx).getAuthRole();
+        Mockito.doReturn(pulsar.getBrokerService()).when(cnx).getBrokerService();
+        Mockito.doReturn(commandSender).when(cnx).getCommandSender();
+
+        SubscriptionOption option = SubscriptionOption.builder()
+                .cnx(cnx)
+                .subscriptionName(subName)
+                .consumerId(1L)
+                .subType(CommandSubscribe.SubType.Shared)
+                .priorityLevel(0)
+                .consumerName("consumer-1")
+                .isDurable(false)
+                .startMessageId(null)
+                .metadata(Collections.emptyMap())
+                .readCompacted(false)
+                .initialPosition(CommandSubscribe.InitialPosition.Latest)
+                .startMessageRollbackDurationSec(0)
+                .replicatedSubscriptionStateArg(false)
+                .keySharedMeta(null)
+                .subscriptionProperties(Optional.empty())
+                .build();
+
+        long usageBefore = spyTopic.currentUsageCount();
+
+        org.apache.pulsar.broker.service.Consumer consumer =
+                spyTopic.subscribe(option).get(10, TimeUnit.SECONDS);
+        assertNotNull(consumer);
+
+        // The migration redirect must have been sent to the client.
+        Mockito.verify(commandSender).sendTopicMigrated(Mockito.any(), Mockito.eq(1L),
+                Mockito.eq(migratedUrl.getBrokerServiceUrl()), Mockito.eq(migratedUrl.getBrokerServiceUrlTls()));
+
+        // The core regression assertion: a migrated topic must never attach the consumer to the
+        // subscription. The buggy code added it before the async redirect/disconnect could run.
+        Mockito.verify(spySubscription, Mockito.never()).addConsumer(Mockito.any());
+        assertTrue(spySubscription.getConsumers().isEmpty());
+
+        // No usage-count leak: handleConsumerAdded's increment is balanced by the disconnect's removeConsumer.
+        assertEquals(spyTopic.currentUsageCount(), usageBefore);
+    }
 
     @Test
     public void testSubscriptionsOnNonPersistentTopic() throws Exception {


### PR DESCRIPTION
This is a follow-up regression fix for #26051.

### Motivation

#26051 changed `NonPersistentTopic.internalSubscribe` from a blocking, ordered migration redirect into a fire-and-forget async one:

```java
if (isMigrated()) {
    getMigratedClusterUrlAsync().thenAccept(consumer::topicMigrated);
}
addConsumerToSubscription(subscription, consumer).thenRun(...)
```

`getMigratedClusterUrlAsync()` only invokes `topicMigrated()` — which sends the `TopicMigrated` redirect and disconnects the consumer — after a metadata-read hop on `pulsar.getExecutor()`, while `addConsumerToSubscription` runs immediately. The two therefore race.

The later `if (!cnx.isActive())` guard does not mitigate this, because for protocol version `v5` and above `disconnect()` → `closeConsumer()` only sends a `CloseConsumer` command and never flips `cnx.isActive()` to `false`. As a result, a consumer subscribing to a migrated non-persistent topic can be left attached to the subscription on the old (migrated) cluster instead of being cleanly redirected.

Before #26051 this code was synchronous, so `topicMigrated()` always completed before `addConsumerToSubscription`; the async change introduced the race.

This is specific to `NonPersistentTopic`: `PersistentTopic.internalSubscribe` has no inline migration check and relies solely on the post-subscribe check in `ServerCnx`.

### Modifications

- Route the inline migration check through the existing `Consumer.checkAndApplyTopicMigrationAsync()` (already used by `ServerCnx` on the subscribe-success path) and sequence `addConsumerToSubscription` behind it with `thenCompose`:
  - when the topic is migrated, the consumer is redirected and disconnected and `addConsumerToSubscription` is **skipped**, so the consumer is never attached to the subscription on the old cluster;
  - otherwise the original add path runs unchanged (byte-for-byte).
- Failures from resolving the migrated-cluster URL now surface through the existing `exceptionally` handler instead of being silently swallowed by the fire-and-forget `thenAccept`. This metadata read is only reached when the subscription is already migrated (`checkAndApplyTopicMigrationAsync()` short-circuits to `false` otherwise), so the common, non-migrated subscribe path is unchanged and gains no new failure mode.
- The topic usage count stays balanced without any extra bookkeeping: on the migrated path `topicMigrated()` → `disconnect()` → `Consumer.close()` → `NonPersistentSubscription.removeConsumer()` already calls `decrementUsageCount()` (even when the consumer was never added), balancing the increment taken by `handleConsumerAdded()`.

### Verifying this change

This change added tests and can be verified as follows:

- Added `NonPersistentTopicTest.testSubscribeOnMigratedTopicSkipsAddingConsumer`, a deterministic regression test that subscribes directly on a migrated non-persistent topic and asserts the consumer is **never** added to the subscription (`verify(subscription, never()).addConsumer(...)`), the migration redirect is sent, and the topic usage count returns to its pre-subscribe value. The test **fails on the previous code** (Mockito `NeverWantedButInvoked`: `addConsumer` is invoked via `addConsumerToSubscription`) and passes with the fix.
- The existing end-to-end migration suite `ClusterMigrationTest` and the full `NonPersistentTopicTest` continue to pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
