### PR TITLE
[fix][sec][branch-4.0] Upgrade Jackson version to 2.18.8

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -249,17 +249,17 @@ The Apache Software License, Version 2.0
      - info.picocli-picocli-shell-jline3-4.7.7.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.18.6.jar
-     - com.fasterxml.jackson.core-jackson-core-2.18.6.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.18.6.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.6.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.6.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.6.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.6.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.6.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.18.8.jar
+     - com.fasterxml.jackson.core-jackson-core-2.18.8.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.18.8.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.8.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.8.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.8.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.8.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.8.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.8.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.8.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.8.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-2.9.1.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -313,17 +313,17 @@ The Apache Software License, Version 2.0
      - picocli-4.7.7.jar
      - picocli-shell-jline3-4.7.7.jar
  * Jackson
-     - jackson-annotations-2.18.6.jar
-     - jackson-core-2.18.6.jar
-     - jackson-databind-2.18.6.jar
-     - jackson-dataformat-yaml-2.18.6.jar
-     - jackson-jaxrs-base-2.18.6.jar
-     - jackson-jaxrs-json-provider-2.18.6.jar
-     - jackson-module-jaxb-annotations-2.18.6.jar
-     - jackson-module-jsonSchema-2.18.6.jar
-     - jackson-datatype-jdk8-2.18.6.jar
-     - jackson-datatype-jsr310-2.18.6.jar
-     - jackson-module-parameter-names-2.18.6.jar
+     - jackson-annotations-2.18.8.jar
+     - jackson-core-2.18.8.jar
+     - jackson-databind-2.18.8.jar
+     - jackson-dataformat-yaml-2.18.8.jar
+     - jackson-jaxrs-base-2.18.8.jar
+     - jackson-jaxrs-json-provider-2.18.8.jar
+     - jackson-module-jaxb-annotations-2.18.8.jar
+     - jackson-module-jsonSchema-2.18.8.jar
+     - jackson-datatype-jdk8-2.18.8.jar
+     - jackson-datatype-jsr310-2.18.8.jar
+     - jackson-module-parameter-names-2.18.8.jar
  * Caffeine -- caffeine-2.9.1.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.bcpkix-fips.version>2.0.11</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bcutil-fips.version>2.0.6</bouncycastle.bcutil-fips.version>
     <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <reflections.version>0.10.2</reflections.version>
     <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
### Motivation

Upgrade Jackson to 2.18.8 to fix the following vulnerabilities:
- https://github.com/advisories/GHSA-j3rv-43j4-c7qm

### Modifications

Upgrade Jackson from 2.18.6 to 2.18.8 and update the LICENSE.bin.txt files accordingly.