### PR TITLE
[fix][broker] Fix delayed message index data loss when trimming overlapping bucket snapshots

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -887,8 +887,14 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
         }
         ManagedLedger ledger = context.getCursor().getManagedLedger();
 
-        Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets =
-                new HashMap<>(immutableBuckets.subRangeMap(Range.lessThan(firstLedgerId)).asMapOfRanges());
+        Map<Range<Long>, ImmutableBucket> toBeDeletedBuckets = new HashMap<>();
+        // subRangeMap returns clipped intersection ranges. Snapshot deletion must use the original
+        // bucket range, so only select buckets whose complete range precedes the first live ledger.
+        immutableBuckets.asMapOfRanges().forEach((range, bucket) -> {
+            if (range.upperEndpoint() < firstLedgerId) {
+                toBeDeletedBuckets.put(range, bucket);
+            }
+        });
 
         if (toBeDeletedBuckets.isEmpty()) {
             return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -555,6 +555,16 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
     }
 
+    private static class RecordingDeleteStorage extends MockBucketSnapshotStorage {
+        final AtomicLong deleteCalls = new AtomicLong();
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            deleteCalls.incrementAndGet();
+            return super.deleteBucketSnapshot(bucketId);
+        }
+    }
+
     private TrackerWithStorage createTrackerWithMockLedger(long firstLedgerId, int maxNumBuckets)
             throws Exception {
         return createTrackerWithMockLedger(firstLedgerId, maxNumBuckets, new MockBucketSnapshotStorage());
@@ -625,6 +635,38 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         assertEquals(ts.tracker.getNumberOfDelayedMessages(), messagesAfterTrim - scheduledMessages.size());
 
         ts.close();
+    }
+
+    @Test
+    public void testTrimDoesNotDeleteBucketOverlappingFirstActiveLedger() throws Exception {
+        RecordingDeleteStorage storage = new RecordingDeleteStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(3L, 4, storage);
+        try {
+            for (long ledgerId = 1; ledgerId <= 6; ledgerId++) {
+                ts.tracker.addMessage(ledgerId, 0L, 1000L);
+            }
+
+            Awaitility.await().untilAsserted(() -> {
+                assertEquals(ts.tracker.getImmutableBuckets().asMapOfRanges().size(), 1);
+                ImmutableBucket bucket = ts.tracker.getImmutableBuckets().asMapOfRanges()
+                        .values().iterator().next();
+                assertTrue(bucket.getSnapshotCreateFuture().orElseThrow().isDone());
+            });
+
+            // The fifth immutable bucket triggers trimming. All buckets have one snapshot segment,
+            // so merging does not remove any snapshots during this test.
+            for (long ledgerId = 7; ledgerId <= 26; ledgerId++) {
+                ts.tracker.addMessage(ledgerId, 0L, 1000L);
+            }
+            Awaitility.await().untilAsserted(
+                    () -> assertEquals(ts.tracker.getImmutableBuckets().asMapOfRanges().size(), 5));
+
+            Awaitility.await().pollDelay(1, TimeUnit.SECONDS).atMost(2, TimeUnit.SECONDS).untilAsserted(
+                    () -> assertEquals(storage.deleteCalls.get(), 0L,
+                            "A bucket overlapping the first active ledger must not be deleted"));
+        } finally {
+            ts.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

When bucket trimming selects an immutable bucket that overlaps the first active ledger, RangeMap returns a clipped range key. The delete path still deletes the complete bucket snapshot, so the delayed-delivery index cannot be recovered after a broker restart.

### Modifications

- Select only buckets whose complete immutable range ends before the first active ledger.
- Add a regression test for a bucket that overlaps the first active ledger.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Ran the bucket trimming tests covering complete deletion, delete failure, no orphaned buckets, and overlapping buckets.
- Ran pulsar-broker checkstyleMain and checkstyleTest.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment