### PR TITLE
[fix][broker] Prevent early replay of non-strict delayed messages

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -173,6 +173,8 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
      * in a loop until the deliverAt time is reached (see issue #25996).
      *
      * In non-strict mode the timestamp is rounded down, since delivering up to tickTimeMillis early is allowed.
+     * Availability checks account for the full bucket width so that the original deliverAt is still within that
+     * allowed window.
      */
     private long roundTimestamp(long deliverAt) {
         if (isDeliverAtTimeStrict()) {
@@ -181,6 +183,10 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
             return trimLowerBit(roundedUp < deliverAt ? Long.MAX_VALUE : roundedUp, timestampPrecisionBitCnt);
         }
         return trimLowerBit(deliverAt, timestampPrecisionBitCnt);
+    }
+
+    private long getBucketCutoffTime() {
+        return isDeliverAtTimeStrict() ? getCutoffTime() : getCutoffTime() - precisionMillis + 1;
     }
 
     /**
@@ -201,7 +207,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     @Override
     public boolean hasMessageAvailable() {
         boolean hasMessageAvailable = !delayedMessageMap.isEmpty()
-                && delayedMessageMap.firstLongKey() <= getCutoffTime();
+                && delayedMessageMap.firstLongKey() <= getBucketCutoffTime();
         if (!hasMessageAvailable) {
             updateTimer();
         }
@@ -215,7 +221,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     public NavigableSet<Position> getScheduledMessages(int maxMessages) {
         int n = maxMessages;
         NavigableSet<Position> positions = new TreeSet<>();
-        long cutoffTime = getCutoffTime();
+        long cutoffTime = getBucketCutoffTime();
 
         while (n > 0 && !delayedMessageMap.isEmpty()) {
             long timestamp = delayedMessageMap.firstLongKey();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/InMemoryDeliveryTrackerTest.java
@@ -111,6 +111,10 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
                     new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, 0)
             }};
+            case "testNonStrictModeDoesNotReplayPositionRepeatedly" -> new Object[][]{{
+                    new InMemoryDelayedDeliveryTracker(dispatcher, timer, 1000, clock,
+                            false, 0)
+            }};
             case "testAddMessageWithDeliverAtTimeAfterFullTickTimeWithStrict" -> new Object[][]{{
                     new InMemoryDelayedDeliveryTracker(dispatcher, timer, 500, clock,
                             true, 0)
@@ -368,6 +372,41 @@ public class InMemoryDeliveryTrackerTest extends AbstractDeliveryTrackerTest {
         scheduled = tracker.getScheduledMessages(100);
         assertEquals(scheduled, Set.of(PositionFactory.create(2, 2)));
         assertEquals(tracker.getNumberOfDelayedMessages(), 0);
+
+        tracker.close();
+    }
+
+    @Test(dataProvider = "delayedTracker")
+    public void testNonStrictModeDoesNotReplayPositionRepeatedly(InMemoryDelayedDeliveryTracker tracker)
+            throws Exception {
+        clockTime.set(0);
+
+        // tickTimeMillis=1000 uses 512ms buckets. deliverAt=60400 is stored in the bucket starting at 59904.
+        assertTrue(tracker.addMessage(1, 1, 60400));
+
+        // The exact deliverAt is still more than one tick away. Before the fix, each dispatch round popped the
+        // same position from the prematurely eligible bucket, read the entry, and re-added the position because
+        // the original deliverAt was still outside the non-strict early-delivery window.
+        clockTime.set(59000);
+        int replayReads = 0;
+        for (int i = 0; i < 10; i++) {
+            Set<Position> scheduled = tracker.getScheduledMessages(100);
+            replayReads += scheduled.size();
+            for (Position position : scheduled) {
+                assertEquals(position, PositionFactory.create(1, 1));
+                assertTrue(tracker.addMessage(position.getLedgerId(), position.getEntryId(), 60400));
+            }
+        }
+        assertEquals(replayReads, 0, "the position must not be replayed before its early-delivery window");
+
+        // Once the full bucket is inside the non-strict early-delivery window, the position is read exactly once
+        // and cannot be inserted back into the tracker with the original deliverAt.
+        clockTime.set(59415);
+        Set<Position> scheduled = tracker.getScheduledMessages(100);
+        replayReads += scheduled.size();
+        assertEquals(scheduled, Set.of(PositionFactory.create(1, 1)));
+        assertFalse(tracker.addMessage(1, 1, 60400));
+        assertEquals(replayReads, 1);
 
         tracker.close();
     }


### PR DESCRIPTION
### Motivation

`InMemoryDelayedDeliveryTracker` rounds non-strict delivery timestamps down to reduce the number of timestamp keys. Availability checks currently compare that bucket start directly with the non-strict cutoff (`now + tickTimeMillis`).

The original `deliverAt` can be up to `precisionMillis - 1` later than the bucket start. As a result, the tracker can expose a position before the original timestamp is inside the configured early-delivery window. The dispatcher then reads the entry, `addMessage` checks the original `deliverAt`, and inserts the same position back into an already eligible bucket. An active dispatcher can repeat this replay until the original timestamp reaches the cutoff, causing unnecessary reads.

With the default 1000 ms tick and 512 ms timestamp buckets, this inconsistent window can be up to 511 ms.

### Regression source and related changes

- [#23611](https://github.com/apache/pulsar/pull/23611) changed the in-memory tracker from a per-message priority queue to timestamp buckets and trimmed the lower timestamp bits. This is the change that introduced the timestamp-down-rounding behavior involved in this issue.
- [#26012](https://github.com/apache/pulsar/pull/26012) fixed the analogous early-bucket problem for strict delivery by changing strict-mode cutoff handling. This PR complements that fix for non-strict mode, where the configured early-delivery window must remain unchanged.

### Modifications

- Adjust the non-strict bucket cutoff by the maximum timestamp rounding distance, so a bucket is exposed only when its upper bound is inside the configured early-delivery window.
- Keep the existing timestamp representation, strict-mode behavior, timer state machine, and configuration semantics unchanged.
- Add a deterministic regression test that runs repeated dispatch rounds at a fixed clock time and counts replay reads of the same position.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :pulsar-broker:test --tests 'org.apache.pulsar.broker.delayed.InMemoryDeliveryTrackerTest' -PtestRetryCount=0`
- `./gradlew quickCheck`

The new regression test was also verified against the unpatched implementation: the same position was replayed and re-added 10 times while the clock remained fixed. With the fix it is replayed zero times before the early-delivery window, then exactly once after the full bucket enters that window.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
