### PR TITLE
[fix][broker] Log exception in PulsarMetadataEventSynchronizer failure path

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -226,7 +226,8 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                                     log.warn()
                                             .attr("messageId", msg.getMessageId())
                                             .attr("topic", topicName)
-                                            .log("Failed to synchronize for");
+                                            .exception(ex)
+                                            .log("Failed to synchronize metadata event");
                                     return null;
                                 });
                     } else {
@@ -237,7 +238,8 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                                     log.warn()
                                             .attr("messageId", msg.getMessageId())
                                             .attr("topic", topicName)
-                                            .log("Failed to synchronize for");
+                                            .exception(ex)
+                                            .log("Failed to synchronize metadata event");
                                     return null;
                                 });
                     }
@@ -245,7 +247,8 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                     log.warn()
                             .attr("messageId", msg.getMessageId())
                             .attr("topic", topicName)
-                            .log("Failed to synchronize for");
+                            .exception(e)
+                            .log("Failed to synchronize metadata event");
                 }
             });
         consumerBuilder.subscribeAsync().thenAccept(consumer -> {


### PR DESCRIPTION
### Motivation

  In `PulsarMetadataEventSynchronizer`, the message listener has three failure paths (single-listener
  `exceptionally`, multi-listener `waitForAll` `exceptionally`, and the surrounding `catch` block).
  All three logged the warning `"Failed to synchronize for"` without attaching the caught exception,                                                                                                             
  so when metadata-event synchronization failed there was no stack trace or error cause in the broker
  log, making the failure impossible to diagnose. The message text was also truncated/incomplete.

  ### Modifications

  - Attach the caught exception to the slog warn call via `.exception(ex)` / `.exception(e)` in all
    three failure paths of the metadata-event message listener in `PulsarMetadataEventSynchronizer`.
  - Fix the incomplete log message: `"Failed to synchronize for"` → `"Failed to synchronize metadata event"`.

  ### Verifying this change

  - [x] Make sure that the change passes the CI checks.

  This change is a trivial rework / code cleanup without any test coverage.

  ### Does this pull request potentially affect one of the following parts:

  *If the box was checked, please highlight the changes*

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment