### PR TITLE
[fix][meta] Fix NPE in shouldIgnoreEvent when MetadataEvent options is null

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -294,7 +294,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         }
         // ignore event if metadata is ephemeral or
         // sequential
-        if (options.contains(CreateOption.Ephemeral) || event.getOptions().contains(CreateOption.Sequential)) {
+        if (options.contains(CreateOption.Ephemeral) || options.contains(CreateOption.Sequential)) {
             return true;
         }
         // ignore the event if event occurred before the


### PR DESCRIPTION
### Motivation
  `AbstractMetadataStore#shouldIgnoreEvent` normalizes a possibly-null
  `MetadataEvent#getOptions()` into a local `options` variable
  (`options = event.getOptions() != null ? event.getOptions() : Collections.emptySet()`),
  but the ephemeral/sequential check on the next lines only used it for the first half of
  the condition:

  ```java
  if (options.contains(CreateOption.Ephemeral) || event.getOptions().contains(CreateOption.Sequential)) {
  ```

  When a synchronizer delivers a MetadataEvent whose options is null and the metadata
  is not Ephemeral, the short-circuit falls through to
  event.getOptions().contains(...) and throws a NullPointerException, so the event
  fails to be processed instead of being handled by the remaining checks.

### Modifications

  Use the null-normalized local options variable for the CreateOption.Sequential
  check as well, matching the CreateOption.Ephemeral check on the same line. No
  behavior change other than removing the NPE path.