### PR TITLE
[improve][build] Trim unused JDK modules from the Docker image runtime

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 ARG ALPINE_VERSION=3.23
-ARG IMAGE_JDK_MAJOR_VERSION=21
+ARG IMAGE_JDK_MAJOR_VERSION=25
 
 # First create a stage with just the Pulsar tarball and scripts
 FROM alpine:$ALPINE_VERSION as pulsar
@@ -60,8 +60,7 @@ FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine${ALPINE_VERSION} AS jvm
 RUN apk add --no-cache binutils
 
 # Use JLink to create a slimmer JDK runtime (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
-# Include only the modules needed at runtime (one per line below for easy maintenance). The list is
-# kept compatible across the JDK versions we build with (currently 21 and 25).
+# Include only the modules needed at runtime (one per line below for easy maintenance).
 #
 # Kept on purpose:
 #   - java.desktop + jdk.localedata: Jetty/Jersey/SnakeYAML call java.beans.Introspector (in
@@ -73,11 +72,10 @@ RUN apk add --no-cache binutils
 #     jdk.javadoc, jdk.jdeps, jdk.jlink, jdk.jpackage, jdk.jartool
 #   - REPL/console: jdk.jshell, jdk.editpad, jdk.internal.ed, jdk.internal.le, jdk.jconsole
 #   - debug agents: jdk.jdwp.agent, jdk.jdi, jdk.hotspot.agent, jdk.jstatd
-#   - Graal/JVMCI compiler modules (jdk.internal.vm.* on JDK 21, jdk.graal.* on newer JDKs): unused by C2
+#   - Graal/JVMCI compiler modules (jdk.graal.*): unused by the C2 JIT
 #   - java.se aggregator: excluded so it does not transitively pull the above back in
-#   - jdk.random: merged into java.base in newer JDKs (not a separate module on JDK 25)
+#   - jdk.random: part of java.base on JDK 25, not a separate module
 #
-# first try with Java 17/21 compatible jlink command and if it fails, fallback to Java 24+ compatible command
 RUN JDK_MODULES="\
 java.base,\
 java.datatransfer,\
@@ -127,8 +125,7 @@ jdk.security.jgss,\
 jdk.unsupported,\
 jdk.unsupported.desktop,\
 jdk.xml.dom" && \
