### PR TITLE
[improve][broker] Add a broker-level memory limit for in-flight replication

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -3566,6 +3566,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     )
     private int replicationProducerQueueSize = 1000;
     @FieldContext(
+        category = CATEGORY_REPLICATION,
+        dynamic = true,
+        doc = "Broker-level maximum memory (in MB) used by in-flight replication entries across all replicators. "
+            + "When the total inflight bytes reaches this limit, new cursor reads are blocked until inflight "
+            + "bytes drop below the limit. 0 means no limit (backward compatible default)."
+    )
+    private int replicationMaxInflightMemorySizeMB = 0;
+    @FieldContext(
             category = CATEGORY_REPLICATION,
             doc = "Duration to check replication policy to avoid replicator "
                     + "inconsistency due to missing ZooKeeper watch (disable with value 0)"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerReplicationMemoryLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerReplicationMemoryLimiter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Broker-level memory limiter for replication inflight entries.
+ *
+ * <p>All replicators on a broker share a total byte budget for in-flight entry data.
+ * Before each cursor read, a replicator estimates the bytes it will consume and calls
+ * {@link #acquireUpTo(long, Runnable)} to acquire as many bytes as the budget allows.
+ * The returned value determines how many entries can be read. If 0 bytes are available,
+ * the retry task is enqueued and will be drained later when bytes are released via
+ * {@link #release(long)} or {@link #calibrate(long, long)}.
+ *
+ * <p>The limiter is disabled when {@code maxBytes} is 0.
+ */
+public class BrokerReplicationMemoryLimiter {
+
+    private final AtomicLong inflightBytes = new AtomicLong(0);
+    private volatile long maxBytes;
+    private final Queue<PendingTask> pendingTasks = new ConcurrentLinkedQueue<>();
+    private final Executor executor;
+
+    public BrokerReplicationMemoryLimiter(Executor executor) {
+        this.executor = executor;
+        this.maxBytes = 0;
+    }
+
+    /**
+     * Acquire as many bytes as possible from the budget, up to {@code requestedBytes}.
+     * If no bytes are available and a {@code retryTask} is provided, the task is enqueued
+     * for later execution when bytes become available.
+     *
+     * @param requestedBytes the maximum number of bytes the caller would like to acquire
+     * @param retryTask      a Runnable to re-trigger the read when bytes are released;
+     *                       may be null if the caller will retry through another mechanism.
+     *                       Only enqueued when 0 bytes are acquired.
+     * @return the actual number of bytes acquired (0 if budget is fully exhausted)
+     */
+    public long acquireUpTo(long requestedBytes, Runnable retryTask) {
+        if (maxBytes <= 0) {
+            return requestedBytes;
+        }
+
+        while (true) {
+            long current = inflightBytes.get();
+            long available = maxBytes - current;
+            if (available <= 0) {
+                if (retryTask != null) {
+                    pendingTasks.offer(new PendingTask(requestedBytes, retryTask));
+                }
+                return 0;
+            }
+            long acquired = Math.min(available, requestedBytes);
+            if (inflightBytes.compareAndSet(current, current + acquired)) {
+                return acquired;
+            }
+        }
+    }
+
+    /** @deprecated use {@link #acquireUpTo(long, Runnable)} instead */
+    @Deprecated
+    public boolean tryAcquire(long estimatedBytes, Runnable retryTask) {
+        return acquireUpTo(estimatedBytes, retryTask) >= estimatedBytes;
+    }
+
+    /**
+     * Release bytes back to the budget after a send completes and the entry is released.
+     * Triggers draining of one pending task.
+     */
+    public void release(long bytes) {
+        inflightBytes.addAndGet(-bytes);
+        drainPendingTasks();
+    }
+
+    /**
+     * Calibrate the inflight count by adjusting for the difference between the estimate
+     * and the actual byte count. Triggers draining of one pending task.
+     */
+    public void calibrate(long estimatedBytes, long actualBytes) {
+        long delta = actualBytes - estimatedBytes;
+        inflightBytes.addAndGet(delta);
+        drainPendingTasks();
+    }
+
+    /**
+     * Release all estimated bytes (when a read that was acquired cannot proceed,
+     * e.g., errors during read).
+     */
+    public void releaseEstimated(long estimatedBytes) {
+        inflightBytes.addAndGet(-estimatedBytes);
+        drainPendingTasks();
+    }
+
+    /**
+     * Update the maximum byte budget. Drains pending tasks after the change.
+     */
+    public void setMaxBytes(long maxBytes) {
+        this.maxBytes = maxBytes;
+        if (maxBytes > 0) {
+            drainPendingTasks();
+        }
+    }
+
+    public long getMaxBytes() {
+        return maxBytes;
+    }
+
+    public long getInflightBytes() {
+        return inflightBytes.get();
+    }
+
+    public int getPendingTaskCount() {
+        return pendingTasks.size();
+    }
+
+    public boolean isLimitReached() {
+        long max = maxBytes;
+        return max > 0 && inflightBytes.get() >= max;
+    }
+
+    private void drainPendingTasks() {
+        PendingTask task = pendingTasks.poll();
+        if (task != null) {
+            executor.execute(task.retryTask);
+        }
+    }
+
+    private record PendingTask(long estimatedBytes, Runnable retryTask) {
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -305,6 +305,9 @@ public class BrokerService implements Closeable {
 
     private DistributedIdGenerator producerNameGenerator;
 
+    @Getter
+    private final BrokerReplicationMemoryLimiter replicationMemoryLimiter;
+
     public static final String PRODUCER_NAME_GENERATOR_PATH = "/counters/producer-name";
 
     private final BacklogQuotaManager backlogQuotaManager;
@@ -384,6 +387,7 @@ public class BrokerService implements Closeable {
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(
                 pulsar.getConfiguration().getNumAcceptorThreads(), false, acceptorThreadFactory);
         this.workerGroup = eventLoopGroup;
+        this.replicationMemoryLimiter = new BrokerReplicationMemoryLimiter(workerGroup);
 
         this.statsUpdater = new SingleThreadNonConcurrentFixedRateScheduler("pulsar-stats-updater");
         this.authorizationService = new AuthorizationService(
@@ -3305,6 +3309,10 @@ public class BrokerService implements Closeable {
         });
 
         // add more listeners here
+
+        registerConfigurationListener("replicationMaxInflightMemorySizeMB",
+                maxBytesMB -> replicationMemoryLimiter.setMaxBytes(
+                        (long) ((Integer) maxBytesMB) * 1024 * 1024));
 
         // (3) create dynamic-config if not exist.
         createDynamicConfigPathIfNotExist();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +55,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.CursorAlreadyClosedE
 import org.apache.bookkeeper.mledger.ManagedLedgerException.TooManyRequestsException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo.LedgerInfo;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -219,7 +221,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         this.cursor.setInactive();
     }
 
-    private record ReadLimits(int messages, long bytes) {
+    private record ReadLimits(int messages, long bytes, long estimatedBytes) {
         public boolean isReadable() {
             return messages > 0 && bytes > 0;
         }
@@ -227,16 +229,17 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
     /**
      * Calculate read limits for a read operation. Takes the rate limiter into account if it's enabled.
-     * Also limits to current readBatchSize and readMaxSizeBytes.
+     * Also limits to current readBatchSize and readMaxSizeBytes, and checks the broker-level replication
+     * memory budget.
      */
-    private ReadLimits getReadLimits(int permits) {
+    private ReadLimits getReadLimits(int permits, Runnable retryTask) {
 
         // return 0, if Producer queue is full, it will pause read entries.
         if (permits <= 0) {
             log.debug()
                     .attr("permits", permits)
                     .log("Producer queue is full, pausing reads");
-            return new ReadLimits(0, 0);
+            return new ReadLimits(0, 0, 0);
         }
 
         long readLimitOnMsg;
@@ -256,7 +259,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
                         .attr("readLimitOnMsg", readLimitOnMsg)
                         .attr("readLimitOnByte", readLimitOnByte)
                         .log("Message-read exceeded topic replicator rate limit");
-                return new ReadLimits(-1, -1);
+                return new ReadLimits(-1, -1, 0);
             }
             // use given permits if no rate limit configured, otherwise limit to returned rate limiter permits
             readLimitOnMsg = readLimitOnMsg == -1 ? permits : Math.min(permits, readLimitOnMsg);
@@ -270,7 +273,20 @@ public abstract class PersistentReplicator extends AbstractReplicator
         // limit messages to current read batch size
         readLimitOnMsg = Math.min(readLimitOnMsg, readBatchSize);
 
-        return new ReadLimits((int) readLimitOnMsg, readLimitOnByte);
+        // estimate and acquire memory budget (best-effort)
+        final long avgEntrySize = getAverageEntrySize();
+        long tryAcquiredBytes = readLimitOnMsg * avgEntrySize;
+        long acquiredBytes = brokerService.getReplicationMemoryLimiter()
+                .acquireUpTo(tryAcquiredBytes, retryTask);
+        if (acquiredBytes <= 0) {
+            log.debug("No memory budget available, waiting");
+            return new ReadLimits(0, 0, 0);
+        }
+        if (acquiredBytes < tryAcquiredBytes) {
+            readLimitOnMsg = Math.max(1, acquiredBytes / avgEntrySize);
+        }
+
+        return new ReadLimits((int) readLimitOnMsg, readLimitOnByte, acquiredBytes);
     }
 
     public void disconnectIfNoTrafficAndBacklog() {
@@ -320,10 +336,11 @@ public abstract class PersistentReplicator extends AbstractReplicator
                         permits = 1;
                     }
 
-                    readLimits = getReadLimits(permits);
+                    readLimits = getReadLimits(permits, this::readMoreEntriesAsync);
                     if (readLimits.isReadable()) {
                         newInFlightTask = createOrRecycleInFlightTaskIntoQueue(cursor.getReadPosition(),
                                 readLimits.messages);
+                        newInFlightTask.estimatedBytes = readLimits.estimatedBytes;
                     } else {
                         // no rate limiter permits from rate limit
                         log.debug()
@@ -349,12 +366,42 @@ public abstract class PersistentReplicator extends AbstractReplicator
                 newInFlightTask/* Context object */, topic.getMaxReadPosition());
     }
 
+    private void readMoreEntriesAsync() {
+        topic.getBrokerService().executor().execute(this::readMoreEntries);
+    }
+
+    private long getAverageEntrySize() {
+        Position readPosition = cursor.getReadPosition();
+        if (readPosition == null) {
+            return 0;
+        }
+        long ledgerId = readPosition.getLedgerId();
+        NavigableMap<Long, LedgerInfo> ledgers = cursor.getManagedLedger().getLedgersInfo();
+        LedgerInfo info = ledgers.get(ledgerId);
+        if (info != null && info.getEntries() > 0) {
+            return info.getSize() / info.getEntries();
+        }
+        java.util.Map.Entry<Long, LedgerInfo> previousEntry = ledgers.lowerEntry(ledgerId);
+        if (previousEntry != null && previousEntry.getValue().getEntries() > 0) {
+            return previousEntry.getValue().getSize() / previousEntry.getValue().getEntries();
+        }
+        return 0;
+    }
+
+    private long estimateBytes(int messagesToRead, long avgEntrySize) {
+        if (messagesToRead <= 0) {
+            return 0;
+        }
+        return avgEntrySize > 0 ? messagesToRead * avgEntrySize : 0;
+    }
+
     @Override
     public void readEntriesComplete(List<Entry> entries, Object ctx) {
         log.debug()
                 .attr("size", entries.size())
                 .log("Read entries complete");
         InFlightTask inFlightTask = (InFlightTask) ctx;
+        long estimatedBytes = inFlightTask.estimatedBytes;
 
         latestPublishTime = System.currentTimeMillis();
         // The read result must be discarded because the replicator is terminating or the cursor was
@@ -364,6 +411,8 @@ public abstract class PersistentReplicator extends AbstractReplicator
             for (Entry entry : entries) {
                 entry.release();
             }
+            // Entries are discarded and not replicated, return the estimated bytes.
+            brokerService.getReplicationMemoryLimiter().calibrate(estimatedBytes, 0);
             boolean resumeReads = state != State.Terminated && state != State.Terminating;
             // Hold the inFlightTasks lock (the same lock doRewindCursor() and readMoreEntries()'s
             // read-scheduling path use) so completing the task and rewinding the cursor here are atomic with
@@ -432,6 +481,10 @@ public abstract class PersistentReplicator extends AbstractReplicator
 
         // After set entries, the next reading can be start.
         inFlightTask.setEntries(entries);
+
+        // Calibrate the memory estimate with actual entry sizes.
+        long actualBytes = entries.stream().mapToLong(Entry::getLength).sum();
+        brokerService.getReplicationMemoryLimiter().calibrate(estimatedBytes, actualBytes);
 
         // After the replicator starts, the speed will be gradually increased.
         int maxReadBatchSize = getMaxReadBatchSize();
@@ -505,6 +558,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
                 inFlightTask.incCompletedEntries();
                 replicator.cursor.asyncDelete(entry.getPosition(), replicator, entry.getPosition());
             }
+            replicator.brokerService.getReplicationMemoryLimiter().release(entry.getLength());
             entry.release();
 
             // In general, we schedule a new batch read operation when the occupied queue size gets smaller than half
@@ -890,6 +944,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
         volatile int completedEntries;
         volatile boolean skipReadResultDueToCursorRewind;
         final String replicatorId;
+        long estimatedBytes;
 
         public synchronized void incCompletedEntries() {
             if (!CollectionUtils.isEmpty(entries) && completedEntries < entries.size()) {
@@ -908,6 +963,7 @@ public abstract class PersistentReplicator extends AbstractReplicator
             this.entries = null;
             this.completedEntries = 0;
             this.skipReadResultDueToCursorRewind = false;
+            this.estimatedBytes = 0;
         }
 
         public InFlightTask(Position readPos, int readingEntries, String replicatorId) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerReplicationMemoryLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerReplicationMemoryLimiterTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker")
+public class BrokerReplicationMemoryLimiterTest {
+
+    @Test
+    public void testDisabledByDefault() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        assertEquals(limiter.getMaxBytes(), 0);
+        assertEquals(limiter.acquireUpTo(1024 * 1024 * 1024, null), 1024 * 1024 * 1024);
+        assertEquals(limiter.getInflightBytes(), 0);
+    }
+
+    @Test
+    public void testAcquireAndRelease() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(60, null), 60);
+        assertEquals(limiter.getInflightBytes(), 60);
+
+        assertEquals(limiter.acquireUpTo(40, null), 40);
+        assertEquals(limiter.getInflightBytes(), 100);
+
+        limiter.release(40);
+        assertEquals(limiter.getInflightBytes(), 60);
+
+        limiter.release(60);
+        assertEquals(limiter.getInflightBytes(), 0);
+    }
+
+    @Test
+    public void testAcquirePartial() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(80, null), 80);
+        assertEquals(limiter.getInflightBytes(), 80);
+
+        // Only 20 available, request 50 -> get 20
+        assertEquals(limiter.acquireUpTo(50, null), 20);
+        assertEquals(limiter.getInflightBytes(), 100);
+    }
+
+    @Test
+    public void testAcquireZeroEnqueuesRetry() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(100, null), 100);
+
+        AtomicBoolean retryExecuted = new AtomicBoolean(false);
+        assertEquals(limiter.acquireUpTo(10, () -> retryExecuted.set(true)), 0);
+        assertEquals(limiter.getInflightBytes(), 100);
+        assertEquals(limiter.getPendingTaskCount(), 1);
+
+        limiter.release(50);
+        assertEquals(limiter.getInflightBytes(), 50);
+
+        Awaitility.await().untilTrue(retryExecuted);
+        assertEquals(limiter.getPendingTaskCount(), 0);
+    }
+
+    @Test
+    public void testPartialAcquireDoesNotEnqueueRetry() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(80, null), 80);
+
+        // Request 50, only 20 available -> get 20, no pending task
+        assertEquals(limiter.acquireUpTo(50, null), 20);
+        assertEquals(limiter.getInflightBytes(), 100);
+        assertEquals(limiter.getPendingTaskCount(), 0);
+    }
+
+    @Test
+    public void testLimitReached() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(80, null), 80);
+        assertFalse(limiter.isLimitReached());
+
+        assertEquals(limiter.acquireUpTo(50, null), 20);
+        assertTrue(limiter.isLimitReached());
+
+        assertEquals(limiter.acquireUpTo(10, null), 0);
+
+        limiter.release(30);
+        assertFalse(limiter.isLimitReached());
+    }
+
+    @Test
+    public void testCalibrateCorrection() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(50, null), 50);
+        assertEquals(limiter.getInflightBytes(), 50);
+
+        limiter.calibrate(50, 30);
+        assertEquals(limiter.getInflightBytes(), 30);
+    }
+
+    @Test
+    public void testCalibrateTriggersDrain() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(100, null), 100);
+
+        AtomicBoolean retry = new AtomicBoolean(false);
+        assertEquals(limiter.acquireUpTo(20, () -> retry.set(true)), 0);
+
+        limiter.calibrate(100, 50);
+        assertEquals(limiter.getInflightBytes(), 50);
+
+        Awaitility.await().untilTrue(retry);
+    }
+
+    @Test
+    public void testReleaseEstimated() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(60, null), 60);
+        assertEquals(limiter.getInflightBytes(), 60);
+
+        limiter.releaseEstimated(60);
+        assertEquals(limiter.getInflightBytes(), 0);
+    }
+
+    @Test
+    public void testDynamicMaxBytesIncreaseTriggersDrain() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(100);
+
+        assertEquals(limiter.acquireUpTo(100, null), 100);
+        AtomicBoolean retry = new AtomicBoolean(false);
+        assertEquals(limiter.acquireUpTo(20, () -> retry.set(true)), 0);
+        assertEquals(limiter.getPendingTaskCount(), 1);
+
+        limiter.setMaxBytes(200);
+        Awaitility.await().untilTrue(retry);
+        assertEquals(limiter.getPendingTaskCount(), 0);
+    }
+
+    @Test
+    public void testDynamicMaxBytesDecrease() {
+        BrokerReplicationMemoryLimiter limiter =
+                new BrokerReplicationMemoryLimiter(Executors.newSingleThreadExecutor());
+        limiter.setMaxBytes(200);
+
+        assertEquals(limiter.acquireUpTo(150, null), 150);
+        limiter.setMaxBytes(100);
+
+        AtomicBoolean retry = new AtomicBoolean(false);
+        assertEquals(limiter.acquireUpTo(10, () -> retry.set(true)), 0);
+        assertEquals(limiter.getPendingTaskCount(), 1);
+    }
+}


### PR DESCRIPTION
### Motivation

When many topics replicate concurrently, the total memory is unbounded and unpredictable, easily causing OOM.

### Modifications

Add a broker-level memory limit for in-flight replication


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment