### PR TITLE
[fix][broker] Fix replicator stall when a skipped pending read completes after a cursor rewind

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -357,9 +357,15 @@ public abstract class PersistentReplicator extends AbstractReplicator
         InFlightTask inFlightTask = (InFlightTask) ctx;
 
         latestPublishTime = System.currentTimeMillis();
-        // Release memory if terminated.
+        // Release memory if terminated or the result is skipped due to a cursor rewind.
         if (state == State.Terminated || state == State.Terminating
                 || inFlightTask.isSkipReadResultDueToCursorRewind()) {
+            // Record the read result on the task before completing it. A pending read that was cancelled by a
+            // cursor rewind (cursor.cancelPendingReadRequest() returned false) still delivers this callback
+            // with entries == null on the task; without setEntries(...) here, incCompletedEntries() cannot
+            // mark the task done, so it stays pending forever, occupies the single read slot, and blocks
+            // readMoreEntries() from ever scheduling another read (replication stalls).
+            inFlightTask.setEntries(entries);
             for (Entry entry : entries) {
                 inFlightTask.incCompletedEntries();
                 entry.release();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import io.netty.channel.EventLoopGroup;
 import java.util.ArrayList;
@@ -213,6 +214,64 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
 
             assertTrue(task.isDone());
             assertEquals(replicator.getPermitsIfNoPendingRead(), 1000);
+        } finally {
+            inFlightTasks.clear();
+            inFlightTasks.addAll(originalTasks);
+        }
+    }
+
+    /**
+     * Regression test for a replication stall observed at a schema boundary (e.g.
+     * {@code ReplicatorTest.testReplicationWithSchema}).
+     *
+     * <p>When a cursor rewind (for example a schema fetch) cancels in-flight reads while a cursor read has
+     * already been dispatched and cannot be cancelled, {@code cursor.cancelPendingReadRequest()} returns
+     * {@code false}, so {@code cancelPendingReadTasks(false)} flags the pending {@link InFlightTask} with
+     * {@code skipReadResultDueToCursorRewind=true} but leaves it {@code entries == null}. When that read later
+     * completes, {@code readEntriesComplete}'s skip branch must reconcile the task so it becomes
+     * {@code isDone()} and releases its read permit; otherwise the task occupies the single read slot forever
+     * ({@code getPermitsIfNoPendingRead()==0}, {@code hasPendingRead()==true}) and the replicator can never
+     * schedule another read, freezing replication.
+     */
+    @Test
+    public void testSkippedPendingReadDoesNotStallReplication() throws Exception {
+        PersistentReplicator replicator = spy(getReplicator(topicName));
+        // Isolate the InFlightTask state machine from the live read loop.
+        doNothing().when(replicator).readMoreEntries();
+
+        LinkedList<InFlightTask> inFlightTasks = replicator.inFlightTasks;
+        List<InFlightTask> originalTasks = new ArrayList<>(inFlightTasks);
+        inFlightTasks.clear();
+
+        try {
+            // A cursor read for 5 entries is in flight: entries == null means a pending cursor read.
+            InFlightTask pendingRead =
+                    new InFlightTask(PositionFactory.create(1, 1), 5, replicator.getReplicatorId());
+            inFlightTasks.add(pendingRead);
+            assertFalse(pendingRead.isDone());
+            // A pending read occupies the single read slot.
+            assertEquals(replicator.getPermitsIfNoPendingRead(), 0);
+            assertTrue(replicator.hasPendingRead());
+
+            // A cursor rewind fires while the read is already dispatched and cannot be cancelled
+            // (cursor.cancelPendingReadRequest() returned false -> cancelPendingReadTasks(false)): the pending
+            // task is flagged skip but left entries == null.
+            pendingRead.setSkipReadResultDueToCursorRewind(true);
+
+            // The dispatched read now completes with its 5 entries.
+            List<Entry> entries = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                entries.add(mock(Entry.class));
+            }
+            replicator.readEntriesComplete(entries, pendingRead);
+
+            // After the skipped read completes, the task must be reconciled so the read loop can resume.
+            assertTrue(pendingRead.isDone(),
+                    "skipped pending-read task must be done after its read completes; otherwise replication stalls");
+            assertEquals(replicator.getPermitsIfNoPendingRead(), 1000,
+                    "read permits must be restored after the skipped read completes");
+            assertFalse(replicator.hasPendingRead(),
+                    "no read must be considered pending after the skipped read completes");
         } finally {
             inFlightTasks.clear();
             inFlightTasks.addAll(originalTasks);


### PR DESCRIPTION
### Motivation

`PersistentReplicator.readEntriesComplete()` has a "skip" branch that runs when the replicator has terminated or when the read result must be discarded because the cursor was rewound (`InFlightTask.isSkipReadResultDueToCursorRewind()`). A cursor rewind happens, for example, when a new schema is detected and the replicator pauses to fetch it.

When a cursor rewind cancels in-flight reads, `cancelPendingReadTasks()` only resets the pending reading task to a completed state when `cursor.cancelPendingReadRequest()` returns `true`. If the read has already been dispatched to BookKeeper it cannot be cancelled, so the request returns `false` and the pending task is left with `entries == null` while still flagged with `skipReadResultDueToCursorRewind == true`.

That dispatched read still delivers a `readEntriesComplete()` callback. The skip branch then calls `InFlightTask.incCompletedEntries()` for each returned entry, but because the task's `entries` field is still `null`, `incCompletedEntries()` cannot increment `completedEntries` and instead logs `Unexpected calling of increase completed entries`. The task therefore never becomes `isDone()`: it permanently occupies the single read slot (`getPermitsIfNoPendingRead()` returns `0` and `hasPendingRead()` returns `true`), so `readMoreEntries()` can never schedule another read and replication for that direction stalls.

This was observed as a stall at a schema boundary — e.g. flaky failures of `ReplicatorTest.testReplicationWithSchema`, where messages produced with a second schema were never replicated and the consumers on the remote clusters timed out. The race requires a cursor read to already be dispatched to BookKeeper (so it can no longer be cancelled) at the moment the schema-fetch rewind runs, which is why it reproduces under the slower I/O timing of CI but is hard to reproduce on a fast local machine.

### Modifications

- In `readEntriesComplete()`'s skip branch, record the read result on the in-flight task (`setEntries(entries)`) before completing it, so the task becomes `isDone()` and releases its read permit, allowing the read loop to resume.
- Add `PersistentReplicatorInflightTaskTest.testSkippedPendingReadDoesNotStallReplication`, a deterministic regression test that reproduces the stall (a pending read flagged skip whose dispatched read then completes) and asserts the task is reconciled and read permits are restored.

### Verifying this change

This change added tests and can be verified as follows:

- `./gradlew :pulsar-broker:test --tests "org.apache.pulsar.broker.service.persistent.PersistentReplicatorInflightTaskTest.testSkippedPendingReadDoesNotStallReplication"` — the new test fails on `master` (the in-flight task is never completed, so read permits are never restored) and passes with this change.
- `./gradlew :pulsar-broker:test --tests "org.apache.pulsar.broker.service.persistent.PersistentReplicatorInflightTaskTest"` and `--tests "org.apache.pulsar.broker.service.ReplicatorTest.testReplicationWithSchema"` pass.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment