### PR TITLE
[fix][metadata] Fix orphaned UR parent nodes not cleaned up with Oxia metadata backend

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/MetadataStoreException.java
@@ -172,6 +172,14 @@ public class MetadataStoreException extends IOException {
         }
     }
 
+    public static class NotEmptyException extends MetadataStoreException {
+        private static final long serialVersionUID = 1L;
+
+        public NotEmptyException(String path) {
+            super("Key '" + path + "' has children");
+        }
+    }
+
     public static MetadataStoreException unwrap(Throwable t) {
         if (t instanceof MetadataStoreException) {
             return (MetadataStoreException) t;

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -68,7 +68,7 @@ import org.apache.pulsar.metadata.api.extended.CreateOption;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.DualMetadataStore;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.zookeeper.KeeperException;
+import org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore;
 
 @CustomLog
 public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicationManager {
@@ -434,7 +434,8 @@ public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicati
                 store.delete(getUrLedgerPath(ledgerId), Optional.of(l.getLedgerNodeVersion()))
                         .get(BLOCKING_CALL_TIMEOUT, MILLISECONDS);
                 if (store instanceof ZKMetadataStore
-                        || store instanceof DualMetadataStore) {
+                        || store instanceof DualMetadataStore
+                        || store instanceof OxiaMetadataStore) {
                     try {
                         // clean up the hierarchy
                         String[] parts = getUrLedgerPath(ledgerId).split("/");
@@ -452,10 +453,7 @@ public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicati
                         // It's safe to ignore, it simply means another
                         // ledger in the same hierarchy has been marked as
                         // underreplicated.
-                        if (ee.getCause() instanceof MetadataStoreException && ee.getCause().getCause()
-                                instanceof KeeperException.NotEmptyException) {
-                            //do nothing.
-                        } else {
+                        if (!(ee.getCause() instanceof MetadataStoreException.NotEmptyException)) {
                             log.warn().exception(ee).log("Error deleting underreplicated ledger parent node");
                         }
                     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/bookkeeper/PulsarLedgerUnderreplicationManager.java
@@ -69,6 +69,7 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.DualMetadataStore;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.metadata.impl.oxia.OxiaMetadataStore;
+import org.apache.zookeeper.KeeperException;
 
 @CustomLog
 public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicationManager {
@@ -453,7 +454,14 @@ public class PulsarLedgerUnderreplicationManager implements LedgerUnderreplicati
                         // It's safe to ignore, it simply means another
                         // ledger in the same hierarchy has been marked as
                         // underreplicated.
-                        if (!(ee.getCause() instanceof MetadataStoreException.NotEmptyException)) {
+                        // Oxia raises NotEmptyException directly; ZK wraps
+                        // KeeperException.NotEmptyException inside a MetadataStoreException.
+                        boolean isNotEmpty =
+                                ee.getCause() instanceof MetadataStoreException.NotEmptyException
+                                || (ee.getCause() instanceof MetadataStoreException
+                                        && ee.getCause().getCause()
+                                                instanceof KeeperException.NotEmptyException);
+                        if (!isNotEmpty) {
                             log.warn().exception(ee).log("Error deleting underreplicated ledger parent node");
                         }
                     }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -524,8 +524,6 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             return new NotFoundException(ex);
         case NODEEXISTS:
             return new AlreadyExistsException(ex);
-        case NOTEMPTY:
-            return new MetadataStoreException.NotEmptyException(path);
         default:
             return new MetadataStoreException(ex);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKMetadataStore.java
@@ -524,6 +524,8 @@ public class ZKMetadataStore extends AbstractBatchedMetadataStore
             return new NotFoundException(ex);
         case NODEEXISTS:
             return new AlreadyExistsException(ex);
+        case NOTEMPTY:
+            return new MetadataStoreException.NotEmptyException(path);
         default:
             return new MetadataStoreException(ex);
         }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -187,7 +187,7 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
                         children -> {
                             if (!children.isEmpty()) {
                                 return CompletableFuture.failedFuture(
-                                        new MetadataStoreException("Key '" + path + "' has children"));
+                                        new MetadataStoreException.NotEmptyException(path));
                             } else {
                                 Set<DeleteOption> delOption = deleteOptions(opts, expectedVersion);
                                 CompletableFuture<Boolean> result = client.delete(path, delOption);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/LedgerUnderreplicationManagerTest.java
@@ -299,8 +299,8 @@ public class LedgerUnderreplicationManagerTest extends BaseMetadataStoreTest {
         assertEquals(l, lB.get(), "Should be the ledger I marked");
     }
 
-    @Test(dataProvider = "zkImpls", timeOut = 10000)
-    public void testZkMetasStoreMarkReplicatedDeleteEmptyParentNodes(String provider, Supplier<String> urlSupplier)
+    @Test(dataProvider = "distributedImpl", timeOut = 10000)
+    public void testMarkReplicatedDeletesEmptyParentNodes(String provider, Supplier<String> urlSupplier)
             throws Exception {
         methodSetup(urlSupplier);
 


### PR DESCRIPTION
Fixes #26157

### Motivation

When using Oxia as the metadata backend, `markLedgerReplicated()` in `PulsarLedgerUnderreplicationManager` leaves orphaned intermediate nodes in the under-replication (UR) tree after every ledger is successfully replicated.

`OxiaMetadataStore.doStorePut()` calls `createParents()` to explicitly create up to 4 intermediate path entries for every UR leaf (Oxia is a flat key-value store; parent nodes must be created explicitly). However, the hierarchy cleanup in `markLedgerReplicated()` was gated on an `instanceof` check that excluded `OxiaMetadataStore`, so those parent nodes were never deleted.

Additionally, the inner catch block only handled ZK's `KeeperException.NotEmptyException`. Oxia threw a plain `MetadataStoreException` for the same "node has children" condition, causing a spurious `log.warn()` on every successfully-replicated ledger.

Over time, orphaned nodes accumulate proportionally to replication activity and cause `getLedgerToRereplicateFromHierarchy()` to traverse empty subtrees on every replication poll, driving sustained elevated metadata store list ops.

### Modifications

- Add `MetadataStoreException.NotEmptyException` to the metadata API, consistent  with the existing `NotFoundException` / `BadVersionException` pattern
- Map ZK's `NOTEMPTY` error code to `NotEmptyException` in  `ZKMetadataStore.getException()` (was falling through to `default`)
- Throw `NotEmptyException` from `OxiaMetadataStore.storeDelete()` instead of a   plain `MetadataStoreException`, so both backends surface the same exception type
- Add `OxiaMetadataStore` to the `instanceof` guard in `markLedgerReplicated()`
- Replace the ZK-specific `KeeperException.NotEmptyException` check with a clean  `instanceof MetadataStoreException.NotEmptyException` check

### Verifying this change

This change added tests and can be verified as follows:

- Extended `testMarkReplicatedDeletesEmptyParentNodes` to run against all   distributed metadata backends (`dataProvider = "distributedImpl"`: ZK + Oxia)   instead of ZK-only (`dataProvider = "zkImpls"`). The test asserts that all 4  parent hierarchy nodes are deleted after `markLedgerReplicated()` completes.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API — added `MetadataStoreException.NotEmptyException` (new subclass, backward-compatible)
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment