### PR TITLE
[fix][sec][branch-4.2] Upgrade Netty to 4.1.136.Final

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -294,33 +294,33 @@ The Apache Software License, Version 2.0
     - org.apache.commons-commons-lang3-3.19.0.jar
     - org.apache.commons-commons-text-1.15.0.jar
  * Netty
-    - io.netty-netty-buffer-4.1.135.Final.jar
-    - io.netty-netty-codec-4.1.135.Final.jar
-    - io.netty-netty-codec-dns-4.1.135.Final.jar
-    - io.netty-netty-codec-http-4.1.135.Final.jar
-    - io.netty-netty-codec-http2-4.1.135.Final.jar
-    - io.netty-netty-codec-socks-4.1.135.Final.jar
-    - io.netty-netty-codec-haproxy-4.1.135.Final.jar
-    - io.netty-netty-common-4.1.135.Final.jar
-    - io.netty-netty-handler-4.1.135.Final.jar
-    - io.netty-netty-handler-proxy-4.1.135.Final.jar
-    - io.netty-netty-resolver-4.1.135.Final.jar
-    - io.netty-netty-resolver-dns-4.1.135.Final.jar
-    - io.netty-netty-resolver-dns-classes-macos-4.1.135.Final.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.135.Final-osx-aarch_64.jar
-    - io.netty-netty-resolver-dns-native-macos-4.1.135.Final-osx-x86_64.jar
-    - io.netty-netty-transport-4.1.135.Final.jar
-    - io.netty-netty-transport-classes-epoll-4.1.135.Final.jar
-    - io.netty-netty-transport-native-epoll-4.1.135.Final-linux-aarch_64.jar
-    - io.netty-netty-transport-native-epoll-4.1.135.Final-linux-x86_64.jar
-    - io.netty-netty-transport-native-unix-common-4.1.135.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar
-    - io.netty-netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar
-    - io.netty-netty-tcnative-classes-2.0.77.Final.jar
+    - io.netty-netty-buffer-4.1.136.Final.jar
+    - io.netty-netty-codec-4.1.136.Final.jar
+    - io.netty-netty-codec-dns-4.1.136.Final.jar
+    - io.netty-netty-codec-http-4.1.136.Final.jar
+    - io.netty-netty-codec-http2-4.1.136.Final.jar
+    - io.netty-netty-codec-socks-4.1.136.Final.jar
+    - io.netty-netty-codec-haproxy-4.1.136.Final.jar
+    - io.netty-netty-common-4.1.136.Final.jar
+    - io.netty-netty-handler-4.1.136.Final.jar
+    - io.netty-netty-handler-proxy-4.1.136.Final.jar
+    - io.netty-netty-resolver-4.1.136.Final.jar
+    - io.netty-netty-resolver-dns-4.1.136.Final.jar
+    - io.netty-netty-resolver-dns-classes-macos-4.1.136.Final.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.136.Final-osx-aarch_64.jar
+    - io.netty-netty-resolver-dns-native-macos-4.1.136.Final-osx-x86_64.jar
+    - io.netty-netty-transport-4.1.136.Final.jar
+    - io.netty-netty-transport-classes-epoll-4.1.136.Final.jar
+    - io.netty-netty-transport-native-epoll-4.1.136.Final-linux-aarch_64.jar
+    - io.netty-netty-transport-native-epoll-4.1.136.Final-linux-x86_64.jar
+    - io.netty-netty-transport-native-unix-common-4.1.136.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-linux-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-linux-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-osx-aarch_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-osx-x86_64.jar
+    - io.netty-netty-tcnative-boringssl-static-2.0.78.Final-windows-x86_64.jar
+    - io.netty-netty-tcnative-classes-2.0.78.Final.jar
     - io.netty.incubator-netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
     - io.netty.incubator-netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -345,35 +345,35 @@ The Apache Software License, Version 2.0
     - commons-text-1.15.0.jar
     - commons-compress-1.28.0.jar
  * Netty
-    - netty-buffer-4.1.135.Final.jar
-    - netty-codec-4.1.135.Final.jar
-    - netty-codec-dns-4.1.135.Final.jar
-    - netty-codec-http-4.1.135.Final.jar
-    - netty-codec-socks-4.1.135.Final.jar
-    - netty-codec-haproxy-4.1.135.Final.jar
-    - netty-common-4.1.135.Final.jar
-    - netty-handler-4.1.135.Final.jar
-    - netty-handler-proxy-4.1.135.Final.jar
-    - netty-resolver-4.1.135.Final.jar
-    - netty-resolver-dns-4.1.135.Final.jar
-    - netty-transport-4.1.135.Final.jar
-    - netty-transport-classes-epoll-4.1.135.Final.jar
-    - netty-transport-native-epoll-4.1.135.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.135.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.135.Final.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.77.Final.jar
+    - netty-buffer-4.1.136.Final.jar
+    - netty-codec-4.1.136.Final.jar
+    - netty-codec-dns-4.1.136.Final.jar
+    - netty-codec-http-4.1.136.Final.jar
+    - netty-codec-socks-4.1.136.Final.jar
+    - netty-codec-haproxy-4.1.136.Final.jar
+    - netty-common-4.1.136.Final.jar
+    - netty-handler-4.1.136.Final.jar
+    - netty-handler-proxy-4.1.136.Final.jar
+    - netty-resolver-4.1.136.Final.jar
+    - netty-resolver-dns-4.1.136.Final.jar
+    - netty-transport-4.1.136.Final.jar
+    - netty-transport-classes-epoll-4.1.136.Final.jar
+    - netty-transport-native-epoll-4.1.136.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.136.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.136.Final.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.78.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.78.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
-    - netty-resolver-dns-classes-macos-4.1.135.Final.jar
-    - netty-resolver-dns-native-macos-4.1.135.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.135.Final-osx-x86_64.jar
+    - netty-resolver-dns-classes-macos-4.1.136.Final.jar
+    - netty-resolver-dns-native-macos-4.1.136.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.136.Final-osx-x86_64.jar
  * Prometheus client
     - simpleclient-0.16.0.jar
     - simpleclient_log4j2-0.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@ flexible messaging model and an intuitive client API.</description>
     <snappy.version>1.1.10.8</snappy.version> <!-- ZooKeeper server -->
     <dropwizardmetrics.version>4.1.12.1</dropwizardmetrics.version> <!-- ZooKeeper server -->
     <curator.version>5.7.1</curator.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <netty-iouring.version>0.0.26.Final</netty-iouring.version>
     <jetty.version>12.1.10</jetty.version>
     <!-- Jetty 9 is used in tiered-storage/file-system tests and pulsar-io/alluxio -->


### PR DESCRIPTION
### Motivation

Netty 4.1.136.Final addresses several CVEs:
  - https://netty.io/news/2026/07/09/4-1-136-Final.html

### Modifications

- upgrade Netty to 4.1.136.Final
 - upgrades netty-tcnative to 2.0.78.Final