### PR TITLE
[fix][meta] Complete handleMetadataEvent future exceptionally when the initial get fails

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -235,14 +235,14 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
     @Override
     public CompletableFuture<Void> handleMetadataEvent(MetadataEvent event) {
         CompletableFuture<Void> result = new CompletableFuture<>();
-        get(event.getPath()).thenApply(res -> {
+        get(event.getPath()).thenAccept(res -> {
             Set<CreateOption> options = event.getOptions() != null ? event.getOptions()
                     : Collections.emptySet();
             if (res.isPresent()) {
                 GetResult existingValue = res.get();
                 if (shouldIgnoreEvent(event, existingValue)) {
                     result.complete(null);
-                    return result;
+                    return;
                 }
             }
             // else update the event
@@ -262,7 +262,11 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
                 }
                 return false;
             });
-            return result;
+        }).exceptionally(ex -> {
+            Throwable cause = FutureUtil.unwrapCompletionException(ex);
+            log.warn().attr("path", event.getPath()).exception(cause).log("Failed to handle metadata event");
+            result.completeExceptionally(cause);
+            return null;
         });
         return result;
     }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataEventSynchronizerTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/MetadataEventSynchronizerTest.java
@@ -20,13 +20,24 @@ package org.apache.pulsar.metadata.impl;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataEvent;
 import org.apache.pulsar.metadata.api.MetadataStore;
 import org.apache.pulsar.metadata.api.MetadataStoreConfig;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.MetadataStoreFactory;
+import org.apache.pulsar.metadata.api.NotificationType;
+import org.apache.pulsar.metadata.api.Option;
 import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
@@ -73,6 +84,28 @@ public class MetadataEventSynchronizerTest {
         Awaitility.await().untilAsserted(() -> {
             assertFalse(store1.exists("/test").join());
         });
+    }
+
+    @Test
+    public void testHandleMetadataEventCompletesWhenGetFails() throws Exception {
+        @Cleanup
+        LocalMemoryMetadataStore store = new LocalMemoryMetadataStore("memory:local",
+                MetadataStoreConfig.builder().build()) {
+            @Override
+            public CompletableFuture<Optional<GetResult>> storeGet(String path, Set<Option> opts) {
+                return CompletableFuture.failedFuture(
+                        new MetadataStoreException("injected storeGet failure"));
+            }
+        };
+
+        MetadataEvent event = new MetadataEvent("/test", "value".getBytes(StandardCharsets.UTF_8),
+                new HashSet<>(), null, System.currentTimeMillis(), "test-cluster", NotificationType.Modified);
+
+        CompletableFuture<Void> result = store.handleMetadataEvent(event);
+        // The future must not hang when the initial get() fails: it should complete exceptionally
+        ExecutionException ex = expectThrows(ExecutionException.class, () -> result.get(5, TimeUnit.SECONDS));
+        assertTrue(ex.getCause() instanceof MetadataStoreException,
+                "expected MetadataStoreException cause but got: " + ex.getCause());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

  `AbstractMetadataStore#handleMetadataEvent` chains the initial
  `get(event.getPath())` with `thenApply`, but the outer chain has no
  handler for exceptional completion. When that `get` fails (e.g. the
  backing store is unavailable), the `thenApply` callback is skipped and
  the `result` future returned to the caller **never completes**.

  The caller is the `MetadataEventSynchronizer` listener path
  (`PulsarMetadataEventSynchronizer`'s consumer message listener): with a
  hanging future, neither the `acknowledgeAsync` stage nor the
  `exceptionally` stage ever runs, so the event message is not
  acknowledged, the failure cause is never logged, and every ack-timeout
  redelivery registers another never-completing future. The inner
  `updateResult` chain already handles exceptional completion; only the
  outer `get` chain was missing it.

  ### Modifications

  - `AbstractMetadataStore#handleMetadataEvent`: switch the outer chain
    from `thenApply` (whose mapped value was never used) to `thenAccept`,
    and append an `exceptionally` stage that unwraps the
    `CompletionException` via `FutureUtil.unwrapCompletionException`,
    logs a warning, and completes the `result` future exceptionally with
    the root cause.
  - The new `exceptionally` stage also covers exceptions thrown
    synchronously inside the callback body (e.g. from
    `shouldIgnoreEvent`), which previously left the future hanging the
    same way.
  - The existing behavior on the success path is unchanged, including the
    inner `updateResult` handling (`BadVersionException` is still treated
    as success).

  ### Verifying this change

  - [ ] Make sure that the change passes the CI checks.

  This change added tests and can be verified as follows:

    - Added `MetadataEventSynchronizerTest#testHandleMetadataEventCompletesWhenGetFails`,
      which injects a failing `storeGet` into a `LocalMemoryMetadataStore`
      subclass and asserts that the future returned by
      `handleMetadataEvent` completes exceptionally (with a
      `MetadataStoreException` cause) within a timeout. On the unpatched
      code the test fails with a `TimeoutException`, reproducing the hang;
      with the fix it passes.

  ### Does this pull request potentially affect one of the following parts:

  *If the box was checked, please highlight the changes*

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment

  This is an internal behavior change: the future returned by
  `handleMetadataEvent` now completes exceptionally instead of hanging
  when the initial read fails. No public API, schema, configuration,
  wire protocol, REST endpoint, CLI option, or metric is affected.