### PR TITLE
[fix][broker] Prevent repeated consumer close on topic migration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -136,10 +136,6 @@ public class Consumer {
             AtomicIntegerFieldUpdater.newUpdater(Consumer.class, "unackedMessages");
     private volatile int unackedMessages = 0;
     private volatile boolean blockedConsumerOnUnackedMsgs = false;
-    private static final AtomicIntegerFieldUpdater<Consumer> TOPIC_MIGRATION_SENT_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(Consumer.class, "topicMigrationSent");
-    @SuppressWarnings("unused")
-    private volatile int topicMigrationSent = 0;
 
     private final Map<String, String> metadata;
 
@@ -975,13 +971,21 @@ public class Consumer {
     }
 
     public void topicMigrated(Optional<ClusterUrl> clusterUrl) {
-        if (clusterUrl.isPresent() && TOPIC_MIGRATION_SENT_UPDATER.compareAndSet(this, 0, 1)) {
+        if (clusterUrl.isPresent()) {
             ClusterUrl url = clusterUrl.get();
             cnx.getCommandSender().sendTopicMigrated(ResourceType.Consumer, consumerId, url.getBrokerServiceUrl(),
                     url.getBrokerServiceUrlTls());
             // disconnect consumer after sending migrated cluster url
             disconnect();
         }
+    }
+
+    public CompletableFuture<Boolean> checkTopicMigrationAsync() {
+        if (!subscription.isSubscriptionMigrated()) {
+            return CompletableFuture.completedFuture(false);
+        }
+        return AbstractTopic.getMigratedClusterUrlAsync(cnx.getBrokerService().getPulsar(), topicName)
+                .thenApply(Optional::isPresent);
     }
 
     public CompletableFuture<Boolean> checkAndApplyTopicMigrationAsync() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -136,6 +136,10 @@ public class Consumer {
             AtomicIntegerFieldUpdater.newUpdater(Consumer.class, "unackedMessages");
     private volatile int unackedMessages = 0;
     private volatile boolean blockedConsumerOnUnackedMsgs = false;
+    private static final AtomicIntegerFieldUpdater<Consumer> TOPIC_MIGRATION_SENT_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(Consumer.class, "topicMigrationSent");
+    @SuppressWarnings("unused")
+    private volatile int topicMigrationSent = 0;
 
     private final Map<String, String> metadata;
 
@@ -971,7 +975,7 @@ public class Consumer {
     }
 
     public void topicMigrated(Optional<ClusterUrl> clusterUrl) {
-        if (clusterUrl.isPresent()) {
+        if (clusterUrl.isPresent() && TOPIC_MIGRATION_SENT_UPDATER.compareAndSet(this, 0, 1)) {
             ClusterUrl url = clusterUrl.get();
             cnx.getCommandSender().sendTopicMigrated(ResourceType.Consumer, consumerId, url.getBrokerServiceUrl(),
                     url.getBrokerServiceUrlTls());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -346,18 +346,15 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
                     false, cnx, cnx.getAuthRole(), metadata, readCompacted, keySharedMeta, MessageId.latest,
                     DEFAULT_CONSUMER_EPOCH, schemaType);
-            consumer.checkAndApplyTopicMigrationAsync().thenCompose(migrated -> {
+            consumer.checkTopicMigrationAsync().thenCompose(migrated -> {
                 if (migrated) {
-                    // The topic is migrated: checkAndApplyTopicMigrationAsync() has already sent the
-                    // TopicMigrated redirect and disconnected the consumer (which also released the usage
-                    // count taken by handleConsumerAdded above). Skip addConsumerToSubscription so the consumer
-                    // is never attached to the subscription on the old cluster. Sequencing the migration check
-                    // through thenCompose (instead of the previous fire-and-forget thenAccept that raced with
-                    // addConsumerToSubscription) is what guarantees the consumer is not added once migrated.
+                    // The topic is migrated. Skip addConsumerToSubscription so the consumer is never attached to
+                    // the subscription on the old cluster. ServerCnx will apply the migration redirect on the
+                    // common post-subscribe path with checkAndApplyTopicMigrationAsync().
                     log.info()
                             .attr("subscription", subscriptionName)
                             .attr("consumerId", consumerId)
-                            .log("Skipped subscription on migrated topic; consumer was redirected");
+                            .log("Skipped subscription on migrated topic; consumer will be redirected");
                     future.complete(consumer);
                     return CompletableFuture.<Void>completedFuture(null);
                 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -216,6 +216,72 @@ public class NonPersistentTopicTest extends BrokerTestBase {
     }
 
     @Test
+    public void testPostSubscribeMigrationCheckDoesNotDoubleCloseRedirectedConsumer() throws Exception {
+        final String topicName = "non-persistent://prop/ns-abc/migration-double-close-" + UUID.randomUUID();
+        final String subName = "migration-sub";
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        NonPersistentTopic realTopic =
+                (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+
+        ClusterUrl migratedUrl = new ClusterUrl("http://migrated:8080", "https://migrated:8443",
+                "pulsar://migrated:6650", "pulsar+ssl://migrated:6651");
+        admin.clusters().updateClusterMigration(conf.getClusterName(), true, migratedUrl);
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() ->
+                AbstractTopic.getMigratedClusterUrlAsync(pulsar, topicName).get().isPresent());
+
+        NonPersistentTopic spyTopic = Mockito.spy(realTopic);
+        Mockito.doReturn(true).when(spyTopic).isMigrated();
+
+        NonPersistentSubscription spySubscription =
+                Mockito.spy(new NonPersistentSubscription(spyTopic, subName, Collections.emptyMap()));
+        spyTopic.getSubscriptions().put(subName, spySubscription);
+
+        PulsarCommandSender commandSender = Mockito.mock(PulsarCommandSender.class);
+        TransportCnx cnx = Mockito.mock(TransportCnx.class);
+        Mockito.doReturn(true).when(cnx).isActive();
+        Mockito.doReturn(true).when(cnx).isBatchMessageCompatibleVersion();
+        Mockito.doReturn("test-role").when(cnx).getAuthRole();
+        Mockito.doReturn(pulsar.getBrokerService()).when(cnx).getBrokerService();
+        Mockito.doReturn(commandSender).when(cnx).getCommandSender();
+
+        SubscriptionOption option = SubscriptionOption.builder()
+                .cnx(cnx)
+                .subscriptionName(subName)
+                .consumerId(1L)
+                .subType(CommandSubscribe.SubType.Shared)
+                .priorityLevel(0)
+                .consumerName("consumer-1")
+                .isDurable(false)
+                .startMessageId(null)
+                .metadata(Collections.emptyMap())
+                .readCompacted(false)
+                .initialPosition(CommandSubscribe.InitialPosition.Latest)
+                .startMessageRollbackDurationSec(0)
+                .replicatedSubscriptionStateArg(false)
+                .keySharedMeta(null)
+                .subscriptionProperties(Optional.empty())
+                .build();
+
+        long usageBefore = spyTopic.currentUsageCount();
+
+        org.apache.pulsar.broker.service.Consumer consumer =
+                spyTopic.subscribe(option).get(10, TimeUnit.SECONDS);
+        assertNotNull(consumer);
+        assertEquals(spyTopic.currentUsageCount(), usageBefore);
+
+        // Simulate ServerCnx.handleSubscribe's generic post-subscribe migration check. The consumer was already
+        // redirected and closed by NonPersistentTopic.internalSubscribe, so this second check must be idempotent.
+        consumer.checkAndApplyTopicMigrationAsync().get(10, TimeUnit.SECONDS);
+
+        Mockito.verify(commandSender).sendTopicMigrated(Mockito.any(), Mockito.eq(1L),
+                Mockito.eq(migratedUrl.getBrokerServiceUrl()), Mockito.eq(migratedUrl.getBrokerServiceUrlTls()));
+        assertEquals(spyTopic.currentUsageCount(), usageBefore,
+                "The post-subscribe migration check must not close the redirected consumer a second time");
+    }
+
+    @Test
     public void testSubscriptionsOnNonPersistentTopic() throws Exception {
         final String topicName = "non-persistent://prop/ns-abc/topic_" + UUID.randomUUID();
         final String exclusiveSubName = "exclusive";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -138,8 +138,8 @@ public class NonPersistentTopicTest extends BrokerTestBase {
      * {@code addConsumerToSubscription}, and the consumer must NOT be attached to the subscription on the
      * old cluster. The previous code ran {@code getMigratedClusterUrlAsync().thenAccept(consumer::topicMigrated)}
      * concurrently with {@code addConsumerToSubscription}, so the consumer could be added before the redirect
-     * and disconnect ran. The fix sequences the check through {@link org.apache.pulsar.broker.service.Consumer
-     * #checkAndApplyTopicMigrationAsync()} and skips the add when migrated.
+     * and disconnect ran. The fix sequences a pure migration check before {@code addConsumerToSubscription} and
+     * lets the common {@code ServerCnx} post-subscribe path apply the redirect when migrated.
      */
     @Test
     public void testSubscribeOnMigratedTopicSkipsAddingConsumer() throws Exception {
@@ -202,83 +202,24 @@ public class NonPersistentTopicTest extends BrokerTestBase {
                 spyTopic.subscribe(option).get(10, TimeUnit.SECONDS);
         assertNotNull(consumer);
 
-        // The migration redirect must have been sent to the client.
-        Mockito.verify(commandSender).sendTopicMigrated(Mockito.any(), Mockito.eq(1L),
-                Mockito.eq(migratedUrl.getBrokerServiceUrl()), Mockito.eq(migratedUrl.getBrokerServiceUrlTls()));
-
         // The core regression assertion: a migrated topic must never attach the consumer to the
         // subscription. The buggy code added it before the async redirect/disconnect could run.
         Mockito.verify(spySubscription, Mockito.never()).addConsumer(Mockito.any());
         assertTrue(spySubscription.getConsumers().isEmpty());
 
-        // No usage-count leak: handleConsumerAdded's increment is balanced by the disconnect's removeConsumer.
-        assertEquals(spyTopic.currentUsageCount(), usageBefore);
-    }
+        // NonPersistentTopic only checks migration and skips addConsumerToSubscription. The common ServerCnx
+        // post-subscribe check remains responsible for sending the redirect and closing the consumer.
+        Mockito.verify(commandSender, Mockito.never()).sendTopicMigrated(Mockito.any(), Mockito.eq(1L),
+                Mockito.any(), Mockito.any());
+        assertEquals(spyTopic.currentUsageCount(), usageBefore + 1);
 
-    @Test
-    public void testPostSubscribeMigrationCheckDoesNotDoubleCloseRedirectedConsumer() throws Exception {
-        final String topicName = "non-persistent://prop/ns-abc/migration-double-close-" + UUID.randomUUID();
-        final String subName = "migration-sub";
-
-        @Cleanup
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
-        NonPersistentTopic realTopic =
-                (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
-
-        ClusterUrl migratedUrl = new ClusterUrl("http://migrated:8080", "https://migrated:8443",
-                "pulsar://migrated:6650", "pulsar+ssl://migrated:6651");
-        admin.clusters().updateClusterMigration(conf.getClusterName(), true, migratedUrl);
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() ->
-                AbstractTopic.getMigratedClusterUrlAsync(pulsar, topicName).get().isPresent());
-
-        NonPersistentTopic spyTopic = Mockito.spy(realTopic);
-        Mockito.doReturn(true).when(spyTopic).isMigrated();
-
-        NonPersistentSubscription spySubscription =
-                Mockito.spy(new NonPersistentSubscription(spyTopic, subName, Collections.emptyMap()));
-        spyTopic.getSubscriptions().put(subName, spySubscription);
-
-        PulsarCommandSender commandSender = Mockito.mock(PulsarCommandSender.class);
-        TransportCnx cnx = Mockito.mock(TransportCnx.class);
-        Mockito.doReturn(true).when(cnx).isActive();
-        Mockito.doReturn(true).when(cnx).isBatchMessageCompatibleVersion();
-        Mockito.doReturn("test-role").when(cnx).getAuthRole();
-        Mockito.doReturn(pulsar.getBrokerService()).when(cnx).getBrokerService();
-        Mockito.doReturn(commandSender).when(cnx).getCommandSender();
-
-        SubscriptionOption option = SubscriptionOption.builder()
-                .cnx(cnx)
-                .subscriptionName(subName)
-                .consumerId(1L)
-                .subType(CommandSubscribe.SubType.Shared)
-                .priorityLevel(0)
-                .consumerName("consumer-1")
-                .isDurable(false)
-                .startMessageId(null)
-                .metadata(Collections.emptyMap())
-                .readCompacted(false)
-                .initialPosition(CommandSubscribe.InitialPosition.Latest)
-                .startMessageRollbackDurationSec(0)
-                .replicatedSubscriptionStateArg(false)
-                .keySharedMeta(null)
-                .subscriptionProperties(Optional.empty())
-                .build();
-
-        long usageBefore = spyTopic.currentUsageCount();
-
-        org.apache.pulsar.broker.service.Consumer consumer =
-                spyTopic.subscribe(option).get(10, TimeUnit.SECONDS);
-        assertNotNull(consumer);
-        assertEquals(spyTopic.currentUsageCount(), usageBefore);
-
-        // Simulate ServerCnx.handleSubscribe's generic post-subscribe migration check. The consumer was already
-        // redirected and closed by NonPersistentTopic.internalSubscribe, so this second check must be idempotent.
+        // Simulate ServerCnx.handleSubscribe's generic post-subscribe migration check.
         consumer.checkAndApplyTopicMigrationAsync().get(10, TimeUnit.SECONDS);
 
         Mockito.verify(commandSender).sendTopicMigrated(Mockito.any(), Mockito.eq(1L),
                 Mockito.eq(migratedUrl.getBrokerServiceUrl()), Mockito.eq(migratedUrl.getBrokerServiceUrlTls()));
         assertEquals(spyTopic.currentUsageCount(), usageBefore,
-                "The post-subscribe migration check must not close the redirected consumer a second time");
+                "The post-subscribe migration check must close the skipped consumer and balance usage count");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

PR #26075 fixed the non-persistent topic subscribe race by redirecting a migrated consumer before adding it to the subscription. However, that path still completes the subscribe future with the same consumer, and `ServerCnx.handleSubscribe` runs the generic post-subscribe migration check again.

That second check can redirect and disconnect the same consumer a second time. For non-persistent topics this can double-decrement the topic usage count and emit duplicate `TopicMigrated` commands.

### Modifications

- Make `Consumer.topicMigrated(...)` idempotent for each consumer with an atomic once guard.
- Keep the first migration handling unchanged: send `TopicMigrated` and disconnect the consumer.
- Ignore repeated migration handling for the same consumer so the `ServerCnx` post-subscribe check remains safe after an inline non-persistent redirect.
- Add a regression test that simulates the post-subscribe migration check after `NonPersistentTopic.internalSubscribe` already redirected the consumer, verifying one redirect and balanced topic usage count.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopicTest.testPostSubscribeMigrationCheckDoesNotDoubleCloseRedirectedConsumer`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopicTest.testSubscribeOnMigratedTopicSkipsAddingConsumer --tests org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopicTest.testPostSubscribeMigrationCheckDoesNotDoubleCloseRedirectedConsumer`
- `./gradlew :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment