### PR TITLE
[fix][broker] Recover bucket delayed delivery tracker asynchronously to avoid blocking dispatcher threads

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/BucketDelayedDeliveryTrackerFactory.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,32 +80,108 @@ public class BucketDelayedDeliveryTrackerFactory implements DelayedDeliveryTrack
     public DelayedDeliveryTracker newTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher) {
         String topicName = dispatcher.getTopic().getName();
         String subscriptionName = dispatcher.getSubscription().getName();
-        BrokerService brokerService = dispatcher.getTopic().getBrokerService();
         DelayedDeliveryTracker tracker;
 
         try {
             tracker = newTracker0(dispatcher);
+            ((BucketDelayedDeliveryTracker) tracker).recoverBucketSnapshot();
         } catch (RecoverDelayedDeliveryTrackerException ex) {
+            tracker = newFallbackTracker(dispatcher, topicName, subscriptionName, ex);
+        }
+        return tracker;
+    }
+
+    @Override
+    public CompletableFuture<DelayedDeliveryTracker> newTrackerAsync(
+            AbstractPersistentDispatcherMultipleConsumers dispatcher) {
+        String topicName = null;
+        String subscriptionName = null;
+        try {
+            topicName = dispatcher.getTopic().getName();
+            subscriptionName = dispatcher.getSubscription().getName();
+            String currentTopicName = topicName;
+            String currentSubscriptionName = subscriptionName;
+            BucketDelayedDeliveryTracker tracker;
+            tracker = newTracker0(dispatcher);
+            return tracker.recoverBucketSnapshotAsync(dispatcher.getTopic().getBrokerService().executor())
+                    .thenApply(delayedDeliveryTracker -> (DelayedDeliveryTracker) delayedDeliveryTracker)
+                    .exceptionallyCompose(ex -> newFallbackTrackerAsync(dispatcher, currentTopicName,
+                            currentSubscriptionName, FutureUtil.unwrapCompletionException(ex)));
+        } catch (RecoverDelayedDeliveryTrackerException ex) {
+            return newFallbackTrackerAsync(dispatcher, topicName, subscriptionName, ex);
+        } catch (Throwable t) {
+            return FutureUtil.failedFuture(t);
+        }
+    }
+
+    private DelayedDeliveryTracker newFallbackTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher,
+                                                      String topicName,
+                                                      String subscriptionName,
+                                                      Throwable ex) {
+        BrokerService brokerService = dispatcher.getTopic().getBrokerService();
+        brokerService.initializeFallbackDelayedDeliveryTrackerFactory();
+        DelayedDeliveryTrackerFactory fallbackFactory = brokerService.getFallbackDelayedDeliveryTrackerFactory();
+        log.warn()
+                .attr("topic", topicName)
+                .attr("subscription", subscriptionName)
+                .attr("dispatcher", dispatcher.getName())
+                .attr("async", false)
+                .attr("fallbackTrackerFactory", delayedDeliveryTrackerFactoryType(fallbackFactory))
+                .exception(ex)
+                .log("Failed to recover BucketDelayedDeliveryTracker, fallback to InMemoryDelayedDeliveryTracker");
+        return fallbackFactory.newTracker(dispatcher);
+    }
+
+    private CompletableFuture<DelayedDeliveryTracker> newFallbackTrackerAsync(
+            AbstractPersistentDispatcherMultipleConsumers dispatcher, String topicName, String subscriptionName,
+            Throwable ex) {
+        try {
+            BrokerService brokerService = dispatcher.getTopic().getBrokerService();
+            brokerService.initializeFallbackDelayedDeliveryTrackerFactory();
+            DelayedDeliveryTrackerFactory fallbackFactory = brokerService.getFallbackDelayedDeliveryTrackerFactory();
             log.warn()
                     .attr("topic", topicName)
                     .attr("subscription", subscriptionName)
+                    .attr("dispatcher", dispatcher.getName())
+                    .attr("async", true)
+                    .attr("fallbackTrackerFactory", delayedDeliveryTrackerFactoryType(fallbackFactory))
                     .exception(ex)
-                    .log("Failed to recover BucketDelayedDeliveryTracker, fallback to"
-                            + " InMemoryDelayedDeliveryTracker. topic , subscription");
-            // If failed to create BucketDelayedDeliveryTracker, fallback to InMemoryDelayedDeliveryTracker
-            brokerService.initializeFallbackDelayedDeliveryTrackerFactory();
-            tracker = brokerService.getFallbackDelayedDeliveryTrackerFactory().newTracker(dispatcher);
+                    .log("Failed to recover BucketDelayedDeliveryTracker, fallback to InMemoryDelayedDeliveryTracker");
+            return fallbackFactory.newTrackerAsync(dispatcher).whenComplete((__, fallbackEx) -> {
+                if (fallbackEx != null) {
+                    log.error()
+                            .attr("topic", topicName)
+                            .attr("subscription", subscriptionName)
+                            .attr("dispatcher", dispatcher.getName())
+                            .attr("fallbackTrackerFactory", delayedDeliveryTrackerFactoryType(fallbackFactory))
+                            .exception(FutureUtil.unwrapCompletionException(fallbackEx))
+                            .log("Failed to create fallback delayed delivery tracker");
+                }
+            });
+        } catch (Throwable t) {
+            log.error()
+                    .attr("topic", topicName)
+                    .attr("subscription", subscriptionName)
+                    .attr("dispatcher", dispatcher.getName())
+                    .attr("recoveryExceptionType", ex == null ? "null" : ex.getClass().getName())
+                    .exception(t)
+                    .log("Failed to create fallback delayed delivery tracker");
+            return FutureUtil.failedFuture(t);
         }
-        return tracker;
+    }
+
+    private String delayedDeliveryTrackerFactoryType(DelayedDeliveryTrackerFactory factory) {
+        return factory == null ? "null" : factory.getClass().getSimpleName();
     }
 
     @VisibleForTesting
     BucketDelayedDeliveryTracker newTracker0(AbstractPersistentDispatcherMultipleConsumers dispatcher)
             throws RecoverDelayedDeliveryTrackerException {
-        return new BucketDelayedDeliveryTracker(dispatcher, timer, tickTimeMillis,
-                isDelayedDeliveryDeliverAtTimeStrict, bucketSnapshotStorage, delayedDeliveryMinIndexCountPerBucket,
+        return new BucketDelayedDeliveryTracker(new DispatcherDelayedDeliveryContext(dispatcher), timer,
+                tickTimeMillis, Clock.systemUTC(), isDelayedDeliveryDeliverAtTimeStrict,
+                bucketSnapshotStorage, delayedDeliveryMinIndexCountPerBucket,
                 TimeUnit.SECONDS.toMillis(delayedDeliveryMaxTimeStepPerBucketSnapshotSegmentSeconds),
-                delayedDeliveryMaxIndexesPerBucketSnapshotSegment, delayedDeliveryMaxNumBuckets);
+                delayedDeliveryMaxIndexesPerBucketSnapshotSegment, delayedDeliveryMaxNumBuckets, false);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTracker.java
@@ -134,7 +134,7 @@ public interface DelayedDeliveryTracker extends AutoCloseable {
 
         @Override
         public CompletableFuture<Void> clear() {
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
 
         @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerFactory.java
@@ -19,8 +19,10 @@
 package org.apache.pulsar.broker.delayed;
 
 import com.google.common.annotations.Beta;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Factory of InMemoryDelayedDeliveryTracker objects. This is the entry point for implementations.
@@ -43,6 +45,21 @@ public interface DelayedDeliveryTrackerFactory extends AutoCloseable {
      *            a multi-consumer dispatcher instance
      */
     DelayedDeliveryTracker newTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher);
+
+    /**
+     * Create a new tracker instance asynchronously.
+     *
+     * @param dispatcher
+     *            a multi-consumer dispatcher instance
+     */
+    default CompletableFuture<DelayedDeliveryTracker> newTrackerAsync(
+            AbstractPersistentDispatcherMultipleConsumers dispatcher) {
+        try {
+            return CompletableFuture.completedFuture(newTracker(dispatcher));
+        } catch (Throwable t) {
+            return FutureUtil.failedFuture(t);
+        }
+    }
 
     /**
      * Close the factory and release all the resources.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -29,6 +29,7 @@ import io.github.merlimat.slog.Logger;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -151,6 +153,19 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                                         long minIndexCountPerBucket, long timeStepPerBucketSnapshotSegmentInMillis,
                                         int maxIndexesPerBucketSnapshotSegment, int maxNumBuckets)
             throws RecoverDelayedDeliveryTrackerException {
+        this(context, timer, tickTimeMillis, clock, isDelayedDeliveryDeliverAtTimeStrict, bucketSnapshotStorage,
+                minIndexCountPerBucket, timeStepPerBucketSnapshotSegmentInMillis, maxIndexesPerBucketSnapshotSegment,
+                maxNumBuckets, true);
+    }
+
+    public BucketDelayedDeliveryTracker(DelayedDeliveryContext context,
+                                        Timer timer, long tickTimeMillis, Clock clock,
+                                        boolean isDelayedDeliveryDeliverAtTimeStrict,
+                                        BucketSnapshotStorage bucketSnapshotStorage,
+                                        long minIndexCountPerBucket, long timeStepPerBucketSnapshotSegmentInMillis,
+                                        int maxIndexesPerBucketSnapshotSegment, int maxNumBuckets,
+                                        boolean recoverBucketSnapshot)
+            throws RecoverDelayedDeliveryTrackerException {
         super(context, timer, tickTimeMillis, clock, isDelayedDeliveryDeliverAtTimeStrict);
         this.log = LOG.with().ctx(super.log).build();
         this.minIndexCountPerBucket = minIndexCountPerBucket;
@@ -165,22 +180,67 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         bucketSnapshotStorage);
         this.stats = new BucketDelayedMessageIndexStats();
 
-        // Close the tracker if failed to recover.
-        try {
-            long recoveredMessages = recoverBucketSnapshot();
-            this.numberDelayedMessages.set(recoveredMessages);
-        } catch (RecoverDelayedDeliveryTrackerException e) {
-            close();
-            throw e;
+        if (recoverBucketSnapshot) {
+            recoverBucketSnapshot();
         }
     }
 
-    private synchronized long recoverBucketSnapshot() throws RecoverDelayedDeliveryTrackerException {
+    public CompletableFuture<BucketDelayedDeliveryTracker> recoverBucketSnapshotAsync(
+            ScheduledExecutorService timeoutExecutor) {
+        try {
+            CompletableFuture<Long> recoverFuture = recoverBucketSnapshot0();
+            FutureUtil.addTimeoutHandling(recoverFuture, Duration.ofSeconds(AsyncOperationTimeoutSeconds * 5L),
+                    timeoutExecutor, () -> FutureUtil.createTimeoutException(
+                            "Timeout", getClass(), "recoverBucketSnapshotAsync(...)"));
+            return recoverFuture.thenApply(recoveredMessages -> {
+                this.numberDelayedMessages.set(recoveredMessages);
+                return this;
+            }).whenComplete((__, ex) -> {
+                if (ex != null) {
+                    log.warn()
+                            .attr("dispatcher", context.getName())
+                            .attr("timeoutSeconds", AsyncOperationTimeoutSeconds * 5)
+                            .exception(FutureUtil.unwrapCompletionException(ex))
+                            .log("Failed to recover delayed message index bucket snapshot asynchronously, "
+                                    + "closing tracker");
+                    closeAsync();
+                }
+            });
+        } catch (Throwable t) {
+            log.warn()
+                    .attr("dispatcher", context.getName())
+                    .attr("timeoutSeconds", AsyncOperationTimeoutSeconds * 5)
+                    .exception(t)
+                    .log("Failed to start delayed message index bucket snapshot recovery asynchronously, "
+                            + "closing tracker");
+            closeAsync();
+            return FutureUtil.failedFuture(t);
+        }
+    }
+
+    public void recoverBucketSnapshot() throws RecoverDelayedDeliveryTrackerException {
+        try {
+            long recoveredMessages = recoverBucketSnapshot0()
+                    .get(AsyncOperationTimeoutSeconds * 5, TimeUnit.SECONDS);
+            this.numberDelayedMessages.set(recoveredMessages);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.error()
+                    .exception(e)
+                    .log("Failed to recover delayed message index bucket snapshot.");
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            close();
+            throw new RecoverDelayedDeliveryTrackerException(e);
+        }
+    }
+
+    private CompletableFuture<Long> recoverBucketSnapshot0() {
         ManagedCursor cursor = this.lastMutableBucket.getCursor();
         Map<String, String> cursorProperties = cursor.getCursorProperties();
         if (MapUtils.isEmpty(cursorProperties)) {
             log.info("Recover delayed message index bucket snapshot finish, don't find bucket snapshot");
-            return 0;
+            return CompletableFuture.completedFuture(0L);
         }
         FutureUtil.Sequencer<Void> sequencer = this.lastMutableBucket.getSequencer();
         Map<Range<Long>, ImmutableBucket> toBeDeletedBucketMap = new HashMap<>();
@@ -200,7 +260,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         Map<Range<Long>, ImmutableBucket> immutableBucketMap = immutableBuckets.asMapOfRanges();
         if (immutableBucketMap.isEmpty()) {
             log.info("Recover delayed message index bucket snapshot finish, don't find bucket snapshot");
-            return 0;
+            return CompletableFuture.completedFuture(0L);
         }
 
         Map<Range<Long>, CompletableFuture<List<DelayedIndex>>>
@@ -210,57 +270,48 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
             futures.put(key, handleRecoverBucketSnapshotEntry(entry.getValue()));
         }
 
-        try {
-            FutureUtil.waitForAll(futures.values()).get(AsyncOperationTimeoutSeconds * 5, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            log.error()
-                    .exception(e)
-                    .log("Failed to recover delayed message index bucket snapshot.");
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw new RecoverDelayedDeliveryTrackerException(e);
-        }
-
-        for (Map.Entry<Range<Long>, CompletableFuture<List<DelayedIndex>>> entry : futures.entrySet()) {
-            Range<Long> key = entry.getKey();
-            // the future will always be completed since it was waited for above
-            List<DelayedIndex> indexList = entry.getValue().getNow(null);
-            ImmutableBucket immutableBucket = immutableBucketMap.get(key);
-            if (CollectionUtils.isEmpty(indexList)) {
-                // Delete bucket snapshot if indexList is empty
-                toBeDeletedBucketMap.put(key, immutableBucket);
-            } else {
-                DelayedIndex lastDelayedIndex = indexList.get(indexList.size() - 1);
-                this.snapshotSegmentLastIndexMap.put(
-                        new SnapshotKey(lastDelayedIndex.getLedgerId(), lastDelayedIndex.getEntryId()),
-                        immutableBucket);
-                for (DelayedIndex index : indexList) {
-                    this.sharedBucketPriorityQueue.add(index.getTimestamp(), index.getLedgerId(),
-                            index.getEntryId());
+        return FutureUtil.waitForAll(futures.values()).thenApply(__ -> {
+            synchronized (this) {
+                for (Map.Entry<Range<Long>, CompletableFuture<List<DelayedIndex>>> entry : futures.entrySet()) {
+                    Range<Long> key = entry.getKey();
+                    List<DelayedIndex> indexList = entry.getValue().getNow(null);
+                    ImmutableBucket immutableBucket = immutableBucketMap.get(key);
+                    if (CollectionUtils.isEmpty(indexList)) {
+                        // Delete bucket snapshot if indexList is empty
+                        toBeDeletedBucketMap.put(key, immutableBucket);
+                    } else {
+                        DelayedIndex lastDelayedIndex = indexList.get(indexList.size() - 1);
+                        this.snapshotSegmentLastIndexMap.put(
+                                new SnapshotKey(lastDelayedIndex.getLedgerId(), lastDelayedIndex.getEntryId()),
+                                immutableBucket);
+                        for (DelayedIndex index : indexList) {
+                            this.sharedBucketPriorityQueue.add(index.getTimestamp(), index.getLedgerId(),
+                                    index.getEntryId());
+                        }
+                    }
                 }
+
+                for (Map.Entry<Range<Long>, ImmutableBucket> mapEntry : toBeDeletedBucketMap.entrySet()) {
+                    Range<Long> key = mapEntry.getKey();
+                    ImmutableBucket immutableBucket = mapEntry.getValue();
+                    immutableBucketMap.remove(key);
+                    // delete asynchronously without waiting for completion
+                    immutableBucket.asyncDeleteBucketSnapshot(stats);
+                }
+
+                MutableLong numberDelayedMessages = new MutableLong(0);
+                immutableBucketMap.values().forEach(bucket -> {
+                    numberDelayedMessages.add(bucket.numberBucketDelayedMessages);
+                });
+
+                log.info()
+                        .attr("buckets", immutableBucketMap.size())
+                        .attr("numberDelayedMessages", numberDelayedMessages.longValue())
+                        .log("Recover delayed message index bucket snapshot finish");
+
+                return numberDelayedMessages.longValue();
             }
-        }
-
-        for (Map.Entry<Range<Long>, ImmutableBucket> mapEntry : toBeDeletedBucketMap.entrySet()) {
-            Range<Long> key = mapEntry.getKey();
-            ImmutableBucket immutableBucket = mapEntry.getValue();
-            immutableBucketMap.remove(key);
-            // delete asynchronously without waiting for completion
-            immutableBucket.asyncDeleteBucketSnapshot(stats);
-        }
-
-        MutableLong numberDelayedMessages = new MutableLong(0);
-        immutableBucketMap.values().forEach(bucket -> {
-            numberDelayedMessages.add(bucket.numberBucketDelayedMessages);
         });
-
-        log.info()
-                .attr("buckets", immutableBucketMap.size())
-                .attr("numberDelayedMessages", numberDelayedMessages.longValue())
-                .log("Recover delayed message index bucket snapshot finish");
-
-        return numberDelayedMessages.longValue();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -84,6 +85,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDispatcherMultipleConsumers {
 
     private static final Logger LOG = Logger.get(PersistentDispatcherMultipleConsumers.class);
+    private static final long DELAYED_DELIVERY_TRACKER_CREATE_LOG_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(30);
     protected final Logger log;
 
     protected final PersistentTopic topic;
@@ -95,6 +97,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
     protected final RedeliveryTracker redeliveryTracker;
 
     private Optional<DelayedDeliveryTracker> delayedDeliveryTracker = Optional.empty();
+    private CompletableFuture<DelayedDeliveryTracker> delayedDeliveryTrackerCreateFuture = null;
+    private final Map<Position, Long> messagesPendingDelayedDeliveryTracker = new LinkedHashMap<>();
+    private long delayedDeliveryTrackerCreateStartTimeMillis = -1;
 
     protected volatile boolean havePendingRead = false;
     protected volatile boolean havePendingReplayRead = false;
@@ -611,11 +616,19 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
         IS_CLOSED_UPDATER.set(this, TRUE);
 
         Optional<DelayedDeliveryTracker> delayedDeliveryTracker;
+        CompletableFuture<DelayedDeliveryTracker> createFuture;
         synchronized (this) {
             delayedDeliveryTracker = this.delayedDeliveryTracker;
             this.delayedDeliveryTracker = Optional.empty();
+            createFuture = this.delayedDeliveryTrackerCreateFuture;
+            this.delayedDeliveryTrackerCreateFuture = null;
+            delayedDeliveryTrackerCreateStartTimeMillis = -1;
+            messagesPendingDelayedDeliveryTracker.clear();
         }
 
+        if (createFuture != null) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+        }
         CompletableFuture<Void> closeTrackerFuture = delayedDeliveryTracker
                 .map(DelayedDeliveryTracker::closeAsync)
                 .orElseGet(() -> CompletableFuture.completedFuture(null));
@@ -1307,6 +1320,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             return false;
         }
 
+        CompletableFuture<DelayedDeliveryTracker> createFuture = null;
+        boolean startCreate = false;
+        long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
         synchronized (this) {
             if (delayedDeliveryTracker.isEmpty()) {
                 if (!msgMetadata.hasDeliverAtTime()) {
@@ -1314,16 +1330,174 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
                     return false;
                 }
 
-                // Initialize the tracker the first time we need to use it
-                delayedDeliveryTracker = Optional.of(
-                        topic.getBrokerService().getDelayedDeliveryTrackerFactory().newTracker(this));
+                messagesPendingDelayedDeliveryTracker.put(PositionFactory.create(ledgerId, entryId), deliverAtTime);
+                if (delayedDeliveryTrackerCreateFuture == null) {
+                    startCreate = true;
+                    createFuture = new CompletableFuture<>();
+                    delayedDeliveryTrackerCreateFuture = createFuture;
+                    delayedDeliveryTrackerCreateStartTimeMillis = System.currentTimeMillis();
+                }
+            } else {
+                delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
+                return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
             }
-
-            delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
-
-            long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
-            return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
         }
+        if (startCreate) {
+            createDelayedDeliveryTracker(createFuture);
+        }
+        return true;
+    }
+
+    private void createDelayedDeliveryTracker(CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        if (!isDelayedDeliveryTrackerCreateActive(createFuture)) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+            return;
+        }
+        log.info()
+                .attr("topic", topic.getName())
+                .attr("subscription", getSubscriptionName())
+                .attr("dispatcher", getName())
+                .attr("pendingDelayedMessages", getDelayedDeliveryTrackerCreatePendingMessages())
+                .log("Start delayed delivery tracker creation");
+        scheduleDelayedDeliveryTrackerCreatePendingLog(createFuture);
+        if (!isDelayedDeliveryTrackerCreateActive(createFuture)) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+            return;
+        }
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture;
+        try {
+            trackerFuture = topic.getBrokerService().getDelayedDeliveryTrackerFactory().newTrackerAsync(this);
+        } catch (Throwable t) {
+            trackerFuture = FutureUtil.failedFuture(t);
+        }
+        trackerFuture.whenComplete((tracker, ex) -> delayedDeliveryTrackerCreated(createFuture, tracker, ex));
+    }
+
+    private void delayedDeliveryTrackerCreated(CompletableFuture<DelayedDeliveryTracker> createFuture,
+                                               DelayedDeliveryTracker tracker, Throwable ex) {
+        DelayedDeliveryTracker trackerToUse = tracker == null ? DelayedDeliveryTracker.DISABLE : tracker;
+        if (ex != null) {
+            trackerToUse = DelayedDeliveryTracker.DISABLE;
+        }
+
+        boolean shouldCloseTracker = false;
+        boolean shouldReadMore = false;
+        boolean installedTracker = false;
+        boolean dispatcherClosed = false;
+        boolean createFutureChanged = false;
+        int pendingDelayedMessages;
+        int replayDelayedMessages = 0;
+        long durationMillis;
+        synchronized (this) {
+            pendingDelayedMessages = messagesPendingDelayedDeliveryTracker.size();
+            durationMillis = getDelayedDeliveryTrackerCreateDurationMillis();
+            dispatcherClosed = isClosed();
+            createFutureChanged = delayedDeliveryTrackerCreateFuture != createFuture;
+            if (createFutureChanged || dispatcherClosed) {
+                shouldCloseTracker = trackerToUse != DelayedDeliveryTracker.DISABLE;
+            } else {
+                delayedDeliveryTrackerCreateFuture = null;
+                delayedDeliveryTrackerCreateStartTimeMillis = -1;
+                delayedDeliveryTracker = Optional.of(trackerToUse);
+                trackerToUse.resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
+                for (Map.Entry<Position, Long> entry : messagesPendingDelayedDeliveryTracker.entrySet()) {
+                    Position position = entry.getKey();
+                    if (!trackerToUse.addMessage(position.getLedgerId(), position.getEntryId(), entry.getValue())) {
+                        redeliveryMessages.add(position.getLedgerId(), position.getEntryId());
+                        replayDelayedMessages++;
+                    }
+                }
+                messagesPendingDelayedDeliveryTracker.clear();
+                shouldReadMore = true;
+                installedTracker = true;
+            }
+        }
+        if (ex != null) {
+            log.warn()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .exception(FutureUtil.unwrapCompletionException(ex))
+                    .log("Failed to initialize delayed delivery tracker");
+        } else if (installedTracker) {
+            log.info()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .attr("replayDelayedMessages", replayDelayedMessages)
+                    .attr("trackerType", delayedDeliveryTrackerType(trackerToUse))
+                    .log("Delayed delivery tracker creation complete");
+        }
+        createFuture.complete(trackerToUse);
+        if (shouldCloseTracker) {
+            log.info()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .attr("dispatcherClosed", dispatcherClosed)
+                    .attr("createFutureChanged", createFutureChanged)
+                    .attr("trackerType", delayedDeliveryTrackerType(trackerToUse))
+                    .log("Close delayed delivery tracker after async creation is no longer needed");
+            trackerToUse.closeAsync();
+        }
+        if (shouldReadMore) {
+            readMoreEntriesAsync();
+        }
+    }
+
+    private synchronized boolean isDelayedDeliveryTrackerCreateActive(
+            CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        return delayedDeliveryTrackerCreateFuture == createFuture && !isClosed();
+    }
+
+    private void scheduleDelayedDeliveryTrackerCreatePendingLog(
+            CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        topic.getBrokerService().executor().schedule(() -> {
+            int pendingDelayedMessages;
+            long durationMillis;
+            synchronized (PersistentDispatcherMultipleConsumers.this) {
+                if (delayedDeliveryTrackerCreateFuture != createFuture) {
+                    return;
+                }
+                pendingDelayedMessages = messagesPendingDelayedDeliveryTracker.size();
+                durationMillis = getDelayedDeliveryTrackerCreateDurationMillis();
+            }
+            log.warn()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .log("Delayed delivery tracker creation is still pending");
+        }, DELAYED_DELIVERY_TRACKER_CREATE_LOG_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    @VisibleForTesting
+    synchronized boolean isDelayedDeliveryTrackerCreatePending() {
+        return delayedDeliveryTrackerCreateFuture != null;
+    }
+
+    @VisibleForTesting
+    synchronized int getDelayedDeliveryTrackerCreatePendingMessages() {
+        return messagesPendingDelayedDeliveryTracker.size();
+    }
+
+    private long getDelayedDeliveryTrackerCreateDurationMillis() {
+        long startTimeMillis = delayedDeliveryTrackerCreateStartTimeMillis;
+        return startTimeMillis > 0 ? System.currentTimeMillis() - startTimeMillis : -1;
+    }
+
+    private String delayedDeliveryTrackerType(DelayedDeliveryTracker tracker) {
+        if (tracker == DelayedDeliveryTracker.DISABLE) {
+            return "DISABLE";
+        }
+        return tracker.getClass().getSimpleName();
     }
 
     protected synchronized NavigableSet<Position> getMessagesToReplayNow(int maxMessagesToRead, long bytesToRead) {
@@ -1376,12 +1550,14 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
 
 
     protected synchronized boolean shouldPauseDeliveryForDelayTracker() {
-        return delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().shouldPauseAllDeliveries();
+        return delayedDeliveryTrackerCreateFuture != null
+                || delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().shouldPauseAllDeliveries();
     }
 
     @Override
     public synchronized long getNumberOfDelayedMessages() {
-        return delayedDeliveryTracker.map(DelayedDeliveryTracker::getNumberOfDelayedMessages).orElse(0L);
+        return delayedDeliveryTracker.map(DelayedDeliveryTracker::getNumberOfDelayedMessages).orElse(0L)
+                + messagesPendingDelayedDeliveryTracker.size();
     }
 
     @Override
@@ -1390,6 +1566,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractPersistentDis
             return CompletableFuture.completedFuture(null);
         }
 
+        if (delayedDeliveryTrackerCreateFuture != null) {
+            return delayedDeliveryTrackerCreateFuture.thenCompose(__ -> clearDelayedMessages());
+        }
         if (delayedDeliveryTracker.isPresent()) {
             return this.delayedDeliveryTracker.get().clear();
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassic.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -86,6 +87,7 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersistentDispatcherMultipleConsumers {
 
     private static final Logger LOG = Logger.get(PersistentDispatcherMultipleConsumersClassic.class);
+    private static final long DELAYED_DELIVERY_TRACKER_CREATE_LOG_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(30);
     protected final Logger log;
 
     protected final PersistentTopic topic;
@@ -97,6 +99,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     protected final RedeliveryTracker redeliveryTracker;
 
     private Optional<DelayedDeliveryTracker> delayedDeliveryTracker = Optional.empty();
+    private CompletableFuture<DelayedDeliveryTracker> delayedDeliveryTrackerCreateFuture = null;
+    private final Map<Position, Long> messagesPendingDelayedDeliveryTracker = new LinkedHashMap<>();
+    private long delayedDeliveryTrackerCreateStartTimeMillis = -1;
 
     protected volatile boolean havePendingRead = false;
     protected volatile boolean havePendingReplayRead = false;
@@ -523,11 +528,19 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
         IS_CLOSED_UPDATER.set(this, TRUE);
 
         Optional<DelayedDeliveryTracker> delayedDeliveryTracker;
+        CompletableFuture<DelayedDeliveryTracker> createFuture;
         synchronized (this) {
             delayedDeliveryTracker = this.delayedDeliveryTracker;
             this.delayedDeliveryTracker = Optional.empty();
+            createFuture = this.delayedDeliveryTrackerCreateFuture;
+            this.delayedDeliveryTrackerCreateFuture = null;
+            delayedDeliveryTrackerCreateStartTimeMillis = -1;
+            messagesPendingDelayedDeliveryTracker.clear();
         }
 
+        if (createFuture != null) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+        }
         CompletableFuture<Void> closeTrackerFuture = delayedDeliveryTracker
                 .map(DelayedDeliveryTracker::closeAsync)
                 .orElseGet(() -> CompletableFuture.completedFuture(null));
@@ -1148,12 +1161,15 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     }
 
     @Override
-    public synchronized boolean trackDelayedDelivery(long ledgerId, long entryId, MessageMetadata msgMetadata) {
+    public boolean trackDelayedDelivery(long ledgerId, long entryId, MessageMetadata msgMetadata) {
         if (!topic.isDelayedDeliveryEnabled()) {
             // If broker has the feature disabled, always deliver messages immediately
             return false;
         }
 
+        CompletableFuture<DelayedDeliveryTracker> createFuture = null;
+        boolean startCreate = false;
+        long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
         synchronized (this) {
             if (delayedDeliveryTracker.isEmpty()) {
                 if (!msgMetadata.hasDeliverAtTime()) {
@@ -1161,16 +1177,174 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
                     return false;
                 }
 
-                // Initialize the tracker the first time we need to use it
-                delayedDeliveryTracker = Optional.of(
-                        topic.getBrokerService().getDelayedDeliveryTrackerFactory().newTracker(this));
+                messagesPendingDelayedDeliveryTracker.put(PositionFactory.create(ledgerId, entryId), deliverAtTime);
+                if (delayedDeliveryTrackerCreateFuture == null) {
+                    startCreate = true;
+                    createFuture = new CompletableFuture<>();
+                    delayedDeliveryTrackerCreateFuture = createFuture;
+                    delayedDeliveryTrackerCreateStartTimeMillis = System.currentTimeMillis();
+                }
+            } else {
+                delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
+                return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
             }
-
-            delayedDeliveryTracker.get().resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
-
-            long deliverAtTime = msgMetadata.hasDeliverAtTime() ? msgMetadata.getDeliverAtTime() : -1L;
-            return delayedDeliveryTracker.get().addMessage(ledgerId, entryId, deliverAtTime);
         }
+        if (startCreate) {
+            createDelayedDeliveryTracker(createFuture);
+        }
+        return true;
+    }
+
+    private void createDelayedDeliveryTracker(CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        if (!isDelayedDeliveryTrackerCreateActive(createFuture)) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+            return;
+        }
+        log.info()
+                .attr("topic", topic.getName())
+                .attr("subscription", getSubscriptionName())
+                .attr("dispatcher", getName())
+                .attr("pendingDelayedMessages", getDelayedDeliveryTrackerCreatePendingMessages())
+                .log("Start delayed delivery tracker creation");
+        scheduleDelayedDeliveryTrackerCreatePendingLog(createFuture);
+        if (!isDelayedDeliveryTrackerCreateActive(createFuture)) {
+            createFuture.complete(DelayedDeliveryTracker.DISABLE);
+            return;
+        }
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture;
+        try {
+            trackerFuture = topic.getBrokerService().getDelayedDeliveryTrackerFactory().newTrackerAsync(this);
+        } catch (Throwable t) {
+            trackerFuture = FutureUtil.failedFuture(t);
+        }
+        trackerFuture.whenComplete((tracker, ex) -> delayedDeliveryTrackerCreated(createFuture, tracker, ex));
+    }
+
+    private void delayedDeliveryTrackerCreated(CompletableFuture<DelayedDeliveryTracker> createFuture,
+                                               DelayedDeliveryTracker tracker, Throwable ex) {
+        DelayedDeliveryTracker trackerToUse = tracker == null ? DelayedDeliveryTracker.DISABLE : tracker;
+        if (ex != null) {
+            trackerToUse = DelayedDeliveryTracker.DISABLE;
+        }
+
+        boolean shouldCloseTracker = false;
+        boolean shouldReadMore = false;
+        boolean installedTracker = false;
+        boolean dispatcherClosed = false;
+        boolean createFutureChanged = false;
+        int pendingDelayedMessages;
+        int replayDelayedMessages = 0;
+        long durationMillis;
+        synchronized (this) {
+            pendingDelayedMessages = messagesPendingDelayedDeliveryTracker.size();
+            durationMillis = getDelayedDeliveryTrackerCreateDurationMillis();
+            dispatcherClosed = isClosed();
+            createFutureChanged = delayedDeliveryTrackerCreateFuture != createFuture;
+            if (createFutureChanged || dispatcherClosed) {
+                shouldCloseTracker = trackerToUse != DelayedDeliveryTracker.DISABLE;
+            } else {
+                delayedDeliveryTrackerCreateFuture = null;
+                delayedDeliveryTrackerCreateStartTimeMillis = -1;
+                delayedDeliveryTracker = Optional.of(trackerToUse);
+                trackerToUse.resetTickTime(topic.getDelayedDeliveryTickTimeMillis());
+                for (Map.Entry<Position, Long> entry : messagesPendingDelayedDeliveryTracker.entrySet()) {
+                    Position position = entry.getKey();
+                    if (!trackerToUse.addMessage(position.getLedgerId(), position.getEntryId(), entry.getValue())) {
+                        redeliveryMessages.add(position.getLedgerId(), position.getEntryId());
+                        replayDelayedMessages++;
+                    }
+                }
+                messagesPendingDelayedDeliveryTracker.clear();
+                shouldReadMore = true;
+                installedTracker = true;
+            }
+        }
+        if (ex != null) {
+            log.warn()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .exception(FutureUtil.unwrapCompletionException(ex))
+                    .log("Failed to initialize delayed delivery tracker");
+        } else if (installedTracker) {
+            log.info()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .attr("replayDelayedMessages", replayDelayedMessages)
+                    .attr("trackerType", delayedDeliveryTrackerType(trackerToUse))
+                    .log("Delayed delivery tracker creation complete");
+        }
+        createFuture.complete(trackerToUse);
+        if (shouldCloseTracker) {
+            log.info()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .attr("dispatcherClosed", dispatcherClosed)
+                    .attr("createFutureChanged", createFutureChanged)
+                    .attr("trackerType", delayedDeliveryTrackerType(trackerToUse))
+                    .log("Close delayed delivery tracker after async creation is no longer needed");
+            trackerToUse.closeAsync();
+        }
+        if (shouldReadMore) {
+            readMoreEntriesAsync();
+        }
+    }
+
+    private synchronized boolean isDelayedDeliveryTrackerCreateActive(
+            CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        return delayedDeliveryTrackerCreateFuture == createFuture && !isClosed();
+    }
+
+    private void scheduleDelayedDeliveryTrackerCreatePendingLog(
+            CompletableFuture<DelayedDeliveryTracker> createFuture) {
+        topic.getBrokerService().executor().schedule(() -> {
+            int pendingDelayedMessages;
+            long durationMillis;
+            synchronized (PersistentDispatcherMultipleConsumersClassic.this) {
+                if (delayedDeliveryTrackerCreateFuture != createFuture) {
+                    return;
+                }
+                pendingDelayedMessages = messagesPendingDelayedDeliveryTracker.size();
+                durationMillis = getDelayedDeliveryTrackerCreateDurationMillis();
+            }
+            log.warn()
+                    .attr("topic", topic.getName())
+                    .attr("subscription", getSubscriptionName())
+                    .attr("dispatcher", getName())
+                    .attr("durationMillis", durationMillis)
+                    .attr("pendingDelayedMessages", pendingDelayedMessages)
+                    .log("Delayed delivery tracker creation is still pending");
+        }, DELAYED_DELIVERY_TRACKER_CREATE_LOG_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    @VisibleForTesting
+    synchronized boolean isDelayedDeliveryTrackerCreatePending() {
+        return delayedDeliveryTrackerCreateFuture != null;
+    }
+
+    @VisibleForTesting
+    synchronized int getDelayedDeliveryTrackerCreatePendingMessages() {
+        return messagesPendingDelayedDeliveryTracker.size();
+    }
+
+    private long getDelayedDeliveryTrackerCreateDurationMillis() {
+        long startTimeMillis = delayedDeliveryTrackerCreateStartTimeMillis;
+        return startTimeMillis > 0 ? System.currentTimeMillis() - startTimeMillis : -1;
+    }
+
+    private String delayedDeliveryTrackerType(DelayedDeliveryTracker tracker) {
+        if (tracker == DelayedDeliveryTracker.DISABLE) {
+            return "DISABLE";
+        }
+        return tracker.getClass().getSimpleName();
     }
 
     protected synchronized NavigableSet<Position> getMessagesToReplayNow(int maxMessagesToRead) {
@@ -1210,12 +1384,14 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
     }
 
     protected synchronized boolean shouldPauseDeliveryForDelayTracker() {
-        return delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().shouldPauseAllDeliveries();
+        return delayedDeliveryTrackerCreateFuture != null
+                || delayedDeliveryTracker.isPresent() && delayedDeliveryTracker.get().shouldPauseAllDeliveries();
     }
 
     @Override
     public synchronized long getNumberOfDelayedMessages() {
-        return delayedDeliveryTracker.map(DelayedDeliveryTracker::getNumberOfDelayedMessages).orElse(0L);
+        return delayedDeliveryTracker.map(DelayedDeliveryTracker::getNumberOfDelayedMessages).orElse(0L)
+                + messagesPendingDelayedDeliveryTracker.size();
     }
 
     @Override
@@ -1224,6 +1400,9 @@ public class PersistentDispatcherMultipleConsumersClassic extends AbstractPersis
             return CompletableFuture.completedFuture(null);
         }
 
+        if (delayedDeliveryTrackerCreateFuture != null) {
+            return delayedDeliveryTrackerCreateFuture.thenCompose(__ -> clearDelayedMessages());
+        }
         if (delayedDeliveryTracker.isPresent()) {
             return this.delayedDeliveryTracker.get().clear();
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerFactoryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/DelayedDeliveryTrackerFactoryTest.java
@@ -20,15 +20,21 @@ package org.apache.pulsar.broker.delayed;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTracker;
+import org.apache.pulsar.broker.delayed.bucket.BucketSnapshotStorage;
 import org.apache.pulsar.broker.delayed.bucket.RecoverDelayedDeliveryTrackerException;
+import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.Subscription;
@@ -42,6 +48,7 @@ import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -151,6 +158,147 @@ public class DelayedDeliveryTrackerFactoryTest extends ProducerConsumerBase {
         @Cleanup
         DelayedDeliveryTracker tracker = brokerService.getDelayedDeliveryTrackerFactory().newTracker(dispatcher);
         Assert.assertEquals(tracker, DelayedDeliveryTracker.DISABLE);
+    }
+
+    @Test
+    public void testCreateBucketTrackerAsync() throws Exception {
+        // Verify async creation waits for bucket snapshot recovery to complete.
+        BrokerService brokerService = Mockito.spy(pulsar.getBrokerService());
+        AbstractPersistentDispatcherMultipleConsumers dispatcher =
+                Mockito.mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        ManagedCursor cursor = Mockito.mock(ManagedCursor.class);
+        Mockito.doReturn("sub").when(cursor).getName();
+        Mockito.doReturn(Map.of(BucketDelayedDeliveryTracker.DELAYED_BUCKET_KEY_PREFIX + "_1_2", "1"))
+                .when(cursor).getCursorProperties();
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(cursor).removeCursorProperty(Mockito.any());
+        Mockito.doReturn(cursor).when(dispatcher).getCursor();
+        Mockito.doReturn("persistent://public/default/test / sub").when(dispatcher).getName();
+
+        PersistentTopic topic = Mockito.mock(PersistentTopic.class);
+        Mockito.doReturn(brokerService).when(topic).getBrokerService();
+        Mockito.doReturn("topic").when(topic).getName();
+        Subscription subscription = Mockito.mock(Subscription.class);
+        Mockito.doReturn("sub").when(subscription).getName();
+        Mockito.doReturn(topic).when(dispatcher).getTopic();
+        Mockito.doReturn(subscription).when(dispatcher).getSubscription();
+
+        BucketSnapshotStorage storage = Mockito.mock(BucketSnapshotStorage.class);
+        CompletableFuture<SnapshotMetadata> metadataFuture = new CompletableFuture<>();
+        Mockito.doReturn(metadataFuture).when(storage).getBucketSnapshotMetadata(Mockito.anyLong());
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(storage).deleteBucketSnapshot(Mockito.anyLong());
+
+        @Cleanup
+        BucketDelayedDeliveryTrackerFactory factory = new BucketDelayedDeliveryTrackerFactory();
+        factory.initialize(pulsar);
+        factory.bucketSnapshotStorage.close();
+        factory.bucketSnapshotStorage = storage;
+
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = factory.newTrackerAsync(dispatcher);
+        Assert.assertFalse(trackerFuture.isDone());
+
+        metadataFuture.complete(new SnapshotMetadata());
+        @Cleanup
+        DelayedDeliveryTracker tracker = trackerFuture.get(1, TimeUnit.MINUTES);
+        Assert.assertTrue(tracker instanceof BucketDelayedDeliveryTracker);
+    }
+
+    @Test
+    public void testCreateBucketTrackerAsyncRecoveryTimeoutFallbackToInMemoryTracker() throws Exception {
+        // Verify bucket recovery timeout falls back without waiting for the real timeout.
+        BrokerService brokerService = Mockito.spy(pulsar.getBrokerService());
+        AbstractPersistentDispatcherMultipleConsumers dispatcher =
+                Mockito.mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Mockito.doReturn("persistent://public/default/test / sub").when(dispatcher).getName();
+
+        PersistentTopic topic = Mockito.mock(PersistentTopic.class);
+        Mockito.doReturn(brokerService).when(topic).getBrokerService();
+        Mockito.doReturn("topic").when(topic).getName();
+        Subscription subscription = Mockito.mock(Subscription.class);
+        Mockito.doReturn("sub").when(subscription).getName();
+        Mockito.doReturn(topic).when(dispatcher).getTopic();
+        Mockito.doReturn(subscription).when(dispatcher).getSubscription();
+
+        @Cleanup
+        BucketDelayedDeliveryTrackerFactory factory = Mockito.spy(new BucketDelayedDeliveryTrackerFactory());
+        factory.initialize(pulsar);
+        BucketDelayedDeliveryTracker bucketTracker = Mockito.mock(BucketDelayedDeliveryTracker.class);
+        TimeoutException timeoutException = new TimeoutException("recover timeout");
+        var timeoutExecutor = brokerService.executor();
+        Mockito.doReturn(FutureUtil.failedFuture(timeoutException))
+                .when(bucketTracker).recoverBucketSnapshotAsync(Mockito.eq(timeoutExecutor));
+        Mockito.doReturn(bucketTracker).when(factory).newTracker0(Mockito.eq(dispatcher));
+
+        @Cleanup
+        DelayedDeliveryTracker tracker = factory.newTrackerAsync(dispatcher).get(1, TimeUnit.MINUTES);
+        Assert.assertTrue(tracker instanceof InMemoryDelayedDeliveryTracker);
+        Mockito.verify(bucketTracker).recoverBucketSnapshotAsync(Mockito.eq(timeoutExecutor));
+    }
+
+    @Test(timeOut = 60_000)
+    public void testDelayedMessageWaitsForAsyncTrackerCreationInBrokerPath() throws Exception {
+        // Verify broker dispatch waits for bucket snapshot recovery before resuming delayed delivery.
+        String topicName = "persistent://public/default/" + UUID.randomUUID();
+
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .enableBatching(false)
+                .create();
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+        topic = Mockito.spy(topic);
+        BrokerService brokerService = Mockito.spy(pulsar.getBrokerService());
+
+        BucketSnapshotStorage storage = Mockito.mock(BucketSnapshotStorage.class);
+        CompletableFuture<SnapshotMetadata> metadataFuture = new CompletableFuture<>();
+        Mockito.doReturn(metadataFuture).when(storage).getBucketSnapshotMetadata(1L);
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(storage).deleteBucketSnapshot(1L);
+
+        @Cleanup
+        BucketDelayedDeliveryTrackerFactory factory = new BucketDelayedDeliveryTrackerFactory();
+        factory.initialize(pulsar);
+        factory.bucketSnapshotStorage.close();
+        factory.bucketSnapshotStorage = storage;
+
+        Mockito.doReturn(factory).when(brokerService).getDelayedDeliveryTrackerFactory();
+        Mockito.doReturn(brokerService).when(topic).getBrokerService();
+        brokerService.getTopics().put(topicName, CompletableFuture.completedFuture(Optional.of(topic)));
+
+        @Cleanup
+        Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName)
+                .subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+
+        PersistentSubscription subscription = topic.getSubscription("sub");
+        Dispatcher dispatcher = subscription.getDispatcher();
+        Assert.assertTrue(dispatcher instanceof PersistentDispatcherMultipleConsumers);
+        PersistentDispatcherMultipleConsumers dispatcher0 = (PersistentDispatcherMultipleConsumers) dispatcher;
+
+        // Force bucket recovery to wait on snapshot metadata.
+        dispatcher0.getCursor().putCursorProperty(
+                BucketDelayedDeliveryTracker.DELAYED_BUCKET_KEY_PREFIX + "_1_2", "1")
+                .get(1, TimeUnit.MINUTES);
+
+        producer.newMessage()
+                .value("delayed")
+                .deliverAfter(100, TimeUnit.MILLISECONDS)
+                .send();
+
+        Mockito.verify(storage, Mockito.timeout(10_000)).getBucketSnapshotMetadata(1L);
+
+        // The delivery time has passed, but bucket recovery is still pending.
+        Assert.assertNull(consumer.receive(1, TimeUnit.SECONDS));
+
+        // Finish bucket recovery; dispatcher should replay the elapsed delayed message.
+        metadataFuture.complete(new SnapshotMetadata());
+        Mockito.verify(storage, Mockito.timeout(10_000)).deleteBucketSnapshot(1L);
+
+        var message = consumer.receive(10, TimeUnit.SECONDS);
+        Assert.assertNotNull(message);
+        Assert.assertEquals(message.getValue(), "delayed");
+        consumer.acknowledge(message);
     }
 
     // 1. Create BucketDelayedDeliveryTracker failed, fallback to InMemoryDelayedDeliveryTracker,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersClassicTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.service.persistent;
 
 import com.carrotsearch.hppc.ObjectSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,6 +33,9 @@ import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.pulsar.broker.delayed.DelayedDeliveryTracker;
+import org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerFactory;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.SharedPulsarBaseTest;
 import org.apache.pulsar.broker.service.Subscription;
@@ -250,5 +255,146 @@ public class PersistentDispatcherMultipleConsumersClassicTest extends SharedPuls
             }
         }
         Assert.assertEquals(errors.get(), 0, "No exceptions should occur during concurrent operations");
+    }
+
+    @Test
+    public void testCloseReleasesDelayedDeliveryTrackerCreatedAsync() throws Exception {
+        // Verify close prevents a late async tracker from being installed.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        MessageMetadata messageMetadata = newDelayedMessageMetadata(System.currentTimeMillis() + 5_000);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, messageMetadata));
+        Assert.assertTrue(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 1);
+
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+        Assert.assertFalse(clearFuture.isDone());
+
+        dispatcher.close(false, Optional.empty()).get(1, TimeUnit.MINUTES);
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        clearFuture.get(1, TimeUnit.MINUTES);
+
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        trackerFuture.complete(tracker);
+
+        Mockito.verify(tracker, Mockito.timeout(5_000)).close();
+        Mockito.verify(dispatcher, Mockito.never()).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testDelayedDeliveryTrackerCreatedAsyncTracksPendingMessages() throws Exception {
+        // Verify pending delayed messages are drained into the created tracker.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        long deliverAtTime = System.currentTimeMillis() + 5_000;
+        MessageMetadata messageMetadata = newDelayedMessageMetadata(deliverAtTime);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, messageMetadata));
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        Mockito.doReturn(true).when(tracker).addMessage(1, 1, deliverAtTime);
+
+        trackerFuture.complete(tracker);
+
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Mockito.verify(tracker).resetTickTime(1000L);
+        Mockito.verify(tracker).addMessage(1, 1, deliverAtTime);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testClearDelayedMessagesWaitsForDelayedDeliveryTrackerCreatedAsync() throws Exception {
+        // Verify clear waits for async tracker creation before clearing tracker state.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        long deliverAtTime = System.currentTimeMillis() + 5_000;
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, newDelayedMessageMetadata(deliverAtTime)));
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+        Assert.assertFalse(clearFuture.isDone());
+
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        Mockito.doReturn(true).when(tracker).addMessage(1, 1, deliverAtTime);
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(tracker).clear();
+        trackerFuture.complete(tracker);
+
+        clearFuture.get(1, TimeUnit.MINUTES);
+        Mockito.verify(tracker).clear();
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testDelayedDeliveryTrackerCreatedAsyncFailureReplaysPendingMessages() throws Exception {
+        // Verify pending delayed messages are replayed when tracker creation fails.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1,
+                newDelayedMessageMetadata(System.currentTimeMillis() + 5_000)));
+        trackerFuture.completeExceptionally(new RuntimeException("failed to create tracker"));
+
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Assert.assertEquals(dispatcher.getNumberOfMessagesInReplay(), 1);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testClearDelayedMessagesCompletesWhenDelayedDeliveryTrackerCreateFailsAsync() throws Exception {
+        // Verify clear completes even when async tracker creation fails.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1,
+                newDelayedMessageMetadata(System.currentTimeMillis() + 5_000)));
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+
+        trackerFuture.completeExceptionally(new RuntimeException("failed to create tracker"));
+
+        clearFuture.get(1, TimeUnit.MINUTES);
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    private PersistentDispatcherMultipleConsumersClassic newDispatcherWithDelayedTrackerFuture(
+            CompletableFuture<DelayedDeliveryTracker> trackerFuture) {
+        BrokerService brokerService = Mockito.spy(getPulsar().getBrokerService());
+        DelayedDeliveryTrackerFactory factory = Mockito.mock(DelayedDeliveryTrackerFactory.class);
+        Mockito.doReturn(trackerFuture).when(factory).newTrackerAsync(Mockito.any());
+        Mockito.doReturn(factory).when(brokerService).getDelayedDeliveryTrackerFactory();
+
+        PersistentTopic topic = Mockito.mock(PersistentTopic.class);
+        Mockito.doReturn(brokerService).when(topic).getBrokerService();
+        Mockito.doReturn("persistent://public/default/test").when(topic).getName();
+        Mockito.doReturn(true).when(topic).isDelayedDeliveryEnabled();
+        Mockito.doReturn(1000L).when(topic).getDelayedDeliveryTickTimeMillis();
+
+        ManagedCursor cursor = Mockito.mock(ManagedCursorImpl.class);
+        Mockito.doReturn("sub").when(cursor).getName();
+
+        Subscription sub = Mockito.mock(PersistentSubscription.class);
+        Mockito.doReturn("sub").when(sub).getName();
+        Mockito.doReturn(topic).when(sub).getTopic();
+
+        PersistentDispatcherMultipleConsumersClassic dispatcher =
+                Mockito.spy(new PersistentDispatcherMultipleConsumersClassic(topic, cursor, sub));
+        Mockito.doNothing().when(dispatcher).readMoreEntriesAsync();
+        return dispatcher;
+    }
+
+    private MessageMetadata newDelayedMessageMetadata(long deliverAtTime) {
+        return new MessageMetadata()
+                .setSequenceId(1)
+                .setProducerName("testProducer")
+                .setPublishTime(System.currentTimeMillis())
+                .setDeliverAtTime(deliverAtTime);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumersTest.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.broker.service.persistent;
 
 import com.carrotsearch.hppc.ObjectSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,6 +33,9 @@ import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.pulsar.broker.delayed.DelayedDeliveryTracker;
+import org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerFactory;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.SharedPulsarBaseTest;
 import org.apache.pulsar.broker.service.Subscription;
@@ -250,5 +255,146 @@ public class PersistentDispatcherMultipleConsumersTest extends SharedPulsarBaseT
             }
         }
         Assert.assertEquals(errors.get(), 0, "No exceptions should occur during concurrent operations");
+    }
+
+    @Test
+    public void testCloseReleasesDelayedDeliveryTrackerCreatedAsync() throws Exception {
+        // Verify close prevents a late async tracker from being installed.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        MessageMetadata messageMetadata = newDelayedMessageMetadata(System.currentTimeMillis() + 5_000);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, messageMetadata));
+        Assert.assertTrue(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 1);
+
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+        Assert.assertFalse(clearFuture.isDone());
+
+        dispatcher.close(false, Optional.empty()).get(1, TimeUnit.MINUTES);
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        clearFuture.get(1, TimeUnit.MINUTES);
+
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        trackerFuture.complete(tracker);
+
+        Mockito.verify(tracker, Mockito.timeout(5_000)).close();
+        Mockito.verify(dispatcher, Mockito.never()).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testDelayedDeliveryTrackerCreatedAsyncTracksPendingMessages() throws Exception {
+        // Verify pending delayed messages are drained into the created tracker.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        long deliverAtTime = System.currentTimeMillis() + 5_000;
+        MessageMetadata messageMetadata = newDelayedMessageMetadata(deliverAtTime);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, messageMetadata));
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        Mockito.doReturn(true).when(tracker).addMessage(1, 1, deliverAtTime);
+
+        trackerFuture.complete(tracker);
+
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Mockito.verify(tracker).resetTickTime(1000L);
+        Mockito.verify(tracker).addMessage(1, 1, deliverAtTime);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testClearDelayedMessagesWaitsForDelayedDeliveryTrackerCreatedAsync() throws Exception {
+        // Verify clear waits for async tracker creation before clearing tracker state.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+        long deliverAtTime = System.currentTimeMillis() + 5_000;
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1, newDelayedMessageMetadata(deliverAtTime)));
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+        Assert.assertFalse(clearFuture.isDone());
+
+        DelayedDeliveryTracker tracker = Mockito.mock(DelayedDeliveryTracker.class);
+        Mockito.doReturn(true).when(tracker).addMessage(1, 1, deliverAtTime);
+        Mockito.doReturn(CompletableFuture.completedFuture(null)).when(tracker).clear();
+        trackerFuture.complete(tracker);
+
+        clearFuture.get(1, TimeUnit.MINUTES);
+        Mockito.verify(tracker).clear();
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testDelayedDeliveryTrackerCreatedAsyncFailureReplaysPendingMessages() throws Exception {
+        // Verify pending delayed messages are replayed when tracker creation fails.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1,
+                newDelayedMessageMetadata(System.currentTimeMillis() + 5_000)));
+        trackerFuture.completeExceptionally(new RuntimeException("failed to create tracker"));
+
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Assert.assertEquals(dispatcher.getNumberOfMessagesInReplay(), 1);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    @Test
+    public void testClearDelayedMessagesCompletesWhenDelayedDeliveryTrackerCreateFailsAsync() throws Exception {
+        // Verify clear completes even when async tracker creation fails.
+        CompletableFuture<DelayedDeliveryTracker> trackerFuture = new CompletableFuture<>();
+        PersistentDispatcherMultipleConsumers dispatcher =
+                newDispatcherWithDelayedTrackerFuture(trackerFuture);
+
+        Assert.assertTrue(dispatcher.trackDelayedDelivery(1, 1,
+                newDelayedMessageMetadata(System.currentTimeMillis() + 5_000)));
+        CompletableFuture<Void> clearFuture = dispatcher.clearDelayedMessages();
+
+        trackerFuture.completeExceptionally(new RuntimeException("failed to create tracker"));
+
+        clearFuture.get(1, TimeUnit.MINUTES);
+        Assert.assertFalse(dispatcher.isDelayedDeliveryTrackerCreatePending());
+        Assert.assertEquals(dispatcher.getDelayedDeliveryTrackerCreatePendingMessages(), 0);
+        Mockito.verify(dispatcher).readMoreEntriesAsync();
+    }
+
+    private PersistentDispatcherMultipleConsumers newDispatcherWithDelayedTrackerFuture(
+            CompletableFuture<DelayedDeliveryTracker> trackerFuture) {
+        BrokerService brokerService = Mockito.spy(getPulsar().getBrokerService());
+        DelayedDeliveryTrackerFactory factory = Mockito.mock(DelayedDeliveryTrackerFactory.class);
+        Mockito.doReturn(trackerFuture).when(factory).newTrackerAsync(Mockito.any());
+        Mockito.doReturn(factory).when(brokerService).getDelayedDeliveryTrackerFactory();
+
+        PersistentTopic topic = Mockito.mock(PersistentTopic.class);
+        Mockito.doReturn(brokerService).when(topic).getBrokerService();
+        Mockito.doReturn("persistent://public/default/test").when(topic).getName();
+        Mockito.doReturn(true).when(topic).isDelayedDeliveryEnabled();
+        Mockito.doReturn(1000L).when(topic).getDelayedDeliveryTickTimeMillis();
+
+        ManagedCursor cursor = Mockito.mock(ManagedCursorImpl.class);
+        Mockito.doReturn("sub").when(cursor).getName();
+
+        Subscription sub = Mockito.mock(PersistentSubscription.class);
+        Mockito.doReturn("sub").when(sub).getName();
+        Mockito.doReturn(topic).when(sub).getTopic();
+
+        PersistentDispatcherMultipleConsumers dispatcher =
+                Mockito.spy(new PersistentDispatcherMultipleConsumers(topic, cursor, sub));
+        Mockito.doNothing().when(dispatcher).readMoreEntriesAsync();
+        return dispatcher;
+    }
+
+    private MessageMetadata newDelayedMessageMetadata(long deliverAtTime) {
+        return new MessageMetadata()
+                .setSequenceId(1)
+                .setProducerName("testProducer")
+                .setPublishTime(System.currentTimeMillis())
+                .setDeliverAtTime(deliverAtTime);
     }
 }


### PR DESCRIPTION
Fixes #26103

### Motivation

`BucketDelayedDeliveryTracker` is lazily created from the broker dispatch path
when the first delayed message needs a delayed delivery tracker.

For the bucket implementation, tracker creation also recovers delayed bucket
snapshots. This recovery can depend on metadata or storage operations, but it was
previously waited for synchronously during tracker creation.

As a result, a dispatcher thread could be blocked while holding the dispatcher
lock. If bucket snapshot recovery is slow, dispatch for the current subscription
is stalled, and other tasks queued on the same broker-topic worker can also be
delayed.

### Modifications

- Add an asynchronous tracker creation path to `DelayedDeliveryTrackerFactory`.
- Recover bucket delayed delivery snapshots asynchronously before installing the
  tracker into the dispatcher.
- Keep delayed messages pending while tracker creation is in progress, and pause
  dispatch until the tracker is ready.
- Replay pending delayed messages when tracker creation fails or when their
  delivery time has already elapsed.
- Fall back to the in-memory delayed delivery tracker when bucket recovery fails
  or times out.
- Clean up pending delayed messages on dispatcher close/unload, and close
  trackers that complete after they are no longer needed.
- Add lifecycle logs for tracker creation start, pending creation, completion,
  failure, fallback, and stale tracker cleanup.
- Add tests for async bucket recovery, fallback behavior, dispatcher
  close/clear/replay behavior, and a broker-path delayed message scenario using
  the real bucket tracker.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.delayed.DelayedDeliveryTrackerFactoryTest`
- `./gradlew :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`
- `git diff --check`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

This changes delayed delivery tracker creation from synchronous recovery on the
dispatcher path to asynchronous recovery with dispatcher-side pending state and
replay handling.
