### PR TITLE
[improve][broker] Skip system cursor when check inactive cursor.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -3684,7 +3684,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             subscriptions.forEach((subName, sub) -> {
                 if (sub.dispatcher != null && sub.dispatcher.isConsumerConnected()
                         || sub.isReplicated()
-                        || isCompactionSubscription(subName)) {
+                        || isSystemCursor(subName)) {
                     return;
                 }
                 if (System.currentTimeMillis() - sub.cursor.getLastActive() > expirationTimeMillis) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -2080,6 +2080,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     @Test
     public void testCheckInactiveSubscriptions() throws Exception {
         pulsarTestContext.getConfig().setSubscriptionExpirationTimeMinutes(5);
+        pulsarTestContext.getConfig().setAdditionalSystemCursorNames(Set.of("additionalSystemCursor"));
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
 
         final var subscriptions = new ConcurrentHashMap<String, PersistentSubscription>();
@@ -2098,6 +2099,11 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
                 spyWithClassAndConstructorArgsRecordingInvocations(PersistentSubscription.class, topic,
                         "nonDeletableSubscription2", cursorMock, true);
         subscriptions.put(nonDeletableSubscription2.getName(), nonDeletableSubscription2);
+        // This subscription is an additional system cursor.
+        PersistentSubscription nonDeletableSubscription3 =
+                spyWithClassAndConstructorArgsRecordingInvocations(PersistentSubscription.class, topic,
+                        "additionalSystemCursor", cursorMock, false);
+        subscriptions.put(nonDeletableSubscription3.getName(), nonDeletableSubscription3);
 
         Field field = topic.getClass().getDeclaredField("subscriptions");
         field.setAccessible(true);
@@ -2122,6 +2128,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         verify(nonDeletableSubscription1, times(0)).delete();
         verify(deletableSubscription1, times(1)).delete();
         verify(nonDeletableSubscription2, times(0)).delete();
+        verify(nonDeletableSubscription3, times(0)).delete();
     }
 
     @Test


### PR DESCRIPTION
### Motivation
`PersistentTopic#checkInactiveSubscriptions` skips built-in system subscriptions such as the compaction subscription when deleting expired inactive subscriptions. However, subscriptions configured through `additionalSystemCursorNames` are also treated as system cursors elsewhere, but were not skipped by this expiration cleanup path. As a result, an additional system cursor could be deleted when it became inactive past the subscription expiration threshold.


### Modifications
• Updated `PersistentTopic#checkInactiveSubscriptions` to skip subscriptions identified by isSystemCursor(subName) instead of only checking the compaction subscription.
• Extended `PersistentTopicTest#testCheckInactiveSubscriptions` to configure an additionalSystemCursorNames entry and verify that the corresponding subscription is not deleted during inactive subscription cleanup.


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment