### PR TITLE
[fix][cli] Fix V5 scalable-topics property parsing

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdScalableTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdScalableTopics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -41,15 +42,15 @@ public class CmdScalableTopics extends CmdBase {
         private String namespace;
 
         @Option(names = {"-p", "--property"},
-                description = "Filter to topics whose properties contain this key=value pair."
-                        + " Repeat to AND multiple filters together.",
-                arity = "0..*")
+                description = "Filter to topics whose properties contain key=value pairs."
+                        + " Repeat or separate with commas to AND multiple filters together.",
+                arity = "1")
         private List<String> properties;
 
         @Override
         void run() throws Exception {
             String ns = validateNamespace(namespace);
-            Map<String, String> filters = parseListKeyValueMap(properties);
+            Map<String, String> filters = parseProperties(properties);
             if (filters == null || filters.isEmpty()) {
                 print(scalableTopics().listScalableTopics(ns));
             } else {
@@ -67,13 +68,14 @@ public class CmdScalableTopics extends CmdBase {
                 description = "Number of initial segments", defaultValue = "1")
         private int numInitialSegments;
 
-        @Option(names = {"-p", "--property"}, description = "Key-value properties (key=value)",
-                arity = "0..*")
+        @Option(names = {"-p", "--property"},
+                description = "Key-value properties. Repeat or separate with commas (key=value[,key=value...])",
+                arity = "1")
         private List<String> properties;
 
         @Override
         void run() throws Exception {
-            Map<String, String> props = parseListKeyValueMap(properties);
+            Map<String, String> props = parseProperties(properties);
             if (props != null) {
                 scalableTopics().createScalableTopic(topic, numInitialSegments, props);
             } else {
@@ -230,5 +232,18 @@ public class CmdScalableTopics extends CmdBase {
         addCommand("merge-segments", new MergeSegmentsCmd());
         addCommand("seek", new SeekSubscriptionCmd());
         addCommand("clear-backlog", new ClearBacklogCmd());
+    }
+
+    private Map<String, String> parseProperties(List<String> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        List<String> entries = new ArrayList<>();
+        for (String property : properties) {
+            for (String entry : property.split(",", -1)) {
+                entries.add(entry.trim());
+            }
+        }
+        return parseListKeyValueMap(entries);
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdScalableTopics.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/TestCmdScalableTopics.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import java.util.List;
+import java.util.Map;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.ScalableTopics;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestCmdScalableTopics {
+
+    private ScalableTopics scalableTopics;
+    private CmdScalableTopics cmdScalableTopics;
+
+    @BeforeMethod
+    public void setup() {
+        PulsarAdmin pulsarAdmin = mock(PulsarAdmin.class);
+        scalableTopics = mock(ScalableTopics.class);
+        when(pulsarAdmin.scalableTopics()).thenReturn(scalableTopics);
+        cmdScalableTopics = new CmdScalableTopics(() -> pulsarAdmin);
+    }
+
+    @Test
+    public void testCreateAcceptsPropertiesBeforeTopic() throws Exception {
+        String topic = "topic://public/default/v5-cli-create-before";
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "create", "-p", "app=cli", "-p", "mode=blackbox", topic
+        }));
+
+        verify(scalableTopics).createScalableTopic(eq(topic), eq(1),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testCreateAcceptsPropertiesAfterTopic() throws Exception {
+        String topic = "topic://public/default/v5-cli-create-after";
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "create", topic, "-p", "app=cli", "-p", "mode=blackbox"
+        }));
+
+        verify(scalableTopics).createScalableTopic(eq(topic), eq(1),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testCreateAcceptsCommaSeparatedPropertiesBeforeTopic() throws Exception {
+        String topic = "topic://public/default/v5-cli-create-comma-before";
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "create", "-p", "app=cli,mode=blackbox", topic
+        }));
+
+        verify(scalableTopics).createScalableTopic(eq(topic), eq(1),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testCreateAcceptsCommaSeparatedPropertiesAfterTopic() throws Exception {
+        String topic = "topic://public/default/v5-cli-create-comma-after";
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "create", topic, "-p", "app=cli,mode=blackbox"
+        }));
+
+        verify(scalableTopics).createScalableTopic(eq(topic), eq(1),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testListAcceptsPropertiesBeforeNamespace() throws Exception {
+        String namespace = "public/default";
+        when(scalableTopics.listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox"))))
+                .thenReturn(List.of("topic://public/default/v5-cli-list-before"));
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "list", "-p", "app=cli", "-p", "mode=blackbox", namespace
+        }));
+
+        verify(scalableTopics).listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testListAcceptsCommaSeparatedPropertiesBeforeNamespace() throws Exception {
+        String namespace = "public/default";
+        when(scalableTopics.listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox"))))
+                .thenReturn(List.of("topic://public/default/v5-cli-list-comma-before"));
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "list", "-p", "app=cli,mode=blackbox", namespace
+        }));
+
+        verify(scalableTopics).listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testListAcceptsCommaSeparatedPropertiesAfterNamespace() throws Exception {
+        String namespace = "public/default";
+        when(scalableTopics.listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox"))))
+                .thenReturn(List.of("topic://public/default/v5-cli-list-comma-after"));
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "list", namespace, "-p", "app=cli,mode=blackbox"
+        }));
+
+        verify(scalableTopics).listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+
+    @Test
+    public void testListAcceptsPropertiesAfterNamespace() throws Exception {
+        String namespace = "public/default";
+        when(scalableTopics.listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox"))))
+                .thenReturn(List.of("topic://public/default/v5-cli-list-after"));
+
+        assertTrue(cmdScalableTopics.run(new String[] {
+                "list", namespace, "-p", "app=cli", "-p", "mode=blackbox"
+        }));
+
+        verify(scalableTopics).listScalableTopicsByProperties(eq(namespace),
+                eq(Map.of("app", "cli", "mode", "blackbox")));
+    }
+}


### PR DESCRIPTION
Fixes #26176

### Motivation

The V5 `scalable-topics` CLI consumed the topic or namespace argument as a `-p` / `--property` value when `-p` was placed before the positional argument.

Examples:

```bash
pulsar-admin scalable-topics create -p app=cli topic://public/default/t1
pulsar-admin scalable-topics list -p app=cli public/default
```

### Modifications

- Make `-p` / `--property` consume one value per occurrence.
- Keep repeated `-p key=value` support.
- Support comma-separated properties, such as `-p key=value,key2=value2`.
- Add CLI parser tests for `create` and `list`.

After this change, both forms are accepted:

```bash
pulsar-admin scalable-topics create -p app=cli -p mode=blackbox topic://public/default/t1
pulsar-admin scalable-topics create -p app=cli,mode=blackbox topic://public/default/t1
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew --no-daemon :pulsar-client-tools:test --tests org.apache.pulsar.admin.cli.TestCmdScalableTopics`
- `./gradlew --no-daemon :pulsar-client-tools:checkstyleMain :pulsar-client-tools:checkstyleTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
