### PR TITLE
[improve][admin] Validate dynamic configuration updates against FieldContext constraints

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/FieldContextValidator.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/FieldContextValidator.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.util.FieldParser;
+
+/**
+ * Validates {@link FieldContext} value constraints ({@code required}, numeric bounds,
+ * {@code maxCharLength}, and boolean format for string inputs) on reflected configuration fields.
+ * <p>
+ * Used when validating configuration completeness at startup
+ * ({@link PulsarConfigurationLoader#isComplete}) and when validating dynamic configuration
+ * updates via the admin API.
+ */
+public final class FieldContextValidator {
+
+    private FieldContextValidator() {
+    }
+
+    /**
+     * Validates a string configuration value for a reflected field.
+     * <p>
+     * Parses {@code valueStr} with {@link FieldParser}, then checks {@code required},
+     * numeric bounds, {@code maxCharLength}, and boolean format. Blank {@code valueStr}
+     * is valid for optional fields; for dynamic configuration, blank means clearing the
+     * override.
+     *
+     * @param field    configuration field
+     * @param valueStr raw string value from the admin API
+     * @return error message if validation fails, or empty if the field has no
+     *         {@link FieldContext} or the value passes
+     */
+    public static Optional<String> validateString(Field field, String valueStr) {
+        if (field == null || !field.isAnnotationPresent(FieldContext.class)) {
+            return Optional.empty();
+        }
+        FieldContext fieldContext = field.getAnnotation(FieldContext.class);
+        if (StringUtils.isBlank(valueStr)) {
+            if (fieldContext.required()) {
+                return Optional.of(String.format("Required %s is null", field.getName()));
+            }
+            return Optional.empty();
+        }
+        if (isBooleanField(field) && !isValidBooleanString(valueStr)) {
+            return Optional.of(String.format("%s must be 'true' or 'false'", field.getName()));
+        }
+        final Object parsedValue;
+        try {
+            parsedValue = FieldParser.value(valueStr, field);
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return Optional.of(String.format("Failed to parse %s: %s", field.getName(), message));
+        }
+        return validateParsedValue(field, parsedValue);
+    }
+
+    /**
+     * Validates a configuration value that is already parsed to the field's Java type.
+     * <p>
+     * Checks {@code required}, numeric {@code minValue}/{@code maxValue}, and
+     * {@code maxCharLength} from {@link FieldContext}. Does not parse strings or validate
+     * boolean string format.
+     *
+     * @param field configuration field
+     * @param value value in the field's Java type
+     * @return error message if validation fails, or empty if the field has no
+     *         {@link FieldContext} or the value passes
+     */
+    public static Optional<String> validateParsedValue(Field field, Object value) {
+        if (field == null || !field.isAnnotationPresent(FieldContext.class)) {
+            return Optional.empty();
+        }
+        FieldContext fieldContext = field.getAnnotation(FieldContext.class);
+        if (fieldContext.required() && isEmpty(value)) {
+            return Optional.of(String.format("Required %s is null", field.getName()));
+        }
+        if (value != null && Number.class.isAssignableFrom(value.getClass())) {
+            long fieldVal = ((Number) value).longValue();
+            long minValue = fieldContext.minValue();
+            long maxValue = fieldContext.maxValue();
+            if (fieldVal < minValue || fieldVal > maxValue) {
+                return Optional.of(String.format("%s value %d doesn't fit in given range (%d, %d)",
+                        field.getName(), fieldVal, minValue, maxValue));
+            }
+        }
+        if (value instanceof String stringValue && stringValue.length() > fieldContext.maxCharLength()) {
+            return Optional.of(String.format("%s exceeds maxCharLength %d",
+                    field.getName(), fieldContext.maxCharLength()));
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isBooleanField(Field field) {
+        Class<?> type = field.getType();
+        return type == boolean.class || type == Boolean.class;
+    }
+
+    private static boolean isValidBooleanString(String valueStr) {
+        return "true".equalsIgnoreCase(valueStr) || "false".equalsIgnoreCase(valueStr);
+    }
+
+    private static boolean isEmpty(Object value) {
+        if (value == null) {
+            return true;
+        }
+        if (value instanceof String stringValue) {
+            return StringUtils.isBlank(stringValue);
+        }
+        return false;
+    }
+}

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoader.java
@@ -29,10 +29,10 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeMap;
 import lombok.CustomLog;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 
 /**
@@ -135,37 +135,14 @@ public class PulsarConfigurationLoader {
                         .attr("field", field.getName())
                         .attr("value", value)
                         .log("Validating configuration field");
-                boolean isRequired = field.getAnnotation(FieldContext.class).required();
-                long minValue = field.getAnnotation(FieldContext.class).minValue();
-                long maxValue = field.getAnnotation(FieldContext.class).maxValue();
-                if (isRequired && isEmpty(value)) {
-                    error.append(String.format("Required %s is null,", field.getName()));
-                }
-
-                if (value != null && Number.class.isAssignableFrom(value.getClass())) {
-                    long fieldVal = ((Number) value).longValue();
-                    boolean valid = fieldVal >= minValue && fieldVal <= maxValue;
-                    if (!valid) {
-                        error.append(String.format("%s value %d doesn't fit in given range (%d, %d),", field.getName(),
-                                fieldVal, minValue, maxValue));
-                    }
-                }
+                Optional<String> validationError = FieldContextValidator.validateParsedValue(field, value);
+                validationError.ifPresent(err -> error.append(err).append(","));
             }
         }
         if (error.length() > 0) {
             throw new IllegalArgumentException(error.substring(0, error.length() - 1));
         }
         return true;
-    }
-
-    private static boolean isEmpty(Object obj) {
-        if (obj == null) {
-            return true;
-        } else if (obj instanceof String) {
-            return StringUtils.isBlank((String) obj);
-        } else {
-            return false;
-        }
     }
 
     /**

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/FieldContextValidatorTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/FieldContextValidatorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.configuration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+public class FieldContextValidatorTest {
+
+    @Test
+    public void testValidateStringSkipsWhenFieldHasNoAnnotation() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("noAnnotation");
+        assertFalse(FieldContextValidator.validateString(field, "value").isPresent());
+    }
+
+    @Test
+    public void testValidateStringAllowsBlankForOptionalField() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("optionalString");
+        assertFalse(FieldContextValidator.validateString(field, "").isPresent());
+        assertFalse(FieldContextValidator.validateString(field, "   ").isPresent());
+        assertFalse(FieldContextValidator.validateString(field, null).isPresent());
+    }
+
+    @Test
+    public void testValidateStringRejectsBlankForRequiredField() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("requiredString");
+        Optional<String> error = FieldContextValidator.validateString(field, "");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "Required requiredString is null");
+    }
+
+    @Test
+    public void testValidateStringAcceptsValidBooleanValues() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("enabled");
+        assertFalse(FieldContextValidator.validateString(field, "true").isPresent());
+        assertFalse(FieldContextValidator.validateString(field, "false").isPresent());
+        assertFalse(FieldContextValidator.validateString(field, "TRUE").isPresent());
+    }
+
+    @Test
+    public void testValidateStringRejectsInvalidBooleanValues() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("enabled");
+        Optional<String> error = FieldContextValidator.validateString(field, "abc");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "enabled must be 'true' or 'false'");
+    }
+
+    @Test
+    public void testValidateStringRejectsUnparseableNumericValue() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("boundedInt");
+        Optional<String> error = FieldContextValidator.validateString(field, "abc");
+        assertTrue(error.isPresent());
+        assertTrue(error.get().startsWith("Failed to parse boundedInt:"));
+    }
+
+    @Test
+    public void testValidateStringRejectsOutOfRangeNumericValue() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("boundedInt");
+        Optional<String> error = FieldContextValidator.validateString(field, "0");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "boundedInt value 0 doesn't fit in given range (1, 3)");
+    }
+
+    @Test
+    public void testValidateStringAcceptsValidNumericValue() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("boundedInt");
+        assertFalse(FieldContextValidator.validateString(field, "2").isPresent());
+    }
+
+    @Test
+    public void testValidateStringRejectsStringExceedingMaxCharLength() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("shortString");
+        Optional<String> error = FieldContextValidator.validateString(field, "abcd");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "shortString exceeds maxCharLength 3");
+    }
+
+    @Test
+    public void testValidateParsedValueSkipsWhenFieldHasNoAnnotation() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("noAnnotation");
+        assertFalse(FieldContextValidator.validateParsedValue(field, "value").isPresent());
+    }
+
+    @Test
+    public void testValidateParsedValueRejectsRequiredNull() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("requiredString");
+        Optional<String> error = FieldContextValidator.validateParsedValue(field, null);
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "Required requiredString is null");
+    }
+
+    @Test
+    public void testValidateParsedValueRejectsRequiredBlankString() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("requiredString");
+        Optional<String> error = FieldContextValidator.validateParsedValue(field, "  ");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "Required requiredString is null");
+    }
+
+    @Test
+    public void testValidateParsedValueRejectsOutOfRangeNumber() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("boundedInt");
+        Optional<String> error = FieldContextValidator.validateParsedValue(field, 4);
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "boundedInt value 4 doesn't fit in given range (1, 3)");
+    }
+
+    @Test
+    public void testValidateParsedValueAcceptsInRangeNumber() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("boundedInt");
+        assertFalse(FieldContextValidator.validateParsedValue(field, 2).isPresent());
+    }
+
+    @Test
+    public void testValidateParsedValueRejectsStringExceedingMaxCharLength() throws Exception {
+        Field field = TestConfig.class.getDeclaredField("shortString");
+        Optional<String> error = FieldContextValidator.validateParsedValue(field, "abcd");
+        assertTrue(error.isPresent());
+        assertEquals(error.get(), "shortString exceeds maxCharLength 3");
+    }
+
+    static class TestConfig {
+        String noAnnotation;
+
+        @FieldContext(required = true)
+        String requiredString;
+
+        @FieldContext
+        String optionalString;
+
+        @FieldContext(dynamic = true)
+        boolean enabled;
+
+        @FieldContext(minValue = 1, maxValue = 3)
+        int boundedInt;
+
+        @FieldContext(maxCharLength = 3)
+        String shortString;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -338,9 +339,10 @@ public class BrokersBase extends AdminResource {
      */
     private synchronized CompletableFuture<Void> persistDynamicConfigurationAsync(
             String configName, String configValue) {
-        if (!pulsar().getBrokerService().validateDynamicConfiguration(configName, configValue)) {
-            return FutureUtil
-                    .failedFuture(new RestException(Status.PRECONDITION_FAILED, " Invalid dynamic-config value"));
+        Optional<String> validationError = pulsar().getBrokerService()
+                .getDynamicConfigurationValidationError(configName, configValue);
+        if (validationError.isPresent()) {
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED, validationError.get()));
         }
         if (pulsar().getBrokerService().isDynamicConfiguration(configName)) {
             return dynamicConfigurationResources().setDynamicConfigurationWithCreateAsync(old -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -162,6 +162,7 @@ import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.configuration.BindAddress;
 import org.apache.pulsar.common.configuration.FieldContext;
+import org.apache.pulsar.common.configuration.FieldContextValidator;
 import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.intercept.BrokerEntryMetadataUtils;
@@ -3504,10 +3505,27 @@ public class BrokerService implements Closeable {
     }
 
     public boolean validateDynamicConfiguration(String key, String value) {
-        if (dynamicConfigurationMap.containsKey(key) && dynamicConfigurationMap.get(key).validator != null) {
-            return dynamicConfigurationMap.get(key).validator.test(value);
+        return getDynamicConfigurationValidationError(key, value).isEmpty();
+    }
+
+    /**
+     * @return validation error message if the value is invalid, otherwise empty
+     */
+    public Optional<String> getDynamicConfigurationValidationError(String key, String value) {
+        ConfigField configField = dynamicConfigurationMap.get(key);
+        if (configField == null) {
+            return Optional.of("Unknown dynamic configuration: " + key);
         }
-        return true;
+        if (configField.field != null) {
+            Optional<String> fieldValidationError = FieldContextValidator.validateString(configField.field, value);
+            if (fieldValidationError.isPresent()) {
+                return fieldValidationError;
+            }
+        }
+        if (configField.validator != null && !configField.validator.test(value)) {
+            return Optional.of("Invalid dynamic-config value for " + key);
+        }
+        return Optional.empty();
     }
 
     private Map<String, ConfigField> prepareDynamicConfigurationMap() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDynamicConfigurationsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiDynamicConfigurationsTest.java
@@ -113,6 +113,16 @@ public class AdminApiDynamicConfigurationsTest extends MockedPulsarServiceBaseTe
     }
 
     @Test
+    public void testRejectInvalidBuiltInDynamicConfiguration() {
+        assertThrows(PulsarAdminException.PreconditionFailedException.class,
+                () -> admin.brokers().updateDynamicConfiguration("brokerShutdownTimeoutMs", "abc"));
+        assertThrows(PulsarAdminException.PreconditionFailedException.class,
+                () -> admin.brokers().updateDynamicConfiguration("failureDomainsEnabled", "abc"));
+        assertThrows(PulsarAdminException.PreconditionFailedException.class,
+                () -> admin.brokers().updateDynamicConfiguration("subscribeRatePeriodPerConsumerInSecond", "0"));
+    }
+
+    @Test
     public void testDeleteStringDynamicConfig() throws PulsarAdminException {
         String syncEventTopic = BrokerTestUtil.newUniqueName(SYSTEM_NAMESPACE + "/tp");
         // The default value is null;


### PR DESCRIPTION


<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

Most built-in dynamic configuration updates were not checked against `@FieldContext` before being written to metadata. Validation only ran when a custom `Predicate` was registered, for example on `loadManagerClassName`.
That meant invalid strings could be stored and only fail later at runtime, or not fail at all. Boolean fields were a concrete example: `FieldParser` uses `Boolean.valueOf()`, so `failureDomainsEnabled=abc` was stored as `"abc"` but
applied as `false` with no error.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

- Route `isComplete()` through `FieldContextValidator.validateParsedValue()`.
- Validate admin dynamic-config updates with `FieldContextValidator.validateString()` before persisting to ZK.
- Add `BrokerService.getDynamicConfigurationValidationError()` and return the   specific message on HTTP 412 instead of `" Invalid dynamic-config value"`.
- Run custom validators (e.g. classpath check for `loadManagerClassName`) after  `FieldContext` checks.
- Add `FieldContextValidatorTest` and extend `AdminApiDynamicConfigurationsTest`.


Admin updates now reject boolean values that are not exactly `true` or `false`.
Startup and runtime loading still use `FieldParser`, which calls `Boolean.valueOf()` and treats any other string as `false`.
This change is scoped to the admin write path. Tightening `broker.conf` parsing or ZK replay would be a separate compatibility discussion.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- `./gradlew :pulsar-broker-common:test --tests org.apache.pulsar.common.configuration.FieldContextValidatorTest`
- `./gradlew :pulsar-broker-common:test --tests org.apache.pulsar.common.configuration.PulsarConfigurationLoaderTest`
-  `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.admin.AdminApiDynamicConfigurationsTest`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Behavior changes
Affected admin API:
- `POST /admin/v2/brokers/configuration/{configName}/{configValue}`
Changes on this endpoint:
- Built-in dynamic configs now reject values that fail type parsing, `minValue`/`maxValue`, `maxCharLength`, or boolean format.
- HTTP 412 responses include a specific error message in the response body.
- Unknown keys return `Unknown dynamic configuration: <key>` instead of `Can't update non-dynamic configuration`.
- Boolean dynamic configs accept only `true` or `false` (case-insensitive).
