### PR TITLE
[improve][broker] Add consumer_address label to per-consumer Prometheus metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -616,7 +616,8 @@ class TopicStats {
                                             String[] customLabelsAndValues) {
         String[] extraLabels =
             mergeArrays(customLabelsAndValues, "subscription", subscription, "consumer_name", consumer.consumerName(),
-                "consumer_id", String.valueOf(consumer.consumerId()));
+                "consumer_id", String.valueOf(consumer.consumerId()),
+                "consumer_address", consumer.getClientAddressAndPort());
         writeTopicMetric(stream, metricName, value, cluster, namespace, topic, splitTopicAndPartitionIndexLabel,
             extraLabels);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/TopicStats.java
@@ -617,7 +617,7 @@ class TopicStats {
         String[] extraLabels =
             mergeArrays(customLabelsAndValues, "subscription", subscription, "consumer_name", consumer.consumerName(),
                 "consumer_id", String.valueOf(consumer.consumerId()),
-                "consumer_address", consumer.getClientAddressAndPort());
+                "consumer_address", consumer.getClientAddress());
         writeTopicMetric(stream, metricName, value, cluster, namespace, topic, splitTopicAndPartitionIndexLabel,
             extraLabels);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -1186,17 +1187,9 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
-        var topic1Stats = admin.topics().getStats("persistent://my-property/my-ns/my-topic1");
-        var topic2Stats = admin.topics().getStats("persistent://my-property/my-ns/my-topic2");
-        String topic1ConsumerAddress =
-                topic1Stats.getSubscriptions().get("test").getConsumers().get(0).getAddress();
-        String topic2ConsumerAddress =
-                topic2Stats.getSubscriptions().get("test").getConsumers().get(0).getAddress();
-
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
-
         // Sort by topic, then by consumer_id presence (subscription-level first, then consumer-level)
         Comparator<Metric> byTopicAndConsumer = Comparator
                 .comparing((Metric m) -> m.tags.getOrDefault("topic", ""))
@@ -1215,7 +1208,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("subscription"), "test");
         assertEquals(cm.get(1).tags.get("consumer_id"), "0");
-        assertEquals(cm.get(1).tags.get("consumer_address"), topic1ConsumerAddress);
+        assertNotNull(cm.get(1).tags.get("consumer_address"));
 
         assertEquals(cm.get(2).tags.get("namespace"), "my-property/my-ns");
         assertEquals(cm.get(2).tags.get("topic"), "persistent://my-property/my-ns/my-topic2");
@@ -1226,7 +1219,7 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(3).tags.get("topic"), "persistent://my-property/my-ns/my-topic2");
         assertEquals(cm.get(3).tags.get("subscription"), "test");
         assertEquals(cm.get(3).tags.get("consumer_id"), "1");
-        assertEquals(cm.get(3).tags.get("consumer_address"), topic2ConsumerAddress);
+        assertNotNull(cm.get(3).tags.get("consumer_address"));
 
         cm = new ArrayList<>(metrics.get("pulsar_out_messages_total"));
         assertEquals(cm.size(), 4);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -1186,6 +1186,13 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         Multimap<String, Metric> metrics = parseMetrics(metricsStr);
 
+        var topic1Stats = admin.topics().getStats("persistent://my-property/my-ns/my-topic1");
+        var topic2Stats = admin.topics().getStats("persistent://my-property/my-ns/my-topic2");
+        String topic1ConsumerAddress =
+                topic1Stats.getSubscriptions().get("test").getConsumers().get(0).getAddress();
+        String topic2ConsumerAddress =
+                topic2Stats.getSubscriptions().get("test").getConsumers().get(0).getAddress();
+
         metrics.entries().forEach(e -> {
             System.out.println(e.getKey() + ": " + e.getValue());
         });
@@ -1202,20 +1209,24 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(0).tags.get("namespace"), "my-property/my-ns");
         assertEquals(cm.get(0).tags.get("topic"), "persistent://my-property/my-ns/my-topic1");
         assertEquals(cm.get(0).tags.get("subscription"), "test");
+        assertNull(cm.get(0).tags.get("consumer_address"));
 
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/my-ns");
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("subscription"), "test");
         assertEquals(cm.get(1).tags.get("consumer_id"), "0");
+        assertEquals(cm.get(1).tags.get("consumer_address"), topic1ConsumerAddress);
 
         assertEquals(cm.get(2).tags.get("namespace"), "my-property/my-ns");
         assertEquals(cm.get(2).tags.get("topic"), "persistent://my-property/my-ns/my-topic2");
         assertEquals(cm.get(2).tags.get("subscription"), "test");
+        assertNull(cm.get(2).tags.get("consumer_address"));
 
         assertEquals(cm.get(3).tags.get("namespace"), "my-property/my-ns");
         assertEquals(cm.get(3).tags.get("topic"), "persistent://my-property/my-ns/my-topic2");
         assertEquals(cm.get(3).tags.get("subscription"), "test");
         assertEquals(cm.get(3).tags.get("consumer_id"), "1");
+        assertEquals(cm.get(3).tags.get("consumer_address"), topic2ConsumerAddress);
 
         cm = new ArrayList<>(metrics.get("pulsar_out_messages_total"));
         assertEquals(cm.size(), 4);


### PR DESCRIPTION


<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes/closes an issue — use "Fixes #xyz" or, equivalently, "Closes #xyz", -->


<!-- or this PR is one task of an issue -->

Main Issue: #24322

<!-- If the PR belongs to a PIP, please add the PIP link here -->

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Per-consumer metrics only have consumer_name and consumer_id as labels.
Trouble is, consumer_id isn't globally unique — it's assigned per connection and gets reused.
If consumer_name is empty and consumer_id happens to collide, Prometheus can't tell consumers apart. This is probably the reason for the duplicate samples in #24322.



### Modifications

- Add a `consumer_address` label to per-consumer Prometheus metrics in `TopicStats.writeConsumerMetric()`, using the same client source address and port already exposed in consumer stats (`consumer.getClientAddressAndPort()`).

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change is already covered by existing tests, such as *(please describe tests)*.

- `PrometheusMetricsTest.testPerConsumerStats()` — verifies `consumer_address` is present on consumer-level metrics and absent on subscription-level metrics, and that the value matches admin topic stats



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment