### PR TITLE
[fix][broker] Fix BucketDelayedDeliveryTracker recovery after LightProto migration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BookkeeperBucketSnapshotStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BookkeeperBucketSnapshotStorage.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.delayed.bucket;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
 import org.apache.pulsar.broker.delayed.proto.SnapshotSegment;
+import org.apache.pulsar.broker.delayed.proto.SnapshotSegmentMetadata;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
@@ -134,12 +136,17 @@ public class BookkeeperBucketSnapshotStorage implements BucketSnapshotStorage {
         return FutureUtil.waitForAll(addFutures);
     }
 
-    private SnapshotMetadata parseSnapshotMetadataEntry(LedgerEntry ledgerEntry) {
+    @VisibleForTesting
+    public SnapshotMetadata parseSnapshotMetadataEntry(LedgerEntry ledgerEntry) {
         ByteBuf entryBuffer = null;
         try {
             entryBuffer = ledgerEntry.getEntryBuffer();
             SnapshotMetadata metadata = new SnapshotMetadata();
             metadata.parseFrom(entryBuffer, entryBuffer.readableBytes());
+            for (int i = 0; i < metadata.getMetadataListCount(); i++) {
+                SnapshotSegmentMetadata segment = metadata.getMetadataAt(i);
+                segment.forEachDelayedIndexBitMap(segment::putDelayedIndexBitMap);
+            }
             return metadata;
         } finally {
             if (entryBuffer != null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
@@ -241,10 +241,6 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
 
     @Test
     public void testParseSnapshotMetadataEntryMaterializesLazyBytes() {
-        BookkeeperBucketSnapshotStorage storage = mock(BookkeeperBucketSnapshotStorage.class);
-        when(storage.parseSnapshotMetadataEntry(mock(LedgerEntry.class)))
-                .thenCallRealMethod();
-
         long ts = System.currentTimeMillis();
         SnapshotSegmentMetadata segmentMetadata = new SnapshotSegmentMetadata();
         segmentMetadata.setMinScheduleTimestamp(ts);
@@ -260,7 +256,7 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
         LedgerEntry entry = mock(LedgerEntry.class);
         when(entry.getEntryBuffer()).thenReturn(buffer);
 
-        SnapshotMetadata parsed = storage.parseSnapshotMetadataEntry(entry);
+        SnapshotMetadata parsed = bucketSnapshotStorage.parseSnapshotMetadataEntry(entry);
         assertEquals(buffer.refCnt(), 0);
 
         AtomicInteger entryCount = new AtomicInteger();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/BookkeeperBucketSnapshotStorageTest.java
@@ -18,12 +18,21 @@
  */
 package org.apache.pulsar.broker.delayed;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.delayed.bucket.BookkeeperBucketSnapshotStorage;
 import org.apache.pulsar.broker.delayed.proto.DelayedIndex;
@@ -230,4 +239,36 @@ public class BookkeeperBucketSnapshotStorageTest extends MockedPulsarServiceBase
         FutureUtil.waitForAll(futures).join();
     }
 
+    @Test
+    public void testParseSnapshotMetadataEntryMaterializesLazyBytes() {
+        BookkeeperBucketSnapshotStorage storage = mock(BookkeeperBucketSnapshotStorage.class);
+        when(storage.parseSnapshotMetadataEntry(mock(LedgerEntry.class)))
+                .thenCallRealMethod();
+
+        long ts = System.currentTimeMillis();
+        SnapshotSegmentMetadata segmentMetadata = new SnapshotSegmentMetadata();
+        segmentMetadata.setMinScheduleTimestamp(ts);
+        segmentMetadata.setMaxScheduleTimestamp(ts);
+        segmentMetadata.putDelayedIndexBitMap(100L, "payload-1".getBytes(StandardCharsets.UTF_8));
+        segmentMetadata.putDelayedIndexBitMap(200L, "payload-2".getBytes(StandardCharsets.UTF_8));
+        SnapshotMetadata original = new SnapshotMetadata();
+        original.addMetadata().copyFrom(segmentMetadata);
+
+        ByteBuf buffer = Unpooled.wrappedBuffer(original.toByteArray());
+        assertEquals(buffer.refCnt(), 1);
+
+        LedgerEntry entry = mock(LedgerEntry.class);
+        when(entry.getEntryBuffer()).thenReturn(buffer);
+
+        SnapshotMetadata parsed = storage.parseSnapshotMetadataEntry(entry);
+        assertEquals(buffer.refCnt(), 0);
+
+        AtomicInteger entryCount = new AtomicInteger();
+        parsed.getMetadataAt(0).forEachDelayedIndexBitMap((k, v) -> {
+            assertNotNull(v);
+            assertTrue(v.length > 0);
+            entryCount.incrementAndGet();
+        });
+        assertEquals(entryCount.get(), 2);
+    }
 }


### PR DESCRIPTION
### Motivation

PR #25337 migrated broker delayed-delivery protos from protobuf-java to LightProto. Unlike protobuf-java which eagerly copies bytes fields, LightProto lazily references the parsed ByteBuf. The existing `parseSnapshotMetadataEntry` released the buffer immediately after parsing, so any later access to `delayed_index_bit_map` entries (via `forEachDelayedIndexBitMap`) threw `IllegalReferenceCountException` (refCnt: 0).

This caused `BucketDelayedDeliveryTracker` recovery to fail on every broker restart, silently falling back to `InMemoryDelayedDeliveryTracker` — all bucket snapshots became unreachable, bucket-level metrics disappeared, and new snapshots were no longer created.

### Modifications

* Force materialization of `delayed_index_bit_map` entries into standalone `byte[]` copies before releasing the entry buffer in `parseSnapshotMetadataEntry`.
* Add `testParseSnapshotMetadataEntryMaterializesLazyBytes` that reproduces the bug by mocking `LedgerEntry` with a refCnt=1 buffer (matching real BK, unlike `MockedBookKeeper` which masks the bug with an extra reference).

### Verifying

The test fails without the fix (`IllegalReferenceCountException: refCnt: 0`) and passes with it.