### PR TITLE
[fix][common] Keep equal-load bundles addressable after sorting

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparator.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparator.java
@@ -52,10 +52,6 @@ public class NamespaceBundleStatsComparator implements Comparator<String>, Seria
             result = map.get(a).compareTo(map.get(b));
         }
 
-        if (result > 0) {
-            return -1;
-        } else {
-            return 1;
-        }
+        return result != 0 ? -result : a.compareTo(b);
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparatorTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/NamespaceBundleStatsComparatorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
+import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage.ResourceType;
+import org.testng.annotations.Test;
+
+public class NamespaceBundleStatsComparatorTest {
+
+    @Test
+    public void keepsEqualLoadBundlesAddressable() {
+        NamespaceBundleStats firstStats = new NamespaceBundleStats();
+        NamespaceBundleStats secondStats = new NamespaceBundleStats();
+        Map<String, NamespaceBundleStats> stats = new HashMap<>();
+        stats.put("bundle-a", firstStats);
+        stats.put("bundle-b", secondStats);
+
+        NamespaceBundleStatsComparator comparator =
+                new NamespaceBundleStatsComparator(stats, ResourceType.CPU);
+        TreeMap<String, NamespaceBundleStats> sortedStats = new TreeMap<>(comparator);
+        sortedStats.putAll(stats);
+
+        assertThat(comparator.compare("bundle-a", "bundle-a")).isZero();
+        assertThat(sortedStats).containsOnlyKeys("bundle-a", "bundle-b");
+        assertThat(sortedStats.get("bundle-a")).isSameAs(firstStats);
+        assertThat(sortedStats.get("bundle-b")).isSameAs(secondStats);
+    }
+}


### PR DESCRIPTION
### Motivation

NamespaceBundleStatsComparator returns a non-zero value when a bundle key is compared with itself. The TreeMap returned by LoadReport.getSortedBundleStats therefore cannot reliably resolve existing entries through get or containsKey, particularly when multiple bundles have equal load statistics.

### Modifications

Use the bundle name as a deterministic tie-breaker when load statistics compare equal. This preserves every equal-load bundle while restoring the comparator contract for identical keys.

Add a focused regression test that verifies identical keys compare as equal and both equal-load entries remain addressable in the sorted map.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- env JAVA_HOME=/Applications/IntelliJ\ IDEA.app/Contents/jbr/Contents/Home ./gradlew :pulsar-common:test --tests org.apache.pulsar.common.util.NamespaceBundleStatsComparatorTest -PtestRetryCount=0
- pulsar-common checkstyleMain, checkstyleTest, and spotlessCheck passed

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment