### PR TITLE
[fix][ci] Upgrade sandboxed-trivy-action to approved sha

### DIFF
--- a/.github/workflows/pulsar-ci.yaml
+++ b/.github/workflows/pulsar-ci.yaml
@@ -678,7 +678,7 @@ jobs:
 
       - name: Run Trivy container scan
         id: trivy_scan
-        uses: lhotari/sandboxed-trivy-action@555963036b2012b44c1071508a236e569db28ebb
+        uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0
         if: ${{ github.repository == 'apache/pulsar' && github.event_name != 'pull_request' }}
         continue-on-error: true
         with:


### PR DESCRIPTION
### Motivation

sandboxed-trivy-action sha has expired

### Modifications

upgrade to [approved sha](https://github.com/apache/infrastructure-actions/blob/50681b96ef17f05b73380d43b4336b63851808e5/approved_patterns.yml#L247) 
