### PR TITLE
[fix][client] Guard geo-replication duplicate rewind acks

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/GeoReplicationProducerImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.github.merlimat.slog.Logger;
 import io.netty.channel.Channel;
 import io.netty.util.ReferenceCountUtil;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.api.proto.KeyValue;
@@ -135,6 +137,18 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
                         .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
                         .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
                         .log("Received msg send receipt, pending send is repeated due to repl cursor rewind");
+            if (isDuplicateAckWithoutTargetPosition(targetLId, targetEid)
+                    && isBeforeLastPersistedSourcePosition(pendingLId, pendingEId)) {
+                log.warn()
+                        .attr("sourceLedgerId", sourceLId).attr("sourceEntryId", sourceEId)
+                        .attr("pendingLedgerId", pendingLId).attr("pendingEntryId", pendingEId)
+                        .attr("persistedSourceLedgerId", lastPersistedSourceLedgerId)
+                        .attr("persistedSourceEntryId", lastPersistedSourceEntryId)
+                        .log("Received duplicate ack for rewound replicated message without target position");
+                removeAndFailCallback(op, sourceLId, sourceEId, new PulsarClientException(
+                        "Replicated message was acknowledged as duplicate without a target position"));
+                return;
+            }
             removeAndApplyCallback(op, sourceLId, sourceEId, targetLId, targetEid, false);
             ackReceived(cnx, sourceLId, sourceEId, targetLId, targetEid);
             return;
@@ -257,6 +271,31 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
         cnx.channel().close();
     }
 
+    private boolean isDuplicateAckWithoutTargetPosition(long ledgerId, long entryId) {
+        return ledgerId == -1 && entryId == -1;
+    }
+
+    private boolean isBeforeLastPersistedSourcePosition(long ledgerId, long entryId) {
+        return ledgerId < lastPersistedSourceLedgerId
+                || (ledgerId == lastPersistedSourceLedgerId && entryId < lastPersistedSourceEntryId);
+    }
+
+    private void removeAndFailCallback(OpSendMsg op, long lIdSent, long eIdSent, Exception exception) {
+        pendingMessages.remove();
+        releaseSemaphoreForSendOp(op);
+        try {
+            op.sendComplete(exception);
+        } catch (Throwable t) {
+            log.warn()
+                    .attr("sourceMessage", lIdSent)
+                    .attr("eIdSent", eIdSent)
+                    .exception(t)
+                    .log("Got exception while completing the failed callback");
+        }
+        ReferenceCountUtil.safeRelease(op.cmd);
+        op.recycle();
+    }
+
     private void removeAndApplyCallback(OpSendMsg op, long lIdSent, long eIdSent, long ledgerId, long entryId,
                                         boolean isMarker) {
         pendingMessages.remove();
@@ -285,6 +324,12 @@ public class GeoReplicationProducerImpl extends ProducerImpl{
     private boolean isReplicationMarker(OpSendMsg op) {
         return op.msg != null && op.msg.getMessageBuilder().hasMarkerType()
                 && Markers.isReplicationMarker(op.msg.getMessageBuilder().getMarkerType());
+    }
+
+    @VisibleForTesting
+    void setLastPersistedSourcePosition(long ledgerId, long entryId) {
+        lastPersistedSourceLedgerId = ledgerId;
+        lastPersistedSourceEntryId = entryId;
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/GeoReplicationProducerImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/GeoReplicationProducerImplTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
+import org.apache.pulsar.client.impl.metrics.InstrumentProvider;
+import org.apache.pulsar.client.impl.metrics.LatencyHistogram;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.testng.annotations.Test;
+
+public class GeoReplicationProducerImplTest {
+
+    private static final String TOPIC = "persistent://public/default/geo-repl-producer";
+
+    @Test
+    public void testRewindDuplicateAckWithoutTargetPositionFailsCallback() {
+        GeoReplicationProducerImpl producer = newProducer();
+        producer.setLastPersistedSourcePosition(7, 9);
+        AtomicReference<Throwable> callbackError = new AtomicReference<>(new AssertionError("not called"));
+        ProducerImpl.OpSendMsg op = newPendingOp(7, 3, callbackError);
+        producer.pendingMessages.add(op);
+
+        producer.ackReceived(newClientCnx(), 7, 3, -1, -1);
+
+        assertTrue(callbackError.get() instanceof PulsarClientException);
+        assertEquals(producer.pendingMessages.messagesCount(), 0);
+    }
+
+    @Test
+    public void testRewindAckWithTargetPositionCompletesCallback() {
+        GeoReplicationProducerImpl producer = newProducer();
+        producer.setLastPersistedSourcePosition(7, 9);
+        AtomicReference<Throwable> callbackError = new AtomicReference<>(new AssertionError("not called"));
+        ProducerImpl.OpSendMsg op = newPendingOp(7, 3, callbackError);
+        producer.pendingMessages.add(op);
+
+        producer.ackReceived(newClientCnx(), 7, 3, 10, 11);
+
+        assertNull(callbackError.get());
+        assertEquals(producer.pendingMessages.messagesCount(), 0);
+    }
+
+    @Test
+    public void testRewindDuplicateAckAtLastPersistedPositionCompletesCallback() {
+        GeoReplicationProducerImpl producer = newProducer();
+        producer.setLastPersistedSourcePosition(7, 3);
+        AtomicReference<Throwable> callbackError = new AtomicReference<>(new AssertionError("not called"));
+        ProducerImpl.OpSendMsg op = newPendingOp(7, 3, callbackError);
+        producer.pendingMessages.add(op);
+
+        producer.ackReceived(newClientCnx(), 7, 3, -1, -1);
+
+        assertNull(callbackError.get());
+        assertEquals(producer.pendingMessages.messagesCount(), 0);
+    }
+
+    private static GeoReplicationProducerImpl newProducer() {
+        PulsarClientImpl client = mock(PulsarClientImpl.class);
+        ClientConfigurationData clientConfiguration = new ClientConfigurationData();
+        clientConfiguration.setStatsIntervalSeconds(0);
+        ConnectionPool connectionPool = mock(ConnectionPool.class);
+        when(connectionPool.genRandomKeyToSelectCon()).thenReturn(1);
+        when(client.getCnxPool()).thenReturn(connectionPool);
+        when(client.newProducerId()).thenReturn(1L);
+        when(client.getConfiguration()).thenReturn(clientConfiguration);
+        when(client.instrumentProvider()).thenReturn(InstrumentProvider.NOOP);
+        when(client.getMemoryLimitController()).thenReturn(mock(MemoryLimitController.class));
+        when(client.getConnection(anyString(), anyInt())).thenReturn(new CompletableFuture<>());
+
+        ProducerConfigurationData producerConfiguration = new ProducerConfigurationData();
+        producerConfiguration.setBatchingEnabled(false);
+        producerConfiguration.setMaxPendingMessages(0);
+        producerConfiguration.setSendTimeoutMs(0);
+        CompletableFuture<Producer<byte[]>> createdFuture = new CompletableFuture<>();
+        return new GeoReplicationProducerImpl(client, TOPIC, producerConfiguration, createdFuture, -1,
+                Schema.BYTES, null, Optional.empty());
+    }
+
+    private static ClientCnx newClientCnx() {
+        ClientCnx cnx = mock(ClientCnx.class);
+        when(cnx.isBrokerSupportsReplDedupByLidAndEid()).thenReturn(true);
+        return cnx;
+    }
+
+    private static ProducerImpl.OpSendMsg newPendingOp(long ledgerId, long entryId,
+                                                       AtomicReference<Throwable> callbackError) {
+        MessageMetadata metadata = new MessageMetadata();
+        metadata.setProducerName("repl");
+        metadata.setSequenceId(entryId);
+        metadata.setPublishTime(System.currentTimeMillis());
+        metadata.addProperty()
+                .setKey(GeoReplicationProducerImpl.MSG_PROP_REPL_SOURCE_POSITION)
+                .setValue(ledgerId + ":" + entryId);
+        MessageImpl<byte[]> message = MessageImpl.create(metadata, ByteBuffer.allocate(0), Schema.BYTES, TOPIC);
+        return ProducerImpl.OpSendMsg.create(LatencyHistogram.NOOP, message, null, entryId, new SendCallback() {
+            @Override
+            public void sendComplete(Throwable error, OpSendMsgStats opSendMsgStats) {
+                callbackError.set(error);
+            }
+
+            @Override
+            public void addCallback(MessageImpl<?> msg, SendCallback scb) {
+            }
+
+            @Override
+            public SendCallback getNextSendCallback() {
+                return null;
+            }
+
+            @Override
+            public MessageImpl<?> getNextMessage() {
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<MessageId> getFuture() {
+                return null;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Fixes #26113

### Motivation

Geo-replication can rewind the source cursor after a head-of-queue send failure while later pipelined sends have already advanced the replicated deduplication watermark on the remote cluster. If the rewound head message is then acknowledged as a duplicate with target position `-1:-1`, completing that send as success lets the source cursor move past an entry that was not confirmed persisted on the remote side.

### Modifications

- Treat a duplicate acknowledgement without a target position as a failed send when the rewound source position is earlier than the last persisted source position.
- Keep the existing success path for valid target positions and for duplicate acknowledgements at the current persisted source position.
- Add focused `GeoReplicationProducerImpl` tests for the failed rewind path and the success cases that should remain unchanged.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Added `GeoReplicationProducerImplTest` coverage for rewound duplicate acknowledgements with no target position, valid target positions, and duplicate acknowledgements at the current persisted source position.
  - `./gradlew :pulsar-client-original:test --tests "org.apache.pulsar.client.impl.GeoReplicationProducerImplTest" -PtestRetryCount=0 --no-build-cache --rerun-tasks`
  - `./gradlew :pulsar-client-original:spotlessCheck :pulsar-client-original:checkstyleMain :pulsar-client-original:checkstyleTest`
  - `./gradlew quickCheck`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [x] Anything that affects deployment

This changes a geo-replication failure path from completing a duplicate rewind acknowledgement as success to failing the send callback, so the source cursor does not advance past an entry that was not confirmed persisted on the remote side.
