### PR TITLE
[improve][client] Use SHA-256 for generated reader subscription names

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsReaderImpl.java
@@ -61,7 +61,8 @@ public class MultiTopicsReaderImpl<T> implements Reader<T> {
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionName())) {
             subscription = readerConfiguration.getSubscriptionName();
         } else {
-            subscription = "multiTopicsReader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+            subscription = "multiTopicsReader-"
+                    + DigestUtils.sha256Hex(UUID.randomUUID().toString()).substring(0, 10);
             if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
                 subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -65,7 +65,7 @@ public class ReaderImpl<T> implements Reader<T> {
         if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionName())) {
             subscription = readerConfiguration.getSubscriptionName();
         } else {
-            subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+            subscription = "reader-" + DigestUtils.sha256Hex(UUID.randomUUID().toString()).substring(0, 10);
             if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
                 subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
             }


### PR DESCRIPTION
### Motivation

When a reader is created without an explicit subscription name, `ReaderImpl`/`MultiTopicsReaderImpl` generate one by hashing a random UUID with SHA-1 (`DigestUtils.sha1Hex`). The hash is not a security control — it just produces a short random identifier — but strict security providers reject SHA-1: under BC-FIPS in approved-only mode the call throws, so creating a reader without a subscription name fails on FIPS-configured JVMs.

This is one of a set of small preparatory cleanups for FIPS-restricted deployments; a broader PIP is being drafted separately.

### Modifications

Replaced `DigestUtils.sha1Hex(...)` with `DigestUtils.sha256Hex(...)` in the generated-subscription-name paths of `ReaderImpl` and `MultiTopicsReaderImpl`. The generated names keep the same shape (`reader-` / `multiTopicsReader-` prefix + 10 hex chars) and entropy (40 bits of a hash over a random UUID). The names are ephemeral, used for non-durable subscriptions, and never persisted, so nothing is observable across versions.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. (Existing reader tests, e.g. `ReaderImplTest`, exercise the generated-name path.)

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
