### PR TITLE
[fix][test][branch-4.2] Fix OpenTelemetry sanity test metric

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/metrics/OpenTelemetrySanityTest.java
@@ -71,7 +71,7 @@ public class OpenTelemetrySanityTest {
 
         // TODO: Validate cluster name and service version are present once
         // https://github.com/open-telemetry/opentelemetry-java/issues/6108 is solved.
-        var metricName = "queueSize_ratio"; // Sent automatically by the OpenTelemetry SDK.
+        var metricName = "jvm_cpu_count"; // Configured by the OpenTelemetryService.
         waitAtMost(90, TimeUnit.SECONDS).ignoreExceptions().pollInterval(1, TimeUnit.SECONDS).until(() -> {
             var metrics = getMetricsFromPrometheus(
                     openTelemetryCollectorContainer, OpenTelemetryCollectorContainer.PROMETHEUS_EXPORTER_PORT);


### PR DESCRIPTION
### Motivation

The OpenTelemetry sanity test on branch-4.2 still checks `queueSize_ratio` for OTLP export after the OpenTelemetry upgrade. That metric is no longer a stable sanity signal with the upgraded OpenTelemetry runtime telemetry path, and the metrics CI can time out while waiting for it.

Master already switched this sanity check to `jvm_cpu_count`, which is configured by `OpenTelemetryService`.

### Modifications

Use `jvm_cpu_count` for the OTLP export sanity check, matching the existing master-side test adjustment.

### Verifying this change

- `git diff --check`
