### PR TITLE
[fix][broker] Fix TableViewLoadDataStoreImpl close deadlock that stalls broker shutdown

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/store/TableViewLoadDataStoreImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.store;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
@@ -145,7 +146,14 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
     public synchronized void closeTableView() throws IOException {
         validateState();
         if (tableView != null) {
-            tableView.close();
+            // Close asynchronously without waiting: the close future may only be able to complete on the
+            // client's internal executor thread, and that thread can be blocked on this store's monitor
+            // (e.g. a ServiceUnitStateChannel StateChangeListener calling pushAsync/removeAsync), so a
+            // blocking close while holding the monitor could deadlock.
+            tableView.closeAsync().exceptionally(e -> {
+                log.warn().attr("topic", topic).exception(e).log("Failed to close table view");
+                return null;
+            });
             tableView = null;
         }
     }
@@ -160,7 +168,11 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
     private synchronized void closeProducer() throws IOException {
         validateState();
         if (producer != null) {
-            producer.close();
+            // Close asynchronously without waiting; see closeTableView() for the deadlock rationale.
+            producer.closeAsync().exceptionally(e -> {
+                log.warn().attr("topic", topic).exception(e).log("Failed to close producer");
+                return null;
+            });
             producer = null;
         }
     }
@@ -209,6 +221,11 @@ public class TableViewLoadDataStoreImpl<T> implements LoadDataStore<T> {
     public synchronized void shutdown() throws IOException {
         close();
         isShutdown = true;
+    }
+
+    @VisibleForTesting
+    synchronized void setTableView(TableView<T> tableView) {
+        this.tableView = tableView;
     }
 
     private String validateProducer() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/extensions/store/LoadDataStoreTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pulsar.broker.loadbalance.extensions.store;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
@@ -29,12 +32,15 @@ import com.google.common.collect.Sets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.TableView;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -186,6 +192,53 @@ public class LoadDataStoreTest extends MockedPulsarServiceBaseTest {
 
         loadDataStore.pushAsync("2", 2).get();
         loadDataStore.removeAsync("2").get();
+    }
+
+    @Test(timeOut = 30_000)
+    @SuppressWarnings("unchecked")
+    public void testShutdownDoesNotDeadlockWithConcurrentStoreAccess() throws Exception {
+        String topic = TopicDomain.persistent + "://" + NamespaceName.SYSTEM_NAMESPACE + "/" + UUID.randomUUID();
+        var loadDataStore =
+                (TableViewLoadDataStoreImpl<Integer>) LoadDataStoreFactory.create(pulsar, topic, Integer.class);
+        loadDataStore.start();
+        loadDataStore.closeTableView();
+
+        // Replace the table view with a stub whose close future completes only after another thread has
+        // called a synchronized method of the store. This mirrors the production interleaving where the
+        // reader close future completes on the client's internal executor thread while a channel
+        // StateChangeListener on that same thread is blocked in removeAsync() waiting for the store
+        // monitor held by the closing thread.
+        CompletableFuture<Void> closeSignal = new CompletableFuture<>();
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        TableView<Integer> stubTableView = mock(TableView.class);
+        when(stubTableView.closeAsync()).thenAnswer(invocation -> {
+            closeStarted.countDown();
+            return closeSignal;
+        });
+        doAnswer(invocation -> {
+            closeStarted.countDown();
+            closeSignal.get();
+            return null;
+        }).when(stubTableView).close();
+        loadDataStore.setTableView(stubTableView);
+
+        Thread concurrentAccess = new Thread(() -> {
+            try {
+                closeStarted.await();
+                loadDataStore.removeAsync("key");
+                closeSignal.complete(null);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        concurrentAccess.start();
+        try {
+            loadDataStore.shutdown();
+        } finally {
+            concurrentAccess.join(5000);
+        }
+        assertFalse(concurrentAccess.isAlive());
+        assertTrue(closeSignal.isDone());
     }
 
     @Test


### PR DESCRIPTION
Fixes #24628

### Motivation

`ExtensibleLoadManagerCloseTest.testCloseAfterLoadingBundles` has been flaky in CI for a long time (#24628), with several failure signatures. Analysis of a recent failure (test-report artifact of [this run](https://github.com/apache/pulsar/actions/runs/30143918418/job/89674053236)) shows the reported `deferGetOwner` `TimeoutException` is only fallout: one invocation earlier, `broker.close()` hung for 300 seconds until the TestNG method timeout killed the test thread, leaving half-closed zombie brokers that poisoned the subsequent invocation's lookups.

The hang is a deadlock in `TableViewLoadDataStoreImpl` that can stall broker shutdown in production:

* All methods of `TableViewLoadDataStoreImpl` are `synchronized`, and `shutdown()`/`close()` performed a blocking `tableView.close()` while holding the store monitor (via `ExtensibleLoadManagerImpl.disableBroker` → `stopLoadDataReportTasks`).
* The table view reader's close future can only complete via a task on the Pulsar client's pinned internal executor thread (`ConsumerImpl.cleanupAtClose` → `failPendingReceive`).
* That same executor thread can concurrently be inside a `ServiceUnitStateChannel` `StateChangeListener` calling back into the store — `BrokerLoadDataReporter.handleEvent` → `tombstone()` → `removeAsync()`, also `synchronized` — where it blocks on the store monitor.

The closing thread holds the monitor and waits for the close future; the only thread that can complete that future waits for the monitor: a permanent deadlock. The trigger window is exactly what the test creates: a broker closing while `Owned` events from a previously closed broker's bundle handoff are still being processed. The captured logs confirm the mechanism: the reader's `Closed consumer` wire-level log appears immediately, and the blocked executor thread's `Restarted producer ... restartReason=object is null` fires at the exact moment the 300s interrupt releases the monitor.

The same lock/executor contention also explains the other #24628 signatures (bounded 5s `startTableView`/`startProducer` restart failures and cascade failures in later invocations).

### Modifications

* `TableViewLoadDataStoreImpl.closeTableView()`/`closeProducer()`: close the table view and producer with non-blocking `closeAsync()` and log failures, instead of blocking `close()` under the store monitor. No client close is awaited while holding the monitor anymore, which removes the deadlock. `PulsarService` closes the shared internal client later during shutdown, so in-flight asynchronous closes cannot leak.
* Added a deterministic regression test `LoadDataStoreTest.testShutdownDoesNotDeadlockWithConcurrentStoreAccess` that reproduces the interleaving with a stubbed table view whose close future only completes after another thread has entered a synchronized store method. It deadlocks (30s test timeout) on the previous code and passes with the fix.
* Added a package-private `@VisibleForTesting` `setTableView` accessor used by the test.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - `LoadDataStoreTest.testShutdownDoesNotDeadlockWithConcurrentStoreAccess` deterministically reproduces the deadlock: it fails with a 30s timeout on the previous code (test thread parked in the blocking close holding the store monitor) and passes with the fix.
  - Full `LoadDataStoreTest` passes (7/7).
  - `ExtensibleLoadManagerCloseTest` passes locally with all 10 `invocationCount` runs of `testCloseAfterLoadingBundles` plus `testLookup`.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
