### PR TITLE
[improve][meta] Upgrade Oxia client to 0.9.4

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -487,8 +487,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.github.oxia-db-oxia-client-api-0.8.0.jar
-    - io.github.oxia-db-oxia-client-0.8.0.jar
+    - io.github.oxia-db-oxia-client-api-0.9.4.jar
+    - io.github.oxia-db-oxia-client-0.9.4.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,7 +138,7 @@ jakarta-validation = "3.0.2"
 javax-servlet = "3.1.0"
 jakarta-servlet = "6.0.0"
 # Oxia / etcd
-oxia = "0.8.0"
+oxia = "0.9.4"
 oxia-testcontainers = "0.7.4"
 # Build plugins
 lightproto = "0.7.3"

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -86,10 +86,6 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
         super("oxia-metadata", Objects.requireNonNull(metadataStoreConfig).getOpenTelemetry(),
                 metadataStoreConfig.getNodeSizeStats(), metadataStoreConfig.getNumSerDesThreads());
 
-        var linger = metadataStoreConfig.getBatchingMaxDelayMillis();
-        if (!metadataStoreConfig.isBatchingEnabled()) {
-            linger = 0;
-        }
         synchronizer = Optional.ofNullable(metadataStoreConfig.getSynchronizer());
         identity = UUID.randomUUID().toString();
         OxiaClientBuilder oxiaClientBuilder = OxiaClientBuilder
@@ -97,7 +93,6 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
                 .clientIdentifier(identity)
                 .namespace(namespace)
                 .sessionTimeout(Duration.ofMillis(metadataStoreConfig.getSessionTimeoutMillis()))
-                .batchLinger(Duration.ofMillis(linger))
                 .maxRequestsPerBatch(metadataStoreConfig.getBatchingMaxOperations());
         if (StringUtils.isNotBlank(metadataStoreConfig.getConfigFilePath())) {
             oxiaClientBuilder.loadConfig(metadataStoreConfig.getConfigFilePath());

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStoreProvider.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStoreProvider.java
@@ -20,8 +20,6 @@ package org.apache.pulsar.metadata.impl.oxia;
 
 import io.oxia.client.api.AsyncOxiaClient;
 import io.oxia.client.api.OxiaClientBuilder;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import lombok.NonNull;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.metadata.api.MetadataStore;
@@ -82,7 +80,6 @@ public class OxiaMetadataStoreProvider implements MetadataStoreProvider {
         try {
             return OxiaClientBuilder.create(pair.getLeft())
                     .namespace(pair.getRight())
-                    .batchLinger(Duration.of(100, ChronoUnit.MILLIS))
                     .asyncClient().get();
         } catch (Exception e) {
             throw new MetadataStoreException(e);


### PR DESCRIPTION
### Motivation

The Oxia Java client 0.9.x line is a performance-focused set of releases on top of 0.8.0, with **no breaking public API changes** (each 0.9.x release note states that code built against the prior version keeps compiling):

- **0.9.0** — fewer allocations and less lock contention on the hot read/write paths; batch assembly moved from two dedicated threads per shard to a small shared pool; end-to-end backpressure via a bounded total size of pending operations.
- **0.9.1 / 0.9.2** — `SharedResources`: many client instances in one JVM can share a background thread pool, gRPC connection pool, shard-assignment stream and batcher threads.
- **0.9.3 / 0.9.4** — rate-adaptive write and read batching with a bounded per-shard in-flight window, so under load operations accumulate into larger requests instead of flooding the server with small RPCs.

### Modifications

- Bump `oxia` from `0.8.0` to `0.9.4` in the Gradle version catalog. `oxia-testcontainers` stays at `0.7.4` (its latest published version; the two version refs were already decoupled in the 0.8.0 bump).
- Update the two bundled Oxia jar versions in `distribution/server/src/assemble/LICENSE.bin.txt`. The client's bundled runtime dependencies (`slog`, `caffeine`, `failsafe`) are unchanged between 0.8.0 and 0.9.4, so only the two `oxia-client` / `oxia-client-api` jar names change.
- Drop the `batchLinger(...)` calls in `OxiaMetadataStore` and `OxiaMetadataStoreProvider`. `batchLinger` is a no-op in 0.9.x (batching is adaptive) and is deprecated for removal. `maxRequestsPerBatch` still honors the configured `batchingMaxOperations`, so there is no runtime behavior change.

### Verifying this change

This change is a dependency upgrade covered by the existing Oxia metadata-store tests (`pulsar-metadata` `MetadataStore*`/`Oxia*` suites and the Oxia integration tests). Compilation, checkstyle, and dependency resolution were verified locally.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)

Upgrades `io.github.oxia-db:oxia-client` from 0.8.0 to 0.9.4. No public API, wire-protocol, schema, config-default, or metrics changes.
