### PR TITLE
[fix][test] Fix flaky GeoReplicationTest.testTopicReplication

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/GeoReplicationTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/messaging/GeoReplicationTest.java
@@ -30,6 +30,8 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.apache.pulsar.tests.integration.topologies.PulsarClusterSpec;
 import org.apache.pulsar.tests.integration.topologies.PulsarGeoClusterTestBase;
 import org.awaitility.Awaitility;
@@ -43,6 +45,9 @@ import org.testng.annotations.Test;
  */
 @CustomLog
 public class GeoReplicationTest extends PulsarGeoClusterTestBase {
+
+    private static final int PARTITION_COUNT = 10;
+    private static final int MESSAGES = 10;
 
     @BeforeClass(alwaysRun = true)
     public final void setupBeforeClass() throws Exception {
@@ -68,7 +73,7 @@ public class GeoReplicationTest extends PulsarGeoClusterTestBase {
         cleanup();
     }
 
-    @Test(timeOut = 1000 * 30, dataProvider = "TopicDomain")
+    @Test(timeOut = 1000 * 60, dataProvider = "TopicDomain")
     public void testTopicReplication(String domain) throws Exception {
         String cluster1 = getGeoCluster().getClusters()[0].getClusterName();
         String cluster2 = getGeoCluster().getClusters()[1].getClusterName();
@@ -82,12 +87,12 @@ public class GeoReplicationTest extends PulsarGeoClusterTestBase {
         String topic = domain + "://public/default/testTopicReplication-" + UUID.randomUUID();
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             try {
-                admin.topics().createPartitionedTopic(topic, 10);
+                admin.topics().createPartitionedTopic(topic, PARTITION_COUNT);
             } catch (Exception e) {
                 log.error().attr("topic", topic).exception(e).log("Failed to create partitioned topic .");
                 Assert.fail("Failed to create partitioned topic " + topic);
             }
-            Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topic).partitions, 10);
+            Assert.assertEquals(admin.topics().getPartitionedTopicMetadata(topic).partitions, PARTITION_COUNT);
         });
         log.info().attr("topic", topic).log("Test geo-replication produce and consume for topic .");
 
@@ -120,7 +125,11 @@ public class GeoReplicationTest extends PulsarGeoClusterTestBase {
                 .attr("topic", topic)
                 .log("Successfully create consumer in cluster for topic .");
 
-        for (int i = 0; i < 10; i++) {
+        if ("non-persistent".equals(domain)) {
+            waitForNonPersistentReplicators(admin, topic, cluster2);
+        }
+
+        for (int i = 0; i < MESSAGES; i++) {
             p.send(String.format("Message [%d]", i).getBytes(StandardCharsets.UTF_8));
         }
         log.info()
@@ -128,7 +137,7 @@ public class GeoReplicationTest extends PulsarGeoClusterTestBase {
                 .attr("topic", topic)
                 .log("Successfully produce message to cluster for topic .");
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < MESSAGES; i++) {
             Message<byte[]> message = c.receive(10, TimeUnit.SECONDS);
             Assert.assertNotNull(message);
         }
@@ -136,5 +145,21 @@ public class GeoReplicationTest extends PulsarGeoClusterTestBase {
                 .attr("cluster", cluster2)
                 .attr("topic", topic)
                 .log("Successfully consume message from cluster for topic .");
+    }
+
+    private void waitForNonPersistentReplicators(PulsarAdmin admin, String topic, String remoteCluster)
+            throws Exception {
+        TopicName topicName = TopicName.get(topic);
+        Awaitility.await().atMost(20, TimeUnit.SECONDS).untilAsserted(() -> {
+            for (int i = 0; i < PARTITION_COUNT; i++) {
+                String partitionName = topicName.getPartition(i).toString();
+                ReplicatorStats replicatorStats = admin.topics()
+                        .getStats(partitionName)
+                        .getReplication()
+                        .get(remoteCluster);
+                Assert.assertNotNull(replicatorStats);
+                Assert.assertTrue(replicatorStats.isConnected());
+            }
+        });
     }
 }


### PR DESCRIPTION
### Motivation

`GeoReplicationTest.testTopicReplication` can fail for the `non-persistent` variant because the test sends messages immediately after creating the producer and consumer. Non-persistent replication can drop messages when the remote replicator producer is not connected yet, so the test can time out waiting for messages on the remote cluster.

Fixes #15913.

### Modifications

- Wait for every partition replicator to the remote cluster to be present and connected before sending messages for the non-persistent variant.
- Keep the persistent and non-persistent variants in the existing data provider.
- Use constants for the partition and message counts.
- Increase the test timeout to account for the explicit replicator readiness wait.

### Verification

- `./gradlew :tests:integration:compileTestJava --max-workers=1`
- `./gradlew :tests:integration:checkstyleTest --max-workers=1`

The container integration test was not run locally because the local Docker context is not available to Testcontainers.