### PR TITLE
[improve][broker] PIP-486: entry-bucket wire format, hash & layout foundation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
@@ -341,6 +341,8 @@ public class DagWatchSession implements ScalableTopicResources.MetadataPathListe
             if (seg.legacyTopicName() != null) {
                 segProto.setLegacyTopicName(seg.legacyTopicName());
             }
+            // PIP-486: per-segment entry-bucket count (1 = no intra-segment bucketing).
+            segProto.setBucketCount(seg.bucketCount());
         }
 
         // Add broker addresses for active segments

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/DagWatchSession.java
@@ -341,8 +341,10 @@ public class DagWatchSession implements ScalableTopicResources.MetadataPathListe
             if (seg.legacyTopicName() != null) {
                 segProto.setLegacyTopicName(seg.legacyTopicName());
             }
-            // PIP-486: per-segment entry-bucket count (1 = no intra-segment bucketing).
-            segProto.setBucketCount(seg.bucketCount());
+            // PIP-486: per-segment entry-bucket split points (empty = single bucket).
+            for (int i = 0; i < seg.entryBucketSplits().size(); i++) {
+                segProto.addEntryBucketSplit(seg.entryBucketSplits().get(i));
+            }
         }
 
         // Add broker addresses for active segments

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -466,7 +467,7 @@ public class DagWatchSessionTest {
                 createdAtMs,
                 sealedAtMs,
                 null,
-                java.util.List.of());
+                List.of());
     }
 
     private static java.util.List<Long> toList(long[] arr) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
@@ -465,7 +465,8 @@ public class DagWatchSessionTest {
                 sealedAt,
                 createdAtMs,
                 sealedAtMs,
-                null);
+                null,
+                1);
     }
 
     private static java.util.List<Long> toList(long[] arr) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/DagWatchSessionTest.java
@@ -466,7 +466,7 @@ public class DagWatchSessionTest {
                 createdAtMs,
                 sealedAtMs,
                 null,
-                1);
+                java.util.List.of());
     }
 
     private static java.util.List<Long> toList(long[] arr) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -119,7 +120,7 @@ public class ScalableTopicControllerTest {
 
         // Default: all admin ops succeed.
         when(topics.getSubscriptionsAsync(anyString()))
-                .thenReturn(CompletableFuture.completedFuture(java.util.List.of()));
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
         when(scalableTopics.createSegmentAsync(anyString(), any()))
                 .thenReturn(CompletableFuture.completedFuture(null));
         when(scalableTopics.terminateSegmentAsync(anyString()))
@@ -308,7 +309,7 @@ public class ScalableTopicControllerTest {
 
         controller.unregisterConsumer("sub-a", "c1").get();
         assertEquals(resources.listConsumersAsync(topicName, "sub-a").get(),
-                java.util.List.of("c2"));
+                List.of("c2"));
     }
 
     @Test
@@ -537,21 +538,21 @@ public class ScalableTopicControllerTest {
                 0L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x0000, 0x3FFF),
                 org.apache.pulsar.common.scalable.SegmentState.SEALED,
-                java.util.List.of(), java.util.List.of(3L),
+                List.of(), List.of(3L),
                 /*createdAtEpoch*/ 0, /*sealedAtEpoch*/ 1,
-                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null, /*entryBucketSplits*/ java.util.List.of());
+                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null, /*entryBucketSplits*/ List.of());
         org.apache.pulsar.common.scalable.SegmentInfo seg1 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 1L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x4000, 0x7FFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
-                java.util.List.of(), java.util.List.of(),
-                0, -1, t1, -1, null, /*entryBucketSplits*/ java.util.List.of());
+                List.of(), List.of(),
+                0, -1, t1, -1, null, /*entryBucketSplits*/ List.of());
         org.apache.pulsar.common.scalable.SegmentInfo seg2 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 2L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x8000, 0xFFFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
-                java.util.List.of(), java.util.List.of(),
-                0, -1, t3, -1, null, /*entryBucketSplits*/ java.util.List.of());
+                List.of(), List.of(),
+                0, -1, t3, -1, null, /*entryBucketSplits*/ List.of());
 
         TopicName seekTopic = TopicName.get("topic://tenant/ns/seek-topic");
         ScalableTopicMetadata md = ScalableTopicMetadata.builder()
@@ -842,7 +843,7 @@ public class ScalableTopicControllerTest {
             assertEquals(parent.hashRange().start(), 0x0000);
             assertEquals(parent.hashRange().end(), org.apache.pulsar.common.scalable.HashRange.MAX_HASH);
             assertTrue(parent.parentIds().isEmpty());
-            assertEquals(parent.childIds(), java.util.List.of(3L, 4L, 5L));
+            assertEquals(parent.childIds(), List.of(3L, 4L, 5L));
         }
 
         // Children 3..5: active, range-based tiling, parents = [0,1,2], not legacy.
@@ -852,7 +853,7 @@ public class ScalableTopicControllerTest {
             org.apache.pulsar.common.scalable.SegmentInfo child = md.getSegments().get(id);
             assertTrue(child.isActive(), "child " + id + " must be active");
             assertFalse(child.isLegacy(), "child " + id + " must be a regular segment");
-            assertEquals(child.parentIds(), java.util.List.of(0L, 1L, 2L));
+            assertEquals(child.parentIds(), List.of(0L, 1L, 2L));
             assertTrue(child.childIds().isEmpty());
             int expectedStart = j * expectedWidth;
             assertEquals(child.hashRange().start(), expectedStart);
@@ -877,12 +878,12 @@ public class ScalableTopicControllerTest {
         assertTrue(parent.isSealed());
         assertTrue(parent.isLegacy());
         assertEquals(parent.legacyTopicName(), "persistent://tenant/ns/np-topic");
-        assertEquals(parent.childIds(), java.util.List.of(1L));
+        assertEquals(parent.childIds(), List.of(1L));
 
         org.apache.pulsar.common.scalable.SegmentInfo child = md.getSegments().get(1L);
         assertTrue(child.isActive());
         assertFalse(child.isLegacy());
-        assertEquals(child.parentIds(), java.util.List.of(0L));
+        assertEquals(child.parentIds(), List.of(0L));
         assertEquals(child.hashRange().start(), 0x0000);
         assertEquals(child.hashRange().end(), org.apache.pulsar.common.scalable.HashRange.MAX_HASH);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -539,19 +539,19 @@ public class ScalableTopicControllerTest {
                 org.apache.pulsar.common.scalable.SegmentState.SEALED,
                 java.util.List.of(), java.util.List.of(3L),
                 /*createdAtEpoch*/ 0, /*sealedAtEpoch*/ 1,
-                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null);
+                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null, /*bucketCount*/ 1);
         org.apache.pulsar.common.scalable.SegmentInfo seg1 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 1L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x4000, 0x7FFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
                 java.util.List.of(), java.util.List.of(),
-                0, -1, t1, -1, null);
+                0, -1, t1, -1, null, /*bucketCount*/ 1);
         org.apache.pulsar.common.scalable.SegmentInfo seg2 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 2L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x8000, 0xFFFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
                 java.util.List.of(), java.util.List.of(),
-                0, -1, t3, -1, null);
+                0, -1, t3, -1, null, /*bucketCount*/ 1);
 
         TopicName seekTopic = TopicName.get("topic://tenant/ns/seek-topic");
         ScalableTopicMetadata md = ScalableTopicMetadata.builder()

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/ScalableTopicControllerTest.java
@@ -539,19 +539,19 @@ public class ScalableTopicControllerTest {
                 org.apache.pulsar.common.scalable.SegmentState.SEALED,
                 java.util.List.of(), java.util.List.of(3L),
                 /*createdAtEpoch*/ 0, /*sealedAtEpoch*/ 1,
-                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null, /*bucketCount*/ 1);
+                /*createdAtMs*/ t0, /*sealedAtMs*/ t1, null, /*entryBucketSplits*/ java.util.List.of());
         org.apache.pulsar.common.scalable.SegmentInfo seg1 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 1L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x4000, 0x7FFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
                 java.util.List.of(), java.util.List.of(),
-                0, -1, t1, -1, null, /*bucketCount*/ 1);
+                0, -1, t1, -1, null, /*entryBucketSplits*/ java.util.List.of());
         org.apache.pulsar.common.scalable.SegmentInfo seg2 = new org.apache.pulsar.common.scalable.SegmentInfo(
                 2L,
                 org.apache.pulsar.common.scalable.HashRange.of(0x8000, 0xFFFF),
                 org.apache.pulsar.common.scalable.SegmentState.ACTIVE,
                 java.util.List.of(), java.util.List.of(),
-                0, -1, t3, -1, null, /*bucketCount*/ 1);
+                0, -1, t3, -1, null, /*entryBucketSplits*/ java.util.List.of());
 
         TopicName seekTopic = TopicName.get("topic://tenant/ns/seek-topic");
         ScalableTopicMetadata md = ScalableTopicMetadata.builder()

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
@@ -83,7 +83,8 @@ final class ClientSegmentLayout {
             // managed persistent:// topic) carry that URI. Regular controller-managed
             // segments leave it null and attach to segTopicName instead.
             String legacy = seg.hasLegacyTopicName() ? seg.getLegacyTopicName() : null;
-            ActiveSegment ref = new ActiveSegment(seg.getSegmentId(), range, segTopicName, legacy);
+            ActiveSegment ref = new ActiveSegment(seg.getSegmentId(), range, segTopicName, legacy,
+                    seg.getBucketCount());
             if (seg.getState() == org.apache.pulsar.common.api.proto.SegmentState.ACTIVE) {
                 activeSegments.add(ref);
             } else if (seg.getState() == org.apache.pulsar.common.api.proto.SegmentState.SEALED) {

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ClientSegmentLayout.java
@@ -83,8 +83,12 @@ final class ClientSegmentLayout {
             // managed persistent:// topic) carry that URI. Regular controller-managed
             // segments leave it null and attach to segTopicName instead.
             String legacy = seg.hasLegacyTopicName() ? seg.getLegacyTopicName() : null;
+            List<Integer> bucketSplits = new ArrayList<>(seg.getEntryBucketSplitsCount());
+            for (int j = 0; j < seg.getEntryBucketSplitsCount(); j++) {
+                bucketSplits.add(seg.getEntryBucketSplitAt(j));
+            }
             ActiveSegment ref = new ActiveSegment(seg.getSegmentId(), range, segTopicName, legacy,
-                    seg.getBucketCount());
+                    bucketSplits);
             if (seg.getState() == org.apache.pulsar.common.api.proto.SegmentState.ACTIVE) {
                 activeSegments.add(ref);
             } else if (seg.getState() == org.apache.pulsar.common.api.proto.SegmentState.SEALED) {

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
@@ -318,7 +318,8 @@ final class ScalableConsumerClient implements ScalableConsumerSession, AutoClose
                     s.getSegmentId(),
                     HashRange.of((int) s.getHashStart(), (int) s.getHashEnd()),
                     s.getSegmentTopic(),
-                    /*legacyTopicName*/ null));
+                    /*legacyTopicName*/ null,
+                    /*bucketCount, set by the controller assignment in a later PIP-486 PR*/ 1));
         }
         return Collections.unmodifiableList(segments);
     }

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableConsumerClient.java
@@ -319,7 +319,8 @@ final class ScalableConsumerClient implements ScalableConsumerSession, AutoClose
                     HashRange.of((int) s.getHashStart(), (int) s.getHashEnd()),
                     s.getSegmentTopic(),
                     /*legacyTopicName*/ null,
