### PR TITLE
[feat][broker] Expose managed ledger properties via topic internal stats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -5006,6 +5006,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         stats.lastConfirmedEntry = this.getLastConfirmedEntry().toString();
         stats.state = this.getState().toString();
 
+        stats.properties = new HashMap<>(propertiesMap);
+
         stats.cursors = new HashMap<>();
         this.getCursors().forEach(c -> {
             ManagedCursorImpl cursor = (ManagedCursorImpl) c;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3203,6 +3203,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                 stats.lastConfirmedEntry = ledgerInternalStats.getLastConfirmedEntry();
                 stats.state = ledgerInternalStats.getState();
                 stats.ledgers = ledgerInternalStats.ledgers;
+                stats.properties = ledgerInternalStats.getProperties();
 
                 // Add ledger info for compacted topic ledger if exist.
                 LedgerInfo info = new LedgerInfo();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -71,7 +71,9 @@ import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import lombok.Data;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -1451,20 +1453,38 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testGetInternalStatsWithProperties() throws Exception {
-        final String namespace = newUniqueName(defaultTenant + "/ns2");
-        final String topicName = "persistent://" + namespace + "/testGetInternalStatsWithProperties";
-        admin.namespaces().createNamespace(namespace, 20);
+        final var namespace = newUniqueName(defaultTenant + "/ns2");
+        final var topicName = "persistent://" + namespace + "/testGetInternalStatsWithProperties";
+        admin.namespaces().createNamespace(namespace);
 
-        Map<String, String> topicProperties = new HashMap<>();
-        topicProperties.put("key1", "value1");
-        topicProperties.put("key2", "value2");
+        final var topicProperties = Map.of("key1", "value1", "key2", "value2");
         admin.topics().createNonPartitionedTopic(topicName, topicProperties);
 
-        PersistentTopicInternalStats stats = admin.topics().getInternalStats(topicName);
-        assertNotNull(stats.properties);
-        assertEquals(stats.properties.get("key1"), "value1");
-        assertEquals(stats.properties.get("key2"), "value2");
-        assertEquals(stats.properties.size(), 2);
+        var stats = admin.topics().getInternalStats(topicName);
+        assertEquals(stats.properties, topicProperties);
+
+        var persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopicIfExists(topicName).get()
+                .orElseThrow();
+        final var future = new CompletableFuture<Map<String, String>>();
+        persistentTopic.getManagedLedger().asyncSetProperty("new-key", "new-value",
+                new AsyncCallbacks.UpdatePropertiesCallback() {
+                    @Override
+                    public void updatePropertiesComplete(Map<String, String> properties, Object ctx) {
+                        future.complete(properties);
+                    }
+
+                    @Override
+                    public void updatePropertiesFailed(ManagedLedgerException exception, Object ctx) {
+                        future.completeExceptionally(exception);
+                    }
+                }, null);
+        assertEquals(future.get(), Map.of("key1", "value1", "key2", "value2", "new-key", "new-value"));
+
+        admin.namespaces().unload(namespace);
+        persistentTopic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, true).get()
+                .orElseThrow();
+        stats = admin.topics().getInternalStats(topicName);
+        assertEquals(stats.properties, Map.of("key1", "value1", "key2", "value2", "new-key", "new-value"));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1450,6 +1450,24 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     @Test
+    public void testGetInternalStatsWithProperties() throws Exception {
+        final String namespace = newUniqueName(defaultTenant + "/ns2");
+        final String topicName = "persistent://" + namespace + "/testGetInternalStatsWithProperties";
+        admin.namespaces().createNamespace(namespace, 20);
+
+        Map<String, String> topicProperties = new HashMap<>();
+        topicProperties.put("key1", "value1");
+        topicProperties.put("key2", "value2");
+        admin.topics().createNonPartitionedTopic(topicName, topicProperties);
+
+        PersistentTopicInternalStats stats = admin.topics().getInternalStats(topicName);
+        assertNotNull(stats.properties);
+        assertEquals(stats.properties.get("key1"), "value1");
+        assertEquals(stats.properties.get("key2"), "value2");
+        assertEquals(stats.properties.size(), 2);
+    }
+
+    @Test
     public void testNonPersistentTopics() throws Exception {
         final String namespace = newUniqueName(defaultTenant + "/ns2");
         final String topicName = "non-persistent://" + namespace + "/topic";

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -71,6 +71,9 @@ public class ManagedLedgerInternalStats {
     /** The list of all cursors on this topic. Each subscription in the topic stats has a cursor. */
     public Map<String, CursorStats> cursors;
 
+    /** The properties map of the managed ledger. */
+    public Map<String, String> properties;
+
     /**
      * Ledger information.
      */


### PR DESCRIPTION
### Motivation

Currently there is no way to check managed ledger properties unless reading directly from the metadata store or dumping the heap memory. The managed ledger properties could include the topic properties, or last index if `AppendIndexMetadataInterceptor` is configured, or a custom property set from downstream plugins via `ManagedLedger#setProperty`. It would be helpful if we can directly check the properties via admin tools like `pulsar-shell`.

### Modifications

Add a `properties` field to managed ledger stats and fill it with a snapshot of `propertiesMap`. Add `testGetInternalStatsWithProperties` to verify the change.