### PR TITLE
[fix][sec][branch-4.2] Upgrade Jackson version to 2.18.9

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -249,17 +249,17 @@ The Apache Software License, Version 2.0
      - info.picocli-picocli-shell-jline3-4.7.7.jar
  * High Performance Primitive Collections for Java -- com.carrotsearch-hppc-0.9.1.jar
  * Jackson
-     - com.fasterxml.jackson.core-jackson-annotations-2.18.8.jar
-     - com.fasterxml.jackson.core-jackson-core-2.18.8.jar
-     - com.fasterxml.jackson.core-jackson-databind-2.18.8.jar
-     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.8.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.8.jar
-     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.8.jar
-     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.8.jar
-     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.8.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.8.jar
-     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.8.jar
-     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.8.jar
+     - com.fasterxml.jackson.core-jackson-annotations-2.18.9.jar
+     - com.fasterxml.jackson.core-jackson-core-2.18.9.jar
+     - com.fasterxml.jackson.core-jackson-databind-2.18.9.jar
+     - com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.18.9.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.18.9.jar
+     - com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.18.9.jar
+     - com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.18.9.jar
+     - com.fasterxml.jackson.module-jackson-module-jsonSchema-2.18.9.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jdk8-2.18.9.jar
+     - com.fasterxml.jackson.datatype-jackson-datatype-jsr310-2.18.9.jar
+     - com.fasterxml.jackson.module-jackson-module-parameter-names-2.18.9.jar
  * Caffeine -- com.github.ben-manes.caffeine-caffeine-3.2.4.jar
  * Conscrypt -- org.conscrypt-conscrypt-openjdk-uber-2.5.2.jar
  * Fastutil -- it.unimi.dsi-fastutil-8.5.16.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -313,17 +313,17 @@ The Apache Software License, Version 2.0
      - picocli-4.7.7.jar
      - picocli-shell-jline3-4.7.7.jar
  * Jackson
-     - jackson-annotations-2.18.8.jar
-     - jackson-core-2.18.8.jar
-     - jackson-databind-2.18.8.jar
-     - jackson-dataformat-yaml-2.18.8.jar
-     - jackson-jaxrs-base-2.18.8.jar
-     - jackson-jaxrs-json-provider-2.18.8.jar
-     - jackson-module-jaxb-annotations-2.18.8.jar
-     - jackson-module-jsonSchema-2.18.8.jar
-     - jackson-datatype-jdk8-2.18.8.jar
-     - jackson-datatype-jsr310-2.18.8.jar
-     - jackson-module-parameter-names-2.18.8.jar
+     - jackson-annotations-2.18.9.jar
+     - jackson-core-2.18.9.jar
+     - jackson-databind-2.18.9.jar
+     - jackson-dataformat-yaml-2.18.9.jar
+     - jackson-jaxrs-base-2.18.9.jar
+     - jackson-jaxrs-json-provider-2.18.9.jar
+     - jackson-module-jaxb-annotations-2.18.9.jar
+     - jackson-module-jsonSchema-2.18.9.jar
+     - jackson-datatype-jdk8-2.18.9.jar
+     - jackson-datatype-jsr310-2.18.9.jar
+     - jackson-module-parameter-names-2.18.9.jar
  * Caffeine -- caffeine-3.2.4.jar
  * Conscrypt -- conscrypt-openjdk-uber-2.5.2.jar
  * Gson

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.bcpkix-fips.version>2.0.11</bouncycastle.bcpkix-fips.version>
     <bouncycastle.bcutil-fips.version>2.0.6</bouncycastle.bcutil-fips.version>
     <bouncycastle.bc-fips.version>2.0.1</bouncycastle.bc-fips.version>
-    <jackson.version>2.18.8</jackson.version>
+    <jackson.version>2.18.9</jackson.version>
     <fastutil.version>8.5.16</fastutil.version>
     <jctools.version>4.0.5</jctools.version>
     <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
### Motivation

Upgrade Jackson to 2.18.9 to fix the following vulnerability:
- https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-5jmj-h7xm-6q6v (CVE-2026-54515)

Affected versions can make properties ignored with `@JsonIgnoreProperties` writable again when per-property case-insensitive deserialization is enabled.

### Modifications

Upgrade Jackson from 2.18.8 to 2.18.9 and update the server and shell `LICENSE.bin.txt` files accordingly.

### Verifications

- `./mvnw -q -N help:evaluate -Dexpression=jackson.version -DforceStdout`
- `./mvnw -pl pulsar-client -am -Dtest=ConfigurationDataUtilsTest -Dsurefire.failIfNoSpecifiedTests=false -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drat.skip=true test` (9 tests, 0 failures, 0 errors)
