### PR TITLE
[improve][client] PIP-486 (PR1): producer entry-bucketing for scalable topics

### DIFF
--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.v5.Producer;
 import org.apache.pulsar.client.api.v5.PulsarClientException;
 import org.apache.pulsar.client.api.v5.async.AsyncProducer;
 import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.client.impl.EntryBucketBatcherBuilder;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
@@ -582,6 +583,15 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
             if (producerConf.getProducerName() != null
                     && !producerConf.getProducerName().isEmpty()) {
                 segConf.setProducerName(producerConf.getProducerName() + "-seg-" + id);
+            }
+            // PIP-486 entry-bucketing. End-to-end encryption disables batching (an encrypted batch
+            // can't be reshaped if re-routed across a divergent layout); otherwise, when batching is
+            // enabled, route this segment's batches by entry-bucket so the broker can dispatch a whole
+            // entry to one consumer. A segment's bucketing is immutable for its life.
+            if (segConf.isEncryptionEnabled()) {
+                segConf.setBatchingEnabled(false);
+            } else if (segConf.isBatchingEnabled()) {
+                segConf.setBatcherBuilder(new EntryBucketBatcherBuilder(segment.entryBucketSplits()));
             }
             return v4Client.createSegmentProducerAsync(segConf, v4Schema);
         });

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducer.java
@@ -584,17 +584,23 @@ final class ScalableTopicProducer<T> implements Producer<T>, DagWatchClient.Layo
                     && !producerConf.getProducerName().isEmpty()) {
                 segConf.setProducerName(producerConf.getProducerName() + "-seg-" + id);
             }
-            // PIP-486 entry-bucketing. End-to-end encryption disables batching (an encrypted batch
-            // can't be reshaped if re-routed across a divergent layout); otherwise, when batching is
-            // enabled, route this segment's batches by entry-bucket so the broker can dispatch a whole
-            // entry to one consumer. A segment's bucketing is immutable for its life.
-            if (segConf.isEncryptionEnabled()) {
-                segConf.setBatchingEnabled(false);
-            } else if (segConf.isBatchingEnabled()) {
-                segConf.setBatcherBuilder(new EntryBucketBatcherBuilder(segment.entryBucketSplits()));
-            }
+            applyEntryBucketing(segConf, segment);
             return v4Client.createSegmentProducerAsync(segConf, v4Schema);
         });
+    }
+
+    /**
+     * PIP-486: configure a per-segment producer's batching for entry-bucketing. End-to-end encryption
+     * disables batching (an encrypted batch can't be reshaped if re-routed across a divergent layout);
+     * otherwise, when batching is enabled, route the segment's batches by entry-bucket so the broker can
+     * dispatch a whole entry to one consumer. A segment's bucketing is immutable for its life.
+     */
+    static void applyEntryBucketing(ProducerConfigurationData segConf, ActiveSegment segment) {
+        if (segConf.isEncryptionEnabled()) {
+            segConf.setBatchingEnabled(false);
+        } else if (segConf.isBatchingEnabled()) {
+            segConf.setBatcherBuilder(new EntryBucketBatcherBuilder(segment.entryBucketSplits()));
+        }
     }
 
     /**

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/SegmentRouter.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pulsar.common.scalable.HashRange;
+import org.apache.pulsar.common.scalable.ScalableTopicHashing;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 
 /**
@@ -118,18 +119,18 @@ final class SegmentRouter {
      * clears bit 31, which would confine the high half to {@code [0, 0x7FFF]}.
      */
     static int murmur(byte[] keyBytes) {
-        return Murmur3_32Hash.makeRawHash(keyBytes);
+        return ScalableTopicHashing.murmur(keyBytes);
     }
 
     /** The 16-bit segment-routing hash (high 16 bits) from a precomputed {@link #murmur(byte[])}. */
     static int segmentHash(int murmur) {
-        return (murmur >>> 16) & HashRange.MAX_HASH;
+        return ScalableTopicHashing.segmentHash(murmur);
     }
 
     /** The 16-bit entry-bucket hash (low 16 bits) from a precomputed {@link #murmur(byte[])} (PIP-486).
      *  Independent of the segment-routing hash, so a segment's keys spread evenly across its buckets. */
     static int entryBucketHash(int murmur) {
-        return murmur & HashRange.MAX_HASH;
+        return ScalableTopicHashing.entryBucketHash(murmur);
     }
 
     /** Convenience: the segment-routing hash for a key. Equivalent to {@code segmentHash(murmur(key))}. */

--- a/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducerTest.java
+++ b/pulsar-client-v5/src/test/java/org/apache/pulsar/client/impl/v5/ScalableTopicProducerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.v5;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.EncryptionKeyInfo;
+import org.apache.pulsar.client.impl.EntryBucketBatcherBuilder;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.client.impl.v5.SegmentRouter.ActiveSegment;
+import org.apache.pulsar.common.scalable.HashRange;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link ScalableTopicProducer#applyEntryBucketing} — the PIP-486 wiring that picks a
+ * per-segment producer's batching mode.
+ */
+public class ScalableTopicProducerTest {
+
+    private static ActiveSegment segment() {
+        return new ActiveSegment(0L, HashRange.of(0x0000, 0xFFFF), "segment://t/n/x/0", null,
+                List.of(0x8000));
+    }
+
+    @Test
+    public void testBatchingEnabledUsesEntryBucketBatcher() {
+        ProducerConfigurationData conf = new ProducerConfigurationData();
+        ScalableTopicProducer.applyEntryBucketing(conf, segment());
+        assertTrue(conf.isBatchingEnabled());
+        assertTrue(conf.getBatcherBuilder() instanceof EntryBucketBatcherBuilder);
+    }
+
+    @Test
+    public void testEncryptionDisablesBatching() {
+        ProducerConfigurationData conf = new ProducerConfigurationData();
+        conf.setEncryptionKeys(Set.of("my-key"));
+        conf.setCryptoKeyReader(new CryptoKeyReader() {
+            @Override
+            public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> metadata) {
+                return null;
+            }
+
+            @Override
+            public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> metadata) {
+                return null;
+            }
+        });
+        ScalableTopicProducer.applyEntryBucketing(conf, segment());
+        assertFalse(conf.isBatchingEnabled());
+        assertFalse(conf.getBatcherBuilder() instanceof EntryBucketBatcherBuilder);
+    }
+
+    @Test
+    public void testBatchingAlreadyDisabledIsLeftUntouched() {
+        ProducerConfigurationData conf = new ProducerConfigurationData();
+        conf.setBatchingEnabled(false);
+        ScalableTopicProducer.applyEntryBucketing(conf, segment());
+        assertFalse(conf.isBatchingEnabled());
+        assertFalse(conf.getBatcherBuilder() instanceof EntryBucketBatcherBuilder);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainerImpl.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.ToIntFunction;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
@@ -62,6 +63,31 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
     protected SendCallback previousCallback = null;
     // keep track of callbacks for individual messages being published in a batch
     protected SendCallback firstCallback;
+
+    // PIP-486: when set, createOpSendMsg() stamps entry_hash_min/max on the batch metadata from the
+    // min/max entry-bucket hash of the batch's messages. Null for non-scalable producers (no stamping,
+    // so the path is byte-identical to before).
+    private ToIntFunction<MessageImpl<?>> entryBucketHashFn;
+
+    void setEntryBucketHashFn(ToIntFunction<MessageImpl<?>> entryBucketHashFn) {
+        this.entryBucketHashFn = entryBucketHashFn;
+    }
+
+    /** PIP-486: stamp the effective entry-bucket hash range (min/max over the batch's messages). */
+    private void stampEntryBucketRange() {
+        if (entryBucketHashFn == null || messages.isEmpty()) {
+            return;
+        }
+        int min = Integer.MAX_VALUE;
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < messages.size(); i++) {
+            int h = entryBucketHashFn.applyAsInt(messages.get(i));
+            min = Math.min(min, h);
+            max = Math.max(max, h);
+        }
+        messageMetadata.setEntryHashMin(min);
+        messageMetadata.setEntryHashMax(max);
+    }
 
     protected final ByteBufAllocator allocator;
     private static final int SHRINK_COOLING_OFF_PERIOD = 10;
@@ -268,6 +294,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         if (messages.size() == 1) {
             messageMetadata.clear();
             messageMetadata.copyFrom(messages.get(0).getMessageBuilder());
+            stampEntryBucketRange();
             ByteBuf encryptedPayload = producer.encryptMessage(messageMetadata,
                     getCompressedBatchMetadataAndPayload());
             updateAndReserveBatchAllocatedSize(encryptedPayload.capacity());
@@ -323,6 +350,7 @@ class BatchMessageContainerImpl extends AbstractBatchMessageContainer {
         if (currentTxnidLeastBits != -1) {
             messageMetadata.setTxnidLeastBits(currentTxnidLeastBits);
         }
+        stampEntryBucketRange();
         ByteBufPair cmd = producer.sendMessage(producer.producerId, messageMetadata.getSequenceId(),
                 messageMetadata.getHighestSequenceId(), numMessagesInBatch, messageMetadata, encryptedPayload);
             log.debug(e -> e.attr("topic", topicName)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
-import org.apache.pulsar.common.util.Murmur3_32Hash;
+import org.apache.pulsar.common.scalable.ScalableTopicHashing;
 
 /**
  * PIP-486 entry-bucket batch container for scalable topics.
@@ -81,7 +81,7 @@ class EntryBucketBatchContainer extends AbstractBatchMessageContainer {
         } else {
             return 0;
         }
-        return Murmur3_32Hash.makeRawHash(keyBytes) & 0xFFFF;
+        return ScalableTopicHashing.entryBucketHash(ScalableTopicHashing.murmur(keyBytes));
     }
 
     /** The bucket a hash falls in: the number of split points {@code <=} it (splits are ascending). */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatchContainer.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.apache.pulsar.common.util.Murmur3_32Hash;
+
+/**
+ * PIP-486 entry-bucket batch container for scalable topics.
+ *
+ * <p>Within one segment, each message's key maps to an <i>entry-bucket</i> — a contiguous sub-range of
+ * the 16-bit entry-bucket hash ring (the low 16 bits of the key's {@code Murmur3_32} hash). This
+ * container keeps each batch within a single bucket (one {@link BatchMessageContainerImpl} per bucket),
+ * so the broker can route a whole entry to the consumer owning that bucket without reading per-message
+ * keys. Each emitted batch stamps {@code entry_hash_min}/{@code entry_hash_max} — the effective range of
+ * its messages — via {@link BatchMessageContainerImpl}'s hook.
+ *
+ * <p>The buckets are defined by {@code splits}: the ascending, inclusive bucket-start hashes of buckets
+ * {@code 1..N-1} (bucket 0 implicitly starts at {@code 0x0000}). An empty list means a single bucket
+ * spanning the whole ring — in which case this behaves like the default batcher plus the stamping.
+ */
+@CustomLog
+class EntryBucketBatchContainer extends AbstractBatchMessageContainer {
+
+    private final int[] splits;
+    private final Map<Integer, BatchMessageContainerImpl> batches = new HashMap<>();
+
+    EntryBucketBatchContainer(List<Integer> entryBucketSplits) {
+        this.splits = entryBucketSplits == null ? new int[0]
+                : entryBucketSplits.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    @Override
+    public boolean add(MessageImpl<?> msg, SendCallback callback) {
+        int bucket = bucketOf(splits, entryBucketHash(msg));
+        final BatchMessageContainerImpl batchMessageContainer = batches.computeIfAbsent(bucket, __ -> {
+            BatchMessageContainerImpl c = new BatchMessageContainerImpl(producer);
+            c.setEntryBucketHashFn(this::entryBucketHash);
+            return c;
+        });
+        batchMessageContainer.add(msg, callback);
+        // `add` fails iff the container was empty and `msg` (the first message) failed; then the
+        // container is cleared and there is nothing to count.
+        if (!batchMessageContainer.isEmpty()) {
+            numMessagesInBatch++;
+            currentBatchSizeBytes += msg.getDataBuffer().readableBytes();
+        }
+        tryUpdateTimestamp();
+        return isBatchFull();
+    }
+
+    /** The 16-bit entry-bucket hash (low 16 bits of {@code Murmur3_32}) of a message's key. */
+    private int entryBucketHash(MessageImpl<?> msg) {
+        byte[] keyBytes;
+        if (msg.hasOrderingKey()) {
+            keyBytes = msg.getOrderingKey();
+        } else if (msg.getKey() != null) {
+            keyBytes = msg.getKey().getBytes(StandardCharsets.UTF_8);
+        } else {
+            return 0;
+        }
+        return Murmur3_32Hash.makeRawHash(keyBytes) & 0xFFFF;
+    }
+
+    /** The bucket a hash falls in: the number of split points {@code <=} it (splits are ascending). */
+    static int bucketOf(int[] splits, int hash) {
+        int idx = 0;
+        for (int split : splits) {
+            if (split <= hash) {
+                idx++;
+            } else {
+                break;
+            }
+        }
+        return idx;
+    }
+
+    @Override
+    public void clear() {
+        clearTimestamp();
+        numMessagesInBatch = 0;
+        currentBatchSizeBytes = 0;
+        batches.clear();
+        currentTxnidMostBits = -1L;
+        currentTxnidLeastBits = -1L;
+        batchAllocatedSizeBytes = 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return batches.isEmpty();
+    }
+
+    @Override
+    public void discard(Exception ex) {
+        batches.forEach((k, v) -> v.discard(ex));
+        clear();
+    }
+
+    @Override
+    public boolean isMultiBatches() {
+        return true;
+    }
+
+    @Override
+    public int getBatchAllocatedSizeBytes() {
+        return batches.values().stream().mapToInt(AbstractBatchMessageContainer::getBatchAllocatedSizeBytes).sum();
+    }
+
+    @Override
+    public List<ProducerImpl.OpSendMsg> createOpSendMsgs() throws IOException {
+        try {
+            // As in key-based batching: within a bucket the sequence ids need not be contiguous, so
+            // collapse to the highest sequence id and drop the highest_sequence_id field to allow the
+            // broker's weak-order check to pass.
+            batches.values().forEach(c -> c.setLowestSequenceId(c.getHighestSequenceId()));
+            return batches.values().stream()
+                    .sorted((o1, o2) -> (int) (o1.getLowestSequenceId() - o2.getLowestSequenceId()))
+                    .map(c -> {
+                        try {
+                            return c.createOpSendMsg();
+                        } catch (IOException e) {
+                            throw new IllegalStateException(e);
+                        }
+                    }).collect(Collectors.toList());
+        } catch (IllegalStateException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public void resetPayloadAfterFailedPublishing() {
+        for (BatchMessageContainerImpl batch : batches.values()) {
+            batch.resetPayloadAfterFailedPublishing();
+        }
+    }
+
+    @Override
+    public boolean hasSameSchema(MessageImpl<?> msg) {
+        BatchMessageContainerImpl c = batches.get(bucketOf(splits, entryBucketHash(msg)));
+        return c == null || c.hasSameSchema(msg);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatcherBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EntryBucketBatcherBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.List;
+import org.apache.pulsar.client.api.BatchMessageContainer;
+import org.apache.pulsar.client.api.BatcherBuilder;
+
+/**
+ * PIP-486: builds an {@link EntryBucketBatchContainer} that groups a scalable-topic segment producer's
+ * batches by entry-bucket. The segment's bucket {@code splits} are captured at construction (a segment's
+ * bucketing is immutable for its life), so the V5 producer sets one of these per per-segment producer.
+ */
+public class EntryBucketBatcherBuilder implements BatcherBuilder {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<Integer> entryBucketSplits;
+
+    public EntryBucketBatcherBuilder(List<Integer> entryBucketSplits) {
+        this.entryBucketSplits = entryBucketSplits == null ? List.of() : List.copyOf(entryBucketSplits);
+    }
+
+    @Override
+    public BatchMessageContainer build() {
+        return new EntryBucketBatchContainer(entryBucketSplits);
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/EntryBucketBatchContainerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/EntryBucketBatchContainerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import org.apache.pulsar.client.api.BatchMessageContainer;
+import org.testng.annotations.Test;
+
+public class EntryBucketBatchContainerTest {
+
+    @Test
+    public void testBucketOfEmptySplitsIsAlwaysZero() {
+        int[] none = new int[0];
+        for (int h : new int[]{0x0000, 0x4000, 0x8000, 0xFFFF}) {
+            assertEquals(EntryBucketBatchContainer.bucketOf(none, h), 0);
+        }
+    }
+
+    @Test
+    public void testBucketOfEvenSplits() {
+        int[] splits = {0x4000, 0x8000, 0xC000}; // 4 equal buckets
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x0000), 0);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x3FFF), 0);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x4000), 1);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x7FFF), 1);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x8000), 2);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xBFFF), 2);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xC000), 3);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xFFFF), 3);
+    }
+
+    @Test
+    public void testBucketOfUnevenSplits() {
+        // 3 uneven buckets: [0x0000,0x0FFF], [0x1000,0xEFFF], [0xF000,0xFFFF]
+        int[] splits = {0x1000, 0xF000};
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x0000), 0);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x0FFF), 0);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0x1000), 1);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xEFFF), 1);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xF000), 2);
+        assertEquals(EntryBucketBatchContainer.bucketOf(splits, 0xFFFF), 2);
+    }
+
+    @Test
+    public void testBuilderBuildsMultiBatchContainer() {
+        BatchMessageContainer c = new EntryBucketBatcherBuilder(List.of(0x8000)).build();
+        assertTrue(c instanceof EntryBucketBatchContainer);
+        assertTrue(((EntryBucketBatchContainer) c).isMultiBatches());
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/ScalableTopicHashing.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/scalable/ScalableTopicHashing.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.scalable;
+
+import org.apache.pulsar.common.util.Murmur3_32Hash;
+
+/**
+ * PIP-486 scalable-topic key hashing — the single source of truth shared by the producer's
+ * entry-bucket batcher and the V5 segment router.
+ *
+ * <p>A single 32-bit {@code Murmur3_32} hash of a key splits into two independent 16-bit halves: the
+ * <b>high half</b> routes segments ({@link #segmentHash}), the <b>low half</b> routes entry-buckets
+ * ({@link #entryBucketHash}). The <i>raw</i> (unmasked) hash is used so the high half is full-range
+ * ({@link Murmur3_32Hash#makeHash} clears bit 31, confining the high half to {@code [0, 0x7FFF]}).
+ * Compute {@link #murmur} once per key and split it.
+ */
+public final class ScalableTopicHashing {
+
+    private ScalableTopicHashing() {
+    }
+
+    /** The raw 32-bit {@code Murmur3_32} hash of a key. */
+    public static int murmur(byte[] keyBytes) {
+        return Murmur3_32Hash.makeRawHash(keyBytes);
+    }
+
+    /** The 16-bit segment-routing hash (high 16 bits) from a precomputed {@link #murmur(byte[])}. */
+    public static int segmentHash(int murmur) {
+        return (murmur >>> 16) & HashRange.MAX_HASH;
+    }
+
+    /** The 16-bit entry-bucket hash (low 16 bits) from a precomputed {@link #murmur(byte[])}. */
+    public static int entryBucketHash(int murmur) {
+        return murmur & HashRange.MAX_HASH;
+    }
+}


### PR DESCRIPTION
### Motivation

Follow-up to the PIP-486 foundation ([#26114](https://github.com/apache/pulsar/pull/26114)). PIP-486 ([#26077](https://github.com/apache/pulsar/pull/26077)) routes a scalable topic in two levels: the high 16 bits of a key's `Murmur3_32` hash pick a segment, the low 16 bits pick an *entry-bucket* within that segment. For the broker to dispatch a whole entry (batch) to the single consumer owning a bucket — without reading per-message keys — the producer must keep each batch within one entry-bucket and stamp the batch's effective hash range.

This PR adds that producer-side behavior. It is **behavior-neutral** for non-scalable producers and for scalable topics at `N = 1` (a single bucket): the entry-bucket batcher with empty splits produces exactly one batch, same as today, plus a pair of metadata fields the broker ignores until a later PR consumes them.

### Modifications

- **`ScalableTopicHashing`** (`pulsar-common`) — single source of truth for the PIP-486 key hashing: one raw `Murmur3_32` hash split into the segment-routing half (high 16) and the entry-bucket half (low 16). The v5 `SegmentRouter` and the producer's batcher both delegate to it instead of duplicating the math.
- **`EntryBucketBatchContainer` + `EntryBucketBatcherBuilder`** (`pulsar-client`) — a batch container that keeps one `BatchMessageContainerImpl` per entry-bucket (bucket = number of `splits` `<=` the key's entry-bucket hash; empty splits = a single bucket spanning the whole ring). It must live in `org.apache.pulsar.client.impl` because it reuses the package-private `BatchMessageContainerImpl` and the protected `ProducerImpl.OpSendMsg`; only the thin bucketing *policy* (splits, hashing) is scalable-specific.
- **`BatchMessageContainerImpl`** — an optional, default-off hook to stamp `entry_hash_min`/`entry_hash_max` (the effective min/max entry-bucket hash over a batch's messages). Off by default, so existing producers are byte-identical.
- **`ScalableTopicProducer`** — per-segment producers select their batching mode via `applyEntryBucketing`: when batching is enabled, route batches by entry-bucket; when end-to-end encryption is configured, disable batching (an encrypted batch can't be reshaped if re-routed across a divergent layout); a producer that already disabled batching is left untouched.

### Verifications

- `EntryBucketBatchContainerTest` covers the bucketing math (even / uneven / empty splits) and the builder.
- `ScalableTopicProducerTest` covers the per-segment batching decision (batching → entry-bucket batcher; encryption → batching off; already-disabled → untouched).
