### PR TITLE
[fix][broker] Prevent partition expansion from inheriting delayed-delivery bucket state

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin.impl;
 
+import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPERTY_PREFIX;
 import static org.apache.pulsar.common.api.proto.CompressionType.NONE;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isSystemTopic;
 import static org.apache.pulsar.common.naming.SystemTopicNames.isTransactionCoordinatorAssign;
@@ -460,6 +461,9 @@ public class PersistentTopicsBase extends AdminResource {
                                                 // We must not re-create non-durable subscriptions on the new partitions
                                                 .stream().filter(entry -> entry.getValue().isDurable())
                                                 .map(entry -> {
+                                                    Map<String, String> subscriptionProperties =
+                                                            filterSubscriptionPropertiesForPartitionExpansion(
+                                                                    entry.getValue().getSubscriptionProperties());
                                                     final List<CompletableFuture<Void>> innerFutures =
                                                             new ArrayList<>(expectPartitions);
                                                     for (int i = 0; i < expectPartitions; i++) {
@@ -467,7 +471,7 @@ public class PersistentTopicsBase extends AdminResource {
                                                                         topicName.getPartition(i).toString(),
                                                                         entry.getKey(), MessageId.earliest,
                                                                         entry.getValue().isReplicated(),
-                                                                        entry.getValue().getSubscriptionProperties())
+                                                                        subscriptionProperties)
                                                                 .exceptionally(ex -> {
                                                                     Throwable rc =
                                                                             FutureUtil.unwrapCompletionException(ex);
@@ -532,6 +536,23 @@ public class PersistentTopicsBase extends AdminResource {
                             });
                 });
             });
+    }
+
+    /**
+     * Returns the properties that can be applied to a subscription on a newly created partition.
+     *
+     * <p>Cursor internal properties belong to the source partition and must not be copied. Keep all filtering
+     * rules here so partition expansion has a single property-copy boundary.</p>
+     */
+    private static Map<String, String> filterSubscriptionPropertiesForPartitionExpansion(
+            Map<String, String> subscriptionProperties) {
+        if (subscriptionProperties == null) {
+            return null;
+        }
+
+        Map<String, String> filteredProperties = new HashMap<>(subscriptionProperties);
+        filteredProperties.keySet().removeIf(key -> key.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX));
+        return filteredProperties;
     }
 
     private CompletableFuture<Set<String>> getReplicationClusters() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPERTY_PREFIX;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +32,7 @@ import lombok.Cleanup;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.admin.AdminApiTest.MockedPulsarService;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -147,6 +150,39 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
         Map<String, String> subscriptionProperties = stats.getSubscriptions()
                 .get("sub-1").getSubscriptionProperties();
         Assert.assertEquals(properties, subscriptionProperties);
