### PR TITLE
[fix][broker] Fix `getEstimatedSizeSinceMarkDeletePosition` throw `IllegalArgumentException`

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1278,7 +1278,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         Position markDeletePosition = this.markDeletePosition;
         Position lastPosition = ledger.getLastPosition();
         if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) >= 0) {
-            if (markDeletePosition == null || !ledger.ledgerExists(markDeletePosition.getLedgerId())
+            if (!ledger.ledgerExists(lastPosition.getLedgerId())
                     || isMarkDeletePositionOnEmptyCurrentLedger(markDeletePosition)) {
                 return 0;
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1275,6 +1275,12 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long getEstimatedSizeSinceMarkDeletePosition() {
+        Position markDeletePosition = this.markDeletePosition;
+        Position lastPosition = ledger.getLastPosition();
+        if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) >= 0) {
+            return 0;
+        }
+
         long totalSize = ledger.estimateBacklogFromPosition(markDeletePosition);
 
         // Need to subtract size of individual deleted messages
@@ -1287,7 +1293,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         long deletedCount = 0;
         lock.readLock().lock();
         try {
-            Range<Position> backlogRange = Range.openClosed(markDeletePosition, ledger.getLastPosition());
+            Range<Position> backlogRange = Range.openClosed(markDeletePosition, lastPosition);
             deletedCount = individualDeletedMessages.cardinality(
                     backlogRange.lowerEndpoint().getLedgerId(), backlogRange.lowerEndpoint().getEntryId(),
                     backlogRange.upperEndpoint().getLedgerId(), backlogRange.upperEndpoint().getEntryId());
@@ -1300,7 +1306,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         // Estimate size by using average entry size from the backlog range
-        Range<Position> backlogRange = Range.openClosed(markDeletePosition, ledger.getLastPosition());
+        Range<Position> backlogRange = Range.openClosed(markDeletePosition, lastPosition);
         long totalEntriesInBacklog = ledger.getNumberOfEntries(backlogRange);
 
         if (totalEntriesInBacklog <= deletedCount || totalEntriesInBacklog == 0) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1277,8 +1277,11 @@ public class ManagedCursorImpl implements ManagedCursor {
     public long getEstimatedSizeSinceMarkDeletePosition() {
         Position markDeletePosition = this.markDeletePosition;
         Position lastPosition = ledger.getLastPosition();
-        if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) >= 0) {
-            if (markDeletePosition == null || !ledger.ledgerExists(lastPosition.getLedgerId())
+        if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) == 0) {
+            return 0;
+        }
+        if (markDeletePosition.compareTo(lastPosition) > 0) {
+            if (!ledger.ledgerExists(lastPosition.getLedgerId())
                     || isMarkDeletePositionOnEmptyCurrentLedger(markDeletePosition)) {
                 return 0;
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1278,7 +1278,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         Position markDeletePosition = this.markDeletePosition;
         Position lastPosition = ledger.getLastPosition();
         if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) >= 0) {
-            if (!ledger.ledgerExists(lastPosition.getLedgerId())
+            if (markDeletePosition == null || !ledger.ledgerExists(lastPosition.getLedgerId())
                     || isMarkDeletePositionOnEmptyCurrentLedger(markDeletePosition)) {
                 return 0;
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1278,7 +1278,13 @@ public class ManagedCursorImpl implements ManagedCursor {
         Position markDeletePosition = this.markDeletePosition;
         Position lastPosition = ledger.getLastPosition();
         if (markDeletePosition == null || markDeletePosition.compareTo(lastPosition) >= 0) {
-            return 0;
+            if (markDeletePosition == null || !ledger.ledgerExists(markDeletePosition.getLedgerId())
+                    || isMarkDeletePositionOnEmptyCurrentLedger(markDeletePosition)) {
+                return 0;
+            }
+            throw new IllegalArgumentException(String.format(
+                    "Cursor %s mark-delete position %s is ahead of the last position %s for managed ledger %s",
+                    name, markDeletePosition, lastPosition, ledger.getName()));
         }
 
         long totalSize = ledger.estimateBacklogFromPosition(markDeletePosition);
@@ -1334,6 +1340,12 @@ public class ManagedCursorImpl implements ManagedCursor {
                 .log("Adjusted backlog size");
 
         return adjustedSize;
+    }
+
+    private boolean isMarkDeletePositionOnEmptyCurrentLedger(Position markDeletePosition) {
+        return ledger.currentLedger != null
+                && markDeletePosition.getLedgerId() == ledger.currentLedger.getId()
+                && ledger.currentLedgerEntries == 0;
     }
 
     private long getNumberOfEntriesInBacklog() {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4178,6 +4178,17 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 10 * entryData.length);
     }
 
+    @Test
+    public void testEstimatedUnackedSizeWhenCursorIsAheadOfLastPosition() throws Exception {
+        ManagedLedger ledger = factory.open("test_estimated_unacked_size_cursor_ahead");
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        Position lastPosition = ledger.addEntry("entry".getBytes(Encoding));
+        cursor.markDeletePosition = PositionFactory.create(lastPosition.getLedgerId() + 1, -1);
+
+        assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+    }
+
     /**
      * Test that cursor.getEstimatedSizeSinceMarkDeletePosition() correctly accounts for individual
      * message deletions (asyncDelete/individual ack).

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4187,12 +4187,19 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testEstimatedUnackedSizeWhenCursorLedgerIsNoLongerInLedgerList() throws Exception {
-        ManagedLedger ledger = factory.open("test_estimated_unacked_size_cursor_ledger_removed");
-        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+    public void testEstimatedUnackedSizeWhenLastPositionLedgerIsNoLongerInLedgerList() {
+        ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
+        when(ledger.getName()).thenReturn("test_estimated_unacked_size_last_position_ledger_removed");
+        when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
+        when(ledger.getLogger()).thenReturn(log);
 
-        Position lastPosition = ledger.addEntry("entry".getBytes(Encoding));
-        cursor.markDeletePosition = PositionFactory.create(lastPosition.getLedgerId() + 1, -1);
+        Position lastPosition = PositionFactory.create(3, 0);
+        Position markDeletePosition = PositionFactory.create(4, -1);
+        when(ledger.getLastPosition()).thenReturn(lastPosition);
+        when(ledger.ledgerExists(lastPosition.getLedgerId())).thenReturn(false);
+
+        ManagedCursorImpl cursor = new ManagedCursorImpl(mock(BookKeeper.class), ledger, "c1");
+        cursor.markDeletePosition = markDeletePosition;
 
         assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
     }
@@ -4207,12 +4214,13 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Position lastPosition = PositionFactory.create(1, 10);
         Position markDeletePosition = PositionFactory.create(2, -1);
         when(ledger.getLastPosition()).thenReturn(lastPosition);
+        when(ledger.ledgerExists(lastPosition.getLedgerId())).thenReturn(true);
         when(ledger.ledgerExists(markDeletePosition.getLedgerId())).thenReturn(true);
 
         ManagedCursorImpl cursor = new ManagedCursorImpl(mock(BookKeeper.class), ledger, "c1");
         cursor.markDeletePosition = markDeletePosition;
 
-        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
                 cursor::getEstimatedSizeSinceMarkDeletePosition);
         assertTrue(exception.getMessage().contains("is ahead of the last position"));
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4179,14 +4179,42 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testEstimatedUnackedSizeWhenCursorIsAheadOfLastPosition() throws Exception {
-        ManagedLedger ledger = factory.open("test_estimated_unacked_size_cursor_ahead");
+    public void testEstimatedUnackedSizeWhenLatestLedgerIsEmpty() throws Exception {
+        ManagedLedger ledger = factory.open("test_estimated_unacked_size_empty_latest_ledger");
+        ManagedCursor cursor = ledger.openCursor("c1");
+
+        assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+    }
+
+    @Test
+    public void testEstimatedUnackedSizeWhenCursorLedgerIsNoLongerInLedgerList() throws Exception {
+        ManagedLedger ledger = factory.open("test_estimated_unacked_size_cursor_ledger_removed");
         ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
 
         Position lastPosition = ledger.addEntry("entry".getBytes(Encoding));
         cursor.markDeletePosition = PositionFactory.create(lastPosition.getLedgerId() + 1, -1);
 
         assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+    }
+
+    @Test
+    public void testEstimatedUnackedSizeFailsWhenCursorIsUnexpectedlyAheadOfLastPosition() {
+        ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
+        when(ledger.getName()).thenReturn("test_estimated_unacked_size_unexpected_position");
+        when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
+        when(ledger.getLogger()).thenReturn(log);
+
+        Position lastPosition = PositionFactory.create(1, 10);
+        Position markDeletePosition = PositionFactory.create(2, -1);
+        when(ledger.getLastPosition()).thenReturn(lastPosition);
+        when(ledger.ledgerExists(markDeletePosition.getLedgerId())).thenReturn(true);
+
+        ManagedCursorImpl cursor = new ManagedCursorImpl(mock(BookKeeper.class), ledger, "c1");
+        cursor.markDeletePosition = markDeletePosition;
+
+        IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+                cursor::getEstimatedSizeSinceMarkDeletePosition);
+        assertTrue(exception.getMessage().contains("is ahead of the last position"));
     }
 
     /**

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4187,6 +4187,17 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testEstimatedUnackedSizeWhenCursorCaughtUpWithLastPosition() throws Exception {
+        ManagedLedger ledger = factory.open("test_estimated_unacked_size_cursor_caught_up");
+        ManagedCursor cursor = ledger.openCursor("c1");
+
+        Position lastPosition = ledger.addEntry("entry".getBytes(Encoding));
+        cursor.markDelete(lastPosition);
+
+        assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+    }
+
+    @Test
     public void testEstimatedUnackedSizeWhenLastPositionLedgerIsNoLongerInLedgerList() {
         ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
         when(ledger.getName()).thenReturn("test_estimated_unacked_size_last_position_ledger_removed");

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -94,6 +94,7 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.PulsarMockBookKeeper;
 import org.apache.bookkeeper.client.PulsarMockReadHandleInterceptor;
 import org.apache.bookkeeper.client.api.LedgerEntries;
@@ -4195,6 +4196,31 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         cursor.markDelete(lastPosition);
 
         assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+    }
+
+    @Test
+    public void testEstimatedUnackedSizeWhenCursorAdvancedToEmptyCurrentLedger() {
+        ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
+        when(ledger.getName()).thenReturn("test_estimated_unacked_size_empty_current_ledger");
+        when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
+        when(ledger.getLogger()).thenReturn(log);
+
+        long currentLedgerId = 4;
+        Position lastPosition = PositionFactory.create(3, 9);
+        Position markDeletePosition = PositionFactory.create(currentLedgerId, -1);
+        when(ledger.getLastPosition()).thenReturn(lastPosition);
+        when(ledger.ledgerExists(lastPosition.getLedgerId())).thenReturn(true);
+
+        LedgerHandle currentLedger = mock(LedgerHandle.class);
+        when(currentLedger.getId()).thenReturn(currentLedgerId);
+        ledger.currentLedger = currentLedger;
+        ledger.currentLedgerEntries = 0;
+
+        ManagedCursorImpl cursor = new ManagedCursorImpl(mock(BookKeeper.class), ledger, "c1");
+        cursor.markDeletePosition = markDeletePosition;
+
+        assertEquals(cursor.getEstimatedSizeSinceMarkDeletePosition(), 0);
+        verify(ledger, never()).estimateBacklogFromPosition(any());
     }
 
     @Test


### PR DESCRIPTION

### Motivation



```

2026-07-04T08:12:28,153+0000 [pulsar-compaction-monitor-26-1] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://email/org-74/__change_events-partition-0] Error getting policies and skipping compaction check
java.lang.IllegalArgumentException: Invalid range: (25257774:-1..25234514:0]
	at com.google.common.collect.Range.<init>(Range.java:363)
	at com.google.common.collect.Range.create(Range.java:161)
	at com.google.common.collect.Range.openClosed(Range.java:210)
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getEstimatedSizeSinceMarkDeletePosition(ManagedCursorImpl.java:1306)
--
	at org.apache.pulsar.common.util.SingleThreadNonConcurrentFixedRateScheduler$ScheduledFutureTask.run(SingleThreadNonConcurrentFixedRateScheduler.java:371)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
2026-07-04T08:12:28,159+0000 [pulsar-compaction-monitor-26-1] WARN  org.apache.pulsar.broker.service.persistent.PersistentTopic - [persistent://email/org-87/__change_events-partition-0] Error getting policies and skipping compaction check
java.lang.IllegalArgumentException: Invalid range: (25519982:-1..25495087:0]
	at com.google.common.collect.Range.<init>(Range.java:363)
	at com.google.common.collect.Range.create(Range.java:161)
	at com.google.common.collect.Range.openClosed(Range.java:210)
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getEstimatedSizeSinceMarkDeletePosition(ManagedCursorImpl.java:1306)
```
### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment