### PR TITLE
[fix][broker] Add missing bundle Prometheus metrics for extensible load manager

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -100,6 +100,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.coordination.LeaderElectionState;
+import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 
 @CustomLog
 public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerSelectionStrategyFactory {
@@ -1041,8 +1042,34 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager, BrokerS
         metricsCollection.addAll(this.assignCounter.toMetrics(pulsar.getAdvertisedAddress()));
         metricsCollection.addAll(this.serviceUnitStateChannel.getMetrics());
         metricsCollection.addAll(getIgnoredCommandMetrics(pulsar.getAdvertisedAddress()));
+        if (conf.isExposeBundlesMetricsInPrometheus()) {
+            metricsCollection.addAll(getBundleMetrics(pulsar.getAdvertisedAddress()));
+        }
 
         return metricsCollection;
+    }
+
+    private List<Metrics> getBundleMetrics(String advertisedBrokerAddress) {
+        List<Metrics> metrics = new ArrayList<>();
+        for (Map.Entry<String, NamespaceBundleStats> entry
+                : pulsar.getBrokerService().getBundleStats().entrySet()) {
+            final String bundle = entry.getKey();
+            final NamespaceBundleStats stats = entry.getValue();
+            Map<String, String> dimensions = new HashMap<>();
+            dimensions.put("broker", advertisedBrokerAddress);
+            dimensions.put("bundle", bundle);
+            dimensions.put("metric", "bundle");
+            Metrics m = Metrics.create(dimensions);
+            m.put("brk_bundle_msg_rate_in", stats.msgRateIn);
+            m.put("brk_bundle_msg_rate_out", stats.msgRateOut);
+            m.put("brk_bundle_topics_count", stats.topics);
+            m.put("brk_bundle_consumer_count", stats.consumerCount);
+            m.put("brk_bundle_producer_count", stats.producerCount);
+            m.put("brk_bundle_msg_throughput_in", stats.msgThroughputIn);
+            m.put("brk_bundle_msg_throughput_out", stats.msgThroughputOut);
+            metrics.add(m);
+        }
+        return metrics;
     }
 
     private List<Metrics> getIgnoredCommandMetrics(String advertisedBrokerAddress) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -78,6 +79,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetricsToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.extensions.channel.ServiceUnitStateData;
 import org.apache.pulsar.broker.loadbalance.extensions.manager.UnloadManager;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
@@ -965,6 +967,60 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
         // cleanup.
         mockZooKeeper.delete(mockedBroker, 0);
+    }
+
+    @Test
+    public void testBundlesMetricsWithExtensibleLoadManager() throws Exception {
+        cleanup();
+        conf.setLoadManagerClassName(ExtensibleLoadManagerImpl.class.getName());
+        conf.setExposeBundlesMetricsInPrometheus(true);
+        setup();
+
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/my-ns/elm-bundle-metrics")
+                .create();
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/my-ns/elm-bundle-metrics")
+                .subscriptionName("test")
+                .subscribe();
+
+        final int messages = 10;
+        for (int i = 0; i < messages; i++) {
+            producer.send(("my-message-" + i).getBytes());
+        }
+        for (int i = 0; i < messages; i++) {
+            consumer.acknowledge(consumer.receive());
+        }
+
+        pulsar.getBrokerService().updateRates();
+        Awaitility.await().until(() -> !pulsar.getBrokerService().getBundleStats().isEmpty());
+
+        ByteArrayOutputStream statsOut = new ByteArrayOutputStream();
+        PrometheusMetricsTestUtil.generate(pulsar, false, false, false, statsOut);
+        Multimap<String, Metric> metrics = parseMetrics(statsOut.toString());
+
+        assertTrue(metrics.containsKey("pulsar_bundle_msg_rate_in"));
+        assertTrue(metrics.containsKey("pulsar_bundle_msg_rate_out"));
+        assertTrue(metrics.containsKey("pulsar_bundle_topics_count"));
+        assertTrue(metrics.containsKey("pulsar_bundle_consumer_count"));
+        assertTrue(metrics.containsKey("pulsar_bundle_producer_count"));
+        assertTrue(metrics.containsKey("pulsar_bundle_msg_throughput_in"));
+        assertTrue(metrics.containsKey("pulsar_bundle_msg_throughput_out"));
+
+        conf.setExposeBundlesMetricsInPrometheus(false);
+        statsOut.reset();
+        PrometheusMetricsTestUtil.generate(pulsar, false, false, false, statsOut);
+        Multimap<String, Metric> metricsDisabled = parseMetrics(statsOut.toString());
+
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_msg_rate_in"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_msg_rate_out"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_topics_count"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_consumer_count"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_producer_count"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_msg_throughput_in"));
+        assertFalse(metricsDisabled.containsKey("pulsar_bundle_msg_throughput_out"));
     }
 
     @Test


### PR DESCRIPTION
<!--
### Contribution Checklist

  - PR title format should be *[type][component] summary*. The valid `[type]` and `[component]`/scope
    prefixes are enforced by CI (see `.github/workflows/ci-semantic-pull-request.yml`); for details,
    see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - The **Motivation** and **Modifications** sections are required: explain *why* (the problem/context)
    and *what/how* (the change). A title alone, or a description that only restates the title, is not enough.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message

  - For the local build/test/PR workflow see `CONTRIBUTING.md`, and for coding conventions see
    `CODING.md`. If you use an AI coding assistant, see `AGENTS.md`.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes/closes an issue — use "Fixes #xyz" or, equivalently, "Closes #xyz", -->

Fixes #23923

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

`exposeBundlesMetricsInPrometheus=true` has no effect under `ExtensibleLoadManagerImpl`. Bundle metrics such as `pulsar_bundle_topics_count` are missing from the scrape output.
`ModularLoadManagerImpl` already publishes them.

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

If `exposeBundlesMetricsInPrometheus` is enabled, `ExtensibleLoadManagerImpl.getMetrics()` now pulls
`BrokerService#getBundleStats()` and publishes the same `brk_bundle_*` metrics  and labels that `ModularLoadManagerImpl` uses.

<!-- Describe the modifications you've done. -->

### Verifying this change



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
- [ ] Anything that affects deployment