+    }
+
+    @Test
+    public void testIncrementPartitionsDoesNotCopyInternalCursorProperties() throws Exception {
+        String partitionedTopicName = UUID.randomUUID()
+                + "-testIncrementPartitionsDoesNotCopyInternalCursorProperties";
+        String subscriptionName = "sub-1";
+        Map<String, String> subscriptionProperties = Map.of("property", "value");
+
+        admin.topics().createPartitionedTopic(partitionedTopicName, 1);
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(partitionedTopicName)
+                .subscriptionName(subscriptionName)
+                .subscriptionProperties(subscriptionProperties)
+                .subscribe();
+
+        String sourcePartition = TopicName.get(partitionedTopicName).getPartition(0).toString();
+        PersistentTopic sourceTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(sourcePartition)
+                .orElseThrow();
+        String internalProperty = CURSOR_INTERNAL_PROPERTY_PREFIX + "test";
+        sourceTopic.getSubscription(subscriptionName).getCursor()
+                .putCursorProperty(internalProperty, "internal-value").get();
+
+        admin.topics().updatePartitionedTopic(partitionedTopicName, 2);
+
+        String newPartition = TopicName.get(partitionedTopicName).getPartition(1).toString();
+        PersistentTopic newTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(newPartition)
+                .orElseThrow();
+        Map<String, String> newCursorProperties = newTopic.getSubscription(subscriptionName)
+                .getCursor().getCursorProperties();
+        assertEquals(newCursorProperties, subscriptionProperties);
+        assertFalse(newCursorProperties.containsKey(internalProperty));
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -144,6 +144,7 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
         @Cleanup
         Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
                 .topic(sourcePartition)
+                .enableBatching(false)
                 .create();
 
         for (int i = 0; i < 1000; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/BucketDelayedDeliveryTest.java
@@ -22,6 +22,7 @@ import static org.apache.bookkeeper.mledger.ManagedCursor.CURSOR_INTERNAL_PROPER
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.Metric;
 import static org.apache.pulsar.broker.stats.prometheus.PrometheusMetricsClient.parseMetrics;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import com.google.common.collect.Multimap;
@@ -48,6 +49,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.naming.TopicName;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -124,6 +126,60 @@ public class BucketDelayedDeliveryTest extends DelayedDeliveryTest {
 
         Awaitility.await().untilAsserted(() -> Assert.assertEquals(dispatcher2.getNumberOfDelayedMessages(), 1000));
         Assert.assertEquals(bucketKeys, bucketKeys2);
+    }
+
+    @Test
+    public void testIncrementPartitionsDoesNotCopyBucketDelayedDeliveryState() throws Exception {
+        String topic = BrokerTestUtil.newUniqueName("persistent://public/default/testBucketStatePartitionExpansion");
+        String subscriptionName = "sub";
+        admin.topics().createPartitionedTopic(topic, 1);
+        String sourcePartition = TopicName.get(topic).getPartition(0).toString();
+
+        @Cleanup
+        Consumer<String> sourceConsumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(sourcePartition)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(sourcePartition)
+                .create();
+
+        for (int i = 0; i < 1000; i++) {
+            producer.newMessage().value("msg").deliverAfter(1, TimeUnit.HOURS).send();
+        }
+
+        Dispatcher sourceDispatcher = pulsar.getBrokerService().getTopicReference(sourcePartition)
+                .get().getSubscription(subscriptionName).getDispatcher();
+        Awaitility.await().untilAsserted(
+                () -> Assert.assertEquals(sourceDispatcher.getNumberOfDelayedMessages(), 1000));
+        List<String> bucketKeys = ((AbstractPersistentDispatcherMultipleConsumers) sourceDispatcher)
+                .getCursor().getCursorProperties().keySet().stream()
+                .filter(key -> key.startsWith(CURSOR_INTERNAL_PROPERTY_PREFIX + "delayed.bucket")).toList();
+        assertFalse(bucketKeys.isEmpty());
+
+        admin.topics().updatePartitionedTopic(topic, 2);
+
+        String newPartition = TopicName.get(topic).getPartition(1).toString();
+        PersistentTopic newTopic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(newPartition)
+                .orElseThrow();
+        Map<String, String> newCursorProperties = newTopic.getSubscription(subscriptionName)
+                .getCursor().getCursorProperties();
+        assertTrue(newCursorProperties == null
+                || newCursorProperties.keySet().stream().noneMatch(bucketKeys::contains));
+
+        @Cleanup
+        Consumer<String> newPartitionConsumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(newPartition)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscribe();
+        Dispatcher newPartitionDispatcher = newTopic.getSubscription(subscriptionName).getDispatcher();
+        Awaitility.await().untilAsserted(
+                () -> assertEquals(newPartitionDispatcher.getNumberOfDelayedMessages(), 0));
+        assertTrue(((AbstractPersistentDispatcherMultipleConsumers) sourceDispatcher).getCursor().getCursorProperties()
+                .keySet().containsAll(bucketKeys));
     }
 
 


### PR DESCRIPTION
Fixes #26178

### Motivation

When increasing partitions, Pulsar copies durable subscription properties from
partition-0 to new partitions.

Bucket delayed delivery stores cursor-local snapshot metadata as
`#pulsar.internal.delayed.bucket*`. Copying that state makes a new partition
recover delayed-message indexes that belong to partition-0, which can result in
incorrect delayed-delivery state and invalid replay attempts.

### Modifications

Filter `#pulsar.internal.*` properties before creating subscriptions on new
partitions. User-defined subscription properties are still copied.

Existing cursor-property and stats exposure is unchanged.

### Verifying this change

- Added partition-expansion coverage for internal cursor properties.
- Added bucket delayed-delivery coverage that activates the new partition's
  tracker and verifies it recovers zero delayed messages.
- `./gradlew --no-daemon --console=plain :pulsar-broker:test --tests org.apache.pulsar.broker.admin.IncrementPartitionsTest --tests org.apache.pulsar.broker.service.persistent.BucketDelayedDeliveryTest`
- `./gradlew --no-daemon --console=plain :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