-    { /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$JDK_MODULES" --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm || \
-      /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules "$JDK_MODULES" --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm; }
+    /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules "$JDK_MODULES" --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -59,10 +59,76 @@ FROM amazoncorretto:${IMAGE_JDK_MAJOR_VERSION}-alpine${ALPINE_VERSION} AS jvm
 
 RUN apk add --no-cache binutils
 
-# Use JLink to create a slimmer JDK distribution (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
-# This still includes all JDK modules, though in the future we could compile a list of required modules
+# Use JLink to create a slimmer JDK runtime (see: https://adoptium.net/blog/2021/10/jlink-to-produce-own-runtime/)
+# Include only the modules needed at runtime (one per line below for easy maintenance). The list is
+# kept compatible across the JDK versions we build with (currently 21 and 25).
+#
+# Kept on purpose:
+#   - java.desktop + jdk.localedata: Jetty/Jersey/SnakeYAML call java.beans.Introspector (in
+#     java.desktop), and localedata is needed for non-English date/number formatting.
+#   - jdk.jcmd, jdk.jfr, jdk.management.agent: live ops/diagnostics on a running broker.
+#
+# Left out (never used by a running broker):
+#   - build/compile tools: java.compiler, jdk.compiler (also drops the ~10MB lib/ct.sym),
+#     jdk.javadoc, jdk.jdeps, jdk.jlink, jdk.jpackage, jdk.jartool
+#   - REPL/console: jdk.jshell, jdk.editpad, jdk.internal.ed, jdk.internal.le, jdk.jconsole
+#   - debug agents: jdk.jdwp.agent, jdk.jdi, jdk.hotspot.agent, jdk.jstatd
+#   - Graal/JVMCI compiler modules (jdk.internal.vm.* on JDK 21, jdk.graal.* on newer JDKs): unused by C2
+#   - java.se aggregator: excluded so it does not transitively pull the above back in
+#   - jdk.random: merged into java.base in newer JDKs (not a separate module on JDK 25)
+#
 # first try with Java 17/21 compatible jlink command and if it fails, fallback to Java 24+ compatible command
-RUN /usr/lib/jvm/default-jvm/bin/jlink --add-modules ALL-MODULE-PATH --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm || /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules ALL-MODULE-PATH --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
+RUN JDK_MODULES="\
+java.base,\
+java.datatransfer,\
+java.xml,\
+java.prefs,\
+java.desktop,\
+java.instrument,\
+java.logging,\
+java.management,\
+java.security.sasl,\
+java.naming,\
+java.rmi,\
+java.management.rmi,\
+java.net.http,\
+java.scripting,\
+java.security.jgss,\
+java.transaction.xa,\
+java.sql,\
+java.sql.rowset,\
+java.xml.crypto,\
+java.smartcardio,\
+jdk.accessibility,\
+jdk.internal.jvmstat,\
+jdk.attach,\
+jdk.charsets,\
+jdk.internal.opt,\
+jdk.zipfs,\
+jdk.crypto.ec,\
+jdk.crypto.cryptoki,\
+jdk.dynalink,\
+jdk.httpserver,\
+jdk.incubator.vector,\
+jdk.jcmd,\
+jdk.management,\
+jdk.management.agent,\
+jdk.jfr,\
+jdk.jsobject,\
+jdk.localedata,\
+jdk.management.jfr,\
+jdk.naming.dns,\
+jdk.naming.rmi,\
+jdk.net,\
+jdk.nio.mapmode,\
+jdk.sctp,\
+jdk.security.auth,\
+jdk.security.jgss,\
+jdk.unsupported,\
+jdk.unsupported.desktop,\
+jdk.xml.dom" && \
+    { /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$JDK_MODULES" --compress=2 --no-man-pages --no-header-files --strip-debug --output /opt/jvm || \
+      /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules "$JDK_MODULES" --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm; }
 RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 

--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -66,12 +66,14 @@ RUN apk add --no-cache binutils
 #   - java.desktop + jdk.localedata: Jetty/Jersey/SnakeYAML call java.beans.Introspector (in
 #     java.desktop), and localedata is needed for non-English date/number formatting.
 #   - jdk.jcmd, jdk.jfr, jdk.management.agent: live ops/diagnostics on a running broker.
+#   - jdk.jdwp.agent: lets you attach a remote debugger (-agentlib:jdwp) inside the container.
 #
-# Left out (never used by a running broker):
+# Left out (verified unused by Pulsar's shipped jars via a jdeps/bytecode scan):
 #   - build/compile tools: java.compiler, jdk.compiler (also drops the ~10MB lib/ct.sym),
 #     jdk.javadoc, jdk.jdeps, jdk.jlink, jdk.jpackage, jdk.jartool
 #   - REPL/console: jdk.jshell, jdk.editpad, jdk.internal.ed, jdk.internal.le, jdk.jconsole
-#   - debug agents: jdk.jdwp.agent, jdk.jdi, jdk.hotspot.agent, jdk.jstatd
+#   - debugger client + serviceability: jdk.jdi, jdk.hotspot.agent, jdk.jstatd
+#   - GUI/applet/legacy: java.smartcardio, jdk.jsobject, jdk.accessibility, jdk.sctp, jdk.dynalink
 #   - Graal/JVMCI compiler modules (jdk.graal.*): unused by the C2 JIT
 #   - java.se aggregator: excluded so it does not transitively pull the above back in
 #   - jdk.random: part of java.base on JDK 25, not a separate module
@@ -96,8 +98,6 @@ java.transaction.xa,\
 java.sql,\
 java.sql.rowset,\
 java.xml.crypto,\
-java.smartcardio,\
-jdk.accessibility,\
 jdk.internal.jvmstat,\
 jdk.attach,\
 jdk.charsets,\
@@ -105,28 +105,27 @@ jdk.internal.opt,\
 jdk.zipfs,\
 jdk.crypto.ec,\
 jdk.crypto.cryptoki,\
-jdk.dynalink,\
 jdk.httpserver,\
 jdk.incubator.vector,\
 jdk.jcmd,\
 jdk.management,\
 jdk.management.agent,\
 jdk.jfr,\
-jdk.jsobject,\
+jdk.jdwp.agent,\
 jdk.localedata,\
 jdk.management.jfr,\
 jdk.naming.dns,\
 jdk.naming.rmi,\
 jdk.net,\
 jdk.nio.mapmode,\
-jdk.sctp,\
 jdk.security.auth,\
 jdk.security.jgss,\
 jdk.unsupported,\
 jdk.unsupported.desktop,\
 jdk.xml.dom" && \
     /usr/lib/jvm/default-jvm/bin/jlink --module-path /usr/lib/jvm/default-jvm/jmods --add-modules "$JDK_MODULES" --compress=zip-9 --no-man-pages --no-header-files --strip-debug --output /opt/jvm
-RUN echo networkaddress.cache.ttl=1 >> /opt/jvm/conf/security/java.security
+# Corretto bundles async-profiler as a native lib (not a JDK module), so jlink does not copy it; restore it
+RUN if [ -f /usr/lib/jvm/default-jvm/lib/libasyncProfiler.so ]; then cp /usr/lib/jvm/default-jvm/lib/libasyncProfiler.so /opt/jvm/lib/; fi
 RUN echo networkaddress.cache.negative.ttl=1 >> /opt/jvm/conf/security/java.security
 
 ## Create one stage to include snappy-java native lib


### PR DESCRIPTION
### Motivation

The `apachepulsar/pulsar` image already uses `jlink` to assemble its bundled JDK runtime, but it passes `--add-modules ALL-MODULE-PATH`, which keeps **every** JDK module. As a result the runtime still ships the full developer/build/debug toolchain that a running broker/bookie never uses: `javac` and its ~10 MB `ct.sym`, `javadoc`, `jdeps`, `jlink`, `jpackage`, the jshell/console REPL, and the `jdwp`/`jdi`/`hotspot-agent`/`jstatd` serviceability agents.

### Modifications

In `docker/pulsar/Dockerfile` (the JVM stage):

- Replace `--add-modules ALL-MODULE-PATH` with an explicit list of the modules needed at runtime (one per line for easy maintenance), with a comment documenting what is excluded and why.
- Kept for live operations: `jdk.jcmd`, `jdk.jfr`, `jdk.management.agent`.
- `java.desktop` and `jdk.localedata` are **kept on purpose**: `jdeps` over the shipped jars shows Jetty, Jersey/HK2 and SnakeYAML statically call `java.beans.Introspector` (in `java.desktop`), and `localedata` is needed for non-English date/number formatting. Dropping them would be higher risk, so this change is limited to modules with no runtime exposure.
- Since the image is built with JDK 25 (`gradle/libs.versions.toml` `docker.jdk`), make the stage JDK 25-only: bump the stale `ARG IMAGE_JDK_MAJOR_VERSION` default `21` → `25`, and collapse the `--compress=2 || --compress=zip-9` jlink fallback to the single `--compress=zip-9` form.

### Result

On the JDK 25 build, with the same `--strip-debug` / `--no-man-pages` / `--no-header-files` flags as today, `/opt/jvm` drops from **104 MB to 78 MB (~26 MB)**.

Verified by building the `jvm` stage: it resolves all 48 requested modules, runs `java -version`, and no longer contains `ct.sym`.
