### PR TITLE
[fix][ml] Tolerate concurrent creation of the managed ledger z-node

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImpl.java
@@ -132,6 +132,18 @@ public class MetaStoreImpl implements MetaStore, Consumer<Notification> {
                                         }
                                         callback.operationComplete(ledgerBuilder, stat);
                                     }).exceptionally(ex -> {
+                                        if (FutureUtil.unwrapCompletionException(ex)
+                                                instanceof MetadataStoreException.BadVersionException) {
+                                            // The z-node was created concurrently after the read above returned
+                                            // "not found". This happens for example when the broker creates the
+                                            // partitions of a topic while the same topic is being loaded. Read the
+                                            // z-node back instead of failing the managed ledger initialization.
+                                            log.info().attr("path", path)
+                                                    .log("Managed ledger path was concurrently created, reading it "
+                                                            + "back");
+                                            getManagedLedgerInfo(ledgerName, false, null, callback);
+                                            return null;
+                                        }
                                         callback.operationFailed(getException(ex));
                                         return null;
                                     });

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplTest.java
@@ -18,6 +18,11 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -25,6 +30,7 @@ import static org.testng.Assert.fail;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -37,6 +43,7 @@ import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.Stat;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.FaultInjectionMetadataStore;
 import org.testng.annotations.Test;
 
@@ -156,6 +163,48 @@ public class MetaStoreImplTest extends MockedBookKeeperTestCase {
             }
         });
         promise.get();
+    }
+
+    /**
+     * The z-node backing a managed ledger can be created by another party (for example
+     * {@code AdminResource#tryCreatePartitionAsync}) in between the read and the write that
+     * {@code getManagedLedgerInfo(createIfMissing = true)} performs. The metadata store reports that as a
+     * {@link MetadataStoreException.BadVersionException}, which must not fail the managed ledger initialization.
+     */
+    @Test(timeOut = 20000)
+    void createMLNodeConcurrently() throws Exception {
+        String ledgerName = "my_test";
+        String path = "/managed-ledgers/" + ledgerName;
+
+        AtomicBoolean raceInjected = new AtomicBoolean();
+        MetadataStoreExtended racyStore = spy(metadataStore);
+        doAnswer(invocation -> {
+            if (path.equals(invocation.getArgument(0)) && raceInjected.compareAndSet(false, true)) {
+                // Create the z-node behind the caller's back and report it as still missing, so that the
+                // subsequent create hits an already existing z-node.
+                metadataStore.put(path, new byte[0], Optional.of(-1L)).get();
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            return invocation.callRealMethod();
+        }).when(racyStore).get(anyString(), any());
+
+        MetaStore store = new MetaStoreImpl(racyStore, executor);
+
+        final CompletableFuture<ManagedLedgerInfo> promise = new CompletableFuture<>();
+        store.getManagedLedgerInfo(ledgerName, true, new MetaStoreCallback<ManagedLedgerInfo>() {
+            public void operationFailed(MetaStoreException e) {
+                promise.completeExceptionally(e);
+            }
+
+            public void operationComplete(ManagedLedgerInfo result, Stat version) {
+                promise.complete(result);
+            }
+        });
+
+        ManagedLedgerInfo info = promise.get();
+        assertNotNull(info);
+        assertEquals(info.getLedgerInfosCount(), 0);
+        assertTrue(raceInjected.get());
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
### Motivation

`MetaStoreImpl.getManagedLedgerInfo(createIfMissing = true)` reads the managed ledger z-node and, when it is missing, creates it with `put(path, new byte[0], Optional.of(-1L))`. If another party creates the same z-node between that read and that write, the metadata store returns `BadVersionException`, and the current code fails the callback. `ManagedLedgerImpl` then moves to the `Fenced` state and the topic load fails.

`AdminResource#tryCreatePartitionAsync` creates exactly the same z-node, and it already treats `BadVersionException` as "partition is already created" and continues. So the two paths race, and only one of them tolerates losing.

The race is hit whenever a topic is loaded while its partitions are being created. It showed up as a flaky `OneWayReplicatorUsingGlobalZKTest.testPartitionedTopicWithTopicPolicyAndNoReplicationClusters` failure ([branch-4.0 CI run](https://github.com/apache/pulsar/actions/runs/30167255830/job/89702916431)), where `admin.topics().updatePartitionedTopic(topic, 3, false)` failed with:

```
org.apache.pulsar.client.admin.PulsarAdminException$ServerSideErrorException:
Message: org.apache.bookkeeper.mledger.ManagedLedgerException: ...BadVersionException:
  KeeperErrorCode = BadVersion for /managed-ledgers/public/default/persistent/tp_...-partition-0
	at org.apache.pulsar.broker.service.BrokerService$2.openLedgerFailed(BrokerService.java:1953)
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl$2.initializeFailed(...)
	at org.apache.bookkeeper.mledger.impl.MetaStoreImpl.lambda$getManagedLedgerInfo$2(MetaStoreImpl.java:129)
```

The broker log of the remote cluster shows the two writers colliding:

```
51,081  [pulsar.repl.r1-->r2] Creating producer on ...-partition-0   -> topic load starts on r2
51,089  GET /admin/v2/persistent/public/default                       -> internalUpdatePartitionedTopicAsync on r2
51,090  Opening managed ledger ...-partition-0                        -> read reports the z-node as missing
51,092  Creating '/managed-ledgers/...-partition-0'                   -> put(..., -1) loses the race
51,097  Moving to Fenced state / Failed to initialize managed ledger: BadVersion
51,098  Failed to get stats for ...-partition-0 -> HTTP 500 -> updatePartitionedTopic fails
```

The replication producer loading `partition-0` on the remote cluster collides with `updatePartitionedTopic`'s remote leg calling `tryCreatePartitionsAsync`. This is not specific to the test topology: any concurrent "create the partitions" and "load the topic" pair can hit it.

### Modifications

- `MetaStoreImpl.getManagedLedgerInfo`: when the create-if-missing `put` fails with `BadVersionException`, read the z-node back instead of failing the callback. `BadVersion` from a `put` with expected version `-1` means the z-node exists now, which is exactly what `createIfMissing` asked for. The re-read also yields the correct `Stat`, which the managed ledger needs for its subsequent compare-and-swap updates.

The re-read is done with `createIfMissing = false`, so there is no retry loop: if the z-node is gone again by then, the operation fails with `MetadataNotFoundException` as it would for any other missing managed ledger.

### Verifying this change

This change added tests and can be verified as follows:

- `MetaStoreImplTest.createMLNodeConcurrently` injects the race deterministically: a spied metadata store creates the z-node behind the caller's back while still reporting it as missing, so the following create hits an already existing z-node. The test fails without the fix with the same `ManagedLedgerException$BadVersionException` seen in CI, and passes with it.
- The full `managed-ledger` module test suite passes locally (721 tests, 0 failures).

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you don't update yet -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs are already added -->

### Matching PR in forked repository

PR in forked repository: N/A (fix verified locally; apache/pulsar CI will run on this PR)
