### PR TITLE
fix(managed-ledger): handle stale backlog after trimmed ledgers

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4354,17 +4354,38 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      */
     Pair<Position, Long> getFirstPositionAndCounter() {
         Position pos;
+        Position firstPosition;
         long count;
         Pair<Position, Long> lastPositionAndCounter;
 
         do {
-            pos = getFirstPosition();
+            firstPosition = getFirstPosition();
             lastPositionAndCounter = getLastPositionAndCounter();
-            count = lastPositionAndCounter.getRight()
-                    - getNumberOfEntries(Range.openClosed(pos, lastPositionAndCounter.getLeft()));
-        } while (pos.compareTo(getFirstPosition()) != 0
+            if (isSyntheticFirstPosition(firstPosition)) {
+                pos = lastPositionAndCounter.getLeft();
+                count = lastPositionAndCounter.getRight();
+            } else {
+                pos = firstPosition;
+                count = lastPositionAndCounter.getRight()
+                        - getNumberOfEntries(Range.openClosed(pos, lastPositionAndCounter.getLeft()));
+            }
+        } while (firstPosition.compareTo(getFirstPosition()) != 0
                 || lastPositionAndCounter.getLeft().compareTo(getLastPosition()) != 0);
         return Pair.of(pos, count);
+    }
+
+    private boolean isSyntheticFirstPosition(Position position) {
+        Long firstLedgerId = ledgers.firstKey();
+        if (firstLedgerId == null || position == null) {
+            return false;
+        }
+
+        LedgerInfo firstLedger = ledgers.get(firstLedgerId);
+        return firstLedgerId > lastConfirmedEntry.getLedgerId()
+                && position.getLedgerId() == lastConfirmedEntry.getLedgerId()
+                && position.getEntryId() == -1
+                && firstLedger != null
+                && firstLedger.getEntries() == 0;
     }
 
     public void activateCursor(ManagedCursor cursor) {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2554,6 +2554,39 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testEarliestCursorAfterTrimmedLedgersUsesCurrentEntriesAddedCounter() throws Exception {
+        @Cleanup("shutdown")
+        ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        initManagedLedgerConfig(config);
+        config.setRetentionTime(0, TimeUnit.MINUTES);
+        config.setMaxEntriesPerLedger(1);
+
+        ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open("earliest_cursor_after_trimmed_ledgers", config);
+        ManagedCursor cursor = ml.openCursor("c1");
+        ml.addEntry("message1".getBytes(Encoding));
+        cursor.skipEntries(1, IndividualDeletedEntries.Exclude);
+        cursor.close();
+        ml.deleteCursor(cursor.getName());
+        ml.internalTrimConsumedLedgers(CompletableFuture.completedFuture(null));
+
+        assertFalse(ml.getLedgersInfo().containsKey(ml.lastConfirmedEntry.getLedgerId()),
+                "the ledger at lastConfirmedEntry has not been trimmed!");
+
+        Pair<Position, Long> earliestPositionAndCounter = ml.getFirstPositionAndCounter();
+        assertEquals(earliestPositionAndCounter.getLeft(), ml.getLastConfirmedEntry());
+        assertEquals(earliestPositionAndCounter.getRight().longValue(), ml.getEntriesAddedCounter());
+
+        ManagedCursorImpl earliestCursor = (ManagedCursorImpl) ml.openCursor("earliest", InitialPosition.Earliest);
+        assertEquals(earliestCursor.getMessagesConsumedCounter(), ml.getEntriesAddedCounter());
+        assertEquals(earliestCursor.getNumberOfEntriesInBacklog(false), 0);
+        assertEquals(earliestCursor.getNumberOfEntriesInBacklog(true), 0);
+        assertEquals(earliestCursor.getMarkDeletedPosition(), ml.getLastConfirmedEntry());
+        earliestCursor.close();
+        ml.close();
+    }
+
+    @Test
     public void testInfiniteRetention() throws Exception {
         @Cleanup("shutdown")
         ManagedLedgerFactory factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);


### PR DESCRIPTION
## Motivation

When an inactive durable subscription is deleted and later recreated(or first creation) with `SubscriptionInitialPosition.Earliest`, backlog can be reported incorrectly if historical ledgers have already been trimmed and only an empty current ledger remains.

In this case, `getFirstPositionAndCounter()` may derive the initial counter from a synthetic earliest position that points to a trimmed ledger range. As a result:

- approximate backlog can stay greater than 0
- precise backlog is 0
- no messages can actually be consumed
- unloading the topic clears the stale in-memory backlog state

## Changes

- handle the synthetic earliest-position case in `ManagedLedgerImpl#getFirstPositionAndCounter()`
- return the current `lastConfirmedEntry` and `entriesAddedCounter` when historical ledgers are already trimmed and only an empty current ledger remains
- add a regression test covering earliest cursor recreation after ledger trim

## Result

After the fix, recreating a durable subscription with `Earliest` in this scenario no longer reports stale backlog. Approximate backlog and precise backlog remain consistent.

## Testing

- added `ManagedLedgerTest#testEarliestCursorAfterTrimmedLedgersUsesCurrentEntriesAddedCounter`


## issues
https://github.com/apache/pulsar/issues/25813