### PR TITLE
[fix][broker] Fix bucket delayed message index metrics reset on scrape

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/StatsBuckets.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/StatsBuckets.java
@@ -60,12 +60,40 @@ public class StatsBuckets {
         sumCounter.add(value);
     }
 
+    /**
+     * Snapshots the current values into {@link #getBuckets()}, {@link #getCount()}, and
+     * {@link #getSum()}, then resets the internal counters to zero.
+     *
+     * <p>Use this for periodic aggregation where the consumer reads values on a fixed
+     * schedule (e.g. {@code ManagedLedgerMBeanImpl} refreshes every
+     * {@code managedLedgerStatsPeriodSeconds}). Do <b>not</b> use this for metrics that
+     * are scraped on demand (e.g. Prometheus {@code /metrics}), because data recorded
+     * between scrapes is lost after each call — use {@link #snapshot()} instead.
+     */
     public void refresh() {
         long count = 0;
         sum = sumCounter.sumThenReset();
 
         for (int i = 0; i < buckets.length; i++) {
             long value = buckets[i].sumThenReset();
+            count += value;
+            values[i] = value;
+        }
+
+        this.count = count;
+    }
+
+    /**
+     * Snapshots the current cumulative values without resetting the internal counters.
+     * Use this instead of {@link #refresh()} when the data should survive across reads
+     * (e.g. Prometheus metrics that are scraped multiple times).
+     */
+    public void snapshot() {
+        long count = 0;
+        sum = sumCounter.sum();
+
+        for (int i = 0; i < buckets.length; i++) {
+            long value = buckets[i].sum();
             count += value;
             values[i] = value;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedMessageIndexStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedMessageIndexStats.java
@@ -47,8 +47,8 @@ public class BucketDelayedMessageIndexStats {
     private static final String BUCKET_TOTAL_NAME = "pulsar_delayed_message_index_bucket_total";
     private static final String INDEX_LOADED_NAME = "pulsar_delayed_message_index_loaded";
     private static final String SNAPSHOT_SIZE_BYTES_NAME = "pulsar_delayed_message_index_bucket_snapshot_size_bytes";
-    private static final String OP_COUNT_NAME = "pulsar_delayed_message_index_bucket_op_count";
-    private static final String OP_LATENCY_NAME = "pulsar_delayed_message_index_bucket_op_latency_ms";
+    static final String OP_COUNT_NAME = "pulsar_delayed_message_index_bucket_op_count";
+    static final String OP_LATENCY_NAME = "pulsar_delayed_message_index_bucket_op_latency_ms";
 
     private final AtomicInteger delayedMessageIndexBucketTotal = new AtomicInteger();
     private final AtomicLong delayedMessageIndexLoaded = new AtomicLong();
@@ -75,11 +75,11 @@ public class BucketDelayedMessageIndexStats {
             String[] labels = splitKey(k);
             String[] labelsAndValues = new String[] {"state", labels[0], "type", labels[1]};
             String key = OP_COUNT_NAME + joinKey(labelsAndValues);
-            metrics.put(key, new TopicMetricBean(OP_COUNT_NAME, count.sumThenReset(), labelsAndValues));
+            metrics.put(key, new TopicMetricBean(OP_COUNT_NAME, count.sum(), labelsAndValues));
         });
 
         delayedMessageIndexBucketOpLatencyMs.forEach((typeName, statsBuckets) -> {
-            statsBuckets.refresh();
+            statsBuckets.snapshot();
             long[] buckets = statsBuckets.getBuckets();
             for (int i = 0; i < buckets.length; i++) {
                 long count = buckets[i];

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedMessageIndexStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedMessageIndexStatsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.delayed.bucket;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import java.util.Map;
+import org.apache.pulsar.common.policies.data.stats.TopicMetricBean;
+import org.testng.annotations.Test;
+
+public class BucketDelayedMessageIndexStatsTest {
+
+    private static final String OP_COUNT = BucketDelayedMessageIndexStats.OP_COUNT_NAME;
+    private static final String OP_LATENCY_COUNT = BucketDelayedMessageIndexStats.OP_LATENCY_NAME + "_count";
+    private static final String OP_LATENCY_SUM = BucketDelayedMessageIndexStats.OP_LATENCY_NAME + "_sum";
+
+    @Test
+    public void testMetricsAreCumulativeAcrossScrapes() {
+        BucketDelayedMessageIndexStats stats = new BucketDelayedMessageIndexStats();
+        var type = BucketDelayedMessageIndexStats.Type.create;
+
+        stats.recordTriggerEvent(type);
+        stats.recordSuccessEvent(type, 200);
+        stats.recordSuccessEvent(type, 300);
+
+        // First scrape
+        var m1 = stats.genTopicMetricMap();
+        assertEquals(get(m1, OP_COUNT, "state", "succeed", "type", "create"), 2);
+        assertEquals(get(m1, OP_LATENCY_COUNT, "type", "create"), 2);
+        assertEquals(get(m1, OP_LATENCY_SUM, "type", "create"), 500);
+
+        // Second scrape — must not reset
+        var m2 = stats.genTopicMetricMap();
+        assertEquals(get(m2, OP_COUNT, "state", "succeed", "type", "create"), 2);
+        assertEquals(get(m2, OP_LATENCY_COUNT, "type", "create"), 2);
+        assertEquals(get(m2, OP_LATENCY_SUM, "type", "create"), 500);
+
+        // Third event — cumulative
+        stats.recordSuccessEvent(type, 100);
+        var m3 = stats.genTopicMetricMap();
+        assertEquals(get(m3, OP_COUNT, "state", "succeed", "type", "create"), 3);
+        assertEquals(get(m3, OP_LATENCY_COUNT, "type", "create"), 3);
+        assertEquals(get(m3, OP_LATENCY_SUM, "type", "create"), 600);
+    }
+
+    private static long get(Map<String, TopicMetricBean> metrics, String name, String... labelsAndValues) {
+        String key = name + BucketDelayedMessageIndexStats.joinKey(labelsAndValues);
+        TopicMetricBean bean = metrics.get(key);
+        assertNotNull(bean, "Metric not found: " + key);
+        return (long) bean.value;
+    }
+}


### PR DESCRIPTION
### Motivation

`BucketDelayedMessageIndexStats` used `LongAdder.sumThenReset()` for operation
counts and `StatsBuckets.refresh()` for latency buckets. Since both reset their
internal counters after reading, every stats collection cleared the accumulated
metrics. As a result, both topic stats and exported metrics only reported values
from the first read after new operations, while subsequent reads returned zero
until more operations occurred.

### Modifications

* Add `StatsBuckets.snapshot()` to read cumulative values without resetting
  internal counters.
* Switch `BucketDelayedMessageIndexStats` to use cumulative reads for operation
  counts and latency buckets.
* Add tests covering repeated stats collection.