### PR TITLE
[improve][build] Upgrade slog to 0.10.0

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -277,7 +277,7 @@ The Apache Software License, Version 2.0
  * Netty Reactive Streams -- com.typesafe.netty-netty-reactive-streams-2.0.6.jar
  * Swagger
     - io.swagger.core.v3-swagger-annotations-jakarta-2.2.50.jar
- * slog -- io.github.merlimat.slog-slog-0.9.9.jar
+ * slog -- io.github.merlimat.slog-slog-0.10.0.jar
  * DataSketches
     - org.apache.datasketches-datasketches-java-7.0.1.jar
     - org.apache.datasketches-datasketches-memory-4.1.0.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -394,7 +394,7 @@ The Apache Software License, Version 2.0
     - opentelemetry-common-1.62.0.jar
     - opentelemetry-context-1.62.0.jar
   * Slog
-    - slog-0.9.9.jar
+    - slog-0.10.0.jar
 
  * BookKeeper
     - bookkeeper-common-allocator-4.18.0.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ jackson-annotations = "2.21"
 protobuf = "4.35.0"
 grpc = "1.79.0"
 slf4j = "2.0.18"
-slog = "0.9.9"
+slog = "0.10.0"
 log4j2 = "2.26.0"
 lombok = "1.18.42"
 # OpenTelemetry


### PR DESCRIPTION
### Motivation

[slog](https://github.com/merlimat/slog) 0.10.0 is a correctness and performance pass over the logging hot paths, relevant to how Pulsar uses it:

- Fixes stale-level races in the Log4j2 cached level scheme (generation and effective level packed into a single word, atomic generation bumps)
- Routes through `AsyncLogger` in full-async mode (`AsyncLoggerContextSelector`) instead of calling `LoggerConfig` directly, which silently ran appender I/O on the application thread
- Pools log events only when Log4j2 thread-locals are enabled, avoiding cross-contamination of records when `AsyncLoggerConfig` enqueues events by reference
- Guards the pooled event against reentrant logging (e.g. an attr supplier that logs)
- Performance: monotonic clock for `timed()`, touched-keys-only MDC save/restore in the SLF4J handler, flattened logger context (+14% throughput, −60% allocation on context-bearing events), no per-thread event pooling on virtual threads, interleaved attr array (80 → 64 B/op on the fluent path)

Release notes: https://github.com/merlimat/slog/releases/tag/v0.10.0

### Modifications

- Bump `slog` from 0.9.9 to 0.10.0 in `gradle/libs.versions.toml`. This also upgrades the transitive slog 0.9.9 pulled in by `bookkeeper-common-allocator` 4.18.0 via the platform constraint.
- Update the bundled jar version in `distribution/server/src/assemble/LICENSE.bin.txt` and `distribution/shell/src/assemble/LICENSE.bin.txt`.

No code changes are needed; 0.10.0 has no API changes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial dependency upgrade without any test coverage. Verified locally with `./gradlew sanityCheck` (all modules' main and test sources compile) and `checkBinaryLicense` for the server and shell distributions.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment