### PR TITLE
[improve][fn] Standardize log4j2 Root logger configuration to use system property

### DIFF
--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -120,10 +120,9 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>${sys:pulsar.log.appender}</ref>
-                <level>${sys:pulsar.log.level}</level>
             </AppenderRef>
         </Root>
     </Loggers>

--- a/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/java_instance_log4j2.xml
@@ -120,7 +120,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>${sys:pulsar.log.level}</level>
+            <level>${sys:pulsar.log.level:-info}</level>
             <AppenderRef>
                 <ref>${sys:pulsar.log.appender}</ref>
             </AppenderRef>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -50,7 +50,7 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>${sys:pulsar.log.level}</level>
+            <level>${sys:pulsar.log.level:-info}</level>
             <AppenderRef>
                 <ref>Console</ref>
             </AppenderRef>

--- a/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
+++ b/pulsar-functions/runtime-all/src/main/resources/kubernetes_instance_log4j2.xml
@@ -50,10 +50,9 @@
             </AppenderRef>
         </Logger>
         <Root>
-            <level>info</level>
+            <level>${sys:pulsar.log.level}</level>
             <AppenderRef>
                 <ref>Console</ref>
-                <level>${sys:pulsar.log.level}</level>
             </AppenderRef>
         </Root>
     </Loggers>


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #23783

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Both `java_instance_log4j2.xml` and `kubernetes_instance_log4j2.xml` had their Root logger levels hardcoded to 'info', which prevented the `pulsar.log.level` system property from controlling the actual logging level. While the system property was defined in both files, it was only being applied at the AppenderRef level.

### Modifications

<!-- Describe the modifications you've done. -->
Updated both log4j2 configuration files in `pulsar-functions/runtime-all/src/main/resources/`:
- Changed Root logger `<level>` from hardcoded `info` to `${sys:pulsar.log.level:-info}`
- Removed the `<level>` attribute from the AppenderRef element

Both files now consistently use the `${sys:pulsar.log.level}` system property at the Root logger level, enabling proper dynamic log level control.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment