### PR TITLE
[fix][broker] Fix delayed index loss when bucket merge fails

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -568,17 +568,26 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         return CombinedSegmentDelayedIndexQueue.wrap(
                                 getRemainFutures.stream().map(CompletableFuture::join).toList());
                     })
-                    .thenAccept(combinedDelayedIndexQueue -> {
+                    .thenCompose(combinedDelayedIndexQueue -> {
+                        TripleLongPriorityQueue mergedBucketPriorityQueue = new TripleLongPriorityQueue();
+                        Pair<ImmutableBucket, DelayedIndex> immutableBucketDelayedIndexPair;
+                        long createStartTime = System.currentTimeMillis();
                         synchronized (BucketDelayedDeliveryTracker.this) {
-                            long createStartTime = System.currentTimeMillis();
                             stats.recordTriggerEvent(BucketDelayedMessageIndexStats.Type.create);
-                            Pair<ImmutableBucket, DelayedIndex> immutableBucketDelayedIndexPair =
+                            immutableBucketDelayedIndexPair =
                                     lastMutableBucket.createImmutableBucketAndAsyncPersistent(
                                             timeStepPerBucketSnapshotSegmentInMillis,
                                             maxIndexesPerBucketSnapshotSegment,
-                                            sharedBucketPriorityQueue, combinedDelayedIndexQueue,
+                                            mergedBucketPriorityQueue, combinedDelayedIndexQueue,
                                             buckets.get(0).startLedgerId,
                                             buckets.get(buckets.size() - 1).endLedgerId);
+
+                            if (immutableBucketDelayedIndexPair == null) {
+                                mergedBucketPriorityQueue.close();
+                                stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
+                                return FutureUtil.failedFuture(new IllegalStateException(
+                                        "Can't merge buckets without remaining snapshot segments"));
+                            }
 
                             // Merge bit map to new bucket
                             Map<Long, LongBitmap> delayedIndexBitMap =
@@ -597,22 +606,72 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                             }
 
                             immutableBucketDelayedIndexPair.getLeft().setDelayedIndexBitMap(delayedIndexBitMap);
-
-                            afterCreateImmutableBucket(immutableBucketDelayedIndexPair, createStartTime);
-
-                            immutableBucketDelayedIndexPair.getLeft().getSnapshotCreateFuture()
-                                    .orElse(NULL_LONG_PROMISE).thenCompose(___ -> {
-                                        List<CompletableFuture<Void>> removeFutures =
-                                                buckets.stream().map(bucket -> bucket.asyncDeleteBucketSnapshot(stats))
-                                                        .toList();
-                                        return FutureUtil.waitForAll(removeFutures);
-                                    });
-
-                            for (ImmutableBucket bucket : buckets) {
-                                removeBucket(Range.closed(bucket.startLedgerId, bucket.endLedgerId));
-                            }
                         }
+                        return asyncCommitMergedBucket(immutableBucketDelayedIndexPair, buckets,
+                                mergedBucketPriorityQueue, createStartTime);
                     });
+        });
+    }
+
+    private CompletableFuture<Void> asyncCommitMergedBucket(
+            Pair<ImmutableBucket, DelayedIndex> immutableBucketDelayedIndexPair,
+            List<ImmutableBucket> sourceBuckets, TripleLongPriorityQueue mergedBucketPriorityQueue,
+            long createStartTime) {
+        ImmutableBucket mergedBucket = immutableBucketDelayedIndexPair.getLeft();
+        DelayedIndex lastDelayedIndex = immutableBucketDelayedIndexPair.getRight();
+        CompletableFuture<Long> createFuture = mergedBucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE);
+        return createFuture.<CompletableFuture<Void>>handle((bucketId, ex) -> {
+            if (ex != null) {
+                log.error()
+                        .attr("bucketKey", mergedBucket.bucketKey())
+                        .exception(ex)
+                        .log("Failed to create merged bucket snapshot");
+                stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
+                return FutureUtil.<Void>failedFuture(ex);
+            }
+
+            String bucketIdValue = String.valueOf(bucketId);
+            if (!bucketIdValue.equals(mergedBucket.getCursor().getCursorProperties().get(mergedBucket.bucketKey()))) {
+                IllegalStateException exception = new IllegalStateException(
+                        "Merged bucket snapshot is missing its cursor property");
+                log.error()
+                        .attr("bucketKey", mergedBucket.bucketKey())
+                        .attr("bucketId", bucketId)
+                        .log("Merged bucket snapshot is not recoverable");
+                stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
+                return FutureUtil.failedFuture(exception);
+            }
+
+            synchronized (BucketDelayedDeliveryTracker.this) {
+                while (!mergedBucketPriorityQueue.isEmpty()) {
+                    sharedBucketPriorityQueue.add(mergedBucketPriorityQueue.peekN1(),
+                            mergedBucketPriorityQueue.peekN2(), mergedBucketPriorityQueue.peekN3());
+                    mergedBucketPriorityQueue.pop();
+                }
+                mergedBucket.setSnapshotSegments(null);
+                putBucket(Range.closed(mergedBucket.startLedgerId, mergedBucket.endLedgerId), mergedBucket);
+                snapshotSegmentLastIndexMap.entrySet().removeIf(entry -> sourceBuckets.contains(entry.getValue()));
+                snapshotSegmentLastIndexMap.put(
+                        new SnapshotKey(lastDelayedIndex.getLedgerId(), lastDelayedIndex.getEntryId()), mergedBucket);
+            }
+
+            mergedBucket.asyncUpdateSnapshotLength().thenAccept(newLength -> {
+                synchronized (BucketDelayedDeliveryTracker.this) {
+                    updateBucketSnapshotLength(mergedBucket, newLength);
+                }
+            });
+            log.debug()
+                    .attr("bucketKey", mergedBucket.bucketKey())
+                    .log("Create merged bucket snapshot finish");
+            stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.create,
+                    System.currentTimeMillis() - createStartTime);
+
+            List<CompletableFuture<Void>> removeFutures =
+                    sourceBuckets.stream().map(bucket -> bucket.asyncDeleteBucketSnapshot(stats)).toList();
+            return FutureUtil.waitForAll(removeFutures);
+        }).thenCompose(future -> future).whenComplete((__, ex) -> {
+            mergedBucket.setSnapshotSegments(null);
+            mergedBucketPriorityQueue.close();
         });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -126,6 +126,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private volatile CompletableFuture<Void> trimFuture;
 
+    private boolean closing;
+
+    private CompletableFuture<Void> closeFuture;
+
     public BucketDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher,
                                         Timer timer, long tickTimeMillis,
                                         boolean isDelayedDeliveryDeliverAtTimeStrict,
@@ -328,7 +332,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     @Override
     public void run(Timeout timeout) throws Exception {
         synchronized (this) {
-            if (timeout == null || timeout.isCancelled()) {
+            if (closing || timeout == null || timeout.isCancelled()) {
                 return;
             }
             lastMutableBucket.moveScheduledMessageToSharedQueue(getCutoffTime(), sharedBucketPriorityQueue);
@@ -409,6 +413,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     @Override
     public synchronized boolean addMessage(long ledgerId, long entryId, long deliverAt) {
+        if (closing) {
+            return false;
+        }
+
         if (deliverAt < 0 || deliverAt <= getCutoffTime()) {
             return false;
         }
@@ -531,6 +539,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                     immutableBucket.merging = false;
                 }
             }
+            rescheduleTimerIfNotClosing();
             if (ex != null) {
                 log.error()
                         .attr("bucketKeys", bucketsStr)
@@ -620,7 +629,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         ImmutableBucket mergedBucket = immutableBucketDelayedIndexPair.getLeft();
         DelayedIndex lastDelayedIndex = immutableBucketDelayedIndexPair.getRight();
         CompletableFuture<Long> createFuture = mergedBucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE);
-        return createFuture.<CompletableFuture<Void>>handle((bucketId, ex) -> {
+        return createFuture.<CompletableFuture<Void>>handle((__, ex) -> {
             if (ex != null) {
                 log.error()
                         .attr("bucketKey", mergedBucket.bucketKey())
@@ -628,18 +637,6 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         .log("Failed to create merged bucket snapshot");
                 stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
                 return FutureUtil.<Void>failedFuture(ex);
-            }
-
-            String bucketIdValue = String.valueOf(bucketId);
-            if (!bucketIdValue.equals(mergedBucket.getCursor().getCursorProperties().get(mergedBucket.bucketKey()))) {
-                IllegalStateException exception = new IllegalStateException(
-                        "Merged bucket snapshot is missing its cursor property");
-                log.error()
-                        .attr("bucketKey", mergedBucket.bucketKey())
-                        .attr("bucketId", bucketId)
-                        .log("Merged bucket snapshot is not recoverable");
-                stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.create);
-                return FutureUtil.failedFuture(exception);
             }
 
             synchronized (BucketDelayedDeliveryTracker.this) {
@@ -655,28 +652,84 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         new SnapshotKey(lastDelayedIndex.getLedgerId(), lastDelayedIndex.getEntryId()), mergedBucket);
             }
 
-            mergedBucket.asyncUpdateSnapshotLength().thenAccept(newLength -> {
-                synchronized (BucketDelayedDeliveryTracker.this) {
-                    updateBucketSnapshotLength(mergedBucket, newLength);
-                }
-            });
+            updateMergedBucketSnapshotLength(mergedBucket);
             log.debug()
                     .attr("bucketKey", mergedBucket.bucketKey())
                     .log("Create merged bucket snapshot finish");
             stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.create,
                     System.currentTimeMillis() - createStartTime);
 
-            List<CompletableFuture<Void>> removeFutures =
-                    sourceBuckets.stream().map(bucket -> bucket.asyncDeleteBucketSnapshot(stats)).toList();
-            return FutureUtil.waitForAll(removeFutures);
+            cleanupSourceBucketSnapshots(mergedBucket, sourceBuckets);
+            return CompletableFuture.completedFuture(null);
         }).thenCompose(future -> future).whenComplete((__, ex) -> {
             mergedBucket.setSnapshotSegments(null);
-            mergedBucketPriorityQueue.close();
+            try {
+                mergedBucketPriorityQueue.close();
+            } catch (RuntimeException e) {
+                log.warn()
+                        .attr("bucketKey", mergedBucket.bucketKey())
+                        .exception(e)
+                        .log("Failed to close merged bucket staging queue");
+            }
         });
+    }
+
+    private void updateMergedBucketSnapshotLength(ImmutableBucket mergedBucket) {
+        try {
+            mergedBucket.asyncUpdateSnapshotLength().thenAccept(newLength -> {
+                synchronized (BucketDelayedDeliveryTracker.this) {
+                    updateBucketSnapshotLength(mergedBucket, newLength);
+                }
+            }).exceptionally(__ -> null);
+        } catch (RuntimeException e) {
+            log.warn()
+                    .attr("bucketKey", mergedBucket.bucketKey())
+                    .exception(e)
+                    .log("Failed to update merged bucket snapshot length");
+        }
+    }
+
+    private void cleanupSourceBucketSnapshots(ImmutableBucket mergedBucket, List<ImmutableBucket> sourceBuckets) {
+        List<CompletableFuture<Void>> removeFutures = new ArrayList<>(sourceBuckets.size());
+        for (ImmutableBucket sourceBucket : sourceBuckets) {
+            try {
+                removeFutures.add(sourceBucket.asyncDeleteBucketSnapshot(stats));
+            } catch (RuntimeException e) {
+                stats.recordFailEvent(BucketDelayedMessageIndexStats.Type.delete);
+                log.warn()
+                        .attr("bucketKey", sourceBucket.bucketKey())
+                        .exception(e)
+                        .log("Failed to start source bucket snapshot cleanup after merge");
+            }
+        }
+        FutureUtil.waitForAll(removeFutures).whenComplete((__, cleanupException) -> {
+            if (cleanupException != null) {
+                log.warn()
+                        .attr("bucketKey", mergedBucket.bucketKey())
+                        .exception(cleanupException)
+                        .log("Failed to cleanup source bucket snapshots after merge");
+            }
+        });
+    }
+
+    private synchronized void rescheduleTimerIfNotClosing() {
+        if (!closing) {
+            try {
+                rescheduleTimer(0);
+            } catch (RuntimeException e) {
+                log.warn()
+                        .exception(e)
+                        .log("Failed to reschedule delayed delivery after bucket operation");
+            }
+        }
     }
 
     @Override
     public synchronized boolean hasMessageAvailable() {
+        if (closing) {
+            return false;
+        }
+
         long cutoffTime = getCutoffTime();
 
         boolean hasMessageAvailable = getNumberOfDelayedMessages() > 0 && nextDeliveryTime() <= cutoffTime;
@@ -715,6 +768,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     @Override
     public synchronized NavigableSet<Position> getScheduledMessages(int maxMessages) {
+        if (closing) {
+            return Collections.emptyNavigableSet();
+        }
+
         if (!checkPendingLoadDone()) {
             log.debug("Skip getScheduledMessages to wait for bucket snapshot load finish");
             return Collections.emptyNavigableSet();
@@ -813,7 +870,7 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
                         stats.recordSuccessEvent(BucketDelayedMessageIndexStats.Type.load,
                                 System.currentTimeMillis() - loadStartTime);
                     }
-                    rescheduleTimer(0);
+                    rescheduleTimerIfNotClosing();
                 });
 
                 if (!checkPendingLoadDone() || loadFuture.isCompletedExceptionally()) {
@@ -850,6 +907,10 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     @Override
     public synchronized CompletableFuture<Void> clear() {
+        if (closing) {
+            return FutureUtil.failedFuture(new IllegalStateException("Delayed delivery tracker is closing"));
+        }
+
         // Wait for any in-flight trim+merge to settle, then clear.
         // Reuse trimFuture to block new triggers until the clear chain completes.
         CompletableFuture<Void> before = trimFuture != null && !trimFuture.isDone()
@@ -879,20 +940,49 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
     }
 
     @Override
-    public CompletableFuture<Void> closeAsync() {
-        List<CompletableFuture<Long>> completableFutures;
-        synchronized (this) {
-            super.close();
-            lastMutableBucket.close();
-            sharedBucketPriorityQueue.close();
-            completableFutures = immutableBuckets.asMapOfRanges().values().stream()
-                    .map(bucket -> bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)).toList();
+    public synchronized CompletableFuture<Void> closeAsync() {
+        if (closeFuture != null) {
+            return closeFuture;
         }
-        return FutureUtil.waitForAll(completableFutures)
-                .exceptionally(e -> {
-                    log.warn().exception(e).log("Failed wait to snapshot generate");
-                    return null;
-                });
+
+        closing = true;
+        super.close();
+
+        List<CompletableFuture<?>> inFlightFutures = new ArrayList<>();
+        if (trimFuture != null) {
+            inFlightFutures.add(trimFuture);
+        }
+        if (pendingLoad != null) {
+            inFlightFutures.add(pendingLoad);
+        }
+        immutableBuckets.asMapOfRanges().values().stream()
+                .map(bucket -> bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE))
+                .forEach(inFlightFutures::add);
+
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        closeFuture = result;
+        FutureUtil.waitForAll(inFlightFutures).whenComplete((__, ex) -> {
+            if (ex != null) {
+                log.warn()
+                        .exception(ex)
+                        .log("Failed to wait for delayed delivery tracker operations during close");
+            }
+            try {
+                closeResources();
+                result.complete(null);
+            } catch (Throwable closeException) {
+                result.completeExceptionally(closeException);
+            }
+        });
+        return result;
+    }
+
+    private synchronized void closeResources() {
+        try {
+            lastMutableBucket.close();
+        } finally {
+            sharedBucketPriorityQueue.close();
+        }
     }
 
     private CompletableFuture<Void> cleanImmutableBuckets() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockBucketSnapshotStorage.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/MockBucketSnapshotStorage.java
@@ -135,8 +135,9 @@ public class MockBucketSnapshotStorage implements BucketSnapshotStorage {
             long lastEntryId = Math.min(lastSegmentEntryId, this.bucketSnapshots.get(bucketId).size());
             for (int i = (int) firstSegmentEntryId; i <= lastEntryId; i++) {
                 ByteBuf byteBuf = this.bucketSnapshots.get(bucketId).get(i);
+                ByteBuf slice = byteBuf.slice();
                 SnapshotSegment snapshotSegment = new SnapshotSegment();
-                snapshotSegment.parseFrom(byteBuf, byteBuf.readableBytes());
+                snapshotSegment.parseFrom(slice, slice.readableBytes());
                 snapshotSegments.add(snapshotSegment);
             }
             return snapshotSegments;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -56,7 +57,10 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.pulsar.broker.delayed.AbstractDeliveryTrackerTest;
 import org.apache.pulsar.broker.delayed.MockBucketSnapshotStorage;
 import org.apache.pulsar.broker.delayed.MockManagedCursor;
+import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
+import org.apache.pulsar.broker.delayed.proto.SnapshotSegment;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -377,6 +381,60 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         tracker2.close();
     }
 
+    @Test
+    public void testMergeSnapshotCreationFailureRetainsSourceBuckets() throws Exception {
+        FailingMergedSnapshotStorage storage = new FailingMergedSnapshotStorage();
+        storage.start();
+        MockManagedCursor cursor = new MockManagedCursor("merge-failure-cursor");
+        AtomicLong now = new AtomicLong();
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        when(testClock.millis()).then(__ -> now.get());
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testDelay / " + cursor.getName()).when(testDispatcher).getName();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(testDispatcher, mock(Timer.class),
+                1, testClock, true, storage, 1, TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+        boolean trackerClosed = false;
+        try {
+            for (int ledgerId = 1; ledgerId <= 6; ledgerId++) {
+                tracker.addMessage(ledgerId, 1, ledgerId * 100L);
+                tracker.addMessage(ledgerId, 2, ledgerId * 100L + 20);
+                tracker.addMessage(ledgerId, 3, ledgerId * 100L + 40);
+            }
+
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(storage.getMergedSnapshotCreateAttempts() > 0);
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(bucket -> bucket.merging));
+            });
+
+            assertEquals(storage.getDeleteCalls(), 0,
+                    "Source snapshots must not be deleted when the replacement snapshot cannot be created");
+            assertEquals(tracker.getImmutableBuckets().asMapOfRanges().size(), 5);
+            assertEquals(cursor.getCursorProperties().keySet().stream()
+                    .filter(key -> key.startsWith(BucketDelayedDeliveryTracker.DELAYED_BUCKET_KEY_PREFIX))
+                    .count(), 5L);
+
+            tracker.close();
+            trackerClosed = true;
+            BucketDelayedDeliveryTracker recoveredTracker = new BucketDelayedDeliveryTracker(testDispatcher,
+                    mock(Timer.class), 1, testClock, true, storage, 1,
+                    TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+            try {
+                assertEquals(recoveredTracker.getNumberOfDelayedMessages(), 15L);
+            } finally {
+                recoveredTracker.close();
+            }
+        } finally {
+            if (!trackerClosed) {
+                tracker.close();
+            }
+            storage.close();
+        }
+    }
+
     @SuppressWarnings("deprecation")
     @Test(dataProvider = "delayedTracker")
     public void testWithBkException(final BucketDelayedDeliveryTracker tracker) throws Exception {
@@ -539,6 +597,38 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         void close() throws Exception {
             tracker.close();
             storage.close();
+        }
+    }
+
+    private static class FailingMergedSnapshotStorage extends MockBucketSnapshotStorage {
+        private final AtomicInteger mergedSnapshotCreateAttempts = new AtomicInteger();
+        private final AtomicInteger deleteCalls = new AtomicInteger();
+
+        @Override
+        public CompletableFuture<Long> createBucketSnapshot(SnapshotMetadata snapshotMetadata,
+                                                            List<SnapshotSegment> bucketSnapshotSegments,
+                                                            String bucketKey, String topicName, String cursorName) {
+            String[] keyParts = bucketKey.split(Bucket.DELIMITER);
+            if (!keyParts[keyParts.length - 2].equals(keyParts[keyParts.length - 1])) {
+                mergedSnapshotCreateAttempts.incrementAndGet();
+                return FutureUtil.failedFuture(new BucketSnapshotPersistenceException("Merged snapshot failed"));
+            }
+            return super.createBucketSnapshot(snapshotMetadata, bucketSnapshotSegments, bucketKey, topicName,
+                    cursorName);
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            deleteCalls.incrementAndGet();
+            return super.deleteBucketSnapshot(bucketId);
+        }
+
+        int getMergedSnapshotCreateAttempts() {
+            return mergedSnapshotCreateAttempts.get();
+        }
+
+        int getDeleteCalls() {
+            return deleteCalls.get();
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.delayed.bucket;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -47,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -428,11 +430,310 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
                 recoveredTracker.close();
             }
         } finally {
-            if (!trackerClosed) {
-                tracker.close();
+            try {
+                if (!trackerClosed) {
+                    tracker.close();
+                }
+            } finally {
+                storage.close();
             }
-            storage.close();
         }
+    }
+
+    @Test
+    public void testCloseWaitsForInFlightBucketMerge() throws Exception {
+        BlockingMergedSnapshotStorage storage = new BlockingMergedSnapshotStorage(true);
+        storage.start();
+        MockManagedCursor cursor = new MockManagedCursor("close-during-merge-cursor");
+        AtomicLong now = new AtomicLong();
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        when(testClock.millis()).then(__ -> now.get());
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testDelay / " + cursor.getName()).when(testDispatcher).getName();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(testDispatcher, mock(Timer.class),
+                1, testClock, true, storage, 1, TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+        CompletableFuture<Void> closeFuture = null;
+        try {
+            addMessagesAndTriggerMerge(tracker);
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(storage.getMergedSnapshotCreateAttempts() > 0));
+
+            closeFuture = tracker.closeAsync();
+            assertFalse("closeAsync must wait for the staged merge before closing its queues", closeFuture.isDone());
+            CompletableFuture<Void> repeatedCloseFuture = tracker.closeAsync();
+            assertFalse("Repeated closeAsync calls must wait for the same close operation",
+                    repeatedCloseFuture.isDone());
+
+            storage.completeMergedSnapshotCreation();
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(storage.getSourceSnapshotDeleteAttempts() > 0));
+            closeFuture.get(10, TimeUnit.SECONDS);
+            repeatedCloseFuture.get(10, TimeUnit.SECONDS);
+            long delayedMessagesInSnapshots = tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                    .mapToLong(ImmutableBucket::getNumberBucketDelayedMessages)
+                    .sum();
+            assertEquals(delayedMessagesInSnapshots, 11L);
+            assertEquals(cursor.getCursorProperties().keySet().stream()
+                    .filter(key -> key.startsWith(BucketDelayedDeliveryTracker.DELAYED_BUCKET_KEY_PREFIX))
+                    .count(), 6L, "Close must not wait for post-commit source cleanup");
+
+            BucketDelayedDeliveryTracker recoveredTracker = new BucketDelayedDeliveryTracker(testDispatcher,
+                    mock(Timer.class), 1, testClock, true, storage, 1,
+                    TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+            try {
+                assertEquals(recoveredTracker.getNumberOfDelayedMessages(), delayedMessagesInSnapshots);
+            } finally {
+                recoveredTracker.close();
+            }
+        } finally {
+            storage.completeMergedSnapshotCreation();
+            try {
+                if (closeFuture == null) {
+                    tracker.close();
+                } else {
+                    closeFuture.get(10, TimeUnit.SECONDS);
+                }
+            } finally {
+                try {
+                    storage.completeSourceSnapshotDeletionAndWait();
+                } finally {
+                    storage.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMergeCompletionReschedulesBlockedDelivery() throws Exception {
+        BlockingMergedSnapshotStorage storage = new BlockingMergedSnapshotStorage(true);
+        storage.start();
+        MockManagedCursor cursor = new MockManagedCursor("merge-reschedule-cursor");
+        AtomicLong now = new AtomicLong();
+        AtomicInteger triggerCalls = new AtomicInteger();
+        AtomicReference<ScheduledTimer> scheduledTimer = new AtomicReference<>();
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        Timer testTimer = createRecordingTimer(scheduledTimer);
+        when(testClock.millis()).then(__ -> now.get());
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testDelay / " + cursor.getName()).when(testDispatcher).getName();
+        doAnswer(__ -> {
+            triggerCalls.incrementAndGet();
+            return null;
+        }).when(testDispatcher).readMoreEntriesAsync();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(testDispatcher, testTimer,
+                1, testClock, true, storage, 1, TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+        try {
+            addMessagesAndTriggerMerge(tracker);
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(storage.getMergedSnapshotCreateAttempts() > 0));
+
+            now.set(10_000);
+            ScheduledTimer initialTimer = scheduledTimer.get();
+            assertTrue(initialTimer != null, "The first delayed message should have an armed timer");
+            initialTimer.task().run(initialTimer.timeout());
+            assertEquals(triggerCalls.get(), 1);
+
+            scheduledTimer.set(null);
+            assertTrue(tracker.getScheduledMessages(100).isEmpty(),
+                    "Delivery should pause at the snapshot segment boundary while its bucket is merging");
+            assertTrue(scheduledTimer.get() == null,
+                    "An already-due blocked message should not leave a timer armed");
+
+            storage.completeMergedSnapshotCreation();
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(storage.getSourceSnapshotDeleteAttempts() > 0));
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(scheduledTimer.get() != null,
+                            "Merge commit must schedule another delivery attempt before source cleanup finishes"));
+
+            ScheduledTimer mergeCompletionTimer = scheduledTimer.get();
+            assertEquals(mergeCompletionTimer.delayMillis(), 0L);
+            mergeCompletionTimer.task().run(mergeCompletionTimer.timeout());
+            assertEquals(triggerCalls.get(), 2);
+
+            assertAllMergeMessagesDelivered(tracker);
+            storage.completeSourceSnapshotDeletionAndWait();
+        } finally {
+            storage.completeMergedSnapshotCreation();
+            try {
+                tracker.close();
+            } finally {
+                try {
+                    storage.completeSourceSnapshotDeletionAndWait();
+                } finally {
+                    storage.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMergeFailureReschedulesBlockedDelivery() throws Exception {
+        BlockingMergedSnapshotStorage storage = new BlockingMergedSnapshotStorage();
+        storage.start();
+        MockManagedCursor cursor = new MockManagedCursor("merge-failure-reschedule-cursor");
+        AtomicLong now = new AtomicLong();
+        AtomicInteger triggerCalls = new AtomicInteger();
+        AtomicReference<ScheduledTimer> scheduledTimer = new AtomicReference<>();
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        Timer testTimer = createRecordingTimer(scheduledTimer);
+        when(testClock.millis()).then(__ -> now.get());
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testDelay / " + cursor.getName()).when(testDispatcher).getName();
+        doAnswer(__ -> {
+            triggerCalls.incrementAndGet();
+            return null;
+        }).when(testDispatcher).readMoreEntriesAsync();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(testDispatcher, testTimer,
+                1, testClock, true, storage, 1, TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+        try {
+            addMessagesAndTriggerMerge(tracker);
+            Awaitility.await().atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertTrue(storage.getMergedSnapshotCreateAttempts() > 0));
+
+            now.set(10_000);
+            ScheduledTimer initialTimer = scheduledTimer.get();
+            assertTrue(initialTimer != null, "The first delayed message should have an armed timer");
+            initialTimer.task().run(initialTimer.timeout());
+
+            scheduledTimer.set(null);
+            assertTrue(tracker.getScheduledMessages(100).isEmpty(),
+                    "Delivery should pause at the snapshot segment boundary while its bucket is merging");
+            assertTrue(scheduledTimer.get() == null,
+                    "An already-due blocked message should not leave a timer armed");
+
+            storage.failMergedSnapshotCreation();
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(bucket -> bucket.merging));
+                assertTrue(scheduledTimer.get() != null,
+                        "Merge failure must schedule another delivery attempt after retaining source buckets");
+            });
+
+            assertEquals(scheduledTimer.get().delayMillis(), 0L);
+            assertEquals(storage.getSourceSnapshotDeleteAttempts(), 0);
+            ScheduledTimer mergeFailureTimer = scheduledTimer.get();
+            mergeFailureTimer.task().run(mergeFailureTimer.timeout());
+            assertEquals(triggerCalls.get(), 2);
+            assertAllMergeMessagesDelivered(tracker);
+        } finally {
+            storage.completeMergedSnapshotCreation();
+            try {
+                tracker.close();
+            } finally {
+                try {
+                    storage.completeSourceSnapshotDeletionAndWait();
+                } finally {
+                    storage.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSourceCleanupFailureDoesNotFailCommittedMerge() throws Exception {
+        FailingSourceSnapshotDeleteStorage storage = new FailingSourceSnapshotDeleteStorage();
+        storage.start();
+        MockManagedCursor cursor = new MockManagedCursor("merge-cleanup-failure-cursor");
+        AtomicLong now = new AtomicLong();
+        AbstractPersistentDispatcherMultipleConsumers testDispatcher =
+                mock(AbstractPersistentDispatcherMultipleConsumers.class);
+        Clock testClock = mock(Clock.class);
+        when(testClock.millis()).then(__ -> now.get());
+        doReturn(cursor).when(testDispatcher).getCursor();
+        doReturn("persistent://public/default/testDelay / " + cursor.getName()).when(testDispatcher).getName();
+
+        BucketDelayedDeliveryTracker tracker = new BucketDelayedDeliveryTracker(testDispatcher, mock(Timer.class),
+                1, testClock, true, storage, 1, TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+        try {
+            addMessagesAndTriggerMerge(tracker);
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertTrue(storage.getSourceSnapshotDeleteAttempts() > 0);
+                assertTrue(tracker.getImmutableBuckets().asMapOfRanges().values().stream()
+                        .noneMatch(bucket -> bucket.merging));
+                assertEquals(getBucketOperationCount(tracker, "succeed", "merge"), 1L);
+                assertEquals(getBucketOperationCount(tracker, "failed", "merge"), 0L);
+            });
+
+            assertEquals(tracker.getImmutableBuckets().asMapOfRanges().size(), 2,
+                    "The committed merged bucket must remain active when source cleanup fails");
+            assertEquals(tracker.getNumberOfDelayedMessages(), 18L);
+
+            BucketDelayedDeliveryTracker recoveredTracker = new BucketDelayedDeliveryTracker(testDispatcher,
+                    mock(Timer.class), 1, testClock, true, storage, 1,
+                    TimeUnit.MILLISECONDS.toMillis(10), -1, 4);
+            try {
+                assertEquals(recoveredTracker.getNumberOfDelayedMessages(), 11L);
+                assertEquals(recoveredTracker.getImmutableBuckets().asMapOfRanges().size(), 2);
+            } finally {
+                recoveredTracker.close();
+            }
+        } finally {
+            try {
+                tracker.close();
+            } finally {
+                storage.close();
+            }
+        }
+    }
+
+    private static void addMessagesAndTriggerMerge(BucketDelayedDeliveryTracker tracker) {
+        for (int ledgerId = 1; ledgerId <= 6; ledgerId++) {
+            tracker.addMessage(ledgerId, 1, ledgerId * 100L);
+            tracker.addMessage(ledgerId, 2, ledgerId * 100L + 20);
+            tracker.addMessage(ledgerId, 3, ledgerId * 100L + 40);
+        }
+    }
+
+    private static void assertAllMergeMessagesDelivered(BucketDelayedDeliveryTracker tracker) {
+        NavigableSet<Position> scheduledMessages = new TreeSet<>();
+        AtomicInteger returnedMessages = new AtomicInteger();
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            NavigableSet<Position> batch = tracker.getScheduledMessages(100);
+            returnedMessages.addAndGet(batch.size());
+            scheduledMessages.addAll(batch);
+            assertEquals(scheduledMessages.size(), 18);
+        });
+        assertEquals(returnedMessages.get(), 18, "Merge delivery must not return duplicate positions");
+        assertEquals(tracker.getNumberOfDelayedMessages(), 0L);
+        for (int ledgerId = 1; ledgerId <= 6; ledgerId++) {
+            for (int entryId = 1; entryId <= 3; entryId++) {
+                assertTrue(scheduledMessages.contains(PositionFactory.create(ledgerId, entryId)));
+            }
+        }
+    }
+
+    private record ScheduledTimer(TimerTask task, Timeout timeout, long delayMillis) {}
+
+    private static Timer createRecordingTimer(AtomicReference<ScheduledTimer> scheduledTimer) {
+        Timer timer = mock(Timer.class);
+        when(timer.newTimeout(any(), anyLong(), any())).thenAnswer(invocation -> {
+            TimerTask task = invocation.getArgument(0, TimerTask.class);
+            Timeout timeout = mock(Timeout.class);
+            when(timeout.isCancelled()).thenReturn(false);
+            when(timeout.cancel()).thenReturn(true);
+            long delayMillis = invocation.getArgument(2, TimeUnit.class)
+                    .toMillis(invocation.getArgument(1, Long.class));
+            scheduledTimer.set(new ScheduledTimer(task, timeout, delayMillis));
+            return timeout;
+        });
+        return timer;
+    }
+
+    private static long getBucketOperationCount(BucketDelayedDeliveryTracker tracker, String state, String type) {
+        String key = BucketDelayedMessageIndexStats.OP_COUNT_NAME
+                + BucketDelayedMessageIndexStats.joinKey("state", state, "type", type);
+        var metric = tracker.genTopicMetricMap().get(key);
+        return metric == null ? 0 : (long) metric.value;
     }
 
     @SuppressWarnings("deprecation")
@@ -629,6 +930,86 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
         int getDeleteCalls() {
             return deleteCalls.get();
+        }
+    }
+
+    private static class BlockingMergedSnapshotStorage extends MockBucketSnapshotStorage {
+        private final CompletableFuture<Void> allowMergedSnapshotCreation = new CompletableFuture<>();
+        private final CompletableFuture<Void> allowSourceSnapshotDeletion = new CompletableFuture<>();
+        private final AtomicInteger mergedSnapshotCreateAttempts = new AtomicInteger();
+        private final AtomicInteger sourceSnapshotDeleteAttempts = new AtomicInteger();
+        private final AtomicInteger sourceSnapshotDeleteCompletions = new AtomicInteger();
+
+        BlockingMergedSnapshotStorage() {
+            this(false);
+        }
+
+        BlockingMergedSnapshotStorage(boolean blockSourceSnapshotDeletion) {
+            if (!blockSourceSnapshotDeletion) {
+                allowSourceSnapshotDeletion.complete(null);
+            }
+        }
+
+        @Override
+        public CompletableFuture<Long> createBucketSnapshot(SnapshotMetadata snapshotMetadata,
+                                                            List<SnapshotSegment> bucketSnapshotSegments,
+                                                            String bucketKey, String topicName, String cursorName) {
+            String[] keyParts = bucketKey.split(Bucket.DELIMITER);
+            if (!keyParts[keyParts.length - 2].equals(keyParts[keyParts.length - 1])) {
+                mergedSnapshotCreateAttempts.incrementAndGet();
+                return allowMergedSnapshotCreation.thenCompose(__ ->
+                        super.createBucketSnapshot(snapshotMetadata, bucketSnapshotSegments, bucketKey, topicName,
+                                cursorName));
+            }
+            return super.createBucketSnapshot(snapshotMetadata, bucketSnapshotSegments, bucketKey, topicName,
+                    cursorName);
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            sourceSnapshotDeleteAttempts.incrementAndGet();
+            return allowSourceSnapshotDeletion.thenCompose(__ -> super.deleteBucketSnapshot(bucketId))
+                    .whenComplete((__, ___) -> sourceSnapshotDeleteCompletions.incrementAndGet());
+        }
+
+        void completeMergedSnapshotCreation() {
+            allowMergedSnapshotCreation.complete(null);
+        }
+
+        void failMergedSnapshotCreation() {
+            allowMergedSnapshotCreation.completeExceptionally(
+                    new BucketSnapshotPersistenceException("Merged snapshot failed"));
+        }
+
+        void completeSourceSnapshotDeletionAndWait() {
+            int expectedCompletions = sourceSnapshotDeleteAttempts.get();
+            allowSourceSnapshotDeletion.complete(null);
+            Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
+                    () -> assertEquals(sourceSnapshotDeleteCompletions.get(), expectedCompletions));
+        }
+
+        int getMergedSnapshotCreateAttempts() {
+            return mergedSnapshotCreateAttempts.get();
+        }
+
+        int getSourceSnapshotDeleteAttempts() {
+            return sourceSnapshotDeleteAttempts.get();
+        }
+    }
+
+    private static class FailingSourceSnapshotDeleteStorage extends MockBucketSnapshotStorage {
+        private final AtomicInteger sourceSnapshotDeleteAttempts = new AtomicInteger();
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            if (sourceSnapshotDeleteAttempts.incrementAndGet() <= 2) {
+                throw new IllegalStateException("Source snapshot delete failed synchronously");
+            }
+            return FutureUtil.failedFuture(new BucketSnapshotPersistenceException("Source snapshot delete failed"));
+        }
+
+        int getSourceSnapshotDeleteAttempts() {
+            return sourceSnapshotDeleteAttempts.get();
         }
     }
 


