### PR TITLE
[fix][test] Fix flaky PersistentTopicsTest setup caused by concurrent Mockito stubbing

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
@@ -54,10 +53,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.admin.v2.NonPersistentTopics;
 import org.apache.pulsar.broker.admin.v2.PersistentTopics;
@@ -127,7 +128,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
     protected Field uriField;
     protected UriInfo uriInfo;
     private NonPersistentTopics nonPersistentTopic;
-    private NamespaceResources namespaceResources;
+    private volatile NamespaceResources namespaceResourcesOverride;
+    private volatile Function<NamespaceName, CompletableFuture<List<String>>> listPersistentTopicsAsyncHandler;
 
     @BeforeClass
     public void initPersistentTopics() throws Exception {
@@ -161,7 +163,6 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         nonPersistentTopic = spy(NonPersistentTopics.class);
         nonPersistentTopic.setServletContext(mock(ServletContext.class));
         nonPersistentTopic.setPulsar(pulsar);
-        namespaceResources = mock(NamespaceResources.class);
         doReturn(false).when(nonPersistentTopic).isRequestHttps();
         doReturn(null).when(nonPersistentTopic).originalPrincipal();
         doReturn("test").when(nonPersistentTopic).clientAppId();
@@ -169,10 +170,27 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         doNothing().when(nonPersistentTopic).validateAdminAccessForTenant(this.testTenant);
         doReturn(mock(AuthenticationDataHttps.class)).when(nonPersistentTopic).clientAuthData();
 
-        PulsarResources resources =
-                spy(new PulsarResources(pulsar.getLocalMetadataStore(), pulsar.getConfigurationMetadataStore()));
-        doReturn(spy(new TopicResources(pulsar.getLocalMetadataStore()))).when(resources).getTopicResources();
-        doReturn(resources).when(pulsar).getPulsarResources();
+        TopicResources topicResources = BrokerTestUtil.spyWithoutRecordingInvocations(
+                new TopicResources(pulsar.getLocalMetadataStore()));
+        PulsarResources resources = BrokerTestUtil.spyWithoutRecordingInvocations(
+                new PulsarResources(pulsar.getLocalMetadataStore(), pulsar.getConfigurationMetadataStore()));
+        NamespaceResources namespaceResources = resources.getNamespaceResources();
+        doAnswer(invocation -> {
+            NamespaceResources override = namespaceResourcesOverride;
+            return override != null ? override : namespaceResources;
+        }).when(resources).getNamespaceResources();
+        doReturn(topicResources).when(resources).getTopicResources();
+        doAnswer(invocation -> {
+            Function<NamespaceName, CompletableFuture<List<String>>> handler = listPersistentTopicsAsyncHandler;
+            if (handler != null) {
+                CompletableFuture<List<String>> result = handler.apply(invocation.getArgument(0));
+                if (result != null) {
+                    return result;
+                }
+            }
+            return invocation.callRealMethod();
+        }).when(topicResources).listPersistentTopicsAsync(any());
+        FieldUtils.writeField(pulsar, "pulsarResources", resources, true);
 
         admin.clusters().createCluster("use", ClusterData.builder().serviceUrl("http://127.0.0.3:8082").build());
         admin.clusters().createCluster("test", ClusterData.builder().serviceUrl(pulsar.getWebServiceAddress()).build());
@@ -188,6 +206,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
     @Override
     @AfterMethod(alwaysRun = true)
     protected void cleanup() throws Exception {
+        namespaceResourcesOverride = null;
+        listPersistentTopicsAsyncHandler = null;
         super.internalCleanup();
     }
 
@@ -598,8 +618,8 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<Optional<Policies>> policyFuture = new CompletableFuture<>();
         Policies policies = new Policies();
         policyFuture.complete(Optional.of(policies));
-        when(pulsar.getPulsarResources().getNamespaceResources()).thenReturn(namespaceResources);
-        doReturn(policyFuture).when(namespaceResources).getPoliciesAsync(namespaceName);
+        namespaceResourcesOverride = mock(NamespaceResources.class);
+        doReturn(policyFuture).when(namespaceResourcesOverride).getPoliciesAsync(namespaceName);
         AsyncResponse response = mock(AsyncResponse.class);
         ArgumentCaptor<RestException> errCaptor = ArgumentCaptor.forClass(RestException.class);
         persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2, true);
@@ -611,7 +631,7 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         // Test policy not exist and return 'Namespace not found'
         CompletableFuture<Optional<Policies>> policyFuture2 = new CompletableFuture<>();
         policyFuture2.complete(Optional.empty());
-        doReturn(policyFuture2).when(namespaceResources).getPoliciesAsync(namespaceName);
+        doReturn(policyFuture2).when(namespaceResourcesOverride).getPoliciesAsync(namespaceName);
         response = mock(AsyncResponse.class);
         errCaptor = ArgumentCaptor.forClass(RestException.class);
         persistentTopics.createPartitionedTopic(response, testTenant, testNamespace, topicName, 2, true);
@@ -646,12 +666,13 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
         final String nonPartitionTopicName2 = "special-topic-partition-123";
         final String partitionedTopicName = "special-topic";
 
-        when(pulsar.getPulsarResources().getTopicResources()
-                .listPersistentTopicsAsync(NamespaceName.get("my-tenant/my-namespace")))
-                .thenReturn(CompletableFuture.completedFuture(List.of(
+        NamespaceName namespaceName = NamespaceName.get("my-tenant/my-namespace");
+        listPersistentTopicsAsyncHandler = namespace -> namespaceName.equals(namespace)
+                ? CompletableFuture.completedFuture(List.of(
                         "persistent://my-tenant/my-namespace/" + nonPartitionTopicName1,
                         "persistent://my-tenant/my-namespace/" + nonPartitionTopicName2
-                )));
+                ))
+                : null;
 //        doReturn(ImmutableSet.of(nonPartitionTopicName1, nonPartitionTopicName2)).when(mockZooKeeperChildrenCache)
 //        .get(anyString());
 //        doReturn(CompletableFuture.completedFuture(ImmutableSet.of(nonPartitionTopicName1, nonPartitionTopicName2))


### PR DESCRIPTION
### Motivation

Fixes #26076.

`PersistentTopicsTest.setup` starts a real test broker through `super.internalSetup()`. After the broker is started, the test replaces the broker resources with Mockito stubbing:

```java
doReturn(resources).when(pulsar).getPulsarResources();
```

This is fragile because `pulsar` is a spy of a live `PulsarService`. Once the broker has started, broker services and background tasks can call methods on the same `PulsarService` instance concurrently. Mockito can usually handle concurrent method invocations on an already-configured mock, but it is not safe to create or modify stubs while another thread is invoking the same mock.

The failure stack points at this setup-time stubbing:

```text
at org.apache.pulsar.broker.PulsarService.getPulsarResources(PulsarService.java:313)
at org.apache.pulsar.broker.admin.PersistentTopicsTest.setup(PersistentTopicsTest.java:175)
```

When another broker thread calls the spy while the setup thread is in the middle of `doReturn(...).when(pulsar).getPulsarResources()`, Mockito can observe an incomplete stubbing operation. That explains both failure modes from the issue:

- `AssertionError` from Mockito internals while recording the method for stubbing.
- `UnfinishedStubbingException` during cleanup because Mockito still sees the interrupted or incomplete stubbing state.

There are also two test methods that later update resource-related stubs through chains such as:

```java
when(pulsar.getPulsarResources().getNamespaceResources()).thenReturn(...)
when(pulsar.getPulsarResources().getTopicResources().listPersistentTopicsAsync(...)).thenReturn(...)
```

Those have the same basic problem: they touch the live `PulsarService` spy after the broker has started, and they use chained Mockito stubbing around objects that can also be used by broker code.

### Modifications

- Stop modifying the `pulsar.getPulsarResources()` stub after broker startup.
- Create the replacement `PulsarResources` and `TopicResources` spies, configure their stubs first, and then install the replacement resources on the test `PulsarService`.
- Replace per-test resource re-stubbing with volatile switches:
  - `namespaceResourcesOverride` selects a mocked `NamespaceResources` only for the test that needs custom namespace policies.
  - `listPersistentTopicsAsyncHandler` returns custom topic listings only for the test namespace that needs them, otherwise it falls back to the real method.
- Clear both switches in `cleanup()` to avoid leaking test-specific behavior to the next test method.

### Result

The test still exercises the same admin paths, but Mockito stubbing is no longer created or modified on the live `PulsarService` spy while broker threads may be using it. Test-specific behavior is changed by updating volatile references, which is safe for concurrent readers and avoids Mockito unfinished stubbing state.

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Verifications

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.admin.PersistentTopicsTest :pulsar-broker:checkstyleTest`