### PR TITLE
[fix][test] Run makeReadEntryProbFail's errorOrNot on a caller-provided executor

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -194,13 +194,14 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         LedgerHandle currentLedger = ml.currentLedger;
         final LedgerHandle spyLedgerHandle = spy(currentLedger);
         doAnswer(invocation -> {
-            long ledgerId = (long) invocation.getArguments()[0];
-            long entryId = (long) invocation.getArguments()[1];
-            ManagedLedgerException mightError = errorOrNot.get();
-            if (mightError != null) {
-                return CompletableFuture.failedFuture(mightError);
-            }
-            return currentLedger.readUnconfirmedAsync(ledgerId, entryId);
+            long ledgerId = invocation.getArgument(0);
+            long entryId = invocation.getArgument(1);
+            // Evaluate errorOrNot on a separate thread (ForkJoinPool.commonPool()) so the calling thread
+            // isn't blocked while it runs, e.g. when errorOrNot waits on a CountDownLatch.
+            return CompletableFuture.supplyAsync(errorOrNot)
+                    .thenCompose(mightError -> mightError != null
+                            ? CompletableFuture.<LedgerEntries>failedFuture(mightError)
+                            : currentLedger.readUnconfirmedAsync(ledgerId, entryId));
         }).when(spyLedgerHandle).readUnconfirmedAsync(anyLong(), anyLong());
         ml.currentLedger = spyLedgerHandle;
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -77,6 +77,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
@@ -188,17 +189,18 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ml.currentLedger = spyLedgerHandle;
     }
 
-    public static void makeReadEntryProbFail(ManagedLedgerImpl ml, Supplier<ManagedLedgerException> errorOrNot)
-            throws Exception {
+    public static void makeReadEntryProbFail(ManagedLedgerImpl ml, Supplier<ManagedLedgerException> errorOrNot,
+                                             Executor errorSupplierExecutor) throws Exception {
         ml.entryCache.clear();
         LedgerHandle currentLedger = ml.currentLedger;
         final LedgerHandle spyLedgerHandle = spy(currentLedger);
         doAnswer(invocation -> {
             long ledgerId = invocation.getArgument(0);
             long entryId = invocation.getArgument(1);
-            // Evaluate errorOrNot on a separate thread (ForkJoinPool.commonPool()) so the calling thread
-            // isn't blocked while it runs, e.g. when errorOrNot waits on a CountDownLatch.
-            return CompletableFuture.supplyAsync(errorOrNot)
+            // Evaluate errorOrNot on errorSupplierExecutor. Pass a single-threaded executor when errorOrNot may
+            // block (e.g. it waits on a CountDownLatch) so it doesn't block the calling read thread; pass
+            // MoreExecutors.directExecutor() to evaluate it inline on the calling thread.
+            return CompletableFuture.supplyAsync(errorOrNot, errorSupplierExecutor)
                     .thenCompose(mightError -> mightError != null
                             ? CompletableFuture.<LedgerEntries>failedFuture(mightError)
                             : currentLedger.readUnconfirmedAsync(ledgerId, entryId));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorTest.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import java.lang.reflect.Field;
@@ -937,7 +938,8 @@ public class OneWayReplicatorTest extends OneWayReplicatorTestBase {
             }
             return new ManagedLedgerException.TooManyRequestsException("mocked error");
         };
-        ManagedLedgerTest.makeReadEntryProbFail(ml1, bkErrorOrNot);
+        // bkErrorOrNot doesn't block, so evaluate it inline on the calling read thread via directExecutor().
+        ManagedLedgerTest.makeReadEntryProbFail(ml1, bkErrorOrNot, MoreExecutors.directExecutor());
 
         // Verify: the replication will finish even though received ManagedLedgerException.TooManyRequestsException.
         pulsar1.getConfig().setReplicationStartAt("earliest");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentReplicatorInflightTaskTest.java
@@ -46,9 +46,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -162,6 +165,10 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
             PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopic(topicName, false)
                     .join().get();
             ManagedLedgerImpl ml = (ManagedLedgerImpl) topic.getManagedLedger();
+            // errorOrNot blocks on failRead, so run it on a dedicated single-threaded executor instead of the
+            // calling read thread; otherwise the blocked read thread would stall replicator.terminate().
+            @Cleanup("shutdownNow")
+            ExecutorService readFailExecutor = Executors.newSingleThreadExecutor();
             ManagedLedgerTest.makeReadEntryProbFail(ml, () -> {
                 readStarted.countDown();
                 try {
@@ -173,7 +180,7 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
                     return new ManagedLedgerException(e);
                 }
                 return new ManagedLedgerException.TooManyRequestsException("mocked read failure");
-            });
+            }, readFailExecutor);
 
             pulsar1.getConfig().setReplicationStartAt("earliest");
             admin1.topics().setReplicationClusters(topicName, Arrays.asList(cluster1, cluster2));
@@ -324,6 +331,10 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
             ManagedLedgerImpl ml = (ManagedLedgerImpl) topic.getManagedLedger();
             // Clear the entry cache and intercept ledger reads: block the first read so it stays in flight
             // (the in-flight task keeps entries == null), then let it and all later reads succeed.
+            // errorOrNot blocks the first read on releaseRead, so run it on a dedicated single-threaded executor
+            // instead of the calling read thread.
+            @Cleanup("shutdownNow")
+            ExecutorService readFailExecutor = Executors.newSingleThreadExecutor();
             ManagedLedgerTest.makeReadEntryProbFail(ml, () -> {
                 if (blockNextRead.compareAndSet(true, false)) {
                     readBlocked.countDown();
@@ -335,7 +346,7 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
                 }
                 // Never fail the read; it must complete successfully to reach the skip branch.
                 return null;
-            });
+            }, readFailExecutor);
 
             // Start replication from earliest; the first read blocks inside the ledger read (in flight).
             pulsar1.getConfig().setReplicationStartAt("earliest");
