### PR TITLE
[fix][broker] Fix snapshot creation race causing delayed delivery bucket trim failures

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTracker.java
@@ -126,6 +126,11 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private volatile CompletableFuture<Void> trimFuture;
 
+    @VisibleForTesting
+    CompletableFuture<Void> getTrimFuture() {
+        return trimFuture;
+    }
+
     public BucketDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher,
                                         Timer timer, long tickTimeMillis,
                                         boolean isDelayedDeliveryDeliverAtTimeStrict,
@@ -918,20 +923,32 @@ public class BucketDelayedDeliveryTracker extends AbstractDelayedDeliveryTracker
 
     private CompletableFuture<Void> deleteBucketSnapshot(String ledgerName,
                                                           Range<Long> range, ImmutableBucket bucket) {
-        return bucket.asyncDeleteBucketSnapshot(stats)
-                .handle((__, t) -> {
-                    if (t != null) {
-                        log.warn().attr("LedgerName", ledgerName)
-                                .attr("BucketKey", bucket.bucketKey())
-                                .log("Failed to delete bucket snapshot");
-                        throw new CompletionException(t);
-                    }
+        return bucket.getSnapshotCreateFuture().orElse(NULL_LONG_PROMISE)
+                .thenCompose(bucketId -> {
                     synchronized (this) {
-                        snapshotSegmentLastIndexMap.entrySet().removeIf(entry -> entry.getValue() == bucket);
-                        removeBucket(range);
-                        numberDelayedMessages.addAndGet(-bucket.getNumberBucketDelayedMessages());
+                        Long firstLedgerId = firstActiveLedgerId();
+                        if (INVALID_BUCKET_ID.equals(bucketId)
+                                || firstLedgerId == null
+                                || range.upperEndpoint() >= firstLedgerId
+                                || immutableBuckets.asMapOfRanges().get(range) != bucket) {
+                            return CompletableFuture.completedFuture(null);
+                        }
                     }
-                    return null;
+                    return bucket.asyncDeleteBucketSnapshot(stats).thenRun(() -> {
+                        synchronized (this) {
+                            if (immutableBuckets.asMapOfRanges().get(range) != bucket) {
+                                return;
+                            }
+                            snapshotSegmentLastIndexMap.entrySet().removeIf(entry -> entry.getValue() == bucket);
+                            removeBucket(range);
+                            numberDelayedMessages.addAndGet(-bucket.getNumberBucketDelayedMessages());
+                        }
+                    });
+                }).exceptionally(t -> {
+                    log.warn().attr("LedgerName", ledgerName)
+                            .attr("BucketKey", bucket.bucketKey())
+                            .log("Failed to delete bucket snapshot");
+                    throw new CompletionException(t);
                 });
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/delayed/bucket/BucketDelayedDeliveryTrackerTest.java
@@ -57,6 +57,8 @@ import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.pulsar.broker.delayed.AbstractDeliveryTrackerTest;
 import org.apache.pulsar.broker.delayed.MockBucketSnapshotStorage;
 import org.apache.pulsar.broker.delayed.MockManagedCursor;
+import org.apache.pulsar.broker.delayed.proto.SnapshotMetadata;
+import org.apache.pulsar.broker.delayed.proto.SnapshotSegment;
 import org.apache.pulsar.broker.service.persistent.AbstractPersistentDispatcherMultipleConsumers;
 import org.awaitility.Awaitility;
 import org.roaringbitmap.RoaringBitmap;
@@ -556,6 +558,28 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         }
     }
 
+    private static class BlockingCreateStorage extends MockBucketSnapshotStorage {
+        final CompletableFuture<Void> allowCreate = new CompletableFuture<>();
+        final AtomicLong createCalls = new AtomicLong();
+        final AtomicLong deleteCalls = new AtomicLong();
+
+        @Override
+        public CompletableFuture<Long> createBucketSnapshot(
+                SnapshotMetadata snapshotMetadata, List<SnapshotSegment> bucketSnapshotSegments, String bucketKey,
+                String topicName, String cursorName) {
+            createCalls.incrementAndGet();
+            return super.createBucketSnapshot(snapshotMetadata, bucketSnapshotSegments, bucketKey, topicName,
+                            cursorName)
+                    .thenCompose(bucketId -> allowCreate.thenApply(ignored -> bucketId));
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteBucketSnapshot(long bucketId) {
+            deleteCalls.incrementAndGet();
+            return super.deleteBucketSnapshot(bucketId);
+        }
+    }
+
     private static class RecordingDeleteStorage extends MockBucketSnapshotStorage {
         final AtomicLong deleteCalls = new AtomicLong();
 
@@ -586,11 +610,17 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
     private TrackerWithStorage createTrackerWithMockLedger(long firstLedgerId, int maxNumBuckets,
                                                           MockBucketSnapshotStorage storage)
             throws Exception {
+        return createTrackerWithMockLedger(new AtomicLong(firstLedgerId), maxNumBuckets, storage);
+    }
+
+    private TrackerWithStorage createTrackerWithMockLedger(AtomicLong firstLedgerId, int maxNumBuckets,
+                                                           MockBucketSnapshotStorage storage)
+            throws Exception {
         storage.start();
 
         ManagedLedger mockLedger = mock(ManagedLedger.class);
         NavigableMap<Long, LedgerInfo> ledgerInfo = new TreeMap<>();
-        ledgerInfo.put(firstLedgerId, mock(LedgerInfo.class));
+        ledgerInfo.put(firstLedgerId.get(), mock(LedgerInfo.class));
         when(mockLedger.getLedgersInfo()).thenReturn(ledgerInfo);
         when(mockLedger.getName()).thenReturn("test-ledger");
 
@@ -602,7 +632,7 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
 
             @Override
             public Position getMarkDeletedPosition() {
-                return PositionFactory.create(firstLedgerId, -1);
+                return PositionFactory.create(firstLedgerId.get(), -1);
             }
         };
 
@@ -828,6 +858,55 @@ public class BucketDelayedDeliveryTrackerTest extends AbstractDeliveryTrackerTes
         assertEquals(ts.tracker.getSharedBucketPriorityQueue().size(), 0);
 
         ts.close();
+    }
+
+    @Test
+    public void testTrimWaitsForSnapshotCreation() throws Exception {
+        BlockingCreateStorage storage = new BlockingCreateStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(50L, 5, storage);
+        try {
+            for (int i = 1; i <= 31; i++) {
+                ts.tracker.addMessage(i, i, i * 10);
+            }
+
+            assertEquals(storage.createCalls.get(), 6L);
+            assertEquals(storage.deleteCalls.get(), 0L,
+                    "Trim must not delete a snapshot while its creation is in flight");
+
+            storage.allowCreate.complete(null);
+            ts.tracker.getTrimFuture().get(1, TimeUnit.MINUTES);
+
+            assertEquals(storage.deleteCalls.get(), 6L);
+            assertTrue(ts.tracker.getImmutableBuckets().asMapOfRanges().isEmpty());
+        } finally {
+            storage.allowCreate.complete(null);
+            ts.close();
+        }
+    }
+
+    @Test
+    public void testTrimRevalidatesBucketAfterSnapshotCreation() throws Exception {
+        AtomicLong firstLedgerId = new AtomicLong(50L);
+        BlockingCreateStorage storage = new BlockingCreateStorage();
+        TrackerWithStorage ts = createTrackerWithMockLedger(firstLedgerId, 5, storage);
+        try {
+            for (int i = 1; i <= 31; i++) {
+                ts.tracker.addMessage(i, i, 1000L);
+            }
+
+            assertEquals(storage.createCalls.get(), 6L);
+            firstLedgerId.set(0L);
+            storage.allowCreate.complete(null);
+            ts.tracker.getTrimFuture().get(1, TimeUnit.MINUTES);
+
+            assertEquals(storage.deleteCalls.get(), 0L,
+                    "Trim must revalidate that a bucket is still orphaned after snapshot creation");
+            assertEquals(ts.tracker.getImmutableBuckets().asMapOfRanges().size(), 6);
+            assertEquals(ts.tracker.getNumberOfDelayedMessages(), 31L);
+        } finally {
+            storage.allowCreate.complete(null);
+            ts.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation

`BucketDelayedDeliveryTracker` publishes a newly sealed immutable bucket before its asynchronous snapshot creation completes. If the same `addMessage` call causes the bucket count to exceed `delayedDeliveryMaxNumBuckets`, trim can immediately select a bucket whose snapshot ID is not available yet. This makes the current trim pass fail and delays cleanup until a later trim is triggered.

### Modifications

Consider a tracker with a maximum of 5 buckets and a first active ledger ID of 50:

1. Rapid message additions create 6 immutable buckets while their snapshot creations are still in flight. The same `addMessage` call that creates the sixth bucket starts trim because the limit has been exceeded.
2. Since the bucket ranges end before ledger 50, trim considers them orphaned and attempts to delete them sequentially.
3. Before this change, deletion starts immediately. For an in-flight snapshot, the bucket ID is neither cached in the bucket nor recorded in the cursor properties, so `getAndUpdateBucketId()` calls `Long.parseLong(null)` and throws `NumberFormatException`. The trim chain stops at that failure and `trimFuture` completes exceptionally. It is not permanently pending, but the failed deletion is left for a later trim attempt.
4. With this change, each deletion is chained from the bucket's snapshot creation future. After creation completes, trim revalidates under the tracker lock that the bucket ID is valid, the range is still before the current first active ledger, and the exact range still maps to the same bucket instance.
5. Only a bucket that still passes those checks is deleted. After deletion succeeds, the mapping is checked again before removing the bucket indexes and updating the delayed-message count, preventing an older asynchronous continuation from modifying newer tracker state.

The wait is asynchronous and does not block the dispatcher thread.

### Verifying this change

Added deterministic tests that hold snapshot creation in flight and verify that:

- Trim does not delete snapshots before creation completes and resumes after creation is released.
- Trim revalidates bucket eligibility after waiting and does not delete based on stale state.

Verified with:

- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTrackerTest`
- `./gradlew :pulsar-broker:test --tests org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTrackerThreadSafetyTest`
- `./gradlew quickCheck`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
