### PR TITLE
[fix][broker] Prevent stale service unit callbacks from dropping active lookup and cleanup jobs

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -232,6 +232,16 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         this.channelState = Constructed;
     }
 
+    @VisibleForTesting
+    Map<String, CompletableFuture<String>> getOwnerRequests() {
+        return getOwnerRequests;
+    }
+
+    @VisibleForTesting
+    Map<String, CompletableFuture<Void>> getCleanupJobs() {
+        return cleanupJobs;
+    }
+
     @Override
     public void scheduleOwnershipMonitor() {
         if (monitorTask == null) {
@@ -854,13 +864,15 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         }
     }
 
-    private void handleSkippedEvent(String serviceUnit) {
+    @VisibleForTesting
+    void handleSkippedEvent(String serviceUnit) {
         var getOwnerRequest = getOwnerRequests.get(serviceUnit);
         if (getOwnerRequest != null) {
             var data = tableview.get(serviceUnit);
             if (data != null && data.state() == Owned) {
                 getOwnerRequest.complete(data.dstBroker());
-                getOwnerRequests.remove(serviceUnit);
+                // Completing the request can run callbacks that install a newer request for the same service unit.
+                getOwnerRequests.remove(serviceUnit, getOwnerRequest);
                 stateChangeListeners.notify(serviceUnit, data, null);
             }
         }
@@ -1024,7 +1036,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return future;
     }
 
-    private CompletableFuture<String> dedupeGetOwnerRequest(String serviceUnit) {
+    @VisibleForTesting
+    CompletableFuture<String> dedupeGetOwnerRequest(String serviceUnit) {
 
         var requested = new MutableObject<CompletableFuture<String>>();
         try {
@@ -1057,7 +1070,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             var future = requested.get();
             if (future != null) {
                 future.whenComplete((__, e) -> {
-                    getOwnerRequests.remove(serviceUnit);
+                    // The request may have been replaced by a later lookup before this callback runs.
+                    getOwnerRequests.remove(serviceUnit, future);
                     if (e != null) {
                         log.warn().attr("broker", brokerId).attr("serviceUnit", serviceUnit).exception(e)
                                 .log("failed to getOwner for serviceUnit");
@@ -1340,14 +1354,15 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
 
     private void handleBrokerCreationEvent(String broker) {
 
-        if (!cleanupJobs.isEmpty() && cleanupJobs.containsKey(broker)) {
+        CompletableFuture<Void> cleanupJob = cleanupJobs.get(broker);
+        if (cleanupJob != null) {
             healthCheckBrokerAsync(broker)
                     .orTimeout(MAX_BROKER_HEALTH_CHECK_DELAY_IN_MILLIS * (MAX_BROKER_HEALTH_CHECK_RETRY + 1)
                             , MILLISECONDS)
                     .thenAccept(__ -> {
-                        CompletableFuture<Void> future = cleanupJobs.remove(broker);
-                        if (future != null) {
-                            future.cancel(false);
+                        // The health check is async; only cancel the cleanup job observed before the check.
+                        if (cleanupJobs.remove(broker, cleanupJob)) {
+                            cleanupJob.cancel(false);
                             totalInactiveBrokerCleanupCancelledCnt++;
                             log.info().attr("broker", broker).attr("count", cleanupJobs.size())
                                     .log("Successfully cancelled the ownership cleanup for broker: ."
@@ -1413,7 +1428,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return false;
     }
 
-    private void scheduleCleanup(String broker, long delayInSecs) {
+    @VisibleForTesting
+    void scheduleCleanup(String broker, long delayInSecs) {
         var scheduled = new MutableObject<CompletableFuture<Void>>();
         try {
             if (channelDisabled()) {
@@ -1443,7 +1459,8 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             var future = scheduled.get();
             if (future != null) {
                 future.whenComplete((v, ex) -> {
-                    cleanupJobs.remove(broker);
+                    // The job may have been replaced by a later cleanup schedule before this callback runs.
+                    cleanupJobs.remove(broker, future);
                 });
             }
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -289,17 +289,30 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<String> oldRequest = channel.dedupeGetOwnerRequest(serviceUnit);
         assertEquals(getOwnerRequests.get(serviceUnit), oldRequest);
 
+        CompletableFuture<String> newRequest = null;
         try {
-            CompletableFuture<String> newRequest = new CompletableFuture<>();
-            getOwnerRequests.put(serviceUnit, newRequest);
+            // State-event handlers remove the current request before completing it, allowing a later lookup
+            // to install a new request generation before the old request's completion cleanup runs.
+            assertTrue(getOwnerRequests.remove(serviceUnit, oldRequest));
+            newRequest = channel.dedupeGetOwnerRequest(serviceUnit);
+            assertTrue(newRequest != oldRequest);
+            assertTrue(getOwnerRequests.get(serviceUnit) == newRequest);
 
             // The previous unconditional removal would remove newRequest here.
-            oldRequest.complete(brokerId1);
+            assertTrue(oldRequest.complete(brokerId1));
 
             assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
                     "A stale get-owner cleanup must not remove a newer request future");
+
+            assertTrue(newRequest.complete(brokerId2));
+            assertFalse(getOwnerRequests.containsKey(serviceUnit),
+                    "The newer request must remove itself after completion");
         } finally {
             getOwnerRequests.remove(serviceUnit);
+            oldRequest.cancel(false);
+            if (newRequest != null) {
+                newRequest.cancel(false);
+            }
         }
     }
 
@@ -337,18 +350,31 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<Void> oldJob = cleanupJobs.get(broker);
         assertNotNull(oldJob);
 
+        CompletableFuture<Void> newJob = null;
         try {
-            CompletableFuture<Void> newJob = new CompletableFuture<>();
-            cleanupJobs.put(broker, newJob);
+            // Broker-creation handling removes a cleanup job before cancelling it. A later broker-deletion
+            // event can therefore schedule a new job before the old job's completion cleanup runs.
+            assertTrue(cleanupJobs.remove(broker, oldJob));
+            channel.scheduleCleanup(broker, 60L);
+            newJob = cleanupJobs.get(broker);
+            assertNotNull(newJob);
+            assertTrue(newJob != oldJob);
 
             // The previous unconditional removal would remove newJob here.
-            oldJob.complete(null);
+            assertTrue(oldJob.cancel(false));
 
             assertTrue(cleanupJobs.get(broker) == newJob,
                     "A stale cleanup job completion must not remove a newer cleanup job future");
+
+            assertTrue(newJob.cancel(false));
+            assertFalse(cleanupJobs.containsKey(broker),
+                    "The newer cleanup job must remove itself after completion");
         } finally {
             cleanupJobs.remove(broker);
             oldJob.cancel(false);
+            if (newJob != null) {
+                newJob.cancel(false);
+            }
         }
     }
 
@@ -899,32 +925,47 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
         var cleanupJobs = channel.getCleanupJobs();
         String broker = brokerId2;
-        CompletableFuture<Void> oldJob = new CompletableFuture<>();
-        CompletableFuture<Void> newJob = new CompletableFuture<>();
         CompletableFuture<Void> healthCheck = new CompletableFuture<>();
-        cleanupJobs.put(broker, oldJob);
+        cleanupJobs.remove(broker);
+        channel.scheduleCleanup(broker, 60L);
+        CompletableFuture<Void> oldJob = cleanupJobs.get(broker);
+        assertNotNull(oldJob);
 
         reset(brokers);
         doReturn(healthCheck).when(brokers).healthcheckAsync(any());
         doReturn(brokers).when(pulsarAdmin).brokers();
+        CompletableFuture<Void> newJob = null;
         try {
             channel.handleBrokerRegistrationEvent(broker, NotificationType.Created);
             verify(brokers, times(1)).healthcheckAsync(any());
 
-            // Replace the cleanup job before completing the broker health-check callback.
-            cleanupJobs.put(broker, newJob);
+            // The old cleanup can finish while the asynchronous health check is still pending. A later
+            // broker-deletion event can then schedule a new cleanup job for the same broker.
+            assertTrue(oldJob.complete(null));
+            assertFalse(cleanupJobs.containsKey(broker));
+            channel.scheduleCleanup(broker, 60L);
+            newJob = cleanupJobs.get(broker);
+            assertNotNull(newJob);
+            assertTrue(newJob != oldJob);
+
             healthCheck.complete(null);
 
+            CompletableFuture<Void> expectedNewJob = newJob;
             Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-                assertTrue(cleanupJobs.get(broker) == newJob,
+                assertTrue(cleanupJobs.get(broker) == expectedNewJob,
                         "A stale broker-creation callback must not remove a newer cleanup job");
-                assertFalse(newJob.isCancelled());
-                assertFalse(oldJob.isCancelled());
+                assertFalse(expectedNewJob.isCancelled());
             });
+
+            assertTrue(newJob.cancel(false));
+            assertFalse(cleanupJobs.containsKey(broker),
+                    "The newer cleanup job must remove itself after cancellation");
         } finally {
             cleanupJobs.remove(broker);
             oldJob.cancel(false);
-            newJob.cancel(false);
+            if (newJob != null) {
+                newJob.cancel(false);
+            }
             reset(brokers);
             doReturn(CompletableFuture.failedFuture(new RuntimeException("failed"))).when(brokers)
                     .healthcheckAsync(any());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -65,7 +65,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -282,7 +281,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test(priority = 1)
-    public void testCompletedGetOwnerRequestDoesNotRemoveNewRequest() throws Exception {
+    public void testCompletedGetOwnerRequestDoesNotRemoveNewRequest() {
         ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
         String serviceUnit = namespaceName + "/0x10000000_0x10000001";
         var getOwnerRequests = channel.getOwnerRequests();
@@ -290,37 +289,16 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<String> oldRequest = channel.dedupeGetOwnerRequest(serviceUnit);
         assertEquals(getOwnerRequests.get(serviceUnit), oldRequest);
 
-        CountDownLatch staleCallbackRunning = new CountDownLatch(1);
-        CountDownLatch releaseStaleCallback = new CountDownLatch(1);
-        oldRequest.whenComplete((__, ___) -> {
-            staleCallbackRunning.countDown();
-            try {
-                assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new CompletionException(e);
-            }
-        });
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
-            Future<?> completeOldRequest = executor.submit(() -> oldRequest.complete(brokerId1));
-            assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
-                    "The stale get-owner completion callback did not start");
-            assertTrue(getOwnerRequests.get(serviceUnit) == oldRequest,
-                    "The stale cleanup must not run before the new request is installed");
-
-            // Replace the map entry before releasing the old callback.
             CompletableFuture<String> newRequest = new CompletableFuture<>();
             getOwnerRequests.put(serviceUnit, newRequest);
-            releaseStaleCallback.countDown();
-            completeOldRequest.get(5, TimeUnit.SECONDS);
+
+            // The previous unconditional removal would remove newRequest here.
+            oldRequest.complete(brokerId1);
 
             assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
                     "A stale get-owner cleanup must not remove a newer request future");
         } finally {
-            releaseStaleCallback.countDown();
-            executor.shutdownNow();
             getOwnerRequests.remove(serviceUnit);
         }
     }
@@ -331,43 +309,17 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         String serviceUnit = namespaceName + "/0x10000002_0x10000003";
         var getOwnerRequests = channel.getOwnerRequests();
         CompletableFuture<String> oldRequest = new CompletableFuture<>();
+        CompletableFuture<String> newRequest = new CompletableFuture<>();
         try {
             overrideTableView(channel, serviceUnit, new ServiceUnitStateData(Owned, brokerId1, 1));
             getOwnerRequests.put(serviceUnit, oldRequest);
+            oldRequest.whenComplete((__, ___) -> getOwnerRequests.put(serviceUnit, newRequest));
 
-            CountDownLatch staleCallbackRunning = new CountDownLatch(1);
-            CountDownLatch releaseStaleCallback = new CountDownLatch(1);
-            oldRequest.whenComplete((__, ___) -> {
-                staleCallbackRunning.countDown();
-                try {
-                    assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new CompletionException(e);
-                }
-            });
+            channel.handleSkippedEvent(serviceUnit);
 
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            try {
-                Future<?> handleSkippedEvent = executor.submit(() -> channel.handleSkippedEvent(serviceUnit));
-                assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
-                        "The stale skipped-event callback did not start");
-                assertTrue(getOwnerRequests.get(serviceUnit) == oldRequest,
-                        "The skipped-event cleanup must not run before the new request is installed");
-
-                // Replace the map entry before releasing the old callback.
-                CompletableFuture<String> newRequest = new CompletableFuture<>();
-                getOwnerRequests.put(serviceUnit, newRequest);
-                releaseStaleCallback.countDown();
-                handleSkippedEvent.get(5, TimeUnit.SECONDS);
-
-                assertEquals(oldRequest.getNow(null), brokerId1);
-                assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
-                        "A stale skipped-event cleanup must not remove a newer request future");
-            } finally {
-                releaseStaleCallback.countDown();
-                executor.shutdownNow();
-            }
+            assertEquals(oldRequest.getNow(null), brokerId1);
+            assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
+                    "A stale skipped-event cleanup must not remove a newer request future");
         } finally {
             getOwnerRequests.remove(serviceUnit);
             oldRequest.cancel(false);
@@ -376,7 +328,7 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test(priority = 1)
-    public void testCompletedCleanupJobDoesNotRemoveNewCleanupJob() throws Exception {
+    public void testCompletedCleanupJobDoesNotRemoveNewCleanupJob() {
         ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
         String broker = brokerId3;
         var cleanupJobs = channel.getCleanupJobs();
@@ -385,37 +337,16 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         CompletableFuture<Void> oldJob = cleanupJobs.get(broker);
         assertNotNull(oldJob);
 
-        CountDownLatch staleCallbackRunning = new CountDownLatch(1);
-        CountDownLatch releaseStaleCallback = new CountDownLatch(1);
-        oldJob.whenComplete((__, ___) -> {
-            staleCallbackRunning.countDown();
-            try {
-                assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new CompletionException(e);
-            }
-        });
-
-        ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
-            Future<?> completeOldJob = executor.submit(() -> oldJob.complete(null));
-            assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
-                    "The stale cleanup job completion callback did not start");
-            assertTrue(cleanupJobs.get(broker) == oldJob,
-                    "The stale cleanup callback must not run before the new cleanup job is installed");
-
-            // Replace the cleanup job before releasing the old callback.
             CompletableFuture<Void> newJob = new CompletableFuture<>();
             cleanupJobs.put(broker, newJob);
-            releaseStaleCallback.countDown();
-            completeOldJob.get(5, TimeUnit.SECONDS);
+
+            // The previous unconditional removal would remove newJob here.
+            oldJob.complete(null);
 
             assertTrue(cleanupJobs.get(broker) == newJob,
                     "A stale cleanup job completion must not remove a newer cleanup job future");
         } finally {
-            releaseStaleCallback.countDown();
-            executor.shutdownNow();
             cleanupJobs.remove(broker);
             oldJob.cancel(false);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -277,6 +278,146 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         } else {
             assertFalse(channel1.isChannelOwnerAsync().get(2, TimeUnit.SECONDS));
             assertTrue(channel2.isChannelOwnerAsync().get(2, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test(priority = 1)
+    public void testCompletedGetOwnerRequestDoesNotRemoveNewRequest() throws Exception {
+        ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
+        String serviceUnit = namespaceName + "/0x10000000_0x10000001";
+        var getOwnerRequests = channel.getOwnerRequests();
+        getOwnerRequests.remove(serviceUnit);
+        CompletableFuture<String> oldRequest = channel.dedupeGetOwnerRequest(serviceUnit);
+        assertEquals(getOwnerRequests.get(serviceUnit), oldRequest);
+
+        CountDownLatch staleCallbackRunning = new CountDownLatch(1);
+        CountDownLatch releaseStaleCallback = new CountDownLatch(1);
+        oldRequest.whenComplete((__, ___) -> {
+            staleCallbackRunning.countDown();
+            try {
+                assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CompletionException(e);
+            }
+        });
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> completeOldRequest = executor.submit(() -> oldRequest.complete(brokerId1));
+            assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
+                    "The stale get-owner completion callback did not start");
+            assertTrue(getOwnerRequests.get(serviceUnit) == oldRequest,
+                    "The stale cleanup must not run before the new request is installed");
+
+            // Replace the map entry before releasing the old callback.
+            CompletableFuture<String> newRequest = new CompletableFuture<>();
+            getOwnerRequests.put(serviceUnit, newRequest);
+            releaseStaleCallback.countDown();
+            completeOldRequest.get(5, TimeUnit.SECONDS);
+
+            assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
+                    "A stale get-owner cleanup must not remove a newer request future");
+        } finally {
+            releaseStaleCallback.countDown();
+            executor.shutdownNow();
+            getOwnerRequests.remove(serviceUnit);
+        }
+    }
+
+    @Test(priority = 1)
+    public void testSkippedEventDoesNotRemoveNewGetOwnerRequest() throws Exception {
+        ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
+        String serviceUnit = namespaceName + "/0x10000002_0x10000003";
+        var getOwnerRequests = channel.getOwnerRequests();
+        CompletableFuture<String> oldRequest = new CompletableFuture<>();
+        try {
+            overrideTableView(channel, serviceUnit, new ServiceUnitStateData(Owned, brokerId1, 1));
+            getOwnerRequests.put(serviceUnit, oldRequest);
+
+            CountDownLatch staleCallbackRunning = new CountDownLatch(1);
+            CountDownLatch releaseStaleCallback = new CountDownLatch(1);
+            oldRequest.whenComplete((__, ___) -> {
+                staleCallbackRunning.countDown();
+                try {
+                    assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new CompletionException(e);
+                }
+            });
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<?> handleSkippedEvent = executor.submit(() -> channel.handleSkippedEvent(serviceUnit));
+                assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
+                        "The stale skipped-event callback did not start");
+                assertTrue(getOwnerRequests.get(serviceUnit) == oldRequest,
+                        "The skipped-event cleanup must not run before the new request is installed");
+
+                // Replace the map entry before releasing the old callback.
+                CompletableFuture<String> newRequest = new CompletableFuture<>();
+                getOwnerRequests.put(serviceUnit, newRequest);
+                releaseStaleCallback.countDown();
+                handleSkippedEvent.get(5, TimeUnit.SECONDS);
+
+                assertEquals(oldRequest.getNow(null), brokerId1);
+                assertTrue(getOwnerRequests.get(serviceUnit) == newRequest,
+                        "A stale skipped-event cleanup must not remove a newer request future");
+            } finally {
+                releaseStaleCallback.countDown();
+                executor.shutdownNow();
+            }
+        } finally {
+            getOwnerRequests.remove(serviceUnit);
+            oldRequest.cancel(false);
+            overrideTableView(channel, serviceUnit, null);
+        }
+    }
+
+    @Test(priority = 1)
+    public void testCompletedCleanupJobDoesNotRemoveNewCleanupJob() throws Exception {
+        ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
+        String broker = brokerId3;
+        var cleanupJobs = channel.getCleanupJobs();
+        cleanupJobs.remove(broker);
+        channel.scheduleCleanup(broker, 60L);
+        CompletableFuture<Void> oldJob = cleanupJobs.get(broker);
+        assertNotNull(oldJob);
+
+        CountDownLatch staleCallbackRunning = new CountDownLatch(1);
+        CountDownLatch releaseStaleCallback = new CountDownLatch(1);
+        oldJob.whenComplete((__, ___) -> {
+            staleCallbackRunning.countDown();
+            try {
+                assertTrue(releaseStaleCallback.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CompletionException(e);
+            }
+        });
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> completeOldJob = executor.submit(() -> oldJob.complete(null));
+            assertTrue(staleCallbackRunning.await(5, TimeUnit.SECONDS),
+                    "The stale cleanup job completion callback did not start");
+            assertTrue(cleanupJobs.get(broker) == oldJob,
+                    "The stale cleanup callback must not run before the new cleanup job is installed");
+
+            // Replace the cleanup job before releasing the old callback.
+            CompletableFuture<Void> newJob = new CompletableFuture<>();
+            cleanupJobs.put(broker, newJob);
+            releaseStaleCallback.countDown();
+            completeOldJob.get(5, TimeUnit.SECONDS);
+
+            assertTrue(cleanupJobs.get(broker) == newJob,
+                    "A stale cleanup job completion must not remove a newer cleanup job future");
+        } finally {
+            releaseStaleCallback.countDown();
+            executor.shutdownNow();
+            cleanupJobs.remove(broker);
+            oldJob.cancel(false);
         }
     }
 
@@ -820,6 +961,44 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
             assertTrue(future.isCancelled());
         });
 
+    }
+
+    @Test(priority = 8)
+    public void handleBrokerCreationEventDoesNotCancelNewCleanupJobTest() {
+        ServiceUnitStateChannelImpl channel = (ServiceUnitStateChannelImpl) channel1;
+        var cleanupJobs = channel.getCleanupJobs();
+        String broker = brokerId2;
+        CompletableFuture<Void> oldJob = new CompletableFuture<>();
+        CompletableFuture<Void> newJob = new CompletableFuture<>();
+        CompletableFuture<Void> healthCheck = new CompletableFuture<>();
+        cleanupJobs.put(broker, oldJob);
+
+        reset(brokers);
+        doReturn(healthCheck).when(brokers).healthcheckAsync(any());
+        doReturn(brokers).when(pulsarAdmin).brokers();
+        try {
+            channel.handleBrokerRegistrationEvent(broker, NotificationType.Created);
+            verify(brokers, times(1)).healthcheckAsync(any());
+
+            // Replace the cleanup job before completing the broker health-check callback.
+            cleanupJobs.put(broker, newJob);
+            healthCheck.complete(null);
+
+            Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(cleanupJobs.get(broker) == newJob,
+                        "A stale broker-creation callback must not remove a newer cleanup job");
+                assertFalse(newJob.isCancelled());
+                assertFalse(oldJob.isCancelled());
+            });
+        } finally {
+            cleanupJobs.remove(broker);
+            oldJob.cancel(false);
+            newJob.cancel(false);
+            reset(brokers);
+            doReturn(CompletableFuture.failedFuture(new RuntimeException("failed"))).when(brokers)
+                    .healthcheckAsync(any());
+            reset(pulsarAdmin);
+        }
     }
 
     @Test(priority = 9)
@@ -2075,9 +2254,9 @@ public class ServiceUnitStateChannelTest extends MockedPulsarServiceBaseTest {
         }
     }
 
-    private static ConcurrentHashMap<String, CompletableFuture<Optional<String>>> getOwnerRequests(
+    private static ConcurrentHashMap<String, CompletableFuture<String>> getOwnerRequests(
             ServiceUnitStateChannel channel) throws IllegalAccessException {
-        return (ConcurrentHashMap<String, CompletableFuture<Optional<String>>>)
+        return (ConcurrentHashMap<String, CompletableFuture<String>>)
                 FieldUtils.readDeclaredField(channel,
                         "getOwnerRequests", true);
     }


### PR DESCRIPTION
### Motivation

`ServiceUnitStateChannelImpl` stores pending owner lookups and inactive-broker cleanup jobs in maps keyed by service unit or broker. These futures can be replaced when a lookup is retried, when an Owned event completes a waiting lookup, or when cleanup is rescheduled.

Some completion and cancellation paths removed entries by key only. A stale callback could remove or cancel a newer future for the same key, causing owner lookups to wait for timeout or delaying inactive-broker ownership cleanup.

### Modifications

- Guard `getOwnerRequests` removals with the captured request future.
- Guard `cleanupJobs` removals with the captured cleanup future.
- Guard broker-creation cleanup cancellation with the cleanup future observed before the async health check.
- Add regression tests for stale owner-lookup, skipped Owned event, cleanup-job completion, and broker-creation cancellation callbacks.

### Verifying this change

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelTest.testCompletedGetOwnerRequestDoesNotRemoveNewRequest --tests org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelTest.testSkippedEventDoesNotRemoveNewGetOwnerRequest --tests org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelTest.testCompletedCleanupJobDoesNotRemoveNewCleanupJob --tests org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateChannelTest.handleBrokerCreationEventDoesNotCancelNewCleanupJobTest`
- `./gradlew :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`
- `git diff --check`