@@ -467,6 +478,10 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
             ManagedLedgerImpl ml = (ManagedLedgerImpl) topic.getManagedLedger();
             // Clear the entry cache and intercept ledger reads: block the first read so it stays in flight
             // (the in-flight task keeps entries == null), then let it and all later reads succeed.
+            // errorOrNot blocks the first read on releaseRead, so run it on a dedicated single-threaded executor
+            // instead of the calling read thread.
+            @Cleanup("shutdownNow")
+            ExecutorService readFailExecutor = Executors.newSingleThreadExecutor();
             ManagedLedgerTest.makeReadEntryProbFail(ml, () -> {
                 if (blockNextRead.compareAndSet(true, false)) {
                     readBlocked.countDown();
@@ -478,7 +493,7 @@ public class PersistentReplicatorInflightTaskTest extends OneWayReplicatorTestBa
                 }
                 // Never fail the read; it must complete successfully to reach the skip branch.
                 return null;
-            });
+            }, readFailExecutor);
 
             // Start replication from earliest; the first read blocks inside the ledger read (in flight).
             pulsar1.getConfig().setReplicationStartAt("earliest");


### PR DESCRIPTION
### Motivation

`ManagedLedgerTest.makeReadEntryProbFail` installs a Mockito answer on
`LedgerHandle.readUnconfirmedAsync` that consults a caller-supplied
`Supplier<ManagedLedgerException>` (`errorOrNot`) to decide whether a read should
fail. `errorOrNot` was evaluated directly on the thread that calls
`readUnconfirmedAsync`.

When a test supplies a *blocking* `errorOrNot`, that read thread is held for the
whole duration of the block, which can stall or deadlock the test. For example,
`PersistentReplicatorInflightTaskTest#testReadEntriesFailedCompletesInFlightTaskAfterReplicatorTerminated`
(added in #25767) blocks in `errorOrNot` on a `CountDownLatch` until the test
releases it after terminating the replicator. Because the calling thread was
blocked, the test flow could not make progress and its
`failRead.await(30, SECONDS)` always timed out.

### Modifications

- `makeReadEntryProbFail` now takes an `Executor` that runs `errorOrNot`, so each
  caller decides where it runs (composing the resulting read via `thenCompose`).
- `OneWayReplicatorTest.testProbBKErrorWhenReplicating` passes
  `MoreExecutors.directExecutor()` to keep read interception inline and ordered
  on the calling thread — its `errorOrNot` never blocks.
- The three blocking `PersistentReplicatorInflightTaskTest` cases pass a
  dedicated single-threaded executor (`@Cleanup("shutdownNow")`) so a blocking
  `errorOrNot` runs off the read thread while reads stay ordered.

This only touches test code; production code is unaffected.

### Verifying this change

This change is covered by the existing tests that use `makeReadEntryProbFail`.

Verified locally:

```
./gradlew :pulsar-broker:test \
  --tests "org.apache.pulsar.broker.service.OneWayReplicatorTest.testProbBKErrorWhenReplicating" \
  --tests "org.apache.pulsar.broker.service.persistent.PersistentReplicatorInflightTaskTest"
```

- `OneWayReplicatorTest.testProbBKErrorWhenReplicating`: passes in ~17s.
- `PersistentReplicatorInflightTaskTest`: 15 tests, 0 failures, including
  `testReadEntriesFailedCompletesInFlightTaskAfterReplicatorTerminated`.

- [ ] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
