### PR TITLE
[fix][metadata]Solve the problem of broker log looping and request failure stagnation after network packet loss recovery

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/ZKSessionWatcher.java
@@ -160,43 +160,81 @@ public class ZKSessionWatcher implements AutoCloseable, Watcher {
             break;
 
         case Disconnected:
-            if (disconnectedAt == 0) {
-                // this is the first disconnect event, we should monitor the time out from now, so we record the
-                // time of disconnect
-                disconnectedAt = System.nanoTime();
-            }
+        case ConnectedReadOnly:
+            handleDisconnected(zkClientState);
+            break;
 
-            long timeRemainingMillis = monitorTimeoutMillis
-                    - TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - disconnectedAt);
-            if (timeRemainingMillis <= 0 && currentStatus != SessionEvent.SessionLost) {
-                log.error("ZooKeeper session reconnection timeout. Notifying session is lost.");
+        case SyncConnected:
+            handleSyncConnected();
+            break;
+
+        case AuthFailed:
+            if (currentStatus != SessionEvent.SessionLost) {
+                log.error("ZooKeeper client authentication failed. Notifying session is lost.");
                 currentStatus = SessionEvent.SessionLost;
                 sessionListener.accept(currentStatus);
-            } else if (currentStatus != SessionEvent.SessionLost) {
+            }
+            break;
+
+        case SaslAuthenticated:
+            log.info().attr("currentStatus", currentStatus)
+                    .log("ZooKeeper client SASL authentication completed");
+            break;
+
+        case Closed:
+            log.info().attr("currentStatus", currentStatus).log("ZooKeeper client is closed");
+            break;
+
+        default:
+            log.warn().attr("zkClientState", zkClientState).attr("currentStatus", currentStatus)
+                    .log("Ignoring ZooKeeper client state that does not indicate a reconnection");
+            break;
+        }
+    }
+
+    private void handleDisconnected(Watcher.Event.KeeperState zkClientState) {
+        if (disconnectedAt == 0) {
+            // this is the first disconnect event, we should monitor the time out from now, so we record the
+            // time of disconnect
+            disconnectedAt = System.nanoTime();
+        }
+
+        long timeRemainingMillis = monitorTimeoutMillis
+                - TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - disconnectedAt);
+        if (timeRemainingMillis <= 0 && currentStatus != SessionEvent.SessionLost) {
+            log.error("ZooKeeper session reconnection timeout. Notifying session is lost.");
+            currentStatus = SessionEvent.SessionLost;
+            sessionListener.accept(currentStatus);
+        } else if (currentStatus != SessionEvent.SessionLost) {
+            if (zkClientState == Watcher.Event.KeeperState.ConnectedReadOnly) {
+                log.warn()
+                        .attr("sessionId", zk.getSessionId())
+                        .attr("timeRemainingSeconds", timeRemainingMillis / 1000.0)
+                        .log("ZooKeeper client is connected to a read-only server. Waiting for read-write connection");
+            } else {
                 log.warn()
                         .attr("sessionId", zk.getSessionId())
                         .attr("timeRemainingSeconds", timeRemainingMillis / 1000.0)
                         .log("ZooKeeper client is disconnected. Waiting to reconnect");
-                if (currentStatus == SessionEvent.SessionReestablished) {
-                    currentStatus = SessionEvent.ConnectionLost;
-                    sessionListener.accept(currentStatus);
-                }
             }
-            break;
-
-        default:
-            if (currentStatus != SessionEvent.SessionReestablished) {
-                // since it reconnected to zoo keeper, we reset the disconnected time
-                log.info().attr("currentStatus", currentStatus).log("ZooKeeper client reconnection with server quorum");
-                disconnectedAt = 0;
-
-                sessionListener.accept(SessionEvent.Reconnected);
-                if (currentStatus == SessionEvent.SessionLost) {
-                    sessionListener.accept(SessionEvent.SessionReestablished);
-                }
-                currentStatus = SessionEvent.SessionReestablished;
+            if (currentStatus == SessionEvent.SessionReestablished) {
+                currentStatus = SessionEvent.ConnectionLost;
+                sessionListener.accept(currentStatus);
             }
-            break;
+        }
+    }
+
+    private void handleSyncConnected() {
+        if (currentStatus != SessionEvent.SessionReestablished) {
+            // since it reconnected to zoo keeper, we reset the disconnected time
+            log.info().attr("currentStatus", currentStatus).log("ZooKeeper client reconnection with server quorum");
+            disconnectedAt = 0;
+
+            sessionListener.accept(SessionEvent.Reconnected);
+            if (currentStatus == SessionEvent.SessionLost) {
+                sessionListener.accept(SessionEvent.SessionReestablished);
+            }
+            currentStatus = SessionEvent.SessionReestablished;
         }
     }
 }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/ZKSessionWatcherTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/impl/ZKSessionWatcherTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.metadata.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.pulsar.metadata.api.extended.SessionEvent;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher.Event.EventType;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooKeeper;
+import org.testng.annotations.Test;
+
+@Test
+public class ZKSessionWatcherTest {
+
+    @Test
+    public void testClosedEventShouldNotBeTreatedAsReconnectedAfterSessionLost() throws Exception {
+        List<SessionEvent> events = new CopyOnWriteArrayList<>();
+        try (ZKSessionWatcher watcher = newSessionWatcher(events)) {
+            watcher.setSessionInvalid();
+            watcher.process(new WatchedEvent(EventType.None, KeeperState.Closed, null));
+
+            assertTrue(events.isEmpty(),
+                    "Closed is a terminal state for the old ZooKeeper handle and must not be treated as "
+                            + "Reconnected or SessionReestablished, but received " + events);
+        }
+    }
+
+    @Test
+    public void testOnlySyncConnectedShouldBeTreatedAsReconnectedAfterSessionLost() throws Exception {
+        List<SessionEvent> events = new CopyOnWriteArrayList<>();
+        try (ZKSessionWatcher watcher = newSessionWatcher(events)) {
+            watcher.setSessionInvalid();
+            watcher.process(new WatchedEvent(EventType.None, KeeperState.SyncConnected, null));
+
+            assertEquals(events, Arrays.asList(SessionEvent.Reconnected, SessionEvent.SessionReestablished));
+        }
+    }
+
+    @Test
+    public void testNonSyncConnectedEventsShouldNotBeTreatedAsReconnectedAfterSessionLost() throws Exception {
+        for (KeeperState keeperState : Arrays.asList(
+                KeeperState.Disconnected,
+                KeeperState.AuthFailed,
+                KeeperState.ConnectedReadOnly,
+                KeeperState.SaslAuthenticated,
+                KeeperState.Closed)) {
+            List<SessionEvent> events = new CopyOnWriteArrayList<>();
+            try (ZKSessionWatcher watcher = newSessionWatcher(events)) {
+                watcher.setSessionInvalid();
+                watcher.process(new WatchedEvent(EventType.None, keeperState, null));
+
+                assertTrue(events.stream().noneMatch(event -> event == SessionEvent.Reconnected
+                                || event == SessionEvent.SessionReestablished),
+                        keeperState + " must not be treated as a ZooKeeper reconnection event, but received "
+                                + events);
+            }
+        }
+    }
+
+    private static ZKSessionWatcher newSessionWatcher(List<SessionEvent> events) {
+        ZooKeeper zk = mock(ZooKeeper.class);
+        when(zk.getSessionTimeout()).thenReturn(30_000);
+        when(zk.getSessionId()).thenReturn(0x1234L);
+        return new ZKSessionWatcher(zk, events::add);
+    }
+}


### PR DESCRIPTION


### Motivation

During ZooKeeper session-expired recovery, the broker can close the old ZooKeeper handle and create a new
ZooKeeper client. The old handle may emit `KeeperState.Closed` as part of this local close sequence.

Before this change, `ZKSessionWatcher` treated every ZooKeeper `KeeperState` other than `Expired` and
`Disconnected` as a successful reconnection. This means `KeeperState.Closed` could be translated into
`Reconnected` and `SessionReestablished`, even though `Closed` only means the old ZooKeeper handle was closed. It
does not prove that a new session has connected to the ZooKeeper quorum.

This matters because `Reconnected` and `SessionReestablished` are not passive notifications in Pulsar. They trigger
metadata recovery work, including persistent watch recreation, resource lock revalidation, and leader election
revalidation. If these events are published before the new ZooKeeper session is actually healthy, the broker can start
recovery work against an unstable or expired session.

In a severe network-loss scenario, this can become a recovery storm:

1. ZooKeeper session expires.
2. The broker starts the reconnect flow and closes the old ZooKeeper handle.
3. The old handle emits `KeeperState.Closed`.
4. `Closed` is incorrectly treated as a successful reconnection.
5. Pulsar publishes `Reconnected` / `SessionReestablished`.
6. Watch recreation, lock revalidation, and leader election recovery start too early.
7. These recovery operations fail against the unstable session and can trigger more reconnect/recovery work.

The logs will output in a loop as follows:
```text
PulsarZooKeeperClient - ZooKeeper session 0 is created to pulsar-zookeeper.pulsar:2181.
ZKSessionWatcher - Got ZK session watch event: WatchedEvent state:Closed type:None path:null
PulsarService - Received metadata service session event: Reconnected
ZKMetadataStore - Failed to recreate persistent watch on ZooKeeper: SESSIONEXPIRED
ResourceLockImpl - Failed to revalidate the lock at /namespace/... SessionExpiredException - Retrying ...
```


The fix is to make the state machine explicit: only `KeeperState.SyncConnected` should be treated as a successful
reconnection.

### Modifications

- Tightened `ZKSessionWatcher` state handling so only `KeeperState.SyncConnected` publishes `Reconnected` and
  `SessionReestablished`.
- Handled non-recovery states explicitly:
  - `Disconnected` continues to wait for reconnection.
  - `ConnectedReadOnly` waits for a writable quorum connection instead of treating the read-only connection as fully
    recovered.
  - `AuthFailed` marks the metadata session as lost.
  - `SaslAuthenticated` is logged without publishing recovery events.
  - `Closed` is logged without changing the metadata session state.
- Added `ZKSessionWatcherTest` to verify that `Closed` and other non-`SyncConnected` states do not publish
  `Reconnected` or `SessionReestablished` after `SessionLost`.
- Kept the existing stale session-id protection in `ZKSessionWatcher`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Added unit tests for `ZKSessionWatcher` state transitions.
- Verified existing ZooKeeper session recovery behavior with `ZKSessionTest`.

Commands run locally:

```bash
./gradlew :pulsar-metadata:test --tests org.apache.pulsar.metadata.impl.ZKSessionWatcherTest --tests org.apache.pulsar.metadata.ZKSessionTest
./gradlew :pulsar-metadata:checkstyleMain :pulsar-metadata:checkstyleTest
```

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
