### PR TITLE
[fix][ml] Track all pending read callbacks for timeouts

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -133,6 +133,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private long lastStatTimestamp = System.nanoTime();
     private final ScheduledFuture<?> statsTask;
     private final ScheduledFuture<?> flushCursorsTask;
+    private final ReadEntryTimeoutTracker readEntryTimeoutTracker;
 
     private volatile long cacheEvictionTimeThresholdNanos;
     private final MetadataStore metadataStore;
@@ -245,6 +246,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
         this.config = config;
         this.mbean = new ManagedLedgerFactoryMBeanImpl(this);
         this.entryCacheManager = new RangeEntryCacheManagerImpl(this, scheduledExecutor, openTelemetry);
+        this.readEntryTimeoutTracker = new ReadEntryTimeoutTracker(scheduledExecutor);
         this.statsTask = scheduledExecutor.scheduleWithFixedDelay(catchingAndLoggingThrowables(this::refreshStats),
                 0, config.getStatsPeriodSeconds(), TimeUnit.SECONDS);
         this.flushCursorsTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::flushCursors),
@@ -322,6 +324,10 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     @VisibleForTesting
     public synchronized void doCacheEviction() {
         entryCacheManager.doCacheEviction();
+    }
+
+    ReadEntryTimeoutTracker getReadEntryTimeoutTracker() {
+        return readEntryTimeoutTracker;
     }
 
     /**
@@ -662,6 +668,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
 
         statsTask.cancel(true);
         flushCursorsTask.cancel(true);
+        readEntryTimeoutTracker.close();
         cacheEvictionExecutor.shutdownNow();
 
         List<String> ledgerNames = new ArrayList<>(this.ledgers.keySet());

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -348,8 +349,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             .newUpdater(ManagedLedgerImpl.class, "addOpCount");
     private volatile long addOpCount = 0;
 
-    // Pending read callbacks tracked by read operation id for read-timeout checks.
-    private final ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks = new ConcurrentHashMap<>();
+    // Pending reads ordered by timeout so checks can stop at the first operation that has not expired.
+    private final PriorityBlockingQueue<PendingReadCallback> pendingReadCallbacks = new PriorityBlockingQueue<>();
 
     /**
      * Queue of pending entries to be added to the managed ledger. Typically, entries are queued when a new ledger is.
@@ -2434,10 +2435,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (config.getReadEntryTimeoutSeconds() > 0) {
             // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
-            long createdTime = System.nanoTime();
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, position.getLedgerId(),
-                    position.getEntryId(), callback, readOpCount, createdTime, ctx, pendingReadCallbacks);
-            pendingReadCallbacks.put(readOpCount, readCallback);
+                    position.getEntryId(), callback, readOpCount, ctx);
+            PendingReadCallback pendingReadCallback = new PendingReadCallback(readOpCount,
+                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()), position.getLedgerId(), position.getEntryId(),
+                    readCallback);
+            readCallback.pendingReadCallback = pendingReadCallback;
+            pendingReadCallbacks.add(pendingReadCallback);
             entryCache.asyncReadEntry(ledger, position, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, position, callback, ctx);
@@ -2450,13 +2454,54 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (config.getReadEntryTimeoutSeconds() > 0) {
             // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
-            long createdTime = System.nanoTime();
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, ledger.getId(), firstEntry,
-                    opReadEntry, readOpCount, createdTime, ctx, pendingReadCallbacks);
-            pendingReadCallbacks.put(readOpCount, readCallback);
+                    opReadEntry, readOpCount, ctx);
+            PendingReadCallback pendingReadCallback = new PendingReadCallback(readOpCount,
+                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()), ledger.getId(), firstEntry, readCallback);
+            readCallback.pendingReadCallback = pendingReadCallback;
+            pendingReadCallbacks.add(pendingReadCallback);
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, opReadEntry, ctx);
+        }
+    }
+
+    private static long timeoutAtNanos(long timeoutSec) {
+        return System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSec);
+    }
+
+    static final class PendingReadCallback implements Comparable<PendingReadCallback> {
+        private static final AtomicReferenceFieldUpdater<PendingReadCallback, ReadEntryCallbackWrapper>
+                CALLBACK_UPDATER = AtomicReferenceFieldUpdater
+                .newUpdater(PendingReadCallback.class, ReadEntryCallbackWrapper.class, "callback");
+
+        final long readOpCount;
+        final long timeoutAtNanos;
+        final long ledgerId;
+        final long entryId;
+        volatile ReadEntryCallbackWrapper callback;
+
+        PendingReadCallback(long readOpCount, long timeoutAtNanos, long ledgerId, long entryId,
+                ReadEntryCallbackWrapper callback) {
+            this.readOpCount = readOpCount;
+            this.timeoutAtNanos = timeoutAtNanos;
+            this.ledgerId = ledgerId;
+            this.entryId = entryId;
+            this.callback = callback;
+        }
+
+        @Override
+        public int compareTo(PendingReadCallback other) {
+            int result = Long.compare(timeoutAtNanos, other.timeoutAtNanos);
+            return result != 0 ? result : Long.compare(readOpCount, other.readOpCount);
+        }
+
+        ReadEntryCallbackWrapper clearCallback() {
+            return CALLBACK_UPDATER.getAndSet(this, null);
+        }
+
+        void clearCallback(ReadEntryCallbackWrapper callback) {
+            CALLBACK_UPDATER.compareAndSet(this, callback, null);
         }
     }
 
@@ -2470,9 +2515,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         volatile long readOpCount = -1;
         private static final AtomicLongFieldUpdater<ReadEntryCallbackWrapper> READ_OP_COUNT_UPDATER =
                 AtomicLongFieldUpdater.newUpdater(ReadEntryCallbackWrapper.class, "readOpCount");
-        volatile long createdTime = -1;
         volatile Object cntx;
-        volatile ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks;
+        volatile PendingReadCallback pendingReadCallback;
 
         final Handle<ReadEntryCallbackWrapper> recyclerHandle;
 
@@ -2481,8 +2525,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntryCallback callback,
-                long readOpCount, long createdTime, Object ctx,
-                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks) {
+                long readOpCount, Object ctx) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
             readCallback.name = name;
             readCallback.ledgerId = ledgerId;
@@ -2490,14 +2533,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             readCallback.readEntryCallback = callback;
             readCallback.cntx = ctx;
             readCallback.readOpCount = readOpCount;
-            readCallback.createdTime = createdTime;
-            readCallback.pendingReadCallbacks = pendingReadCallbacks;
             return readCallback;
         }
 
         static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntriesCallback callback,
-                long readOpCount, long createdTime, Object ctx,
-                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks) {
+                long readOpCount, Object ctx) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
             readCallback.name = name;
             readCallback.ledgerId = ledgerId;
@@ -2505,8 +2545,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             readCallback.readEntriesCallback = callback;
             readCallback.cntx = ctx;
             readCallback.readOpCount = readOpCount;
-            readCallback.createdTime = createdTime;
-            readCallback.pendingReadCallbacks = pendingReadCallbacks;
             return readCallback;
         }
 
@@ -2577,18 +2615,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         private boolean recycle(long readOpCount) {
             if (readOpCount != -1
                     && READ_OP_COUNT_UPDATER.compareAndSet(ReadEntryCallbackWrapper.this, readOpCount, -1)) {
-                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingCallbacks = pendingReadCallbacks;
-                if (pendingCallbacks != null) {
-                    pendingCallbacks.remove(readOpCount, this);
+                PendingReadCallback pendingCallback = pendingReadCallback;
+                if (pendingCallback != null) {
+                    pendingCallback.clearCallback(this);
                 }
-                createdTime = -1;
                 readEntryCallback = null;
                 readEntriesCallback = null;
                 ledgerId = -1;
                 entryId = -1;
                 name = null;
                 cntx = null;
-                pendingReadCallbacks = null;
+                pendingReadCallback = null;
                 recyclerHandle.recycle(this);
                 return true;
             }
@@ -4780,19 +4817,25 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return;
         }
         long now = System.nanoTime();
-        pendingReadCallbacks.forEach((readOpCount, callback) -> {
-            if (readOpCount <= 0 || callback == null || callback.createdTime < 0) {
-                return;
+        while (true) {
+            PendingReadCallback pendingCallback = pendingReadCallbacks.peek();
+            if (pendingCallback == null || pendingCallback.timeoutAtNanos > now) {
+                break;
             }
-            boolean timeout = TimeUnit.NANOSECONDS.toSeconds(now - callback.createdTime) >= timeoutSec;
-            if (timeout && pendingReadCallbacks.remove(readOpCount, callback)) {
-                log.warn().attr("ledgerId", callback.ledgerId)
-                        .attr("entryId", callback.entryId)
+            pendingCallback = pendingReadCallbacks.poll();
+            if (pendingCallback == null) {
+                break;
+            }
+            ReadEntryCallbackWrapper callback = pendingCallback.clearCallback();
+            if (callback != null) {
+                log.warn().attr("ledgerId", pendingCallback.ledgerId)
+                        .attr("entryId", pendingCallback.entryId)
                         .attr("timeoutSec", timeoutSec)
                         .log("Read entry timeout");
-                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException), readOpCount);
+                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException),
+                        pendingCallback.readOpCount);
             }
-        });
+        }
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -348,11 +348,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             .newUpdater(ManagedLedgerImpl.class, "addOpCount");
     private volatile long addOpCount = 0;
 
-    // last read-operation's callback to check read-timeout on it.
-    private volatile ReadEntryCallbackWrapper lastReadCallback = null;
-    private static final AtomicReferenceFieldUpdater<ManagedLedgerImpl, ReadEntryCallbackWrapper>
-            LAST_READ_CALLBACK_UPDATER = AtomicReferenceFieldUpdater
-            .newUpdater(ManagedLedgerImpl.class, ReadEntryCallbackWrapper.class, "lastReadCallback");
+    // Pending read callbacks tracked by read operation id for read-timeout checks.
+    private final ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks = new ConcurrentHashMap<>();
 
     /**
      * Queue of pending entries to be added to the managed ledger. Typically, entries are queued when a new ledger is.
@@ -2439,8 +2436,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
             long createdTime = System.nanoTime();
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, position.getLedgerId(),
-                    position.getEntryId(), callback, readOpCount, createdTime, ctx);
-            lastReadCallback = readCallback;
+                    position.getEntryId(), callback, readOpCount, createdTime, ctx, pendingReadCallbacks);
+            pendingReadCallbacks.put(readOpCount, readCallback);
             entryCache.asyncReadEntry(ledger, position, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, position, callback, ctx);
@@ -2455,8 +2452,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
             long createdTime = System.nanoTime();
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, ledger.getId(), firstEntry,
-                    opReadEntry, readOpCount, createdTime, ctx);
-            lastReadCallback = readCallback;
+                    opReadEntry, readOpCount, createdTime, ctx, pendingReadCallbacks);
+            pendingReadCallbacks.put(readOpCount, readCallback);
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, opReadEntry, ctx);
@@ -2475,6 +2472,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 AtomicLongFieldUpdater.newUpdater(ReadEntryCallbackWrapper.class, "readOpCount");
         volatile long createdTime = -1;
         volatile Object cntx;
+        volatile ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks;
 
         final Handle<ReadEntryCallbackWrapper> recyclerHandle;
 
@@ -2483,7 +2481,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntryCallback callback,
-                long readOpCount, long createdTime, Object ctx) {
+                long readOpCount, long createdTime, Object ctx,
+                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
             readCallback.name = name;
             readCallback.ledgerId = ledgerId;
@@ -2492,11 +2491,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             readCallback.cntx = ctx;
             readCallback.readOpCount = readOpCount;
             readCallback.createdTime = createdTime;
+            readCallback.pendingReadCallbacks = pendingReadCallbacks;
             return readCallback;
         }
 
         static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntriesCallback callback,
-                long readOpCount, long createdTime, Object ctx) {
+                long readOpCount, long createdTime, Object ctx,
+                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingReadCallbacks) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
             readCallback.name = name;
             readCallback.ledgerId = ledgerId;
@@ -2505,6 +2506,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             readCallback.cntx = ctx;
             readCallback.readOpCount = readOpCount;
             readCallback.createdTime = createdTime;
+            readCallback.pendingReadCallbacks = pendingReadCallbacks;
             return readCallback;
         }
 
@@ -2575,12 +2577,18 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         private boolean recycle(long readOpCount) {
             if (readOpCount != -1
                     && READ_OP_COUNT_UPDATER.compareAndSet(ReadEntryCallbackWrapper.this, readOpCount, -1)) {
+                ConcurrentHashMap<Long, ReadEntryCallbackWrapper> pendingCallbacks = pendingReadCallbacks;
+                if (pendingCallbacks != null) {
+                    pendingCallbacks.remove(readOpCount, this);
+                }
                 createdTime = -1;
                 readEntryCallback = null;
                 readEntriesCallback = null;
                 ledgerId = -1;
                 entryId = -1;
                 name = null;
+                cntx = null;
+                pendingReadCallbacks = null;
                 recyclerHandle.recycle(this);
                 return true;
             }
@@ -4771,17 +4779,20 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (timeoutSec < 1) {
             return;
         }
-        ReadEntryCallbackWrapper callback = this.lastReadCallback;
-        long readOpCount = callback != null ? callback.readOpCount : 0;
-        boolean timeout = callback != null && (TimeUnit.NANOSECONDS
-                .toSeconds(System.nanoTime() - callback.createdTime) >= timeoutSec);
-        if (readOpCount > 0 && timeout) {
-            log.warn().attr("ledgerId", this.lastReadCallback.ledgerId)
-                    .attr("entryId", this.lastReadCallback.entryId)
-                    .attr("timeoutSec", timeoutSec).log("Read entry timeout");
-            callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException), readOpCount);
-            LAST_READ_CALLBACK_UPDATER.compareAndSet(this, callback, null);
-        }
+        long now = System.nanoTime();
+        pendingReadCallbacks.forEach((readOpCount, callback) -> {
+            if (readOpCount <= 0 || callback == null || callback.createdTime < 0) {
+                return;
+            }
+            boolean timeout = TimeUnit.NANOSECONDS.toSeconds(now - callback.createdTime) >= timeoutSec;
+            if (timeout && pendingReadCallbacks.remove(readOpCount, callback)) {
+                log.warn().attr("ledgerId", callback.ledgerId)
+                        .attr("entryId", callback.entryId)
+                        .attr("timeoutSec", timeoutSec)
+                        .log("Read entry timeout");
+                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException), readOpCount);
+            }
+        });
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -56,7 +56,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -349,9 +348,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             .newUpdater(ManagedLedgerImpl.class, "addOpCount");
     private volatile long addOpCount = 0;
 
-    // Pending reads ordered by timeout so checks can stop at the first operation that has not expired.
-    private final PriorityBlockingQueue<PendingReadCallback> pendingReadCallbacks = new PriorityBlockingQueue<>();
-
     /**
      * Queue of pending entries to be added to the managed ledger. Typically, entries are queued when a new ledger is.
      * created asynchronously and hence there is no ready ledger to write into.
@@ -527,7 +523,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             }
         });
 
-        scheduleTimeoutTask();
+        scheduleAddEntryTimeoutTask();
     }
 
     protected ManagedLedgerInterceptor.LastEntryHandle createLastEntryHandle(LedgerHandle lh) {
@@ -2435,13 +2431,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (config.getReadEntryTimeoutSeconds() > 0) {
             // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
-            ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, position.getLedgerId(),
+            ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(this, position.getLedgerId(),
                     position.getEntryId(), callback, readOpCount, ctx);
-            PendingReadCallback pendingReadCallback = new PendingReadCallback(readOpCount,
-                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()), position.getLedgerId(), position.getEntryId(),
-                    readCallback);
-            readCallback.pendingReadCallback = pendingReadCallback;
-            pendingReadCallbacks.add(pendingReadCallback);
+            readCallback.readTimeout = factory.getReadEntryTimeoutTracker().add(readCallback, readOpCount,
+                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
             entryCache.asyncReadEntry(ledger, position, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, position, callback, ctx);
@@ -2454,12 +2447,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (config.getReadEntryTimeoutSeconds() > 0) {
             // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
             long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
-            ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(name, ledger.getId(), firstEntry,
+            ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(this, ledger.getId(), firstEntry,
                     opReadEntry, readOpCount, ctx);
-            PendingReadCallback pendingReadCallback = new PendingReadCallback(readOpCount,
-                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()), ledger.getId(), firstEntry, readCallback);
-            readCallback.pendingReadCallback = pendingReadCallback;
-            pendingReadCallbacks.add(pendingReadCallback);
+            readCallback.readTimeout = factory.getReadEntryTimeoutTracker().add(readCallback, readOpCount,
+                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, readCallback, readOpCount);
         } else {
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, opReadEntry, ctx);
@@ -2470,53 +2461,18 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSec);
     }
 
-    static final class PendingReadCallback implements Comparable<PendingReadCallback> {
-        private static final AtomicReferenceFieldUpdater<PendingReadCallback, ReadEntryCallbackWrapper>
-                CALLBACK_UPDATER = AtomicReferenceFieldUpdater
-                .newUpdater(PendingReadCallback.class, ReadEntryCallbackWrapper.class, "callback");
-
-        final long readOpCount;
-        final long timeoutAtNanos;
-        final long ledgerId;
-        final long entryId;
-        volatile ReadEntryCallbackWrapper callback;
-
-        PendingReadCallback(long readOpCount, long timeoutAtNanos, long ledgerId, long entryId,
-                ReadEntryCallbackWrapper callback) {
-            this.readOpCount = readOpCount;
-            this.timeoutAtNanos = timeoutAtNanos;
-            this.ledgerId = ledgerId;
-            this.entryId = entryId;
-            this.callback = callback;
-        }
-
-        @Override
-        public int compareTo(PendingReadCallback other) {
-            int result = Long.compare(timeoutAtNanos, other.timeoutAtNanos);
-            return result != 0 ? result : Long.compare(readOpCount, other.readOpCount);
-        }
-
-        ReadEntryCallbackWrapper clearCallback() {
-            return CALLBACK_UPDATER.getAndSet(this, null);
-        }
-
-        void clearCallback(ReadEntryCallbackWrapper callback) {
-            CALLBACK_UPDATER.compareAndSet(this, callback, null);
-        }
-    }
-
     static final class ReadEntryCallbackWrapper implements ReadEntryCallback, ReadEntriesCallback {
 
         volatile ReadEntryCallback readEntryCallback;
         volatile ReadEntriesCallback readEntriesCallback;
-        String name;
+        volatile ManagedLedgerImpl managedLedger;
         long ledgerId;
         long entryId;
         volatile long readOpCount = -1;
         private static final AtomicLongFieldUpdater<ReadEntryCallbackWrapper> READ_OP_COUNT_UPDATER =
                 AtomicLongFieldUpdater.newUpdater(ReadEntryCallbackWrapper.class, "readOpCount");
         volatile Object cntx;
-        volatile PendingReadCallback pendingReadCallback;
+        volatile ReadEntryTimeoutTracker.ReadTimeoutWrapper readTimeout;
 
         final Handle<ReadEntryCallbackWrapper> recyclerHandle;
 
@@ -2524,10 +2480,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             this.recyclerHandle = recyclerHandle;
         }
 
-        static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntryCallback callback,
-                long readOpCount, Object ctx) {
+        static ReadEntryCallbackWrapper create(ManagedLedgerImpl managedLedger, long ledgerId, long entryId,
+                                               ReadEntryCallback callback, long readOpCount, Object ctx) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
-            readCallback.name = name;
+            readCallback.managedLedger = managedLedger;
             readCallback.ledgerId = ledgerId;
             readCallback.entryId = entryId;
             readCallback.readEntryCallback = callback;
@@ -2536,10 +2492,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return readCallback;
         }
 
-        static ReadEntryCallbackWrapper create(String name, long ledgerId, long entryId, ReadEntriesCallback callback,
-                long readOpCount, Object ctx) {
+        static ReadEntryCallbackWrapper create(ManagedLedgerImpl managedLedger, long ledgerId, long entryId,
+                                               ReadEntriesCallback callback, long readOpCount, Object ctx) {
             ReadEntryCallbackWrapper readCallback = RECYCLER.get();
-            readCallback.name = name;
+            readCallback.managedLedger = managedLedger;
             readCallback.ledgerId = ledgerId;
             readCallback.entryId = entryId;
             readCallback.readEntriesCallback = callback;
@@ -2602,6 +2558,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return (ctx instanceof Long) ? (long) ctx : -1;
         }
 
+        boolean shouldTriggerReadTimeout() {
+            ManagedLedgerImpl ledger = managedLedger;
+            if (ledger == null) {
+                return false;
+            }
+            State state = STATE_UPDATER.get(ledger);
+            return state != State.Closed && !state.isFenced();
+        }
+
         public void readFailed(ManagedLedgerException exception, Object ctx) {
             if (readEntryCallback != null) {
                 readEntryFailed(exception, ctx);
@@ -2615,17 +2580,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         private boolean recycle(long readOpCount) {
             if (readOpCount != -1
                     && READ_OP_COUNT_UPDATER.compareAndSet(ReadEntryCallbackWrapper.this, readOpCount, -1)) {
-                PendingReadCallback pendingCallback = pendingReadCallback;
-                if (pendingCallback != null) {
-                    pendingCallback.clearCallback(this);
+                ReadEntryTimeoutTracker.ReadTimeoutWrapper timeout = readTimeout;
+                if (timeout != null) {
+                    timeout.clearCallback(this);
                 }
                 readEntryCallback = null;
                 readEntriesCallback = null;
                 ledgerId = -1;
                 entryId = -1;
-                name = null;
+                managedLedger = null;
                 cntx = null;
-                pendingReadCallback = null;
+                readTimeout = null;
                 recyclerHandle.recycle(this);
                 return true;
             }
@@ -4769,29 +4734,20 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return false;
     }
 
-    private void scheduleTimeoutTask() {
-        // disable timeout task checker if timeout <= 0
-        if (config.getAddEntryTimeoutSeconds() > 0 || config.getReadEntryTimeoutSeconds() > 0) {
-            long timeoutSec = Math.min(config.getAddEntryTimeoutSeconds(), config.getReadEntryTimeoutSeconds());
-            timeoutSec = timeoutSec <= 0
-                    ? Math.max(config.getAddEntryTimeoutSeconds(), config.getReadEntryTimeoutSeconds())
-                    : timeoutSec;
+    private void scheduleAddEntryTimeoutTask() {
+        if (config.getAddEntryTimeoutSeconds() > 0) {
+            long timeoutSec = config.getAddEntryTimeoutSeconds();
             this.timeoutTask = this.scheduledExecutor.scheduleAtFixedRate(
-                    this::checkTimeouts, timeoutSec, timeoutSec, TimeUnit.SECONDS);
+                    this::checkAddTimeout, timeoutSec, timeoutSec, TimeUnit.SECONDS);
         }
     }
 
-    private void checkTimeouts() {
+    private void checkAddTimeout() {
         final State state = STATE_UPDATER.get(this);
         if (state == State.Closed
                 || state.isFenced()) {
             return;
         }
-        checkAddTimeout();
-        checkReadTimeout();
-    }
-
-    private void checkAddTimeout() {
         long timeoutSec = config.getAddEntryTimeoutSeconds();
         if (timeoutSec < 1) {
             return;
@@ -4807,33 +4763,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                         .log("Failed to add entry in time-out");
                 currentLedgerTimeoutTriggered.set(true);
                 opAddEntry.handleAddFailure(opAddEntry.ledger, null);
-            }
-        }
-    }
-
-    private void checkReadTimeout() {
-        long timeoutSec = config.getReadEntryTimeoutSeconds();
-        if (timeoutSec < 1) {
-            return;
-        }
-        long now = System.nanoTime();
-        while (true) {
-            PendingReadCallback pendingCallback = pendingReadCallbacks.peek();
-            if (pendingCallback == null || pendingCallback.timeoutAtNanos > now) {
-                break;
-            }
-            pendingCallback = pendingReadCallbacks.poll();
-            if (pendingCallback == null) {
-                break;
-            }
-            ReadEntryCallbackWrapper callback = pendingCallback.clearCallback();
-            if (callback != null) {
-                log.warn().attr("ledgerId", pendingCallback.ledgerId)
-                        .attr("entryId", pendingCallback.entryId)
-                        .attr("timeoutSec", timeoutSec)
-                        .log("Read entry timeout");
-                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException),
-                        pendingCallback.readOpCount);
             }
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -30,8 +30,6 @@ import com.google.common.collect.Range;
 import io.github.merlimat.slog.Logger;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.Recycler;
-import io.netty.util.Recycler.Handle;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -62,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -341,9 +340,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     protected final ManagedLedgerMBeanImpl mbean;
     protected final Clock clock;
 
-    private static final AtomicLongFieldUpdater<ManagedLedgerImpl> READ_OP_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(ManagedLedgerImpl.class, "readOpCount");
-    private volatile long readOpCount = 0;
     protected static final AtomicLongFieldUpdater<ManagedLedgerImpl> ADD_OP_COUNT_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ManagedLedgerImpl.class, "addOpCount");
     private volatile long addOpCount = 0;
@@ -2429,13 +2425,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     protected void asyncReadEntry(ReadHandle ledger, Position position, ReadEntryCallback callback, Object ctx) {
         mbean.addEntriesRead(1);
         if (config.getReadEntryTimeoutSeconds() > 0) {
-            // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
-            long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(this, position.getLedgerId(),
-                    position.getEntryId(), callback, readOpCount, ctx);
-            readCallback.readTimeout = factory.getReadEntryTimeoutTracker().add(readCallback, readOpCount,
-                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
-            entryCache.asyncReadEntry(ledger, position, readCallback, readOpCount);
+                    position.getEntryId(), callback, ctx, timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
+            entryCache.asyncReadEntry(ledger, position, readCallback, ctx);
+            if (readCallback.registerTimeout()) {
+                factory.getReadEntryTimeoutTracker().add(readCallback);
+            }
         } else {
             entryCache.asyncReadEntry(ledger, position, callback, ctx);
         }
@@ -2445,13 +2440,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             Object ctx) {
         IntSupplier expectedReadCount = opReadEntry.cursor::getNumberOfCursorsAtSamePositionOrBefore;
         if (config.getReadEntryTimeoutSeconds() > 0) {
-            // set readOpCount to uniquely validate if ReadEntryCallbackWrapper is already recycled
-            long readOpCount = READ_OP_COUNT_UPDATER.incrementAndGet(this);
             ReadEntryCallbackWrapper readCallback = ReadEntryCallbackWrapper.create(this, ledger.getId(), firstEntry,
-                    opReadEntry, readOpCount, ctx);
-            readCallback.readTimeout = factory.getReadEntryTimeoutTracker().add(readCallback, readOpCount,
-                    timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
-            entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, readCallback, readOpCount);
+                    opReadEntry, ctx, timeoutAtNanos(config.getReadEntryTimeoutSeconds()));
+            entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, readCallback, ctx);
+            if (readCallback.registerTimeout()) {
+                factory.getReadEntryTimeoutTracker().add(readCallback);
+            }
         } else {
             entryCache.asyncReadEntry(ledger, firstEntry, lastEntry, expectedReadCount, opReadEntry, ctx);
         }
@@ -2463,54 +2457,49 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     static final class ReadEntryCallbackWrapper implements ReadEntryCallback, ReadEntriesCallback {
 
-        volatile ReadEntryCallback readEntryCallback;
-        volatile ReadEntriesCallback readEntriesCallback;
-        volatile ManagedLedgerImpl managedLedger;
-        long ledgerId;
-        long entryId;
-        volatile long readOpCount = -1;
-        private static final AtomicLongFieldUpdater<ReadEntryCallbackWrapper> READ_OP_COUNT_UPDATER =
-                AtomicLongFieldUpdater.newUpdater(ReadEntryCallbackWrapper.class, "readOpCount");
-        volatile Object cntx;
-        volatile ReadEntryTimeoutTracker.ReadTimeoutWrapper readTimeout;
+        private static final int WAITING = 0;
+        private static final int TRACKED = 1;
+        private static final int COMPLETED = 2;
+        private static final AtomicIntegerFieldUpdater<ReadEntryCallbackWrapper> STATE_UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(ReadEntryCallbackWrapper.class, "completionState");
 
-        final Handle<ReadEntryCallbackWrapper> recyclerHandle;
+        final ReadEntryCallback readEntryCallback;
+        final ReadEntriesCallback readEntriesCallback;
+        final ManagedLedgerImpl managedLedger;
+        final String managedLedgerName;
+        final long ledgerId;
+        final long entryId;
+        final long timeoutAtNanos;
+        final Object cntx;
+        private volatile int completionState;
 
-        private ReadEntryCallbackWrapper(Handle<ReadEntryCallbackWrapper> recyclerHandle) {
-            this.recyclerHandle = recyclerHandle;
+        private ReadEntryCallbackWrapper(ManagedLedgerImpl managedLedger, long ledgerId, long entryId,
+                                         ReadEntryCallback readEntryCallback, ReadEntriesCallback readEntriesCallback,
+                                         Object ctx, long timeoutAtNanos) {
+            this.managedLedger = managedLedger;
+            this.managedLedgerName = managedLedger.name;
+            this.ledgerId = ledgerId;
+            this.entryId = entryId;
+            this.readEntryCallback = readEntryCallback;
+            this.readEntriesCallback = readEntriesCallback;
+            this.cntx = ctx;
+            this.timeoutAtNanos = timeoutAtNanos;
         }
 
         static ReadEntryCallbackWrapper create(ManagedLedgerImpl managedLedger, long ledgerId, long entryId,
-                                               ReadEntryCallback callback, long readOpCount, Object ctx) {
-            ReadEntryCallbackWrapper readCallback = RECYCLER.get();
-            readCallback.managedLedger = managedLedger;
-            readCallback.ledgerId = ledgerId;
-            readCallback.entryId = entryId;
-            readCallback.readEntryCallback = callback;
-            readCallback.cntx = ctx;
-            readCallback.readOpCount = readOpCount;
-            return readCallback;
+                                               ReadEntryCallback callback, Object ctx, long timeoutAtNanos) {
+            return new ReadEntryCallbackWrapper(managedLedger, ledgerId, entryId, callback, null, ctx, timeoutAtNanos);
         }
 
         static ReadEntryCallbackWrapper create(ManagedLedgerImpl managedLedger, long ledgerId, long entryId,
-                                               ReadEntriesCallback callback, long readOpCount, Object ctx) {
-            ReadEntryCallbackWrapper readCallback = RECYCLER.get();
-            readCallback.managedLedger = managedLedger;
-            readCallback.ledgerId = ledgerId;
-            readCallback.entryId = entryId;
-            readCallback.readEntriesCallback = callback;
-            readCallback.cntx = ctx;
-            readCallback.readOpCount = readOpCount;
-            return readCallback;
+                                               ReadEntriesCallback callback, Object ctx, long timeoutAtNanos) {
+            return new ReadEntryCallbackWrapper(managedLedger, ledgerId, entryId, null, callback, ctx, timeoutAtNanos);
         }
 
         @Override
         public void readEntryComplete(Entry entry, Object ctx) {
-            long reOpCount = reOpCount(ctx);
-            ReadEntryCallback callback = this.readEntryCallback;
-            Object cbCtx = this.cntx;
-            if (recycle(reOpCount)) {
-                callback.readEntryComplete(entry, cbCtx);
+            if (complete()) {
+                readEntryCallback.readEntryComplete(entry, cntx);
             } else {
                 slog.debug().attr("ledgerId", ledgerId).attr("entryId", entryId).log("Read entry already completed");
                 entry.release();
@@ -2519,11 +2508,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         @Override
         public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
-            long reOpCount = reOpCount(ctx);
-            ReadEntryCallback callback = this.readEntryCallback;
-            Object cbCtx = this.cntx;
-            if (recycle(reOpCount)) {
-                callback.readEntryFailed(exception, cbCtx);
+            if (complete()) {
+                readEntryCallback.readEntryFailed(exception, cntx);
             } else {
                 slog.debug().attr("ledgerId", ledgerId).attr("entryId", entryId).log("Read entry already completed");
             }
@@ -2531,11 +2517,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         @Override
         public void readEntriesComplete(List<Entry> returnedEntries, Object ctx) {
-            long reOpCount = reOpCount(ctx);
-            ReadEntriesCallback callback = this.readEntriesCallback;
-            Object cbCtx = this.cntx;
-            if (recycle(reOpCount)) {
-                callback.readEntriesComplete(returnedEntries, cbCtx);
+            if (complete()) {
+                readEntriesCallback.readEntriesComplete(returnedEntries, cntx);
             } else {
                 slog.debug().attr("ledgerId", ledgerId).attr("entryId", entryId).log("Read entry already completed");
                 returnedEntries.forEach(Entry::release);
@@ -2544,65 +2527,40 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         @Override
         public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-            long reOpCount = reOpCount(ctx);
-            ReadEntriesCallback callback = this.readEntriesCallback;
-            Object cbCtx = this.cntx;
-            if (recycle(reOpCount)) {
-                callback.readEntriesFailed(exception, cbCtx);
+            if (complete()) {
+                readEntriesCallback.readEntriesFailed(exception, cntx);
             } else {
                 slog.debug().attr("ledgerId", ledgerId).attr("entryId", entryId).log("Read entry already completed");
             }
         }
 
-        private long reOpCount(Object ctx) {
-            return (ctx instanceof Long) ? (long) ctx : -1;
+        boolean isCompleted() {
+            return completionState == COMPLETED;
         }
 
-        boolean shouldTriggerReadTimeout() {
-            ManagedLedgerImpl ledger = managedLedger;
-            if (ledger == null) {
+        boolean registerTimeout() {
+            return STATE_UPDATER.compareAndSet(this, WAITING, TRACKED);
+        }
+
+        boolean triggerReadTimeout(ManagedLedgerException exception) {
+            if (!STATE_UPDATER.compareAndSet(this, TRACKED, COMPLETED)) {
                 return false;
             }
-            State state = STATE_UPDATER.get(ledger);
-            return state != State.Closed && !state.isFenced();
+            managedLedger.getExecutor().execute(() -> notifyReadFailed(exception));
+            return true;
         }
 
-        public void readFailed(ManagedLedgerException exception, Object ctx) {
+        private void notifyReadFailed(ManagedLedgerException exception) {
             if (readEntryCallback != null) {
-                readEntryFailed(exception, ctx);
+                readEntryCallback.readEntryFailed(exception, cntx);
             } else if (readEntriesCallback != null) {
-                readEntriesFailed(exception, ctx);
+                readEntriesCallback.readEntriesFailed(exception, cntx);
             }
-            // It happens when timeout-thread and read-callback both recycles at the same time.
-            // this read-callback has already been recycled so, do nothing..
         }
 
-        private boolean recycle(long readOpCount) {
-            if (readOpCount != -1
-                    && READ_OP_COUNT_UPDATER.compareAndSet(ReadEntryCallbackWrapper.this, readOpCount, -1)) {
-                ReadEntryTimeoutTracker.ReadTimeoutWrapper timeout = readTimeout;
-                if (timeout != null) {
-                    timeout.clearCallback(this);
-                }
-                readEntryCallback = null;
-                readEntriesCallback = null;
-                ledgerId = -1;
-                entryId = -1;
-                managedLedger = null;
-                cntx = null;
-                readTimeout = null;
-                recyclerHandle.recycle(this);
-                return true;
-            }
-            return false;
+        private boolean complete() {
+            return STATE_UPDATER.getAndSet(this, COMPLETED) != COMPLETED;
         }
-
-        private static final Recycler<ReadEntryCallbackWrapper> RECYCLER = new Recycler<ReadEntryCallbackWrapper>() {
-            @Override
-            protected ReadEntryCallbackWrapper newObject(Handle<ReadEntryCallbackWrapper> handle) {
-                return new ReadEntryCallbackWrapper(handle);
-            }
-        };
 
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
+import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import lombok.CustomLog;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.jctools.queues.MpscUnboundedArrayQueue;
+
+@CustomLog
+class ReadEntryTimeoutTracker implements AutoCloseable {
+    private static final int READ_TIMEOUT_QUEUE_CHUNK_SIZE = 128 * 1024;
+    private static final int CHECK_INTERVAL_SECONDS = 1;
+
+    private final MpscUnboundedArrayQueue<ReadTimeoutWrapper> timeoutQueue = new MpscUnboundedArrayQueue<>(
+            READ_TIMEOUT_QUEUE_CHUNK_SIZE);
+    private final AtomicInteger timeoutQueueSize = new AtomicInteger();
+    private final ScheduledFuture<?> timeoutTask;
+
+    ReadEntryTimeoutTracker(OrderedScheduler scheduledExecutor) {
+        this.timeoutTask = scheduledExecutor.scheduleAtFixedRate(catchingAndLoggingThrowables(this::checkTimeouts),
+                CHECK_INTERVAL_SECONDS, CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    ReadTimeoutWrapper add(ManagedLedgerImpl.ReadEntryCallbackWrapper callback, long readOpCount,
+                           long timeoutAtNanos) {
+        ReadTimeoutWrapper timeout = new ReadTimeoutWrapper(readOpCount, timeoutAtNanos, callback);
+        timeoutQueue.offer(timeout);
+        timeoutQueueSize.incrementAndGet();
+        return timeout;
+    }
+
+    @VisibleForTesting
+    synchronized void checkTimeouts() {
+        long now = System.nanoTime();
+        int entriesToProcess = timeoutQueueSize.get();
+        for (int i = 0; i < entriesToProcess; i++) {
+            ReadTimeoutWrapper timeout = timeoutQueue.poll();
+            if (timeout == null) {
+                return;
+            }
+            timeoutQueueSize.decrementAndGet();
+            ManagedLedgerImpl.ReadEntryCallbackWrapper callback = timeout.getCallback();
+            if (callback == null) {
+                continue;
+            }
+            if (!callback.shouldTriggerReadTimeout()) {
+                timeout.clearCallback(callback);
+                continue;
+            }
+            if (timeout.timeoutAtNanos > now) {
+                requeue(timeout);
+                continue;
+            }
+            callback = timeout.clearCallback();
+            if (callback != null) {
+                log.warn()
+                        .attr("overdueNanos", now - timeout.timeoutAtNanos)
+                        .log("Read entry timeout");
+                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException),
+                        timeout.readOpCount);
+            }
+        }
+    }
+
+    private void requeue(ReadTimeoutWrapper timeout) {
+        timeoutQueue.offer(timeout);
+        timeoutQueueSize.incrementAndGet();
+    }
+
+    @Override
+    public void close() {
+        timeoutTask.cancel(false);
+    }
+
+    @VisibleForTesting
+    int pendingTimeoutCount() {
+        return timeoutQueueSize.get();
+    }
+
+    static final class ReadTimeoutWrapper {
+        private static final AtomicReferenceFieldUpdater<ReadTimeoutWrapper,
+                ManagedLedgerImpl.ReadEntryCallbackWrapper> CALLBACK_UPDATER = AtomicReferenceFieldUpdater
+                .newUpdater(ReadTimeoutWrapper.class, ManagedLedgerImpl.ReadEntryCallbackWrapper.class, "callback");
+
+        final long readOpCount;
+        final long timeoutAtNanos;
+        volatile ManagedLedgerImpl.ReadEntryCallbackWrapper callback;
+
+        ReadTimeoutWrapper(long readOpCount, long timeoutAtNanos,
+                           ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
+            this.readOpCount = readOpCount;
+            this.timeoutAtNanos = timeoutAtNanos;
+            this.callback = callback;
+        }
+
+        ManagedLedgerImpl.ReadEntryCallbackWrapper getCallback() {
+            return callback;
+        }
+
+        ManagedLedgerImpl.ReadEntryCallbackWrapper clearCallback() {
+            return CALLBACK_UPDATER.getAndSet(this, null);
+        }
+
+        void clearCallback(ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
+            CALLBACK_UPDATER.compareAndSet(this, callback, null);
+        }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -35,8 +34,8 @@ class ReadEntryTimeoutTracker implements AutoCloseable {
     private static final int READ_TIMEOUT_QUEUE_CHUNK_SIZE = 128 * 1024;
     private static final int CHECK_INTERVAL_SECONDS = 1;
 
-    private final MpscUnboundedArrayQueue<ReadTimeoutWrapper> timeoutQueue = new MpscUnboundedArrayQueue<>(
-            READ_TIMEOUT_QUEUE_CHUNK_SIZE);
+    private final MpscUnboundedArrayQueue<ManagedLedgerImpl.ReadEntryCallbackWrapper> timeoutQueue =
+            new MpscUnboundedArrayQueue<>(READ_TIMEOUT_QUEUE_CHUNK_SIZE);
     private final AtomicInteger timeoutQueueSize = new AtomicInteger();
     private final ScheduledFuture<?> timeoutTask;
 
@@ -45,49 +44,47 @@ class ReadEntryTimeoutTracker implements AutoCloseable {
                 CHECK_INTERVAL_SECONDS, CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
-    ReadTimeoutWrapper add(ManagedLedgerImpl.ReadEntryCallbackWrapper callback, long readOpCount,
-                           long timeoutAtNanos) {
-        ReadTimeoutWrapper timeout = new ReadTimeoutWrapper(readOpCount, timeoutAtNanos, callback);
-        timeoutQueue.offer(timeout);
+    void add(ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
+        timeoutQueue.offer(callback);
         timeoutQueueSize.incrementAndGet();
-        return timeout;
     }
 
     @VisibleForTesting
     synchronized void checkTimeouts() {
         long now = System.nanoTime();
+        // This is intentionally O(all tracked reads). Read-entry timeout is disabled by default, the
+        // tracker runs once per second, and the MPSC queue keeps this maintenance path cheap while
+        // avoiding per-ledger timeout tasks. The assumption is that deployments enabling this feature
+        // prefer one lightweight broker-level scan over creating a scheduled task per ManagedLedger or
+        // per read. Expired callbacks are handed back to the owning ledger's executor, so this shared
+        // scan does not serialize completion callbacks across unrelated ledgers.
         int entriesToProcess = timeoutQueueSize.get();
         for (int i = 0; i < entriesToProcess; i++) {
-            ReadTimeoutWrapper timeout = timeoutQueue.poll();
-            if (timeout == null) {
+            ManagedLedgerImpl.ReadEntryCallbackWrapper callback = timeoutQueue.poll();
+            if (callback == null) {
                 return;
             }
             timeoutQueueSize.decrementAndGet();
-            ManagedLedgerImpl.ReadEntryCallbackWrapper callback = timeout.getCallback();
-            if (callback == null) {
+            if (callback.isCompleted()) {
                 continue;
             }
-            if (!callback.shouldTriggerReadTimeout()) {
-                timeout.clearCallback(callback);
+            if (callback.timeoutAtNanos > now) {
+                requeue(callback);
                 continue;
             }
-            if (timeout.timeoutAtNanos > now) {
-                requeue(timeout);
-                continue;
-            }
-            callback = timeout.clearCallback();
-            if (callback != null) {
+            if (callback.triggerReadTimeout(createManagedLedgerException(BKException.Code.TimeoutException))) {
                 log.warn()
-                        .attr("overdueNanos", now - timeout.timeoutAtNanos)
+                        .attr("ledgerName", callback.managedLedgerName)
+                        .attr("ledgerId", callback.ledgerId)
+                        .attr("entryId", callback.entryId)
+                        .attr("overdueNanos", now - callback.timeoutAtNanos)
                         .log("Read entry timeout");
-                callback.readFailed(createManagedLedgerException(BKException.Code.TimeoutException),
-                        timeout.readOpCount);
             }
         }
     }
 
-    private void requeue(ReadTimeoutWrapper timeout) {
-        timeoutQueue.offer(timeout);
+    private void requeue(ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
+        timeoutQueue.offer(callback);
         timeoutQueueSize.incrementAndGet();
     }
 
@@ -99,34 +96,5 @@ class ReadEntryTimeoutTracker implements AutoCloseable {
     @VisibleForTesting
     int pendingTimeoutCount() {
         return timeoutQueueSize.get();
-    }
-
-    static final class ReadTimeoutWrapper {
-        private static final AtomicReferenceFieldUpdater<ReadTimeoutWrapper,
-                ManagedLedgerImpl.ReadEntryCallbackWrapper> CALLBACK_UPDATER = AtomicReferenceFieldUpdater
-                .newUpdater(ReadTimeoutWrapper.class, ManagedLedgerImpl.ReadEntryCallbackWrapper.class, "callback");
-
-        final long readOpCount;
-        final long timeoutAtNanos;
-        volatile ManagedLedgerImpl.ReadEntryCallbackWrapper callback;
-
-        ReadTimeoutWrapper(long readOpCount, long timeoutAtNanos,
-                           ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
-            this.readOpCount = readOpCount;
-            this.timeoutAtNanos = timeoutAtNanos;
-            this.callback = callback;
-        }
-
-        ManagedLedgerImpl.ReadEntryCallbackWrapper getCallback() {
-            return callback;
-        }
-
-        ManagedLedgerImpl.ReadEntryCallbackWrapper clearCallback() {
-            return CALLBACK_UPDATER.getAndSet(this, null);
-        }
-
-        void clearCallback(ManagedLedgerImpl.ReadEntryCallbackWrapper callback) {
-            CALLBACK_UPDATER.compareAndSet(this, callback, null);
-        }
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadEntryTimeoutTracker.java
@@ -59,10 +59,15 @@ class ReadEntryTimeoutTracker implements AutoCloseable {
         // per read. Expired callbacks are handed back to the owning ledger's executor, so this shared
         // scan does not serialize completion callbacks across unrelated ledgers.
         int entriesToProcess = timeoutQueueSize.get();
+        int timeoutCount = 0;
+        long maxOverdueNanos = 0;
+        String sampleLedgerName = null;
+        long sampleLedgerId = -1;
+        long sampleEntryId = -1;
         for (int i = 0; i < entriesToProcess; i++) {
             ManagedLedgerImpl.ReadEntryCallbackWrapper callback = timeoutQueue.poll();
             if (callback == null) {
-                return;
+                break;
             }
             timeoutQueueSize.decrementAndGet();
             if (callback.isCompleted()) {
@@ -73,13 +78,24 @@ class ReadEntryTimeoutTracker implements AutoCloseable {
                 continue;
             }
             if (callback.triggerReadTimeout(createManagedLedgerException(BKException.Code.TimeoutException))) {
-                log.warn()
-                        .attr("ledgerName", callback.managedLedgerName)
-                        .attr("ledgerId", callback.ledgerId)
-                        .attr("entryId", callback.entryId)
-                        .attr("overdueNanos", now - callback.timeoutAtNanos)
-                        .log("Read entry timeout");
+                timeoutCount++;
+                long overdueNanos = now - callback.timeoutAtNanos;
+                maxOverdueNanos = Math.max(maxOverdueNanos, overdueNanos);
+                if (sampleLedgerName == null) {
+                    sampleLedgerName = callback.managedLedgerName;
+                    sampleLedgerId = callback.ledgerId;
+                    sampleEntryId = callback.entryId;
+                }
             }
+        }
+        if (timeoutCount > 0) {
+            log.warn()
+                    .attr("timeoutCount", timeoutCount)
+                    .attr("sampleLedgerName", sampleLedgerName)
+                    .attr("sampleLedgerId", sampleLedgerId)
+                    .attr("sampleEntryId", sampleEntryId)
+                    .attr("maxOverdueNanos", maxOverdueNanos)
+                    .log("Read entry timeouts");
         }
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3428,6 +3428,68 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testManagedLedgerWithConcurrentReadEntryTimeOut() throws Exception {
+        ManagedLedgerConfig config = initManagedLedgerConfig(new ManagedLedgerConfig()).setReadEntryTimeoutSeconds(1);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("concurrent_timeout_ledger_test", config);
+
+        Position position1 = ledger.addEntry("entry-1".getBytes());
+        Position position2 = ledger.addEntry("entry-2".getBytes());
+
+        // ensure that the reads aren't cached
+        factory.getEntryCacheManager().clear();
+
+        bkc.setReadHandleInterceptor(new PulsarMockReadHandleInterceptor() {
+            @Override
+            public CompletableFuture<LedgerEntries> interceptReadAsync(long ledgerId, long firstEntry, long lastEntry,
+                                                                       LedgerEntries entries) {
+                return CompletableFuture.supplyAsync(() -> entries,
+                        CompletableFuture.delayedExecutor(3, TimeUnit.SECONDS));
+            }
+        });
+
+        AtomicReference<ManagedLedgerException> responseException1 = new AtomicReference<>();
+        AtomicReference<ManagedLedgerException> responseException2 = new AtomicReference<>();
+        String ctxStr = "timeoutCtx";
+
+        ledger.asyncReadEntry(position1, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                entry.release();
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                assertEquals(ctxStr, (String) ctx);
+                responseException1.set(exception);
+            }
+        }, ctxStr);
+
+        ledger.asyncReadEntry(position2, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                entry.release();
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                assertEquals(ctxStr, (String) ctx);
+                responseException2.set(exception);
+            }
+        }, ctxStr);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNotNull(responseException1.get());
+            assertTrue(responseException1.get().getMessage()
+                    .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+            assertNotNull(responseException2.get());
+            assertTrue(responseException2.get().getMessage()
+                    .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+        });
+
+        ledger.close();
+    }
+
+    @Test
     public void testAddEntryResponseTimeout() throws Exception {
         // Create ML with feature Add Entry Timeout Check.
         final ManagedLedgerConfig config =

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3490,6 +3490,33 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testCompletedReadEntryTimeoutsAreRemovedFromSharedTracker() throws Exception {
+        ManagedLedgerConfig config = initManagedLedgerConfig(new ManagedLedgerConfig()).setReadEntryTimeoutSeconds(60);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("completed_read_timeout_tracker_test", config);
+        Position position = ledger.addEntry("entry-1".getBytes());
+
+        CompletableFuture<Void> readComplete = new CompletableFuture<>();
+        ledger.asyncReadEntry(position, new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                entry.release();
+                readComplete.complete(null);
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                readComplete.completeExceptionally(exception);
+            }
+        }, null);
+
+        readComplete.get(5, TimeUnit.SECONDS);
+        factory.getReadEntryTimeoutTracker().checkTimeouts();
+        assertEquals(factory.getReadEntryTimeoutTracker().pendingTimeoutCount(), 0);
+
+        ledger.close();
+    }
+
+    @Test
     public void testAddEntryResponseTimeout() throws Exception {
         // Create ML with feature Add Entry Timeout Check.
         final ManagedLedgerConfig config =

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -3490,6 +3490,67 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testReadEntryTimeoutCallbackRunsOnManagedLedgerExecutor() throws Exception {
+        ManagedLedgerConfig config = initManagedLedgerConfig(new ManagedLedgerConfig()).setReadEntryTimeoutSeconds(1);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("timeout_executor_test", config);
+        Position position = ledger.addEntry("entry-1".getBytes());
+
+        factory.getEntryCacheManager().clear();
+
+        bkc.setReadHandleInterceptor(new PulsarMockReadHandleInterceptor() {
+            @Override
+            public CompletableFuture<LedgerEntries> interceptReadAsync(long ledgerId, long firstEntry, long lastEntry,
+                                                                       LedgerEntries entries) {
+                return CompletableFuture.supplyAsync(() -> entries,
+                        CompletableFuture.delayedExecutor(3, TimeUnit.SECONDS));
+            }
+        });
+
+        CountDownLatch executorBlocked = new CountDownLatch(1);
+        CountDownLatch releaseExecutor = new CountDownLatch(1);
+        AtomicReference<ManagedLedgerException> responseException = new AtomicReference<>();
+        try {
+            ledger.getExecutor().execute(() -> {
+                executorBlocked.countDown();
+                try {
+                    releaseExecutor.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertTrue(executorBlocked.await(5, TimeUnit.SECONDS));
+
+            ledger.asyncReadEntry(position, new ReadEntryCallback() {
+                @Override
+                public void readEntryComplete(Entry entry, Object ctx) {
+                    entry.release();
+                }
+
+                @Override
+                public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                    responseException.set(exception);
+                }
+            }, null);
+
+            Awaitility.await().untilAsserted(() -> {
+                factory.getReadEntryTimeoutTracker().checkTimeouts();
+                assertEquals(factory.getReadEntryTimeoutTracker().pendingTimeoutCount(), 0);
+            });
+            assertNull(responseException.get());
+
+            releaseExecutor.countDown();
+            Awaitility.await().untilAsserted(() -> {
+                assertNotNull(responseException.get());
+                assertTrue(responseException.get().getMessage()
+                        .startsWith(BKException.getMessage(BKException.Code.TimeoutException)));
+            });
+        } finally {
+            releaseExecutor.countDown();
+            ledger.close();
+        }
+    }
+
+    @Test
     public void testCompletedReadEntryTimeoutsAreRemovedFromSharedTracker() throws Exception {
         ManagedLedgerConfig config = initManagedLedgerConfig(new ManagedLedgerConfig()).setReadEntryTimeoutSeconds(60);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("completed_read_timeout_tracker_test", config);
@@ -3514,6 +3575,33 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(factory.getReadEntryTimeoutTracker().pendingTimeoutCount(), 0);
 
         ledger.close();
+    }
+
+    @Test
+    public void testCompletedReadEntryIsNotRegisteredForReadTimeout() throws Exception {
+        Object expectedCtx = new Object();
+        CompletableFuture<Object> callbackContext = new CompletableFuture<>();
+        ReadEntryCallback callback = new ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                callbackContext.complete(ctx);
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                callbackContext.complete(ctx);
+            }
+        };
+        ManagedLedgerImpl.ReadEntryCallbackWrapper readCallback = ManagedLedgerImpl.ReadEntryCallbackWrapper.create(
+                mock(ManagedLedgerImpl.class), 1L, 2L, callback, expectedCtx,
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(60));
+
+        readCallback.readEntryFailed(new ManagedLedgerException("completed"), null);
+
+        assertSame(callbackContext.get(5, TimeUnit.SECONDS), expectedCtx);
+        assertTrue(readCallback.isCompleted());
+        assertFalse(readCallback.registerTimeout());
+        assertFalse(readCallback.triggerReadTimeout(new ManagedLedgerException("timeout")));
     }
 
     @Test


### PR DESCRIPTION
### Motivation

When managed ledger read-entry timeout is enabled, `ManagedLedgerImpl` only keeps the most recent `ReadEntryCallbackWrapper` in `lastReadCallback`. If multiple reads are pending and an older read hangs, a newer read can overwrite that callback, so the older operation is no longer checked by `checkReadTimeout()`.

That can leave a cursor read pending indefinitely and block follow-up cursor operations such as reset/mark-delete progress.

### Modifications

- Replace the single `lastReadCallback` with a pending-read callback map keyed by read operation id.
- Remove callbacks from the pending map when they are recycled by success, failure, or timeout paths.
- Iterate all pending callbacks during read-timeout checks so each timed-out read can fail independently.
- Add a regression test covering concurrent read-entry timeouts.

### Verifying this change

- `./gradlew :managed-ledger:test --tests org.apache.bookkeeper.mledger.impl.ManagedLedgerTest.testManagedLedgerWithReadEntryTimeOut --tests org.apache.bookkeeper.mledger.impl.ManagedLedgerTest.testManagedLedgerWithConcurrentReadEntryTimeOut`