### PR TITLE
[fix][broker] Trigger max read position callback for messages published during transaction buffer recovery

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBuffer.java
@@ -155,7 +155,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     public void recoverComplete() {
                         synchronized (TopicTransactionBuffer.this) {
                             if (ongoingTxns.isEmpty()) {
-                                maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
+                                updateMaxReadPositionAfterRecovery();
                             }
                             if (!changeToReadyState()) {
                                 log.error("Transaction buffer recover fail");
@@ -175,7 +175,7 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
                     @Override
                     public void noNeedToRecover() {
                         synchronized (TopicTransactionBuffer.this) {
-                            maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
+                            updateMaxReadPositionAfterRecovery();
                             if (!changeToNoSnapshotState()) {
                                 log.error().log("Transaction buffer recover fail");
                             } else {
@@ -641,6 +641,23 @@ public class TopicTransactionBuffer extends TopicTransactionBufferState implemen
             if (!disableCallback) {
                 maxReadPositionCallBack.maxReadPositionMovedForward(preMaxReadPosition, this.maxReadPosition);
             }
+        }
+    }
+
+    /**
+     * Advance the max read position to the last confirmed entry when recovery finishes. While the transaction
+     * buffer is recovering, {@link #syncMaxReadPositionForNormalPublish(Position, boolean)} ignores publishes, so
+     * messages published during recovery would otherwise never trigger the maxReadPositionMovedForward callback.
+     * {@link PersistentTopic} uses that callback to maintain lastMaxReadPositionMovedForwardTimestamp, which
+     * ReplicatedSubscriptionsController relies on to detect new data when deciding whether to start a snapshot.
+     * Must be called while synchronized on this transaction buffer.
+     */
+    private void updateMaxReadPositionAfterRecovery() {
+        Position preMaxReadPosition = this.maxReadPosition;
+        this.maxReadPosition = topic.getManagedLedger().getLastConfirmedEntry();
+        if (this.maxReadPosition != null
+                && (preMaxReadPosition == null || preMaxReadPosition.compareTo(this.maxReadPosition) < 0)) {
+            this.maxReadPositionCallBack.maxReadPositionMovedForward(preMaxReadPosition, this.maxReadPosition);
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TopicTransactionBufferRecoveryTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link TopicTransactionBuffer} recovery completion behavior.
+ */
+@Test(groups = "broker")
+public class TopicTransactionBufferRecoveryTest extends ProducerConsumerBase {
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        conf.setTransactionCoordinatorEnabled(true);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "snapshotExists")
+    public Object[][] snapshotExists() {
+        return new Object[][] { { false }, { true } };
+    }
+
+    /**
+     * While the transaction buffer is recovering, normal publishes don't move the max read position, so they
+     * don't update the topic's lastMaxReadPositionMovedForwardTimestamp either. When recovery completes, the
+     * transaction buffer must account for the messages published during recovery and trigger the
+     * maxReadPositionMovedForward callback; otherwise ReplicatedSubscriptionsController would consider the topic
+     * to have no new data and never start a subscription snapshot until further traffic arrives.
+     */
+    @Test(dataProvider = "snapshotExists")
+    public void testMaxReadPositionMovedForwardForMessagesPublishedDuringRecovery(boolean snapshotExists)
+            throws Exception {
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp-tb-recovery");
+        CompletableFuture<Position> recoverFuture = new CompletableFuture<>();
+        TransactionBufferProvider originalProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(originTopic -> {
+            AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+            when(processor.recoverFromSnapshot()).thenReturn(recoverFuture);
+            when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+            return new TopicTransactionBuffer(
+                    (PersistentTopic) originTopic, processor, AbortedTxnProcessor.SnapshotType.Single);
+        });
+        try {
+            @Cleanup
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(tpName).create();
+            // The transaction buffer is stuck in the recovering state until recoverFuture completes, so these
+            // messages are published while it is still recovering.
+            for (int i = 0; i < 3; i++) {
+                producer.send(("msg-" + i).getBytes(StandardCharsets.UTF_8));
+            }
+            PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                    .getTopicIfExists(tpName).get().orElseThrow();
+            assertEquals(persistentTopic.getLastMaxReadPositionMovedForwardTimestamp(), 0L,
+                    "Publishes during recovery are not expected to move the max read position forward");
+
+            // Let the recovery finish, either replaying from a snapshot position or without any snapshot.
+            recoverFuture.complete(snapshotExists ? PositionFactory.EARLIEST : null);
+
+            Awaitility.await().untilAsserted(() -> {
+                assertTrue(persistentTopic.getLastMaxReadPositionMovedForwardTimestamp() > 0,
+                        "Completed recovery should move the max read position forward for the messages"
+                                + " published during recovery");
+                assertEquals(persistentTopic.getTransactionBuffer().getMaxReadPosition(),
+                        persistentTopic.getManagedLedger().getLastConfirmedEntry());
+            });
+        } finally {
+            pulsar.setTransactionBufferProvider(originalProvider);
+        }
+    }
+
+    /**
+     * When nothing is published while the transaction buffer recovers, completing the recovery must not trigger
+     * the maxReadPositionMovedForward callback, so an idle topic isn't mistaken for one with new data.
+     */
+    @Test
+    public void testMaxReadPositionNotMovedForwardWhenNothingPublishedDuringRecovery() throws Exception {
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp-tb-recovery-idle");
+        CompletableFuture<Position> recoverFuture = new CompletableFuture<>();
+        TransactionBufferProvider originalProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(originTopic -> {
+            AbortedTxnProcessor processor = mock(AbortedTxnProcessor.class);
+            when(processor.recoverFromSnapshot()).thenReturn(recoverFuture);
+            when(processor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+            return new TopicTransactionBuffer(
+                    (PersistentTopic) originTopic, processor, AbortedTxnProcessor.SnapshotType.Single);
+        });
+        try {
+            PersistentTopic persistentTopic = (PersistentTopic) pulsar.getBrokerService()
+                    .getTopic(tpName, true).get().orElseThrow();
+            recoverFuture.complete(null);
+            Awaitility.await().untilAsserted(() ->
+                    assertEquals(persistentTopic.getTransactionBuffer().getMaxReadPosition(),
+                            persistentTopic.getManagedLedger().getLastConfirmedEntry()));
+            assertEquals(persistentTopic.getLastMaxReadPositionMovedForwardTimestamp(), 0L,
+                    "Recovery of an idle topic should not move the max read position forward");
+        } finally {
+            pulsar.setTransactionBufferProvider(originalProvider);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

`ReplicatedSubscriptionWithTransactionTest.testReplicatedSubscribeAndSwitchToStandbyCluster` fails intermittently in CI with:

```
org.awaitility.core.ConditionTimeoutException: Assertion condition One snapshot should be finished expected [true] but found [false] within 10 seconds.
```

Example failure: https://github.com/apache/pulsar/actions/runs/29992607875/job/89160931729 (a dependabot PR unrelated to this code path).

The captured test logs show that both clusters' replicators were connected and all test messages were replicated within ~1 second of the test starting, followed by total silence: no replicated-subscription snapshot round trip was ever attempted during the remaining ~9 seconds of the Awaitility window.

Root cause is in `TopicTransactionBuffer`, not in the test:

- While the transaction buffer is recovering (`Initializing` state), `syncMaxReadPositionForNormalPublish()` ignores normal publishes: `maxReadPosition` does not move and the `maxReadPositionMovedForward` callback is not invoked.
- When recovery completes, `recoverComplete()` / `noNeedToRecover()` catch `maxReadPosition` up to the managed ledger's last confirmed entry by direct field assignment, without invoking the `maxReadPositionMovedForward` callback.

As a result, messages published while the transaction buffer is recovering never update `PersistentTopic.lastMaxReadPositionMovedForwardTimestamp`. `ReplicatedSubscriptionsController.startNewSnapshot()` uses that timestamp to decide whether the topic has new data; with the timestamp stuck at 0, every snapshot tick is skipped with "There is no new data in topic. Skipping snapshot creation." until some new message is published after recovery.

In the flaky test, the whole publish burst races the transaction buffer recovery of the freshly created topic. When all messages land before recovery completes, no subscription snapshot can ever start (the test publishes nothing more while polling the assertion), so the test times out regardless of the Awaitility timeout. In production the condition self-heals on the next publish, which is why it mainly surfaces as a test flake, but until new traffic arrives a replicated-subscription snapshot is silently delayed the same way.

### Modifications

- `TopicTransactionBuffer`: extract a `updateMaxReadPositionAfterRecovery()` helper used by both `recoverComplete()` and `noNeedToRecover()`. It advances `maxReadPosition` to the last confirmed entry and invokes the `maxReadPositionMovedForward` callback if the position actually moved forward while recovery was in progress. When nothing was published during recovery, the position does not move and the callback is not invoked, preserving the existing "no snapshot without traffic" behavior (covered by `ReplicatedSubscriptionTest.testReplicationSnapshotStopWhenNoTraffic`).
- Add `TopicTransactionBufferRecoveryTest`, a deterministic regression test that gates transaction buffer recovery on a controllable future (mocked `AbortedTxnProcessor.recoverFromSnapshot()`), publishes messages while recovery is pending, and asserts that completing the recovery (both with and without a snapshot to replay) moves `lastMaxReadPositionMovedForwardTimestamp` forward. It also asserts the negative case: recovery of an idle topic must not move the timestamp.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `TopicTransactionBufferRecoveryTest.testMaxReadPositionMovedForwardForMessagesPublishedDuringRecovery` deterministically reproduces the bug: it fails without the production change and passes with it.
- `TopicTransactionBufferRecoveryTest.testMaxReadPositionNotMovedForwardWhenNothingPublishedDuringRecovery` guards against spuriously triggering snapshots for idle topics.
- The previously flaky `ReplicatedSubscriptionWithTransactionTest.testReplicatedSubscribeAndSwitchToStandbyCluster` passed 10/10 locally with a temporary `invocationCount = 10` (annotation not included in this PR).
- Full `ReplicatedSubscriptionTest` and `ReplicatedSubscriptionWithTransactionTest` classes pass locally.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
