### PR TITLE
[fix][build] Upgrade Jackson to 2.18.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.bcpkix-fips.version>2.0.11</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bcutil-fips.version>2.0.6</bouncycastle.bcutil-fips.version>
     <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <jctools.version>4.0.5</jctools.version>
     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
### Motivation

Keep the 4.2 release branch on the latest Jackson 2.18.x patch level used by the dependency BOM.

### Modifications

- Bump the root `jackson.version` property from `2.18.6` to `2.18.8`.

### Verifications

- `./mvnw -N -q help:evaluate -Dexpression=jackson.version -DforceStdout`
- `./mvnw -pl pulsar-common -DskipTests -Dskip.npm -Dcheckstyle.skip -Dlicense.skip -Dspotbugs.skip=true dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind`