### PR TITLE
[fix][test][branch-4.2] Fix ManagedCursorTest compilation

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -3834,7 +3834,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
         when(ledger.getName()).thenReturn("test_estimated_unacked_size_empty_current_ledger");
         when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
-        when(ledger.getLogger()).thenReturn(log);
 
         long currentLedgerId = 4;
         Position lastPosition = PositionFactory.create(3, 9);
@@ -3859,7 +3858,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
         when(ledger.getName()).thenReturn("test_estimated_unacked_size_last_position_ledger_removed");
         when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
-        when(ledger.getLogger()).thenReturn(log);
 
         Position lastPosition = PositionFactory.create(3, 0);
         Position markDeletePosition = PositionFactory.create(4, -1);
@@ -3877,7 +3875,6 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         ManagedLedgerImpl ledger = mock(ManagedLedgerImpl.class);
         when(ledger.getName()).thenReturn("test_estimated_unacked_size_unexpected_position");
         when(ledger.getConfig()).thenReturn(new ManagedLedgerConfig());
-        when(ledger.getLogger()).thenReturn(log);
 
         Position lastPosition = PositionFactory.create(1, 10);
         Position markDeletePosition = PositionFactory.create(2, -1);


### PR DESCRIPTION
### Motivation

The branch-4.2 cherry-pick of #26184 added tests that stub `ManagedLedgerImpl#getLogger()`. That accessor is only available after the managed-ledger slog migration and is not present in branch-4.2, so managed-ledger test compilation fails.

### Modifications

Remove the unnecessary logger stubs from the affected `ManagedCursorTest` cases.

### Verifying this change

This change is already covered by existing tests:

- `mvn -pl managed-ledger -Dspotbugs.skip=true "-Dtest=ManagedCursorTest#testEstimatedUnackedSizeWhenLatestLedgerIsEmpty+testEstimatedUnackedSizeWhenCursorCaughtUpWithLastPosition+testEstimatedUnackedSizeWhenCursorAdvancedToEmptyCurrentLedger+testEstimatedUnackedSizeWhenLastPositionLedgerIsNoLongerInLedgerList+testEstimatedUnackedSizeFailsWhenCursorIsUnexpectedlyAheadOfLastPosition" test`
- `mvn -pl managed-ledger -am -DskipTests -Dspotbugs.skip=true install`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
