### PR TITLE
[improve] Exclude filesystem offloader NAR from base image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -83,6 +83,9 @@ FROM busybox AS offloaders
 ARG PULSAR_OFFLOADER_TARBALL
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
+# Exclude the filesystem (Hadoop) offloader: it pulls in hadoop-common and bloats the image by ~50MB.
+# It remains available in the apache-pulsar-offloaders distribution tarball for users who need it.
+RUN rm -f /offloaders/tiered-storage-file-system-*.nar
 
 ## Create final stage from Alpine image
 ## and add OpenJDK and Python dependencies (for Pulsar functions)

--- a/docker/pulsar/Dockerfile.wolfi
+++ b/docker/pulsar/Dockerfile.wolfi
@@ -73,6 +73,9 @@ FROM busybox AS offloaders
 ARG PULSAR_OFFLOADER_TARBALL
 ADD ${PULSAR_OFFLOADER_TARBALL} /
 RUN mv /apache-pulsar-offloaders-*/offloaders /offloaders
+# Exclude the filesystem (Hadoop) offloader: it pulls in hadoop-common and bloats the image by ~50MB.
+# It remains available in the apache-pulsar-offloaders distribution tarball for users who need it.
+RUN rm -f /offloaders/tiered-storage-file-system-*.nar
 
 ## Create final stage
 ## and add OpenJDK and Python dependencies (for Pulsar functions)

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -77,6 +77,10 @@ COPY target/certificate-authority /pulsar/certificate-authority/
 # copy broker plugins
 COPY target/plugins/ /pulsar/examples/
 
+# Add the filesystem offloader NAR as an overlay (it is excluded from the base image, but the
+# filesystem offload integration tests require it).
+COPY target/offloaders/ /pulsar/offloaders/
+
 # Fix permissions for filesystem offloader
 RUN mkdir -p pulsar
 RUN chmod g+rwx pulsar

--- a/tests/docker-images/latest-version-image/build.gradle.kts
+++ b/tests/docker-images/latest-version-image/build.gradle.kts
@@ -45,11 +45,22 @@ val buildtoolsJar by configurations.creating {
     isCanBeConsumed = false
     isTransitive = false
 }
+// The filesystem offloader NAR is excluded from the base image; layer it back in here as an overlay
+// so the filesystem offload integration tests can run against this image.
+val offloaderNar by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+    attributes {
+        attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "nar")
+    }
+}
 
 dependencies {
     testFunctionsJar(project(":tests:java-test-functions"))
     testPluginsJar(project(":tests:java-test-plugins"))
     buildtoolsJar(project(":buildtools"))
+    offloaderNar(project(":tiered-storage:tiered-storage-file-system"))
 }
 
 // Prepare the build context in target/ (to match Dockerfile COPY paths)
@@ -78,6 +89,11 @@ val prepareBuildContext by tasks.registering(Sync::class) {
     // Copy buildtools.jar
     from(buildtoolsJar) {
         rename { "buildtools.jar" }
+    }
+
+    // Copy the filesystem offloader NAR (excluded from the base image)
+    from(offloaderNar) {
+        into("offloaders")
     }
 
     into("${projectDir}/target")


### PR DESCRIPTION
### Motivation

The filesystem (Hadoop) tiered-storage offloader NAR bundles `hadoop-common` and its transitive dependencies, adding ~50MB to the base Pulsar Docker image. The vast majority of deployments use the jcloud offloader (S3/GCS/Azure) or no offloader at all, so this is dead weight in the default image.

### Modifications

- Remove `tiered-storage-file-system-*.nar` from the offloader staging stage of both the Alpine (`Dockerfile`) and Wolfi (`Dockerfile.wolfi`) base image builds, so it never reaches the final image. The jcloud offloader is unaffected.
- Overlay the filesystem offloader NAR back onto the `pulsar-test-latest-version` integration-test image, since the filesystem offload integration tests (`TestFileSystemOffload`, `TestOffloadDeletionFS`) require it. The NAR is resolved via a `nar`-typed configuration, staged into the build context, and copied into `/pulsar/offloaders/`.

The filesystem offloader is still built and shipped in the `apache-pulsar-offloaders-*-bin.tar.gz` distribution tarball, so users who rely on local-disk/HDFS offload can add the NAR back into `/pulsar/offloaders`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This is a build/packaging-only change. Verified by inspecting the produced image contents and the filesystem offload integration tests, which run against the test image that overlays the NAR.
