### PR TITLE
[fix][broker] Fix silently dropped acknowledgement failures in PulsarMetadataEventSynchronizer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarMetadataEventSynchronizer.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
@@ -216,32 +217,16 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
                         .log("Processing metadata event for with listeners");
                 try {
                     if (listeners.size() == 0) {
-                        c.acknowledgeAsync(msg);
+                        acknowledgeAfter(CompletableFuture.completedFuture(null), c, msg);
                         return;
 
                     }
                     if (listeners.size() == 1) {
-                        listeners.get(0).apply(msg.getValue()).thenApply(__ -> c.acknowledgeAsync(msg))
-                                .exceptionally(ex -> {
-                                    log.warn()
-                                            .attr("messageId", msg.getMessageId())
-                                            .attr("topic", topicName)
-                                            .exception(ex)
-                                            .log("Failed to synchronize metadata event");
-                                    return null;
-                                });
+                        acknowledgeAfter(listeners.get(0).apply(msg.getValue()), c, msg);
                     } else {
-                        FutureUtil
-                                .waitForAll(listeners.stream().map(listener -> listener.apply(msg.getValue()))
-                                        .collect(Collectors.toList()))
-                                .thenApply(__ -> c.acknowledgeAsync(msg)).exceptionally(ex -> {
-                                    log.warn()
-                                            .attr("messageId", msg.getMessageId())
-                                            .attr("topic", topicName)
-                                            .exception(ex)
-                                            .log("Failed to synchronize metadata event");
-                                    return null;
-                                });
+                        acknowledgeAfter(
+                                FutureUtil.waitForAll(listeners.stream().map(listener -> listener.apply(msg.getValue()))
+                                        .collect(Collectors.toList())), c, msg);
                     }
                 } catch (Exception e) {
                     log.warn()
@@ -282,6 +267,23 @@ public class PulsarMetadataEventSynchronizer implements MetadataEventSynchronize
             brokerService.executor().schedule(this::startConsumer, waitTimeMs, TimeUnit.MILLISECONDS);
             return null;
         });
+    }
+
+    /**
+     * Acknowledge {@code msg} only after {@code processed} completes, and log (rather than silently drop)
+     * an exception from either the processing stage or the acknowledgement itself.
+     */
+    private CompletableFuture<Void> acknowledgeAfter(CompletableFuture<Void> processed, Consumer<MetadataEvent> c,
+                                                      Message<MetadataEvent> msg) {
+        return processed.thenCompose(__ -> c.acknowledgeAsync(msg))
+                .exceptionally(ex -> {
+                    log.warn()
+                            .attr("messageId", msg.getMessageId())
+                            .attr("topic", topicName)
+                            .exception(ex)
+                            .log("Failed to synchronize metadata event");
+                    return null;
+                });
     }
 
     public boolean isStarted() {


### PR DESCRIPTION
Motivation

  PulsarMetadataEventSynchronizer.startConsumer()'s messageListener acknowledged consumed MetadataEvent messages with .thenApply(__ -> c.acknowledgeAsync(msg)). Since acknowledgeAsync itself returns a CompletableFuture<Void>, thenApply treated that return value as plain data instead of composing on it: the outer future completed as soon as the metadata event was applied to the local store, without ever waiting for the acknowledgement to actually finish.

  As a result, if acknowledgeAsync later failed asynchronously (e.g. a connection issue while sending the ack command), the exception was never observed by the attached .exceptionally() handler and was silently dropped — no log
  signal, with recovery relying entirely on the 60s ackTimeout redelivering the same event. The zero-listener branch had the same problem in an even more direct form: acknowledgeAsync was called with no error handling attached at all.

  Modifications
  - Extracted a shared acknowledgeAfter(CompletableFuture<Void> processed, Consumer<MetadataEvent> c, Message<MetadataEvent> msg) helper that uses thenCompose instead of thenApply, so the returned future genuinely waits for the acknowledgement and routes its failure into the existing .exceptionally() log handler.
  - Applied the helper uniformly to all three code paths in the listener (zero, one, and multiple registered MetadataEvent listeners).

  Verifying this change
  - [ ] Make sure that the change passes the CI checks.
  This change is a trivial rework / code cleanup without any test coverage.
  (Note: the fix was manually verified locally with a temporary unit test that mocked Consumer.acknowledgeAsync and asserted the returned future doesn't settle until the ack future completes — confirmed it failed against the 
  original thenApply shape and passed after switching to thenCompose. That test was not included in this PR.)
  Does this pull request potentially affect one of the following parts:
  If the box was checked, please highlight the changes
  - [ ] Dependencies (add or upgrade a dependency)
  - [ ] The public API
  - [ ] The schema
  - [ ] The default values of configurations
  - [ ] The threading model
  - [ ] The binary protocol
  - [ ] The REST endpoints
  - [ ] The admin CLI options
  - [ ] The metrics
  - [ ] Anything that affects deployment