### PR TITLE
[fix][test] Fix flaky PendingAckInMemoryDeleteTest.txnAckTestBatchAndSharedSubMemoryDeleteTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/pendingack/PendingAckInMemoryDeleteTest.java
@@ -253,12 +253,18 @@ public class PendingAckInMemoryDeleteTest extends TransactionTestBase {
                             // and it won't clear the last message in cursor batch index ack set
                             consumer.acknowledgeAsync(messageIds[1], commitTwice).get();
                             assertEquals(batchDeletedIndexes.size(), 1);
-                            assertEquals(testPersistentSubscription.getConsumers().get(0).getPendingAcks().size(), 0);
+                            // the consumer pending ack is removed asynchronously on the broker after it processes
+                            // the transactional acknowledgement, so the client side future completing does not
+                            // guarantee the pending ack has been cleared yet; await instead of asserting immediately
+                            Awaitility.await().untilAsserted(() -> assertEquals(
+                                    testPersistentSubscription.getConsumers().get(0).getPendingAcks().size(), 0));
 
                             // the messages has been produced were all acked,
                             // the memory in broker for the messages has been cleared.
                             commitTwice.commit().get();
-                            assertEquals(batchDeletedIndexes.size(), 0);
+                            // the cursor batch deleted indexes are cleared asynchronously on the broker after it
+                            // processes the transaction commit, so await instead of asserting immediately
+                            Awaitility.await().untilAsserted(() -> assertEquals(batchDeletedIndexes.size(), 0));
                             assertEquals(testPersistentSubscription.getConsumers().get(0).getPendingAcks().size(), 0);
                         }
                         count++;


### PR DESCRIPTION
### Motivation

`PendingAckInMemoryDeleteTest.txnAckTestBatchAndSharedSubMemoryDeleteTest` is flaky. Example failure (Pulsar CI):
https://github.com/apache/pulsar/actions/runs/28408271293/job/84176549857

```
java.lang.AssertionError: expected [0] but found [1]
	at org.apache.pulsar.broker.transaction.pendingack.PendingAckInMemoryDeleteTest.txnAckTestBatchAndSharedSubMemoryDeleteTest(PendingAckInMemoryDeleteTest.java:256)
```

The test acknowledges a message within a transaction via `consumer.acknowledgeAsync(messageIds[1], commitTwice).get()` and then **immediately** asserts that the broker-side consumer's pending-ack map has been cleared:

```java
consumer.acknowledgeAsync(messageIds[1], commitTwice).get();
assertEquals(batchDeletedIndexes.size(), 1);
assertEquals(testPersistentSubscription.getConsumers().get(0).getPendingAcks().size(), 0); // <-- found 1
```

The consumer pending ack is removed **asynchronously** on the broker after it processes the acknowledgement command. The client-side future completing only guarantees that the ack response was received, not that the broker has finished updating its `pendingAcks` map. This leaves a small window where the assertion observes the stale size `1`, causing the intermittent failure.

The same hazard applies to the assertion that the cursor's batch deleted indexes are cleared (`batchDeletedIndexes.size() == 0`) immediately after `commitTwice.commit().get()` — the commit is also processed asynchronously on the broker.

Note that the earlier checks in the same test method already use `Awaitility.await()` for exactly this reason; only these two post-`.get()` assertions were left as immediate assertions.

### Modifications

Wrap the two affected assertions in `Awaitility.await().untilAsserted(...)` so the test waits for the asynchronous broker-side state updates to settle instead of asserting immediately. The assertions are unchanged in strength (they still assert the values reach `0`); this only allows the eventual consistency to converge, consistent with the existing `Awaitility` usage in the same method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by the existing test `PendingAckInMemoryDeleteTest.txnAckTestBatchAndSharedSubMemoryDeleteTest`. Verified locally with a temporary `@Test(invocationCount = 10)` (10/10 passes); the temporary annotation was removed before submitting.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
