### PR TITLE
[fix][meta] Fix RocksdbMetadataStore instanceId not advancing across restarts

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/RocksdbMetadataStore.java
@@ -265,7 +265,7 @@ public class RocksdbMetadataStore extends AbstractMetadataStore {
         if (value != null) {
             generator.set(toLong(value));
         } else {
-            db.put(writeOptions, INSTANCE_ID_KEY, toBytes(generator.get()));
+            db.put(writeOptions, SEQUENTIAL_ID_KEY, toBytes(generator.get()));
         }
         return generator;
     }


### PR DESCRIPTION
### Motivation

  `RocksdbMetadataStore#loadSequentialIdGenerator` is supposed to persist
  the initial value of the sequential-id counter to `SEQUENTIAL_ID_KEY`
  when no such record exists yet in RocksDB. Instead, it wrote that value
  to `INSTANCE_ID_KEY` by mistake.

  Since the constructor calls `loadSequentialIdGenerator()` before
  `loadInstanceId()`, this bug clobbers `INSTANCE_ID_KEY` to `0` right
  before `loadInstanceId()` reads it back — so `instanceId` is always
  computed as `0 + 1 = 1` on startup, instead of advancing (`0`, `1`,
  `2`, ...) across restarts, whenever no sequential node has ever been
  created in that store.

  `instanceId` is used to tag ownership of ephemeral nodes
  (`metaValue.owner == instanceId`), so a store stuck on the same
  `instanceId` across restarts loses the ability to distinguish the
  current process instance from a previous one for ephemeral-node
  ownership checks.

  ### Modifications

  - In `RocksdbMetadataStore#loadSequentialIdGenerator`, write the
    initial counter value to `SEQUENTIAL_ID_KEY` instead of
    `INSTANCE_ID_KEY`.

  ### Verifying this change
  
  - [x] Make sure that the change passes the CI checks.

  This change is already covered by existing tests, such as
  `RocksdbMetadataStoreTest#testMultipleInstances` and
  `RocksdbMetadataStoreTest#testOpenDbWithConfigFile`, which exercise
  store open/close/reopen cycles.

  ### Does this pull request potentially affect one of the following parts:

  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment