### PR TITLE
[improve][monitor][branch-4.0] Upgrade OpenTelemetry libraries

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -552,7 +552,7 @@ The Apache Software License, Version 2.0
      - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-2.28.1-alpha.jar
      - io.opentelemetry.semconv-opentelemetry-semconv-1.41.1.jar
      - com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar
-     - io.opentelemetry.contrib-opentelemetry-gcp-resources-1.57.0-alpha.jar
+     - io.opentelemetry.contrib-opentelemetry-gcp-resources-1.48.0-alpha.jar
   * Spotify completable-futures
     - com.spotify-completable-futures-0.3.6.jar
   * JSpecify

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -337,12 +337,12 @@ The Apache Software License, Version 2.0
     - io.prometheus-simpleclient_tracer_otel-0.16.0.jar
     - io.prometheus-simpleclient_tracer_otel_agent-0.16.0.jar
  * Prometheus exporter
-    - io.prometheus-prometheus-metrics-config-1.3.10.jar
-    - io.prometheus-prometheus-metrics-exporter-common-1.3.10.jar
-    - io.prometheus-prometheus-metrics-exporter-httpserver-1.3.10.jar
-    - io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.3.10.jar
-    - io.prometheus-prometheus-metrics-model-1.3.10.jar
-    - io.prometheus-prometheus-metrics-exposition-textformats-1.3.10.jar
+     - io.prometheus-prometheus-metrics-config-1.5.1.jar
+     - io.prometheus-prometheus-metrics-exporter-common-1.5.1.jar
+     - io.prometheus-prometheus-metrics-exporter-httpserver-1.5.1.jar
+     - io.prometheus-prometheus-metrics-exposition-formats-no-protobuf-1.5.1.jar
+     - io.prometheus-prometheus-metrics-exposition-textformats-1.5.1.jar
+     - io.prometheus-prometheus-metrics-model-1.5.1.jar
  * Jakarta Bean Validation API
     - jakarta.validation-jakarta.validation-api-2.0.2.jar
     - javax.validation-validation-api-1.1.0.Final.jar
@@ -529,31 +529,30 @@ The Apache Software License, Version 2.0
     - io.reactivex.rxjava3-rxjava-3.0.1.jar
   * RoaringBitmap
     - org.roaringbitmap-RoaringBitmap-1.6.9.jar
-  * OpenTelemetry
-    - io.opentelemetry-opentelemetry-api-1.56.0.jar
-    - io.opentelemetry-opentelemetry-api-incubator-1.56.0-alpha.jar
-    - io.opentelemetry-opentelemetry-common-1.56.0.jar
-    - io.opentelemetry-opentelemetry-context-1.56.0.jar
-    - io.opentelemetry-opentelemetry-exporter-common-1.56.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-1.56.0.jar
-    - io.opentelemetry-opentelemetry-exporter-otlp-common-1.56.0.jar
-    - io.opentelemetry-opentelemetry-exporter-prometheus-1.56.0-alpha.jar
-    - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-common-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-logs-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-metrics-1.56.0.jar
-    - io.opentelemetry-opentelemetry-sdk-trace-1.56.0.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.21.0.jar
-    - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.21.0-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-resources-2.21.0-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java17-2.21.0-alpha.jar
-    - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-java8-2.21.0-alpha.jar
-    - io.opentelemetry.semconv-opentelemetry-semconv-1.37.0.jar
-    - com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar
-    - io.opentelemetry.contrib-opentelemetry-gcp-resources-1.48.0-alpha.jar
+* OpenTelemetry
+     - io.opentelemetry-opentelemetry-api-1.62.0.jar
+     - io.opentelemetry-opentelemetry-api-incubator-1.62.0-alpha.jar
+     - io.opentelemetry-opentelemetry-common-1.62.0.jar
+     - io.opentelemetry-opentelemetry-context-1.62.0.jar
+     - io.opentelemetry-opentelemetry-exporter-common-1.62.0.jar
+     - io.opentelemetry-opentelemetry-exporter-otlp-1.62.0.jar
+     - io.opentelemetry-opentelemetry-exporter-otlp-common-1.62.0.jar
+     - io.opentelemetry-opentelemetry-exporter-prometheus-1.62.0-alpha.jar
+     - io.opentelemetry-opentelemetry-exporter-sender-okhttp-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-common-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-extension-autoconfigure-spi-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-logs-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-metrics-1.62.0.jar
+     - io.opentelemetry-opentelemetry-sdk-trace-1.62.0.jar
+     - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-2.28.1.jar
+     - io.opentelemetry.instrumentation-opentelemetry-instrumentation-api-incubator-2.28.1-alpha.jar
+     - io.opentelemetry.instrumentation-opentelemetry-resources-2.28.1-alpha.jar
+     - io.opentelemetry.instrumentation-opentelemetry-runtime-telemetry-2.28.1-alpha.jar
+     - io.opentelemetry.semconv-opentelemetry-semconv-1.41.1.jar
+     - com.google.cloud.opentelemetry-detector-resources-support-0.36.0.jar
+     - io.opentelemetry.contrib-opentelemetry-gcp-resources-1.57.0-alpha.jar
   * Spotify completable-futures
     - com.spotify-completable-futures-0.3.6.jar
   * JSpecify

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -385,11 +385,11 @@ The Apache Software License, Version 2.0
     - log4j-core-2.25.4.jar
     - log4j-slf4j2-impl-2.25.4.jar
     - log4j-web-2.25.4.jar
