### PR TITLE
[fix][build] Restore Maven-era async-profiler wiring for integration test images

### DIFF
--- a/tests/docker-images/java-test-image/Dockerfile
+++ b/tests/docker-images/java-test-image/Dockerfile
@@ -44,12 +44,12 @@ COPY target/java-test-functions.jar /pulsar/examples/
 COPY target/buildtools.jar /pulsar/lib/
 
 ARG INSTALL_ASYNC_PROFILER=false
-# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.1 to /opt/async-profiler
+# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.4 to /opt/async-profiler
 RUN if [ "${INSTALL_ASYNC_PROFILER}" = "true" ]; then \
     mkdir -p /opt/async-profiler \
     && cd /opt/async-profiler \
     && curl -L \
-    "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
+    "https://github.com/async-profiler/async-profiler/releases/download/v4.4/async-profiler-4.4-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
     | tar -zxvf - --strip-components=1; \
     else \
     echo "async-profiler installation skipped"; \

--- a/tests/docker-images/java-test-image/build.gradle.kts
+++ b/tests/docker-images/java-test-image/build.gradle.kts
@@ -21,6 +21,7 @@ val pulsarVersion = project.version.toString()
 val dockerOrganization = providers.gradleProperty("docker.organization").getOrElse("apachepulsar")
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
+val dockerInstallAsyncProfiler = providers.gradleProperty("docker.install.asyncprofiler").getOrElse("false")
 
 // Ensure the parent project is configured before resolving cross-project task references.
 // Required for --configure-on-demand: the Kotlin DSL needs parent ClassLoaderScopes to be locked.
@@ -93,6 +94,7 @@ val dockerBuild by tasks.registering(Exec::class) {
         "docker", "build",
         "-t", imageName,
         "--build-arg", "PULSAR_IMAGE=${pulsarImage}",
+        "--build-arg", "INSTALL_ASYNC_PROFILER=${dockerInstallAsyncProfiler}",
     )
 
     if (dockerPlatforms.isNotEmpty()) {

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -86,12 +86,12 @@ RUN mkdir -p pulsar
 RUN chmod g+rwx pulsar
 
 ARG INSTALL_ASYNC_PROFILER=false
-# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.1 to /opt/async-profiler
+# install async-profiler from https://github.com/async-profiler/async-profiler/releases/tag/v4.4 to /opt/async-profiler
 RUN if [ "${INSTALL_ASYNC_PROFILER}" = "true" ]; then \
     mkdir -p /opt/async-profiler \
     && cd /opt/async-profiler \
     && curl -L \
-    "https://github.com/async-profiler/async-profiler/releases/download/v4.1/async-profiler-4.1-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
+    "https://github.com/async-profiler/async-profiler/releases/download/v4.4/async-profiler-4.4-linux-$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64").tar.gz" \
     | tar -zxvf - --strip-components=1; \
     else \
     echo "async-profiler installation skipped"; \

--- a/tests/docker-images/latest-version-image/build.gradle.kts
+++ b/tests/docker-images/latest-version-image/build.gradle.kts
@@ -21,6 +21,7 @@ val pulsarVersion = project.version.toString()
 val dockerOrganization = providers.gradleProperty("docker.organization").getOrElse("apachepulsar")
 val dockerTag = providers.gradleProperty("docker.tag").getOrElse("latest")
 val dockerPlatforms = providers.gradleProperty("docker.platforms").getOrElse("")
+val dockerInstallAsyncProfiler = providers.gradleProperty("docker.install.asyncprofiler").getOrElse("false")
 val golangImage = providers.gradleProperty("docker.golang.image").getOrElse("golang:1.25-alpine")
 
 // Ensure the parent project is configured before resolving cross-project task references.
@@ -115,6 +116,7 @@ val dockerBuild by tasks.registering(Exec::class) {
         "-t", imageName,
         "--build-arg", "PULSAR_IMAGE=${pulsarImage}",
         "--build-arg", "GOLANG_IMAGE=${golangImage}",
+        "--build-arg", "INSTALL_ASYNC_PROFILER=${dockerInstallAsyncProfiler}",
     )
 
     if (dockerPlatforms.isNotEmpty()) {

--- a/tests/integration/build.gradle.kts
+++ b/tests/integration/build.gradle.kts
@@ -93,6 +93,8 @@ val integrationTestSuiteFile = integrationTestSuiteFileProperty.getOrElse("pulsa
 val integrationTestSuiteFileExplicit = integrationTestSuiteFileProperty.isPresent
 val integrationTestGroups = providers.gradleProperty("testGroups").orNull
 val integrationTestExcludedGroups = providers.gradleProperty("excludedTestGroups").orNull
+val integrationTestAsyncProfilerDir = providers.gradleProperty("inttest.asyncprofiler.dir")
+    .getOrElse(layout.buildDirectory.get().asFile.absolutePath)
 val ideaActive = providers.systemProperty("idea.active").map { it.toBoolean() }.getOrElse(false)
 // When `--tests` is passed on the CLI, let TestNG discover tests directly from the classpath
 // instead of restricting discovery to the suite XML — unless -PintegrationTestSuiteFile was
@@ -124,6 +126,19 @@ val integrationTest by tasks.registering(Test::class) {
 
     systemProperty("currentVersion", project.version.toString())
     systemProperty("buildDirectory", layout.buildDirectory.get().asFile.absolutePath)
+    systemProperty("inttest.asyncprofiler.dir", integrationTestAsyncProfilerDir)
+    providers.gradleProperty("inttest.asyncprofiler.opts").orNull?.let {
+        systemProperty("inttest.asyncprofiler.opts", it)
+    }
+    providers.gradleProperty("inttest.asyncprofiler.outputformat").orNull?.let {
+        systemProperty("inttest.asyncprofiler.outputformat", it)
+    }
+    providers.gradleProperty("git.commit.id.abbrev").orNull?.let {
+        systemProperty("git.commit.id.abbrev", it)
+    }
+    providers.gradleProperty("build.timestamp").orNull?.let {
+        systemProperty("build.timestamp", it)
+    }
 
     jvmArgs(
         "-XX:+ExitOnOutOfMemoryError",

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/profiling/PulsarProfilingTest.java
@@ -48,7 +48,7 @@ import org.testng.annotations.Test;
  * # compile integration test dependencies
  * ./gradlew assemble
  * # compile apachepulsar/java-test-image with async profiler (add "clean" to ensure a clean build with recent changes)
- * ./build/build_java_test_image.sh -Ddocker.install.asyncprofiler=true -Pdocker-wolfi
+ * ./gradlew :tests:java-test-image:dockerBuild -Pdocker.install.asyncprofiler=true -Pdocker.wolfi
  * # set environment variables
  * export PULSAR_TEST_IMAGE_NAME=apachepulsar/java-test-image:latest
  * export NETTY_LEAK_DETECTION=off
@@ -65,7 +65,8 @@ import org.testng.annotations.Test;
  * kernel.perf_event_max_stack=1024
  * kernel.perf_event_mlock_kb=2048
  * # run the test
- * ./gradlew :tests:integration:integrationTest -PintegrationTestSuiteFile=pulsar-profiling.xml -PtestRetryCount=0
+ * ./gradlew :tests:integration:integrationTest \
+ *   --tests org.apache.pulsar.tests.integration.profiling.PulsarProfilingTest -PtestRetryCount=0
  * By default, the .jfr files will go into tests/integration/build
  * You can use jfrconv from async profiler to convert them into html flamegraphs or use other tools such
  * as Eclipse Mission Control (https://adoptium.net/jmc) or IntelliJ to open them.
@@ -226,7 +227,7 @@ public class PulsarProfilingTest extends PulsarTestSuite {
     protected void beforeStartCluster() throws Exception {
         super.beforeStartCluster();
         pulsarCluster.forEachContainer(
-                // This is effective only when -Pdocker-wolfi has been passed when building java-test-image
+                // This is effective only when -Pdocker.wolfi has been passed when building java-test-image
                 // setting mmap_threshold explicitly will avoid it's dynamic increase
                 // https://sourceware.org/glibc/manual/latest/html_node/Memory-Allocation-Tunables.html
                 c -> c.withEnv("GLIBC_TUNABLES",


### PR DESCRIPTION
### Motivation

`PulsarProfilingTest` supports profiling broker-side workloads with async-profiler. This support existed in the Maven-based workflow, where the build could install async-profiler into the test images and pass the profiler options to the integration test JVM.

After the Gradle migration, the same async-profiler wiring was no longer available through the Gradle build. This PR backports the Maven-era async-profiler wiring to Gradle. It does not introduce a new profiling mode; it restores the existing profiling workflow for the Gradle build.

### Modifications

- Ported the Maven-era `docker.install.asyncprofiler` option to `:tests:java-test-image:dockerBuild`.
- Ported the Maven-era `docker.install.asyncprofiler` option to `:tests:latest-version-image:dockerBuild`.
- Updated the async-profiler installed into the test images to 4.4.
- Ported the Maven-era integration test profiler properties to the `integrationTest` JVM:
  - `inttest.asyncprofiler.dir`
  - `inttest.asyncprofiler.opts`
  - `inttest.asyncprofiler.outputformat`
  - `git.commit.id.abbrev`
  - `build.timestamp`
- Kept the existing `PulsarContainer` defaults for optional profiler settings when the matching Gradle properties are not provided.
- Updated `PulsarProfilingTest` usage comments to use the Gradle Docker image build task and `--tests`.

### Usage

Build the test image with async-profiler installed:

```bash
./gradlew :tests:java-test-image:dockerBuild \
  -Pdocker.install.asyncprofiler=true \
  -Pdocker.wolfi
```

Run the profiling integration test:

```bash
export PULSAR_TEST_IMAGE_NAME=apachepulsar/java-test-image:latest
export ENABLE_MANUAL_TEST=true
export NETTY_LEAK_DETECTION=off

./gradlew :tests:integration:integrationTest \
  --tests org.apache.pulsar.tests.integration.profiling.PulsarProfilingTest \
  -PtestRetryCount=0 \
  -Pinttest.asyncprofiler.dir=/tmp/pulsar-profiles \
  -Pinttest.asyncprofiler.outputformat=jfr
```

The profiler output is written to the directory configured by `inttest.asyncprofiler.dir`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change can be verified with the existing profiling integration test workflow:

- `./gradlew :tests:integration:compileTestJava :tests:integration:checkstyleTest --no-configuration-cache`
- `./gradlew :tests:java-test-image:dockerBuild -Pdocker.install.asyncprofiler=true -Pdocker.wolfi`
- `./gradlew :tests:latest-version-image:dockerBuild -Pdocker.install.asyncprofiler=true -Pdocker.wolfi`
- Verified that explicitly provided profiler Gradle properties are passed to the `integrationTest` JVM.
- Verified that both generated test images contain async-profiler 4.4.
- Verified that `PulsarProfilingTest.runPulsarPerf` passes with `ENABLE_MANUAL_TEST=true`.
- Verified that the broker JVM starts with the async-profiler `-agentpath` option.
- Verified that the test generates a non-empty `.jfr` file readable by `jfr summary`.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
