### PR TITLE
[fix][ml] Prevent writes to empty ledgers closed in metadata

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -285,7 +285,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     // ledger metadata stored. This variable used to record the result of the latest once re-checking.
     private Pair<Long, CompletableFuture<Integer>> ledgerRecheckInProgress = new ImmutablePair<>(-1L,
             CompletableFuture.completedFuture(Code.OK));
-    private boolean emptyLedgerMetadataCheckInProgress;
+    // Accessed only while holding this object's monitor.
+    private LedgerHandle emptyLedgerMetadataCheckLedger;
+    private boolean emptyLedgerRolloverInProgress;
 
     public enum State {
         None, // Uninitialized
@@ -864,7 +866,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         if (!beforeAddEntry(addOperation)) {
             return;
         }
-        final State state = STATE_UPDATER.get(this);
+        State state = STATE_UPDATER.get(this);
         if (state.isFenced()) {
             addOperation.failed(new ManagedLedgerFencedException());
             return;
@@ -880,14 +882,19 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         pendingAddEntries.add(addOperation);
 
-        if (state == State.LedgerOpened && currentLedgerEntries == 0 && maximumRolloverTimeReached()
-                && !emptyLedgerMetadataCheckInProgress) {
-            emptyLedgerMetadataCheckInProgress = true;
-            checkEmptyLedgerMetadata(currentLedger);
+        if (state == State.LedgerOpened && currentLedgerEntries == 0
+                && ledgers.containsKey(currentLedger.getId())) {
+            if (maximumRolloverTimeReached()) {
+                startEmptyLedgerRollover(currentLedger, null);
+            } else if (emptyLedgerMetadataCheckLedger == null) {
+                emptyLedgerMetadataCheckLedger = currentLedger;
+                checkEmptyLedgerMetadata(currentLedger);
+            }
+            state = STATE_UPDATER.get(this);
         }
 
         if (state == State.ClosingLedger || state == State.CreatingLedger
-                || emptyLedgerMetadataCheckInProgress) {
+                || emptyLedgerMetadataCheckLedger != null) {
             // We don't have a ready ledger to write into
             // We are waiting for a new ledger to be created
             log.debug("Queue addEntry request");
@@ -1544,6 +1551,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         log.info("Terminating managed ledger");
         state = State.Terminated;
+        if (emptyLedgerMetadataCheckLedger != null || emptyLedgerRolloverInProgress) {
+            emptyLedgerMetadataCheckLedger = null;
+            emptyLedgerRolloverInProgress = false;
+            clearPendingAddEntries(new ManagedLedgerTerminatedException("Managed ledger was terminated"));
+        }
 
         LedgerHandle lh = currentLedger;
         log.debug().attr("ledgerId", lh.getId()).log("Closing current writing ledger");
@@ -1882,6 +1894,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     protected synchronized void updateLedgersIdsComplete(@Nullable LedgerHandle originalCurrentLedger) {
         STATE_UPDATER.set(this, State.LedgerOpened);
+        emptyLedgerMetadataCheckLedger = null;
+        emptyLedgerRolloverInProgress = false;
         // Delete original "currentLedger" if it has been removed from "ledgers".
         if (originalCurrentLedger != null && !ledgers.containsKey(originalCurrentLedger.getId())){
             asyncDeleteLedgerWithConcurrencyLimit(originalCurrentLedger.getId(), (rc, ctx) -> {
@@ -2060,55 +2074,110 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     ledgerClosed(lh);
                 }
             }, null);
-        } else if (currentLedgerEntries == 0 && maximumRolloverTimeReached()
-                && STATE_UPDATER.get(this) == State.LedgerOpened
-                && !emptyLedgerMetadataCheckInProgress) {
-            emptyLedgerMetadataCheckInProgress = true;
-            checkEmptyLedgerMetadata(currentLedger);
+        } else if (currentLedgerEntries == 0 && ledgers.containsKey(currentLedger.getId())) {
+            startEmptyLedgerRollover(currentLedger, null);
         }
     }
 
     private void checkEmptyLedgerMetadata(LedgerHandle ledger) {
-        bookKeeper.newOpenLedgerOp().withRecovery(false).withLedgerId(ledger.getId())
-                .withDigestType(config.getDigestType()).withPassword(config.getPassword())
-                .withLoggerContext(log).execute()
-                .whenCompleteAsync((readHandle, exception) -> {
-                    try {
-                        synchronized (this) {
-                            emptyLedgerMetadataCheckInProgress = false;
+        final CompletableFuture<ReadHandle> metadataFuture;
+        try {
+            metadataFuture = openLedgerForMetadataCheck(ledger);
+        } catch (Throwable cause) {
+            completeEmptyLedgerMetadataCheck(ledger, null, cause);
+            return;
+        }
+        metadataFuture.whenCompleteAsync(
+                (readHandle, exception) -> completeEmptyLedgerMetadataCheck(ledger, readHandle, exception), executor);
+    }
 
-                            if (currentLedger != ledger || STATE_UPDATER.get(this) != State.LedgerOpened) {
-                                return;
-                            }
+    @VisibleForTesting
+    CompletableFuture<ReadHandle> openLedgerForMetadataCheck(LedgerHandle ledger) {
+        return bookKeeper.newOpenLedgerOp()
+                .withRecovery(false)
+                .withLedgerId(ledger.getId())
+                .withDigestType(config.getDigestType())
+                .withPassword(config.getPassword())
+                .withLoggerContext(log)
+                .execute();
+    }
 
-                            if (exception != null) {
-                                log.warn().attr("ledgerId", ledger.getId()).exception(exception)
-                                        .log("Failed to check the metadata of an empty ledger");
-                                clearPendingAddEntries(createManagedLedgerException(exception));
-                                return;
-                            }
-
-                            LedgerMetadata metadata = readHandle.getLedgerMetadata();
-                            if (metadata.isClosed()) {
-                                if (STATE_UPDATER.compareAndSet(this, State.LedgerOpened, State.ClosingLedger)) {
-                                    log.info().attr("ledgerId", ledger.getId())
-                                            .log("Rolling over an empty ledger that is closed in metadata");
-                                    ledgerClosed(ledger, metadata.getLastEntryId());
-                                }
-                            } else {
-                                resendPendingAddEntries();
-                            }
-                        }
-                    } finally {
-                        if (readHandle != null) {
-                            readHandle.closeAsync().exceptionally(closeException -> {
-                                log.warn().attr("ledgerId", ledger.getId()).exception(closeException)
-                                        .log("Failed to close the ledger metadata check handle");
-                                return null;
-                            });
-                        }
+    private void completeEmptyLedgerMetadataCheck(
+            LedgerHandle ledger, @Nullable ReadHandle readHandle, @Nullable Throwable exception) {
+        try {
+            synchronized (this) {
+                if (emptyLedgerMetadataCheckLedger == ledger) {
+                    emptyLedgerMetadataCheckLedger = null;
+                }
+                if (currentLedger != ledger || STATE_UPDATER.get(this) != State.LedgerOpened) {
+                    return;
+                }
+                if (exception != null) {
+                    log.warn().attr("ledgerId", ledger.getId()).exception(exception)
+                            .log("Failed to verify empty ledger metadata before its first write; rolling it over");
+                    if (!pendingAddEntries.isEmpty()) {
+                        startEmptyLedgerRollover(ledger, null);
                     }
-                }, executor);
+                    return;
+                }
+
+                LedgerMetadata metadata = readHandle.getLedgerMetadata();
+                if (metadata.getState() != LedgerMetadata.State.OPEN) {
+                    startEmptyLedgerRollover(ledger, metadata.getLastEntryId());
+                } else if (!pendingAddEntries.isEmpty()) {
+                    if (maximumRolloverTimeReached()) {
+                        startEmptyLedgerRollover(ledger, null);
+                    } else {
+                        resendPendingAddEntries();
+                    }
+                }
+            }
+        } finally {
+            if (readHandle != null) {
+                try {
+                    readHandle.closeAsync().exceptionally(closeException -> {
+                        log.warn().attr("ledgerId", ledger.getId()).exception(closeException)
+                                .log("Failed to close empty ledger metadata read handle");
+                        return null;
+                    });
+                } catch (Throwable cause) {
+                    log.warn().attr("ledgerId", ledger.getId()).exception(cause)
+                            .log("Failed to initiate closing empty ledger metadata read handle");
+                }
+            }
+        }
+    }
+
+    private synchronized void startEmptyLedgerRollover(LedgerHandle ledger, @Nullable Long lastAddConfirmed) {
+        if (currentLedger != ledger || currentLedgerEntries != 0
+                || !STATE_UPDATER.compareAndSet(this, State.LedgerOpened, State.ClosingLedger)) {
+            return;
+        }
+        emptyLedgerRolloverInProgress = true;
+        if (lastAddConfirmed != null) {
+            ledgerClosed(ledger, lastAddConfirmed);
+        } else {
+            asyncCloseEmptyLedgerBeforeFirstWrite(ledger);
+        }
+    }
+
+    @VisibleForTesting
+    void asyncCloseEmptyLedgerBeforeFirstWrite(LedgerHandle ledger) {
+        log.debug().attr("ledgerId", ledger.getId()).log("Rolling over an empty ledger before its first write");
+        try {
+            ledger.asyncClose((rc, closedLedger, ctx) -> {
+                if (rc != BKException.Code.OK) {
+                    log.warn().attr("ledgerId", ledger.getId())
+                            .attr("status", BKException.getMessage(rc))
+                            .log("Error when closing an empty ledger before its first write");
+                }
+                ledgerClosed(ledger);
+            }, null);
+        } catch (Throwable cause) {
+            log.warn().attr("ledgerId", ledger.getId()).exception(cause)
+                    .log("Failed to initiate closing an empty ledger before its first write");
+            ledgerClosed(ledger);
+        }
     }
 
     @Override
@@ -4529,8 +4598,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private boolean maximumRolloverTimeReached() {
-        return factory.isMetadataServiceAvailable()
-                && config.getMaximumRolloverTimeMs() > 0
+        return config.getMaximumRolloverTimeMs() > 0
                 && clock.millis() - lastLedgerCreatedTimestamp >= config.getMaximumRolloverTimeMs();
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -285,6 +285,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     // ledger metadata stored. This variable used to record the result of the latest once re-checking.
     private Pair<Long, CompletableFuture<Integer>> ledgerRecheckInProgress = new ImmutablePair<>(-1L,
             CompletableFuture.completedFuture(Code.OK));
+    private boolean emptyLedgerMetadataCheckInProgress;
 
     public enum State {
         None, // Uninitialized
@@ -879,7 +880,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
         pendingAddEntries.add(addOperation);
 
-        if (state == State.ClosingLedger || state == State.CreatingLedger) {
+        if (state == State.LedgerOpened && currentLedgerEntries == 0 && maximumRolloverTimeReached()
+                && !emptyLedgerMetadataCheckInProgress) {
+            emptyLedgerMetadataCheckInProgress = true;
+            checkEmptyLedgerMetadata(currentLedger);
+        }
+
+        if (state == State.ClosingLedger || state == State.CreatingLedger
+                || emptyLedgerMetadataCheckInProgress) {
             // We don't have a ready ledger to write into
             // We are waiting for a new ledger to be created
             log.debug("Queue addEntry request");
@@ -1885,7 +1893,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         updateLastLedgerCreatedTimeAndScheduleRolloverTask();
 
         log.debug().attr("count", pendingAddEntries.size()).log("Resending pending messages");
+        resendPendingAddEntries();
+    }
 
+    private void resendPendingAddEntries() {
         createNewOpAddEntryForNewLedger();
 
         // Process all the pending addEntry requests
@@ -2023,9 +2034,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     @VisibleForTesting
     @SuppressWarnings("deprecation")
     @Override
-    public void rollCurrentLedgerIfFull() {
+    public synchronized void rollCurrentLedgerIfFull() {
         log.info("Start checking if current ledger is full");
-        if (currentLedgerEntries > 0 && currentLedgerIsFull()
+        if (!currentLedgerIsFull()) {
+            return;
+        }
+
+        if (currentLedgerEntries > 0
                 && STATE_UPDATER.compareAndSet(this, State.LedgerOpened, State.ClosingLedger)) {
             currentLedger.asyncClose(new AsyncCallback.CloseCallback() {
                 @Override
@@ -2045,7 +2060,55 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     ledgerClosed(lh);
                 }
             }, null);
+        } else if (currentLedgerEntries == 0 && maximumRolloverTimeReached()
+                && STATE_UPDATER.get(this) == State.LedgerOpened
+                && !emptyLedgerMetadataCheckInProgress) {
+            emptyLedgerMetadataCheckInProgress = true;
+            checkEmptyLedgerMetadata(currentLedger);
         }
+    }
+
+    private void checkEmptyLedgerMetadata(LedgerHandle ledger) {
+        bookKeeper.newOpenLedgerOp().withRecovery(false).withLedgerId(ledger.getId())
+                .withDigestType(config.getDigestType()).withPassword(config.getPassword())
+                .withLoggerContext(log).execute()
+                .whenCompleteAsync((readHandle, exception) -> {
+                    try {
+                        synchronized (this) {
+                            emptyLedgerMetadataCheckInProgress = false;
+
+                            if (currentLedger != ledger || STATE_UPDATER.get(this) != State.LedgerOpened) {
+                                return;
+                            }
+
+                            if (exception != null) {
+                                log.warn().attr("ledgerId", ledger.getId()).exception(exception)
+                                        .log("Failed to check the metadata of an empty ledger");
+                                clearPendingAddEntries(createManagedLedgerException(exception));
+                                return;
+                            }
+
+                            LedgerMetadata metadata = readHandle.getLedgerMetadata();
+                            if (metadata.isClosed()) {
+                                if (STATE_UPDATER.compareAndSet(this, State.LedgerOpened, State.ClosingLedger)) {
+                                    log.info().attr("ledgerId", ledger.getId())
+                                            .log("Rolling over an empty ledger that is closed in metadata");
+                                    ledgerClosed(ledger, metadata.getLastEntryId());
+                                }
+                            } else {
+                                resendPendingAddEntries();
+                            }
+                        }
+                    } finally {
+                        if (readHandle != null) {
+                            readHandle.closeAsync().exceptionally(closeException -> {
+                                log.warn().attr("ledgerId", ledger.getId()).exception(closeException)
+                                        .log("Failed to close the ledger metadata check handle");
+                                return null;
+                            });
+                        }
+                    }
+                }, executor);
     }
 
     @Override
@@ -4463,6 +4526,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         } else {
             return false;
         }
+    }
+
+    private boolean maximumRolloverTimeReached() {
+        return factory.isMetadataServiceAvailable()
+                && config.getMaximumRolloverTimeMs() > 0
+                && clock.millis() - lastLedgerCreatedTimestamp >= config.getMaximumRolloverTimeMs();
     }
 
     public List<LedgerInfo> getLedgersInfoAsList() {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -42,8 +43,10 @@ import lombok.Cleanup;
 import lombok.CustomLog;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerMetadataBuilder;
 import org.apache.bookkeeper.client.PulsarBookKeeperTestClient;
 import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
@@ -59,8 +62,10 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.impl.cache.EntryCacheManager;
 import org.apache.bookkeeper.mledger.proto.PositionInfo;
+import org.apache.bookkeeper.mledger.util.MockClock;
 import org.apache.bookkeeper.mledger.util.ThrowableToStringUtil;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.pulsar.common.policies.data.PersistentOfflineTopicStats;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
@@ -757,5 +762,51 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         // cleanup
         ledger1.close();
         factory.shutdown();
+    }
+
+    @Test
+    public void rollEmptyLedgerClosedInMetadata() throws Exception {
+        MockClock clock = new MockClock();
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setClock(clock);
+        config.setMaximumRolloverTime(1, TimeUnit.HOURS);
+        config.setEnsembleSize(2).setAckQuorumSize(2).setMetadataEnsembleSize(2);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + testName, config);
+        ManagedCursor cursor = ledger.openCursor("c1");
+
+        long ledgerId = ledger.currentLedger.getId();
+        clock.advance(1, TimeUnit.HOURS);
+
+        ledger.rollCurrentLedgerIfFull();
+        Awaitility.await().during(1, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ledger.currentLedger.getId())
+                .as("an empty ledger that is still open in metadata should not be rolled over")
+                .isEqualTo(ledgerId));
+
+        Versioned<LedgerMetadata> versionedMetadata =
+                bkc.getLedgerManager().readLedgerMetadata(ledgerId).get();
+        LedgerMetadata closedMetadata = LedgerMetadataBuilder.from(versionedMetadata.getValue())
+                .withClosedState()
+                .withLastEntryId(-1)
+                .withLength(0)
+                .build();
+        bkc.getLedgerManager()
+                .writeLedgerMetadata(ledgerId, closedMetadata, versionedMetadata.getVersion()).get();
+
+        assertThat(ledger.currentLedger.getLedgerMetadata().isClosed())
+                .as("the broker's write handle should still consider the ledger open")
+                .isFalse();
+
+        // Trigger the scheduled check and immediately produce to exercise the race with the metadata lookup.
+        ledger.rollCurrentLedgerIfFull();
+        Position position = ledger.addEntry("msg1".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(position.getLedgerId()).as("the first entry should be written to a new ledger")
+                .isNotEqualTo(ledgerId);
+        List<Entry> entries = cursor.readEntries(1);
+        assertThat(entries).singleElement().extracting(entry -> new String(entry.getData(), StandardCharsets.UTF_8))
+                .isEqualTo("msg1");
+        entries.forEach(Entry::release);
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -19,6 +19,8 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
@@ -47,6 +49,7 @@ import org.apache.bookkeeper.client.LedgerMetadataBuilder;
 import org.apache.bookkeeper.client.PulsarBookKeeperTestClient;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
+import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
@@ -56,6 +59,7 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerAlreadyClosedException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.Position;
@@ -764,49 +768,151 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         factory.shutdown();
     }
 
-    @Test
-    public void rollEmptyLedgerClosedInMetadata() throws Exception {
-        MockClock clock = new MockClock();
+    @DataProvider(name = "emptyLedgerMetadataStates")
+    public Object[][] emptyLedgerMetadataStates() {
+        return new Object[][] {
+                {LedgerMetadata.State.OPEN, false},
+                {LedgerMetadata.State.CLOSED, true},
+                {LedgerMetadata.State.IN_RECOVERY, true},
+        };
+    }
+
+    @Test(dataProvider = "emptyLedgerMetadataStates", timeOut = 60000)
+    public void verifyEmptyLedgerMetadataBeforeFirstWrite(
+            LedgerMetadata.State metadataState, boolean shouldRollLedger) throws Exception {
         @Cleanup("shutdown")
         ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
         ManagedLedgerConfig config = new ManagedLedgerConfig();
-        config.setClock(clock);
-        config.setMaximumRolloverTime(1, TimeUnit.HOURS);
         config.setEnsembleSize(2).setAckQuorumSize(2).setMetadataEnsembleSize(2);
-        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("my_test_ledger" + testName, config);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("my_test_ledger" + testName + metadataState, config);
         ManagedCursor cursor = ledger.openCursor("c1");
+
+        long ledgerId = ledger.currentLedger.getId();
+        if (metadataState != LedgerMetadata.State.OPEN) {
+            Versioned<LedgerMetadata> versionedMetadata =
+                    bkc.getLedgerManager().readLedgerMetadata(ledgerId).get();
+            LedgerMetadataBuilder metadataBuilder = LedgerMetadataBuilder.from(versionedMetadata.getValue());
+            if (metadataState == LedgerMetadata.State.CLOSED) {
+                metadataBuilder.withClosedState().withLastEntryId(-1).withLength(0);
+            } else {
+                metadataBuilder.withInRecoveryState();
+            }
+            bkc.getLedgerManager()
+                    .writeLedgerMetadata(ledgerId, metadataBuilder.build(), versionedMetadata.getVersion()).get();
+        }
+
+        assertThat(ledger.currentLedger.getLedgerMetadata().getState())
+                .as("the broker's write handle should still consider the ledger open")
+                .isEqualTo(LedgerMetadata.State.OPEN);
+
+        List<String> messages = new ArrayList<>();
+        List<CompletableFuture<Position>> addFutures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String message = "msg-" + i;
+            messages.add(message);
+            CompletableFuture<Position> addFuture = new CompletableFuture<>();
+            addFutures.add(addFuture);
+            ledger.asyncAddEntry(message.getBytes(StandardCharsets.UTF_8), new AddEntryCallback() {
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    addFuture.complete(position);
+                }
+
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                    addFuture.completeExceptionally(exception);
+                }
+            }, null);
+        }
+
+        CompletableFuture.allOf(addFutures.toArray(CompletableFuture[]::new)).get(30, TimeUnit.SECONDS);
+        assertThat(addFutures).allSatisfy(addFuture -> {
+            if (shouldRollLedger) {
+                assertThat(addFuture.join().getLedgerId())
+                        .as("queued entries should be written to a new ledger")
+                        .isNotEqualTo(ledgerId);
+            } else {
+                assertThat(addFuture.join().getLedgerId())
+                        .as("a healthy ledger should not be rolled over")
+                        .isEqualTo(ledgerId);
+            }
+        });
+
+        List<Entry> entries = cursor.readEntries(messages.size());
+        try {
+            assertThat(entries)
+                    .extracting(entry -> new String(entry.getData(), StandardCharsets.UTF_8))
+                    .containsExactlyElementsOf(messages);
+        } finally {
+            entries.forEach(Entry::release);
+        }
+    }
+
+    @Test(timeOut = 30000)
+    public void rollExpiredEmptyLedgerBeforeFirstWrite() throws Exception {
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        MockClock clock = new MockClock();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setEnsembleSize(2).setAckQuorumSize(2).setMetadataEnsembleSize(2);
+        config.setClock(clock).setMaximumRolloverTime(1, TimeUnit.HOURS);
+        ManagedLedgerImpl ledger =
+                (ManagedLedgerImpl) factory.open("my_test_ledger" + testName + "expired", config);
 
         long ledgerId = ledger.currentLedger.getId();
         clock.advance(1, TimeUnit.HOURS);
 
-        ledger.rollCurrentLedgerIfFull();
-        Awaitility.await().during(1, TimeUnit.SECONDS).untilAsserted(() -> assertThat(ledger.currentLedger.getId())
-                .as("an empty ledger that is still open in metadata should not be rolled over")
-                .isEqualTo(ledgerId));
+        Position position = ledger.addEntry("msg".getBytes(StandardCharsets.UTF_8));
 
-        Versioned<LedgerMetadata> versionedMetadata =
-                bkc.getLedgerManager().readLedgerMetadata(ledgerId).get();
-        LedgerMetadata closedMetadata = LedgerMetadataBuilder.from(versionedMetadata.getValue())
-                .withClosedState()
-                .withLastEntryId(-1)
-                .withLength(0)
-                .build();
-        bkc.getLedgerManager()
-                .writeLedgerMetadata(ledgerId, closedMetadata, versionedMetadata.getVersion()).get();
+        assertThat(position.getLedgerId()).isNotEqualTo(ledgerId);
+    }
 
-        assertThat(ledger.currentLedger.getLedgerMetadata().isClosed())
-                .as("the broker's write handle should still consider the ledger open")
-                .isFalse();
+    @Test(timeOut = 30000)
+    public void rollEmptyLedgerWhenMetadataCheckFails() throws Exception {
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setEnsembleSize(2).setAckQuorumSize(2).setMetadataEnsembleSize(2);
+        ManagedLedgerImpl ledger =
+                spy((ManagedLedgerImpl) factory.open("my_test_ledger" + testName + "metadata-failure", config));
+        long ledgerId = ledger.currentLedger.getId();
+        doReturn(CompletableFuture.<ReadHandle>failedFuture(new RuntimeException("metadata read failed")))
+                .when(ledger).openLedgerForMetadataCheck(ledger.currentLedger);
 
-        // Trigger the scheduled check and immediately produce to exercise the race with the metadata lookup.
-        ledger.rollCurrentLedgerIfFull();
-        Position position = ledger.addEntry("msg1".getBytes(StandardCharsets.UTF_8));
+        Position position = ledger.addEntry("msg".getBytes(StandardCharsets.UTF_8));
 
-        assertThat(position.getLedgerId()).as("the first entry should be written to a new ledger")
-                .isNotEqualTo(ledgerId);
-        List<Entry> entries = cursor.readEntries(1);
-        assertThat(entries).singleElement().extracting(entry -> new String(entry.getData(), StandardCharsets.UTF_8))
-                .isEqualTo("msg1");
-        entries.forEach(Entry::release);
+        assertThat(position.getLedgerId()).isNotEqualTo(ledgerId);
+    }
+
+    @Test(timeOut = 30000)
+    public void terminateWhileEmptyLedgerMetadataCheckIsPending() throws Exception {
+        @Cleanup("shutdown")
+        ManagedLedgerFactoryImpl factory = new ManagedLedgerFactoryImpl(metadataStore, bkc);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setEnsembleSize(2).setAckQuorumSize(2).setMetadataEnsembleSize(2);
+        ManagedLedgerImpl ledger =
+                spy((ManagedLedgerImpl) factory.open("my_test_ledger" + testName + "terminate", config));
+        CompletableFuture<ReadHandle> metadataFuture = new CompletableFuture<>();
+        doReturn(metadataFuture).when(ledger).openLedgerForMetadataCheck(ledger.currentLedger);
+
+        CompletableFuture<ManagedLedgerException> addFailure = new CompletableFuture<>();
+        ledger.asyncAddEntry("msg".getBytes(StandardCharsets.UTF_8), new AddEntryCallback() {
+            @Override
+            public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                addFailure.completeExceptionally(new AssertionError("add should not complete after termination"));
+            }
+
+            @Override
+            public void addFailed(ManagedLedgerException exception, Object ctx) {
+                addFailure.complete(exception);
+            }
+        }, null);
+
+        Awaitility.await().untilAsserted(() -> assertThat(ledger.pendingAddEntries).hasSize(1));
+        ledger.terminate();
+
+        assertThat(addFailure.get(10, TimeUnit.SECONDS)).isInstanceOf(ManagedLedgerTerminatedException.class);
+        metadataFuture.completeExceptionally(new RuntimeException("test metadata check completed after termination"));
     }
 }


### PR DESCRIPTION
Fixes #26074

### Motivation

BookKeeper auto-recovery can close an empty head ledger in durable metadata while the broker still holds the same ledger as open in memory. Once the maximum rollover time is reached, the empty-ledger guard prevents the background rollover from healing this state. The first subsequent write can then be acknowledged on a ledger whose durable metadata records `lastEntryId=-1`, resulting in a stuck backlog and silent message loss.

### Modifications

- Check durable BookKeeper metadata when an empty ledger reaches the maximum rollover time.
- Roll to a new ledger when the durable metadata is already closed, while keeping healthy empty ledgers open.
- Queue writes that arrive during the metadata check so they cannot enter the stale write handle.
- Add a real BookKeeper regression test that recreates the durable-closed/in-memory-open mismatch and verifies the first message is written to and read from the new ledger.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `./gradlew :managed-ledger:test -PtestRetryCount=0`
- `./gradlew quickCheck`
- `./gradlew sanityCheck`

The managed-ledger suite completed 722 tests with no failures. Repository-wide `quickCheck` and `sanityCheck` also completed successfully.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [x] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

The change coordinates pending writes with an asynchronous BookKeeper metadata check using the existing managed-ledger executor; it does not add threads or executors.