- * OpenTelemetry
-    - opentelemetry-api-1.56.0.jar
-    - opentelemetry-api-incubator-1.56.0-alpha.jar
-    - opentelemetry-common-1.56.0.jar
-    - opentelemetry-context-1.56.0.jar
+* OpenTelemetry
+     - opentelemetry-api-1.62.0.jar
+     - opentelemetry-api-incubator-1.62.0-alpha.jar
+     - opentelemetry-common-1.62.0.jar
+     - opentelemetry-context-1.62.0.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.17.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -305,11 +305,11 @@ flexible messaging model and an intuitive client API.</description>
     the core logic is switched to java implementation of zstd in org.apache.commons:commons-compress -->
     <zstd-jni.version>1.5.7-3</zstd-jni.version>
     <netty-reactive-streams.version>2.0.6</netty-reactive-streams.version>
-    <opentelemetry.version>1.56.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <opentelemetry.alpha.version>${opentelemetry.version}-alpha</opentelemetry.alpha.version>
-    <opentelemetry.instrumentation.version>2.21.0</opentelemetry.instrumentation.version>
+    <opentelemetry.instrumentation.version>2.28.1</opentelemetry.instrumentation.version>
     <opentelemetry.instrumentation.alpha.version>${opentelemetry.instrumentation.version}-alpha</opentelemetry.instrumentation.alpha.version>
-    <opentelemetry.semconv.version>1.37.0</opentelemetry.semconv.version>
+    <opentelemetry.semconv.version>1.41.1</opentelemetry.semconv.version>
     <picocli.version>4.7.7</picocli.version>
     <re2j.version>1.8</re2j.version>
     <completable-futures.version>0.3.6</completable-futures.version>

--- a/pulsar-opentelemetry/pom.xml
+++ b/pulsar-opentelemetry/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-runtime-telemetry-java17</artifactId>
+      <artifactId>opentelemetry-runtime-telemetry</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
+++ b/pulsar-opentelemetry/src/main/java/org/apache/pulsar/opentelemetry/OpenTelemetryService.java
@@ -22,7 +22,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
-import io.opentelemetry.instrumentation.runtimemetrics.java17.RuntimeMetrics;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetryBuilder;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Experimental;
+import io.opentelemetry.instrumentation.runtimetelemetry.internal.Internal;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
@@ -44,11 +47,12 @@ import org.apache.commons.lang3.StringUtils;
 public class OpenTelemetryService implements Closeable {
 
     public static final String OTEL_SDK_DISABLED_KEY = "otel.sdk.disabled";
+    static final String OTEL_EXPORTER_PROMETHEUS_HOST_KEY = "otel.exporter.prometheus.host";
     static final int MAX_CARDINALITY_LIMIT = 10000;
 
     private final AtomicReference<OpenTelemetrySdk> openTelemetrySdkReference = new AtomicReference<>();
 
-    private final AtomicReference<RuntimeMetrics> runtimeMetricsReference = new AtomicReference<>();
+    private final AtomicReference<RuntimeTelemetry> runtimeTelemetryReference = new AtomicReference<>();
 
     /**
      * Instantiates the OpenTelemetry SDK. All attributes are overridden by system properties or environment
@@ -76,7 +80,9 @@ public class OpenTelemetryService implements Closeable {
                 // Cardinality limit includes the overflow attribute set, so we need to add 1.
                 "otel.java.metrics.cardinality.limit", Integer.toString(MAX_CARDINALITY_LIMIT + 1),
                 // Reduce number of allocations by using reusable data mode.
-                "otel.java.exporter.memory_mode", MemoryMode.REUSABLE_DATA.name()
+                "otel.java.exporter.memory_mode", MemoryMode.REUSABLE_DATA.name(),
+                // Preserve the pre-1.62.0 Prometheus exporter default of binding to all interfaces.
+                OTEL_EXPORTER_PROMETHEUS_HOST_KEY, "0.0.0.0"
         ));
 
         sdkBuilder.addResourceCustomizer(
@@ -119,12 +125,13 @@ public class OpenTelemetryService implements Closeable {
         openTelemetrySdkReference.set(sdkBuilder.build().getOpenTelemetrySdk());
 
         // For a list of exposed metrics, see https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/
-        runtimeMetricsReference.set(RuntimeMetrics.builder(openTelemetrySdkReference.get())
-                // disable JFR based telemetry and use only JMX telemetry
-                .disableAllFeatures()
-                // enable experimental JMX telemetry in addition
-                .emitExperimentalTelemetry()
-                .build());
+        RuntimeTelemetryBuilder runtimeTelemetryBuilder =
+                RuntimeTelemetry.builder(openTelemetrySdkReference.get());
+        // Disable JFR-based telemetry and rely on JMX-based metrics only.
+        Internal.setDisableAllJfrFeatures(runtimeTelemetryBuilder, true);
+        // Emit experimental JMX-based runtime metrics in addition to the stable ones.
+        Experimental.setEmitExperimentalMetrics(runtimeTelemetryBuilder, true);
+        runtimeTelemetryReference.set(runtimeTelemetryBuilder.build());
     }
 
     public OpenTelemetry getOpenTelemetry() {
@@ -133,9 +140,9 @@ public class OpenTelemetryService implements Closeable {
 
     @Override
     public void close() {
-        RuntimeMetrics runtimeMetrics = runtimeMetricsReference.getAndSet(null);
-        if (runtimeMetrics != null) {
-            runtimeMetrics.close();
+        RuntimeTelemetry runtimeTelemetry = runtimeTelemetryReference.getAndSet(null);
+        if (runtimeTelemetry != null) {
+            runtimeTelemetry.close();
         }
         OpenTelemetrySdk openTelemetrySdk = openTelemetrySdkReference.getAndSet(null);
         if (openTelemetrySdk != null) {

--- a/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
+++ b/pulsar-opentelemetry/src/test/java/org/apache/pulsar/opentelemetry/OpenTelemetryServiceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import org.apache.commons.lang3.StringUtils;
@@ -151,6 +152,22 @@ public class OpenTelemetryServiceTest {
             var overflowMetric = allMetrics.findByNameAndLabels("dummyCounter_total", "otel_metric_overflow", "true");
             return actualMetrics.size() == OpenTelemetryService.MAX_CARDINALITY_LIMIT + 1 && overflowMetric.size() == 1;
         });
+    }
+
+    @Test
+    public void testPrometheusExporterDefaultsToAllInterfacesHost() {
+        var capturedHost = new AtomicReference<String>();
+        @Cleanup
+        var ots = OpenTelemetryService.builder()
+                .builderCustomizer(getBuilderCustomizer(null,
+                        Map.of(OpenTelemetryService.OTEL_SDK_DISABLED_KEY, "false"))
+                        .andThen(builder -> builder.addPropertiesCustomizer(config -> {
+                            capturedHost.set(config.getString(OpenTelemetryService.OTEL_EXPORTER_PROMETHEUS_HOST_KEY));
+                            return Map.of();
+                        })))
+                .clusterName("openTelemetryServicePrometheusHostTestCluster")
+                .build();
+        assertThat(capturedHost.get()).isEqualTo("0.0.0.0");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Backport the OpenTelemetry upgrades from #25662, #25779 and #25906 to branch-4.0.

This updates the OpenTelemetry dependencies used by Pulsar 4.0.x to include the fixes shipped in OpenTelemetry 1.62.0 and aligns the Maven build with the corresponding changes already merged on master.

## Modifications

- upgrade OpenTelemetry Java to 1.62.0
- upgrade OpenTelemetry instrumentation to 2.28.1 and semconv to 1.41.1
- switch pulsar-opentelemetry from opentelemetry-runtime-telemetry-java17 to opentelemetry-runtime-telemetry
- update OpenTelemetryService to use the new RuntimeTelemetry API
- preserve the pre-1.62.0 Prometheus exporter host default (0.0.0.0) to avoid a metrics reachability regression
- add a test covering the Prometheus host default behavior

## Verification

- mvn -pl pulsar-opentelemetry -am -DskipTests package
- mvn -pl pulsar-broker -am -DskipTests package