### PR DESCRIPTION
### Motivation

`afterCreateImmutableBucket` converts snapshot creation failures to `INVALID_BUCKET_ID`. The merge cleanup chain therefore continues and deletes the source snapshots even when the replacement snapshot was not created. The indexes are still available in memory, but they cannot be recovered after the tracker is unloaded or the broker restarts.

The merge path is asynchronous. Delivery can stop at a source bucket segment boundary while the bucket is merging, with no timer left to resume delivery after the merge settles. Closing the tracker while a merge callback is pending can also release the shared queues before the callback finishes.

Source snapshot deletion happens after the replacement bucket has been committed. A deletion failure cannot roll back that commit and should not make the merge appear to have failed.

### Modifications

- Build the merged bucket with a staging priority queue and leave the source buckets active while the replacement snapshot is being created.
- Commit the merged bucket only after snapshot creation succeeds. The queue transfer, bucket range replacement, and segment mapping update are performed together while holding the tracker lock.
- Keep the source buckets unchanged when snapshot creation fails.
- Clear the merging state and schedule another delivery attempt after both commit and rollback.
- Run source snapshot deletion as post-commit cleanup. Cleanup failures are logged and reported as delete failures without changing the merge result or blocking tracker close.
- Stop new tracker operations during close and wait for in-flight trim/merge, segment load, and snapshot creation callbacks before closing the queues.
- Make mock snapshot segment reads non-destructive so the same snapshot can be loaded again after a failed merge attempt.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change adds tests for:

- retaining and recovering source buckets after merged snapshot creation fails;
- delivering all 18 delayed messages without loss or duplication after rollback;
- resuming delivery after merge commit and rollback;
- closing during an in-flight merge without waiting for post-commit cleanup;
- synchronous and asynchronous source cleanup failures; and
- recovering the committed merged bucket when failed cleanup leaves source metadata behind.

The following command passes with test retries disabled:

```shell
./gradlew :pulsar-broker:test \
  --tests org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTrackerTest \
  :pulsar-broker:checkstyleMain \
  :pulsar-broker:checkstyleTest \
  -PtestRetryCount=0 \
  --no-daemon
```

Result: 41 tests, 0 failures, 0 skipped.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
  - Coordinate asynchronous merge completion, timer rescheduling, and tracker close.
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] The metrics
  - Report post-commit cleanup failures as delete failures instead of merge failures.
- [ ] Anything that affects deployment
