### PR TITLE
[cleanup][misc] Fix all javac warnings in main sources

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -26,6 +26,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeMultimap;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -238,7 +239,7 @@ public class SimpleLoadManagerImpl implements LoadManager, Consumer<Notification
                 });
 
         int entryExpiryTime = (int) pulsar.getConfiguration().getLoadBalancerSheddingGracePeriodMinutes();
-        unloadedHotNamespaceCache = CacheBuilder.newBuilder().expireAfterWrite(entryExpiryTime, TimeUnit.MINUTES)
+        unloadedHotNamespaceCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(entryExpiryTime))
                 .build(new CacheLoader<String, Long>() {
                     @Override
                     public Long load(String key) throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -578,7 +578,7 @@ public class BrokerService implements Closeable {
             bootstrap.option(ChannelOption.SO_REUSEADDR, true);
             bootstrap.childOption(ChannelOption.ALLOCATOR, PulsarByteBufAllocator.DEFAULT);
             bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
-            bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,
+            bootstrap.childOption(ChannelOption.RECVBUF_ALLOCATOR,
                     new AdaptiveRecvByteBufAllocator(1024, 16 * 1024, 1 * 1024 * 1024));
             EventLoopUtil.enableTriggeredMode(bootstrap);
             DefaultThreadFactory defaultThreadFactory =
@@ -606,7 +606,7 @@ public class BrokerService implements Closeable {
         bootstrap.childOption(ChannelOption.ALLOCATOR, PulsarByteBufAllocator.DEFAULT);
         bootstrap.group(acceptorGroup, workerGroup);
         bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
-        bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,
+        bootstrap.childOption(ChannelOption.RECVBUF_ALLOCATOR,
             new AdaptiveRecvByteBufAllocator(1024, 16 * 1024, 1 * 1024 * 1024));
         bootstrap.channel(EventLoopUtil.getServerSocketChannelClass(workerGroup));
         EventLoopUtil.enableTriggeredMode(bootstrap);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/LegacyAwareTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/LegacyAwareTopicPoliciesService.java
@@ -125,6 +125,7 @@ public class LegacyAwareTopicPoliciesService implements TopicPoliciesService {
                 .thenCompose(service -> service.registerListenerAsync(topicName, listener));
     }
 
+    @Deprecated
     @Override
     public boolean registerListener(TopicName topicName, TopicPolicyListener listener) {
         throw new RuntimeException("should not be called");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/MetadataStoreTopicPoliciesService.java
@@ -135,6 +135,7 @@ public class MetadataStoreTopicPoliciesService implements TopicPoliciesService {
                 .thenApply(policies -> policies.map(policy -> cloneWithScope(policy, global)));
     }
 
+    @Deprecated
     @Override
     public boolean registerListener(TopicName topicName, TopicPolicyListener listener) {
         listeners.compute(normalizeTopicName(topicName), (__, topicListeners) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -951,7 +951,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         // Complete the removed init future outside the compute() remapping function: completing it can run the
         // awaiting topic-load callbacks synchronously, and doing that while holding the ConcurrentHashMap bin lock
         // risks a recursive map update / deadlock (see #24977).
-        failPendingPolicyCacheInit(namespace, removedInitFuture.getValue());
+        failPendingPolicyCacheInit(namespace, removedInitFuture.get());
         if (readerFuture != null && !readerFuture.isCompletedExceptionally()) {
             readerFuture
                     .thenCompose(SystemTopicClient.Reader::closeAsync)
@@ -1152,6 +1152,7 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
         return policyCacheInitMap.get(namespaceName);
     }
 
+    @Deprecated
     @Override
     public boolean registerListener(TopicName topicName, TopicPolicyListener listener) {
         listeners.compute(topicName, (k, topicListeners) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -625,7 +625,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      * @param subscriptionName the name of the subscription
      * @param cursor the cursor to use for the subscription
      * @param replicated the subscription replication flag
-     * @param subscriptionProperties the subscription properties
+     * @param subscriptionProperties the subscription properties. No longer used to build the subscription — the cursor
+     *                               already carries them — but retained so overriding implementations keep working.
      * @return the subscription instance
      */
     protected PersistentSubscription createPersistentSubscription(String subscriptionName, ManagedCursor cursor,
@@ -636,7 +637,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             CompactedTopicImpl compactedTopic = pulsarTopicCompactionService.getCompactedTopic();
             return new PulsarCompactorSubscription(this, compactedTopic, subscriptionName, cursor);
         } else {
-            return new PersistentSubscription(this, subscriptionName, cursor, replicated, subscriptionProperties);
+            return new PersistentSubscription(this, subscriptionName, cursor, replicated);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/scalable/ScalableTopicController.java
@@ -1264,10 +1264,10 @@ public class ScalableTopicController {
             // No subscribers ever attached / all unsubscribed → nothing left to drain.
             return CompletableFuture.completedFuture(true);
         }
-        CompletableFuture<Boolean>[] checks = subs.stream()
+        List<CompletableFuture<Boolean>> checks = subs.stream()
                 .map(sub -> isSegmentDrained(seg, sub))
-                .toArray(CompletableFuture[]::new);
-        return CompletableFuture.allOf(checks)
+                .toList();
+        return CompletableFuture.allOf(checks.toArray(CompletableFuture<?>[]::new))
                 .thenApply(__ -> {
                     for (CompletableFuture<Boolean> c : checks) {
                         if (!c.join()) {

--- a/pulsar-client-admin/build.gradle.kts
+++ b/pulsar-client-admin/build.gradle.kts
@@ -43,5 +43,9 @@ dependencies {
     implementation(libs.commons.lang3)
     implementation(libs.completable.futures)
 
+    // pulsar-client's configuration-data classes carry runtime-retained @Schema annotations, so javac needs
+    // the OpenAPI annotation types on the compile classpath to read their class files without warning.
+    compileOnly(libs.swagger.annotations)
+
     testImplementation(libs.wiremock)
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -637,6 +637,8 @@ public interface ConsumerBuilder<T> extends Cloneable {
      *
      * @param interceptors the list of interceptors to intercept the consumer created by this builder.
      */
+    // @SafeVarargs cannot be applied to an abstract method; implementations declare it on their final override.
+    @SuppressWarnings("unchecked")
     ConsumerBuilder<T> intercept(ConsumerInterceptor<T> ...interceptors);
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -561,6 +561,8 @@ public interface ProducerBuilder<T> extends Cloneable {
      * @return the producer builder instance
      */
     @Deprecated
+    // @SafeVarargs cannot be applied to an abstract method; implementations declare it on their final override.
+    @SuppressWarnings("unchecked")
     ProducerBuilder<T> intercept(ProducerInterceptor<T> ... interceptors);
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -342,6 +342,8 @@ public interface ReaderBuilder<T> extends Cloneable {
      * @param interceptors the list of interceptors to intercept the reader created by this builder.
      * @return the reader builder instance
      */
+    // @SafeVarargs cannot be applied to an abstract method; implementations declare it on their final override.
+    @SuppressWarnings("unchecked")
     ReaderBuilder<T> intercept(ReaderInterceptor<T>... interceptors);
 
     /**

--- a/pulsar-client-v5/build.gradle.kts
+++ b/pulsar-client-v5/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     compileOnly(libs.protobuf.java)
     implementation(libs.netty.handler)
     implementation(libs.jackson.annotations)
+    // pulsar-client's configuration-data classes carry runtime-retained @Schema annotations, so javac needs
+    // the OpenAPI annotation types on the compile classpath to read their class files without warning.
+    compileOnly(libs.swagger.annotations)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
     testImplementation(libs.testng)

--- a/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AuthenticationAdapter.java
+++ b/pulsar-client-v5/src/main/java/org/apache/pulsar/client/impl/v5/AuthenticationAdapter.java
@@ -110,6 +110,9 @@ final class AuthenticationAdapter {
         }
 
         @Override
+        // The v4 no-arg getAuthData() is deprecated in favour of the broker-host variant, but this bridge has to
+        // preserve the host-less semantics of the v5 no-arg authData() it implements.
+        @SuppressWarnings("deprecation")
         public AuthenticationData authData() throws PulsarClientException {
             try {
                 AuthenticationDataProvider v4Data = v4Auth.getAuthData();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -154,7 +154,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     private final LoadingCache<String, SchemaInfoProvider> schemaProviderLoadingCache =
             CacheBuilder.newBuilder().maximumSize(100000)
-                    .expireAfterAccess(30, TimeUnit.MINUTES)
+                    .expireAfterAccess(Duration.ofMinutes(30))
                     .build(new CacheLoader<String, SchemaInfoProvider>() {
 
                         @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarServiceNameResolver.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Collectors;
@@ -155,7 +156,7 @@ public class PulsarServiceNameResolver implements ServiceNameResolver {
     private static int randomIndex(int numAddresses) {
         return numAddresses == 1
                 ?
-                0 : io.netty.util.internal.PlatformDependent.threadLocalRandom().nextInt(numAddresses);
+                0 : ThreadLocalRandom.current().nextInt(numAddresses);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/MultiVersionSchemaInfoProvider.java
@@ -22,9 +22,9 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.apache.pulsar.client.api.schema.SchemaInfoProvider;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -44,7 +44,7 @@ public class MultiVersionSchemaInfoProvider implements SchemaInfoProvider {
 
     private final LoadingCache<BytesSchemaVersion, CompletableFuture<SchemaInfo>> cache = CacheBuilder.newBuilder()
         .maximumSize(100000)
-        .expireAfterAccess(30, TimeUnit.MINUTES)
+        .expireAfterAccess(Duration.ofMinutes(30))
         .build(new CacheLoader<BytesSchemaVersion, CompletableFuture<SchemaInfo>>() {
             @Override
             public CompletableFuture<SchemaInfo> load(BytesSchemaVersion schemaVersion) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
@@ -22,8 +22,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.apache.avro.AvroTypeException;
 import org.apache.commons.codec.binary.Hex;
@@ -45,7 +45,7 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
     protected SchemaInfoProvider schemaInfoProvider;
 
     LoadingCache<BytesSchemaVersion, SchemaReader<T>> readerCache = CacheBuilder.newBuilder().maximumSize(100000)
-            .expireAfterAccess(30, TimeUnit.MINUTES).build(new CacheLoader<BytesSchemaVersion, SchemaReader<T>>() {
+            .expireAfterAccess(Duration.ofMinutes(30)).build(new CacheLoader<BytesSchemaVersion, SchemaReader<T>>() {
                 @Override
                 public SchemaReader<T> load(BytesSchemaVersion schemaVersion) {
                     return loadReader(schemaVersion);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamespaceName.java
@@ -23,10 +23,10 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Parser of a value from the namespace field provided in configuration.
@@ -39,7 +39,7 @@ public class NamespaceName implements ServiceUnitId {
     private final String localName;
 
     private static final LoadingCache<String, NamespaceName> cache = CacheBuilder.newBuilder().maximumSize(100000)
-            .expireAfterAccess(30, TimeUnit.MINUTES).build(new CacheLoader<String, NamespaceName>() {
+            .expireAfterAccess(Duration.ofMinutes(30)).build(new CacheLoader<String, NamespaceName>() {
                 @Override
                 public NamespaceName load(String name) throws Exception {
                     return new NamespaceName(name);

--- a/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
+++ b/pulsar-package-management/core/src/main/java/org/apache/pulsar/packages/management/core/common/PackageName.java
@@ -25,10 +25,10 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.net.UrlEscapers;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A package name has five parts, type, tenant, namespace, package-name, and version.
@@ -49,7 +49,7 @@ public class PackageName {
     private static final LoadingCache<String, PackageName> cache =
         CacheBuilder.newBuilder()
             .maximumSize(100000)
-            .expireAfterAccess(30, TimeUnit.MINUTES)
+            .expireAfterAccess(Duration.ofMinutes(30))
             .build(new CacheLoader<String, PackageName>() {
                 @Override
                 public PackageName load(String name) throws Exception {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/DirectProxyHandler.java
@@ -30,8 +30,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.epoll.EpollChannelOption;
-import io.netty.channel.epoll.EpollMode;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.haproxy.HAProxyCommand;
@@ -160,9 +158,8 @@ public class DirectProxyHandler {
         b.group(inboundChannel.eventLoop())
                 .channel(inboundChannel.getClass());
 
-        if (service.proxyZeroCopyModeEnabled && EpollSocketChannel.class.isAssignableFrom(inboundChannel.getClass())) {
-            b.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
-        }
+        // Zero-copy (splice) requires the epoll transport to be level-triggered. Netty always uses
+        // level-triggered mode since 4.2, so no channel option needs to be set for it anymore.
 
         b.handler(new ChannelInitializer<SocketChannel>() {
             @Override

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -255,7 +255,7 @@ public class ProxyService implements Closeable {
         bootstrap.childOption(ChannelOption.ALLOCATOR, PulsarByteBufAllocator.DEFAULT);
         bootstrap.group(acceptorGroup, workerGroup);
         bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
-        bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,
+        bootstrap.childOption(ChannelOption.RECVBUF_ALLOCATOR,
                 new AdaptiveRecvByteBufAllocator(1024, 16 * 1024, 1 * 1024 * 1024));
 
         Class<? extends ServerSocketChannel> serverSocketChannelClass =
@@ -361,7 +361,7 @@ public class ProxyService implements Closeable {
             bootstrap.option(ChannelOption.SO_REUSEADDR, true);
             bootstrap.childOption(ChannelOption.ALLOCATOR, PulsarByteBufAllocator.DEFAULT);
             bootstrap.childOption(ChannelOption.TCP_NODELAY, true);
-            bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR,
+            bootstrap.childOption(ChannelOption.RECVBUF_ALLOCATOR,
                     new AdaptiveRecvByteBufAllocator(1024, 16 * 1024, 1 * 1024 * 1024));
 
             EventLoopUtil.enableTriggeredMode(bootstrap);

--- a/pulsar-testclient/build.gradle.kts
+++ b/pulsar-testclient/build.gradle.kts
@@ -54,6 +54,10 @@ dependencies {
     implementation(libs.jetty.util)
     implementation(libs.opentelemetry.sdk.extension.autoconfigure)
 
+    // pulsar-client's configuration-data classes carry runtime-retained @Schema annotations, so javac needs
+    // the OpenAPI annotation types on the compile classpath to read their class files without warning.
+    compileOnly(libs.swagger.annotations)
+
     testImplementation(project(":pulsar-broker"))
     testImplementation(project(path = ":pulsar-broker", configuration = "testJar"))
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -262,7 +262,7 @@ public abstract class AbstractWebSocketHandler extends Session.Listener.Abstract
     }
 
     @Override
-    public void onWebSocketClose(int statusCode, String reason) {
+    public void onWebSocketClose(int statusCode, String reason, Callback callback) {
         log.info()
                 .attr("remoteAddress", getSession().getRemoteSocketAddress())
                 .attr("topic", topic)
@@ -279,6 +279,7 @@ public abstract class AbstractWebSocketHandler extends Session.Listener.Abstract
                     .exception(e)
                     .log("Failed to close handler for topic");
         }
+        callback.succeed();
     }
 
     public void close(WebSocketError error) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -27,6 +27,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -96,7 +97,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     // Make sure use the same BatchMessageIdImpl to acknowledge the batch message, otherwise the BatchMessageAcker
     // of the BatchMessageIdImpl will not complete.
     private Cache<String, MessageId> messageIdCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(1, TimeUnit.HOURS)
+            .expireAfterWrite(Duration.ofHours(1))
             .build();
 
     public ConsumerHandler(WebSocketService service, HttpServletRequest request, JettyServerUpgradeResponse response) {

--- a/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
+++ b/pulsar-websocket/src/test/java/org/apache/pulsar/websocket/AbstractWebSocketHandlerTest.java
@@ -57,6 +57,7 @@ import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
 import org.eclipse.jetty.ee10.websocket.server.JettyServerUpgradeResponse;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
 import org.mockito.Answers;
 import org.mockito.Mock;
@@ -395,7 +396,8 @@ public class AbstractWebSocketHandlerTest {
         assertNotNull(pingFuture);
         assertFalse(pingFuture.isDone());
 
-        webSocketHandler.onWebSocketClose(HttpStatus.INTERNAL_SERVER_ERROR_500, "INTERNAL_SERVER_ERROR_500");
+        webSocketHandler.onWebSocketClose(HttpStatus.INTERNAL_SERVER_ERROR_500, "INTERNAL_SERVER_ERROR_500",
+                Callback.NOOP);
         assertTrue(pingFuture.isDone());
 
 


### PR DESCRIPTION
### Motivation

`./gradlew compileJava --warning-mode all` emits **77 javac warnings across ten modules** on a clean
`master`. Almost all of them are deprecations left behind by the Netty 4.2, Jetty 12.1, Guava 33 and
commons-lang3 3.20 upgrades:

| Module | Warnings |
|---|---|
| `pulsar-client-admin-original` | 30 |
| `pulsar-client-v5` | 17 |
| `pulsar-broker` | 10 |
| `pulsar-testclient` | 5 |
| `pulsar-client-original` | 4 |
| `pulsar-proxy` | 4 |
| `pulsar-client-api` | 3 |
| `pulsar-websocket` | 2 |
| `pulsar-common` | 1 |
| `pulsar-package-core` | 1 |

Two reasons to clean this up now rather than later:

1. **One warning is a latent break, not just noise.** Jetty deprecated
   `Session.Listener.onWebSocketClose(int, String)` *for removal*
   (`@Deprecated(since = "12.1.0", forRemoval = true)`). `AbstractWebSocketHandler` still overrides it,
   so the WebSocket proxy stops receiving close callbacks the moment Jetty drops the method.
2. **The volume hides new warnings.** 52 of the 77 are the same repeated
   `unknown enum constant RequiredMode.REQUIRED` message, which drowns out anything genuinely new
   appearing in a PR's build log.

### Modifications

**1. Deprecated APIs moved to their documented successors.** Each of these was checked against the
dependency's own sources rather than assumed:

- `CacheBuilder.expireAfterAccess/Write(long, TimeUnit)` → the `Duration` overloads, in the 7 caches in
  `NamespaceName`, `PackageName`, `PulsarClientImpl`, `AbstractMultiVersionReader`,
  `MultiVersionSchemaInfoProvider`, `ConsumerHandler` and `SimpleLoadManagerImpl`.
- `PlatformDependent.threadLocalRandom()` → `ThreadLocalRandom.current()` in
  `PulsarServiceNameResolver`. Netty's deprecated method body is literally
  `return ThreadLocalRandom.current();`.
- `ChannelOption.RCVBUF_ALLOCATOR` → `RECVBUF_ALLOCATOR` in `BrokerService` and `ProxyService`
  (4 call sites). A pure rename — Netty declares the deprecated field as `= RECVBUF_ALLOCATOR`, the
  same object.
- `MutableObject.getValue()` → `get()` in `SystemTopicBasedTopicPoliciesService`.
- The deprecated 5-arg `PersistentSubscription` constructor → the 4-arg one, in `PersistentTopic`.
  The 5-arg version ignores `subscriptionProperties` entirely (the cursor already carries them), so
  this is behaviour-identical. `createPersistentSubscription` keeps its signature because
  `BrokerTestInterceptor` overrides it; its javadoc now records that the parameter is unused.
- Jetty's `onWebSocketClose(int, String)` → `onWebSocketClose(int, String, Callback)` in
  `AbstractWebSocketHandler`, completing the callback. The old override had to be *removed* rather
  than kept alongside the new one: `JettyWebSocketFrameHandlerFactory` throws
  `InvalidWebSocketException("Cannot use two versions of onWebSocketClose")` for an endpoint that
  declares both. Its `isOverridden` check keys on `getDeclaringClass() != Session.Listener.class`, so
  the inherited default is correctly ignored once ours is gone.
- Removed the `EpollChannelOption.EPOLL_MODE` call in `DirectProxyHandler`. Netty 4.2 documents both
  the option and the `EpollMode` enum as no-ops ("Netty always uses level-triggered mode and so this
  method is just a no-op"), and level-triggered is exactly what zero-copy splice requires — so the
  guarded block was dead code. The `proxyZeroCopyModeEnabled` splice path itself is untouched.

**2. One unchecked-generics fix.** `ScalableTopicController.prunable` built a
`CompletableFuture<Boolean>[]` from a stream, which is an unchecked array creation. It now collects
into a `List` and keeps the same short-circuiting drain check.

**3. Narrow suppressions where no successor API exists** — placed at the declaration, each with a
comment giving the reason:

- `intercept(...)` in `ProducerBuilder` / `ConsumerBuilder` / `ReaderBuilder`: `@SafeVarargs` is
  illegal on an abstract method, so the heap-pollution warning is suppressed on the interface
  declaration. The implementations (`ConsumerBuilderImpl`, `ReaderBuilderImpl`) already carry
  `@SafeVarargs` on their `final` overrides.
- The v5 `AuthenticationAdapter` bridge must call v4's deprecated host-less `getAuthData()` in order to
  implement v5's host-less `authData()`; there is no non-deprecated v4 equivalent without a broker
  host.
- The three `TopicPoliciesService.registerListener` overrides
  (`SystemTopicBased`, `MetadataStore`, `LegacyAware`) are now `@Deprecated` themselves, matching the
  interface method they implement.

**4. `compileOnly(swagger-annotations)` added to three modules** — this is the 52-warning group.
`pulsar-client`'s configuration-data classes (`ClientConfigurationData` and friends) carry
runtime-retained `@Schema(requiredMode = REQUIRED)` annotations. `pulsar-client-admin`,
`pulsar-client-v5` and `pulsar-testclient` compile against those class files without the annotation
types on their compile classpath, so javac can't resolve the enum constant. Six other modules
(`pulsar-broker`, `pulsar-common`, `pulsar-client`, `pulsar-proxy`, `pulsar-websocket`,
`pulsar-client-tools`) already declare it exactly this way; this just extends the existing convention.

No production code behaviour is intended to change anywhere in this PR.

**Compatibility note:** `AbstractWebSocketHandler.onWebSocketClose` changes signature. That class is
`public` in `pulsar-websocket`, so an out-of-tree subclass overriding the 2-arg form would need the
same one-line migration — but Jetty forces this move regardless, and the method being overridden is
Jetty's listener callback rather than a Pulsar API. I have not ticked *The public API* below for this
reason; happy to reclassify if a reviewer sees it differently.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is already covered by existing tests, such as:

- **`ProxyPublishConsumeTest`** (18 tests) — the end-to-end WebSocket path against a real Jetty
  server. This is the important one: it exercises endpoint registration (which is where a botched
  `onWebSocketClose` migration throws `InvalidWebSocketException`) and real session closes.
- **The full `pulsar-websocket` suite** (33 tests), including `AbstractWebSocketHandlerTest`, whose
  direct `onWebSocketClose` call was updated to pass `Callback.NOOP`.
- **`NamespaceNameTest`, `PackageNameTest`, `PulsarServiceNameResolverTest`** (29 tests) — the Guava
  `Duration` and `ThreadLocalRandom` changes.
- **`PersistentSubscriptionTest`, `CreateSubscriptionTest`, `ScalableTopicControllerTest`,
  `SimpleLoadManagerImplTest`, `ProxyTest`, `ProxyDisableZeroCopyTest`** (90 tests) — the
  `PersistentSubscription` constructor, the `prunable` rewrite, the load-manager cache and the Netty
  channel-option renames.
- **`SystemTopicBasedTopicPoliciesServiceTest`, `LegacyAwareTopicPoliciesServiceTest`,
  `TopicPoliciesServiceDisableTest`, `InmemoryTopicPoliciesServiceServiceTest`** (27 tests) — the
  `MutableObject.get()` change sits on the namespace-cleanup path these cover.

197 tests total, 0 failures and 0 errors. No new tests were added: every change is either a
like-for-like API swap or annotation-only, so there is no new behaviour to cover.

Build verification:

- `./gradlew compileJava --rerun-tasks --warning-mode all` → **BUILD SUCCESSFUL with zero warnings**
  (was 77).
- `./gradlew sanityCheck` → passes (license headers, checkstyle, and main *and* test compilation for
  every module).

Two things a reviewer should know:

- **The `DirectProxyHandler` change is not covered by a local test run.** epoll is Linux-only, so
  `proxyZeroCopyModeEnabled` never engages on macOS and `ProxyDisableZeroCopyTest` only covers the
  disabled path. The removal rests on Netty 4.2's own javadoc marking the option a no-op. CI on Linux
  will exercise the zero-copy path.
- **Test sources still emit warnings** — roughly 197 across 14 `compileTestJava` tasks, mostly
  unchecked conversions in Mockito stubs, plus the same swagger classpath issue in `pulsar-proxy`'s
  tests. Deliberately left out to keep this PR reviewable; happy to follow up separately.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

**Dependencies:** `compileOnly(libs.swagger.annotations)` is added to `pulsar-client-admin`,
`pulsar-client-v5` and `pulsar-testclient`. Nothing is added or upgraded at the project level — the
artifact and its version already come from the version catalog and are already used by six other
modules. Because the scope is `compileOnly`, it reaches neither the runtime classpath nor the
published artifacts: I regenerated all three POMs with `generatePomFileForMavenPublication` and
confirmed `swagger` appears zero times in each. No distribution contents or LICENSE/NOTICE files
change. Flagged only because the diff touches `build.gradle.kts` files.