### PR TITLE
[improve][pip] PIP-489: FIPS 140-3 compliance mode for Apache Pulsar

### DIFF
--- a/pip/pip-489.md
+++ b/pip/pip-489.md
@@ -1,0 +1,550 @@
+# PIP-489: FIPS 140-3 compliance mode for Apache Pulsar
+
+# Background knowledge
+
+**FIPS 140-3** is the current U.S./Canadian government standard (managed by NIST's Cryptographic
+Module Validation Program, CMVP) for validating cryptographic modules. Deployments subject to
+FedRAMP, DoD, and many healthcare/financial regulatory regimes must perform *all* cryptography
+inside a CMVP-validated module operating in *approved-only* mode, using only approved algorithms
+(e.g. AES, SHA-2, RSA-OAEP with SHA-2, ECDH on NIST curves, HMAC, NIST DRBGs). Non-approved
+algorithms (MD5, DES, ECIES, SHA-1 for signatures) and non-validated crypto libraries are
+disallowed in the data path.
+
+**Bouncy Castle FIPS (BC-FIPS)** is a CMVP-validated Java cryptographic module
+(`org.bouncycastle:bc-fips`, with `bcpkix-fips`/`bcutil-fips` companions). It is a drop-in JCA/JCE
+provider (`BCFIPS`) that replaces the general-purpose Bouncy Castle provider (`BC`,
+`bcprov-jdk18on`). The two are mutually exclusive on a classpath: they share the
+`org.bouncycastle` package namespace but BC-FIPS omits non-approved classes such as
+`org.bouncycastle.jce.*` and the ECIES cipher. When the JVM system property
+`org.bouncycastle.fips.approved_only=true` is set, BC-FIPS rejects all non-approved algorithms.
+
+**How Pulsar resolves Bouncy Castle today.** `SecurityUtility` (in `pulsar-common`,
+`org.apache.pulsar.common.util.SecurityUtility`) loads whichever BC flavor is on the classpath by
+reflection — it tries `org.bouncycastle.jce.provider.BouncyCastleProvider` and falls back to
+`org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider` — and exposes
+`SecurityUtility.isBCFIPS()` so callers can branch on the active flavor. This means Pulsar is
+already *FIPS-capable at the JCA layer*: swap the jars and the provider swap works.
+
+**Pulsar's TLS stack.** Pulsar terminates TLS in two distinct stacks:
+
+1. The **binary protocol** listeners (broker, proxy) use Netty. Netty selects an `SslProvider`:
+   `OPENSSL` (native, backed by `netty-tcnative-boringssl-static`, i.e. Google BoringSSL — not
+   FIPS-validated) or `JDK` (the JVM's JSSE, which delegates to the installed JCA providers and
+   therefore to BC-FIPS when it is the active provider). Since PIP-337, TLS contexts are built
+   through the pluggable `PulsarSslFactory` abstraction: each listener builds a
+   `PulsarSslConfiguration` (including an optional `tlsProvider` field) and passes it to the
+   configured factory (default `DefaultPulsarSslFactory`), which maps `tlsProvider` to Netty's
+   `SslProvider` — or passes `null`, letting Netty pick its default, which is `OPENSSL` whenever
+   tcnative is on the classpath.
+2. The **HTTP/admin/WebSocket/function-worker** listeners use Jetty, whose `SslContextFactory`
+   accepts a JSSE provider name (e.g. `SunJSSE`, `Conscrypt`). Conscrypt is another
+   BoringSSL-based, non-FIPS-validated provider.
+
+**End-to-end message encryption.** `MessageCryptoBc`
+(`pulsar-client-messagecrypto-bc`) encrypts payloads with AES-GCM under a per-producer data key,
+and wraps that data key with each consumer's public key — RSA-OAEP for RSA keys, ECIES for EC
+keys. The wrapped keys travel in the `EncryptionKeys` field of the message metadata, which carries
+a `key`, a `value` (the wrapped bytes), and an extensible list of `KeyValue` **metadata** entries —
+this metadata list is the natural place for algorithm negotiation.
+
+**Pulsar Functions on Kubernetes.** `KubernetesRuntime` derives StatefulSet/Service/job names
+from `tenant-namespace-function` plus a short hash, and those names are *persisted state*: a
+running function's StatefulSet must keep its name across broker/worker upgrades, or the upgrade
+orphans and recreates every function.
+
+# Motivation
+
+Pulsar has no supported FIPS deployment path today, despite being most of the way there at the
+JCA layer. Users in regulated environments (FedRAMP, DoD IL levels, PCI, healthcare) either cannot
+deploy Pulsar or deploy it with unsupported hand-rolled jar surgery that silently fails to be
+FIPS-compliant. Concretely, on current `master`:
+
+1. **The BC/BC-FIPS swap lost its packaging story in the Gradle migration.** The Maven-era
+   swappable `bouncy-castle-bc` / `bouncy-castle-bcfips` NAR modules did not survive the migration.
+   The version catalog still declares `bc-fips` 2.0.1 / `bcpkix-fips` 2.0.11 / `bcutil-fips` 2.0.6
+   (`gradle/libs.versions.toml:59-61`), but the server distribution bundles the non-FIPS
+   `bcprov`/`bcpkix` 1.84 and *explicitly excludes* `bc-fips`
+   (`distribution/server/build.gradle.kts:59`). The only remaining consumer of the FIPS artifacts
+   is the `tests/pulsar-client-test-bcfips` test module.
+
+2. **Broker TLS cannot be steered off BoringSSL.** The broker binary listener never wires the
+   `tlsProvider` setting: `ServiceConfiguration.tlsProvider` exists
+   (`pulsar-broker-common/.../ServiceConfiguration.java:4244`, default `null`) but
+   `PulsarChannelInitializer.buildSslConfiguration`
+   (`pulsar-broker/.../service/PulsarChannelInitializer.java:137`) never calls `.tlsProvider(...)`
+   on the `PulsarSslConfiguration` builder. `DefaultPulsarSslFactory` then passes a `null`
+   `SslProvider` to Netty, and because `netty-tcnative-boringssl-static` is an *unconditional*
+   dependency of `pulsar-common` (`pulsar-common/build.gradle.kts:180-185`), Netty's default is
+   always `OPENSSL` = BoringSSL. Broker PEM TLS is therefore hardwired to non-FIPS native crypto
+   with no configuration escape hatch. The proxy does this correctly
+   (`pulsar-proxy/.../ServiceChannelInitializer.java:94` wires `.tlsProvider(config.getTlsProvider())`);
+   the broker web service (`WebService.java:596`), WebSocket proxy (`pulsar-websocket/.../ProxyServer.java`),
+   and function worker (`pulsar-functions/worker/.../WorkerServer.java`) all omit it.
+
+3. **Non-FIPS providers are the shipped defaults.** `webServiceTlsProvider` defaults to
+   `Conscrypt` in `ServiceConfiguration` (line 211), `ProxyConfiguration` (line 336), and
+   `WebSocketProxyConfiguration` (`tlsProvider`, line 229), and in the shipped `conf/proxy.conf`
+   (line 118).
+
+4. **The false-confidence FIPS test.** `tests/pulsar-client-test-bcfips` runs a TLS
+   produce/consume with `bc-fips` on the classpath, which validates the JCA provider swap (PEM
+   key parsing through BC-FIPS) — but the TLS transport on both sides still terminates in the
+   default BoringSSL engine, so it does *not* validate a FIPS TLS stack.
+
+5. **Several security-path algorithms are not FIPS-approved** (detailed per-item below):
+   SHA-1-based RSA-OAEP and ECIES in `MessageCryptoBc`, MD5-crypt/DES-crypt in
+   `AuthenticationProviderBasic`, a non-HMAC SHA-512 concat construction in
+   `SaslRoleTokenSigner`, and SHA-1 in persisted Kubernetes resource names.
+
+6. **Zero FIPS documentation exists** — neither a deployment guide nor a statement of which
+   components are in scope.
+
+This PIP defines a supported, tested, documented "FIPS mode" that closes these gaps.
+
+# Goals
+
+## In Scope
+
+- A documented **FIPS mode** deployment profile for broker, proxy, WebSocket proxy, and function
+  worker: BC-FIPS as the sole Bouncy Castle JCA provider, JDK (or BCJSSE) TLS with no
+  BoringSSL/Conscrypt on the crypto path, and only approved algorithms in security paths.
+- Wiring the existing `tlsProvider` / `webServiceTlsProvider` settings through every listener's
+  `PulsarSslConfiguration` so `JDK`/`SunJSSE` TLS is actually selectable (broker binary listener,
+  broker web, WebSocket proxy, function worker — matching the proxy's existing pattern).
+- A **FIPS distribution variant** (or, at minimum, first-class Gradle wiring plus a documented,
+  supported jar-swap procedure) that ships `bc-fips`/`bcpkix-fips`/`bcutil-fips` and omits
+  `bcprov`/`bcpkix`, `netty-tcnative-boringssl-static`, and Conscrypt.
+- A `fipsMode` startup switch that fail-fast validates the configuration (provider selection,
+  algorithm choices) rather than discovering violations at runtime.
+- FIPS-approved options, with versioned/negotiated migrations, for: message-crypto key wrapping
+  (RSA-OAEP-SHA256; ECDH+KDF+AES-KW or documented non-support for EC), Basic authentication
+  password hashes (SHA-256/512-crypt), and the SASL role-token signature (HMAC-SHA256 with
+  dual-verify rolling upgrade).
+- A name-stable fix for the SHA-1 usage in `KubernetesRuntime` resource naming.
+- BCFKS/PKCS11 keystore support **documented** (the keystore-type plumbing already accepts them;
+  this PIP adds docs and test coverage, not new code paths).
+- A real FIPS TLS integration test replacing the false-confidence one, plus user-facing
+  documentation on pulsar-site.
+
+## Out of Scope
+
+- **Obtaining a CMVP certificate for Pulsar itself.** Pulsar is an *application using* a validated
+  module (BC-FIPS); the validation boundary is BC-FIPS's, per the standard "user of a validated
+  module" model.
+- FIPS-validating the C++, Python, Go, or Node.js clients (each has its own TLS stack; may be
+  follow-up work per client).
+- FIPS posture of embedded/companion components beyond configuration guidance: BookKeeper and
+  ZooKeeper/etcd have their own TLS stacks — the FIPS deployment guide will cover *configuring*
+  them onto JDK TLS, but changing their code is out of scope.
+- Non-security uses of hashing that never touch JCA (e.g. Murmur3 topic hashing) — not crypto,
+  not in scope.
+- The four "quick win" fixes already in flight as standalone PRs (see *General Notes*).
+
+# High Level Design
+
+FIPS mode is a **deployment profile**, not a fork: every change below is independently useful and
+independently configurable, and a new boolean `fipsMode` setting ties them together by (a)
+fail-fast validating at startup that the process is actually in a FIPS-capable state and (b)
+rejecting configurations that would silently use non-approved crypto.
+
+End to end, a FIPS deployment looks like:
+
+1. **Packaging.** The operator deploys the FIPS distribution variant (or performs the documented
+   swap): `bc-fips` + `bcpkix-fips` + `bcutil-fips` on the classpath; `bcprov-jdk18on`,
+   `bcpkix-jdk18on`, `netty-tcnative-boringssl-static`, and Conscrypt absent. The JVM is started
+   with `-Dorg.bouncycastle.fips.approved_only=true`. `SecurityUtility` picks up BC-FIPS exactly
+   as it does today — no code change needed at the JCA layer.
+2. **TLS.** All listeners honor `tlsProvider=JDK` (Netty/binary) and
+   `webServiceTlsProvider=SunJSSE` (Jetty/HTTP), so every TLS handshake runs in JSSE on top of
+   the BC-FIPS provider. Keystores may be PEM, BCFKS, or PKCS11.
+3. **Validation.** With `fipsMode=true`, the broker/proxy/worker verifies at startup: BC-FIPS is
+   the active BC provider (`SecurityUtility.isBCFIPS()`), no `OPENSSL`/`Conscrypt` TLS provider
+   is configured on any listener, Basic-auth password files contain no MD5/DES entries, and the
+   SASL token signer is in HMAC mode. Violations abort startup with an explicit error.
+4. **Algorithms.** Security paths that today hardcode non-approved algorithms gain approved
+   alternatives behind explicit, compatibility-safe migration mechanisms (metadata-negotiated for
+   message crypto, dual-verify for SASL tokens, prefix-dispatched for Basic auth, name-stable for
+   Kubernetes naming).
+5. **Verification.** A new integration test group runs a broker+proxy+client on a
+   BC-FIPS-only, tcnative-free, approved-only-mode classpath and exercises binary TLS, HTTPS,
+   mTLS auth, and E2E encryption.
+
+# Detailed Design
+
+## Design & Implementation Details
+
+### (a) TLS provider wiring
+
+The fix is mechanical and follows the proxy's existing pattern
+(`ServiceChannelInitializer.buildSslConfiguration`, which already calls
+`.tlsProvider(config.getTlsProvider())`):
+
+- `pulsar-broker/.../service/PulsarChannelInitializer.buildSslConfiguration` adds
+  `.tlsProvider(serviceConfig.getTlsProvider())`. This wires the **existing**
+  `ServiceConfiguration.tlsProvider` key (currently declared but dead for the binary listener).
+  Default stays `null`; behavior only changes for users who had set the key expecting it to work.
+- `pulsar-broker/.../web/WebService.buildSslConfiguration` adds
+  `.tlsProvider(serviceConfig.getWebServiceTlsProvider())`. Note the subtlety on current master:
+  `webServiceTlsProvider` *is* passed to Jetty's `SslContextFactory`
+  (`WebService.java:178`) but is *not* propagated into the `PulsarSslConfiguration`, so the
+  `PulsarSslFactory` that builds the underlying `SSLContext` ignores it. After this change the
+  provider is honored at both layers.
+- Same one-line additions in `pulsar-websocket/.../ProxyServer.buildSslConfiguration` (using
+  `WebSocketProxyConfiguration.tlsProvider`) and
+  `pulsar-functions/worker/.../WorkerServer.buildSslConfiguration` (using the worker's TLS
+  provider setting).
+- The `Conscrypt` **defaults are left unchanged** in this PIP (changing them is a performance
+  regression for non-FIPS users); FIPS deployments set `SunJSSE` explicitly, and `fipsMode=true`
+  rejects `Conscrypt`/`OPENSSL`. A follow-up may revisit defaults once JDK TLS performance is
+  re-benchmarked on modern JVMs.
+
+### (b) Packaging: FIPS distribution variant
+
+Two layers, phased:
+
+1. **Gradle wiring (this PIP, phase 1).** Add a `fips` capability to the build:
+   - A version-catalog *bundle* `bouncycastle-fips` = { `bc-fips`, `bcpkix-fips`, `bcutil-fips` }
+     (versions already declared in `gradle/libs.versions.toml:59-61`).
+   - A resolvable `fipsRuntimeClasspath` in `distribution/server` that substitutes
+     `bcprov-jdk18on`/`bcpkix-jdk18on` → FIPS artifacts and excludes
+     `netty-tcnative-boringssl-static` and `org.conscrypt:conscrypt-openjdk-uber` (Netty falls
+     back to `SslProvider.JDK` automatically when tcnative is absent).
+   - A documented, supported **jar-swap procedure** for the standard distribution: remove
+     `bcprov-jdk18on-*.jar`/`bcpkix-jdk18on-*.jar`, `netty-tcnative-boringssl-static-*.jar`, and
+     `conscrypt-*.jar` from `lib/`, add the three FIPS jars. This works because
+     `SecurityUtility`'s reflective loading already handles either flavor.
+2. **Published variant (phase 2).** A `distribution/server-fips` module producing
+   `apache-pulsar-<version>-fips-bin.tar.gz` from the `fipsRuntimeClasspath`, wired into CI.
+   Whether to *publish* this to dist.apache.org (vs. providing the build recipe) is a release-
+   management question flagged for the DISCUSS thread.
+
+Two packaging caveats handled explicitly:
+
+- **Shaded client jars** (`pulsar-client-shaded`, `pulsar-client-admin-shaded`,
+  `pulsar-client-all`) bundle the non-FIPS BC classes **un-relocated** (BC jars are signed and
+  cannot be relocated), so they inherently conflict with a BC-FIPS classpath. FIPS mode documents:
+  use the **non-shaded** client artifacts and supply the FIPS jars yourself. No shaded FIPS
+  client is planned.
+- **`grpc-netty-shaded`** (`pulsar-functions/runtime/build.gradle.kts:63`) embeds a *second,
+  private* copy of Netty+BoringSSL used for the function-instance control channel, with no
+  provider override. By default that channel is localhost plaintext and thus outside the FIPS
+  crypto boundary; the FIPS variant nevertheless replaces `grpc-netty-shaded` with plain
+  `grpc-netty` (sharing Pulsar's Netty, JDK provider) so that no BoringSSL object code ships in
+  the FIPS distribution at all — auditors scan jars, not call graphs.
+
+### (c) Message crypto: `MessageCryptoBc`
+
+Current state (`pulsar-client-messagecrypto-bc/.../MessageCryptoBc.java`):
+
+- RSA key wrap is hardcoded to `RSA/NONE/OAEPWithSHA1AndMGF1Padding` (line 92). SHA-1 OAEP is
+  not FIPS-approved.
+- EC key wrap uses `ECIES` (lines 88, 373, 535) — not FIPS-approved and **absent from BC-FIPS**.
+- The class compile-imports `org.bouncycastle.jce.*` (lines 74-77:
+  `ECPublicKey`, `ECParameterSpec`, `ECPrivateKeySpec`, `ECPublicKeySpec`), classes that do not
+  exist in `bc-fips` — so on a FIPS classpath the class fails to load
+  (`NoClassDefFoundError`) even for RSA-only users.
+- The `SecureRandom` is pinned to `NativePRNGNonBlocking` (line 127) rather than the BC-FIPS
+  DRBG (the RNG fix is one of the in-flight quick-win PRs; see *General Notes*).
+- There is no EC curve allowlist.
+
+Design:
+
+1. **Class-loading fix (prerequisite).** Replace the `org.bouncycastle.jce.*` compile
+   dependencies with JCA-standard types (`java.security.spec.ECPoint`,
+   `java.security.interfaces.ECPublicKey`, `AlgorithmParameters.getInstance("EC")`) or isolate
+   the EC deserialization path into a lazily-loaded inner class, so `MessageCryptoBc` loads and
+   RSA encryption works on a BC-FIPS classpath.
+2. **Versioned key-wrap negotiation via `EncryptionKeys` metadata.** The wire already supports
+   it: each `EncryptionKeys` entry carries an extensible `metadata` list of `KeyValue` pairs.
+   Producers add `keyWrapAlgo=<id>` to each wrapped key's metadata:
+   - absent / `RSA_OAEP_SHA1` — legacy, `RSA/NONE/OAEPWithSHA1AndMGF1Padding` (today's format);
+   - `RSA_OAEP_SHA256` — `RSA/NONE/OAEPWithSHA256AndMGF1Padding` (FIPS-approved);
+   - `ECDH_AES_KW` (phase 2) — ephemeral-static ECDH on the consumer's curve + a NIST KDF
+     (SP 800-56C one-step KDF with SHA-256) + AES-256 key wrap (SP 800-38F, `AESWrap`), all
+     available in BC-FIPS approved mode; the ephemeral public key travels in a second metadata
+     entry. This replaces ECIES.
+
+   Consumers dispatch on the metadata value when unwrapping; old consumers ignore unknown
+   metadata and try SHA-1 OAEP, which **fails against SHA-256-wrapped keys** — hence the producer
+   default stays `RSA_OAEP_SHA1` and the new algorithm is opt-in via a new client/producer
+   setting `cryptoKeyWrapAlgorithm` (see Configuration). The operational contract is: upgrade all
+   consumers first, then flip producers. `fipsMode` guidance requires `RSA_OAEP_SHA256` (and, in
+   phase 1, documents EC encryption keys as unsupported in FIPS mode until `ECDH_AES_KW` lands).
+3. **EC curve allowlist.** When `SecurityUtility.isBCFIPS()`, restrict accepted EC keys to NIST
+   curves (P-256/P-384/P-521); BC-FIPS in approved-only mode enforces this anyway — the allowlist
+   converts a deep provider exception into an actionable error message.
+
+The decryption path retains support for *all* algorithm ids indefinitely (subject to the FIPS
+classpath physically lacking ECIES), so mixed-version fleets and stored backlogs keep working.
+
+### (d) Basic authentication: `AuthenticationProviderBasic`
+
+Current state (`pulsar-broker-common/.../AuthenticationProviderBasic.java:141-149`): entries
+starting with `$apr1$` are verified with Apache MD5-crypt (`Md5Crypt.apr1Crypt`); everything else
+falls through to traditional 2-character-salt DES `Crypt.crypt(password, hash.substring(0, 2))`.
+There is no FIPS-approved verification path at all.
+
+Design: add prefix-dispatched support for the standard crypt(3) SHA-2 schemes, using
+`org.apache.commons.codec.digest.Sha2Crypt` (already a Pulsar dependency via commons-codec):
+
+- `$5$...` → SHA-256-crypt, `$6$...` → SHA-512-crypt.
+- **Salt parsing must pass the full salt specification**, not a fixed-index split: SHA-2 crypt
+  salts are variable-length and may carry a `rounds=N$` prefix (e.g.
+  `$6$rounds=10000$saltsalt$hash`). The implementation passes the entire stored hash as the salt
+  argument (`Sha2Crypt.crypt(password, storedHash)` semantics), which commons-codec resolves
+  correctly, then constant-time-compares the result — mirroring how the `$apr1$` branch works but
+  without the brittle `split("\\$")` arity check.
+- Existing `$apr1$` and DES verification is untouched for compatibility. With `fipsMode=true`,
+  the provider logs each non-SHA-2 entry at startup and **refuses to start** (validation is at
+  startup, not per-request, so a stale htpasswd file cannot silently downgrade a running broker).
+
+Files are generated with standard tooling (`mkpasswd -m sha-512`, `openssl passwd -6`), so no new
+Pulsar CLI is needed.
+
+### (e) SASL role token signature: `SaslRoleTokenSigner`
+
+Current state (`pulsar-broker-auth-sasl/.../SaslRoleTokenSigner.java:92-104`):
+`computeSignature` is `Base64(SHA-512(str || secret))` — a bare hash-concat construction, not an
+HMAC. FIPS 140-3 approves keyed hashing only as HMAC (FIPS 198-1); the concat construction is
+also vulnerable to length-extension in principle. But the signature is verified by **other
+brokers/proxies**, so unilaterally changing it breaks mixed-version clusters mid-rolling-upgrade.
+
+Design — dual-verify, two-phase migration:
+
+- Signatures gain a format marker: HMAC signatures are emitted as `&s=v2:<Base64(HMAC-SHA256(secret, str))>`;
+  legacy signatures remain the unprefixed Base64 SHA-512 digest. (`:` cannot appear in the legacy
+  Base64 alphabet's output position, so dispatch is unambiguous.)
+- `verify()` accepts **both** formats whenever `saslRoleTokenSignerAlgorithm` is `HmacSHA256`
+  or unset; each comparison already uses `MessageDigest.isEqual` (constant-time) and continues to.
+- New setting `saslRoleTokenSignerAlgorithm` = `SHA-512` (default, sign legacy / verify both) |
+  `HmacSHA256` (sign HMAC / verify both) | `HmacSHA256-strict` (sign and verify HMAC only;
+  implied by `fipsMode=true`).
+- Rolling upgrade: upgrade all brokers/proxies (still signing legacy, now *able* to verify HMAC),
+  then flip `HmacSHA256` fleet-wide, then optionally `-strict`. SASL role tokens are short-lived
+  (they carry an expiry), so the mixed-format window self-drains within the token lifetime.
+- A later release may flip the default to `HmacSHA256`; removing legacy *verification* is
+  deferred until a release whose supported-upgrade matrix guarantees all peers sign HMAC.
+
+### (f) Kubernetes function resource names: `KubernetesRuntime`
+
+Current state (`pulsar-functions/runtime/.../KubernetesRuntime.java:1141`): when a custom
+`jobName` is supplied, resource names embed
+`DigestUtils.sha1Hex(jobName-tenant-namespace-functionName).substring(0, 8)`; the derived name is
+used for the StatefulSet, Service, and secrets (lines 322, 511, 601, 730, 886) and is **persisted
+cluster state** — a running function's StatefulSet name must survive upgrades.
+
+This SHA-1 usage is *name derivation*, not security, and SHA-1 as a bare digest is not actually
+disallowed by FIPS 140-3 for non-signature use. It only breaks on hardened stacks whose crypto
+policy removes SHA-1 from JCA entirely (e.g. restrictive `java.security` configurations /
+OS-level FIPS crypto-policies), where `DigestUtils.sha1Hex` → `MessageDigest.getInstance("SHA-1")`
+throws.
+
+Design — **keep the names, drop the JCA dependency**: compute the identical 8-hex-character
+short hash via a small, self-contained, non-JCA SHA-1 implementation (a ~60-line pure-Java
+class in `pulsar-functions-runtime`, implemented from the FIPS 180-4 specification for
+provenance cleanliness, package-private, used only by `createJobName`, with a class-level comment
+stating it is a *non-cryptographic name-derivation* function). Every existing function keeps its
+exact resource names across the upgrade; no migration, no versioned naming scheme, no new
+configuration. A versioned naming scheme (SHA-256 names for *new* functions behind a
+`jobNameHashVersion` knob) was considered and rejected as complexity without benefit — the hash
+here has no security property to upgrade (see *Alternatives*).
+
+### (g) Startup validation, `fipsMode`
+
+A new `fipsMode` boolean (broker `ServiceConfiguration`, `ProxyConfiguration`,
+`WebSocketProxyConfiguration`, function-worker config; default `false`). When `true`, a shared
+validator (in `pulsar-broker-common`, invoked from each component's startup) asserts:
+
+- `SecurityUtility.isBCFIPS()` is true (BC-FIPS is the loaded BC provider);
+- `org.bouncycastle.fips.approved_only=true` is set (via
+  `CryptoServicesRegistrar.isInApprovedOnlyMode()` reflectively, to avoid a compile-time bc-fips
+  dependency);
+- no configured TLS provider on any enabled listener resolves to `OPENSSL` or `Conscrypt`, and
+  `netty-tcnative` classes are absent from the classpath;
+- Basic-auth password file (if that provider is enabled) contains only `$5$`/`$6$` entries;
+- `saslRoleTokenSignerAlgorithm` is `HmacSHA256`/`HmacSHA256-strict` (if SASL is enabled).
+
+Failures abort startup with a single aggregated, actionable error. `fipsMode` never *changes*
+crypto behavior by itself (each behavior has its own setting) — it only validates, so there is
+exactly one source of truth per algorithm choice and no hidden coupling.
+
+The Java **client** gets no `fipsMode` flag: client FIPS posture is determined by the classpath
+(BC-FIPS present, tcnative absent → Netty falls back to JDK TLS automatically) plus
+`cryptoKeyWrapAlgorithm`. This is documented in the FIPS guide.
+
+### Testing
+
+- **New integration test group `fips`** (replacing the current
+  `tests/pulsar-client-test-bcfips`): assembles a broker + proxy + Java client on a classpath
+  containing `bc-fips`/`bcpkix-fips`/`bcutil-fips` and **excluding** `bcprov`, `bcpkix`,
+  `netty-tcnative-boringssl-static`, and Conscrypt, with
+  `-Dorg.bouncycastle.fips.approved_only=true` and `fipsMode=true`. It asserts
+  `SecurityUtility.isBCFIPS()`, then exercises: binary-protocol TLS produce/consume (PEM and
+  BCFKS keystore), HTTPS admin calls, mTLS client authentication, token authentication
+  (HMAC-signed JWTs), and E2E encryption with `RSA_OAEP_SHA256`. A negative test asserts startup
+  *fails* under `fipsMode=true` when a Conscrypt provider is configured.
+- **Unit tests**: dual-format `SaslRoleTokenSigner` sign/verify matrix (legacy↔HMAC, tampering,
+  strict mode); Basic-auth `$5$`/`$6$` verification including `rounds=N$` salts and rejection
+  behavior under `fipsMode`; `MessageCryptoBc` cross-algorithm matrix (SHA-1-wrap producer →
+  SHA-256-capable consumer and vice versa, metadata dispatch, EC rejection in FIPS mode);
+  `KubernetesRuntime.createJobName` golden-value tests pinning the exact current names before and
+  after the non-JCA hash swap.
+- **CI**: the `fips` group runs in a dedicated workflow job (it needs a different classpath
+  assembly), on the same cadence as other integration test groups.
+
+## Public-facing Changes
+
+### Public API
+
+None. No REST endpoints, client interfaces, or admin APIs change. (`MessageCrypto` is an
+interface but its contract is unchanged; the new algorithms are internal to the default
+implementation and selected by configuration.)
+
+### Binary protocol
+
+No new commands or fields. The existing `EncryptionKeys.metadata` (`KeyValue` list) carries the
+new `keyWrapAlgo` (and, later, `ecdhEphemeralPublicKey`) entries; peers that do not recognize the
+keys ignore them, per existing semantics.
+
+### Configuration
+
+| Key | Component | Type | Default | Change |
+|---|---|---|---|---|
+| `fipsMode` | broker, proxy, websocket, function worker | boolean | `false` | **New.** Startup fail-fast validation of FIPS posture. |
+| `tlsProvider` | broker | string | `null` | **Now honored by the binary listener** (previously declared but ignored there). No behavior change unless set. |
+| `webServiceTlsProvider` | broker | string | `Conscrypt` | Now also propagated into `PulsarSslConfiguration` (previously Jetty-layer only). Default unchanged. |
+| `tlsProvider` | websocket proxy | string | `Conscrypt` | Now propagated into `PulsarSslConfiguration`. Default unchanged. |
+| (worker TLS provider) | function worker | string | — | Now propagated into `PulsarSslConfiguration`. |
+| `cryptoKeyWrapAlgorithm` | Java client (producer) | enum | `RSA_OAEP_SHA1` | **New.** `RSA_OAEP_SHA1` \| `RSA_OAEP_SHA256` \| (phase 2) `ECDH_AES_KW`. Consumers auto-detect from metadata; no consumer setting. |
+| `saslRoleTokenSignerAlgorithm` | broker, proxy (SASL) | enum | `SHA-512` | **New.** `SHA-512` \| `HmacSHA256` \| `HmacSHA256-strict`. Default preserves current bytes on the wire; verify accepts both formats except in `-strict`. |
+
+Basic auth gains no new key: `$5$`/`$6$` hashes are recognized by prefix in the existing password
+file format. Shipped `conf/*.conf` files gain commented FIPS-mode examples; no shipped default
+changes.
+
+### CLI
+
+None.
+
+### Metrics
+
+None. (Posture is validated at startup and logged; see Monitoring.)
+
+# Monitoring
+
+At startup each component logs a single security-posture summary line (component, active BC
+provider name/version, approved-only mode flag, effective TLS provider per listener, `fipsMode`
+result). Operators verify FIPS posture from this line and from `fipsMode=true` simply refusing to
+start when the posture is wrong — fail-fast replaces runtime monitoring by design. No alerting
+changes are required; existing TLS handshake-failure and auth-failure signals cover the runtime
+behavior of the new algorithms.
+
+# Security Considerations
+
+- **Downgrade resistance of dual-verify paths.** During SASL migration, verify-both necessarily
+  accepts legacy signatures; both comparisons are constant-time (`MessageDigest.isEqual`), the
+  tokens are expiring, and `HmacSHA256-strict` / `fipsMode` closes the window. The same shape
+  applies to Basic auth (`fipsMode` rejects weak entries at startup rather than per-request, so
+  there is no per-request oracle) and message crypto (decrypt-side algorithm support is
+  data-driven by metadata the *consumer's own keys* must still unwrap; a forged `keyWrapAlgo`
+  cannot select a weaker unwrap than the consumer's configured classpath provides).
+- **Fail-fast over fail-open.** All `fipsMode` checks abort startup; no check degrades to a
+  warning, because a warned-but-running broker is exactly the silent non-compliance this PIP
+  exists to prevent.
+- **No new endpoints, roles, or multi-tenancy surface.** All changes are transport/crypto-layer;
+  tenant isolation and authorization are untouched.
+- The non-JCA SHA-1 in (f) is used solely for name derivation and is documented as
+  non-cryptographic; it is package-private to prevent accidental reuse for security purposes.
+- Review of this PIP should double-check the claim that BCFKS/PKCS11 keystore types flow through
+  `tlsKeyStoreType` unchanged (believed true; the integration test makes it verified rather than
+  believed).
+
+# Backward & Forward Compatibility
+
+Per-item analysis:
+
+| Item | Compatibility impact |
+|---|---|
+| (a) TLS wiring | None by default (`tlsProvider` default `null` → Netty default, unchanged; `webServiceTlsProvider` default unchanged). Users who had set broker `tlsProvider` expecting it to work will now get what they asked for — called out in release notes. |
+| (b) Packaging | Standard distribution unchanged. FIPS variant is additive. |
+| (c) Message crypto | Producer default remains SHA-1 OAEP → zero wire change until opted in. **Opt-in ordering constraint: upgrade all consumers of a topic before any producer sets `RSA_OAEP_SHA256`** — old consumers cannot unwrap SHA-256-wrapped keys (they will land in retry/DLQ paths per existing crypto-failure handling). Decrypt side reads both formats forever. |
+| (d) Basic auth | Existing `$apr1$`/DES files keep working outside FIPS mode. New `$5$`/`$6$` entries require the upgraded broker — update brokers before rewriting password files. |
+| (e) SASL signer | Default signs the exact bytes signed today. Verify-both is forward-compatible: a fully-upgraded fleet can flip to `HmacSHA256` without a restart ordering constraint beyond "upgrade everything first". |
+| (f) K8s names | Byte-identical names before/after (golden tests enforce this). No impact on running functions. |
+| (g) `fipsMode` | New, default off. |
+
+## Upgrade
+
+No mandatory steps. To adopt FIPS mode: (1) upgrade all brokers/proxies/workers to the release
+containing this PIP; (2) upgrade Java clients that use E2E encryption; (3) switch to the FIPS
+classpath and set `tlsProvider=JDK`, `webServiceTlsProvider=SunJSSE`,
+`saslRoleTokenSignerAlgorithm=HmacSHA256` (if SASL), rewrite Basic-auth files to `$6$`, set
+producers' `cryptoKeyWrapAlgorithm=RSA_OAEP_SHA256`; (4) set `fipsMode=true` and restart — the
+validator confirms the posture.
+
+## Downgrade / Rollback
+
+- Config-level rollback: unset `fipsMode` and revert the individual settings; restore the
+  standard-classpath jars. Legacy verification paths (SHA-1 OAEP decrypt, legacy SASL verify,
+  `$apr1$`) are still present in the new release, so partial rollback of *settings* is safe.
+- Binary rollback to a pre-PIP release is safe **provided** no producer is still emitting
+  `RSA_OAEP_SHA256`-wrapped keys (old consumers cannot unwrap them) and SASL was reverted off
+  `HmacSHA256` first (old brokers cannot verify `v2:` signatures; tokens expire, so revert order
+  is: flip setting back → wait one token lifetime → downgrade binaries).
+
+## Pulsar Geo-Replication Upgrade & Downgrade/Rollback Considerations
+
+Replication is a client of each cluster's TLS endpoints, so clusters may adopt FIPS mode
+independently — a FIPS cluster's JDK-TLS listener interoperates with a non-FIPS peer's
+replication client and vice versa (TLS is negotiated per-connection). E2E-encrypted payloads are
+replicated opaquely, wrapped keys and metadata included; the consumer-upgrade-first constraint in
+(c) therefore extends to consumers in **all** replicated clusters before any producer anywhere
+opts into `RSA_OAEP_SHA256`.
+
+# Alternatives
+
+1. **Rely on OS-level FIPS (e.g. RHEL crypto-policies) with the stock distribution.** Rejected:
+   BoringSSL via tcnative bypasses the JVM's provider machinery entirely, so OS policy does not
+   make Pulsar's Netty TLS FIPS-validated, and the non-approved algorithms in (c)-(e) remain.
+2. **A custom `PulsarSslFactory` plugin as the only TLS answer.** The plugin point (PIP-337)
+   helps, but it cannot fix the broker binary listener never passing `tlsProvider` into the
+   configuration object, nor remove BoringSSL from the shipped classpath, nor address anything
+   outside TLS. Used as a building block, not the solution.
+3. **Switch to a FIPS-validated native TLS engine** (e.g. the AWS-LC-based netty-tcnative
+   flavor, whose FIPS branch is CMVP-validated) instead of JDK TLS. Attractive for performance
+   and worth tracking as a follow-up, but rejected for now: it adds a second validated-module
+   boundary to document, its Netty integration is newer, and JDK-over-BCFIPS is the
+   well-trodden, auditor-familiar path.
+4. **Versioned Kubernetes naming scheme** (SHA-256 names for new functions behind a config knob)
+   instead of a non-JCA SHA-1. Rejected: adds a permanent compatibility knob and split-brain
+   naming for zero security gain — the hash has no adversary; only its *JCA lookup* is the
+   problem.
+5. **Fork-style separate FIPS build of Pulsar with different defaults.** Rejected: doubles the
+   release matrix and drifts; a validation switch over one codebase keeps FIPS a configuration,
+   not a fork.
+6. **Changing `webServiceTlsProvider` default from Conscrypt to SunJSSE now.** Deferred:
+   performance-sensitive default change affecting all users, orthogonal to FIPS correctness once
+   the key is properly wired.
+
+# General Notes
+
+- **Prior art / companion quick-win PRs (already open, intentionally outside this PIP):**
+  [#26152](https://github.com/apache/pulsar/pull/26152) MD5 NAR/archive checksums → SHA-256;
+  [#26153](https://github.com/apache/pulsar/pull/26153) SHA-1-derived reader subscription names →
+  SHA-256; [#26154](https://github.com/apache/pulsar/pull/26154) `KeyManagerProxy` JKS fallback +
+  `MessageCryptoBc` `SecureRandom` preferring the BC-FIPS `DEFAULT` DRBG when the `BCFIPS`
+  provider is registered.
+- Implementation is phased to match the item list: **Phase 1** — (a) TLS wiring + (g) `fipsMode`
+  validator + (b) Gradle wiring & documented swap + (c) class-loading fix and
+  `RSA_OAEP_SHA256` + the integration test group; **Phase 2** — (d) Basic auth SHA-2-crypt,
+  (e) SASL dual-verify, (f) K8s naming, BCFKS/PKCS11 docs & tests; **Phase 3** — (b) published
+  FIPS distribution variant, (c) `ECDH_AES_KW`, pulsar-site FIPS deployment guide. Each phase is
+  independently shippable.
+- Documentation lands in `apache/pulsar-site` as a "Deploying Pulsar in FIPS 140-3 environments"
+  security page, cross-linked from the TLS and encryption docs.
+
+# Links
+
+<!-- Updated afterwards -->
+* Mailing List discussion thread:
+* Mailing List voting thread:

--- a/pip/pip-489.md
+++ b/pip/pip-489.md
@@ -40,6 +40,22 @@ already *FIPS-capable at the JCA layer*: swap the jars and the provider swap wor
    accepts a JSSE provider name (e.g. `SunJSSE`, `Conscrypt`). Conscrypt is another
    BoringSSL-based, non-FIPS-validated provider.
 
+**PIP-478 (Pulsar 5.0 TLS transport & asynchronous authentication).** PIP-478
+([PR #25890](https://github.com/apache/pulsar/pull/25890),
+[discussion](https://lists.apache.org/thread/s9n9jksr9vqgn9o982zmnnkcxdcncy3f)) reworks the TLS
+transport configuration for Pulsar 5.0 on both the client and the server: a `TlsPolicy`
+configuration that selects the TLS engine and the JCA provider (`TlsPolicy.jcaProvider`), wired
+through every server component and the client; a `PulsarTlsFactory` plugin interface for
+deployments where key material must stay outside the process (HSM integration via PKCS#11 — the
+FIPS 140-3 Level 3 case); and a `PulsarHttpClient` API so the HTTP clients used by
+authentication plugins (e.g. OAuth2 token-endpoint calls) share the same TLS configuration.
+Historically the TLS transport was never routed through a BouncyCastle/FIPS TLS provider —
+Pulsar has no BC JSSE dependency
+([pulsar-site#974](https://github.com/apache/pulsar-site/pull/974)) — and the crypto paths have
+not consistently honored an installed FIPS provider (see the SunJCE discussion on
+[#23122](https://github.com/apache/pulsar/pull/23122)). This PIP builds on PIP-478 for the TLS
+transport rather than defining a parallel configuration path (see Design (a)).
+
 **End-to-end message encryption.** `MessageCryptoBc`
 (`pulsar-client-messagecrypto-bc`) encrypts payloads with AES-GCM under a per-producer data key,
 and wraps that data key with each consumer's public key — RSA-OAEP for RSA keys, ECIES for EC
@@ -106,23 +122,33 @@ This PIP defines a supported, tested, documented "FIPS mode" that closes these g
 ## In Scope
 
 - A documented **FIPS mode** deployment profile for broker, proxy, WebSocket proxy, and function
-  worker: BC-FIPS as the sole Bouncy Castle JCA provider, JDK (or BCJSSE) TLS with no
-  BoringSSL/Conscrypt on the crypto path, and only approved algorithms in security paths.
-- Wiring the existing `tlsProvider` / `webServiceTlsProvider` settings through every listener's
-  `PulsarSslConfiguration` so `JDK`/`SunJSSE` TLS is actually selectable (broker binary listener,
-  broker web, WebSocket proxy, function worker — matching the proxy's existing pattern).
+  worker: BC-FIPS as the sole Bouncy Castle JCA provider, the JDK TLS engine (over BC-FIPS via
+  the `java.security` provider configuration) with no BoringSSL/Conscrypt on the crypto path,
+  and only approved algorithms in security paths.
+- A FIPS-capable TLS transport **by building on PIP-478** — `TlsPolicy` engine/JCA-provider
+  selection, `PulsarTlsFactory` for PKCS#11/HSM-backed deployments, `PulsarHttpClient` for the
+  auth plugins' outbound HTTPS — rather than defining a parallel TLS configuration path. (The
+  minimal interim fix for maintenance branches — passing the existing `tlsProvider` /
+  `webServiceTlsProvider` keys into each listener's `PulsarSslConfiguration`, as the proxy
+  already does — remains available but is not a deliverable of this PIP.)
 - A **FIPS distribution variant** (or, at minimum, first-class Gradle wiring plus a documented,
   supported jar-swap procedure) that ships `bc-fips`/`bcpkix-fips`/`bcutil-fips` and omits
   `bcprov`/`bcpkix`, `netty-tcnative-boringssl-static`, and Conscrypt.
-- A `fipsMode` startup switch that fail-fast validates the configuration (provider selection,
-  algorithm choices) rather than discovering violations at runtime.
+- A `fipsMode` startup switch that fail-fast validates the configuration — provider selection,
+  keystore/truststore types (JKS rejected; PKCS12 documented as unsupported), a TLS 1.2
+  protocol floor, cipher-suite and certificate-algorithm screening, and algorithm choices —
+  rather than discovering violations at runtime.
 - FIPS-approved options, with versioned/negotiated migrations, for: message-crypto key wrapping
   (RSA-OAEP-SHA256; ECDH+KDF+AES-KW or documented non-support for EC), Basic authentication
   password hashes (SHA-256/512-crypt), and the SASL role-token signature (HMAC-SHA256 with
   dual-verify rolling upgrade).
 - A name-stable fix for the SHA-1 usage in `KubernetesRuntime` resource naming.
 - BCFKS/PKCS11 keystore support **documented** (the keystore-type plumbing already accepts them;
-  this PIP adds docs and test coverage, not new code paths).
+  this PIP adds docs and test coverage, not new code paths). The deployment guide also covers
+  the required `java.security` configuration (BC-FIPS provider ordering, `keystore.type=bcfks`,
+  approved `securerandom.source`) and converting the JVM default truststore (`cacerts`, which
+  ships as JKS) to BCFKS for default-`SSLContext` consumers — OAuth2/OIDC token-endpoint calls
+  and connectors making outbound HTTPS calls.
 - A real FIPS TLS integration test replacing the false-confidence one, plus user-facing
   documentation on pulsar-site.
 
@@ -154,13 +180,18 @@ End to end, a FIPS deployment looks like:
    `bcpkix-jdk18on`, `netty-tcnative-boringssl-static`, and Conscrypt absent. The JVM is started
    with `-Dorg.bouncycastle.fips.approved_only=true`. `SecurityUtility` picks up BC-FIPS exactly
    as it does today — no code change needed at the JCA layer.
-2. **TLS.** All listeners honor `tlsProvider=JDK` (Netty/binary) and
-   `webServiceTlsProvider=SunJSSE` (Jetty/HTTP), so every TLS handshake runs in JSSE on top of
-   the BC-FIPS provider. Keystores may be PEM, BCFKS, or PKCS11.
+2. **TLS.** The TLS transport is configured through PIP-478's `TlsPolicy` (engine + JCA
+   provider), so every TLS handshake — binary protocol, HTTP/admin, and the auth plugins'
+   outbound HTTPS via `PulsarHttpClient` — runs on the JDK engine over the BC-FIPS provider;
+   HSM-backed deployments (FIPS 140-3 Level 3) integrate via a `PulsarTlsFactory` plugin
+   (PKCS#11). Keystores may be PEM, BCFKS, or PKCS11; JKS and PKCS12 are not supported in FIPS
+   mode.
 3. **Validation.** With `fipsMode=true`, the broker/proxy/worker verifies at startup: BC-FIPS is
    the active BC provider (`SecurityUtility.isBCFIPS()`), no `OPENSSL`/`Conscrypt` TLS provider
-   is configured on any listener, Basic-auth password files contain no MD5/DES entries, and the
-   SASL token signer is in HMAC mode. Violations abort startup with an explicit error.
+   is configured on any listener, keystore/truststore types are FIPS-capable (no JKS/PKCS12),
+   no listener permits TLS 1.0/1.1, configured cipher suites and loaded certificates use only
+   approved algorithms, Basic-auth password files contain no MD5/DES entries, and the SASL
+   token signer is in HMAC mode. Violations abort startup with an explicit error.
 4. **Algorithms.** Security paths that today hardcode non-approved algorithms gain approved
    alternatives behind explicit, compatibility-safe migration mechanisms (metadata-negotiated for
    message crypto, dual-verify for SASL tokens, prefix-dispatched for Basic auth, name-stable for
@@ -173,28 +204,28 @@ End to end, a FIPS deployment looks like:
 
 ## Design & Implementation Details
 
-### (a) TLS provider wiring
+### (a) TLS transport: build on PIP-478
 
-The fix is mechanical and follows the proxy's existing pattern
-(`ServiceChannelInitializer.buildSslConfiguration`, which already calls
-`.tlsProvider(config.getTlsProvider())`):
+PIP-478 already defines the TLS transport configuration for Pulsar 5.0: `TlsPolicy` with engine
+and JCA-provider selection (`TlsPolicy.jcaProvider`) wired through every server component and
+the client, the `PulsarTlsFactory` plugin interface (HSM/PKCS#11 integration — the FIPS 140-3
+Level 3 case, where private keys never enter the Pulsar process), and the `PulsarHttpClient` API
+that brings authentication plugins' HTTP calls (e.g. OAuth2 token endpoints) under the same TLS
+configuration. This PIP therefore **does not define a second TLS configuration path**: FIPS mode
+consumes PIP-478's transport, and the `fipsMode` validator asserts that the effective policy
+resolves every listener (and the client-side HTTP clients, where applicable) to the JDK engine
+over a FIPS-validated provider — never `OPENSSL` (BoringSSL) or `Conscrypt`.
 
-- `pulsar-broker/.../service/PulsarChannelInitializer.buildSslConfiguration` adds
-  `.tlsProvider(serviceConfig.getTlsProvider())`. This wires the **existing**
-  `ServiceConfiguration.tlsProvider` key (currently declared but dead for the binary listener).
-  Default stays `null`; behavior only changes for users who had set the key expecting it to work.
-- `pulsar-broker/.../web/WebService.buildSslConfiguration` adds
-  `.tlsProvider(serviceConfig.getWebServiceTlsProvider())`. Note the subtlety on current master:
-  `webServiceTlsProvider` *is* passed to Jetty's `SslContextFactory`
-  (`WebService.java:178`) but is *not* propagated into the `PulsarSslConfiguration`, so the
-  `PulsarSslFactory` that builds the underlying `SSLContext` ignores it. After this change the
-  provider is honored at both layers.
-- Same one-line additions in `pulsar-websocket/.../ProxyServer.buildSslConfiguration` (using
-  `WebSocketProxyConfiguration.tlsProvider`) and
-  `pulsar-functions/worker/.../WorkerServer.buildSslConfiguration` (using the worker's TLS
-  provider setting).
-- The `Conscrypt` **defaults are left unchanged** in this PIP (changing them is a performance
-  regression for non-FIPS users); FIPS deployments set `SunJSSE` explicitly, and `fipsMode=true`
+Two consequences:
+
+- The per-listener gaps on current `master` (the broker binary listener ignoring `tlsProvider`;
+  the broker web service, WebSocket proxy, and function worker not propagating the web-service
+  provider into `PulsarSslConfiguration`) are subsumed by PIP-478's uniform wiring. If a
+  maintenance-branch fix is wanted before PIP-478 lands, the interim one-line
+  `.tlsProvider(...)` pass-throughs (matching the proxy's existing pattern) remain available,
+  but they are not deliverables of this PIP.
+- The `Conscrypt` **defaults are left unchanged** (changing them is a performance regression
+  for non-FIPS users); FIPS deployments select the JDK engine explicitly, and `fipsMode=true`
   rejects `Conscrypt`/`OPENSSL`. A follow-up may revisit defaults once JDK TLS performance is
   re-benchmarked on modern JVMs.
 
@@ -231,6 +262,16 @@ Two packaging caveats handled explicitly:
   crypto boundary; the FIPS variant nevertheless replaces `grpc-netty-shaded` with plain
   `grpc-netty` (sharing Pulsar's Netty, JDK provider) so that no BoringSSL object code ships in
   the FIPS distribution at all — auditors scan jars, not call graphs.
+- **JSSE stays the JDK's.** Pulsar has never shipped or used BC JSSE
+  ([pulsar-site#974](https://github.com/apache/pulsar-site/pull/974)), and the FIPS profile
+  keeps it that way: the JDK TLS engine on top of the BC-FIPS JCA provider, selected via
+  PIP-478's `TlsPolicy`. `bctls-fips` (BCJSSE) is intentionally **not** bundled. For the JDK
+  engine to actually delegate its cryptography to the validated module, the deployment guide
+  specifies the accompanying `java.security` configuration — BC-FIPS first in the provider
+  order, `keystore.type=bcfks`, an approved `securerandom.source` — and a BCFKS-converted copy
+  of the JVM default truststore (`cacerts` ships as JKS, which a bcfks-default JVM cannot
+  load) for default-`SSLContext` consumers such as OAuth2/OIDC token-endpoint calls and
+  connectors' outbound HTTPS.
 
 ### (c) Message crypto: `MessageCryptoBc`
 
@@ -361,6 +402,15 @@ validator (in `pulsar-broker-common`, invoked from each component's startup) ass
   dependency);
 - no configured TLS provider on any enabled listener resolves to `OPENSSL` or `Conscrypt`, and
   `netty-tcnative` classes are absent from the classpath;
+- every configured keystore/truststore type is FIPS-capable — BCFKS, PKCS11, or PEM. `JKS` is
+  rejected (its integrity/privacy algorithms are not FIPS-approved), and `PKCS12` is rejected
+  and documented as unsupported (FIPS-conformant PKCS#12 requires the RFC 9879 KDF/PBMAC
+  profile, which the current parsing stack does not enforce);
+- no enabled listener permits TLS 1.0/1.1 (protocol floor is TLS 1.2);
+- configured cipher suites contain no non-approved algorithms (e.g. ChaCha20-Poly1305, 3DES),
+  and the certificates/keys loaded at startup use approved algorithms — NIST curves
+  (P-256/P-384/P-521), RSA ≥ 2048 bits, no SHA-1 signatures — converting deep handshake
+  failures into actionable startup errors;
 - Basic-auth password file (if that provider is enabled) contains only `$5$`/`$6$` entries;
 - `saslRoleTokenSignerAlgorithm` is `HmacSHA256`/`HmacSHA256-strict` (if SASL is enabled).
 
@@ -381,8 +431,9 @@ The Java **client** gets no `fipsMode` flag: client FIPS posture is determined b
   `-Dorg.bouncycastle.fips.approved_only=true` and `fipsMode=true`. It asserts
   `SecurityUtility.isBCFIPS()`, then exercises: binary-protocol TLS produce/consume (PEM and
   BCFKS keystore), HTTPS admin calls, mTLS client authentication, token authentication
-  (HMAC-signed JWTs), and E2E encryption with `RSA_OAEP_SHA256`. A negative test asserts startup
-  *fails* under `fipsMode=true` when a Conscrypt provider is configured.
+  (HMAC-signed JWTs), and E2E encryption with `RSA_OAEP_SHA256`. Negative tests assert startup
+  *fails* under `fipsMode=true` when a Conscrypt provider is configured, when a JKS or PKCS12
+  keystore is configured, and when TLS 1.1 is enabled on a listener.
 - **Unit tests**: dual-format `SaslRoleTokenSigner` sign/verify matrix (legacy↔HMAC, tampering,
   strict mode); Basic-auth `$5$`/`$6$` verification including `rounds=N$` salts and rejection
   behavior under `fipsMode`; `MessageCryptoBc` cross-algorithm matrix (SHA-1-wrap producer →
@@ -417,6 +468,13 @@ keys ignore them, per existing semantics.
 | (worker TLS provider) | function worker | string | — | Now propagated into `PulsarSslConfiguration`. |
 | `cryptoKeyWrapAlgorithm` | Java client (producer) | enum | `RSA_OAEP_SHA1` | **New.** `RSA_OAEP_SHA1` \| `RSA_OAEP_SHA256` \| (phase 2) `ECDH_AES_KW`. Consumers auto-detect from metadata; no consumer setting. |
 | `saslRoleTokenSignerAlgorithm` | broker, proxy (SASL) | enum | `SHA-512` | **New.** `SHA-512` \| `HmacSHA256` \| `HmacSHA256-strict`. Default preserves current bytes on the wire; verify accepts both formats except in `-strict`. |
+
+The four TLS-provider rows describe the interim, pre-PIP-478 keys: once PIP-478's `TlsPolicy`
+is available it is the single TLS transport configuration, these keys follow its
+deprecation/migration path, and the `fipsMode` validator evaluates the effective `TlsPolicy`
+instead. The new validator checks (keystore types, TLS protocol floor, cipher-suite/certificate
+screening) introduce no new keys — they validate the existing `tlsKeyStoreType`,
+`tlsProtocols`, and `tlsCiphers` family of settings.
 
 Basic auth gains no new key: `$5$`/`$6$` hashes are recognized by prefix in the existing password
 file format. Shipped `conf/*.conf` files gain commented FIPS-mode examples; no shipped default
@@ -465,7 +523,7 @@ Per-item analysis:
 
 | Item | Compatibility impact |
 |---|---|
-| (a) TLS wiring | None by default (`tlsProvider` default `null` → Netty default, unchanged; `webServiceTlsProvider` default unchanged). Users who had set broker `tlsProvider` expecting it to work will now get what they asked for — called out in release notes. |
+| (a) TLS transport | Follows PIP-478's compatibility contract (`TlsPolicy` and the legacy keys' migration path). No default behavior change from this PIP; `fipsMode=true` only adds validation. |
 | (b) Packaging | Standard distribution unchanged. FIPS variant is additive. |
 | (c) Message crypto | Producer default remains SHA-1 OAEP → zero wire change until opted in. **Opt-in ordering constraint: upgrade all consumers of a topic before any producer sets `RSA_OAEP_SHA256`** — old consumers cannot unwrap SHA-256-wrapped keys (they will land in retry/DLQ paths per existing crypto-failure handling). Decrypt side reads both formats forever. |
 | (d) Basic auth | Existing `$apr1$`/DES files keep working outside FIPS mode. New `$5$`/`$6$` entries require the upgraded broker — update brokers before rewriting password files. |
@@ -477,10 +535,12 @@ Per-item analysis:
 
 No mandatory steps. To adopt FIPS mode: (1) upgrade all brokers/proxies/workers to the release
 containing this PIP; (2) upgrade Java clients that use E2E encryption; (3) switch to the FIPS
-classpath and set `tlsProvider=JDK`, `webServiceTlsProvider=SunJSSE`,
-`saslRoleTokenSignerAlgorithm=HmacSHA256` (if SASL), rewrite Basic-auth files to `$6$`, set
-producers' `cryptoKeyWrapAlgorithm=RSA_OAEP_SHA256`; (4) set `fipsMode=true` and restart — the
-validator confirms the posture.
+classpath and configure the TLS transport onto the JDK engine (PIP-478 `TlsPolicy`, or the
+interim `tlsProvider=JDK` / `webServiceTlsProvider=SunJSSE` keys on maintenance branches), set
+`saslRoleTokenSignerAlgorithm=HmacSHA256` (if SASL), rewrite Basic-auth files to `$6$`, replace
+any JKS/PKCS12 keystores with BCFKS (including a BCFKS-converted `cacerts`), set producers'
+`cryptoKeyWrapAlgorithm=RSA_OAEP_SHA256`; (4) set `fipsMode=true` and restart — the validator
+confirms the posture.
 
 ## Downgrade / Rollback
 
@@ -506,10 +566,12 @@ opts into `RSA_OAEP_SHA256`.
 1. **Rely on OS-level FIPS (e.g. RHEL crypto-policies) with the stock distribution.** Rejected:
    BoringSSL via tcnative bypasses the JVM's provider machinery entirely, so OS policy does not
    make Pulsar's Netty TLS FIPS-validated, and the non-approved algorithms in (c)-(e) remain.
-2. **A custom `PulsarSslFactory` plugin as the only TLS answer.** The plugin point (PIP-337)
-   helps, but it cannot fix the broker binary listener never passing `tlsProvider` into the
-   configuration object, nor remove BoringSSL from the shipped classpath, nor address anything
-   outside TLS. Used as a building block, not the solution.
+2. **A custom TLS-factory plugin as the only TLS answer.** The plugin points (PIP-337's
+   `PulsarSslFactory` today, PIP-478's `PulsarTlsFactory` in Pulsar 5.0) are necessary building
+   blocks — and PIP-478's is exactly how HSM-backed FIPS 140-3 Level 3 deployments integrate —
+   but a plugin alone cannot remove BoringSSL from the shipped classpath, nor address anything
+   outside TLS (message crypto, Basic auth, SASL, packaging, validation). Used as building
+   blocks, not the whole solution.
 3. **Switch to a FIPS-validated native TLS engine** (e.g. the AWS-LC-based netty-tcnative
    flavor, whose FIPS branch is CMVP-validated) instead of JDK TLS. Attractive for performance
    and worth tracking as a follow-up, but rejected for now: it adds a second validated-module
@@ -525,17 +587,28 @@ opts into `RSA_OAEP_SHA256`.
 6. **Changing `webServiceTlsProvider` default from Conscrypt to SunJSSE now.** Deferred:
    performance-sensitive default change affecting all users, orthogonal to FIPS correctness once
    the key is properly wired.
+7. **Dual validated modules: an OpenSSL FIPS provider for native TLS plus BC-FIPS for Java
+   crypto.** A deployment can pair a validated OpenSSL 3 FIPS provider (driving a native TLS
+   engine) with BC-FIPS for the Java crypto paths. Viable for a curated image, but for the
+   upstream distribution it doubles the validated-module boundary to document and keeps a
+   native TLS engine inside the audit scope; the single-module JDK-over-BC-FIPS path is
+   preferred (see also alternative 3).
 
 # General Notes
 
+- **Packaging follows the jar-swap model** rather than reintroducing the Maven-era swappable
+  modules: BC and BC-FIPS cannot co-exist on a classpath, so flavor selection is a
+  classpath-assembly concern — clients exclude/replace dependencies, and the server keeps the
+  two flavors in separate directories (or uses the `fipsRuntimeClasspath` variant) and picks
+  one at startup.
 - **Prior art / companion quick-win PRs (already open, intentionally outside this PIP):**
   [#26152](https://github.com/apache/pulsar/pull/26152) MD5 NAR/archive checksums → SHA-256;
   [#26153](https://github.com/apache/pulsar/pull/26153) SHA-1-derived reader subscription names →
   SHA-256; [#26154](https://github.com/apache/pulsar/pull/26154) `KeyManagerProxy` JKS fallback +
   `MessageCryptoBc` `SecureRandom` preferring the BC-FIPS `DEFAULT` DRBG when the `BCFIPS`
   provider is registered.
-- Implementation is phased to match the item list: **Phase 1** — (a) TLS wiring + (g) `fipsMode`
-  validator + (b) Gradle wiring & documented swap + (c) class-loading fix and
+- Implementation is phased to match the item list: **Phase 1** — (a) PIP-478 TLS integration +
+  (g) `fipsMode` validator + (b) Gradle wiring & documented swap + (c) class-loading fix and
   `RSA_OAEP_SHA256` + the integration test group; **Phase 2** — (d) Basic auth SHA-2-crypt,
   (e) SASL dual-verify, (f) K8s naming, BCFKS/PKCS11 docs & tests; **Phase 3** — (b) published
   FIPS distribution variant, (c) `ECDH_AES_KW`, pulsar-site FIPS deployment guide. Each phase is
@@ -548,3 +621,5 @@ opts into `RSA_OAEP_SHA256`.
 <!-- Updated afterwards -->
 * Mailing List discussion thread: https://lists.apache.org/thread/cq6v9z2wszb6lsorvl0nbj85sc00pd6j
 * Mailing List voting thread:
+* PIP-478 (Pulsar 5.0 TLS transport & asynchronous authentication): https://github.com/apache/pulsar/pull/25890
+* PIP-478 discussion thread: https://lists.apache.org/thread/s9n9jksr9vqgn9o982zmnnkcxdcncy3f

--- a/pip/pip-489.md
+++ b/pip/pip-489.md
@@ -546,5 +546,5 @@ opts into `RSA_OAEP_SHA256`.
 # Links
 
 <!-- Updated afterwards -->
-* Mailing List discussion thread:
+* Mailing List discussion thread: https://lists.apache.org/thread/cq6v9z2wszb6lsorvl0nbj85sc00pd6j
 * Mailing List voting thread:

--- a/pip/pip-489.md
+++ b/pip/pip-489.md
@@ -18,24 +18,30 @@ provider (`BCFIPS`) that replaces the general-purpose Bouncy Castle provider (`B
 `org.bouncycastle.jce.*` and the ECIES cipher. When the JVM system property
 `org.bouncycastle.fips.approved_only=true` is set, BC-FIPS rejects all non-approved algorithms.
 
-**How Pulsar resolves Bouncy Castle today.** `SecurityUtility` (in `pulsar-common`,
-`org.apache.pulsar.common.util.SecurityUtility`) loads whichever BC flavor is on the classpath by
-reflection — it tries `org.bouncycastle.jce.provider.BouncyCastleProvider` and falls back to
-`org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider` — and exposes
-`SecurityUtility.isBCFIPS()` so callers can branch on the active flavor. This means Pulsar is
-already *FIPS-capable at the JCA layer*: swap the jars and the provider swap works.
+**How Pulsar resolves Bouncy Castle today.** `JcaProviders` (in `pulsar-common`,
+`org.apache.pulsar.common.util.tls.JcaProviders`) resolves the BC flavor in two steps: an
+already-registered `BC` or `BCFIPS` provider wins, and only failing that is one loaded from the
+classpath by reflection — `org.bouncycastle.jce.provider.BouncyCastleProvider`, falling back to
+`org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider` — and registered via
+`Security.addProvider`. It returns a `ResolvedBouncyCastleProvider(Provider provider, boolean fips)`,
+classified by both the registered name and the implementation class, so callers can branch on the
+active flavor. This means Pulsar is already *FIPS-capable at the JCA layer*: swap the jars and the
+provider swap works. The registration-first ordering is the FIPS-relevant half: a provider an
+operator registered in `java.security` is preserved rather than shadowed by a classpath-constructed
+one. (Until PIP-478 this lived in `SecurityUtility`, which exposed `isBCFIPS()`;
+[#26322](https://github.com/apache/pulsar/pull/26322) deleted that class along with the rest of the
+PIP-337 TLS stack.)
 
 **Pulsar's TLS stack.** Pulsar terminates TLS in two distinct stacks:
 
 1. The **binary protocol** listeners (broker, proxy) use Netty. Netty selects an `SslProvider`:
    `OPENSSL` (native, backed by `netty-tcnative-boringssl-static`, i.e. Google BoringSSL — not
    FIPS-validated) or `JDK` (the JVM's JSSE, which delegates to the installed JCA providers and
-   therefore to BC-FIPS when it is the active provider). Since PIP-337, TLS contexts are built
-   through the pluggable `PulsarSslFactory` abstraction: each listener builds a
-   `PulsarSslConfiguration` (including an optional `tlsProvider` field) and passes it to the
-   configured factory (default `DefaultPulsarSslFactory`), which maps `tlsProvider` to Netty's
-   `SslProvider` — or passes `null`, letting Netty pick its default, which is `OPENSSL` whenever
-   tcnative is on the classpath.
+   therefore to BC-FIPS when it is the active provider). Since PIP-478 replaced PIP-337's
+   `PulsarSslFactory`/`PulsarSslConfiguration` stack, TLS contexts are built through the
+   `PulsarTlsFactory` SPI: each listener resolves a `TlsPolicy` per `TlsPurpose`, and the default
+   `DefaultBrokerTlsFactory` maps the component's `tlsProvider` onto the Netty engine — an unset
+   value taking the native engine whenever tcnative is on the classpath, which it always is.
 2. The **HTTP/admin/WebSocket/function-worker** listeners use Jetty, whose `SslContextFactory`
    accepts a JSSE provider name (e.g. `SunJSSE`, `Conscrypt`). Conscrypt is another
    BoringSSL-based, non-FIPS-validated provider.
@@ -43,7 +49,10 @@ already *FIPS-capable at the JCA layer*: swap the jars and the provider swap wor
 **PIP-478 (Pulsar 5.0 TLS transport & asynchronous authentication).** PIP-478
 ([PR #25890](https://github.com/apache/pulsar/pull/25890),
 [discussion](https://lists.apache.org/thread/s9n9jksr9vqgn9o982zmnnkcxdcncy3f)) reworks the TLS
-transport configuration for Pulsar 5.0 on both the client and the server: a `TlsPolicy`
+transport configuration for Pulsar 5.0 on both the client and the server. **It has since landed on
+`master`**, which closes several gaps this PIP originally enumerated (noted per item below); the
+remaining follow-ups, including the `jcaProvider` configuration surface, are in
+[#26326](https://github.com/apache/pulsar/pull/26326). PIP-478 provides: a `TlsPolicy`
 configuration that selects the TLS engine and the JCA provider (`TlsPolicy.jcaProvider`), wired
 through every server component and the client; a `PulsarTlsFactory` plugin interface for
 deployments where key material must stay outside the process (HSM integration via PKCS#11 — the
@@ -77,39 +86,49 @@ FIPS-compliant. Concretely, on current `master`:
 
 1. **The BC/BC-FIPS swap has no supported, tested, or documented path.** Swapping the providers
    is mechanically simple — BC and BC-FIPS are mutually exclusive on a classpath, so the swap is
-   a matter of shipping one set of jars instead of the other, and `SecurityUtility`'s reflective
+   a matter of shipping one set of jars instead of the other, and `JcaProviders`' reflective
    loading already accepts either. The Maven-era swappable `bouncy-castle-bc` /
    `bouncy-castle-bcfips` NAR modules did not survive the Gradle migration, and **this PIP does
    not propose resurrecting them**; the gap is not missing machinery.
 
    What is missing is that nothing in the project supports, exercises, or documents the swap. The
-   version catalog still declares `bc-fips`, `bcpkix-fips` and `bcutil-fips`, but the server
-   distribution bundles the non-FIPS `bcprov`/`bcpkix` and *explicitly excludes* `bc-fips`
-   (`distribution/server/build.gradle.kts:59`), so the FIPS artifacts cannot reach a server
-   runtime by any supported route. Their only remaining consumer is the
+   version catalog still declares `bc-fips`, `bcpkix-fips` and `bcutil-fips` — and now says so
+   in as many words, describing them as "Test-only in this build" because "the server distribution
+   excludes bc-fips and ships the non-FIPS provider, so a FIPS deployment assembles its own
+   classpath" (`gradle/libs.versions.toml:62-63`). The distribution bundles the non-FIPS
+   `bcprov`/`bcpkix` (`distribution/server/build.gradle.kts:154`) and *explicitly excludes*
+   `bc-fips` (line 59), so the FIPS artifacts cannot reach a server runtime by any supported
+   route. Their only remaining consumer is the
    `tests/pulsar-client-test-bcfips` module, which covers the JCA provider swap for a client and
    nothing on the server side. No documentation tells an operator which jars to remove and add. An
    operator can therefore assemble a FIPS classpath by hand, but does so unaided and untested —
    which is what this PIP replaces with build wiring, a documented procedure, and coverage.
 
-2. **Broker TLS cannot be steered off BoringSSL.** The broker binary listener never wires the
-   `tlsProvider` setting: `ServiceConfiguration.tlsProvider` exists
-   (`pulsar-broker-common/.../ServiceConfiguration.java:4244`, default `null`) but
-   `PulsarChannelInitializer.buildSslConfiguration`
-   (`pulsar-broker/.../service/PulsarChannelInitializer.java:137`) never calls `.tlsProvider(...)`
-   on the `PulsarSslConfiguration` builder. `DefaultPulsarSslFactory` then passes a `null`
-   `SslProvider` to Netty, and because `netty-tcnative-boringssl-static` is an *unconditional*
-   dependency of `pulsar-common` (`pulsar-common/build.gradle.kts:180-185`), Netty's default is
-   always `OPENSSL` = BoringSSL. Broker PEM TLS is therefore hardwired to non-FIPS native crypto
-   with no configuration escape hatch. The proxy does this correctly
-   (`pulsar-proxy/.../ServiceChannelInitializer.java:94` wires `.tlsProvider(config.getTlsProvider())`);
-   the broker web service (`WebService.java:596`), WebSocket proxy (`pulsar-websocket/.../ProxyServer.java`),
-   and function worker (`pulsar-functions/worker/.../WorkerServer.java`) all omit it.
+2. **BoringSSL is still the default binary-listener engine, though it can now be configured away.**
+   This item originally recorded a wiring gap — the broker binary listener never passing
+   `tlsProvider` into `PulsarSslConfiguration` — and **PIP-478 has closed it**. Every listener now
+   builds its context from a `PulsarTlsFactory`: the broker binary listener goes through
+   `DefaultBrokerTlsFactory.fromServiceConfiguration`, whose settings carry
+   `engineProvider(TlsFactorySupport.engineProvider(conf.getTlsProvider()))`
+   (`pulsar-broker-common/.../tls/DefaultBrokerTlsFactory.java:112`), and the broker web service,
+   WebSocket proxy and function worker run through the same SPI. `PulsarSslConfiguration`,
+   `PulsarSslFactory` and `DefaultPulsarSslFactory` no longer exist.
 
-3. **Non-FIPS providers are the shipped defaults.** `webServiceTlsProvider` defaults to
-   `Conscrypt` in `ServiceConfiguration` (line 211), `ProxyConfiguration` (line 336), and
-   `WebSocketProxyConfiguration` (`tlsProvider`, line 229), and in the shipped `conf/proxy.conf`
-   (line 118).
+   What remains is the **default**. `netty-tcnative-boringssl-static` is still an *unconditional*
+   dependency of `pulsar-common` (`pulsar-common/build.gradle.kts:185-190`), and an unset
+   `tlsProvider` is documented to take "the native engine as OPENSSL_REFCNT when tcnative is
+   available" — so a deployment that configures nothing still terminates binary TLS in BoringSSL.
+   FIPS mode must therefore pin the engine on every component *and* remove tcnative from the
+   classpath, which is what the packaging and validation items below deliver.
+
+3. **Conscrypt is still the effective web-listener default, now by behaviour rather than by
+   literal.** The declared defaults are empty since PIP-478 — `webServiceTlsProvider` is `""` on
+   `ServiceConfiguration` (line 217) and `ProxyConfiguration` (line 343),
+   `WebSocketProxyConfiguration.tlsProvider` is `null` (line 256), and `conf/proxy.conf` ships
+   `webServiceTlsProvider=` (line 138) — but *unset now means Conscrypt*:
+   `TlsFactorySupport.resolveWebJsseProvider` falls back to it whenever it is usable on the
+   platform. The fallback is web-listener-only; the binary listeners carry no Conscrypt default at
+   all any more.
 
 4. **The false-confidence FIPS test.** `tests/pulsar-client-test-bcfips` runs a TLS
    produce/consume with `bc-fips` on the classpath, which validates the JCA provider swap (PEM
@@ -137,9 +156,10 @@ This PIP defines a supported, tested, documented "FIPS mode" that closes these g
 - A FIPS-capable TLS transport **by building on PIP-478** — `TlsPolicy` engine/JCA-provider
   selection, `PulsarTlsFactory` for PKCS#11/HSM-backed deployments, `PulsarHttpClient` for the
   auth plugins' outbound HTTPS — rather than defining a parallel TLS configuration path. (The
-  minimal interim fix for maintenance branches — passing the existing `tlsProvider` /
-  `webServiceTlsProvider` keys into each listener's `PulsarSslConfiguration`, as the proxy
-  already does — remains available but is not a deliverable of this PIP.)
+  per-listener provider wiring this PIP once listed as a prerequisite has landed with PIP-478 and
+  is no longer a deliverable here; the outstanding piece it does depend on is
+  [#26326](https://github.com/apache/pulsar/pull/26326), which honors the `jsseProvider` keys and
+  adds the `jcaProvider` ones.)
 - A **FIPS distribution variant** (or, at minimum, first-class Gradle wiring plus a documented,
   supported jar-swap procedure) that ships `bc-fips`/`bcpkix-fips`/`bcutil-fips` and omits
   `bcprov`/`bcpkix`, `netty-tcnative-boringssl-static`, and Conscrypt.
@@ -187,7 +207,7 @@ End to end, a FIPS deployment looks like:
 1. **Packaging.** The operator deploys the FIPS distribution variant (or performs the documented
    swap): `bc-fips` + `bcpkix-fips` + `bcutil-fips` on the classpath; `bcprov-jdk18on`,
    `bcpkix-jdk18on`, `netty-tcnative-boringssl-static`, and Conscrypt absent. The JVM is started
-   with `-Dorg.bouncycastle.fips.approved_only=true`. `SecurityUtility` picks up BC-FIPS exactly
+   with `-Dorg.bouncycastle.fips.approved_only=true`. `JcaProviders` picks up BC-FIPS exactly
    as it does today — no code change needed at the JCA layer.
 2. **TLS.** The TLS transport is configured through PIP-478's `TlsPolicy` (engine + JCA
    provider), so every TLS handshake — binary protocol, HTTP/admin, and the auth plugins'
@@ -196,7 +216,8 @@ End to end, a FIPS deployment looks like:
    (PKCS#11). Keystores may be PEM, BCFKS, or PKCS11; JKS and PKCS12 are not supported in FIPS
    mode.
 3. **Validation.** With `fipsMode=true`, the broker/proxy/worker verifies at startup: BC-FIPS is
-   the active BC provider (`SecurityUtility.isBCFIPS()`), no `OPENSSL`/`Conscrypt` TLS provider
+   the active BC provider (`JcaProviders.bouncyCastleProvider()` reporting `fips()`), no
+   `OPENSSL`/`Conscrypt` TLS provider
    is configured on any listener, keystore/truststore types are FIPS-capable (no JKS/PKCS12),
    no listener permits TLS 1.0/1.1, configured cipher suites and loaded certificates use only
    approved algorithms, Basic-auth password files contain no MD5/DES entries, and the SASL
@@ -217,8 +238,11 @@ End to end, a FIPS deployment looks like:
 
 PIP-478 already defines the TLS transport configuration for Pulsar 5.0: `TlsPolicy` with engine
 and JCA-provider selection (`TlsPolicy.jcaProvider`) wired through every server component and
-the client, the `PulsarTlsFactory` plugin interface (HSM/PKCS#11 integration — the FIPS 140-3
-Level 3 case, where private keys never enter the Pulsar process), and the `PulsarHttpClient` API
+the client (the `jcaProvider` *configuration keys* on the server and client configuration
+classes arrive with [#26326](https://github.com/apache/pulsar/pull/26326); on `master` today the
+axis is reachable only programmatically through the v5 builder), the `PulsarTlsFactory` plugin
+interface (HSM/PKCS#11 integration — the FIPS 140-3 Level 3 case, where private keys never enter
+the Pulsar process), and the `PulsarHttpClient` API
 that brings authentication plugins' HTTP calls (e.g. OAuth2 token endpoints) under the same TLS
 configuration. This PIP therefore **does not define a second TLS configuration path**: FIPS mode
 consumes PIP-478's transport, and the `fipsMode` validator asserts that the effective policy
@@ -227,16 +251,19 @@ over a FIPS-validated provider — never `OPENSSL` (BoringSSL) or `Conscrypt`.
 
 Two consequences:
 
-- The per-listener gaps on current `master` (the broker binary listener ignoring `tlsProvider`;
-  the broker web service, WebSocket proxy, and function worker not propagating the web-service
-  provider into `PulsarSslConfiguration`) are subsumed by PIP-478's uniform wiring. If a
-  maintenance-branch fix is wanted before PIP-478 lands, the interim one-line
-  `.tlsProvider(...)` pass-throughs (matching the proxy's existing pattern) remain available,
-  but they are not deliverables of this PIP.
-- The `Conscrypt` **defaults are left unchanged** (changing them is a performance regression
-  for non-FIPS users); FIPS deployments select the JDK engine explicitly, and `fipsMode=true`
-  rejects `Conscrypt`/`OPENSSL`. A follow-up may revisit defaults once JDK TLS performance is
-  re-benchmarked on modern JVMs.
+- The per-listener gaps this PIP originally recorded (the broker binary listener ignoring
+  `tlsProvider`; the broker web service, WebSocket proxy and function worker not propagating the
+  web-service provider) **are closed on `master`** by PIP-478's uniform wiring, so no interim
+  maintenance-branch pass-throughs are needed. One outbound gap of the same shape is still open and
+  is fixed by [#26326](https://github.com/apache/pulsar/pull/26326): `DefaultBrokerTlsFactory`
+  resolves its JSSE provider as `resolveJsseProvider(null, conf.getTlsProvider())`, passing `null`
+  for the explicit axis, so the broker's own `jsseProvider` / `brokerClientJsseProvider` keys are
+  declared but ignored. FIPS mode depends on that axis, so this PIP assumes #26326.
+- The `Conscrypt` **default is left unchanged** (changing it is a performance regression
+  for non-FIPS users), in its PIP-478 form: unset resolves to Conscrypt where the platform can use
+  it, on the web listeners only. FIPS deployments select the JDK engine explicitly, and
+  `fipsMode=true` rejects `Conscrypt`/`OPENSSL`. A follow-up may revisit defaults once JDK TLS
+  performance is re-benchmarked on modern JVMs.
 
 ### (b) Packaging: FIPS distribution variant
 
@@ -244,7 +271,7 @@ Two layers, phased:
 
 1. **Gradle wiring (this PIP, phase 1).** Add a `fips` capability to the build:
    - A version-catalog *bundle* `bouncycastle-fips` = { `bc-fips`, `bcpkix-fips`, `bcutil-fips` }
-     (versions already declared in `gradle/libs.versions.toml:59-61`).
+     (versions already declared in `gradle/libs.versions.toml:75-77`).
    - A resolvable `fipsRuntimeClasspath` in `distribution/server` that substitutes
      `bcprov-jdk18on`/`bcpkix-jdk18on` → FIPS artifacts and excludes
      `netty-tcnative-boringssl-static` and `org.conscrypt:conscrypt-openjdk-uber` (Netty falls
@@ -252,7 +279,7 @@ Two layers, phased:
    - A documented, supported **jar-swap procedure** for the standard distribution: remove
      `bcprov-jdk18on-*.jar`/`bcpkix-jdk18on-*.jar`, `netty-tcnative-boringssl-static-*.jar`, and
      `conscrypt-*.jar` from `lib/`, add the three FIPS jars. This works because
-     `SecurityUtility`'s reflective loading already handles either flavor.
+     `JcaProviders`' reflective loading already handles either flavor.
 2. **Published variant (phase 2).** A `distribution/server-fips` module producing
    `apache-pulsar-<version>-fips-bin.tar.gz` from the `fipsRuntimeClasspath`, wired into CI.
    Whether to *publish* this to dist.apache.org (vs. providing the build recipe) is a release-
@@ -288,12 +315,12 @@ Current state (`pulsar-client-messagecrypto-bc/.../MessageCryptoBc.java`):
 
 - RSA key wrap is hardcoded to `RSA/NONE/OAEPWithSHA1AndMGF1Padding` (line 92). SHA-1 OAEP is
   not FIPS-approved.
-- EC key wrap uses `ECIES` (lines 88, 373, 535) — not FIPS-approved and **absent from BC-FIPS**.
+- EC key wrap uses `ECIES` (lines 88, 374, 536) — not FIPS-approved and **absent from BC-FIPS**.
 - The class compile-imports `org.bouncycastle.jce.*` (lines 74-77:
   `ECPublicKey`, `ECParameterSpec`, `ECPrivateKeySpec`, `ECPublicKeySpec`), classes that do not
   exist in `bc-fips` — so on a FIPS classpath the class fails to load
   (`NoClassDefFoundError`) even for RSA-only users.
-- The `SecureRandom` is pinned to `NativePRNGNonBlocking` (line 127) rather than the BC-FIPS
+- The `SecureRandom` is pinned to `NativePRNGNonBlocking` (line 128) rather than the BC-FIPS
   DRBG (the RNG fix is one of the in-flight quick-win PRs; see *General Notes*).
 - There is no EC curve allowlist.
 
@@ -320,9 +347,9 @@ Design:
    setting `cryptoKeyWrapAlgorithm` (see Configuration). The operational contract is: upgrade all
    consumers first, then flip producers. `fipsMode` guidance requires `RSA_OAEP_SHA256` (and, in
    phase 1, documents EC encryption keys as unsupported in FIPS mode until `ECDH_AES_KW` lands).
-3. **EC curve allowlist.** When `SecurityUtility.isBCFIPS()`, restrict accepted EC keys to NIST
-   curves (P-256/P-384/P-521); BC-FIPS in approved-only mode enforces this anyway — the allowlist
-   converts a deep provider exception into an actionable error message.
+3. **EC curve allowlist.** When `JcaProviders.bouncyCastleProvider()` reports `fips()`, restrict
+   accepted EC keys to NIST curves (P-256/P-384/P-521); BC-FIPS in approved-only mode enforces this
+   anyway — the allowlist converts a deep provider exception into an actionable error message.
 
 The decryption path retains support for *all* algorithm ids indefinitely (subject to the FIPS
 classpath physically lacking ECIES), so mixed-version fleets and stored backlogs keep working.
@@ -405,7 +432,7 @@ A new `fipsMode` boolean (broker `ServiceConfiguration`, `ProxyConfiguration`,
 `WebSocketProxyConfiguration`, function-worker config; default `false`). When `true`, a shared
 validator (in `pulsar-broker-common`, invoked from each component's startup) asserts:
 
-- `SecurityUtility.isBCFIPS()` is true (BC-FIPS is the loaded BC provider);
+- `JcaProviders.bouncyCastleProvider()` reports `fips()` (BC-FIPS is the resolved BC provider);
 - `org.bouncycastle.fips.approved_only=true` is set (via
   `CryptoServicesRegistrar.isInApprovedOnlyMode()` reflectively, to avoid a compile-time bc-fips
   dependency);
@@ -438,10 +465,10 @@ The Java **client** gets no `fipsMode` flag: client FIPS posture is determined b
   containing `bc-fips`/`bcpkix-fips`/`bcutil-fips` and **excluding** `bcprov`, `bcpkix`,
   `netty-tcnative-boringssl-static`, and Conscrypt, with
   `-Dorg.bouncycastle.fips.approved_only=true` and `fipsMode=true`. It asserts
-  `SecurityUtility.isBCFIPS()`, then exercises: binary-protocol TLS produce/consume (PEM and
-  BCFKS keystore), HTTPS admin calls, mTLS client authentication, token authentication
-  (HMAC-signed JWTs), and E2E encryption with `RSA_OAEP_SHA256`. Negative tests assert startup
-  *fails* under `fipsMode=true` when a Conscrypt provider is configured, when a JKS or PKCS12
+  that `JcaProviders.bouncyCastleProvider()` reports `fips()`, then exercises: binary-protocol TLS
+  produce/consume (PEM and BCFKS keystore), HTTPS admin calls, mTLS client authentication, token
+  authentication (HMAC-signed JWTs), and E2E encryption with `RSA_OAEP_SHA256`. Negative tests
+  assert startup *fails* under `fipsMode=true` when a Conscrypt provider is configured, when a JKS or PKCS12
   keystore is configured, and when TLS 1.1 is enabled on a listener.
 - **Unit tests**: dual-format `SaslRoleTokenSigner` sign/verify matrix (legacy↔HMAC, tampering,
   strict mode); Basic-auth `$5$`/`$6$` verification including `rounds=N$` salts and rejection
@@ -471,19 +498,17 @@ keys ignore them, per existing semantics.
 | Key | Component | Type | Default | Change |
 |---|---|---|---|---|
 | `fipsMode` | broker, proxy, websocket, function worker | boolean | `false` | **New.** Startup fail-fast validation of FIPS posture. |
-| `tlsProvider` | broker | string | `null` | **Now honored by the binary listener** (previously declared but ignored there). No behavior change unless set. |
-| `webServiceTlsProvider` | broker | string | `Conscrypt` | Now also propagated into `PulsarSslConfiguration` (previously Jetty-layer only). Default unchanged. |
-| `tlsProvider` | websocket proxy | string | `Conscrypt` | Now propagated into `PulsarSslConfiguration`. Default unchanged. |
-| (worker TLS provider) | function worker | string | — | Now propagated into `PulsarSslConfiguration`. |
+| `jsseProvider`, `brokerClientJsseProvider` | broker | string | `null` | Declared but ignored on `master`; honored from [#26326](https://github.com/apache/pulsar/pull/26326), which this PIP assumes. No new key here. |
+| `jcaProvider`, `brokerClientJcaProvider` | broker, proxy, websocket, worker, client | string | unset | Added by #26326; the JCA axis `fipsMode` validates. No new key here. |
 | `cryptoKeyWrapAlgorithm` | Java client (producer) | enum | `RSA_OAEP_SHA1` | **New.** `RSA_OAEP_SHA1` \| `RSA_OAEP_SHA256` \| (phase 2) `ECDH_AES_KW`. Consumers auto-detect from metadata; no consumer setting. |
 | `saslRoleTokenSignerAlgorithm` | broker, proxy (SASL) | enum | `SHA-512` | **New.** `SHA-512` \| `HmacSHA256` \| `HmacSHA256-strict`. Default preserves current bytes on the wire; verify accepts both formats except in `-strict`. |
 
-The four TLS-provider rows describe the interim, pre-PIP-478 keys: once PIP-478's `TlsPolicy`
-is available it is the single TLS transport configuration, these keys follow its
-deprecation/migration path, and the `fipsMode` validator evaluates the effective `TlsPolicy`
-instead. The new validator checks (keystore types, TLS protocol floor, cipher-suite/certificate
-screening) introduce no new keys — they validate the existing `tlsKeyStoreType`,
-`tlsProtocols`, and `tlsCiphers` family of settings.
+The two provider rows add no keys of their own — they record which existing keys `fipsMode`
+evaluates, and that both reach the effective `TlsPolicy` only once #26326 merges. PIP-478's
+`TlsPolicy` is the single TLS transport configuration; the `fipsMode` validator evaluates the
+effective policy rather than the raw keys. The other new validator checks (keystore types, TLS
+protocol floor, cipher-suite/certificate screening) likewise introduce no new keys — they validate
+the existing `tlsKeyStoreType`, `tlsProtocols`, and `tlsCiphers` family of settings.
 
 Basic auth gains no new key: `$5$`/`$6$` hashes are recognized by prefix in the existing password
 file format. Shipped `conf/*.conf` files gain commented FIPS-mode examples; no shipped default
@@ -575,9 +600,9 @@ opts into `RSA_OAEP_SHA256`.
 1. **Rely on OS-level FIPS (e.g. RHEL crypto-policies) with the stock distribution.** Rejected:
    BoringSSL via tcnative bypasses the JVM's provider machinery entirely, so OS policy does not
    make Pulsar's Netty TLS FIPS-validated, and the non-approved algorithms in (c)-(e) remain.
-2. **A custom TLS-factory plugin as the only TLS answer.** The plugin points (PIP-337's
-   `PulsarSslFactory` today, PIP-478's `PulsarTlsFactory` in Pulsar 5.0) are necessary building
-   blocks — and PIP-478's is exactly how HSM-backed FIPS 140-3 Level 3 deployments integrate —
+2. **A custom TLS-factory plugin as the only TLS answer.** The plugin point (PIP-478's
+   `PulsarTlsFactory`, which replaced PIP-337's `PulsarSslFactory`) is a necessary building
+   block — and PIP-478's is exactly how HSM-backed FIPS 140-3 Level 3 deployments integrate —
    but a plugin alone cannot remove BoringSSL from the shipped classpath, nor address anything
    outside TLS (message crypto, Basic auth, SASL, packaging, validation). Used as building
    blocks, not the whole solution.
@@ -610,12 +635,15 @@ opts into `RSA_OAEP_SHA256`.
   classpath-assembly concern — clients exclude/replace dependencies, and the server keeps the
   two flavors in separate directories (or uses the `fipsRuntimeClasspath` variant) and picks
   one at startup.
-- **Prior art / companion quick-win PRs (already open, intentionally outside this PIP):**
-  [#26152](https://github.com/apache/pulsar/pull/26152) MD5 NAR/archive checksums → SHA-256;
-  [#26153](https://github.com/apache/pulsar/pull/26153) SHA-1-derived reader subscription names →
-  SHA-256; [#26154](https://github.com/apache/pulsar/pull/26154) `KeyManagerProxy` JKS fallback +
-  `MessageCryptoBc` `SecureRandom` preferring the BC-FIPS `DEFAULT` DRBG when the `BCFIPS`
-  provider is registered.
+- **Prior art / companion quick-win PRs (intentionally outside this PIP):**
+  [#26152](https://github.com/apache/pulsar/pull/26152) MD5 NAR/archive checksums → SHA-256
+  (**merged**); [#26153](https://github.com/apache/pulsar/pull/26153) SHA-1-derived reader
+  subscription names → SHA-256 (**merged**);
+  [#26154](https://github.com/apache/pulsar/pull/26154) `MessageCryptoBc` `SecureRandom` preferring
+  the BC-FIPS `DEFAULT` DRBG when the `BCFIPS` provider is registered (**open**). #26154 also
+  carried a `KeyManagerProxy` JKS fallback; PIP-478 deleted that class, and its replacement
+  (`JcaKeyStores`, which selects `BCFKS` then `PKCS12` under a pinned JCA provider and never asks
+  for JKS) covers the concern, so that half was dropped.
 - Implementation is phased to match the item list: **Phase 1** — (a) PIP-478 TLS integration +
   (g) `fipsMode` validator + (b) Gradle wiring & documented swap + (c) class-loading fix and
   `RSA_OAEP_SHA256` + the integration test group; **Phase 2** — (d) Basic auth SHA-2-crypt,

--- a/pip/pip-489.md
+++ b/pip/pip-489.md
@@ -75,13 +75,22 @@ JCA layer. Users in regulated environments (FedRAMP, DoD IL levels, PCI, healthc
 deploy Pulsar or deploy it with unsupported hand-rolled jar surgery that silently fails to be
 FIPS-compliant. Concretely, on current `master`:
 
-1. **The BC/BC-FIPS swap lost its packaging story in the Gradle migration.** The Maven-era
-   swappable `bouncy-castle-bc` / `bouncy-castle-bcfips` NAR modules did not survive the migration.
-   The version catalog still declares `bc-fips` 2.0.1 / `bcpkix-fips` 2.0.11 / `bcutil-fips` 2.0.6
-   (`gradle/libs.versions.toml:59-61`), but the server distribution bundles the non-FIPS
-   `bcprov`/`bcpkix` 1.84 and *explicitly excludes* `bc-fips`
-   (`distribution/server/build.gradle.kts:59`). The only remaining consumer of the FIPS artifacts
-   is the `tests/pulsar-client-test-bcfips` test module.
+1. **The BC/BC-FIPS swap has no supported, tested, or documented path.** Swapping the providers
+   is mechanically simple — BC and BC-FIPS are mutually exclusive on a classpath, so the swap is
+   a matter of shipping one set of jars instead of the other, and `SecurityUtility`'s reflective
+   loading already accepts either. The Maven-era swappable `bouncy-castle-bc` /
+   `bouncy-castle-bcfips` NAR modules did not survive the Gradle migration, and **this PIP does
+   not propose resurrecting them**; the gap is not missing machinery.
+
+   What is missing is that nothing in the project supports, exercises, or documents the swap. The
+   version catalog still declares `bc-fips`, `bcpkix-fips` and `bcutil-fips`, but the server
+   distribution bundles the non-FIPS `bcprov`/`bcpkix` and *explicitly excludes* `bc-fips`
+   (`distribution/server/build.gradle.kts:59`), so the FIPS artifacts cannot reach a server
+   runtime by any supported route. Their only remaining consumer is the
+   `tests/pulsar-client-test-bcfips` module, which covers the JCA provider swap for a client and
+   nothing on the server side. No documentation tells an operator which jars to remove and add. An
+   operator can therefore assemble a FIPS classpath by hand, but does so unaided and untested —
+   which is what this PIP replaces with build wiring, a documented procedure, and coverage.
 
 2. **Broker TLS cannot be steered off BoringSSL.** The broker binary listener never wires the
    `tlsProvider` setting: `ServiceConfiguration.tlsProvider` exists


### PR DESCRIPTION
PIP: this PR

### Motivation

Pulsar has no supported FIPS 140-3 deployment path today, despite being most of the way there at the JCA layer (`SecurityUtility` already resolves BC vs. BC-FIPS reflectively). A full audit of `master` found the gaps documented in the proposal: the BC/BC-FIPS swap lost its packaging story in the Gradle migration; the broker binary listener cannot be steered off BoringSSL (`tlsProvider` is declared but never wired); Conscrypt is the shipped web-TLS default; several security paths use non-approved algorithms (SHA-1 OAEP and ECIES in `MessageCryptoBc`, MD5-crypt/DES-crypt in Basic auth, a non-HMAC construction in `SaslRoleTokenSigner`); and there is no FIPS documentation or meaningful FIPS test coverage.

### Modifications

Adds `pip/pip-489.md`, proposing a supported, tested, documented **FIPS mode** deployment profile: TLS provider wiring for every listener (matching the proxy's existing pattern), a FIPS distribution variant / documented jar swap, a `fipsMode` fail-fast startup validator, metadata-negotiated migration to `RSA_OAEP_SHA256` key wrapping (with `ECDH_AES_KW` replacing ECIES in a later phase), SHA-2-crypt Basic auth, a dual-verify HMAC migration for the SASL role-token signer, a name-stable fix for the SHA-1-derived Kubernetes resource names, and a real FIPS TLS integration test group.

Companion quick-win PRs already open (intentionally outside the PIP): #26152, #26153, #26154.

A `DISCUSS` [thread](https://lists.apache.org/thread/cq6v9z2wszb6lsorvl0nbj85sc00pd6j) has been started on dev@pulsar.apache.org referencing this PR.
