### PR TITLE
[fix][broker] Propagate topic policy initialization failures

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1618,8 +1618,14 @@ public class BrokerService implements Closeable {
                 log.warn()
                         .attr("topic", topic)
                         .exceptionMessage(ex.getCause())
-                        .log("Replication check failed. Removing topic from topics list");
-                nonPersistentTopic.stopReplProducers().whenComplete((v, exception) -> {
+                        .log("Failed to complete non-persistent topic creation. Cleaning up topic");
+                nonPersistentTopic.close(true, true).whenComplete((v, closeException) -> {
+                    if (closeException != null) {
+                        log.warn()
+                                .attr("topic", topic)
+                                .exception(closeException)
+                                .log("Failed to clean up partially initialized non-persistent topic");
+                    }
                     topicFuture.completeExceptionally(ex);
                 });
                 return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -187,13 +187,13 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                 }, getPoliciesNotifyThread())
                 // Load the topic's initial policies (global and local) and register the policy listener, so a
                 // non-persistent topic applies its own policies on load, the same as a persistent topic does.
-                .thenCompose(ignore -> initTopicPolicy())
-                // a failure to load the initial topic policies must not fail topic loading.
-                .exceptionally(ex -> {
-                    log.warn().attr("topic", topic).exception(ex)
-                            .log("Error loading topic policies during initialization. Ignoring the failure.");
-                    return null;
-                });
+                .thenCompose(ignore -> initTopicPolicy()
+                        .whenComplete((__, ex) -> {
+                            if (ex != null) {
+                                log.error().attr("topic", topic).exception(ex)
+                                        .log("Failed to initialize topic policies");
+                            }
+                        }));
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -505,17 +505,17 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     isAllowAutoUpdateSchema = policies.is_allow_auto_update_schema;
                     isAllowAutoUpdateSchemaWithReplicator = policies.is_allow_auto_update_schema_with_replicator;
                 }, getPoliciesNotifyThread())
-                .thenCompose(ignore -> initTopicPolicy())
-                .thenCompose(ignore -> removeOrphanReplicationCursors())
-                .exceptionally(ex -> {
-                    log.warn()
-                            .attr("topic", topic)
-                            .exceptionMessage(ex)
-                            .log("Error loading topic policies during initialization. Ignoring the failure. "
-                                    + "isEncryptionRequired will be set to false.");
-                    isEncryptionRequired = false;
-                    return null;
-                }));
+                .thenCompose(ignore -> initTopicPolicy()
+                        .whenComplete((ignoredPolicy, ex) -> {
+                            if (ex != null) {
+                                log.error()
+                                        .attr("topic", topic)
+                                        .exceptionMessage(ex)
+                                        .log("Failed to initialize topic policies");
+                                isEncryptionRequired = false;
+                            }
+                        }))
+                .thenCompose(ignore -> removeOrphanReplicationCursors()));
     }
 
     private void initializeDispatchRateLimiterIfNeeded() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -2225,6 +2225,43 @@ public class BrokerServiceTest extends BrokerTestBase {
     }
 
     @Test
+    public void testNonPersistentTopicPolicyLoadFailureCleansUpListener() throws Exception {
+        final TopicName topicName = TopicName.get(
+                "non-persistent://prop/ns-abc/test-policy-load-cleanup-" + UUID.randomUUID());
+        final BrokerService brokerService = pulsar.getBrokerService();
+
+        admin.lookups().lookupTopic(topicName.toString());
+
+        MockTopicPoliciesService.TRACKED_TOPICS.add(topicName);
+        MockTopicPoliciesService.FAILED_TOPICS.add(topicName);
+
+        try {
+            ExecutionException exception = Assert.expectThrows(ExecutionException.class,
+                    () -> brokerService.getTopic(topicName.toString(), true)
+                            .get(5, TimeUnit.SECONDS));
+            assertTrue(exception.getCause().getMessage().contains("injected failure"));
+
+            Awaitility.await().untilAsserted(() -> {
+                assertFalse(brokerService.getTopics().containsKey(topicName.toString()));
+                assertFalse(MockTopicPoliciesService.LISTENERS.containsKey(topicName));
+            });
+
+            Optional<Topic> retriedTopic = brokerService.getTopic(topicName.toString(), true)
+                    .get(5, TimeUnit.SECONDS);
+            assertTrue(retriedTopic.isPresent());
+
+            Awaitility.await().untilAsserted(() -> {
+                assertTrue(MockTopicPoliciesService.LISTENERS.containsKey(topicName));
+                assertEquals(MockTopicPoliciesService.LISTENERS.get(topicName).size(), 1);
+            });
+        } finally {
+            MockTopicPoliciesService.FAILED_TOPICS.remove(topicName);
+            MockTopicPoliciesService.TRACKED_TOPICS.remove(topicName);
+            MockTopicPoliciesService.LISTENERS.remove(topicName);
+        }
+    }
+
+    @Test
     public void testGetTopicWhenTopicPoliciesFail() throws Exception {
         final var topicName = TopicName.get("prop/ns-abc/test-get-topic-when-topic-policies-fail");
         MockTopicPoliciesService.FAILED_TOPICS.add(topicName);
@@ -2266,6 +2303,25 @@ public class BrokerServiceTest extends BrokerTestBase {
     static class MockTopicPoliciesService extends TopicPoliciesService.TopicPoliciesServiceDisabled {
 
         static final Set<TopicName> FAILED_TOPICS = ConcurrentHashMap.newKeySet();
+        static final Set<TopicName> TRACKED_TOPICS = ConcurrentHashMap.newKeySet();
+        static final Map<TopicName, Set<TopicPolicyListener>> LISTENERS = new ConcurrentHashMap<>();
+
+        @Override
+        public boolean registerListener(TopicName topicName, TopicPolicyListener listener) {
+            if (!TRACKED_TOPICS.contains(topicName)) {
+                return false;
+            }
+            LISTENERS.computeIfAbsent(topicName, ignored -> ConcurrentHashMap.newKeySet()).add(listener);
+            return true;
+        }
+
+        @Override
+        public void unregisterListener(TopicName topicName, TopicPolicyListener listener) {
+            LISTENERS.computeIfPresent(topicName, (ignored, listeners) -> {
+                listeners.remove(listener);
+                return listeners.isEmpty() ? null : listeners;
+            });
+        }
 
         @Override
         public CompletableFuture<Optional<TopicPolicies>> getTopicPoliciesAsync(TopicName topicName, GetType type) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -262,6 +262,41 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     }
 
     @Test
+    public void testInitializeFailsWhenTopicPolicyLoadingFails() {
+        RuntimeException failure =
+                new RuntimeException("Failed to load topic policies");
+
+        TopicPoliciesService topicPoliciesService =
+                mock(TopicPoliciesService.class);
+
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(topicPoliciesService)
+                .registerListenerAsync(any(), any());
+
+        doReturn(FutureUtil.failedFuture(failure))
+                .when(topicPoliciesService)
+                .getTopicPoliciesAsync(any(), any());
+
+        doReturn(topicPoliciesService)
+                .when(pulsarTestContext.getPulsarService())
+                .getTopicPoliciesService();
+
+        PersistentTopic topic =
+                new PersistentTopic(
+                        successTopicName,
+                        ledgerMock,
+                        brokerService);
+
+        ExecutionException exception =
+                Assert.expectThrows(
+                        ExecutionException.class,
+                        () -> topic.initialize()
+                                .get(5, TimeUnit.SECONDS));
+
+        assertSame(exception.getCause(), failure);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testCreateTopic() {
         final ManagedLedger ledgerMock = mock(ManagedLedger.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopicTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service.nonpersistent;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.lang.reflect.Field;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.service.AbstractTopic;
@@ -34,6 +36,7 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.service.PulsarCommandSender;
 import org.apache.pulsar.broker.service.SubscriptionOption;
 import org.apache.pulsar.broker.service.TransportCnx;
+import org.apache.pulsar.broker.service.TopicPoliciesService;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -46,8 +49,10 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterPolicies.ClusterUrl;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -65,6 +70,45 @@ public class NonPersistentTopicTest extends BrokerTestBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @Test
+    public void testInitializeFailsWhenTopicPolicyLoadingFails() {
+        RuntimeException failure =
+                new RuntimeException("Failed to load topic policies");
+
+        TopicPoliciesService topicPoliciesService =
+                Mockito.mock(TopicPoliciesService.class);
+
+        Mockito.doReturn(CompletableFuture.completedFuture(true))
+                .when(topicPoliciesService)
+                .registerListenerAsync(
+                        Mockito.any(),
+                        Mockito.any());
+
+        Mockito.doReturn(FutureUtil.failedFuture(failure))
+                .when(topicPoliciesService)
+                .getTopicPoliciesAsync(
+                        Mockito.any(),
+                        Mockito.any());
+
+        Mockito.doReturn(topicPoliciesService)
+                .when(pulsar)
+                .getTopicPoliciesService();
+
+        NonPersistentTopic topic =
+                new NonPersistentTopic(
+                        "non-persistent://prop/ns-abc/"
+                                + "policy-load-failure",
+                        pulsar.getBrokerService());
+
+        ExecutionException exception =
+                Assert.expectThrows(
+                        ExecutionException.class,
+                        () -> topic.initialize()
+                                .get(5, TimeUnit.SECONDS));
+
+        assertSame(exception.getCause(), failure);
     }
 
     @Test


### PR DESCRIPTION
Fixes #26137

### Motivation

Topic policies are loaded during topic initialization through `AbstractTopic.initTopicPolicy()`.

Previously, both `PersistentTopic.initialize()` and `NonPersistentTopic.initialize()` handled failures from `initTopicPolicy()` with `exceptionally(...)` and returned `null`. This converted the failed future into a successful one, allowing the topic to finish loading without its topic-level policies being applied.

As a result, the topic could temporarily or indefinitely use namespace-level or broker-level fallback settings. This is unsafe for policies such as retention and TTL because the effective behavior may differ from the policy configured directly on the topic.

For non-persistent topics, propagating the initialization failure also requires complete cleanup. The topic-policy listener is registered before the initial policy fetch finishes. If topic creation fails and the topic is only removed from the broker cache without being closed, the listener can continue retaining the failed topic instance. Retrying the same topic could then accumulate stale listeners.

### Modifications

* Updated `PersistentTopic.initialize()` to preserve failures from `initTopicPolicy()` instead of converting them into successful initialization.
* Updated `NonPersistentTopic.initialize()` to preserve failures from `initTopicPolicy()` instead of ignoring them.
* Kept policy-loading failure logging while allowing the original exception to propagate.
* Preserved the existing reset of `isEncryptionRequired` when persistent-topic policy initialization fails.
* Updated `BrokerService#createNonPersistentTopic()` to fully close a partially initialized non-persistent topic when creation fails.
* Replaced the limited `stopReplProducers()` cleanup with `close(true, true)` so registered topic-policy listeners and other topic resources are released.
* Preserved the original topic-creation failure even if cleanup also fails.
* Added tests for persistent and non-persistent topic initialization failures.
* Added a BrokerService-level test that verifies:
  * the failed topic is removed from the topic cache;
  * its topic-policy listener is unregistered;
  * retrying the same topic succeeds;
  * only one listener remains after the retry.

### Verifying this change

This change added tests and can be verified as follows:

* `PersistentTopicTest.testInitializeFailsWhenTopicPolicyLoadingFails`
* `NonPersistentTopicTest.testInitializeFailsWhenTopicPolicyLoadingFails`
* `BrokerServiceTest.testNonPersistentTopicPolicyLoadFailureCleansUpListener`

The following related tests also pass:

* `BrokerServiceTest.testGetTopicWhenTopicPoliciesFail`
* `BrokerServiceTest.testMetricsNonPersistentTopicLoadFails`

```bash
./gradlew :pulsar-broker:test \
  --tests "org.apache.pulsar.broker.service.PersistentTopicTest.testInitializeFailsWhenTopicPolicyLoadingFails" \
  --tests "org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopicTest.testInitializeFailsWhenTopicPolicyLoadingFails" \
  --tests "org.apache.pulsar.broker.service.BrokerServiceTest.testNonPersistentTopicPolicyLoadFailureCleansUpListener" \
  --tests "org.apache.pulsar.broker.service.BrokerServiceTest.testGetTopicWhenTopicPoliciesFail" \
  --tests "org.apache.pulsar.broker.service.BrokerServiceTest.testMetricsNonPersistentTopicLoadFails" \
  -PskipJavaVersionCheck \
  -DtestRetryCount=0 \
  --no-daemon \
  --no-configuration-cache
````

### Does this pull request potentially affect one of the following parts:

* [ ] Dependencies (add or upgrade a dependency)
* [ ] The public API
* [ ] The schema
* [ ] The default values of configurations
* [ ] The threading model
* [ ] The binary protocol
* [ ] The REST endpoints
* [ ] The admin CLI options
* [ ] The metrics
* [x] Anything that affects deployment