### PR TITLE
[fix][ci] Update setup-gradle action to v6.2.0 to match ASF actions allowlist

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Setup Gradle with Develocity
       if: ${{ inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true' }}
-      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         develocity-injection-enabled: true
         develocity-url: https://develocity.apache.org
@@ -62,7 +62,7 @@ runs:
 
     - name: Setup Gradle
       if: ${{ !(inputs.develocity-access-key != '' && inputs.build-scan-publish == 'true') }}
-      uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         build-scan-publish: ${{ inputs.build-scan-publish }}
         build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'


### PR DESCRIPTION
### Motivation

All CI on master-based PRs has been failing since 2026-07-05 with:

> Error: The action gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f is not allowed in apache/pulsar because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...

Root cause: the ASF org-level Actions allowlist (`approved_patterns.yml` in apache/infrastructure-actions) had expired refs removed on 2026-07-05 ("Remove Expired Refs" commit), which dropped the `gradle/actions/setup-gradle` v6.0.1 SHA (`39e147cb...`) that our composite action pins. The currently allowed SHAs are v5.0.2, v6.1.0, and v6.2.0.

Affected examples: #26149, #26152, #26153, #26154 (all failing "Build and License check" / "Flaky tests suite" at startup).

### Modifications

Bump both `uses:` refs in `.github/actions/setup-gradle/action.yml` from v6.0.1 (`39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f`) to v6.2.0 (`3f131e8634966bd73d06cc69884922b02e6faf92`), the newest SHA on the ASF allowlist, and annotate the pins with the version for future reference.

I scanned all other external `uses:` refs in `.github/` against the current allowlist; this was the only non-allowed ref (apache/* and actions/* refs are implicitly allowed).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial CI configuration fix; CI on this PR itself verifies it (the workflow runs from the PR merge ref, so this PR's checks will use the new pin).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
