### PR TITLE
[fix][sec][branch-4.0] Upgrade Hadoop to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@ flexible messaging model and an intuitive client API.</description>
     <wildfly-elytron.version>1.15.16.Final</wildfly-elytron.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>
-    <hadoop3.version>3.4.2</hadoop3.version>
+    <hadoop3.version>3.5.0</hadoop3.version>
     <dnsjava3.version>3.6.2</dnsjava3.version>
     <hdfs-offload-version3>${hadoop3.version}</hdfs-offload-version3>
     <hbase.version>2.6.3-hadoop3</hbase.version>


### PR DESCRIPTION
### Motivation

Hadoop 3.5.0 is the first stable release of the Hadoop 3.5 line and contains 485 fixes and improvements since Hadoop 3.4. This backport aligns `branch-4.0` with the Hadoop version already adopted on Pulsar `master` in #25402 and picks up the following security fixes recorded in the [Hadoop 3.5.0 changelog](https://hadoop.apache.org/docs/r3.5.0/hadoop-project-dist/hadoop-common/release/3.5.0/CHANGELOG.3.5.0.html):

- [HADOOP-19031](https://issues.apache.org/jira/browse/HADOOP-19031) / CVE-2024-23454: prevent local information disclosure through Hadoop temporary files.
- [HADOOP-19761](https://issues.apache.org/jira/browse/HADOOP-19761) / CVE-2025-5115: upgrade Jetty to 9.4.58.
- [HADOOP-19788](https://issues.apache.org/jira/browse/HADOOP-19788) / CVE-2025-67735: upgrade Netty.
- [HADOOP-19765](https://issues.apache.org/jira/browse/HADOOP-19765) / CVE-2025-68161: upgrade Log4j to 2.25.3.

Because `branch-4.0` currently uses Hadoop 3.4.2, the upgrade also includes the security-related dependency updates released in Hadoop 3.4.3:

- [HADOOP-19764](https://issues.apache.org/jira/browse/HADOOP-19764) / CVE-2025-14763: Amazon S3 encryption client.
- [HADOOP-19690](https://issues.apache.org/jira/browse/HADOOP-19690) / CVE-2025-48924: Commons Lang.
- [HADOOP-19689](https://issues.apache.org/jira/browse/HADOOP-19689) / CVE-2025-58057: Netty.
- [HADOOP-19730](https://issues.apache.org/jira/browse/HADOOP-19730) / CVE-2025-8916: Bouncy Castle.
- [HADOOP-19747](https://issues.apache.org/jira/browse/HADOOP-19747) / CVE-2025-12183: LZ4 Java dependency update.

Some transitive dependency versions can still be overridden by Pulsar dependency management; the list above describes fixes included by the upstream Hadoop release rather than claiming that every listed library version is exposed unchanged in Pulsar.

### Modifications

- Upgrade `hadoop3.version` from 3.4.2 to 3.5.0.
- This updates the Hadoop 3 dependencies shared by the HDFS connector, filesystem tiered-storage plugin, and related test/minicluster modules.
- No `LICENSE` or `NOTICE` update is required: the generated Pulsar binary distribution passes `src/check-binary-license.sh`, and the Hadoop artifacts remain packaged in the existing NAR dependency layout.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests and was verified with:

- `mvn -B -T 2 -ntp -Pcore-modules,-main clean install -DskipTests -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true`
- `mvn -B -ntp -pl tiered-storage/file-system,pulsar-io/hdfs3 test -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true` (32 tests, 0 failures, 0 errors, 3 skipped)
- `mvn -B -ntp -pl tiered-storage/file-system,pulsar-io/hdfs3 package -DskipTests -Dlicense.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true`
- `src/check-binary-license.sh ./distribution/server/target/apache-pulsar-*-bin.tar.gz`

The generated filesystem tiered-storage and HDFS3 NAR files contain the Hadoop 3.5.0 artifacts.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