-                    /*bucketCount, set by the controller assignment in a later PIP-486 PR*/ 1));
+                    /*entryBucketSplits, set by the controller assignment in a later PIP-486 PR*/
+                    List.of()));
         }
         return Collections.unmodifiableList(segments);
     }

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -148,12 +148,16 @@ final class SegmentRouter {
      * {@code segmentTopicName} otherwise.
      */
     record ActiveSegment(long segmentId, HashRange hashRange, String segmentTopicName,
-                         String legacyTopicName, int bucketCount) {
+                         String legacyTopicName, List<Integer> entryBucketSplits) {
 
         ActiveSegment {
-            // PIP-486: a segment is divided into bucketCount entry-buckets (>= 1). Normalize so a
-            // missing/zero value (e.g. an older broker) behaves as a single bucket.
-            bucketCount = bucketCount > 0 ? bucketCount : 1;
+            // PIP-486: entry-bucket split points (empty = single bucket over the whole ring).
+            entryBucketSplits = entryBucketSplits != null ? List.copyOf(entryBucketSplits) : List.of();
+        }
+
+        /** Number of entry-buckets this segment is divided into ({@code entryBucketSplits.size()+1}). */
+        int bucketCount() {
+            return entryBucketSplits.size() + 1;
         }
 
         boolean isLegacy() {

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -18,15 +18,19 @@
  */
 package org.apache.pulsar.client.impl.v5;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pulsar.common.scalable.HashRange;
+import org.apache.pulsar.common.util.Murmur3_32Hash;
 
 /**
  * Routes messages to the correct segment based on key hashing.
  *
- * <p>Uses MurmurHash3 masked to a 16-bit hash space (0x0000-0xFFFF)
- * and finds the active segment whose hash range contains the hash.
+ * <p>Segment routing uses the <b>high 16 bits</b> of the key's {@code Murmur3_32} hash as a 16-bit
+ * hash space (0x0000-0xFFFF), and finds the active segment whose hash range contains it. The
+ * <b>low 16 bits</b> of the same hash are reserved for PIP-486 entry-bucketing
+ * ({@link #entryBucketHash}), so the two are independent.
  */
 final class SegmentRouter {
 
@@ -87,8 +91,7 @@ final class SegmentRouter {
      * ({@code signSafeMod(murmurHash3_32(key), N)}).
      */
     private static long routeModN(String key, List<ActiveSegment> activeSegments) {
-        int hash32 = org.apache.pulsar.common.util.Murmur3_32Hash.getInstance()
-                .makeHash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        int hash32 = Murmur3_32Hash.getInstance().makeHash(key.getBytes(StandardCharsets.UTF_8));
         int n = activeSegments.size();
         int partition = signSafeMod(hash32, n);
         for (var segment : activeSegments) {
@@ -105,19 +108,33 @@ final class SegmentRouter {
         return mod < 0 ? mod + divisor : mod;
     }
 
-    /**
-     * Compute the 16-bit hash for a key using MurmurHash3.
-     */
-    static int hash(String key) {
-        return hash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    /** The raw 32-bit {@code Murmur3_32} hash of the key — its two 16-bit halves drive the two
+     *  independent rings: high half → segment routing, low half → entry-bucketing (PIP-486). The
+     *  <i>raw</i> (unmasked) hash is required so the high half is full-range; {@code makeHash} clears
+     *  bit 31, which would confine the high half to [0, 0x7FFF]. */
+    static int murmur(byte[] keyBytes) {
+        return Murmur3_32Hash.makeRawHash(keyBytes);
     }
 
-    /**
-     * Compute the 16-bit hash for key bytes.
-     */
+    /** Compute the 16-bit segment-routing hash (high 16 bits of Murmur3) for a key. */
+    static int hash(String key) {
+        return hash(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Compute the 16-bit segment-routing hash (high 16 bits of Murmur3) for key bytes. */
     static int hash(byte[] keyBytes) {
-        int hash32 = org.apache.pulsar.common.util.Murmur3_32Hash.getInstance().makeHash(keyBytes);
-        return hash32 & HashRange.MAX_HASH;
+        return (murmur(keyBytes) >>> 16) & HashRange.MAX_HASH;
+    }
+
+    /** Compute the 16-bit entry-bucket hash (low 16 bits of Murmur3) for a key (PIP-486). Independent
+     *  of the segment-routing hash, so a segment's keys spread evenly across its entry buckets. */
+    static int entryBucketHash(String key) {
+        return entryBucketHash(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Compute the 16-bit entry-bucket hash (low 16 bits of Murmur3) for key bytes (PIP-486). */
+    static int entryBucketHash(byte[] keyBytes) {
+        return murmur(keyBytes) & HashRange.MAX_HASH;
     }
 
     /**

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -148,7 +148,13 @@ final class SegmentRouter {
      * {@code segmentTopicName} otherwise.
      */
     record ActiveSegment(long segmentId, HashRange hashRange, String segmentTopicName,
-                         String legacyTopicName) {
+                         String legacyTopicName, int bucketCount) {
+
+        ActiveSegment {
+            // PIP-486: a segment is divided into bucketCount entry-buckets (>= 1). Normalize so a
+            // missing/zero value (e.g. an older broker) behaves as a single bucket.
+            bucketCount = bucketCount > 0 ? bucketCount : 1;
+        }
 
         boolean isLegacy() {
             return legacyTopicName != null && !legacyTopicName.isEmpty();

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -108,33 +108,38 @@ final class SegmentRouter {
         return mod < 0 ? mod + divisor : mod;
     }
 
-    /** The raw 32-bit {@code Murmur3_32} hash of the key — its two 16-bit halves drive the two
-     *  independent rings: high half → segment routing, low half → entry-bucketing (PIP-486). The
-     *  <i>raw</i> (unmasked) hash is required so the high half is full-range; {@code makeHash} clears
-     *  bit 31, which would confine the high half to [0, 0x7FFF]. */
+    /**
+     * The raw 32-bit {@code Murmur3_32} hash of a key. Its two 16-bit halves drive the two independent
+     * rings — high half → segment routing ({@link #segmentHash}), low half → entry-bucketing
+     * ({@link #entryBucketHash}, PIP-486). Compute this <b>once</b> per key and split it, rather than
+     * hashing the key twice.
+     *
+     * <p>The <i>raw</i> (unmasked) hash is required so the high half is full-range: {@code makeHash}
+     * clears bit 31, which would confine the high half to {@code [0, 0x7FFF]}.
+     */
     static int murmur(byte[] keyBytes) {
         return Murmur3_32Hash.makeRawHash(keyBytes);
     }
 
-    /** Compute the 16-bit segment-routing hash (high 16 bits of Murmur3) for a key. */
+    /** The 16-bit segment-routing hash (high 16 bits) from a precomputed {@link #murmur(byte[])}. */
+    static int segmentHash(int murmur) {
+        return (murmur >>> 16) & HashRange.MAX_HASH;
+    }
+
+    /** The 16-bit entry-bucket hash (low 16 bits) from a precomputed {@link #murmur(byte[])} (PIP-486).
+     *  Independent of the segment-routing hash, so a segment's keys spread evenly across its buckets. */
+    static int entryBucketHash(int murmur) {
+        return murmur & HashRange.MAX_HASH;
+    }
+
+    /** Convenience: the segment-routing hash for a key. Equivalent to {@code segmentHash(murmur(key))}. */
     static int hash(String key) {
         return hash(key.getBytes(StandardCharsets.UTF_8));
     }
 
-    /** Compute the 16-bit segment-routing hash (high 16 bits of Murmur3) for key bytes. */
+    /** Convenience: the segment-routing hash for key bytes. Equivalent to {@code segmentHash(murmur(b))}. */
     static int hash(byte[] keyBytes) {
-        return (murmur(keyBytes) >>> 16) & HashRange.MAX_HASH;
-    }
-
-    /** Compute the 16-bit entry-bucket hash (low 16 bits of Murmur3) for a key (PIP-486). Independent
-     *  of the segment-routing hash, so a segment's keys spread evenly across its entry buckets. */
-    static int entryBucketHash(String key) {
-        return entryBucketHash(key.getBytes(StandardCharsets.UTF_8));
-    }
-
-    /** Compute the 16-bit entry-bucket hash (low 16 bits of Murmur3) for key bytes (PIP-486). */
-    static int entryBucketHash(byte[] keyBytes) {
-        return murmur(keyBytes) & HashRange.MAX_HASH;
+        return segmentHash(murmur(keyBytes));
     }
 
     /**

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
@@ -21,11 +21,13 @@ package org.apache.pulsar.client.impl.v5;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
 import org.apache.pulsar.common.scalable.HashRange;
+import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.testng.annotations.Test;
 
 public class SegmentRouterTest {
@@ -149,8 +151,7 @@ public class SegmentRouterTest {
         // mod-N over segment_id. Verify a handful of keys land on the expected
         // partition computed exactly as v4 would.
         for (String key : new String[]{"a", "customer-1", "customer-2", "order-99", ""}) {
-            int hash32 = org.apache.pulsar.common.util.Murmur3_32Hash.getInstance()
-                    .makeHash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            int hash32 = Murmur3_32Hash.getInstance().makeHash(key.getBytes(StandardCharsets.UTF_8));
             int mod = hash32 % n;
             int expected = mod < 0 ? mod + n : mod;
             assertEquals(router.route(key, segments), expected,
@@ -208,8 +209,26 @@ public class SegmentRouterTest {
     public void testHashStringAndBytesAgree() {
         String key = "some-key";
         int fromString = SegmentRouter.hash(key);
-        int fromBytes = SegmentRouter.hash(key.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        int fromBytes = SegmentRouter.hash(key.getBytes(StandardCharsets.UTF_8));
         assertEquals(fromString, fromBytes);
+    }
+
+    @Test
+    public void testMurmurDecouplesIntoSegmentAndBucketHash() {
+        // One Murmur3 hash splits into two independent 16-bit halves: high → segment, low → bucket.
+        for (String key : new String[]{"a", "order-42", "customer-99", ""}) {
+            int m = SegmentRouter.murmur(key.getBytes(StandardCharsets.UTF_8));
+            int seg = SegmentRouter.segmentHash(m);
+            int bucket = SegmentRouter.entryBucketHash(m);
+            // Both halves are 16-bit.
+            assertTrue(seg >= 0 && seg <= 0xFFFF, "segmentHash out of 16-bit range: " + seg);
+            assertTrue(bucket >= 0 && bucket <= 0xFFFF, "entryBucketHash out of 16-bit range: " + bucket);
+            // They are exactly the high and low halves of the same hash.
+            assertEquals(seg, (m >>> 16) & 0xFFFF);
+            assertEquals(bucket, m & 0xFFFF);
+            // The hash(key) convenience agrees with the decoupled segment hash.
+            assertEquals(SegmentRouter.hash(key), seg);
+        }
     }
 
     // --- helpers ---

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
@@ -31,12 +31,12 @@ import org.testng.annotations.Test;
 public class SegmentRouterTest {
 
     private static ActiveSegment seg(long id, int start, int end) {
-        return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id, null);
+        return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id, null, 1);
     }
 
     /** Build a legacy segment (synthetic-layout entry wrapping an externally managed persistent:// topic). */
     private static ActiveSegment legacySeg(long id, int start, int end, String underlying) {
-        return new ActiveSegment(id, HashRange.of(start, end), "segment://t/n/x/" + id, underlying);
+        return new ActiveSegment(id, HashRange.of(start, end), "segment://t/n/x/" + id, underlying, 1);
     }
 
     // --- route(key, ...) ---

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
@@ -31,12 +31,14 @@ import org.testng.annotations.Test;
 public class SegmentRouterTest {
 
     private static ActiveSegment seg(long id, int start, int end) {
-        return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id, null, 1);
+        return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id, null,
+                java.util.List.of());
     }
 
     /** Build a legacy segment (synthetic-layout entry wrapping an externally managed persistent:// topic). */
     private static ActiveSegment legacySeg(long id, int start, int end, String underlying) {
-        return new ActiveSegment(id, HashRange.of(start, end), "segment://t/n/x/" + id, underlying, 1);
+        return new ActiveSegment(id, HashRange.of(start, end), "segment://t/n/x/" + id, underlying,
+                java.util.List.of());
     }
 
     // --- route(key, ...) ---

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/SegmentRouterTest.java
@@ -32,13 +32,13 @@ public class SegmentRouterTest {
 
     private static ActiveSegment seg(long id, int start, int end) {
         return new ActiveSegment(id, HashRange.of(start, end), "persistent://t/n/seg-" + id, null,
-                java.util.List.of());
+                List.of());
     }
 
     /** Build a legacy segment (synthetic-layout entry wrapping an externally managed persistent:// topic). */
     private static ActiveSegment legacySeg(long id, int start, int end, String underlying) {
         return new ActiveSegment(id, HashRange.of(start, end), "segment://t/n/x/" + id, underlying,
-                java.util.List.of());
+                List.of());
     }
 
     // --- route(key, ...) ---

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/SegmentInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/SegmentInfo.java
@@ -54,10 +54,11 @@ import java.util.List;
  * @param legacyTopicName    for legacy segments: the externally managed
  *                           {@code persistent://...} topic this segment wraps.
  *                           {@code null} for regular controller-managed segments.
- * @param bucketCount        number of entry-buckets this segment is divided into (PIP-486),
- *                           immutable for the segment's life. Defaults to 1 (no intra-segment
- *                           bucketing). A value of {@code <= 0} (e.g. from older persisted
- *                           metadata) is normalized to 1.
+ * @param entryBucketSplits  PIP-486 entry-bucket split points: the ascending, inclusive start hashes
+ *                           of buckets 1..N-1 within the 16-bit entry-bucket ring (bucket 0 implicitly
+ *                           starts at 0x0000). The segment has {@code entryBucketSplits.size() + 1}
+ *                           buckets; an empty list means a single bucket over the whole ring. Splits
+ *                           may be uneven. Immutable for the segment's life.
  */
 public record SegmentInfo(
         long segmentId,
@@ -70,26 +71,31 @@ public record SegmentInfo(
         long createdAtMs,
         long sealedAtMs,
         String legacyTopicName,
-        int bucketCount
+        List<Integer> entryBucketSplits
 ) {
     public SegmentInfo {
         parentIds = parentIds != null ? List.copyOf(parentIds) : List.of();
         childIds = childIds != null ? List.copyOf(childIds) : List.of();
-        bucketCount = bucketCount > 0 ? bucketCount : 1;
+        entryBucketSplits = entryBucketSplits != null ? List.copyOf(entryBucketSplits) : List.of();
+    }
+
+    /** Number of entry-buckets this segment is divided into ({@code entryBucketSplits.size() + 1}). */
+    public int bucketCount() {
+        return entryBucketSplits.size() + 1;
     }
 
     /** Create a new active segment with no parents (single entry-bucket). */
     public static SegmentInfo active(long segmentId, HashRange hashRange,
                                      long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, null, 1);
+                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, null, List.of());
     }
 
     /** Create a new active segment with the given parent IDs (single entry-bucket). */
     public static SegmentInfo active(long segmentId, HashRange hashRange,
                                      List<Long> parentIds, long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                parentIds, List.of(), createdAtEpoch, -1, createdAtMs, -1, null, 1);
+                parentIds, List.of(), createdAtEpoch, -1, createdAtMs, -1, null, List.of());
     }
 
     /**
@@ -101,35 +107,35 @@ public record SegmentInfo(
                                            String legacyTopicName,
                                            long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, legacyTopicName, 1);
+                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, legacyTopicName, List.of());
     }
 
     /** Return a sealed copy of this segment with the given child IDs. */
     public SegmentInfo sealed(long sealedAtEpoch, long sealedAtMs, List<Long> childIds) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.SEALED,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName, bucketCount);
+                legacyTopicName, entryBucketSplits);
     }
 
     /** Return a copy with different parent IDs. */
     public SegmentInfo withParentIds(List<Long> parentIds) {
         return new SegmentInfo(segmentId, hashRange, state,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName, bucketCount);
+                legacyTopicName, entryBucketSplits);
     }
 
     /** Return a copy with different child IDs. */
     public SegmentInfo withChildIds(List<Long> childIds) {
         return new SegmentInfo(segmentId, hashRange, state,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName, bucketCount);
+                legacyTopicName, entryBucketSplits);
     }
 
-    /** Return a copy with a different entry-bucket count (PIP-486). */
-    public SegmentInfo withBucketCount(int bucketCount) {
+    /** Return a copy with different entry-bucket split points (PIP-486). */
+    public SegmentInfo withEntryBucketSplits(List<Integer> entryBucketSplits) {
         return new SegmentInfo(segmentId, hashRange, state,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName, bucketCount);
+                legacyTopicName, entryBucketSplits);
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/SegmentInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/SegmentInfo.java
@@ -54,6 +54,10 @@ import java.util.List;
  * @param legacyTopicName    for legacy segments: the externally managed
  *                           {@code persistent://...} topic this segment wraps.
  *                           {@code null} for regular controller-managed segments.
+ * @param bucketCount        number of entry-buckets this segment is divided into (PIP-486),
+ *                           immutable for the segment's life. Defaults to 1 (no intra-segment
+ *                           bucketing). A value of {@code <= 0} (e.g. from older persisted
+ *                           metadata) is normalized to 1.
  */
 public record SegmentInfo(
         long segmentId,
@@ -65,25 +69,27 @@ public record SegmentInfo(
         long sealedAtEpoch,
         long createdAtMs,
         long sealedAtMs,
-        String legacyTopicName
+        String legacyTopicName,
+        int bucketCount
 ) {
     public SegmentInfo {
         parentIds = parentIds != null ? List.copyOf(parentIds) : List.of();
         childIds = childIds != null ? List.copyOf(childIds) : List.of();
+        bucketCount = bucketCount > 0 ? bucketCount : 1;
     }
 
-    /** Create a new active segment with no parents. */
+    /** Create a new active segment with no parents (single entry-bucket). */
     public static SegmentInfo active(long segmentId, HashRange hashRange,
                                      long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, null);
+                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, null, 1);
     }
 
-    /** Create a new active segment with the given parent IDs. */
+    /** Create a new active segment with the given parent IDs (single entry-bucket). */
     public static SegmentInfo active(long segmentId, HashRange hashRange,
                                      List<Long> parentIds, long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                parentIds, List.of(), createdAtEpoch, -1, createdAtMs, -1, null);
+                parentIds, List.of(), createdAtEpoch, -1, createdAtMs, -1, null, 1);
     }
 
     /**
@@ -95,28 +101,35 @@ public record SegmentInfo(
                                            String legacyTopicName,
                                            long createdAtEpoch, long createdAtMs) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.ACTIVE,
-                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, legacyTopicName);
+                List.of(), List.of(), createdAtEpoch, -1, createdAtMs, -1, legacyTopicName, 1);
     }
 
     /** Return a sealed copy of this segment with the given child IDs. */
     public SegmentInfo sealed(long sealedAtEpoch, long sealedAtMs, List<Long> childIds) {
         return new SegmentInfo(segmentId, hashRange, SegmentState.SEALED,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName);
+                legacyTopicName, bucketCount);
     }
 
     /** Return a copy with different parent IDs. */
     public SegmentInfo withParentIds(List<Long> parentIds) {
         return new SegmentInfo(segmentId, hashRange, state,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName);
+                legacyTopicName, bucketCount);
     }
 
     /** Return a copy with different child IDs. */
     public SegmentInfo withChildIds(List<Long> childIds) {
         return new SegmentInfo(segmentId, hashRange, state,
                 parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
-                legacyTopicName);
+                legacyTopicName, bucketCount);
+    }
+
+    /** Return a copy with a different entry-bucket count (PIP-486). */
+    public SegmentInfo withBucketCount(int bucketCount) {
+        return new SegmentInfo(segmentId, hashRange, state,
+                parentIds, childIds, createdAtEpoch, sealedAtEpoch, createdAtMs, sealedAtMs,
+                legacyTopicName, bucketCount);
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/Murmur3_32Hash.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/Murmur3_32Hash.java
@@ -53,6 +53,17 @@ public class Murmur3_32Hash implements Hash {
         return makeHash0(b) & Integer.MAX_VALUE;
     }
 
+    /**
+     * The raw, signed 32-bit MurmurHash3 of {@code b}, <i>without</i> the sign-bit masking that
+     * {@link #makeHash(byte[])} applies. Useful when both 16-bit halves of the hash are needed as
+     * independent, full-range fields — e.g. PIP-486 routes scalable-topic segments on the high half
+     * and entry-buckets on the low half. ({@link #makeHash(byte[])} clears bit 31, which would make
+     * the high half only span [0, 0x7FFF].)
+     */
+    public static int makeRawHash(byte[] b) {
+        return instance.makeHash0(b);
+    }
+
     private int makeHash0(byte[] bytes) {
         int len = bytes.length;
         int reminder = len % CHUNK_SIZE;

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -871,6 +871,11 @@ message SegmentInfoProto {
     // been migrated to a scalable topic. When absent, the segment URI is computed normally
     // from the scalable topic name and segment_id (segment://<topic>/<descriptor>).
     optional string legacy_topic_name = 11;
+
+    // PIP-486: number of entry-buckets this segment is divided into. Equal-width sub-ranges of the
+    // 16-bit entry-bucket hash ring; producers bucket their batches accordingly and the broker routes
+    // by bucket. Defaults to 1 (no intra-segment bucketing).
+    optional uint32 bucket_count = 12 [default = 1];
 }
 
 message SegmentBrokerAddress {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -175,6 +175,13 @@ message MessageMetadata {
     // messages (e.g., `k1 => v1` and `k1 => null` in the example above).
     repeated int32 compacted_batch_indexes = 31;
     optional bytes schema_id = 32;
+
+    // PIP-486 scalable-topic entry-bucketing. The effective entry-bucket hash range covered by this
+    // entry: the smallest and largest entry-bucket hash (the low 16 bits of the key's Murmur3_32 hash)
+    // among the batched messages, both bounds inclusive. Set only by scalable-topic (segment://)
+    // producers; the broker routes the whole entry to the consumer owning that bucket on the segment.
+    optional uint32 entry_hash_min = 33;
+    optional uint32 entry_hash_max = 34;
 }
 
 message SingleMessageMetadata {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -872,10 +872,12 @@ message SegmentInfoProto {
     // from the scalable topic name and segment_id (segment://<topic>/<descriptor>).
     optional string legacy_topic_name = 11;
 
-    // PIP-486: number of entry-buckets this segment is divided into. Equal-width sub-ranges of the
-    // 16-bit entry-bucket hash ring; producers bucket their batches accordingly and the broker routes
-    // by bucket. Defaults to 1 (no intra-segment bucketing).
-    optional uint32 bucket_count = 12 [default = 1];
+    // PIP-486: entry-bucket split points — the ascending, inclusive start hashes of buckets 1..N-1
+    // within the 16-bit entry-bucket hash ring (bucket 0 implicitly starts at 0x0000). The segment is
+    // divided into entry_bucket_splits_count + 1 buckets; an empty list means a single bucket spanning
+    // the whole ring. Splits may be uneven (e.g. to balance buckets by traffic). Producers bucket their
+    // batches accordingly and the broker routes by bucket.
+    repeated uint32 entry_bucket_splits = 12;
 }
 
 message SegmentBrokerAddress {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/Murmur3_32HashTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/Murmur3_32HashTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.nio.charset.StandardCharsets;
+import org.testng.annotations.Test;
+
+@SuppressWarnings("checkstyle:TypeName")
+public class Murmur3_32HashTest {
+
+    private static byte[] b(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testMakeRawHashIsDeterministic() {
+        assertEquals(Murmur3_32Hash.makeRawHash(b("deterministic-key")),
+                Murmur3_32Hash.makeRawHash(b("deterministic-key")));
+        assertEquals(Murmur3_32Hash.makeRawHash(b("")), Murmur3_32Hash.makeRawHash(b("")));
+    }
+
+    @Test
+    public void testMakeRawHashIsUnmaskedMakeHash() {
+        // makeHash() is makeRawHash() with the sign bit cleared. Verify that relationship holds, and
+        // that the low 16 bits (used for PIP-486 entry-bucketing) are identical for both.
+        for (int i = 0; i < 1000; i++) {
+            byte[] key = b("key-" + i);
+            int raw = Murmur3_32Hash.makeRawHash(key);
+            int masked = Murmur3_32Hash.getInstance().makeHash(key);
+            assertEquals(raw & Integer.MAX_VALUE, masked, "key-" + i);
+            assertEquals(raw & 0xFFFF, masked & 0xFFFF, "low 16 bits differ for key-" + i);
+        }
+    }
+
+    @Test
+    public void testMakeRawHashHighHalfIsFullRange() {
+        // The reason makeRawHash exists: the high 16 bits must be full-range. makeHash clears bit 31,
+        // so its high half never reaches 0x8000; the raw hash's high half does.
+        boolean rawReachesUpperHalf = false;
+        boolean maskedReachesUpperHalf = false;
+        for (int i = 0; i < 5000; i++) {
+            byte[] key = b("key-" + i);
+            if (((Murmur3_32Hash.makeRawHash(key) >>> 16) & 0xFFFF) >= 0x8000) {
+                rawReachesUpperHalf = true;
+            }
+            if (((Murmur3_32Hash.getInstance().makeHash(key) >>> 16) & 0xFFFF) >= 0x8000) {
+                maskedReachesUpperHalf = true;
+            }
+        }
+        assertTrue(rawReachesUpperHalf, "raw hash high 16 bits should span the full range");
+        assertFalse(maskedReachesUpperHalf,
+                "makeHash high 16 bits should never reach 0x8000 (bit 31 is cleared)");
+    }
+}


### PR DESCRIPTION
### Motivation

This is the **first implementation PR for [PIP-486: Scalable Topic Key-Shared Consumption](https://github.com/apache/pulsar/blob/master/pip/pip-486.md)** (the PIP was merged in #26077).

PIP-486 adds key-shared (per-message-key) ordered consumption on scalable topics via producer-side
**entry-bucketing**, so multiple consumers can share one segment without coupling the producer's
batching mode to the consumer's subscription mode. The full feature lands across a series of PRs; this
one is the **protocol + hash + layout foundation** and is intentionally **behavior-neutral** — with a
single entry-bucket per segment (the default), everything behaves exactly as today.

### Modifications

- **Wire format (`MessageMetadata`):** add optional `entry_hash_min`/`entry_hash_max` (the effective
  entry-bucket hash range a batch covers; set by scalable-topic producers in a later PR).
- **Bucket hash:** `Murmur3_32Hash.makeRawHash()` — the *unmasked* 32-bit hash. `makeHash()` clears the
  sign bit, which would confine the high 16 bits to `[0, 0x7FFF]`; the raw hash keeps both halves
  full-range. `SegmentRouter` now routes **segments on the high 16 bits** and exposes
  `entryBucketHash()` on the **low 16 bits** (independent ring, PIP-486), with `murmur()` so a caller
  hashes once and splits.
- **Per-segment layout:** `SegmentInfoProto` carries `entry_bucket_splits` — an explicit, possibly
  **uneven** list of bucket split points (empty = a single bucket spanning the whole ring). Plumbed
  through `SegmentInfo`, `DagWatchSession`, and the V5 client (`ClientSegmentLayout` /
  `SegmentRouter.ActiveSegment`). Default is empty/`N=1`.

All new fields default such that existing behavior is unchanged (`N=1`). Tests added for `makeRawHash`
and the decoupled hash API; existing scalable tests updated for the new `SegmentInfo` shape.

Subsequent PRs add producer entry-bucketing, broker bucket-routing + controller assignment, the V5
consumer wiring, and the auto-scale policy.
