### PR TITLE
[improve][build] Upgrade lightproto gradle plugin to 0.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,7 +141,7 @@ jakarta-servlet = "6.0.0"
 oxia = "0.8.0"
 oxia-testcontainers = "0.7.4"
 # Build plugins
-lightproto = "0.7.3"
+lightproto = "0.8.0"
 graalvm-buildtools = "1.1.1"
 errorprone = "2.45.0"
 spotbugs = "4.9.6"


### PR DESCRIPTION
### Motivation

LightProto [v0.8.0](https://github.com/streamnative/lightproto/releases/tag/v0.8.0) is a systematic performance pass over the generated serialization/deserialization code, benchmarked directly on Pulsar's protocol messages (vs 0.7.3):

| Benchmark (ops/µs) | v0.7.3 | v0.8.0 | Δ |
|---|---|---|---|
| `MessageMetadata` deserialize | 14.3 | 23.6 | +66% |
| `BaseCommand` deserialize | 33.2 | 46.7 | +41% |
| `BaseCommand` serialize | 19.5 | 43.3 | +122% |
| `MessageMetadata` serialize | 12.0 | 14.5 | +21% |

Main changes in the generated code:
* O(1) `clear()` with presence-guarded getters (also fixes stale-child reachability after `clearX()` on a message field, and `copyFrom()` now follows protobuf merge semantics for implicit-presence fields)
* Serialization composes into a plain `byte[]` instead of per-field ByteBuf writes; `writeTo(CompositeByteBuf)` now works
* Presence-bit-driven traversal for union-like messages (e.g. `BaseCommand` with ~50 optional sub-commands)
* Removal of `sun.misc.Unsafe` from the write hot loop and the ASCII scan (JDK 24+ taxes each call, and it is on the removal track)

### Modifications

* Bump `lightproto` from 0.7.3 to 0.8.0 in `gradle/libs.versions.toml`; all modules applying the plugin pick it up via the version catalog.