### PR TITLE
[fix][sec] Upgrade lz4-java to 1.11.1 to address CVE-2026-59949

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -383,7 +383,7 @@ The Apache Software License, Version 2.0
     - org.apache.distributedlog-distributedlog-protocol-4.18.0.jar
     - org.apache.bookkeeper-native-io-4.18.0.jar
     - org.apache.bookkeeper-native-library-common-4.18.0.jar
-    - at.yawk.lz4-lz4-java-1.11.0.jar
+    - at.yawk.lz4-lz4-java-1.11.1.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.14.jar
     - org.apache.httpcomponents-httpcore-4.4.16.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -165,7 +165,7 @@ restassured = "5.4.0"
 skyscreamer = "1.5.0"
 # misc
 zstd-jni = "1.5.7-3"
-lz4java = "1.11.0"
+lz4java = "1.11.1"
 spring = "6.2.12"
 kubernetesclient = "26.0.0"
 aws-sdk = "1.12.788"


### PR DESCRIPTION
### Motivation

[CVE-2026-59949](https://github.com/advisories/GHSA-xx22-p4ch-683r) (medium, CVSS 6.5,
CWE-125 / CWE-476) affects `at.yawk.lz4:lz4-java` <= 1.11.0.

Insufficient validation of byte array arguments in the JNI-based XXHash implementations lets a
caller crash the JVM by passing an invalid array reference or an invalid range to the native
XXHash methods:

- `SafeUtils.checkRange(byte[], int, int)` skipped all array access when `len == 0`, so
  `hash(null, 0, 0, seed)` could pass a null array to JNI and fault in
  `GetPrimitiveArrayCritical`.
- The streaming JNI implementations did not validate `bytes`/`off`/`len` at all, so
  `update(new byte[16], 0, Integer.MAX_VALUE)` could read far past the end of the Java array
  before crashing.

The pure-Java (`safeInstance()`) XXHash implementations are not affected, and the LZ4
compression APIs are not the subject of the advisory.

**Exposure in Pulsar is limited but the vulnerable jar does ship.** Pulsar's own LZ4 codec
(`CompressionCodecLZ4`) uses aircompressor, not lz4-java, and no Pulsar source calls the XXHash
APIs at all. However, `at.yawk.lz4:lz4-java` reaches the server distribution transitively via
BookKeeper's `distributedlog-common`, so `lib/at.yawk.lz4-lz4-java-1.11.0.jar` is bundled in the
release tarball and is reported by dependency scanners.

### Modifications

Upgrade `at.yawk.lz4:lz4-java` from 1.11.0 to the fixed 1.11.1 release:

- `gradle/libs.versions.toml` — `lz4java = "1.11.1"`. The version catalog drives the enforced
  platform (`pulsar-dependencies`), so this also pins the transitive BookKeeper/distributedlog
  resolution.
- `distribution/server/src/assemble/LICENSE.bin.txt` — update the bundled jar name.

Upstream 1.11.1 is a security-only patch release
([v1.11.0...v1.11.1](https://github.com/yawkat/lz4-java/compare/v1.11.0...v1.11.1) — two commits,
one of which is a docs-only change). The fix adds argument validation only: no public API change,
no signature change, no new transitive dependencies, unchanged Java 7 target, and the bundled
native libraries are byte-identical to 1.11.0, so compression output cannot change.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a dependency upgrade without new test coverage; it is covered by existing tests.

Verified locally:

- `./gradlew checkBinaryLicense` passes for both the server and shell distributions. This check is
  bidirectional (every bundled jar must be listed in `LICENSE.bin.txt` and vice versa), so it
  confirms the new version both resolves and is correctly recorded.
- The assembled server tarball contains `lib/at.yawk.lz4-lz4-java-1.11.1.jar`.
- `./gradlew :pulsar-common:test --tests CompressorCodecBackwardCompatTest --tests CompressorCodecTest`
  passes — 51 tests, 0 failures, 0 skipped. `CompressorCodecBackwardCompatTest` exercises the
  upgraded library directly via `CompressionCodecLZ4JNI`, checking LZ4 JNI ↔ aircompressor
  round-trips in both directions, which guards the on-the-wire compression format.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest` passes.

### Does this pull request potentially affect one of the following parts:

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
