### PR TITLE
[improve][misc] Replace MD5 NAR/archive checksums with SHA-256

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
@@ -47,28 +47,30 @@ public class FileUtils {
     public static final long MILLIS_BETWEEN_ATTEMPTS = 50L;
 
     /**
-     * Calculates an md5 sum of the specified file.
+     * Calculates a SHA-256 checksum of the specified file. The checksum is used for
+     * change detection, not as a security control; SHA-256 is chosen over MD5/SHA-1 so
+     * that the call also works on JVMs whose security provider rejects weak digests
+     * (e.g. in FIPS deployments).
      *
      * @param file
-     *            to calculate the md5sum of
-     * @return the md5sum bytes
+     *            to calculate the checksum of
+     * @return the checksum bytes
      * @throws IOException
      *             if cannot read file
      */
-    public static byte[] calculateMd5sum(final File file) throws IOException {
+    public static byte[] calculateSha256sum(final File file) throws IOException {
         try (final FileInputStream inputStream = new FileInputStream(file)) {
-            // codeql[java/weak-cryptographic-algorithm] - md5 is sufficient for this use case
-            final MessageDigest md5 = MessageDigest.getInstance("md5");
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
-            final byte[] buffer = new byte[1024];
+            final byte[] buffer = new byte[8192];
             int read = inputStream.read(buffer);
 
             while (read > -1) {
-                md5.update(buffer, 0, read);
+                digest.update(buffer, 0, read);
                 read = inputStream.read(buffer);
             }
 
-            return md5.digest();
+            return digest.digest();
         } catch (NoSuchAlgorithmException nsae) {
             throw new IllegalArgumentException(nsae);
         }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -75,9 +75,9 @@ public class NarUnpacker {
                 throw new IOException("Cannot create " + parentDirectory);
             }
         }
-        String md5Sum = Base64.getUrlEncoder().withoutPadding().encodeToString(FileUtils.calculateMd5sum(nar));
+        String checksum = Base64.getUrlEncoder().withoutPadding().encodeToString(FileUtils.calculateSha256sum(nar));
         // ensure that one process can extract the files
-        File lockFile = new File(parentDirectory, "." + md5Sum + ".lock");
+        File lockFile = new File(parentDirectory, "." + checksum + ".lock");
         // prevent OverlappingFileLockException by ensuring that one thread tries to create a lock in this JVM
         Object localLock = CURRENT_JVM_FILE_LOCKS.computeIfAbsent(lockFile.getAbsolutePath(), key -> new Object());
         synchronized (localLock) {
@@ -85,9 +85,9 @@ public class NarUnpacker {
             // using the same lock file don't execute concurrently
             try (FileChannel channel = new RandomAccessFile(lockFile, "rw").getChannel();
                  FileLock lock = channel.lock()) {
-                File narWorkingDirectory = new File(parentDirectory, md5Sum);
+                File narWorkingDirectory = new File(parentDirectory, checksum);
                 if (!narWorkingDirectory.exists()) {
-                    File narExtractionTempDirectory = new File(parentDirectory, md5Sum + ".tmp");
+                    File narExtractionTempDirectory = new File(parentDirectory, checksum + ".tmp");
                     if (narExtractionTempDirectory.exists()) {
                         FileUtils.deleteFile(narExtractionTempDirectory, true);
                     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionArchive.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionArchive.java
@@ -27,8 +27,8 @@ import org.apache.pulsar.functions.utils.ValidatableFunctionPackage;
 
 public class FunctionArchive implements AutoCloseable {
     private final Path archivePath;
-    /** MD5 hex of archive file contents; empty when {@link #archivePath} is null (test doubles). */
-    private final String archiveMd5Hex;
+    /** SHA-256 hex of archive file contents; empty when {@link #archivePath} is null (test doubles). */
+    private final String archiveChecksumHex;
     private final FunctionDefinition functionDefinition;
     private final String narExtractionDirectory;
     private final boolean enableClassloading;
@@ -41,25 +41,25 @@ public class FunctionArchive implements AutoCloseable {
     }
 
     /**
-     * @param precomputedArchiveMd5Hex MD5 hex of {@code archivePath} contents; if null and path is non-null,
+     * @param precomputedArchiveChecksumHex SHA-256 hex of {@code archivePath} contents; if null and path is non-null,
      *                                   the hash is computed once at construction time.
      */
     public FunctionArchive(Path archivePath, FunctionDefinition functionDefinition, String narExtractionDirectory,
-                           boolean enableClassloading, String precomputedArchiveMd5Hex) {
+                           boolean enableClassloading, String precomputedArchiveChecksumHex) {
         this.archivePath = archivePath;
         this.functionDefinition = functionDefinition;
         this.narExtractionDirectory = narExtractionDirectory;
         this.enableClassloading = enableClassloading;
         if (archivePath != null) {
             try {
-                this.archiveMd5Hex = precomputedArchiveMd5Hex != null
-                        ? precomputedArchiveMd5Hex
-                        : FunctionUtils.computeArchiveMd5Hex(archivePath);
+                this.archiveChecksumHex = precomputedArchiveChecksumHex != null
+                        ? precomputedArchiveChecksumHex
+                        : FunctionUtils.computeArchiveChecksumHex(archivePath);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         } else {
-            this.archiveMd5Hex = "";
+            this.archiveChecksumHex = "";
         }
     }
 
@@ -67,8 +67,8 @@ public class FunctionArchive implements AutoCloseable {
         return archivePath;
     }
 
-    public String getArchiveMd5Hex() {
-        return archiveMd5Hex;
+    public String getArchiveChecksumHex() {
+        return archiveChecksumHex;
     }
 
     public synchronized ValidatableFunctionPackage getFunctionPackage() {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functions/FunctionUtils.java
@@ -47,14 +47,10 @@ public class FunctionUtils {
     private static final String PULSAR_IO_SERVICE_NAME = "pulsar-io.yaml";
 
     /**
-     * Computes MD5 digest of a file as lower-case hex (for function archive identity on reload).
+     * Computes a SHA-256 digest of a file as lower-case hex (for function archive identity on reload).
      */
-    public static String computeArchiveMd5Hex(Path path) throws IOException {
-        return calculateMd5Hex(path.toAbsolutePath().normalize().toFile());
-    }
-
-    private static String calculateMd5Hex(File file) throws IOException {
-        return HexFormat.of().formatHex(FileUtils.calculateMd5sum(file));
+    public static String computeArchiveChecksumHex(Path path) throws IOException {
+        return HexFormat.of().formatHex(FileUtils.calculateSha256sum(path.toAbsolutePath().normalize().toFile()));
     }
 
     /**
@@ -161,12 +157,12 @@ public class FunctionUtils {
                     FunctionDefinition funcDef = FunctionUtils.getFunctionDefinition(archive.toFile());
                     if (!StringUtils.isEmpty(funcDef.getFunctionClass())) {
                         String name = funcDef.getName();
-                        String md5Hex = computeArchiveMd5Hex(archive);
+                        String checksumHex = computeArchiveChecksumHex(archive);
                         FunctionArchive prev = remaining.remove(name);
                         if (prev != null
                                 && prev.getArchivePath() != null
                                 && archive.equals(prev.getArchivePath())
-                                && md5Hex.equals(prev.getArchiveMd5Hex())) {
+                                && checksumHex.equals(prev.getArchiveChecksumHex())) {
                             next.put(name, prev);
                         } else {
                             if (prev != null) {
@@ -178,7 +174,7 @@ public class FunctionUtils {
                                 toClose.add(prev);
                             }
                             next.put(name, new FunctionArchive(archive, funcDef, narExtractionDirectory,
-                                    enableClassloading, md5Hex));
+                                    enableClassloading, checksumHex));
                         }
                     }
                 } catch (Throwable t) {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/Connector.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/Connector.java
@@ -28,8 +28,8 @@ import org.apache.pulsar.functions.utils.ValidatableFunctionPackage;
 
 public class Connector implements AutoCloseable {
     private final Path archivePath;
-    /** MD5 hex of archive file contents; empty when {@link #archivePath} is null (test doubles). */
-    private final String archiveMd5Hex;
+    /** SHA-256 hex of archive file contents; empty when {@link #archivePath} is null (test doubles). */
+    private final String archiveChecksumHex;
     private final String narExtractionDirectory;
     private final boolean enableClassloading;
     private ValidatableFunctionPackage connectorFunctionPackage;
@@ -44,25 +44,25 @@ public class Connector implements AutoCloseable {
     }
 
     /**
-     * @param precomputedArchiveMd5Hex MD5 hex of {@code archivePath} contents; if null and path is non-null,
+     * @param precomputedArchiveChecksumHex SHA-256 hex of {@code archivePath} contents; if null and path is non-null,
      *                                   the hash is computed once at construction time.
      */
     public Connector(Path archivePath, ConnectorDefinition connectorDefinition, String narExtractionDirectory,
-                     boolean enableClassloading, String precomputedArchiveMd5Hex) {
+                     boolean enableClassloading, String precomputedArchiveChecksumHex) {
         this.archivePath = archivePath;
         this.connectorDefinition = connectorDefinition;
         this.narExtractionDirectory = narExtractionDirectory;
         this.enableClassloading = enableClassloading;
         if (archivePath != null) {
             try {
-                this.archiveMd5Hex = precomputedArchiveMd5Hex != null
-                        ? precomputedArchiveMd5Hex
-                        : ConnectorUtils.computeArchiveMd5Hex(archivePath);
+                this.archiveChecksumHex = precomputedArchiveChecksumHex != null
+                        ? precomputedArchiveChecksumHex
+                        : ConnectorUtils.computeArchiveChecksumHex(archivePath);
             } catch (java.io.IOException e) {
                 throw new java.io.UncheckedIOException(e);
             }
         } else {
-            this.archiveMd5Hex = "";
+            this.archiveChecksumHex = "";
         }
     }
 
@@ -70,8 +70,8 @@ public class Connector implements AutoCloseable {
         return archivePath;
     }
 
-    public String getArchiveMd5Hex() {
-        return archiveMd5Hex;
+    public String getArchiveChecksumHex() {
+        return archiveChecksumHex;
     }
 
     public synchronized ValidatableFunctionPackage getConnectorFunctionPackage() {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -56,14 +56,10 @@ import org.apache.pulsar.io.core.annotations.FieldDoc;
 public class ConnectorUtils {
 
     /**
-     * Computes MD5 digest of a file as lower-case hex (for connector archive identity on reload).
+     * Computes a SHA-256 digest of a file as lower-case hex (for connector archive identity on reload).
      */
-    public static String computeArchiveMd5Hex(Path path) throws IOException {
-        return calculateMd5Hex(path.toAbsolutePath().normalize().toFile());
-    }
-
-    private static String calculateMd5Hex(File file) throws IOException {
-        return HexFormat.of().formatHex(FileUtils.calculateMd5sum(file));
+    public static String computeArchiveChecksumHex(Path path) throws IOException {
+        return HexFormat.of().formatHex(FileUtils.calculateSha256sum(path.toAbsolutePath().normalize().toFile()));
     }
 
     /**
@@ -236,12 +232,12 @@ public class ConnectorUtils {
                 try {
                     ConnectorDefinition cntDef = ConnectorUtils.getConnectorDefinition(archive.toFile());
                     String name = cntDef.getName();
-                    String md5Hex = computeArchiveMd5Hex(archive);
+                    String checksumHex = computeArchiveChecksumHex(archive);
                     Connector prev = remaining.remove(name);
                     if (prev != null
                             && prev.getArchivePath() != null
                             && archive.equals(prev.getArchivePath())
-                            && md5Hex.equals(prev.getArchiveMd5Hex())) {
+                            && checksumHex.equals(prev.getArchiveChecksumHex())) {
                         next.put(name, prev);
                     } else {
                         if (prev != null) {
@@ -253,7 +249,7 @@ public class ConnectorUtils {
                             toClose.add(prev);
                         }
                         next.put(name, new Connector(archive, cntDef, narExtractionDirectory, enableClassloading,
-                                md5Hex));
+                                checksumHex));
                     }
                 } catch (Throwable t) {
                     log.warn()


### PR DESCRIPTION
### Motivation

`FileUtils.calculateMd5sum` backs two non-security change-detection mechanisms: the NAR extraction directory checksum (`NarUnpacker`) and the connector/function archive identity used for hot-reload (`ConnectorUtils`/`FunctionUtils`). MD5 is fine for change detection, but strict security providers reject it outright — under BC-FIPS in approved-only mode, `MessageDigest.getInstance("md5")` throws, which breaks NAR extraction (and therefore broker/worker startup with connectors) on FIPS-configured JVMs.

This is one of a set of small preparatory cleanups for FIPS-restricted deployments; a broader PIP covering TLS provider wiring, packaging, and message-crypto algorithm migration is being drafted separately.

### Modifications

- `FileUtils`: replaced `calculateMd5sum` with `calculateSha256sum` (SHA-256, larger read buffer); javadoc documents that the checksum is change detection, not a security control.
- `NarUnpacker`: uses the SHA-256 checksum for the extraction directory and lock-file names; local variable renamed accordingly.
- `ConnectorUtils`/`FunctionUtils`: `computeArchiveMd5Hex` → `computeArchiveChecksumHex` (SHA-256).
- `Connector`/`FunctionArchive`: field/accessor renames (`getArchiveChecksumHex`), javadoc updated.

The archive checksum is only compared in-memory against values computed by the same JVM, so the algorithm change is not observable there. The NAR extraction directory name changes, causing a one-time re-extraction after upgrade; stale checksum-named directories from older versions are left behind in the extraction dir, matching existing behavior when NAR content changes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests: `NarUnpackerTest` (extraction/locking against the new checksum naming), `ConnectorUtilsReloadTest` and `FunctionUtilsReloadTest` (archive-identity change detection).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
