### PR TITLE
[fix][test] Await reader reconnect after seek() to fix flaky TopicReaderTest assertions

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.client.impl.TopicMessageImpl;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -1291,8 +1292,9 @@ public class TopicReaderTest extends SharedPulsarBaseTest {
             testMessageOrderAndDuplicates(messageSetB, receivedMessage, expectedMessage);
         }
 
-        // Reader should be finished
-        assertTrue(reader.isConnected());
+        // Reader should be finished. seek() triggers an asynchronous reconnect of the underlying consumer(s), so
+        // isConnected() can be transiently false right after the post-seek reads; await it to avoid flakiness.
+        Awaitility.await().untilAsserted(() -> assertTrue(reader.isConnected()));
         assertFalse(reader.hasMessageAvailable());
         assertEquals(((ReaderImpl) reader).getConsumer().numMessagesInQueue(), 0);
 
@@ -1337,8 +1339,9 @@ public class TopicReaderTest extends SharedPulsarBaseTest {
             Assert.assertTrue(messageSetB.add(receivedMessage), "Received duplicate message " + receivedMessage);
         }
 
-        // Reader should be finished
-        assertTrue(reader.isConnected());
+        // Reader should be finished. seek() triggers an asynchronous reconnect of the underlying consumer(s), so
+        // isConnected() can be transiently false right after the post-seek reads; await it to avoid flakiness.
+        Awaitility.await().untilAsserted(() -> assertTrue(reader.isConnected()));
         assertFalse(reader.hasMessageAvailable());
         assertEquals(((MultiTopicsReaderImpl) reader).getMultiTopicsConsumer().numMessagesInQueue(), 0);
 
@@ -1392,8 +1395,9 @@ public class TopicReaderTest extends SharedPulsarBaseTest {
             testMessageOrderAndDuplicates(messageSetB, receivedMessage, expectedMessage);
         }
 
-        // Reader should be finished
-        assertTrue(reader.isConnected());
+        // Reader should be finished. seek() triggers an asynchronous reconnect of the underlying consumer(s), so
+        // isConnected() can be transiently false right after the post-seek reads; await it to avoid flakiness.
+        Awaitility.await().untilAsserted(() -> assertTrue(reader.isConnected()));
         assertFalse(reader.hasMessageAvailable());
         assertEquals(((ReaderImpl) reader).getConsumer().numMessagesInQueue(), 0);
 


### PR DESCRIPTION
### Motivation

`TopicReaderTest.testMultiReaderIsAbleToSeekWithTimeOnBeginningOfTopic` fails intermittently in the
"Pulsar CI Flaky" suite with `java.lang.AssertionError: expected [true] but found [false]` at
`assertTrue(reader.isConnected())` — observed on two unrelated PRs
([run 28608140872](https://github.com/apache/pulsar/actions/runs/28608140872/job/84833609791) and
[run 28612964177](https://github.com/apache/pulsar/actions/runs/28612964177/job/84849764585)).

The assertion runs immediately after `seek()` plus reading the messages a second time. `seek()` triggers
an asynchronous reconnect of the underlying consumer(s): the broker disconnects the consumer on cursor
reset so it reconnects at the new position. For a multi-topic reader,
`MultiTopicsConsumerImpl.isConnected()` requires *all* partition consumers to be connected at that
instant, so it can be transiently `false` right after the post-seek reads.

The assertion has always been racy, but it started failing frequently after #25338 migrated the class
to `SharedPulsarBaseTest`: a shared, busier broker widens the seek→reconnect window, so the latent race
now surfaces regularly.

### Modifications

Await `reader.isConnected()` with Awaitility instead of asserting it instantly, in the three tests that
share the "seek() then assert isConnected()" pattern:

- `testReaderIsAbleToSeekWithTimeOnBeginningOfTopic`
- `testMultiReaderIsAbleToSeekWithTimeOnBeginningOfTopic`
- `testReaderIsAbleToSeekWithMessageIdOnMiddleOfTopic`

This is a test-only change; no production code is modified.

Note: #17407 (`testMultiReaderIsAbleToSeekWithTimeOnMiddleOfTopic`) is a *different* flake — that test
has no `isConnected()` assertion — and is not addressed here.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a test-only rework. The three affected tests plus the other seek-with-time reader tests
pass locally with the flaky test group enabled
(`-PtestGroups=flaky -PexcludedTestGroups=quarantine`).

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
