### PR TITLE
[fix][broker] Restore PendingAcksMap#get binary compatibility

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PendingAcksMap.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.service;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongRBTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2LongSortedMap;
@@ -265,6 +266,32 @@ public class PendingAcksMap {
                 return false;
             }
             return ledgerMap.containsKey(entryId);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Get the pending ack for the given ledger ID and entry ID.
+     *
+     * @param ledgerId the ledger ID
+     * @param entryId the entry ID
+     * @return the pending ack, or null if not found
+     * @deprecated retained for compatibility with broker extensions compiled against earlier Pulsar releases;
+     *             broker code should use primitive accessors where only the remaining unacked count is required
+     */
+    @Deprecated
+    public IntIntPair get(long ledgerId, long entryId) {
+        try {
+            readLock.lock();
+            Long2LongSortedMap ledgerMap = pendingAcks.get(ledgerId);
+            if (ledgerMap == null) {
+                return null;
+            }
+            long packedValue = ledgerMap.get(entryId);
+            return PendingAckValues.isNotFound(packedValue) ? null
+                    : IntIntPair.of(PendingAckValues.remainingUnacked(packedValue),
+                            PendingAckValues.stickyKeyHash(packedValue));
         } finally {
             readLock.unlock();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PendingAcksMapTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PendingAcksMapTest.java
@@ -29,9 +29,13 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.pulsar.broker.intercept.MockBrokerInterceptor;
 import org.testng.annotations.Test;
 
 public class PendingAcksMapTest {
@@ -342,6 +346,35 @@ public class PendingAcksMapTest {
         assertEquals(pendingAcksMap.getRemainingUnacked(1L, 3L), PendingAcksMap.PENDING_ACK_NOT_FOUND);
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
+    public void get_ReturnsCompatibilityPairWithPackedValues() {
+        Consumer consumer = createMockConsumer("consumer1");
+        PendingAcksMap pendingAcksMap = new PendingAcksMap(consumer, () -> null, () -> null);
+        pendingAcksMap.addPendingAckIfAllowed(1L, 1L, Integer.MAX_VALUE, Integer.MIN_VALUE);
+
+        IntIntPair pendingAck = pendingAcksMap.get(1L, 1L);
+
+        assertEquals(pendingAck.leftInt(), Integer.MAX_VALUE);
+        assertEquals(pendingAck.rightInt(), Integer.MIN_VALUE);
+        assertNull(pendingAcksMap.get(1L, 2L));
+        assertNull(pendingAcksMap.get(2L, 1L));
+    }
+
+    @Test
+    public void brokerInterceptorUsingLegacyGet_CanReadPendingAck() {
+        Consumer consumer = createMockConsumer("consumer1");
+        PendingAcksMap pendingAcksMap = new PendingAcksMap(consumer, () -> null, () -> null);
+        when(consumer.getPendingAcks()).thenReturn(pendingAcksMap);
+        pendingAcksMap.addPendingAckIfAllowed(1L, 1L, 5, -123);
+        BrokerExtensionUsingLegacyPendingAcksApi interceptor = new BrokerExtensionUsingLegacyPendingAcksApi();
+
+        interceptor.messageDispatched(null, consumer, 1L, 1L, null);
+
+        assertEquals(interceptor.pendingAck.leftInt(), 5);
+        assertEquals(interceptor.pendingAck.rightInt(), -123);
+    }
+
     @Test
     public void removeAndGetRemainingUnacked_RemovesAndInvokesRemoveHandler() {
         Consumer consumer = createMockConsumer("consumer1");
@@ -468,5 +501,21 @@ public class PendingAcksMapTest {
                 }));
         assertEquals(pendingAcks.size(), 1);
         assertEquals(pendingAcks.get(0), new long[] {ledgerId, entryId, remainingUnacked, stickyKeyHash});
+    }
+
+    /**
+     * Models the call site in a broker extension compiled against a Pulsar release that exposed
+     * {@link PendingAcksMap#get(long, long)}.
+     */
+    private static final class BrokerExtensionUsingLegacyPendingAcksApi extends MockBrokerInterceptor {
+        private IntIntPair pendingAck;
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void messageDispatched(ServerCnx cnx, Consumer consumer, long ledgerId, long entryId,
+                                      ByteBuf headersAndPayload) {
+            pendingAck = consumer.getPendingAcks().get(ledgerId, entryId);
+        }
+
     }
 }


### PR DESCRIPTION
### Motivation

PR #26030 replaced `PendingAcksMap` object values with packed primitive values and removed the public `PendingAcksMap#get(long, long)` method. However, this method was included in previous Pulsar releases, including Pulsar 4.0.x and 4.1.x, and is reachable by broker extensions through the public `Consumer#getPendingAcks()` method.

A `BrokerInterceptor` compiled against one of those releases can therefore fail with `NoSuchMethodError` after the broker is upgraded to a version containing #26030.

### Why `NoSuchMethodError` occurs

`BrokerInterceptor` callbacks such as `messageDispatched` receive a broker `Consumer` instance. An existing extension can use the following API path:

```java
@Override
public void messageDispatched(ServerCnx cnx, Consumer consumer,
                              long ledgerId, long entryId,
                              ByteBuf headersAndPayload) {
    IntIntPair pendingAck =
            consumer.getPendingAcks().get(ledgerId, entryId);
}
```

When this extension is compiled against an earlier Pulsar release, the Java compiler records the following symbolic method reference in the extension bytecode:

```text
org/apache/pulsar/broker/service/PendingAcksMap.get:
    (JJ)Lit/unimi/dsi/fastutil/ints/IntIntPair;
```

The relevant bytecode is equivalent to:

```text
invokevirtual Consumer.getPendingAcks:
    ()Lorg/apache/pulsar/broker/service/PendingAcksMap;

invokevirtual PendingAcksMap.get:
    (JJ)Lit/unimi/dsi/fastutil/ints/IntIntPair;
```

The extension does not get recompiled when the broker is upgraded. When the interceptor callback is executed, the JVM resolves the existing `invokevirtual` reference against the `PendingAcksMap` loaded from the upgraded broker.

After #26030, that exact method name and descriptor no longer exist. The newly added primitive accessor has a different name and return type:

```text
PendingAcksMap.getRemainingUnacked:(JJ)I
```

The JVM cannot substitute one method for the other. Method resolution therefore fails with a linkage error similar to:

```text
java.lang.NoSuchMethodError:
  'it.unimi.dsi.fastutil.ints.IntIntPair
   org.apache.pulsar.broker.service.PendingAcksMap.get(long, long)'
```

The interceptor can load successfully and only fail when the affected callback and call site are first executed, making the problem dependent on extension behavior and broker traffic.

### Modifications

- Restore the exact `PendingAcksMap#get(long, long)` JVM method signature available in previous releases.
- Mark the restored method as deprecated so new broker code continues to prefer primitive accessors.
- Reconstruct `IntIntPair` from the packed primitive value while holding the existing read lock.
- Return `null` for missing ledger and entry mappings, preserving the previous behavior.
- Add coverage for maximum remaining-unacked values, signed sticky-key hashes, and missing entries.
- Add a `BrokerInterceptor` extension fixture that accesses the method through `Consumer#getPendingAcks()`, reproducing the extension API call path.

### Performance impact

The broker production paths changed by #26030 continue to use `getRemainingUnacked` and `removeAndGetRemainingUnacked`. They do not call the compatibility method and therefore do not recreate `IntIntPair` objects on the pending-ack hot paths.

An `IntIntPair` is allocated only when an existing extension explicitly invokes the deprecated compatibility method.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

The following targeted test and style checks pass:

```bash
./gradlew :pulsar-broker:test \
  --tests org.apache.pulsar.broker.service.PendingAcksMapTest \
  --max-workers=1 \
  -PtestRetryCount=0 \
  :pulsar-broker:checkstyleMain \
  :pulsar-broker:checkstyleTest
```

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment