### PR TITLE
[fix][broker] Check deliverAt before containsMessage in bucket addMessage

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -409,12 +409,12 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     @Override
     public synchronized boolean addMessage(long ledgerId, long entryId, long deliverAt) {
-        if (containsMessage(ledgerId, entryId)) {
-            return true;
-        }
-
         if (deliverAt < 0 || deliverAt <= getCutoffTime()) {
             return false;
+        }
+
+        if (containsMessage(ledgerId, entryId)) {
+            return true;
         }
 
         boolean existBucket = findImmutableBucket(ledgerId).isPresent();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.Position;
@@ -159,6 +160,10 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                     new BucketDelayedDeliveryTracker(dispatcher, timer, 100000, clock,
                             true, bucketSnapshotStorage, 1000, TimeUnit.MILLISECONDS.toMillis(100), -1, 50)
             }};
+            case "testExpiredTrackedMessageReturnsFalse", "testRecoverThenExpireAddMessage" -> new Object[][]{{
+                    new BucketDelayedDeliveryTracker(dispatcher, timer, 1, clock,
+                            true, bucketSnapshotStorage, 5, TimeUnit.MILLISECONDS.toMillis(10), -1, 50)
+            }};
             default -> new Object[][]{{
                     new BucketDelayedDeliveryTracker(dispatcher, timer, 1, clock,
                             true, bucketSnapshotStorage, 1000, TimeUnit.MILLISECONDS.toMillis(100), -1, 50)
@@ -188,6 +193,51 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         assertTrue(tracker.containsMessage(3, 3));
 
         tracker.close();
+    }
+
+    @Test(dataProvider = "delayedTracker")
+    public void testExpiredTrackedMessageReturnsFalse(BucketDelayedDeliveryTracker tracker) {
+        clockTime.set(1000);
+        assertTrue(tracker.addMessage(1, 1, 2000));
+        assertTrue(tracker.containsMessage(1, 1));
+
+        clockTime.set(2500);
+
+        assertFalse(
+                "Expired tracked message should return false so dispatcher delivers immediately",
+                tracker.addMessage(1, 1, 2000));
+
+        tracker.close();
+    }
+
+    @Test(dataProvider = "delayedTracker")
+    public void testRecoverThenExpireAddMessage(BucketDelayedDeliveryTracker tracker) throws Exception {
+        clockTime.set(0);
+        for (int i = 1; i <= 6; i++) {
+            tracker.addMessage(i, i, i * 1000);
+        }
+
+        Awaitility.await().untilAsserted(() ->
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(x -> x.merging || !x.getSnapshotCreateFuture().get().isDone())));
+
+        tracker.close();
+
+        clockTime.set(0);
+        @Cleanup
+        BucketDelayedDeliveryTracker tracker2 = new BucketDelayedDeliveryTracker(
+                dispatcher, timer, 100000, clock, true,
+                bucketSnapshotStorage, 5, TimeUnit.MILLISECONDS.toMillis(10), -1, 50);
+
+        assertTrue(tracker2.containsMessage(1, 1));
+
+        clockTime.set(10000);
+
+        assertFalse(
+                "Recovered message that is now expired should return false",
+                tracker2.addMessage(1, 1, 1000));
+
+        tracker2.close();
     }
 
     @Test(dataProvider = "delayedTracker", invocationCount = 10)


### PR DESCRIPTION
### Motivation

`BucketDelayedDeliveryTracker` uses lazy loading for sealed bucket segments. During segment loading, expired messages are filtered based on their `deliverAt` timestamp and are not added into `sharedBucketPriorityQueue`.

`delayedIndexBitMap` is persisted with the bucket metadata and restored from BookKeeper. It is used for position deduplication and does not indicate whether a message is currently loaded into `sharedBucketPriorityQueue`.

Therefore, during lazy loading, a message can temporarily exist in `delayedIndexBitMap` but not in `sharedBucketPriorityQueue`.

The current `BucketDelayedDeliveryTracker.addMessage` implementation checks `containsMessage` before checking whether the message has already expired (`deliverAt <= cutoffTime`).

This causes an issue when an expired message exists only in the delayed index:

1. The dispatcher reads the message from the managed ledger.
2. `containsMessage` returns `true` because the position exists in `delayedIndexBitMap`.
3. `addMessage` returns `true`, and the dispatcher skips the message.
4. The message is not in `sharedBucketPriorityQueue`, so delayed delivery cannot return it either.

The message is not lost from storage, but it can remain skip:

```
ManagedLedger:
    message exists

delayedIndexBitMap:
    position exists (dedup index)

sharedBucketPriorityQueue:
    position missing
```


### Modifications

* Change the check order in `BucketDelayedDeliveryTracker.addMessage`.

  * Check `deliverAt <= cutoffTime` before `containsMessage`.
  * Expired messages return `false` so they can be delivered immediately by the dispatcher.
  * Deduplication is only applied to messages that are still delayed.

* Add `testExpiredIndexedMessageReturnsFalse`.

  * Add a message with future `deliverAt`.
  * Advance the clock beyond `deliverAt`.
  * Re-add the same position.
  * Assert that `addMessage` returns `false`.

* Add `testRecoverThenExpireAddMessage`.

  * Seal a bucket.
  * Recover the tracker.
  * Advance the clock beyond the message delivery time.
  * Re-add a recovered position that exists in `delayedIndexBitMap` but has not been loaded into `sharedBucketPriorityQueue`.
  * Assert that `addMessage` returns `false`.

In addition, the dispatcher side will add an explicit expiration check to make the delivery path more robust. The tracker-side fix ensures that an expired message is not incorrectly blocked by the delayed index when it should bypass delayed delivery tracking.

