### PR TITLE
[fix][meta] Record get op stats on the correct completion branch in AbstractMetadataStore

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -370,9 +370,9 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         return storeGet(path, opts)
                 .whenComplete((v, t) -> {
                     if (t != null) {
-                        v.ifPresent(getResult -> nodeSizeStats.recordGetRes(path, getResult));
                         metadataStoreStats.recordGetOpsFailed(System.currentTimeMillis() - start);
                     } else {
+                        v.ifPresent(getResult -> nodeSizeStats.recordGetRes(path, getResult));
                         metadataStoreStats.recordGetOpsSucceeded(System.currentTimeMillis() - start);
                     }
                 });

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/AbstractMetadataStoreGetStatsTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/AbstractMetadataStoreGetStatsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import io.opentelemetry.api.OpenTelemetry;
+import io.prometheus.client.CollectorRegistry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+import lombok.Cleanup;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.metadata.api.GetResult;
+import org.apache.pulsar.metadata.api.MetadataNodeSizeStats;
+import org.apache.pulsar.metadata.api.MetadataStoreException;
+import org.apache.pulsar.metadata.api.Option;
+import org.apache.pulsar.metadata.api.Stat;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@link AbstractMetadataStore#get(String, Set)} records operation stats on the
+ * correct completion branch.
+ */
+public class AbstractMetadataStoreGetStatsTest {
+
+    private static class TestMetadataStore extends AbstractMetadataStore {
+        private volatile Function<String, CompletableFuture<Optional<GetResult>>> getImpl;
+
+        TestMetadataStore(String name, MetadataNodeSizeStats nodeSizeStats) {
+            super(name, OpenTelemetry.noop(), nodeSizeStats, 1);
+        }
+
+        @Override
+        protected CompletableFuture<Optional<GetResult>> storeGet(String path, Set<Option> opts) {
+            return getImpl.apply(path);
+        }
+
+        @Override
+        public CompletableFuture<List<String>> getChildrenFromStore(String path, Set<Option> opts) {
+            return CompletableFuture.completedFuture(List.of());
+        }
+
+        @Override
+        protected CompletableFuture<Boolean> existsFromStore(String path, Set<Option> opts) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        @Override
+        protected CompletableFuture<Void> storeDelete(String path, Optional<Long> expectedVersion, Set<Option> opts) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        protected CompletableFuture<Stat> storePut(String path, byte[] data, Optional<Long> optExpectedVersion,
+                                                   Set<Option> opts) {
+            return FutureUtil.failedFuture(new UnsupportedOperationException());
+        }
+    }
+
+    private static double getOpsCount(String storeName, String status) {
+        Double value = CollectorRegistry.defaultRegistry.getSampleValue(
+                "pulsar_metadata_store_ops_latency_ms_count",
+                new String[]{"name", "type", "status"},
+                new String[]{storeName, "get", status});
+        return value == null ? 0.0 : value;
+    }
+
+    @Test
+    public void testGetSuccessRecordsNodeSizeStats() throws Exception {
+        MetadataNodeSizeStats nodeSizeStats = mock(MetadataNodeSizeStats.class);
+        @Cleanup
+        TestMetadataStore store = new TestMetadataStore("get-stats-success", nodeSizeStats);
+        GetResult result = new GetResult(new byte[]{1, 2, 3}, new Stat("/a", 0, 0, 0, false, false));
+        store.getImpl = path -> CompletableFuture.completedFuture(Optional.of(result));
+
+        assertSame(store.get("/a").join().orElse(null), result);
+
+        verify(nodeSizeStats).recordGetRes("/a", result);
+        assertEquals(getOpsCount("get-stats-success", "success"), 1.0);
+    }
+
+    @Test
+    public void testGetFailureRecordsFailedOpAndPropagatesOriginalException() throws Exception {
+        String storeName = "get-stats-failure";
+        @Cleanup
+        TestMetadataStore store = new TestMetadataStore(storeName, mock(MetadataNodeSizeStats.class));
+        MetadataStoreException injected = new MetadataStoreException("injected failure");
+        store.getImpl = path -> FutureUtil.failedFuture(injected);
+
+        CompletionException ex = expectThrows(CompletionException.class, () -> store.get("/a").join());
+
+        assertSame(ex.getCause(), injected);
+        assertTrue(Arrays.stream(injected.getSuppressed()).noneMatch(s -> s instanceof NullPointerException),
+                "stats callback must not throw NPE on the failure path");
+        assertEquals(getOpsCount(storeName, "fail"), 1.0);
+    }
+}


### PR DESCRIPTION
### Motivation

  Since #24580, the `whenComplete` callback in `AbstractMetadataStore#get` has its
  branch contents inverted. The failure branch (`t != null`) calls
  `v.ifPresent(...)`, but on exceptional completion `v` is always `null`, so the
  callback throws a `NullPointerException` that short-circuits
  `metadataStoreStats.recordGetOpsFailed`. Per `whenComplete` semantics the NPE is
  only attached to the original exception as a suppressed exception, so callers
  still see the original failure — which is why this went unnoticed. The actual
  damage is to observability:

  - Failed get operations are never recorded in the
    `pulsar_metadata_store_ops_latency{type="get", status="fail"}` histogram, so
    the metric silently reports zero failures even when the metadata store is
    unhealthy (the only path still counted is the synchronous invalid-path check).
  - `nodeSizeStats.recordGetRes` — which #24580 intended to run on the success
    path (cf. `recordGetChildrenRes` in `getChildren`) — is never invoked at all,
    so node-size stats for get responses were never collected.

  ### Modifications
  
  - In `AbstractMetadataStore#get`, move `recordGetOpsFailed` back to being the
    sole action of the failure branch, and move
    `v.ifPresent(... nodeSizeStats.recordGetRes ...)` into the success branch
    where it was intended to run.
  - Add `AbstractMetadataStoreGetStatsTest` covering both halves of the bug
    against a minimal `AbstractMetadataStore` test double.

  ### Verifying this change

  - [ ] Make sure that the change passes the CI checks.

  This change added tests and can be verified as follows:

  - *Added `AbstractMetadataStoreGetStatsTest#testGetFailureRecordsFailedOpAndPropagatesOriginalException`:
    injects a failing `storeGet` and asserts the original exception propagates
    without a suppressed NPE and that the `status="fail"` histogram count
    increments — fails before this fix.*
  - *Added `AbstractMetadataStoreGetStatsTest#testGetSuccessRecordsNodeSizeStats`:
    asserts `MetadataNodeSizeStats#recordGetRes` is invoked with the returned
    `GetResult` and the `status="success"` count increments — fails before this
    fix (`recordGetRes` was never called).*

  ### Does this pull request potentially affect one of the following parts:

  *If the box was checked, please highlight the changes*

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [x] The metrics
  - [ ] Anything that affects deployment

  The existing `pulsar_metadata_store_ops_latency{type="get", status="fail"}`
  histogram starts reporting real values (it previously never recorded async get
  failures), and node-size stats for get responses are now actually collected. No
  metric names, labels, or types change.