### PR TITLE
[improve][broker] PIP-486 (PR5): broker-side entry-bucket handoff for orderly consumer scaling

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractSubscription.java
@@ -73,6 +73,15 @@ public abstract class AbstractSubscription implements Subscription {
                                         + "is different than the connecting consumer's key_shared mode '%s'.",
                                 dispatcherKsm.getKeySharedMode(), consumerKsm.getKeySharedMode()))));
             }
+            if (dispatcherKsm.isEntryBucketDispatch() != consumerKsm.isEntryBucketDispatch()) {
+                return Optional.of(FutureUtil.failedFuture(new BrokerServiceException.SubscriptionBusyException(
+                        String.format("Subscription is of different type. %s",
+                                dispatcherKsm.isEntryBucketDispatch()
+                                        ? "Active subscription dispatches by entry-bucket while the connecting "
+                                        + "consumer does not." :
+                                        "Active subscription does not dispatch by entry-bucket while the connecting "
+                                                + "consumer requests it."))));
+            }
             if (dispatcherKsm.isAllowOutOfOrderDelivery() != consumerKsm.isAllowOutOfOrderDelivery()) {
                 return Optional.of(FutureUtil.failedFuture(new BrokerServiceException.SubscriptionBusyException(
                         String.format("Subscription is of different type. %s",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBucketConsumerSelector.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/EntryBucketConsumerSelector.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.Range;
+
+/**
+ * PIP-486: assigns a scalable-topic segment's entry-buckets to the connected consumers.
+ *
+ * <p>The bucket boundaries are fixed for the selector's life (a segment's bucketing is immutable —
+ * every consumer of the subscription declares the identical boundary list at subscribe time, see
+ * {@code KeySharedMeta.entryBucketDispatch}). The selector's only moving part is membership: the
+ * {@code N} buckets are spread <b>deterministically</b> over the connected consumers — consumers
+ * sorted by name (id as tiebreak), consumer {@code j} of {@code k} owning the contiguous bucket
+ * slice {@code [j*N/k, (j+1)*N/k)} — so every broker computes the same spread from the same
+ * membership, and a membership change moves as few whole buckets as possible.
+ *
+ * <p>Every hash this selector sees or produces is a bucket's <b>canonical hash</b> (the bucket's
+ * start hash, nudged to 1 for bucket 0 since 0 is the reserved "not set" value). The owning
+ * dispatcher normalizes each entry's stamped {@code entry_hash_min} — and, for unstamped entries,
+ * the message key's hash — to the canonical value, which is what makes the existing per-hash
+ * machinery (pending acks, replay ordering, {@link DrainingHashesTracker} draining) operate at
+ * exactly bucket granularity: one hash value per bucket.
+ */
+public class EntryBucketConsumerSelector implements StickyKeyConsumerSelector {
+
+    private final List<Range> bucketRanges;
+    private final int[] bucketStarts;
+
+    /** Connected consumers, sorted by (name, id). Guarded by this. */
+    private final List<Consumer> consumers = new ArrayList<>();
+    /** Bucket index → owning consumer; empty array while no consumer is connected. */
+    private volatile Consumer[] bucketOwners = new Consumer[0];
+    private volatile ConsumerHashAssignmentsSnapshot assignmentsSnapshot =
+            ConsumerHashAssignmentsSnapshot.empty();
+
+    /**
+     * @param bucketRanges ascending, inclusive, contiguous ranges tiling {@code [0, 0xFFFF]};
+     *                     already validated by the caller
+     */
+    public EntryBucketConsumerSelector(List<Range> bucketRanges) {
+        this.bucketRanges = List.copyOf(bucketRanges);
+        this.bucketStarts = new int[bucketRanges.size()];
+        for (int i = 0; i < bucketRanges.size(); i++) {
+            bucketStarts[i] = bucketRanges.get(i).getStart();
+        }
+    }
+
+    public List<Range> getBucketRanges() {
+        return bucketRanges;
+    }
+
+    /** The bucket index owning the given (16-bit) hash. */
+    public int bucketIndexOfHash(int hash) {
+        int low = 0;
+        int high = bucketStarts.length - 1;
+        while (low < high) {
+            int mid = (low + high + 1) >>> 1;
+            if (bucketStarts[mid] <= hash) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return low;
+    }
+
+    /**
+     * The canonical hash representing a bucket — its start hash, nudged to 1 for bucket 0
+     * (0 is the reserved {@link #STICKY_KEY_HASH_NOT_SET} value; 1 is still inside bucket 0).
+     */
+    public int canonicalHashOfBucket(int bucketIndex) {
+        return Math.max(bucketStarts[bucketIndex], 1);
+    }
+
+    /** Normalize any 16-bit hash to its bucket's canonical hash. */
+    public int canonicalHashOf(int hash) {
+        return canonicalHashOfBucket(bucketIndexOfHash(hash));
+    }
+
+    @Override
+    public int makeStickyKeyHash(byte[] stickyKey) {
+        return canonicalHashOf(
+                StickyKeyConsumerSelectorUtils.makeStickyKeyHash(stickyKey, getKeyHashRange()));
+    }
+
+    @Override
+    public synchronized CompletableFuture<Optional<ImpactedConsumersResult>> addConsumer(Consumer consumer) {
+        consumers.add(consumer);
+        consumers.sort(Comparator.comparing(Consumer::consumerName)
+                .thenComparingLong(Consumer::consumerId));
+        return CompletableFuture.completedFuture(Optional.of(recomputeAssignments()));
+    }
+
+    @Override
+    public synchronized Optional<ImpactedConsumersResult> removeConsumer(Consumer consumer) {
+        consumers.remove(consumer);
+        return Optional.of(recomputeAssignments());
+    }
+
+    private ImpactedConsumersResult recomputeAssignments() {
+        int bucketCount = bucketRanges.size();
+        Consumer[] owners = new Consumer[consumers.isEmpty() ? 0 : bucketCount];
+        List<HashRangeAssignment> assignments = new ArrayList<>(bucketCount);
+        if (!consumers.isEmpty()) {
+            int consumerCount = consumers.size();
+            for (int j = 0; j < consumerCount; j++) {
+                int from = (int) ((long) j * bucketCount / consumerCount);
+                int to = (int) ((long) (j + 1) * bucketCount / consumerCount);
+                for (int bucket = from; bucket < to; bucket++) {
+                    owners[bucket] = consumers.get(j);
+                    assignments.add(new HashRangeAssignment(bucketRanges.get(bucket), consumers.get(j)));
+                }
+            }
+        }
+        ConsumerHashAssignmentsSnapshot after = ConsumerHashAssignmentsSnapshot.of(assignments);
+        ImpactedConsumersResult impacted = assignmentsSnapshot.resolveImpactedConsumers(after);
+        bucketOwners = owners;
+        assignmentsSnapshot = after;
+        return impacted;
+    }
+
+    @Override
+    public Consumer select(int hash) {
+        Consumer[] owners = bucketOwners;
+        if (owners.length == 0) {
+            return null;
+        }
+        return owners[bucketIndexOfHash(hash)];
+    }
+
+    @Override
+    public Range getKeyHashRange() {
+        return Range.of(0, DEFAULT_RANGE_SIZE - 1);
+    }
+
+    @Override
+    public ConsumerHashAssignmentsSnapshot getConsumerHashAssignmentsSnapshot() {
+        return assignmentsSnapshot;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentEntryBucketDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentEntryBucketDispatcherMultipleConsumers.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.EntryAndMetadata;
+import org.apache.pulsar.broker.service.EntryBucketConsumerSelector;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.client.api.Range;
+import org.apache.pulsar.common.api.proto.IntRange;
+import org.apache.pulsar.common.api.proto.KeySharedMeta;
+
+/**
+ * PIP-486: Key_Shared dispatcher for a scalable-topic segment shared by <b>entry-bucket</b>.
+ *
+ * <p>Selected by {@link PersistentSubscription} when the consumers' {@link KeySharedMeta} carries
+ * {@code entryBucketDispatch}. Producers of a scalable segment batch per entry-bucket and stamp
+ * each entry's effective bucket hash range ({@code entry_hash_min}); this dispatcher routes each
+ * <b>whole entry</b> to the consumer owning its bucket — no per-message key hashing, no entry
+ * filtering, batching intact.
+ *
+ * <p>The mechanics reuse the battle-tested per-hash Key_Shared machinery at bucket granularity by
+ * <b>normalizing every entry's hash to its bucket's canonical value</b> (one hash value per
+ * bucket, see {@link EntryBucketConsumerSelector#canonicalHashOf}): pending acks, replay-order
+ * blocking, and the draining tracker then operate per bucket automatically. A membership change
+ * therefore hands buckets over exactly like AUTO_SPLIT hands over hash ranges — the moving bucket
+ * is blocked until the previous owner's outstanding entries are acked, then flows to the new owner
+ * in order. Clients never re-subscribe, are never rejected, and implement nothing beyond the
+ * subscribe flag: the handoff is entirely broker-side.
+ *
+ * <p>The bucket boundaries arrive in the subscribe itself ({@code KeySharedMeta.hashRanges}): a
+ * segment's bucketing is immutable for its life, so every consumer declares the identical
+ * boundary list; the first consumer's boundaries create the selector and later consumers are
+ * validated against them.
+ */
+public class PersistentEntryBucketDispatcherMultipleConsumers
+        extends PersistentStickyKeyDispatcherMultipleConsumers {
+
+    private final EntryBucketConsumerSelector bucketSelector;
+
+    PersistentEntryBucketDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
+            Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm) {
+        // Draining is required: the inherited DrainingHashesTracker tracks the canonical bucket
+        // hashes, which makes it a per-bucket handoff tracker.
+        super(topic, cursor, subscription, conf, ksm,
+                new EntryBucketConsumerSelector(validateBucketBoundaries(ksm)), true);
+        this.bucketSelector = (EntryBucketConsumerSelector) getSelector();
+    }
+
+    /**
+     * Validate and convert the boundaries declared at subscribe time: ascending, inclusive,
+     * contiguous ranges tiling the whole 16-bit entry-bucket ring, with bucket 0 wide enough to
+     * contain the canonical hash 1.
+     */
+    static List<Range> validateBucketBoundaries(KeySharedMeta ksm) {
+        int count = ksm.getHashRangesCount();
+        if (count == 0) {
+            throw new IllegalArgumentException(
+                    "Entry-bucket subscription must declare the segment's bucket boundaries");
+        }
+        List<Range> ranges = new ArrayList<>(count);
+        int expectedStart = 0;
+        for (int i = 0; i < count; i++) {
+            IntRange r = ksm.getHashRangeAt(i);
+            if (r.getStart() != expectedStart || r.getEnd() < r.getStart()) {
+                throw new IllegalArgumentException("Entry-bucket boundaries must be ascending, "
+                        + "contiguous and start at 0: found [" + r.getStart() + "," + r.getEnd()
+                        + "] where start " + expectedStart + " was expected");
+            }
+            ranges.add(Range.of(r.getStart(), r.getEnd()));
+            expectedStart = r.getEnd() + 1;
+        }
+        if (expectedStart != EntryBucketConsumerSelector.DEFAULT_RANGE_SIZE) {
+            throw new IllegalArgumentException("Entry-bucket boundaries must tile the 16-bit ring: "
+                    + "last range ends at " + (expectedStart - 1));
+        }
+        if (ranges.get(0).getEnd() < 1) {
+            throw new IllegalArgumentException(
+                    "Entry-bucket 0 must span at least [0,1] to hold the canonical hash");
+        }
+        return ranges;
+    }
+
+    @Override
+    public synchronized CompletableFuture<Void> addConsumer(Consumer consumer) {
+        // A segment's bucketing is immutable, so every consumer must declare the boundaries the
+        // dispatcher was created with — a mismatch is a client bug or a stale layout, not a race.
+        try {
+            List<Range> declared = validateBucketBoundaries(consumer.getKeySharedMeta());
+            if (!declared.equals(bucketSelector.getBucketRanges())) {
+                return CompletableFuture.failedFuture(new BrokerServiceException.ConsumerAssignException(
+                        "Consumer declares different entry-bucket boundaries than the subscription: "
+                                + declared + " != " + bucketSelector.getBucketRanges()));
+            }
+        } catch (IllegalArgumentException e) {
+            return CompletableFuture.failedFuture(
+                    new BrokerServiceException.ConsumerAssignException(e.getMessage()));
+        }
+        return super.addConsumer(consumer);
+    }
+
+    @Override
+    public boolean hasSameKeySharedPolicy(KeySharedMeta ksm) {
+        return ksm.getKeySharedMode() == getKeySharedMode()
+                && ksm.isAllowOutOfOrderDelivery() == isAllowOutOfOrderDelivery()
+                && ksm.isEntryBucketDispatch();
+    }
+
+    @Override
+    protected int getStickyKeyHash(Entry entry) {
+        if (entry instanceof EntryAndMetadata entryAndMetadata) {
+            // Cached so pending acks, redelivery and draining all see the same canonical value.
+            return entryAndMetadata.getOrUpdateCachedStickyKeyHash(stickyKey -> {
+                var metadata = entryAndMetadata.getMetadata();
+                if (metadata != null && metadata.hasEntryHashMin()) {
+                    // The producer stamped the entry's effective bucket range: route the whole
+                    // entry by its bucket.
+                    return bucketSelector.canonicalHashOf(metadata.getEntryHashMin());
+                }
+                // Unstamped (non-batched) entry: the key's low-16 Murmur hash is the same value
+                // the producer would have stamped, normalized to the same bucket.
+                return bucketSelector.makeStickyKeyHash(stickyKey);
+            });
+        }
+        return bucketSelector.makeStickyKeyHash(peekStickyKey(entry));
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -69,9 +69,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     private final boolean allowOutOfOrderDelivery;
     private final StickyKeyConsumerSelector selector;
     private final boolean drainingHashesRequired;
-    // PIP-486: dispatch whole entries by their producer-stamped entry-bucket hash range instead of
-    // hashing each message's key. Set only by scalable-topic consumers sharing a segment by bucket.
-    private final boolean entryBucketDispatch;
 
     private boolean skipNextReplayToTriggerLookAhead = false;
     private final KeySharedMode keySharedMode;
@@ -82,34 +79,47 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
             Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm) {
+        this(topic, cursor, subscription, conf, ksm, createSelector(ksm, conf),
+                // recent joined consumer tracking is required only for AUTO_SPLIT mode when
+                // out-of-order delivery is disabled
+                ksm.getKeySharedMode() == KeySharedMode.AUTO_SPLIT && !ksm.isAllowOutOfOrderDelivery());
+    }
+
+    /**
+     * Seam for subclasses (PIP-486 entry-bucket dispatch): supply a custom consumer selector and
+     * opt out of the per-hash draining tracker (a subclass brings its own handoff tracking).
+     */
+    protected PersistentStickyKeyDispatcherMultipleConsumers(PersistentTopic topic, ManagedCursor cursor,
+            Subscription subscription, ServiceConfiguration conf, KeySharedMeta ksm,
+            StickyKeyConsumerSelector selector, boolean drainingHashesRequired) {
         super(topic, cursor, subscription, ksm.isAllowOutOfOrderDelivery());
         this.log = LOG.with().ctx(super.log).build();
 
         this.allowOutOfOrderDelivery = ksm.isAllowOutOfOrderDelivery();
         this.keySharedMode = ksm.getKeySharedMode();
-        this.entryBucketDispatch = ksm.isEntryBucketDispatch();
-        // recent joined consumer tracking is required only for AUTO_SPLIT mode when out-of-order delivery is disabled
-        this.drainingHashesRequired =
-                keySharedMode == KeySharedMode.AUTO_SPLIT && !allowOutOfOrderDelivery;
+        this.drainingHashesRequired = drainingHashesRequired;
         this.drainingHashesTracker =
                 drainingHashesRequired ? new DrainingHashesTracker(this.getName(), this::stickyKeyHashUnblocked) : null;
         this.rescheduleReadHandler = new RescheduleReadHandler(conf::getKeySharedUnblockingIntervalMs,
                 topic.getBrokerService().executor(), this::cancelPendingRead, () -> reScheduleReadInMs(0),
                 () -> havePendingRead, this::getReadMoreEntriesCallCount, () -> !redeliveryMessages.isEmpty());
-        switch (this.keySharedMode) {
+        this.selector = selector;
+    }
+
+    private static StickyKeyConsumerSelector createSelector(KeySharedMeta ksm, ServiceConfiguration conf) {
+        boolean drainingHashesRequired =
+                ksm.getKeySharedMode() == KeySharedMode.AUTO_SPLIT && !ksm.isAllowOutOfOrderDelivery();
+        switch (ksm.getKeySharedMode()) {
         case AUTO_SPLIT:
             if (conf.isSubscriptionKeySharedUseConsistentHashing()) {
-                selector = new ConsistentHashingStickyKeyConsumerSelector(
+                return new ConsistentHashingStickyKeyConsumerSelector(
                         conf.getSubscriptionKeySharedConsistentHashingReplicaPoints(), drainingHashesRequired);
-            } else {
-                selector = new HashRangeAutoSplitStickyKeyConsumerSelector(drainingHashesRequired);
             }
-            break;
+            return new HashRangeAutoSplitStickyKeyConsumerSelector(drainingHashesRequired);
         case STICKY:
-            this.selector = new HashRangeExclusiveStickyKeyConsumerSelector();
-            break;
+            return new HashRangeExclusiveStickyKeyConsumerSelector();
         default:
-            throw new IllegalArgumentException("Invalid key-shared mode: " + keySharedMode);
+            throw new IllegalArgumentException("Invalid key-shared mode: " + ksm.getKeySharedMode());
         }
     }
 
@@ -143,36 +153,46 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             return CompletableFuture.completedFuture(null);
         }
         return super.addConsumer(consumer).thenCompose(__ -> selector.addConsumer(consumer))
-                .thenAccept(impactedConsumers -> {
+                .thenAccept(impactedConsumers ->
             // TODO: Add some way to prevent changes in between the time the consumer is added and the
             // time the draining hashes are applied. It might be fine for ConsistentHashingStickyKeyConsumerSelector
             // since it's not really asynchronous, although it returns a CompletableFuture
-            if (drainingHashesRequired) {
-                consumer.setPendingAcksAddHandler(this::handleAddingPendingAck);
-                consumer.setPendingAcksRemoveHandler(new PendingAcksMap.PendingAcksRemoveHandler() {
-                    @Override
-                    public void handleRemoving(Consumer consumer, long ledgerId, long entryId, int stickyKeyHash,
-                                               boolean closing) {
-                        drainingHashesTracker.reduceRefCount(consumer, stickyKeyHash, closing);
-                    }
-
-                    @Override
-                    public void startBatch() {
-                        drainingHashesTracker.startBatch();
-                    }
-
-                    @Override
-                    public void endBatch() {
-                        drainingHashesTracker.endBatch();
-                    }
-                });
-                consumer.setDrainingHashesConsumerStatsUpdater(drainingHashesTracker::updateConsumerStats);
-                registerDrainingHashes(consumer, impactedConsumers.orElseThrow());
-            }
-        }).exceptionally(ex -> {
+            handleConsumerAdded(consumer, impactedConsumers)
+        ).exceptionally(ex -> {
             internalRemoveConsumer(consumer);
             throw FutureUtil.wrapToCompletionException(ex);
         });
+    }
+
+    /**
+     * Hook invoked (under the dispatcher monitor) after a consumer was added to the selector, with
+     * the ranges the addition moved between consumers. The base wires the AUTO_SPLIT per-hash
+     * draining tracker; the PIP-486 entry-bucket subclass replaces this with per-bucket tracking.
+     */
+    protected synchronized void handleConsumerAdded(Consumer consumer,
+                                                    Optional<ImpactedConsumersResult> impactedConsumers) {
+        if (drainingHashesRequired) {
+            consumer.setPendingAcksAddHandler(this::handleAddingPendingAck);
+            consumer.setPendingAcksRemoveHandler(new PendingAcksMap.PendingAcksRemoveHandler() {
+                @Override
+                public void handleRemoving(Consumer consumer, long ledgerId, long entryId, int stickyKeyHash,
+                                           boolean closing) {
+                    drainingHashesTracker.reduceRefCount(consumer, stickyKeyHash, closing);
+                }
+
+                @Override
+                public void startBatch() {
+                    drainingHashesTracker.startBatch();
+                }
+
+                @Override
+                public void endBatch() {
+                    drainingHashesTracker.endBatch();
+                }
+            });
+            consumer.setDrainingHashesConsumerStatsUpdater(drainingHashesTracker::updateConsumerStats);
+            registerDrainingHashes(consumer, impactedConsumers.orElseThrow());
+        }
     }
 
     private synchronized void registerDrainingHashes(Consumer skipConsumer,
@@ -210,6 +230,16 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         // The consumer must be removed from the selector before calling the superclass removeConsumer method.
         Optional<ImpactedConsumersResult> impactedConsumers = selector.removeConsumer(consumer);
         super.removeConsumer(consumer);
+        handleConsumerRemoved(consumer, impactedConsumers);
+    }
+
+    /**
+     * Hook invoked (under the dispatcher monitor) after a consumer was removed from the selector,
+     * with the ranges the removal moved between the remaining consumers. See
+     * {@link #handleConsumerAdded}.
+     */
+    protected synchronized void handleConsumerRemoved(Consumer consumer,
+                                                      Optional<ImpactedConsumersResult> impactedConsumers) {
         if (drainingHashesRequired) {
             // register draining hashes for the impacted consumers and ranges, in case a hash switched from one
             // consumer to another. This will handle the case where a hash gets switched from an existing
@@ -552,13 +582,20 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         if (readType == ReadType.Normal && redeliveryMessages.containsStickyKeyHash(stickyKeyHash)) {
             return false;
         }
-        if (drainingHashesRequired) {
-            // If the hash is draining, do not send the message
-            if (drainingHashesTracker.shouldBlockStickyKeyHash(consumer, stickyKeyHash)) {
-                return false;
-            }
+        if (shouldBlockDispatch(consumer, stickyKeyHash)) {
+            return false;
         }
         return true;
+    }
+
+    /**
+     * Whether dispatching an entry with the given sticky key hash to the given consumer must be
+     * held back for an in-progress handoff. The base blocks per-hash while AUTO_SPLIT draining is
+     * active; the PIP-486 entry-bucket subclass blocks per moving bucket.
+     */
+    protected boolean shouldBlockDispatch(Consumer consumer, int stickyKeyHash) {
+        // If the hash is draining, do not send the message
+        return drainingHashesRequired && drainingHashesTracker.shouldBlockStickyKeyHash(consumer, stickyKeyHash);
     }
 
     /**
@@ -623,8 +660,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                 return false;
             }
 
-            if (drainingHashesRequired
-                    && drainingHashesTracker.shouldBlockStickyKeyHash(consumer, stickyKeyHash.intValue())) {
+            if (shouldBlockDispatch(consumer, stickyKeyHash.intValue())) {
                 // the hash is draining and the consumer is not the draining consumer
                 alreadyBlockedHashes.add(stickyKeyHash);
                 return false;
@@ -638,23 +674,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
     @Override
     protected int getStickyKeyHash(Entry entry) {
         if (entry instanceof EntryAndMetadata entryAndMetadata) {
-            // PIP-486: an entry-bucket subscription routes each whole entry by its producer-stamped
-            // entry-bucket hash range, so a batch holding one bucket's keys goes to the bucket's owner
-            // with no per-key hashing. The stamp shares the 16-bit key-hash space, so it feeds the
-            // selector directly. Cached as THE entry's sticky-key hash so pending acks, redelivery and
-            // draining all see the value dispatch used. Unstamped entries (non-batched messages) fall
-            // through to the message's sticky-key hash, which is the same low-16 Murmur value the
-            // producer would have stamped.
-            if (entryBucketDispatch) {
-                var metadata = entryAndMetadata.getMetadata();
-                if (metadata != null && metadata.hasEntryHashMin()) {
-                    return entryAndMetadata.getOrUpdateCachedStickyKeyHash(stickyKey -> {
-                        int bucketHash = metadata.getEntryHashMin();
-                        // 0 is reserved as "hash not set"; nudge to 1, which is still inside bucket 0.
-                        return bucketHash == STICKY_KEY_HASH_NOT_SET ? 1 : bucketHash;
-                    });
-                }
-            }
             // use the cached sticky key hash if available, otherwise calculate the sticky key hash and cache it
             return entryAndMetadata.getOrUpdateCachedStickyKeyHash(selector::makeStickyKeyHash);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -806,7 +806,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     public boolean hasSameKeySharedPolicy(KeySharedMeta ksm) {
         return (ksm.getKeySharedMode() == this.keySharedMode
-                && ksm.isAllowOutOfOrderDelivery() == this.allowOutOfOrderDelivery);
+                && ksm.isAllowOutOfOrderDelivery() == this.allowOutOfOrderDelivery
+                // PIP-486: entry-bucket subscriptions use PersistentEntryBucketDispatcherMultipleConsumers
+                && !ksm.isEntryBucketDispatch());
     }
 
     public Map<Consumer, List<Range>> getConsumerKeyHashRanges() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -641,8 +641,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
     }
 
     public boolean hasSameKeySharedPolicy(KeySharedMeta ksm) {
+        // PIP-486 entry-bucket subscriptions always use the modern dispatcher: never let an
+        // entryBucketDispatch consumer reuse a (possibly consumer-less) classic dispatcher.
         return (ksm.getKeySharedMode() == this.keySharedMode
-                && ksm.isAllowOutOfOrderDelivery() == this.allowOutOfOrderDelivery);
+                && ksm.isAllowOutOfOrderDelivery() == this.allowOutOfOrderDelivery
+                && !ksm.isEntryBucketDispatch());
     }
 
     public synchronized LinkedHashMap<Consumer, Position> getRecentlyJoinedConsumers() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -340,7 +340,12 @@ public class PersistentSubscription extends AbstractSubscription {
                         || !((StickyKeyDispatcher) dispatcher)
                         .hasSameKeySharedPolicy(ksm)) {
                     previousDispatcher = dispatcher;
-                    if (config.isSubscriptionKeySharedUseClassicPersistentImplementation()) {
+                    if (ksm.isEntryBucketDispatch()) {
+                        // PIP-486 scalable-topic segment shared by entry-bucket. Always uses the
+                        // modern implementation; the classic dispatcher has no bucket support.
+                        dispatcher = new PersistentEntryBucketDispatcherMultipleConsumers(topic, cursor,
+                                this, config, ksm);
+                    } else if (config.isSubscriptionKeySharedUseClassicPersistentImplementation()) {
                         dispatcher =
                                 new PersistentStickyKeyDispatcherMultipleConsumersClassic(topic, cursor,
                                         this, config, ksm);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/SubscriptionCoordinator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/SubscriptionCoordinator.java
@@ -626,17 +626,17 @@ public class SubscriptionCoordinator {
                     assignmentLists.get(consumer).add(new ConsumerAssignment.AssignedSegment(
                             segment.segmentId(), segment.hashRange(), segmentTopic.toString(), List.of()));
                 } else {
-                    List<HashRange> buckets = EntryBucketSplits.ranges(segment.entryBucketSplits());
-                    int base = buckets.size() / k;
-                    int extra = buckets.size() % k;
-                    int from = 0;
+                    // Shared segment: every attached consumer subscribes Key_Shared declaring the
+                    // segment's full (immutable) bucket boundary list — WHO owns WHICH bucket is
+                    // decided broker-side by the segment dispatcher's deterministic spread, and
+                    // bucket handoffs on membership changes drain broker-side too. The controller
+                    // only directs membership.
+                    List<HashRange> boundaries = EntryBucketSplits.ranges(segment.entryBucketSplits());
                     for (int c = 0; c < k; c++) {
-                        int size = base + (c < extra ? 1 : 0);
-                        List<HashRange> slice = List.copyOf(buckets.subList(from, from + size));
-                        from += size;
                         ConsumerSession consumer = sortedConsumers.get(consumerIndex++);
                         assignmentLists.get(consumer).add(new ConsumerAssignment.AssignedSegment(
-                                segment.segmentId(), segment.hashRange(), segmentTopic.toString(), slice));
+                                segment.segmentId(), segment.hashRange(), segmentTopic.toString(),
+                                boundaries));
                     }
                 }
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBucketConsumerSelectorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/EntryBucketConsumerSelectorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pulsar.client.api.Range;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class EntryBucketConsumerSelectorTest {
+
+    private static final List<Range> FOUR_BUCKETS = List.of(
+            Range.of(0x0000, 0x3FFF),
+            Range.of(0x4000, 0x7FFF),
+            Range.of(0x8000, 0xBFFF),
+            Range.of(0xC000, 0xFFFF));
+
+    private static Consumer mockConsumer(String name, long id) {
+        Consumer consumer = mock(Consumer.class);
+        when(consumer.consumerName()).thenReturn(name);
+        when(consumer.consumerId()).thenReturn(id);
+        return consumer;
+    }
+
+    @Test
+    public void testBucketIndexAndCanonicalHash() {
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        assertEquals(selector.bucketIndexOfHash(0x0000), 0);
+        assertEquals(selector.bucketIndexOfHash(0x3FFF), 0);
+        assertEquals(selector.bucketIndexOfHash(0x4000), 1);
+        assertEquals(selector.bucketIndexOfHash(0x7FFF), 1);
+        assertEquals(selector.bucketIndexOfHash(0x8000), 2);
+        assertEquals(selector.bucketIndexOfHash(0xC000), 3);
+        assertEquals(selector.bucketIndexOfHash(0xFFFF), 3);
+
+        // Bucket 0's canonical hash is nudged to 1 (0 is the reserved "not set" value).
+        assertEquals(selector.canonicalHashOfBucket(0), 1);
+        assertEquals(selector.canonicalHashOfBucket(1), 0x4000);
+        assertEquals(selector.canonicalHashOfBucket(2), 0x8000);
+        assertEquals(selector.canonicalHashOfBucket(3), 0xC000);
+
+        assertEquals(selector.canonicalHashOf(0x1234), 1);
+        assertEquals(selector.canonicalHashOf(0x4000), 0x4000);
+        assertEquals(selector.canonicalHashOf(0x7FFF), 0x4000);
+        assertEquals(selector.canonicalHashOf(0xFFFF), 0xC000);
+    }
+
+    @Test
+    public void testDeterministicSpreadIsAddOrderIndependent() {
+        Consumer a = mockConsumer("consumer-a", 1);
+        Consumer b = mockConsumer("consumer-b", 2);
+
+        EntryBucketConsumerSelector selector1 = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        selector1.addConsumer(a);
+        selector1.addConsumer(b);
+
+        EntryBucketConsumerSelector selector2 = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        selector2.addConsumer(b);
+        selector2.addConsumer(a);
+
+        // Sorted by name: "consumer-a" owns buckets 0-1, "consumer-b" owns buckets 2-3,
+        // regardless of connection order.
+        for (int bucket = 0; bucket < 4; bucket++) {
+            int hash = selector1.canonicalHashOfBucket(bucket);
+            Consumer expected = bucket < 2 ? a : b;
+            assertSame(selector1.select(hash), expected);
+            assertSame(selector2.select(hash), expected);
+        }
+    }
+
+    @Test
+    public void testSpreadWithMoreConsumersThanBuckets() {
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        for (int i = 0; i < 6; i++) {
+            selector.addConsumer(mockConsumer("consumer-" + i, i));
+        }
+        // Every bucket has exactly one owner; only 4 of the 6 consumers own a bucket.
+        Set<Consumer> owners = new HashSet<>();
+        for (int bucket = 0; bucket < 4; bucket++) {
+            Consumer owner = selector.select(selector.canonicalHashOfBucket(bucket));
+            assertNotNull(owner);
+            owners.add(owner);
+        }
+        assertEquals(owners.size(), 4);
+    }
+
+    @Test
+    public void testMakeStickyKeyHashNormalizesToCanonical() {
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        for (int i = 0; i < 100; i++) {
+            byte[] key = ("key-" + i).getBytes(StandardCharsets.UTF_8);
+            int rawHash = StickyKeyConsumerSelectorUtils.makeStickyKeyHash(key, selector.getKeyHashRange());
+            int hash = selector.makeStickyKeyHash(key);
+            assertEquals(hash, selector.canonicalHashOf(rawHash));
+            assertEquals(selector.bucketIndexOfHash(hash), selector.bucketIndexOfHash(rawHash));
+        }
+    }
+
+    @Test
+    public void testMembershipChangeReportsImpactedBuckets() {
+        Consumer a = mockConsumer("consumer-a", 1);
+        Consumer b = mockConsumer("consumer-b", 2);
+
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        selector.addConsumer(a).join();
+
+        // consumer-b joining takes buckets 2-3 away from consumer-a.
+        ImpactedConsumersResult impacted = selector.addConsumer(b).join().get();
+        Map<Consumer, UpdatedHashRanges> removed = new HashMap<>();
+        impacted.processUpdatedHashRanges((consumer, ranges, op) -> {
+            if (op == ImpactedConsumersResult.OperationType.REMOVE) {
+                removed.put(consumer, ranges);
+            }
+        });
+        assertEquals(removed.keySet(), Set.of(a));
+        UpdatedHashRanges lostByA = removed.get(a);
+        assertFalse(lostByA.containsStickyKey(selector.canonicalHashOfBucket(0)));
+        assertFalse(lostByA.containsStickyKey(selector.canonicalHashOfBucket(1)));
+        assertTrue(lostByA.containsStickyKey(selector.canonicalHashOfBucket(2)));
+        assertTrue(lostByA.containsStickyKey(selector.canonicalHashOfBucket(3)));
+
+        // consumer-b leaving hands buckets 2-3 back: the removal is attributed to consumer-b.
+        ImpactedConsumersResult afterLeave = selector.removeConsumer(b).get();
+        Map<Consumer, UpdatedHashRanges> removedOnLeave = new HashMap<>();
+        afterLeave.processUpdatedHashRanges((consumer, ranges, op) -> {
+            if (op == ImpactedConsumersResult.OperationType.REMOVE) {
+                removedOnLeave.put(consumer, ranges);
+            }
+        });
+        assertEquals(removedOnLeave.keySet(), Set.of(b));
+        for (int bucket = 0; bucket < 4; bucket++) {
+            assertSame(selector.select(selector.canonicalHashOfBucket(bucket)), a);
+        }
+    }
+
+    @Test
+    public void testSelectWithNoConsumers() {
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        assertNull(selector.select(1));
+
+        Consumer a = mockConsumer("consumer-a", 1);
+        selector.addConsumer(a).join();
+        selector.removeConsumer(a);
+        assertNull(selector.select(1));
+    }
+
+    @Test
+    public void testConsumerHashAssignmentsSnapshot() {
+        Consumer a = mockConsumer("consumer-a", 1);
+        Consumer b = mockConsumer("consumer-b", 2);
+        EntryBucketConsumerSelector selector = new EntryBucketConsumerSelector(FOUR_BUCKETS);
+        selector.addConsumer(a).join();
+        selector.addConsumer(b).join();
+
+        // Contiguous bucket slices are merged: a owns buckets 0-1, b owns buckets 2-3.
+        Map<Consumer, List<Range>> ranges = selector.getConsumerHashAssignmentsSnapshot().getRangesByConsumer();
+        assertEquals(ranges.get(a), List.of(Range.of(0x0000, 0x7FFF)));
+        assertEquals(ranges.get(b), List.of(Range.of(0x8000, 0xFFFF)));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentEntryBucketDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentEntryBucketDispatcherMultipleConsumersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.persistent;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import java.util.List;
+import org.apache.pulsar.client.api.Range;
+import org.apache.pulsar.common.api.proto.KeySharedMeta;
+import org.apache.pulsar.common.api.proto.KeySharedMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class PersistentEntryBucketDispatcherMultipleConsumersTest {
+
+    private static KeySharedMeta ksmWithRanges(int[][] ranges) {
+        KeySharedMeta ksm = new KeySharedMeta().setKeySharedMode(KeySharedMode.STICKY)
+                .setEntryBucketDispatch(true);
+        for (int[] range : ranges) {
+            ksm.addHashRange().setStart(range[0]).setEnd(range[1]);
+        }
+        return ksm;
+    }
+
+    @Test
+    public void testValidBoundaries() {
+        List<Range> ranges = PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                ksmWithRanges(new int[][]{{0x0000, 0x3FFF}, {0x4000, 0x7FFF}, {0x8000, 0xBFFF}, {0xC000, 0xFFFF}}));
+        assertEquals(ranges, List.of(
+                Range.of(0x0000, 0x3FFF),
+                Range.of(0x4000, 0x7FFF),
+                Range.of(0x8000, 0xBFFF),
+                Range.of(0xC000, 0xFFFF)));
+
+        // A single bucket spanning the whole ring is valid.
+        assertEquals(PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                ksmWithRanges(new int[][]{{0x0000, 0xFFFF}})), List.of(Range.of(0x0000, 0xFFFF)));
+    }
+
+    @Test
+    public void testInvalidBoundariesAreRejected() {
+        // No boundaries at all.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{})));
+        // Not starting at 0.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0001, 0xFFFF}})));
+        // Gap between buckets.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0000, 0x3FFF}, {0x5000, 0xFFFF}})));
+        // Overlapping buckets.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0000, 0x7FFF}, {0x4000, 0xFFFF}})));
+        // End before start.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0000, 0x3FFF}, {0x4000, 0x2000}})));
+        // Not tiling the whole 16-bit ring.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0000, 0x3FFF}, {0x4000, 0x7FFF}})));
+        // Bucket 0 too narrow to hold the canonical hash 1.
+        assertThrows(IllegalArgumentException.class, () ->
+                PersistentEntryBucketDispatcherMultipleConsumers.validateBucketBoundaries(
+                        ksmWithRanges(new int[][]{{0x0000, 0x0000}, {0x0001, 0xFFFF}})));
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassicTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import io.netty.buffer.ByteBuf;
@@ -210,6 +211,17 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassicTest {
             orderedExecutor.shutdownNow();
             orderedExecutor = null;
         }
+    }
+
+    @Test
+    public void testEntryBucketDispatchNeverMatchesClassicPolicy() {
+        // PIP-486: an entry-bucket consumer must never reuse a (possibly consumer-less) classic
+        // dispatcher — bucket dispatch exists only in the modern implementation.
+        KeySharedMeta plain = new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT);
+        assertTrue(persistentDispatcher.hasSameKeySharedPolicy(plain));
+        KeySharedMeta bucketed = new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT)
+                .setEntryBucketDispatch(true);
+        assertFalse(persistentDispatcher.hasSameKeySharedPolicy(bucketed));
     }
 
     @Test(timeOut = 10000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -850,29 +850,34 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
 
     @Test
     public void testEntryBucketDispatchRoutesByStampedRange() {
-        // PIP-486: with entryBucketDispatch set on the subscription's KeySharedMeta, a stamped entry
-        // routes as a whole by its entry-bucket hash (entry_hash_min), not by the message key.
-        PersistentStickyKeyDispatcherMultipleConsumers bucketDispatcher =
-                new PersistentStickyKeyDispatcherMultipleConsumers(topicMock, cursorMock, subscriptionMock,
-                        configMock, new KeySharedMeta().setKeySharedMode(KeySharedMode.STICKY)
-                                .setEntryBucketDispatch(true));
+        // PIP-486: the entry-bucket dispatcher routes a stamped entry as a whole by its entry-bucket
+        // (entry_hash_min normalized to the bucket's canonical hash), not by the message key.
+        KeySharedMeta ksm = new KeySharedMeta().setKeySharedMode(KeySharedMode.STICKY)
+                .setEntryBucketDispatch(true);
+        ksm.addHashRange().setStart(0x0000).setEnd(0x3FFF);
+        ksm.addHashRange().setStart(0x4000).setEnd(0x7FFF);
+        ksm.addHashRange().setStart(0x8000).setEnd(0xBFFF);
+        ksm.addHashRange().setStart(0xC000).setEnd(0xFFFF);
+        PersistentEntryBucketDispatcherMultipleConsumers bucketDispatcher =
+                new PersistentEntryBucketDispatcherMultipleConsumers(topicMock, cursorMock, subscriptionMock,
+                        configMock, ksm);
         EntryImpl entry = createEntry(1, 1, "msg", 1, "some-key");
         try {
             MessageMetadata stamped = new MessageMetadata()
                     .setProducerName("p").setSequenceId(1).setPublishTime(1)
-                    .setEntryHashMin(0x1234).setEntryHashMax(0x5678);
+                    .setEntryHashMin(0x4567).setEntryHashMax(0x4FFF);
             assertEquals(bucketDispatcher.getStickyKeyHash(
-                    EntryAndMetadata.create(entry, stamped)), 0x1234);
+                    EntryAndMetadata.create(entry, stamped)), 0x4000);
 
-            // entry_hash_min == 0 collides with the reserved "hash not set" sentinel, so it is nudged
-            // to 1, which is still inside bucket 0.
+            // Bucket 0's canonical hash is nudged to 1 (0 is the reserved "hash not set" sentinel).
             MessageMetadata zero = new MessageMetadata()
                     .setProducerName("p").setSequenceId(1).setPublishTime(1)
-                    .setEntryHashMin(0).setEntryHashMax(0);
+                    .setEntryHashMin(0).setEntryHashMax(0x3FFF);
             assertEquals(bucketDispatcher.getStickyKeyHash(
                     EntryAndMetadata.create(entry, zero)), 1);
 
-            // Unstamped entries (non-batched messages) fall back to the message's sticky-key hash.
+            // Unstamped entries (non-batched messages) fall back to the message key's hash,
+            // normalized to the same canonical bucket value.
             MessageMetadata unstamped = new MessageMetadata()
                     .setProducerName("p").setSequenceId(1).setPublishTime(1).setPartitionKey("some-key");
             assertEquals(bucketDispatcher.getStickyKeyHash(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/SubscriptionCoordinatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/scalable/SubscriptionCoordinatorTest.java
@@ -27,8 +27,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -461,32 +459,30 @@ public class SubscriptionCoordinatorTest {
 
     @Test
     public void testSurplusConsumersFanOutBucketedSegment() throws Exception {
-        // One segment with N=4 entry-buckets, two consumers: the surplus consumer fans the segment
-        // out — each owner takes a contiguous half of the buckets, disjoint and tiling the ring.
+        // One segment with N=4 entry-buckets, two consumers: the surplus consumer shares the
+        // segment. Every sharer carries the segment's FULL bucket boundary list (identical for
+        // all) — which buckets each consumer owns is decided broker-side by the segment
+        // dispatcher, and handoffs drain broker-side.
         SubscriptionCoordinator c = bucketedCoordinator();
         c.registerConsumer("consumer-1", 1L, mock(TransportCnx.class)).get();
         Map<ConsumerSession, ConsumerAssignment> result =
                 c.registerConsumer("consumer-2", 2L, mock(TransportCnx.class)).get();
 
         assertEquals(result.size(), 2);
-        List<HashRange> owned = new ArrayList<>();
         for (ConsumerAssignment assignment : result.values()) {
             assertEquals(assignment.assignedSegments().size(), 1);
             ConsumerAssignment.AssignedSegment seg = assignment.assignedSegments().get(0);
             assertEquals(seg.segmentId(), 0);
-            assertEquals(seg.bucketRanges().size(), 2);
-            owned.addAll(seg.bucketRanges());
-        }
-        owned.sort(Comparator.comparingInt(HashRange::start));
-        assertEquals(owned, List.of(
+            assertEquals(seg.bucketRanges(), List.of(
                 HashRange.of(0x0000, 0x3FFF), HashRange.of(0x4000, 0x7FFF),
                 HashRange.of(0x8000, 0xBFFF), HashRange.of(0xC000, 0xFFFF)));
+        }
     }
 
     @Test
     public void testFanOutCapsAtBucketCountAndLeavesRestIdle() throws Exception {
-        // One segment with N=4 entry-buckets, five consumers: four owners with one bucket each; the
-        // fifth consumer exceeds the topic's bucket capacity and stays idle (empty assignment).
+        // One segment with N=4 entry-buckets, five consumers: four sharers (each carrying the full
+        // boundary list); the fifth exceeds the segment's bucket capacity and stays idle.
         SubscriptionCoordinator c = bucketedCoordinator();
         for (int i = 1; i <= 4; i++) {
             c.registerConsumer("consumer-" + i, i, mock(TransportCnx.class)).get();
@@ -495,19 +491,20 @@ public class SubscriptionCoordinatorTest {
                 c.registerConsumer("consumer-5", 5L, mock(TransportCnx.class)).get();
 
         assertEquals(result.size(), 5);
-        List<HashRange> owned = new ArrayList<>();
         int idle = 0;
+        int sharers = 0;
         for (ConsumerAssignment assignment : result.values()) {
             if (assignment.assignedSegments().isEmpty()) {
                 idle++;
                 continue;
             }
-            ConsumerAssignment.AssignedSegment seg = assignment.assignedSegments().get(0);
-            assertEquals(seg.bucketRanges().size(), 1);
-            owned.addAll(seg.bucketRanges());
+            sharers++;
+            assertEquals(assignment.assignedSegments().get(0).bucketRanges(), List.of(
+                HashRange.of(0x0000, 0x3FFF), HashRange.of(0x4000, 0x7FFF),
+                HashRange.of(0x8000, 0xBFFF), HashRange.of(0xC000, 0xFFFF)));
         }
         assertEquals(idle, 1);
-        assertEquals(owned.size(), 4);
+        assertEquals(sharers, 4);
     }
 
     private SubscriptionCoordinator bucketedCoordinator() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
@@ -180,22 +180,98 @@ public class V5EntryBucketDispatchTest extends V5ClientBaseTest {
         assertNull(c.receive(Duration.ofSeconds(3)), "acked messages were redelivered");
     }
 
-    /** Drains until idle, recording values per key in arrival order, then acks cumulatively. */
+    @Test
+    public void testConsumerJoiningMidTrafficPreservesPerKeyOrder() throws Exception {
+        String topic = newScalableTopic(1);
+        // Pin the layout so the second consumer is served by entry-bucket fan-out (see above).
+        admin.scalableTopics().setAutoScalePolicy(topic,
+                AutoScalePolicyOverride.builder().enabled(false).build());
+        String subscription = "bucket-handoff";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        @Cleanup
+        StreamConsumer<String> a = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        // Continuous keyed traffic; consumer B joins mid-stream, forcing a live two-phase handoff:
+        // A pauses, drains what it already handed to the application, shrinks from the whole
+        // segment to half the buckets and confirms; only then is B granted the other half.
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < 16; i++) {
+            keys.add("key-" + i);
+        }
+        int perKey = 40;
+        Map<String, List<String>> sent = new HashMap<>();
+        for (String k : keys) {
+            sent.put(k, new ArrayList<>());
+        }
+
+        Map<String, List<String>> aGot = new ConcurrentHashMap<>();
+        Map<String, List<String>> bGot = new ConcurrentHashMap<>();
+        Thread ta = drainOrdered(a, aGot);
+
+        StreamConsumer<String> b = null;
+        try {
+            for (int i = 0; i < perKey; i++) {
+                if (i == perKey / 3) {
+                    // Mid-traffic join: triggers the handoff while messages flow.
+                    b = v5Client.newStreamConsumer(Schema.string())
+                            .topic(topic)
+                            .subscriptionName(subscription)
+                            .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                            .subscribe();
+                }
+                for (String k : keys) {
+                    String value = k + "-" + i;
+                    producer.newMessage().key(k).value(value).send();
+                    sent.get(k).add(value);
+                }
+            }
+
+            Thread tb = drainOrdered(b, bGot);
+            ta.join();
+            tb.join();
+
+            assertFalse(aGot.isEmpty(), "consumer A received nothing");
+            assertFalse(bGot.isEmpty(), "consumer B received nothing — the handoff did not happen");
+
+            // The handoff contract: for every key, what A processed followed by what B processed
+            // is exactly the sent sequence — no loss, no duplicates (a clean drain leaves nothing
+            // to redeliver), and never a message on B before A finished everything older.
+            for (String k : keys) {
+                List<String> combined = new ArrayList<>(aGot.getOrDefault(k, List.of()));
+                combined.addAll(bGot.getOrDefault(k, List.of()));
+                assertEquals(combined, sent.get(k), "per-key order across the handoff for key=" + k);
+            }
+        } finally {
+            if (b != null) {
+                b.close();
+            }
+        }
+    }
+
+    /**
+     * Drains until idle, recording values per key in arrival order. Acks every message as it is
+     * processed — like an order-sensitive application would — so a release drain during a handoff
+     * can complete promptly.
+     */
     private Thread drainOrdered(StreamConsumer<String> consumer, Map<String, List<String>> into) {
         Thread t = new Thread(() -> {
             try {
-                MessageId last = null;
                 while (true) {
                     Message<String> msg = consumer.receive(Duration.ofSeconds(2));
                     if (msg == null) {
-                        if (last != null) {
-                            consumer.acknowledgeCumulative(last);
-                        }
                         return;
                     }
                     String key = msg.key().orElseThrow(() -> new AssertionError("missing key"));
                     into.computeIfAbsent(key, __ -> new ArrayList<>()).add(msg.value());
-                    last = msg.id();
+                    consumer.acknowledgeCumulative(msg.id());
                 }
             } catch (Exception ignored) {
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
@@ -28,7 +28,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.v5.schema.Schema;
@@ -256,16 +258,199 @@ public class V5EntryBucketDispatchTest extends V5ClientBaseTest {
         }
     }
 
+    @Test
+    public void testSegmentReleaseWithPendingAcksHandsOffCleanly() throws Exception {
+        // The release (drop) path: a consumer loses a whole segment in a rebalance while the
+        // application still holds delivered-but-unacked messages. The release must wait for those
+        // acks — and the acks, arriving while the segment is already vacated from the consumer's
+        // active set, must still reach the draining consumer, or the release never completes and the
+        // new owner never gets the segment.
+        String topic = newScalableTopic(2);
+        admin.scalableTopics().setAutoScalePolicy(topic,
+                AutoScalePolicyOverride.builder().enabled(false).build());
+        String subscription = "segment-release";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        @Cleanup
+        StreamConsumer<String> a = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        // Phase 1: A owns both segments; deliver keyed traffic and hold every ack.
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < 16; i++) {
+            keys.add("key-" + i);
+        }
+        int perKey = 10;
+        Map<String, List<String>> sent = new HashMap<>();
+        for (String k : keys) {
+            sent.put(k, new ArrayList<>());
+        }
+        for (int i = 0; i < perKey; i++) {
+            for (String k : keys) {
+                String value = k + "-" + i;
+                producer.newMessage().key(k).value(value).send();
+                sent.get(k).add(value);
+            }
+        }
+        Map<String, List<String>> aGot = new ConcurrentHashMap<>();
+        Message<String> last = null;
+        for (int i = 0; i < keys.size() * perKey; i++) {
+            Message<String> msg = a.receive(Duration.ofSeconds(5));
+            assertNotNull(msg, "missed message #" + i + " in phase 1");
+            String key = msg.key().orElseThrow(() -> new AssertionError("missing key"));
+            aGot.computeIfAbsent(key, __ -> new ArrayList<>()).add(msg.value());
+            last = msg;
+        }
+
+        // B joins: the controller rebalances to one segment each, so A must release one whole
+        // segment — but it cannot until the application acks what it already received. Subscribe
+        // asynchronously: B's attach only completes once A releases, which needs the ack below.
+        CompletableFuture<StreamConsumer<String>> bFuture = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribeAsync();
+        // Let the assignment update land and the release drain start waiting, so the ack below
+        // genuinely arrives mid-drain.
+        Thread.sleep(1500);
+        a.acknowledgeCumulative(last.id());
+        // Bounded: if the release/flip wedges, fail here instead of hanging the suite.
+        @Cleanup
+        StreamConsumer<String> b = bFuture.get(30, TimeUnit.SECONDS);
+
+        // Phase 2: more traffic; the moved segment's share must now flow to B.
+        for (int i = perKey; i < perKey * 2; i++) {
+            for (String k : keys) {
+                String value = k + "-" + i;
+                producer.newMessage().key(k).value(value).send();
+                sent.get(k).add(value);
+            }
+        }
+        Map<String, List<String>> bGot = new ConcurrentHashMap<>();
+        Thread ta = drainOrdered(a, aGot, Duration.ofSeconds(5));
+        Thread tb = drainOrdered(b, bGot, Duration.ofSeconds(5));
+        ta.join();
+        tb.join();
+
+        assertFalse(bGot.isEmpty(), "consumer B received nothing — the segment was never released");
+        // Phase 1 was fully acked before the release completed, so nothing is redelivered: for every
+        // key, A's deliveries followed by B's are exactly the sent sequence.
+        for (String k : keys) {
+            List<String> combined = new ArrayList<>(aGot.getOrDefault(k, List.of()));
+            combined.addAll(bGot.getOrDefault(k, List.of()));
+            assertEquals(combined, sent.get(k), "per-key order across the release for key=" + k);
+        }
+    }
+
+    @Test
+    public void testConsumerJoiningWithSlowAcksPreservesPerKeyOrder() throws Exception {
+        // The mode-flip path with a non-empty drain window: when B joins, A flips the segment from
+        // Exclusive to Key_Shared. Acks issued while the flip's drain is waiting must reach the old
+        // consumer being drained — routed anywhere else they are lost (a cumulative ack is invalid on
+        // the new Key_Shared consumer), the broker redelivers, and keys see duplicates.
+        String topic = newScalableTopic(1);
+        admin.scalableTopics().setAutoScalePolicy(topic,
+                AutoScalePolicyOverride.builder().enabled(false).build());
+        String subscription = "slow-ack-join";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        @Cleanup
+        StreamConsumer<String> a = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        // Phase 1: deliver to A and hold every ack.
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < 16; i++) {
+            keys.add("key-" + i);
+        }
+        int perKey = 5;
+        Map<String, List<String>> sent = new HashMap<>();
+        for (String k : keys) {
+            sent.put(k, new ArrayList<>());
+        }
+        for (int i = 0; i < perKey; i++) {
+            for (String k : keys) {
+                String value = k + "-" + i;
+                producer.newMessage().key(k).value(value).send();
+                sent.get(k).add(value);
+            }
+        }
+        Map<String, List<String>> aGot = new ConcurrentHashMap<>();
+        Message<String> last = null;
+        for (int i = 0; i < keys.size() * perKey; i++) {
+            Message<String> msg = a.receive(Duration.ofSeconds(5));
+            assertNotNull(msg, "missed message #" + i + " in phase 1");
+            String key = msg.key().orElseThrow(() -> new AssertionError("missing key"));
+            aGot.computeIfAbsent(key, __ -> new ArrayList<>()).add(msg.value());
+            last = msg;
+        }
+
+        // B joins → A must flip the segment to Key_Shared, which drains first. Subscribe
+        // asynchronously (B's attach completes only after A's flip) and ack mid-drain.
+        CompletableFuture<StreamConsumer<String>> bFuture = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribeAsync();
+        Thread.sleep(1500);
+        a.acknowledgeCumulative(last.id());
+        // Bounded: if the release/flip wedges, fail here instead of hanging the suite.
+        @Cleanup
+        StreamConsumer<String> b = bFuture.get(30, TimeUnit.SECONDS);
+
+        // Phase 2: post-flip traffic, spread across both owners by bucket.
+        for (int i = perKey; i < perKey * 2; i++) {
+            for (String k : keys) {
+                String value = k + "-" + i;
+                producer.newMessage().key(k).value(value).send();
+                sent.get(k).add(value);
+            }
+        }
+        Map<String, List<String>> bGot = new ConcurrentHashMap<>();
+        Thread ta = drainOrdered(a, aGot, Duration.ofSeconds(5));
+        Thread tb = drainOrdered(b, bGot, Duration.ofSeconds(5));
+        ta.join();
+        tb.join();
+
+        assertFalse(bGot.isEmpty(), "consumer B received nothing — the handoff did not happen");
+        // The mid-drain ack reached the draining consumer, so phase 1 is acked on the broker and
+        // never redelivered: A's deliveries followed by B's are exactly the sent sequence — no
+        // duplicates, no loss, per key.
+        for (String k : keys) {
+            List<String> combined = new ArrayList<>(aGot.getOrDefault(k, List.of()));
+            combined.addAll(bGot.getOrDefault(k, List.of()));
+            assertEquals(combined, sent.get(k), "per-key order across the slow-ack flip for key=" + k);
+        }
+    }
+
     /**
      * Drains until idle, recording values per key in arrival order. Acks every message as it is
      * processed — like an order-sensitive application would — so a release drain during a handoff
      * can complete promptly.
      */
     private Thread drainOrdered(StreamConsumer<String> consumer, Map<String, List<String>> into) {
+        return drainOrdered(consumer, into, Duration.ofSeconds(2));
+    }
+
+    /** Variant with a configurable idle timeout, for tests whose handoff takes a few seconds. */
+    private Thread drainOrdered(StreamConsumer<String> consumer, Map<String, List<String>> into,
+                                Duration idleTimeout) {
         Thread t = new Thread(() -> {
             try {
                 while (true) {
-                    Message<String> msg = consumer.receive(Duration.ofSeconds(2));
+                    Message<String> msg = consumer.receive(idleTimeout);
                     if (msg == null) {
                         return;
                     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/v5/V5EntryBucketDispatchTest.java
@@ -34,7 +34,9 @@ import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.client.api.v5.config.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.v5.schema.Schema;
+import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.policies.data.AutoScalePolicyOverride;
+import org.awaitility.Awaitility;
 import org.testng.annotations.Test;
 
 /**
@@ -432,6 +434,152 @@ public class V5EntryBucketDispatchTest extends V5ClientBaseTest {
             List<String> combined = new ArrayList<>(aGot.getOrDefault(k, List.of()));
             combined.addAll(bGot.getOrDefault(k, List.of()));
             assertEquals(combined, sent.get(k), "per-key order across the slow-ack flip for key=" + k);
+        }
+    }
+
+    @Test
+    public void testConsumerRejoiningAfterLeaveDoesNotWedgeRelease() throws Exception {
+        // Second flip cycle: Exclusive (cumulative ack) → shared (individual acks) → Exclusive →
+        // shared again. The release state of the earlier modes (cumulative high-water, delivered
+        // watermark) must not leak into the last flip's drain: with everything acked and nothing
+        // outstanding, a stale delivered-vs-acked pair would make the drain wait forever and the
+        // rejoining consumer could never attach.
+        // A consumer's clean close is a disconnect to the controller, which holds its session for
+        // the grace period before rebalancing. Shrink it (read at coordinator creation, i.e. on
+        // this subscription's first register) so B1's departure hands the segment back promptly.
+        int defaultGrace = getPulsar().getConfiguration()
+                .getScalableTopicConsumerSessionGracePeriodSeconds();
+        getPulsar().getConfiguration().setScalableTopicConsumerSessionGracePeriodSeconds(1);
+        try {
+            runRejoinAfterLeaveScenario();
+        } finally {
+            getPulsar().getConfiguration()
+                    .setScalableTopicConsumerSessionGracePeriodSeconds(defaultGrace);
+        }
+    }
+
+    private void runRejoinAfterLeaveScenario() throws Exception {
+        String topic = newScalableTopic(1);
+        admin.scalableTopics().setAutoScalePolicy(topic,
+                AutoScalePolicyOverride.builder().enabled(false).build());
+        String subscription = "rejoin-release";
+
+        @Cleanup
+        Producer<String> producer = v5Client.newProducer(Schema.string())
+                .topic(topic)
+                .create();
+        @Cleanup
+        StreamConsumer<String> a = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribe();
+
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < 16; i++) {
+            keys.add("key-" + i);
+        }
+        int perKey = 5;
+        Map<String, List<String>> sent = new HashMap<>();
+        for (String k : keys) {
+            sent.put(k, new ArrayList<>());
+        }
+
+        // Phase 1 — A alone (Exclusive): receive everything, ack cumulatively.
+        sendPhase(producer, keys, sent, 0, perKey);
+        Map<String, List<String>> aGot = new ConcurrentHashMap<>();
+        Message<String> last = null;
+        for (int i = 0; i < keys.size() * perKey; i++) {
+            Message<String> msg = a.receive(Duration.ofSeconds(5));
+            assertNotNull(msg, "missed message #" + i + " in phase 1");
+            aGot.computeIfAbsent(msg.key().orElseThrow(), __ -> new ArrayList<>()).add(msg.value());
+            last = msg;
+        }
+        a.acknowledgeCumulative(last.id());
+
+        // Phase 2 — B1 joins (shared, individual acks), both drain, then B1 leaves. B1 gets its
+        // own client: a departure is only visible to the controller as a connection drop, so
+        // leaving means closing the whole client (the shared client's pooled connection would
+        // keep B1's registration alive indefinitely).
+        PulsarClient b1Client = newV5Client();
+        StreamConsumer<String> b1 = b1Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribeAsync().get(30, TimeUnit.SECONDS);
+        sendPhase(producer, keys, sent, perKey, perKey * 2);
+        Map<String, List<String>> b1Got = new ConcurrentHashMap<>();
+        Thread ta1 = drainOrdered(a, aGot);
+        Thread tb1 = drainOrdered(b1, b1Got);
+        ta1.join();
+        tb1.join();
+        assertFalse(b1Got.isEmpty(), "consumer B1 received nothing — the segment did not fan out");
+        b1.close();
+        b1Client.close();
+        // Wait until the controller has handed the whole segment back to A and A completed the
+        // flip back to Exclusive — the stale-watermark state only matters once that is done.
+        String segmentTopic = admin.scalableTopics().getStats(topic)
+                .getSegments().values().iterator().next().name();
+        Awaitility.await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            var sub = getTopicReference(segmentTopic).orElseThrow().getSubscription(subscription);
+            assertNotNull(sub, "segment subscription missing");
+            assertEquals(sub.getType(), CommandSubscribe.SubType.Exclusive);
+            assertEquals(sub.getConsumers().size(), 1);
+        });
+
+        // Phase 3 — B2 rejoins. Nothing is unacked anywhere: the flip's drain must complete and
+        // B2 must attach (a stale watermark from phases 1-2 would wedge it here forever).
+        CompletableFuture<StreamConsumer<String>> b2Future = v5Client.newStreamConsumer(Schema.string())
+                .topic(topic)
+                .subscriptionName(subscription)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.EARLIEST)
+                .subscribeAsync();
+        @Cleanup
+        StreamConsumer<String> b2 = b2Future.get(30, TimeUnit.SECONDS);
+        sendPhase(producer, keys, sent, perKey * 2, perKey * 3);
+        Map<String, List<String>> b2Got = new ConcurrentHashMap<>();
+        Thread ta2 = drainOrdered(a, aGot, Duration.ofSeconds(5));
+        Thread tb2 = drainOrdered(b2, b2Got, Duration.ofSeconds(5));
+        ta2.join();
+        tb2.join();
+        assertFalse(b2Got.isEmpty(), "consumer B2 received nothing after rejoining");
+
+        // Ownership of a key may differ between the two shared phases, so no single concatenation
+        // order holds. The invariants that must: each consumer saw its share of every key in send
+        // order, and the union across consumers is exactly the sent set — no loss, no duplicates.
+        for (String k : keys) {
+            List<String> expected = sent.get(k);
+            int union = 0;
+            for (Map<String, List<String>> got : List.of(aGot, b1Got, b2Got)) {
+                List<String> values = got.getOrDefault(k, List.of());
+                assertOrderedSubsequence(values, expected, k);
+                union += values.size();
+            }
+            assertEquals(union, expected.size(), "loss or duplicates across handoffs for key=" + k);
+        }
+    }
+
+    private void sendPhase(Producer<String> producer, List<String> keys,
+                           Map<String, List<String>> sent, int from, int to) throws Exception {
+        for (int i = from; i < to; i++) {
+            for (String k : keys) {
+                String value = k + "-" + i;
+                producer.newMessage().key(k).value(value).send();
+                sent.get(k).add(value);
+            }
+        }
+    }
+
+    /** Asserts {@code values} appear in {@code expected}'s order (an ordered subsequence). */
+    private static void assertOrderedSubsequence(List<String> values, List<String> expected, String key) {
+        int i = 0;
+        for (String value : values) {
+            while (i < expected.size() && !expected.get(i).equals(value)) {
+                i++;
+            }
+            assertTrue(i < expected.size(),
+                    "value " + value + " out of order (or duplicated) for key=" + key + ": " + values);
+            i++;
         }
     }
 

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -123,6 +124,15 @@ final class ScalableStreamConsumer<T>
      * already handed to the application can drain before the segment consumer is closed.
      */
     private final Set<Long> pausedSegments = ConcurrentHashMap.newKeySet();
+
+    /**
+     * PIP-486: segment consumers currently draining for a release. A drain completes only when the
+     * application acks what it was handed, so the ack path must keep reaching the old consumer after
+     * its {@link #segmentConsumers} slot is vacated (or repopulated with the re-subscribe chain on a
+     * mode flip) — {@link #ackSegmentUpTo} consults this map first.
+     */
+    private final ConcurrentHashMap<Long, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>>>
+            drainingConsumers = new ConcurrentHashMap<>();
 
     /** Latest controller assignment; {@link #reconcile()} converges the segment consumers onto it. */
     private volatile List<ActiveSegment> latestAssignment;
@@ -288,7 +298,11 @@ final class ScalableStreamConsumer<T>
      */
     private void ackSegmentUpTo(long segmentId, org.apache.pulsar.client.api.MessageId position,
                                 org.apache.pulsar.client.api.transaction.Transaction v4Txn) {
-        var future = segmentConsumers.get(segmentId);
+        // A draining consumer takes precedence: during a release the segment's slot in
+        // segmentConsumers is vacated (or already holds the re-subscribe chain), but the acks that
+        // complete the drain must still reach the consumer being drained.
+        var draining = drainingConsumers.get(segmentId);
+        var future = draining != null ? draining : segmentConsumers.get(segmentId);
         if (future == null) {
             return;
         }
@@ -366,16 +380,19 @@ final class ScalableStreamConsumer<T>
         receiveQueue.close();
         session.close();
 
+        // Draining consumers live outside segmentConsumers; their drain loops observe the closed
+        // flag and finish on their own, but they are closed here too (idempotent) so this future
+        // does not complete before they are gone.
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (var future : segmentConsumers.values()) {
-            futures.add(future
-                    .handle((consumer, ex) -> consumer)
-                    .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
-                            : CompletableFuture.completedFuture(null)));
-        }
+        Stream.concat(segmentConsumers.values().stream(), drainingConsumers.values().stream())
+                .forEach(future -> futures.add(future
+                        .handle((consumer, ex) -> consumer)
+                        .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
+                                : CompletableFuture.completedFuture(null))));
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
                 .whenComplete((__, ___) -> {
                     segmentConsumers.clear();
+                    drainingConsumers.clear();
                     sharedSegmentUnacked.clear();
                     lastCumulativeAcked.clear();
                 });
@@ -502,7 +519,6 @@ final class ScalableStreamConsumer<T>
                 var existing = entry.getValue();
                 log.info().attr("segmentId", segmentId)
                         .log("Releasing segment removed from assignment");
-                segmentConsumers.remove(segmentId, existing);
                 segmentBucketRanges.remove(segmentId);
                 futures.add(drainAndClose(segmentId, existing)
                         .whenComplete((__, ___) -> {
@@ -523,13 +539,14 @@ final class ScalableStreamConsumer<T>
                     && !seg.ownedBucketRanges().equals(segmentBucketRanges.get(seg.segmentId()))) {
                 log.info().attr("segmentId", seg.segmentId())
                         .log("Re-subscribing segment for changed entry-bucket ownership");
-                segmentConsumers.remove(seg.segmentId(), existing);
+                // Drain what the application already holds, then await our own close before
+                // re-subscribing with the new mode: the subscription type cannot change while the
+                // old consumer is still attached. The drain must start outside computeIfAbsent —
+                // it vacates this segment's slot itself, and ConcurrentHashMap forbids mutating
+                // the map from within the mapping function.
+                var drained = drainAndClose(seg.segmentId(), existing);
                 futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(), id ->
-                        // Drain what the application already holds, then await our own close before
-                        // re-subscribing with the new mode: the subscription type cannot change
-                        // while the old consumer is still attached.
-                        drainAndClose(seg.segmentId(), existing)
-                                .thenCompose(__ -> createSegmentConsumerAsync(seg))));
+                        drained.thenCompose(__ -> createSegmentConsumerAsync(seg))));
             } else {
                 futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(),
                         id -> createSegmentConsumerAsync(seg)));
@@ -551,11 +568,19 @@ final class ScalableStreamConsumer<T>
      */
     private CompletableFuture<Void> drainAndClose(
             long segmentId, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> existing) {
+        // Register as draining before vacating the segmentConsumers slot, so at every instant the
+        // ack path resolves to the consumer being drained — the drain only completes through those
+        // acks. The slot removal lives here (not at the call sites) to keep that ordering.
+        drainingConsumers.put(segmentId, existing);
+        segmentConsumers.remove(segmentId, existing);
         pausedSegments.add(segmentId);
         return awaitReleaseDrained(segmentId, 0)
                 .thenCompose(__ -> existing.handle((c, ex) -> c))
                 .thenCompose(c -> c != null ? c.closeAsync() : CompletableFuture.completedFuture(null))
-                .whenComplete((__, ___) -> pausedSegments.remove(segmentId));
+                .whenComplete((__, ___) -> {
+                    drainingConsumers.remove(segmentId, existing);
+                    pausedSegments.remove(segmentId);
+                });
     }
 
     /** Poll until the segment's delivered messages are all acked (or this consumer closes). */

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -109,6 +110,19 @@ final class ScalableStreamConsumer<T>
      */
     private final ConcurrentHashMap<Long, ConcurrentLinkedQueue<org.apache.pulsar.client.api.MessageId>>
             sharedSegmentUnacked = new ConcurrentHashMap<>();
+
+    /**
+     * PIP-486: per whole-segment (Exclusive) consumer, the highest position the application has
+     * cumulatively acked — the release drain barrier for segments without individual-ack tracking.
+     */
+    private final ConcurrentHashMap<Long, org.apache.pulsar.client.api.MessageId> lastCumulativeAcked =
+            new ConcurrentHashMap<>();
+
+    /**
+     * PIP-486: segments paused for a release — their receive loops stop re-arming so what was
+     * already handed to the application can drain before the segment consumer is closed.
+     */
+    private final Set<Long> pausedSegments = ConcurrentHashMap.newKeySet();
 
     /** Latest controller assignment; {@link #reconcile()} converges the segment consumers onto it. */
     private volatile List<ActiveSegment> latestAssignment;
@@ -280,6 +294,8 @@ final class ScalableStreamConsumer<T>
         }
         var unacked = sharedSegmentUnacked.get(segmentId);
         if (unacked == null) {
+            lastCumulativeAcked.merge(segmentId, position,
+                    (a, b) -> a.compareTo(b) >= 0 ? a : b);
             future.thenAccept(c -> {
                 if (v4Txn == null) {
                     c.acknowledgeCumulativeAsync(position);
@@ -361,6 +377,7 @@ final class ScalableStreamConsumer<T>
                 .whenComplete((__, ___) -> {
                     segmentConsumers.clear();
                     sharedSegmentUnacked.clear();
+                    lastCumulativeAcked.clear();
                 });
     }
 
@@ -478,20 +495,25 @@ final class ScalableStreamConsumer<T>
         // consumer): close our v4 consumer so the Exclusive lock is released and
         // the new owner can attach. Sealed-and-drained segments take a different
         // path: the receive loop closes them on TopicTerminated.
+        List<CompletableFuture<?>> futures = new ArrayList<>();
         for (var entry : segmentConsumers.entrySet()) {
             if (!assignedIds.contains(entry.getKey())) {
-                log.info().attr("segmentId", entry.getKey())
-                        .log("Closing consumer for segment removed from assignment");
-                entry.getValue().thenAccept(c -> c.closeAsync());
-                segmentConsumers.remove(entry.getKey());
-                segmentBucketRanges.remove(entry.getKey());
-                sharedSegmentUnacked.remove(entry.getKey());
-                latestDelivered.remove(entry.getKey());
+                long segmentId = entry.getKey();
+                var existing = entry.getValue();
+                log.info().attr("segmentId", segmentId)
+                        .log("Releasing segment removed from assignment");
+                segmentConsumers.remove(segmentId, existing);
+                segmentBucketRanges.remove(segmentId);
+                futures.add(drainAndClose(segmentId, existing)
+                        .whenComplete((__, ___) -> {
+                            sharedSegmentUnacked.remove(segmentId);
+                            lastCumulativeAcked.remove(segmentId);
+                            latestDelivered.remove(segmentId);
+                        }));
             }
         }
 
         // Subscribe to newly-assigned segments.
-        List<CompletableFuture<?>> futures = new ArrayList<>();
         for (var seg : assigned) {
             // PIP-486: if the controller changed which entry-buckets we own on a segment we are
             // already subscribed to (a consumer joined or left), re-subscribe with the new ranges so
@@ -503,12 +525,10 @@ final class ScalableStreamConsumer<T>
                         .log("Re-subscribing segment for changed entry-bucket ownership");
                 segmentConsumers.remove(seg.segmentId(), existing);
                 futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(), id ->
-                        // Await our own close before re-subscribing: the new subscribe (a different
-                        // type, or ranges overlapping the old declaration) is rejected while the old
-                        // consumer is still attached.
-                        existing.handle((c, ex) -> c)
-                                .thenCompose(c -> c != null ? c.closeAsync()
-                                        : CompletableFuture.completedFuture(null))
+                        // Drain what the application already holds, then await our own close before
+                        // re-subscribing with the new mode: the subscription type cannot change
+                        // while the old consumer is still attached.
+                        drainAndClose(seg.segmentId(), existing)
                                 .thenCompose(__ -> createSegmentConsumerAsync(seg))));
             } else {
                 futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(),
@@ -518,6 +538,66 @@ final class ScalableStreamConsumer<T>
 
         log.info().attr("segments", assignedIds).log("Stream consumer assignment applied");
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * PIP-486 release: pause the segment's receive loop (stop handing its messages to the
+     * application), wait until every message already handed out is acked, then close the v4
+     * consumer — anything still prefetched goes back to the broker unread for in-order
+     * redelivery to the next owner. Deliberately unbounded: ownership must not move while the
+     * application still holds unacked messages, so a stalled application stalls the release,
+     * visibly, rather than silently breaking per-key order. Terminates early only when this
+     * consumer closes.
+     */
+    private CompletableFuture<Void> drainAndClose(
+            long segmentId, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> existing) {
+        pausedSegments.add(segmentId);
+        return awaitReleaseDrained(segmentId, 0)
+                .thenCompose(__ -> existing.handle((c, ex) -> c))
+                .thenCompose(c -> c != null ? c.closeAsync() : CompletableFuture.completedFuture(null))
+                .whenComplete((__, ___) -> pausedSegments.remove(segmentId));
+    }
+
+    /** Poll until the segment's delivered messages are all acked (or this consumer closes). */
+    private CompletableFuture<Void> awaitReleaseDrained(long segmentId, int pollCount) {
+        if (closed || isReleaseDrained(segmentId)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (pollCount > 0 && pollCount % 200 == 0) {
+            // ~every 10s at the 50ms poll interval: make a stalled release observable.
+            log.warn().attr("segmentId", segmentId)
+                    .log("Still waiting for the application to ack the segment's messages "
+                            + "before releasing it");
+        }
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        scheduler().schedule(() -> awaitReleaseDrained(segmentId, pollCount + 1)
+                        .whenComplete((__, ex) -> {
+                            if (ex != null) {
+                                result.completeExceptionally(ex);
+                            } else {
+                                result.complete(null);
+                            }
+                        }),
+                50, TimeUnit.MILLISECONDS);
+        return result;
+    }
+
+    /**
+     * Whether everything this consumer handed to the application for the segment has been acked:
+     * bucket-shared segments track individual ids; whole (Exclusive) segments compare the
+     * cumulative-ack high-water mark against the latest delivered position.
+     */
+    private boolean isReleaseDrained(long segmentId) {
+        var unacked = sharedSegmentUnacked.get(segmentId);
+        if (unacked != null) {
+            return unacked.isEmpty();
+        }
+        org.apache.pulsar.client.api.MessageId delivered = latestDelivered.get(segmentId);
+        if (delivered == null) {
+            return true; // nothing was ever handed to the application
+        }
+        org.apache.pulsar.client.api.MessageId acked = lastCumulativeAcked.get(segmentId);
+        return acked != null && acked.compareTo(delivered) >= 0;
     }
 
     private CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> createSegmentConsumerAsync(
@@ -604,7 +684,9 @@ final class ScalableStreamConsumer<T>
             // Re-arm only once the sink has room, so a slow consumer pauses this segment's
             // receive loop (and the v4 flow-control permits) instead of buffering unboundedly.
             messageSink.accept(new MessageV5<>(v4Msg, msgId)).thenRun(() -> {
-                if (!closed) {
+                // A paused segment is being released (PIP-486): stop pulling so the messages
+                // already handed to the application can drain before the close.
+                if (!closed && !pausedSegments.contains(segmentId)) {
                     startReceiveLoop(v4Consumer, segmentId);
                 }
             });
@@ -627,6 +709,7 @@ final class ScalableStreamConsumer<T>
                         .log("Sealed segment drained, closing v4 consumer");
                 segmentConsumers.remove(segmentId);
                 sharedSegmentUnacked.remove(segmentId);
+                lastCumulativeAcked.remove(segmentId);
                 latestDelivered.remove(segmentId);
                 v4Consumer.closeAsync();
                 return null;

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/ScalableStreamConsumer.java
@@ -22,6 +22,7 @@ import io.github.merlimat.slog.Logger;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 import org.apache.pulsar.client.api.KeySharedPolicy;
 import org.apache.pulsar.client.api.Range;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -133,6 +133,25 @@ final class ScalableStreamConsumer<T>
      */
     private final ConcurrentHashMap<Long, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>>>
             drainingConsumers = new ConcurrentHashMap<>();
+
+    /**
+     * PIP-486: the broker acks issued for a segment while it is draining. The release barrier
+     * waits for these to settle, so the old consumer is not closed while its acks are still in
+     * flight (a close racing an unapplied ack would redeliver messages the application already
+     * processed). Settling, not succeeding: a failed ack resolves to redelivery, which is the
+     * correct at-least-once outcome and must not wedge the release.
+     */
+    private final ConcurrentHashMap<Long, ConcurrentLinkedQueue<CompletableFuture<?>>>
+            pendingDrainAcks = new ConcurrentHashMap<>();
+
+    /**
+     * PIP-486: per-segment receive epoch, bumped when a release drain starts. Each receive-loop
+     * arm captures the epoch, and a completion whose epoch is stale is discarded without touching
+     * the tracking maps or the application — the message stays unacked and redelivers, in order,
+     * to the segment's next owner. This fences the receive that was already in flight when the
+     * drain paused the segment.
+     */
+    private final ConcurrentHashMap<Long, Long> segmentReceiveEpoch = new ConcurrentHashMap<>();
 
     /** Latest controller assignment; {@link #reconcile()} converges the segment consumers onto it. */
     private volatile List<ActiveSegment> latestAssignment;
@@ -310,13 +329,9 @@ final class ScalableStreamConsumer<T>
         if (unacked == null) {
             lastCumulativeAcked.merge(segmentId, position,
                     (a, b) -> a.compareTo(b) >= 0 ? a : b);
-            future.thenAccept(c -> {
-                if (v4Txn == null) {
-                    c.acknowledgeCumulativeAsync(position);
-                } else {
-                    c.acknowledgeCumulativeAsync(position, v4Txn);
-                }
-            });
+            trackDrainAck(segmentId, future.thenCompose(c ->
+                    v4Txn == null ? c.acknowledgeCumulativeAsync(position)
+                            : c.acknowledgeCumulativeAsync(position, v4Txn)));
             return;
         }
         // Redeliveries can enqueue ids out of order, so scan the whole queue rather than stopping at
@@ -333,15 +348,28 @@ final class ScalableStreamConsumer<T>
         if (toAck.isEmpty()) {
             return;
         }
-        future.thenAccept(c -> {
+        trackDrainAck(segmentId, future.thenCompose(c -> {
             if (v4Txn == null) {
-                c.acknowledgeAsync(toAck);
-            } else {
-                for (var msgId : toAck) {
-                    c.acknowledgeAsync(msgId, v4Txn);
-                }
+                return c.acknowledgeAsync(toAck);
             }
-        });
+            List<CompletableFuture<Void>> acks = new ArrayList<>(toAck.size());
+            for (var msgId : toAck) {
+                acks.add(c.acknowledgeAsync(msgId, v4Txn));
+            }
+            return FutureUtil.waitForAll(acks);
+        }));
+    }
+
+    /**
+     * While the segment is draining for a release, record the broker ack so the release barrier
+     * can wait for it to settle before the old consumer is closed.
+     */
+    private void trackDrainAck(long segmentId, CompletableFuture<?> ackFuture) {
+        if (!drainingConsumers.containsKey(segmentId)) {
+            return;
+        }
+        pendingDrainAcks.computeIfAbsent(segmentId, __ -> new ConcurrentLinkedQueue<>())
+                .add(ackFuture.exceptionally(ex -> null));
     }
 
     @Override
@@ -382,17 +410,26 @@ final class ScalableStreamConsumer<T>
 
         // Draining consumers live outside segmentConsumers; their drain loops observe the closed
         // flag and finish on their own, but they are closed here too (idempotent) so this future
-        // does not complete before they are gone.
+        // does not complete before they are gone. Two ordered snapshots, segmentConsumers first:
+        // a release migrates a consumer by registering it in drainingConsumers BEFORE vacating its
+        // segmentConsumers slot, so this order guarantees a concurrently-migrating consumer shows
+        // up in at least one snapshot (a single concatenated traversal binds both spliterators up
+        // front and could miss it in both).
+        Set<CompletableFuture<org.apache.pulsar.client.api.Consumer<T>>> toClose =
+                new LinkedHashSet<>(segmentConsumers.values());
+        toClose.addAll(drainingConsumers.values());
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        Stream.concat(segmentConsumers.values().stream(), drainingConsumers.values().stream())
-                .forEach(future -> futures.add(future
-                        .handle((consumer, ex) -> consumer)
-                        .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
-                                : CompletableFuture.completedFuture(null))));
+        for (var future : toClose) {
+            futures.add(future
+                    .handle((consumer, ex) -> consumer)
+                    .thenCompose(consumer -> consumer != null ? consumer.closeAsync()
+                            : CompletableFuture.completedFuture(null)));
+        }
         return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
                 .whenComplete((__, ___) -> {
                     segmentConsumers.clear();
                     drainingConsumers.clear();
+                    pendingDrainAcks.clear();
                     sharedSegmentUnacked.clear();
                     lastCumulativeAcked.clear();
                 });
@@ -525,6 +562,7 @@ final class ScalableStreamConsumer<T>
                             sharedSegmentUnacked.remove(segmentId);
                             lastCumulativeAcked.remove(segmentId);
                             latestDelivered.remove(segmentId);
+                            segmentReceiveEpoch.remove(segmentId);
                         }));
             }
         }
@@ -544,7 +582,17 @@ final class ScalableStreamConsumer<T>
                 // old consumer is still attached. The drain must start outside computeIfAbsent —
                 // it vacates this segment's slot itself, and ConcurrentHashMap forbids mutating
                 // the map from within the mapping function.
-                var drained = drainAndClose(seg.segmentId(), existing);
+                var drained = drainAndClose(seg.segmentId(), existing)
+                        .whenComplete((__, ___) -> {
+                            // A completed drain proves everything delivered was acked: reset the
+                            // release state (as the drop path does) so a watermark from this
+                            // consumer generation cannot leak into the next one — a stale
+                            // delivered-vs-acked pair from an earlier mode would wedge a later
+                            // drain that has nothing left to ack.
+                            sharedSegmentUnacked.remove(seg.segmentId());
+                            lastCumulativeAcked.remove(seg.segmentId());
+                            latestDelivered.remove(seg.segmentId());
+                        });
                 futures.add(segmentConsumers.computeIfAbsent(seg.segmentId(), id ->
                         drained.thenCompose(__ -> createSegmentConsumerAsync(seg))));
             } else {
@@ -568,24 +616,39 @@ final class ScalableStreamConsumer<T>
      */
     private CompletableFuture<Void> drainAndClose(
             long segmentId, CompletableFuture<org.apache.pulsar.client.api.Consumer<T>> existing) {
+        // Fence the receive that may already be in flight: any completion armed under the old
+        // epoch is discarded, so nothing new can reach the application or the tracking maps
+        // once the drain is underway.
+        segmentReceiveEpoch.merge(segmentId, 1L, Long::sum);
         // Register as draining before vacating the segmentConsumers slot, so at every instant the
         // ack path resolves to the consumer being drained — the drain only completes through those
         // acks. The slot removal lives here (not at the call sites) to keep that ordering.
         drainingConsumers.put(segmentId, existing);
         segmentConsumers.remove(segmentId, existing);
         pausedSegments.add(segmentId);
-        return awaitReleaseDrained(segmentId, 0)
+        return awaitReleaseDrained(segmentId, 0, false)
                 .thenCompose(__ -> existing.handle((c, ex) -> c))
                 .thenCompose(c -> c != null ? c.closeAsync() : CompletableFuture.completedFuture(null))
                 .whenComplete((__, ___) -> {
                     drainingConsumers.remove(segmentId, existing);
+                    pendingDrainAcks.remove(segmentId);
                     pausedSegments.remove(segmentId);
                 });
     }
 
-    /** Poll until the segment's delivered messages are all acked (or this consumer closes). */
-    private CompletableFuture<Void> awaitReleaseDrained(long segmentId, int pollCount) {
-        if (closed || isReleaseDrained(segmentId)) {
+    /**
+     * Poll until the segment's delivered messages are all acked (or this consumer closes). The
+     * barrier must hold on two consecutive polls: a receive that raced the drain's start can
+     * publish one more message to the tracking maps microseconds after a first check read them,
+     * and the 50ms-later confirmation is far past that window.
+     */
+    private CompletableFuture<Void> awaitReleaseDrained(long segmentId, int pollCount,
+                                                        boolean drainedOnPreviousPoll) {
+        if (closed) {
+            return CompletableFuture.completedFuture(null);
+        }
+        boolean drained = isReleaseDrained(segmentId);
+        if (drained && drainedOnPreviousPoll) {
             return CompletableFuture.completedFuture(null);
         }
         if (pollCount > 0 && pollCount % 200 == 0) {
@@ -595,7 +658,7 @@ final class ScalableStreamConsumer<T>
                             + "before releasing it");
         }
         CompletableFuture<Void> result = new CompletableFuture<>();
-        scheduler().schedule(() -> awaitReleaseDrained(segmentId, pollCount + 1)
+        scheduler().schedule(() -> awaitReleaseDrained(segmentId, pollCount + 1, drained)
                         .whenComplete((__, ex) -> {
                             if (ex != null) {
                                 result.completeExceptionally(ex);
@@ -610,9 +673,19 @@ final class ScalableStreamConsumer<T>
     /**
      * Whether everything this consumer handed to the application for the segment has been acked:
      * bucket-shared segments track individual ids; whole (Exclusive) segments compare the
-     * cumulative-ack high-water mark against the latest delivered position.
+     * cumulative-ack high-water mark against the latest delivered position. Additionally, every
+     * broker ack issued during the drain must have settled, so the close cannot overtake an ack
+     * still in flight.
      */
     private boolean isReleaseDrained(long segmentId) {
+        var drainAcks = pendingDrainAcks.get(segmentId);
+        if (drainAcks != null) {
+            for (var ack : drainAcks) {
+                if (!ack.isDone()) {
+                    return false;
+                }
+            }
+        }
         var unacked = sharedSegmentUnacked.get(segmentId);
         if (unacked != null) {
             return unacked.isEmpty();
@@ -676,7 +749,8 @@ final class ScalableStreamConsumer<T>
         }
         return v4Client.subscribeSegmentAsync(segConf, v4Schema)
                 .thenApply(consumer -> {
-                    startReceiveLoop(consumer, segment.segmentId());
+                    startReceiveLoop(consumer, segment.segmentId(),
+                            segmentReceiveEpoch.getOrDefault(segment.segmentId(), 0L));
                     return consumer;
                 });
     }
@@ -687,9 +761,18 @@ final class ScalableStreamConsumer<T>
      * 2. Snapshots the current position vector across all segments
      * 3. Wraps the message with a {@link MessageIdV5} carrying that vector
      * 4. Enqueues the wrapped message for the application to receive
+     *
+     * <p>{@code armedEpoch} is the segment's {@link #segmentReceiveEpoch} at arm time: a release
+     * drain bumps the epoch, so a completion carrying a stale epoch belongs to a consumer being
+     * (or already) released and is discarded — the message stays unacked and redelivers, in
+     * order, to the segment's next owner.
      */
-    private void startReceiveLoop(org.apache.pulsar.client.api.Consumer<T> v4Consumer, long segmentId) {
+    private void startReceiveLoop(org.apache.pulsar.client.api.Consumer<T> v4Consumer, long segmentId,
+                                  long armedEpoch) {
         v4Consumer.receiveAsync().thenAccept(v4Msg -> {
+            if (segmentReceiveEpoch.getOrDefault(segmentId, 0L) != armedEpoch) {
+                return;
+            }
             // Update the latest delivered position for this segment
             latestDelivered.put(segmentId, v4Msg.getMessageId());
 
@@ -712,7 +795,7 @@ final class ScalableStreamConsumer<T>
                 // A paused segment is being released (PIP-486): stop pulling so the messages
                 // already handed to the application can drain before the close.
                 if (!closed && !pausedSegments.contains(segmentId)) {
-                    startReceiveLoop(v4Consumer, segmentId);
+                    startReceiveLoop(v4Consumer, segmentId, armedEpoch);
                 }
             });
         }).exceptionally(ex -> {
@@ -736,12 +819,13 @@ final class ScalableStreamConsumer<T>
                 sharedSegmentUnacked.remove(segmentId);
                 lastCumulativeAcked.remove(segmentId);
                 latestDelivered.remove(segmentId);
+                segmentReceiveEpoch.remove(segmentId);
                 v4Consumer.closeAsync();
                 return null;
             }
             log.warn().attr("segmentId", segmentId)
                     .exception(ex).log("Error receiving from segment, retrying");
-            startReceiveLoop(v4Consumer, segmentId);
+            startReceiveLoop(v4Consumer, segmentId, armedEpoch);
             return null;
         });
     }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -950,10 +950,12 @@ message ScalableAssignedSegment {
     required uint32 hash_end               = 3;
     // Fully-qualified segment:// topic name the consumer should attach to.
     required string segment_topic          = 4;
-    // PIP-486: the entry-bucket hash ranges (16-bit, inclusive) this consumer owns within the
-    // segment. Empty means the consumer owns the whole segment (single bucket) and subscribes
-    // Shared; non-empty means the segment is shared by bucket, and the consumer subscribes
-    // Key_Shared STICKY declaring exactly these ranges.
+    // PIP-486: the segment's full entry-bucket boundary list (16-bit inclusive ranges tiling
+    // 0x0000-0xFFFF). Empty means this consumer is the segment's sole owner and subscribes
+    // Exclusive; non-empty means the segment is shared by entry-bucket, and the consumer
+    // subscribes Key_Shared STICKY with entryBucketDispatch, declaring exactly this boundary
+    // list (identical for every sharer). The bucket-to-consumer spread is computed broker-side
+    // from the live membership, so handoffs need no client protocol.
     repeated IntRange bucket_ranges        = 5;
 }
 


### PR DESCRIPTION
### Motivation

Continues PIP-486 after [#26114](https://github.com/apache/pulsar/pull/26114), [#26115](https://github.com/apache/pulsar/pull/26115), [#26118](https://github.com/apache/pulsar/pull/26118), [#26129](https://github.com/apache/pulsar/pull/26129), [#26173](https://github.com/apache/pulsar/pull/26173). PR4 activated bucket-shared consumption for **stable membership** and left the hard part open: preserving per-key order across an ownership *change* of a live bucket (a consumer joining, leaving, or crashing mid-traffic).

The design follows three constraints: every language SDK has to implement whatever protocol we pick, so the client surface must stay minimal; transitions should be orderly, with no transient errors and retries when a consumer joins; and a consumer must not re-subscribe for buckets it keeps. The answer is to move the handoff **into the broker, at entry-bucket granularity** — exactly how `Key_Shared` AUTO_SPLIT hands over hash ranges today, but per whole bucket instead of per key. Consumers keep consuming throughout a membership change; a bucket move is observable only as a short pause on that bucket.

The mechanism that makes this nearly free is **canonical-hash normalization**: the dispatcher normalizes every entry's hash to its bucket's canonical value (the bucket's start hash, nudged to 1 for bucket 0 since 0 is the reserved "not set" sentinel). One hash value per bucket means the existing per-hash `Key_Shared` machinery — pending acks, replay-order blocking, `DrainingHashesTracker` — operates at exactly bucket granularity, with no new tracking code.

### Modifications

**Broker — dispatcher seams**
- `PersistentStickyKeyDispatcherMultipleConsumers` gains a protected constructor taking a `StickyKeyConsumerSelector` and `drainingHashesRequired`, plus `handleConsumerAdded`/`handleConsumerRemoved` and `shouldBlockDispatch` hooks (defaults preserve AUTO_SPLIT behavior exactly).
- PR4's `entryBucketDispatch` field and `getStickyKeyHash` hook are reverted out of the parent: plain `Key_Shared` dispatch is back to its pre-PR4 form, and bucket logic lives only in the subclass. `hasSameKeySharedPolicy` rejects a flag mismatch.

**Broker — entry-bucket dispatcher**
- `EntryBucketConsumerSelector`: the segment's bucket boundaries are fixed at construction; the only moving part is membership. The N buckets are spread deterministically over the connected consumers sorted by `(name, id)` — consumer *j* of *k* owns the contiguous slice `[j*N/k, (j+1)*N/k)` — so a membership change moves as few whole buckets as possible, and membership diffs come from the existing `ConsumerHashAssignmentsSnapshot.resolveImpactedConsumers`.
- `PersistentEntryBucketDispatcherMultipleConsumers` (selected by `PersistentSubscription` when the consumer's `KeySharedMeta` carries `entryBucketDispatch`): the bucket boundaries arrive **in the subscribe itself** (`KeySharedMeta.hashRanges` = the segment's full boundary list, immutable for the segment's life; validated as ascending, contiguous, tiling the 16-bit ring). A joiner declaring different boundaries is rejected (`ConsumerAssignException`) — a mismatch is a stale layout, not a race. `getStickyKeyHash` routes a stamped entry by `canonical(entry_hash_min)` written through the cached-hash path, and unstamped entries by the key's hash normalized to the same canonical value. `drainingHashesRequired=true` gives the per-bucket handoff: a moving bucket is withheld from its new owner until every message the prior owner has in flight for it is acked, then flows in order.

**Controller**
- `SubscriptionCoordinator`: every sharer of a bucketed segment now receives the segment's **full boundary list** in `bucket_ranges` (identical for all sharers) instead of a per-consumer slice; empty still means sole owner → `Exclusive`. The controller only decides *which consumers* share a segment; the bucket→consumer spread is computed broker-side from live membership, so a join/leave needs no controller round-trip and no re-subscribes.

**Client — v5 stream consumer**
- The only client-side transition left is the **mode flip** (`Exclusive` ⇄ `Key_Shared`) when a segment's `bucket_ranges` flips between empty and non-empty, or a segment drop. Before closing the per-segment consumer the client now **drains**: delivery of that segment is paused and the close waits until every already-delivered message is acked (shared segments: the individual-ack translation queue is empty; whole segments: the cumulative high-water mark reached the latest delivered id). Completion is ack-driven, not time-based, so the flip cannot discard or reorder in-flight messages.
- The `bucket_ranges` proto comment is refreshed to the boundaries-for-all semantics. No wire-format changes: field shapes from PR3 and the PR4 flag are unchanged, and no new commands are introduced.

### Verifications

- `EntryBucketConsumerSelectorTest`: bucket-index/canonical-hash math; deterministic, add-order-independent spread; more consumers than buckets; key-hash normalization; impacted-bucket reporting on join/leave; merged assignment snapshot.
- `PersistentEntryBucketDispatcherMultipleConsumersTest`: boundary-list validation accept/reject cases.
- `PersistentStickyKeyDispatcherMultipleConsumersTest`: the stamped-range routing test now exercises the subclass and asserts canonical values; a stamped entry on a plain `Key_Shared` subscription still routes by key.
- `V5EntryBucketDispatchTest`: the PR4 e2e tests, plus `testConsumerJoiningMidTrafficPreservesPerKeyOrder` — a second stream consumer joins while a keyed stream is in flight (per-message acks), and per-key order is asserted across the broker-side handoff with nothing lost or duplicated.
- Regression sweep: all v5 client suites, the scalable broker suites, the sticky-key dispatcher suite, and checkstyle pass.
