### PR TITLE
[fix][ml] Preserve ledger properties when closing ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1969,9 +1969,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         long entriesInLedger = lastAddConfirmed != null ? lastAddConfirmed + 1 : lh.getLastAddConfirmed() + 1;
         log.debug().attr("ledgerId", lh.getId()).attr("entries", entriesInLedger).log("Ledger has been closed");
         if (entriesInLedger > 0) {
-            LedgerInfo info = new LedgerInfo().setLedgerId(lh.getId()).setEntries(entriesInLedger)
-                    .setSize(lh.getLength()).setTimestamp(clock.millis());
-            ledgers.put(lh.getId(), info);
+            ledgers.compute(lh.getId(), (ledgerId, oldInfo) -> {
+                LedgerInfo info = new LedgerInfo();
+                if (oldInfo != null) {
+                    info.copyFrom(oldInfo);
+                } else {
+                    info.setLedgerId(ledgerId);
+                }
+                return info.setEntries(entriesInLedger).setSize(lh.getLength()).setTimestamp(clock.millis());
+            });
         } else {
             // The last ledger was empty, so we can discard it
             ledgers.remove(lh.getId());

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4788,30 +4788,27 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     private ManagedLedger testSetLedgerProperty0(String name) throws Exception {
         ManagedLedgerConfig config = new ManagedLedgerConfig();
         config.setMaxEntriesPerLedger(2);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
         ManagedLedgerImpl ml = (ManagedLedgerImpl) factory.open(name, config);
         ml.addEntry("entry-1".getBytes());
+        long firstLedger = ml.ledgers.firstKey();
+        ml.asyncAddLedgerProperty(firstLedger, "key1", "value1").join();
         ml.addEntry("entry-2".getBytes());
         ml.addEntry("entry-3".getBytes());
+        long lastLedger = ml.ledgers.lastKey();
+        ml.asyncAddLedgerProperty(lastLedger, "key2", "value2").join();
 
-        Assert.assertEquals(ml.getLedgersInfo().size(), 2);
-        long firstLedger = ml.getLedgersInfo().firstKey();
-        LedgerInfo firstLedgerInfo = ml.getLedgersInfo().get(firstLedger);
-        Assert.assertEquals(firstLedgerInfo.getPropertiesCount(), 0);
-        long lastLedger = ml.getLedgersInfo().lastKey();
-        LedgerInfo lastLedgerInfo = ml.getLedgersInfo().get(lastLedger);
-        Assert.assertEquals(lastLedgerInfo.getPropertiesCount(), 0);
+        Assert.assertNotEquals(firstLedger, lastLedger);
+        LedgerInfo firstLedgerInfo = ml.ledgers.get(firstLedger);
+        Assert.assertEquals(firstLedgerInfo.getEntries(), 2);
 
-        ml.asyncAddLedgerProperty(firstLedger, "key1", "value1").get();
-        ml.asyncAddLedgerProperty(lastLedger, "key2", "value2").get();
+        ml.asyncAddLedgerProperty(firstLedger, "key3", "value3").join();
+        ml.asyncAddLedgerProperty(lastLedger, "key4", "value4").join();
 
-        firstLedgerInfo = ml.getLedgersInfo().get(firstLedger);
-        Assert.assertEquals(firstLedgerInfo.getPropertiesCount(), 1);
-        Assert.assertEquals(ml.asyncGetLedgerProperty(firstLedger, "key1").get(), "value1");
-
-        lastLedgerInfo = ml.getLedgersInfo().get(lastLedger);
-        Assert.assertEquals(lastLedgerInfo.getPropertiesCount(), 1);
-        Assert.assertEquals(ml.asyncGetLedgerProperty(lastLedger, "key2").get(), "value2");
-
+        Assert.assertEquals(ml.asyncGetLedgerProperty(firstLedger, "key1").join(), "value1");
+        Assert.assertEquals(ml.asyncGetLedgerProperty(firstLedger, "key3").join(), "value3");
+        Assert.assertEquals(ml.asyncGetLedgerProperty(lastLedger, "key2").join(), "value2");
+        Assert.assertEquals(ml.asyncGetLedgerProperty(lastLedger, "key4").join(), "value4");
         return ml;
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -4822,6 +4822,11 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         ml.asyncRemoveLedgerProperty(firstLedger, "key1").get();
         ml.asyncRemoveLedgerProperty(lastLedger, "key2").get();
 
+        Assert.assertEquals(ml.getLedgersInfo().get(firstLedger).getPropertiesCount(), 1);
+        Assert.assertEquals(ml.getLedgersInfo().get(lastLedger).getPropertiesCount(), 1);
+
+        ml.asyncRemoveLedgerProperty(firstLedger, "key3").get();
+        ml.asyncRemoveLedgerProperty(lastLedger, "key4").get();
         Assert.assertEquals(ml.getLedgersInfo().get(firstLedger).getPropertiesCount(), 0);
         Assert.assertEquals(ml.getLedgersInfo().get(lastLedger).getPropertiesCount(), 0);
     }


### PR DESCRIPTION
### Motivation

  When a ledger is closed (either because it reaches max entries or is manually closed), the `ledgerClosed()` method creates a `new LedgerInfo` object with only basic fields (ledgerId, entries, size, timestamp), which discards any previously set properties.

  This causes a bug where ledger properties are lost after ledger closure:
  1. User calls `asyncAddLedgerProperty(ledgerId, key, value)` to set a property on the current ledger
  2. The property can be read successfully immediately after setting
  3. When the ledger gets closed (e.g., reaches maxEntriesPerLedger), the `ledgerClosed()` method replaces the LedgerInfo with a new instance that has no properties
  4. Subsequent reads of the property return null, even though the property was successfully persisted to the metadata store

### Modifications

1. Modified the `ManagedLedgerImpl.ledgerClosed()` method to preserve existing ledger properties when updating the LedgerInfo on ledger close.
2. Update tests

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment