### PR TITLE
[improve][ml] Per-msgLedger individual ack persistence (DE + CM model)

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -2242,7 +2242,12 @@ dispatcherPauseOnAckStatePersistentEnabled=false
 
 # If enabled, the maximum "acknowledgment holes" will not be limited and "acknowledgment holes" are stored in
 # multiple entries.
-persistentUnackedRangesWithMultipleEntriesEnabled=false
+
+# PIP-488 P2: per-msgLedger Data Entry + Checkpoint Marker model.
+persistentUnackedRangesWithPerLedgerEntryEnabled=false
+
+# Maximum BookKeeper entry payload for cursor state (used by CursorWal chunking).
+#persistentUnackedRangesMaxEntrySize=
 
 # Deprecated - Use managedLedgerCacheEvictionIntervalMs instead
 managedLedgerCacheEvictionFrequency=0

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -1501,6 +1501,16 @@ managedLedgerMaxUnackedRangesToPersistInZooKeeper=-1
 # persist, it will help to reduce the duplicates caused by the ack state that can not be fully persistent.
 dispatcherPauseOnAckStatePersistentEnabled=false
 
+# If enabled, the maximum "acknowledgment holes" will not be limited and "acknowledgment holes" are stored in
+# multiple entries.
+
+# Maximum size in bytes of each BookKeeper entry used when cursor acknowledgment state is split.
+# Keep this below maxMessageSize to leave headroom below the BookKeeper frame limit.
+#persistentUnackedRangesMaxEntrySize=
+
+# PIP-488 P2: per-msgLedger Data Entry + Checkpoint Marker model.
+persistentUnackedRangesWithPerLedgerEntryEnabled=false
+
 # Whether to enable the delayed delivery for messages.
 # If disabled, messages will be immediately delivered and there will
 # be no tracking overhead.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -48,6 +48,9 @@ public class ManagedLedgerConfig {
     private int maxUnackedRangesToPersist = 10000;
     private int maxBatchDeletedIndexToPersist = 10000;
     private boolean persistentUnackedRangesWithMultipleEntriesEnabled = false;
+    private int persistentUnackedRangesMaxEntrySize = 5 * 1024 * 1024;
+    // Per-msgLedger Data Entry + Checkpoint Marker model.
+    private boolean persistentUnackedRangesWithPerLedgerEntryEnabled = false;
     private boolean deletionAtBatchIndexLevelEnabled = true;
     private int maxUnackedRangesToPersistInMetadataStore = 1000;
     private int maxEntriesPerLedger = 50000;
@@ -538,6 +541,23 @@ public class ManagedLedgerConfig {
 
     public void setPersistentUnackedRangesWithMultipleEntriesEnabled(boolean multipleEntriesEnabled) {
         this.persistentUnackedRangesWithMultipleEntriesEnabled = multipleEntriesEnabled;
+    }
+
+    public boolean isPersistentUnackedRangesWithPerLedgerEntryEnabled() {
+        return persistentUnackedRangesWithPerLedgerEntryEnabled;
+    }
+
+    public void setPersistentUnackedRangesWithPerLedgerEntryEnabled(boolean persistentUnackedRangesWithPerLedgerEntryEnabled) {
+        this.persistentUnackedRangesWithPerLedgerEntryEnabled = persistentUnackedRangesWithPerLedgerEntryEnabled;
+    }
+
+    public int getPersistentUnackedRangesMaxEntrySize() {
+        return persistentUnackedRangesMaxEntrySize;
+    }
+
+    public void setPersistentUnackedRangesMaxEntrySize(int maxEntrySize) {
+        checkArgument(maxEntrySize >= 1024, "maximum cursor metadata entry size must be at least 1024 bytes");
+        this.persistentUnackedRangesMaxEntrySize = maxEntrySize;
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AckPersistence.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/AckPersistence.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.proto.BatchedEntryDeletionIndexInfo;
+import org.apache.bookkeeper.mledger.proto.MessageRange;
+import org.apache.bookkeeper.mledger.proto.PositionInfo;
+
+/**
+ * Strategy interface for persisting individual (non-cumulative) ack state to the cursor ledger
+ * and recovering it.
+ *
+ * <h3>Implementations</h3>
+ * <ul>
+ *   <li>Built-in legacy path — ManagedCursorImpl handles flush/recovery inline when no
+ *       AckPersistence is configured (default behavior).</li>
+ *   <li>{@link IndividualAckStatePersistence} — per-msgLedger: per-msgLedger Data Entry + Checkpoint
+ *       Marker.</li>
+ * </ul>
+ */
+public interface AckPersistence {
+
+    CompletableFuture<PersistResult> persist(
+            LedgerHandle lh,
+            Position mdPos,
+            Map<String, Long> properties,
+            BitmapAckState ackState);
+
+    CompletableFuture<RecoveredState> recover(LedgerHandle lh);
+
+    default void onLedgerRollover() { }
+
+    default void setZkCmHint(long cursorLedgerId, long entryId) { }
+
+    /**
+     * Called when the mark-delete position advances past {@code mdLedgerId}.
+     * Implementations that track per-ledger state (e.g. DE+CM) should clean up stale entries.
+     */
+    default void onMarkDeleteAdvance(long mdLedgerId) { }
+
+    /**
+     * Returns {@code true} if old cursor ledgers should be deleted immediately on rollover
+     * (legacy path). Returns {@code false} when old ledgers must be kept (DE+CM cross-ledger refs).
+     */
+    default boolean shouldGcOldCursorLedgerOnRollover() { return true; }
+
+    /**
+     * Returns the minimum cursor ledger ID still referenced by this persistence instance,
+     * or {@code -1} if there are no tracked references.
+     */
+    default long getOldestReferencedCursorLedgerId() { return -1; }
+
+    /**
+     * Returns the serialized byte size of the last persisted unacked ranges (monitoring metric).
+     */
+    default int getSerializedSize() { return 0; }
+
+    /**
+     * Builds the legacy {@link MessageRange} list for MetaStore (ZK close / fallback writes).
+     * Truncates to {@code maxRanges} and emits truncation telemetry.
+     * Returns an empty list for persistence strategies that do not use ZK ranges.
+     */
+    default List<MessageRange> buildIndividualDeletedMessageRanges(BitmapAckState ackState, int maxRanges) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Builds the {@link BatchedEntryDeletionIndexInfo} list for MetaStore writes.
+     * Truncates to {@code maxIndexes} and emits truncation telemetry.
+     * Returns an empty list for persistence strategies that do not use ZK batch ranges.
+     */
+    default List<BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList(
+            BitmapAckState ackState, int maxIndexes) {
+        return Collections.emptyList();
+    }
+
+    final class PersistResult {
+        private final long totalBytes;
+        private final long commitEntryId;
+
+        public PersistResult(long totalBytes, long commitEntryId) {
+            this.totalBytes = totalBytes;
+            this.commitEntryId = commitEntryId;
+        }
+
+        public long totalBytes() { return totalBytes; }
+        public long commitEntryId() { return commitEntryId; }
+    }
+
+    final class RecoveredState {
+        private final PositionInfo positionInfo;
+        private final long commitEntryId;
+        private final long stateSize;
+
+        public RecoveredState(PositionInfo positionInfo, long commitEntryId, long stateSize) {
+            this.positionInfo = positionInfo;
+            this.commitEntryId = commitEntryId;
+            this.stateSize = stateSize;
+        }
+
+        public PositionInfo positionInfo() { return positionInfo; }
+        public long commitEntryId() { return commitEntryId; }
+        public long stateSize() { return stateSize; }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/BitmapAckState.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/BitmapAckState.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Range;
+import io.github.merlimat.slog.Logger;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.proto.BatchedEntryDeletionIndexInfo;
+import org.apache.bookkeeper.mledger.proto.MessageRange;
+import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo.LedgerInfo;
+import org.apache.bookkeeper.mledger.proto.NestedPositionInfo;
+import org.apache.pulsar.common.util.collections.LongPairRangeSet;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * In-memory ack state backed by {@link PositionRangeSet} for individual-ack
+ * tracking and a {@link ConcurrentSkipListMap} for batch-ack tracking.
+ *
+ * <p>This corresponds to the "old" / PositionSet implementation described in the design notes.
+ * The two data structures are always accessed under the owning cursor's read or write lock.
+ */
+class BitmapAckState {
+
+    private static final Logger log = Logger.get(BitmapAckState.class);
+
+    /** Individual-ack ranges (position ranges of deleted entries). */
+    private final PositionRangeSet individualDeletedMessages;
+
+    /**
+     * Partial batch-ack state: (ledgerId, entryId) → BitSet of un-acknowledged batch indexes.
+     * {@code null} when {@code deletionAtBatchIndexLevelEnabled} is {@code false}.
+     */
+    @Nullable
+    private final ConcurrentSkipListMap<Position, BitSet> batchDeletedIndexes;
+
+    /**
+     * @param positionRangeConverter factory for creating {@link Position} from (ledgerId, entryId)
+     * @param enableDirtyTracking    {@code true} when PIP-81/488 multi-entry or DE+CM persistence
+     *                               is enabled and per-ledger dirty tracking is needed
+     * @param batchIndexAckEnabled   {@code true} when deletion-at-batch-index-level is enabled
+     */
+    BitmapAckState(LongPairRangeSet.LongPairConsumer<Position> positionRangeConverter,
+                             boolean enableDirtyTracking,
+                             boolean batchIndexAckEnabled) {
+        this.individualDeletedMessages = new PositionRangeSet(positionRangeConverter, enableDirtyTracking);
+        this.batchDeletedIndexes = batchIndexAckEnabled ? new ConcurrentSkipListMap<>() : null;
+    }
+
+    // =========================================================
+    // Individual-ack mutations
+    // =========================================================
+
+    public void addOpenClosed(long prevLedgerId, long prevEntryId, long ledgerId, long entryId) {
+        individualDeletedMessages.addOpenClosed(prevLedgerId, prevEntryId, ledgerId, entryId);
+    }
+
+    public void removeAtMost(long ledgerId, long entryId) {
+        individualDeletedMessages.removeAtMost(ledgerId, entryId);
+    }
+
+    public void clear() {
+        individualDeletedMessages.clear();
+        if (batchDeletedIndexes != null) {
+            batchDeletedIndexes.clear();
+        }
+    }
+
+    public void markExternalDirty(long ledgerId) {
+        individualDeletedMessages.markExternalDirty(ledgerId);
+    }
+
+    public void markAllDirty() {
+        individualDeletedMessages.markAllDirty();
+    }
+
+    // =========================================================
+    // Batch-ack mutations
+    // =========================================================
+
+    public boolean putBatchAck(Position position, long[] ackSet) {
+        if (batchDeletedIndexes == null) {
+            return false;
+        }
+        final var givenBitSet = BitSet.valueOf(ackSet);
+        final var stored = batchDeletedIndexes.compute(position, (k, v) -> {
+            if (v == null || givenBitSet.nextSetBit(0) > v.nextSetBit(0)) {
+                return givenBitSet;
+            }
+            return v;
+        });
+        return stored.isEmpty();
+    }
+
+    public boolean mergeBatchAck(Position position, long[] ackSet) {
+        if (batchDeletedIndexes == null) {
+            return false;
+        }
+        final var givenBitSet = BitSet.valueOf(ackSet);
+        final var merged = batchDeletedIndexes.computeIfAbsent(position, __ -> givenBitSet);
+        if (merged != givenBitSet) {
+            merged.and(givenBitSet);
+        }
+        return merged.isEmpty();
+    }
+
+    public void removeBatchAck(Position position) {
+        if (batchDeletedIndexes != null) {
+            batchDeletedIndexes.remove(position);
+        }
+    }
+
+    public void removeBatchAcksBefore(Position exclusive) {
+        if (batchDeletedIndexes != null) {
+            batchDeletedIndexes.subMap(PositionFactory.EARLIEST, exclusive).clear();
+        }
+    }
+
+    public void removeBatchAcksAtOrBefore(Position inclusive) {
+        if (batchDeletedIndexes != null) {
+            batchDeletedIndexes.subMap(PositionFactory.EARLIEST, false, inclusive, true).clear();
+        }
+    }
+
+    // =========================================================
+    // Queries
+    // =========================================================
+
+    public boolean contains(long ledgerId, long entryId) {
+        return individualDeletedMessages.contains(ledgerId, entryId);
+    }
+
+    @Nullable
+    public Range<Position> rangeContaining(long ledgerId, long entryId) {
+        return individualDeletedMessages.rangeContaining(ledgerId, entryId);
+    }
+
+    @Nullable
+    public Range<Position> firstRange() {
+        return individualDeletedMessages.firstRange();
+    }
+
+    @Nullable
+    public Range<Position> lastRange() {
+        return individualDeletedMessages.lastRange();
+    }
+
+    public boolean isEmpty() {
+        return individualDeletedMessages.isEmpty();
+    }
+
+    public int size() {
+        return individualDeletedMessages.size();
+    }
+
+    @Nullable
+    public Range<Position> span() {
+        return individualDeletedMessages.span();
+    }
+
+    public long cardinality(long lowerLedgerId, long lowerEntryId,
+                            long upperLedgerId, long upperEntryId) {
+        return individualDeletedMessages.cardinality(lowerLedgerId, lowerEntryId,
+                upperLedgerId, upperEntryId);
+    }
+
+    public void forEach(LongPairRangeSet.RangeProcessor<Position> action) {
+        individualDeletedMessages.forEach(action);
+    }
+
+    public void forEach(LongPairRangeSet.RangeProcessor<Position> action,
+                        LongPairRangeSet.LongPairConsumer<? extends Position> consumer) {
+        individualDeletedMessages.forEach(action, consumer);
+    }
+
+    public void forEachRawRange(LongPairRangeSet.RawRangeProcessor action) {
+        individualDeletedMessages.forEachRawRange(action);
+    }
+
+    public void forEachBatchDeletedIndex(java.util.function.BiConsumer<Position, long[]> action) {
+        if (batchDeletedIndexes != null) {
+            batchDeletedIndexes.forEach((pos, bitSet) -> action.accept(pos, bitSet.toLongArray()));
+        }
+    }
+
+    @Nullable
+    public long[] getBatchPositionAckSet(Position position) {
+        if (batchDeletedIndexes == null) {
+            return null;
+        }
+        final var bitSet = batchDeletedIndexes.get(position);
+        return bitSet == null ? null : bitSet.toLongArray();
+    }
+
+    public boolean isBatchIndexAckEnabled() {
+        return batchDeletedIndexes != null;
+    }
+
+    public int getBatchDeletedIndexesSize() {
+        return batchDeletedIndexes == null ? 0 : batchDeletedIndexes.size();
+    }
+
+    // =========================================================
+    // Recovery
+    // =========================================================
+
+    public void recoverFromMessageRanges(int count, IntFunction<MessageRange> accessor,
+                                  Supplier<NavigableMap<Long, LedgerInfo>> ledgerInfoMapSupplier) {
+        individualDeletedMessages.clear();
+        for (int i = 0; i < count; i++) {
+            MessageRange messageRange = accessor.apply(i);
+            NestedPositionInfo lowerEndpoint = messageRange.getLowerEndpoint();
+            NestedPositionInfo upperEndpoint = messageRange.getUpperEndpoint();
+
+            if (lowerEndpoint.getLedgerId() == upperEndpoint.getLedgerId()) {
+                individualDeletedMessages.addOpenClosed(
+                        lowerEndpoint.getLedgerId(), lowerEndpoint.getEntryId(),
+                        upperEndpoint.getLedgerId(), upperEndpoint.getEntryId());
+            } else {
+                NavigableMap<Long, LedgerInfo> ledgersInfo = ledgerInfoMapSupplier.get();
+                LedgerInfo lowerLedgerInfo = ledgersInfo.get(lowerEndpoint.getLedgerId());
+                if (lowerLedgerInfo != null) {
+                    individualDeletedMessages.addOpenClosed(
+                            lowerEndpoint.getLedgerId(), lowerEndpoint.getEntryId(),
+                            lowerEndpoint.getLedgerId(), lowerLedgerInfo.getEntries() - 1);
+                } else {
+                    log.warn()
+                            .attr("ledgerId", lowerEndpoint.getLedgerId())
+                            .attr("entryId", lowerEndpoint.getEntryId())
+                            .log("No ledger info of lower endpoint");
+                }
+
+                for (LedgerInfo li : ledgersInfo.subMap(
+                        lowerEndpoint.getLedgerId(), false,
+                        upperEndpoint.getLedgerId(), false).values()) {
+                    individualDeletedMessages.addOpenClosed(
+                            li.getLedgerId(), -1, li.getLedgerId(), li.getEntries() - 1);
+                }
+
+                individualDeletedMessages.addOpenClosed(
+                        upperEndpoint.getLedgerId(), -1,
+                        upperEndpoint.getLedgerId(), upperEndpoint.getEntryId());
+            }
+        }
+    }
+
+    public void recoverFromBitmaps(Map<Long, byte[]> bitmaps) {
+        individualDeletedMessages.buildFromSerializedBitmaps(bitmaps);
+    }
+
+    public void recoverFromRanges(Map<Long, long[]> rangeMap) {
+        individualDeletedMessages.build(rangeMap);
+    }
+
+    public void recoverBatchDeletedIndexes(int count, IntFunction<BatchedEntryDeletionIndexInfo> accessor) {
+        if (batchDeletedIndexes == null) {
+            return;
+        }
+        batchDeletedIndexes.clear();
+        for (int i = 0; i < count; i++) {
+            BatchedEntryDeletionIndexInfo info = accessor.apply(i);
+            if (info.getDeleteSetsCount() > 0) {
+                long[] array = new long[info.getDeleteSetsCount()];
+                for (int j = 0; j < array.length; j++) {
+                    array[j] = info.getDeleteSetAt(j);
+                }
+                batchDeletedIndexes.put(
+                        PositionFactory.create(
+                                info.getPosition().getLedgerId(),
+                                info.getPosition().getEntryId()),
+                        BitSet.valueOf(array));
+            }
+        }
+    }
+
+    // =========================================================
+    // Serialization
+    // =========================================================
+
+    public Map<Long, byte[]> toSerializedBitmaps() {
+        return individualDeletedMessages.toSerializedBitmaps();
+    }
+
+    public Map<Long, long[]> toRanges(int maxRanges) {
+        return individualDeletedMessages.toRanges(maxRanges);
+    }
+
+    public List<BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList(int maxIndexes) {
+        if (batchDeletedIndexes == null || batchDeletedIndexes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<BatchedEntryDeletionIndexInfo> result = new ArrayList<>();
+        for (var entry : batchDeletedIndexes.entrySet()) {
+            if (result.size() >= maxIndexes) {
+                break;
+            }
+            BatchedEntryDeletionIndexInfo info = new BatchedEntryDeletionIndexInfo();
+            info.setPosition()
+                    .setLedgerId(entry.getKey().getLedgerId())
+                    .setEntryId(entry.getKey().getEntryId());
+            for (long l : entry.getValue().toLongArray()) {
+                info.addDeleteSet(l);
+            }
+            result.add(info);
+        }
+        return result;
+    }
+
+    public void resetDirtyKeys() {
+        individualDeletedMessages.resetDirtyKeys();
+    }
+
+    // =========================================================
+    // Dirty tracking
+    // =========================================================
+
+    public Set<Long> snapshotAndClearDirtyLedgers() {
+        return individualDeletedMessages.snapshotAndClearDirtyLedgers();
+    }
+
+    public void restoreDirtyLedgers(Set<Long> ledgerIds) {
+        individualDeletedMessages.restoreDirtyLedgers(ledgerIds);
+    }
+
+    @Nullable
+    public byte[] bitmapOf(long ledgerId) {
+        return individualDeletedMessages.bitmapOf(ledgerId);
+    }
+
+    // =========================================================
+    // Testing access
+    // =========================================================
+
+    /**
+     * Returns the underlying {@link PositionRangeSet} for testing and introspection.
+     * Production code should use the {@link AckState} interface instead.
+     */
+    @VisibleForTesting
+    PositionRangeSet getIndividualDeletedMessages() {
+        return individualDeletedMessages;
+    }
+
+    /**
+     * Returns the underlying batch-ack map for testing and introspection, or {@code null}
+     * when batch-index ack is disabled.
+     */
+    @VisibleForTesting
+    @Nullable
+    ConcurrentSkipListMap<Position, BitSet> getBatchDeletedIndexes() {
+        return batchDeletedIndexes;
+    }
+
+    public String toString() {
+        return individualDeletedMessages.toString();
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/CursorWal.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/CursorWal.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.proto.CursorStateChunk;
+import org.apache.bookkeeper.mledger.proto.LongListMap;
+import org.apache.bookkeeper.mledger.proto.PositionInfo;
+import org.apache.pulsar.common.util.FutureUtil;
+
+/**
+ * Append-only WAL over a BookKeeper cursor ledger. Transparently splits large
+ * {@link PositionInfo} across multiple entries via {@link CursorStateChunk} envelopes.
+ * Not thread-safe — callers must hold the cursor lock.
+ */
+class CursorWal {
+
+    /** Scan-back cap: defensive upper bound on how many entries we walk looking for a commit. */
+    private static final long MAX_SCAN_BACK = 10_000L;
+
+    /** Batch size for scan-back reads. Each batch costs one BK read RTT instead of one per entry. */
+    private static final int SCAN_BACK_BATCH = 100;
+
+    // entry-type discriminator stored in PositionInfo.properties (LongProperty named "entry-type").
+    static final String ENTRY_TYPE_PROPERTY = "entry-type";
+    static final long ENTRY_TYPE_DE = 1;
+    static final long ENTRY_TYPE_CM = 2;
+
+    private final int maxEntrySize;
+    // BookKeeper client + password used to open historical cursor ledgers when a CM references
+    // DE entries that live in a previous (rolled-over) cursor ledger. Null when only same-ledger
+    // recovery is needed (legacy P1 sharded-PositionInfo path).
+    private final BookKeeper bookKeeper;
+    private final byte[] password;
+
+    CursorWal(int maxEntrySize) {
+        this(maxEntrySize, null, null);
+    }
+
+    CursorWal(int maxEntrySize, BookKeeper bookKeeper, byte[] password) {
+        if (maxEntrySize < 1024) {
+            throw new IllegalArgumentException("maxEntrySize must be at least 1024 bytes");
+        }
+        this.maxEntrySize = maxEntrySize;
+        this.bookKeeper = bookKeeper;
+        this.password = password;
+    }
+
+    // ============================ append ============================
+
+    /**
+     * Appends {@code pi} to {@code lh}, transparently splitting into chunks when its serialized
+     * size exceeds {@code maxEntrySize}.
+     *
+     * @return a future completed with the append result once the commit entry (or the single
+     *         entry) is BK-acked
+     */
+    CompletableFuture<AppendResult> append(LedgerHandle lh, PositionInfo pi) {
+        final byte[] data = pi.toByteArray();
+        if (data.length <= maxEntrySize) {
+            return addEntry(lh, data).thenApply(entryId -> new AppendResult(data.length, entryId));
+        }
+        return appendChunked(lh, pi, data);
+    }
+
+    private CompletableFuture<AppendResult> appendChunked(LedgerHandle lh, PositionInfo pi,
+                                                          byte[] data) {
+        final int partCount = (data.length + maxEntrySize - 1) / maxEntrySize;
+        // PositionInfo.ledgerId and entryId are proto-required; copy them onto every wrapper
+        // so toByteArray() passes required-field checks. The recovered PositionInfo is parsed
+        // from reassembled bytes, so these wrapper values are envelope-only.
+        final long wrapperLedgerId = pi.getLedgerId();
+        final long wrapperEntryId = pi.getEntryId();
+
+        // Submit all part chunks; collect their futures. BK preserves append order within a
+        // ledger, so the commit chunk (submitted next) is durable only after all parts.
+        int offset = 0;
+        List<CompletableFuture<Long>> partFutures = new ArrayList<>(partCount);
+        for (int partIndex = 0; partIndex < partCount; partIndex++) {
+            int length = Math.min(maxEntrySize, data.length - offset);
+            byte[] payload = new byte[length];
+            System.arraycopy(data, offset, payload, 0, length);
+            offset += length;
+
+            PositionInfo wrapper = new PositionInfo()
+                    .setLedgerId(wrapperLedgerId)
+                    .setEntryId(wrapperEntryId);
+            wrapper.setCursorStateChunk()
+                    .setPartIndex(partIndex)
+                    .setPartCount(partCount)
+                    .setPayload(payload);
+            partFutures.add(addEntry(lh, wrapper.toByteArray()));
+        }
+
+        PositionInfo commitWrapper = new PositionInfo()
+                .setLedgerId(wrapperLedgerId)
+                .setEntryId(wrapperEntryId);
+        commitWrapper.setCursorStateChunk()
+                .setPartIndex(partCount)
+                .setPartCount(partCount);
+        CompletableFuture<Long> commitFuture = addEntry(lh, commitWrapper.toByteArray());
+
+        // Chain allOf(partFutures) before commitFuture so any part-level exception propagates
+        // instead of being silently swallowed. BK order guarantees that commitFuture cannot
+        // succeed while a partFuture failed; the explicit chain makes the failure visible to
+        // the caller instead of relying on that invariant.
+        long totalBytes = data.length;
+        CompletableFuture<Void> allParts = CompletableFuture.allOf(
+                partFutures.toArray(new CompletableFuture[0]));
+        return allParts.thenCompose(ignored -> commitFuture)
+                .thenApply(entryId -> new AppendResult(totalBytes, entryId));
+    }
+
+    // ============================ recover / readLatest ============================
+
+    /**
+     * Reads the most recent committed PositionInfo from {@code lh}.
+     *
+     * <p>Equivalent to {@link #readLatest(LedgerHandle)}; provided as an instance method so
+     * callers can keep a reference to the configured WAL.
+     */
+    CompletableFuture<RecoveredState> recover(LedgerHandle lh) {
+        return readLatest(lh);
+    }
+
+    /**
+     * Static recovery entry point. Reads the last entry, detects single vs chunked form,
+     * and (for chunked form) reads backwards to assemble.
+     */
+    static CompletableFuture<RecoveredState> readLatest(LedgerHandle lh) {
+        long lastAddConfirmed = lh.getLastAddConfirmed();
+        if (lastAddConfirmed < 0) {
+            return FutureUtil.failedFuture(
+                    new ManagedLedgerException("Cursor ledger has no entries"));
+        }
+        return readEntry(lh, lastAddConfirmed).thenCompose(lastBytes -> {
+            PositionInfo lastPi = parsePositionInfo(lastBytes);
+            if (!lastPi.hasCursorStateChunk()) {
+                return CompletableFuture.completedFuture(
+                        new RecoveredState(lastPi, lastAddConfirmed, lastBytes.length));
+            }
+            CursorStateChunk chunk = lastPi.getCursorStateChunk();
+            if (chunk.getPartIndex() == chunk.getPartCount()) {
+                return assembleCommitted(lh, lastAddConfirmed, chunk);
+            }
+            // Partial write: broker crashed before the commit chunk was acked. Scan back for
+            // the previous commit chunk and replay from there.
+            return scanBackForCommit(lh, lastAddConfirmed - 1);
+        });
+    }
+
+    private static CompletableFuture<RecoveredState> assembleCommitted(LedgerHandle lh,
+                                                                       long commitEntryId,
+                                                                       CursorStateChunk commit) {
+        int partCount = commit.getPartCount();
+        if (partCount <= 0) {
+            return FutureUtil.failedFuture(
+                    new ManagedLedgerException("Invalid partCount: " + partCount));
+        }
+        if (commitEntryId - partCount < -1) {
+            return FutureUtil.failedFuture(new ManagedLedgerException(
+                    "Cursor ledger too short for chunk group: commitEntryId=" + commitEntryId
+                            + ", partCount=" + partCount));
+        }
+        // Part chunks live at entryIds [commitEntryId - partCount, commitEntryId - 1].
+        // BK preserves append order, so the read result is already in partIndex order;
+        // we verify continuity explicitly to defend against malformed input.
+        long startEntryId = commitEntryId - partCount;
+        long endEntryId = commitEntryId - 1;
+        return readEntryRange(lh, startEntryId, endEntryId).thenApply(parts -> {
+            int totalLength = 0;
+            for (int i = 0; i < parts.size(); i++) {
+                PositionInfo pi = parsePositionInfo(parts.get(i));
+                if (!pi.hasCursorStateChunk()) {
+                    throw new IllegalStateException(
+                            "Expected CursorStateChunk at part " + i);
+                }
+                CursorStateChunk part = pi.getCursorStateChunk();
+                if (part.getPartIndex() != i) {
+                    throw new IllegalStateException(
+                            "Part index continuity broken at position " + i
+                                    + ": expected " + i + ", got " + part.getPartIndex());
+                }
+                if (part.getPartCount() != partCount) {
+                    throw new IllegalStateException(
+                            "Part count mismatch at part " + i
+                                    + ": expected " + partCount + ", got " + part.getPartCount());
+                }
+                totalLength += part.getPayload().length;
+            }
+
+            byte[] assembled = new byte[totalLength];
+            int writeOffset = 0;
+            for (byte[] partBytes : parts) {
+                PositionInfo pi = parsePositionInfo(partBytes);
+                byte[] payload = pi.getCursorStateChunk().getPayload();
+                System.arraycopy(payload, 0, assembled, writeOffset, payload.length);
+                writeOffset += payload.length;
+            }
+
+            // parseFrom is the soft integrity check: mis-assembled bytes will almost
+            // always fail to parse as a valid PositionInfo.
+            PositionInfo recovered = parsePositionInfo(assembled);
+            return new RecoveredState(recovered, commitEntryId, assembled.length);
+        });
+    }
+
+    private static CompletableFuture<RecoveredState> scanBackForCommit(LedgerHandle lh,
+                                                                       long fromEntryId) {
+        long lac = lh.getLastAddConfirmed();
+        long lowerBound = Math.max(0, lac - MAX_SCAN_BACK);
+        return scanBackBatched(lh, fromEntryId, lowerBound);
+    }
+
+    /**
+     * Batched reverse scan for the most recent committed state. Each round reads up to
+     * {@link #SCAN_BACK_BATCH} entries in one BK call and scans them in-memory, keeping
+     * per-entry RTT bounded regardless of orphan tail length.
+     */
+    private static CompletableFuture<RecoveredState> scanBackBatched(LedgerHandle lh,
+                                                                     long entryId,
+                                                                     long lowerBound) {
+        if (entryId < 0 || entryId < lowerBound) {
+            return FutureUtil.failedFuture(new ManagedLedgerException(
+                    "No commit chunk found while scanning cursor ledger backwards"));
+        }
+        long batchEnd = entryId;
+        long batchStart = Math.max(lowerBound, Math.max(0, entryId - SCAN_BACK_BATCH + 1));
+        return readEntryRange(lh, batchStart, batchEnd).thenCompose(parts -> {
+            // Iterate the batch in reverse so we return the most recent committed state.
+            for (int i = parts.size() - 1; i >= 0; i--) {
+                byte[] bytes = parts.get(i);
+                long currentEntryId = batchStart + i;
+                PositionInfo pi = parsePositionInfo(bytes);
+                if (!pi.hasCursorStateChunk()) {
+                    // Single-entry PositionInfo is itself a valid committed state.
+                    return CompletableFuture.completedFuture(
+                            new RecoveredState(pi, currentEntryId, bytes.length));
+                }
+                CursorStateChunk csc = pi.getCursorStateChunk();
+                if (csc.getPartIndex() == csc.getPartCount()) {
+                    return assembleCommitted(lh, currentEntryId, csc);
+                }
+                // Orphan part chunk, keep going.
+            }
+            // Batch exhausted without a hit. Continue with the previous batch.
+            return scanBackBatched(lh, batchStart - 1, lowerBound);
+        });
+    }
+
+    // ============================ DE+CM recovery (PIP-488 P2) ============================
+
+    /**
+     * Reads the last entry of the cursor ledger and recovers DE+CM state. Since every
+     * flush writes DE × N + CM, the last entry is always a CM. This method reads the CM,
+     * parallel-fetches all referenced DEs (cross-ledger supported), and merges them into
+     * a single synthetic PositionInfo.
+     */
+    CompletableFuture<RecoveredState> readLatestDeCmInstance(LedgerHandle lh) {
+        long lastAddConfirmed = lh.getLastAddConfirmed();
+        if (lastAddConfirmed < 0) {
+            return FutureUtil.failedFuture(
+                    new ManagedLedgerException("Cursor ledger has no entries"));
+        }
+        return readEntry(lh, lastAddConfirmed).thenCompose(lastBytes -> {
+            PositionInfo lastPi = parsePositionInfo(lastBytes);
+            // If the last entry is a chunked CM commit chunk, assemble it first.
+            if (lastPi.hasCursorStateChunk()
+                    && lastPi.getCursorStateChunk().getPartIndex()
+                            == lastPi.getCursorStateChunk().getPartCount()) {
+                return assembleCommitted(lh, lastAddConfirmed, lastPi.getCursorStateChunk())
+                        .thenCompose(assembled ->
+                                recoverFromCmFastPath(lh, lastAddConfirmed, assembled.positionInfo()));
+            }
+            return recoverFromCmFastPath(lh, lastAddConfirmed, lastPi);
+        });
+    }
+
+    /**
+     * CM fast path: parallel-fetch every DE referenced by the CM index and reassemble a
+     * synthetic PositionInfo (mdPos from CM + merged bitmaps from each DE). Both single-entry
+     * and chunked DE entries are handled via {@link #readEntryOrChunk}. Cross-ledger DE
+     * references (cursor-ledger rollover case) are supported when BookKeeper is configured.
+     */
+    private CompletableFuture<RecoveredState> recoverFromCmFastPath(LedgerHandle lh,
+                                                                    long cmEntryId,
+                                                                    PositionInfo cm) {
+        int indexSize = cm.getIndividualDeletedMessageRangesCount();
+        if (indexSize == 0) {
+            return CompletableFuture.completedFuture(new RecoveredState(cm, cmEntryId, 0));
+        }
+        List<CompletableFuture<PositionInfo>> deFutures = new ArrayList<>(indexSize);
+        for (int i = 0; i < indexSize; i++) {
+            LongListMap ref = cm.getIndividualDeletedMessageRangeAt(i);
+            long cursorLedgerId = ref.getValueAt(0);
+            long entryId = ref.getValueAt(1);
+            deFutures.add(readEntryOrChunk(lh, cursorLedgerId, entryId));
+        }
+        return CompletableFuture.allOf(deFutures.toArray(new CompletableFuture[0]))
+                .thenApply(ignored -> {
+                    PositionInfo merged = new PositionInfo()
+                            .setLedgerId(cm.getLedgerId())
+                            .setEntryId(cm.getEntryId());
+                    long totalBytes = 0;
+                    for (CompletableFuture<PositionInfo> f : deFutures) {
+                        PositionInfo de = f.join();
+                        if (de.getIndividualDeletedMessageRangesCount() > 0) {
+                            LongListMap deRange = de.getIndividualDeletedMessageRangeAt(0);
+                            LongListMap copy = merged.addIndividualDeletedMessageRange();
+                            copy.setKey(deRange.getKey());
+                            if (deRange.hasBitmap()) {
+                                copy.setBitmap(deRange.getBitmap());
+                            }
+                        }
+                        if (de.getBatchedEntryDeletionIndexInfosCount() > 0) {
+                            merged.addAllBatchedEntryDeletionIndexInfos(de.getBatchedEntryDeletionIndexInfosList());
+                        }
+                        totalBytes += de.getIndividualDeletedMessageRangesCount();
+                    }
+                    return new RecoveredState(merged, cmEntryId, totalBytes);
+                });
+    }
+
+    /**
+     * Reads one DE from {@code (cursorLedgerId, entryId)}, transparently handling both
+     * single-entry and chunked DE entries. Cross-ledger references (cursor-ledger rollover
+     * case) are supported when {@link #bookKeeper} was supplied at construction.
+     */
+    private CompletableFuture<PositionInfo> readEntryOrChunk(LedgerHandle lh,
+                                                             long cursorLedgerId,
+                                                             long entryId) {
+        if (cursorLedgerId == lh.getId()) {
+            return readEntryOrChunkSameLedger(lh, entryId);
+        }
+        if (bookKeeper == null || password == null) {
+            return FutureUtil.failedFuture(new ManagedLedgerException(
+                    "Cross-ledger DE reference but BookKeeper not configured: cursorLedgerId="
+                            + cursorLedgerId + ", lh.id=" + lh.getId()));
+        }
+        // Open the historical cursor ledger read-only, fetch the DE, then close.
+        CompletableFuture<LedgerHandle> openFuture = new CompletableFuture<>();
+        bookKeeper.asyncOpenLedgerNoRecovery(cursorLedgerId, DigestType.CRC32C, password,
+                (rc, handle, ctx) -> {
+                    if (rc == BKException.Code.OK) {
+                        openFuture.complete(handle);
+                    } else {
+                        openFuture.completeExceptionally(BKException.create(rc));
+                    }
+                }, null);
+        return openFuture.thenCompose(historicalLh ->
+                readEntryOrChunkSameLedger(historicalLh, entryId).whenComplete((pi, err) -> {
+                    try {
+                        historicalLh.close();
+                    } catch (Exception e) {
+                        // Best-effort close; the read result is what we care about.
+                    }
+                }));
+    }
+
+    private static CompletableFuture<PositionInfo> readEntryOrChunkSameLedger(LedgerHandle lh,
+                                                                              long entryId) {
+        return readEntry(lh, entryId).thenCompose(bytes -> {
+            PositionInfo pi = parsePositionInfo(bytes);
+            if (!pi.hasCursorStateChunk()) {
+                return CompletableFuture.completedFuture(pi);
+            }
+            CursorStateChunk chunk = pi.getCursorStateChunk();
+            if (chunk.getPartIndex() == chunk.getPartCount()) {
+                return assembleCommitted(lh, entryId, chunk).thenApply(RecoveredState::positionInfo);
+            }
+            return FutureUtil.failedFuture(new ManagedLedgerException(
+                    "CM referenced a part chunk (partIndex=" + chunk.getPartIndex()
+                            + "), expected commit chunk"));
+        });
+    }
+
+    // ---- BK helpers ----
+
+    private static CompletableFuture<Long> addEntry(LedgerHandle lh, byte[] data) {
+        CompletableFuture<Long> future = new CompletableFuture<>();
+        lh.asyncAddEntry(data, (rc, handle, entryId, ctx) -> {
+            if (rc == BKException.Code.OK) {
+                future.complete(entryId);
+            } else {
+                future.completeExceptionally(BKException.create(rc));
+            }
+        }, null);
+        return future;
+    }
+
+    private static CompletableFuture<byte[]> readEntry(LedgerHandle lh, long entryId) {
+        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        lh.asyncReadEntries(entryId, entryId, (rc, handle, seq, ctx) -> {
+            if (rc != BKException.Code.OK) {
+                future.completeExceptionally(BKException.create(rc));
+                return;
+            }
+            if (!seq.hasMoreElements()) {
+                future.completeExceptionally(
+                        new ManagedLedgerException("Empty read result for entry " + entryId));
+                return;
+            }
+            LedgerEntry entry = seq.nextElement();
+            future.complete(entry.getEntry());
+        }, null);
+        return future;
+    }
+
+    private static CompletableFuture<List<byte[]>> readEntryRange(LedgerHandle lh,
+                                                                  long startEntryId,
+                                                                  long endEntryId) {
+        CompletableFuture<List<byte[]>> future = new CompletableFuture<>();
+        lh.asyncReadEntries(startEntryId, endEntryId, (rc, handle, seq, ctx) -> {
+            if (rc != BKException.Code.OK) {
+                future.completeExceptionally(BKException.create(rc));
+                return;
+            }
+            List<byte[]> buffers = new ArrayList<>();
+            long expected = endEntryId - startEntryId + 1;
+            while (seq.hasMoreElements()) {
+                buffers.add(seq.nextElement().getEntry());
+            }
+            if (buffers.size() != expected) {
+                future.completeExceptionally(new ManagedLedgerException(
+                        "Short read: expected " + expected + ", got " + buffers.size()));
+                return;
+            }
+            future.complete(buffers);
+        }, null);
+        return future;
+    }
+
+    private static PositionInfo parsePositionInfo(byte[] data) {
+        PositionInfo pi = new PositionInfo();
+        pi.parseFrom(data);
+        return pi;
+    }
+
+    // ============================ DTOs ============================
+
+    /** Result of an append: total bytes the logical PositionInfo occupied (pre-chunking). */
+    static final class AppendResult {
+        private final long totalBytes;
+        private final long commitEntryId;
+
+        AppendResult(long totalBytes, long commitEntryId) {
+            this.totalBytes = totalBytes;
+            this.commitEntryId = commitEntryId;
+        }
+
+        public long totalBytes() {
+            return totalBytes;
+        }
+
+        public long commitEntryId() {
+            return commitEntryId;
+        }
+    }
+
+    /** Recovered cursor state: the parsed PositionInfo plus provenance for metrics. */
+    static final class RecoveredState {
+        private final PositionInfo positionInfo;
+        private final long commitEntryId;
+        private final long stateSize;
+
+        RecoveredState(PositionInfo positionInfo, long commitEntryId, long stateSize) {
+            this.positionInfo = positionInfo;
+            this.commitEntryId = commitEntryId;
+            this.stateSize = stateSize;
+        }
+
+        public PositionInfo positionInfo() {
+            return positionInfo;
+        }
+
+        public long commitEntryId() {
+            return commitEntryId;
+        }
+
+        public long stateSize() {
+            return stateSize;
+        }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/IndividualAckStatePersistence.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/IndividualAckStatePersistence.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.BiConsumer;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
+import org.apache.bookkeeper.mledger.proto.BatchedEntryDeletionIndexInfo;
+import org.apache.bookkeeper.mledger.proto.MessageRange;
+import org.apache.bookkeeper.mledger.proto.PositionInfo;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+
+/**
+ * per-msgLedger {@link AckPersistence}: per-msgLedger Data Entry (DE) + Checkpoint Marker (CM).
+ * Every flush writes DE × N + CM. Last entry is always CM, so recovery is always fast path.
+ */
+public class IndividualAckStatePersistence implements AckPersistence {
+
+    private static final io.github.merlimat.slog.Logger log =
+            io.github.merlimat.slog.Logger.get(IndividualAckStatePersistence.class);
+
+    private final CursorWal wal;
+    private final ReadWriteLock lock;
+    private final BiConsumer<Long, Long> cmAckedCallback;
+    private final OpenTelemetryManagedCursorStats otelStats;
+    private final ManagedCursor cursor;
+
+    private final Map<Long, Position> lastAppendedDEPos = new HashMap<>();
+    private final Map<Long, byte[]> lastAppendedBitmap = new HashMap<>();
+
+    public IndividualAckStatePersistence(CursorWal wal, ReadWriteLock lock,
+                                         BiConsumer<Long, Long> cmAckedCallback,
+                                         OpenTelemetryManagedCursorStats otelStats,
+                                         ManagedCursor cursor) {
+        this.wal = wal;
+        this.lock = lock;
+        this.cmAckedCallback = cmAckedCallback;
+        this.otelStats = otelStats;
+        this.cursor = cursor;
+    }
+
+    @Override
+    public CompletableFuture<PersistResult> persist(
+            LedgerHandle lh, Position mdPos, Map<String, Long> properties,
+            BitmapAckState ackState) {
+
+        var batchAckList = ackState.buildBatchEntryDeletionIndexInfoList(Integer.MAX_VALUE);
+        final Set<Long> dirtyLedgers;
+        final Map<Long, byte[]> newBitmaps = new HashMap<>();
+        final Map<Long, List<BatchedEntryDeletionIndexInfo>> batchAcksByLedger = new HashMap<>();
+
+        lock.readLock().lock();
+        try {
+            dirtyLedgers = ackState.snapshotAndClearDirtyLedgers();
+            for (long msgLedgerId : dirtyLedgers) {
+                var bitmap = ackState.bitmapOf(msgLedgerId);
+                var batchAcks = filterBatchAckForLedger(batchAckList, msgLedgerId);
+                if (bitmap == null && batchAcks.isEmpty()) continue;
+                if (bitmap != null && batchAcks.isEmpty()) {
+                    var last = lastAppendedBitmap.get(msgLedgerId);
+                    if (last != null && Arrays.equals(last, bitmap)) continue;
+                }
+                newBitmaps.put(msgLedgerId, bitmap);
+                batchAcksByLedger.put(msgLedgerId, batchAcks);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        var msgLedgerOrder = List.copyOf(newBitmaps.keySet());
+        var deFutures = msgLedgerOrder.stream()
+                .map(id -> wal.append(lh, buildDe(id, newBitmaps.get(id), batchAcksByLedger.get(id)))
+                        .thenApply(CursorWal.AppendResult::commitEntryId))
+                .toList();
+
+        var allDEs = deFutures.isEmpty()
+                ? CompletableFuture.<Void>completedFuture(null)
+                : CompletableFuture.allOf(deFutures.toArray(CompletableFuture[]::new));
+
+        return allDEs.thenCompose(ignored -> {
+            lock.writeLock().lock();
+            try {
+                for (int i = 0; i < msgLedgerOrder.size(); i++) {
+                    long id = msgLedgerOrder.get(i);
+                    lastAppendedDEPos.put(id, PositionFactory.create(lh.getId(), deFutures.get(i).join()));
+                    var bm = newBitmaps.get(id);
+                    if (bm != null) lastAppendedBitmap.put(id, bm);
+                }
+            } finally {
+                lock.writeLock().unlock();
+            }
+            return wal.append(lh, buildCm(mdPos, properties, lastAppendedDEPos)).thenApply(result -> {
+                if (cmAckedCallback != null) cmAckedCallback.accept(lh.getId(), result.commitEntryId());
+                return new PersistResult(result.totalBytes(), result.commitEntryId());
+            });
+        }).exceptionally(error -> {
+            lock.writeLock().lock();
+            try { ackState.restoreDirtyLedgers(dirtyLedgers); }
+            finally { lock.writeLock().unlock(); }
+            throw new java.util.concurrent.CompletionException(error);
+        });
+    }
+
+    @Override
+    public CompletableFuture<RecoveredState> recover(LedgerHandle lh) {
+        return wal.readLatestDeCmInstance(lh).thenApply(s ->
+                new RecoveredState(s.positionInfo(), s.commitEntryId(), s.stateSize()));
+    }
+
+    @Override
+    public void onLedgerRollover() {
+        // Keep lastAppendedDEPos as-is — CM references DEs in old cursor ledger via cross-ledger reads.
+    }
+
+    /**
+     * Called when mark-delete advances. Removes DE references for message-ledgers fully covered
+     * by the mark-delete position (ledgerId < mdLedgerId).
+     */
+    @Override
+    public void onMarkDeleteAdvance(long mdLedgerId) {
+        if (mdLedgerId <= 0) return;
+        lock.writeLock().lock();
+        try {
+            lastAppendedDEPos.keySet().removeIf(id -> id < mdLedgerId);
+            lastAppendedBitmap.keySet().removeIf(id -> id < mdLedgerId);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public void setZkCmHint(long cursorLedgerId, long entryId) { }
+
+    @Override
+    public boolean shouldGcOldCursorLedgerOnRollover() {
+        return false; // DE+CM keeps cross-ledger references to old DEs; GC is deferred.
+    }
+
+    /**
+     * Returns the minimum cursorLedgerId referenced by any DE in the current lastAppendedDEPos.
+     * Used by ManagedCursorImpl to GC old cursor ledgers below this threshold.
+     */
+    @Override
+    public long getOldestReferencedCursorLedgerId() {
+        lock.readLock().lock();
+        try {
+            return lastAppendedDEPos.values().stream()
+                    .mapToLong(Position::getLedgerId)
+                    .min()
+                    .orElse(-1);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    // ---- AckPersistence ZK-MetaStore build helpers ----
+
+    @Override
+    public List<MessageRange> buildIndividualDeletedMessageRanges(BitmapAckState ackState, int maxRanges) {
+        lock.writeLock().lock();
+        try {
+            if (ackState.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<MessageRange> rangeList = new ArrayList<>();
+            final MutableBoolean truncated = new MutableBoolean(false);
+
+            ackState.forEachRawRange((lk, lv, uk, uv) -> {
+                if (rangeList.size() >= maxRanges) {
+                    truncated.setTrue();
+                    return false;
+                }
+                MessageRange mr = new MessageRange();
+                mr.setLowerEndpoint().setLedgerId(lk).setEntryId(lv);
+                mr.setUpperEndpoint().setLedgerId(uk).setEntryId(uv);
+                rangeList.add(mr);
+                return true;
+            });
+
+            ackState.resetDirtyKeys();
+
+            if (truncated.booleanValue()) {
+                if (otelStats != null) otelStats.incrementPersistUnackedRangesTruncated(cursor);
+                log.warn()
+                    .attr("totalRanges", ackState.size())
+                    .attr("maxRanges", maxRanges)
+                    .log("Individually deleted message ranges truncated during DE+CM MetaStore write.");
+            }
+            return rangeList;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public List<BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList(
+            BitmapAckState ackState, int maxIndexes) {
+        lock.readLock().lock();
+        try {
+            List<BatchedEntryDeletionIndexInfo> result =
+                    ackState.buildBatchEntryDeletionIndexInfoList(maxIndexes);
+            int totalIndexes = ackState.getBatchDeletedIndexesSize();
+            if (result.size() < totalIndexes) {
+                if (otelStats != null) otelStats.incrementPersistBatchDeletedIndexesTruncated(cursor);
+                log.warn()
+                    .attr("totalIndexes", totalIndexes)
+                    .attr("maxIndexes", maxIndexes)
+                    .log("Batch deleted indexes truncated during DE+CM MetaStore write.");
+            }
+            return result;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    // ---- builders ----
+
+    private static List<BatchedEntryDeletionIndexInfo> filterBatchAckForLedger(
+            List<BatchedEntryDeletionIndexInfo> list, long msgLedgerId) {
+        if (list == null || list.isEmpty()) return List.of();
+        return list.stream()
+                .filter(i -> i.getPosition().getLedgerId() == msgLedgerId)
+                .collect(toList());
+    }
+
+    private static PositionInfo buildDe(long msgLedgerId, byte[] bitmapBytes,
+                                        List<BatchedEntryDeletionIndexInfo> batchAcks) {
+        var de = new PositionInfo().setLedgerId(0L).setEntryId(0L);
+        var range = de.addIndividualDeletedMessageRange();
+        range.setKey(msgLedgerId);
+        if (bitmapBytes != null) range.setBitmap(bitmapBytes);
+        if (batchAcks != null && !batchAcks.isEmpty()) de.addAllBatchedEntryDeletionIndexInfos(batchAcks);
+        return markType(de, CursorWal.ENTRY_TYPE_DE);
+    }
+
+    private static PositionInfo buildCm(Position mdPos, Map<String, Long> properties,
+                                        Map<Long, Position> dePositions) {
+        var cm = new PositionInfo().setLedgerId(mdPos.getLedgerId()).setEntryId(mdPos.getEntryId());
+        if (properties != null) {
+            properties.forEach((k, v) -> {
+                var p = cm.addProperty();
+                p.setName(k);
+                p.setValue(v);
+            });
+        }
+        dePositions.forEach((id, pos) -> {
+            var entry = cm.addIndividualDeletedMessageRange();
+            entry.setKey(id);
+            entry.addValue(pos.getLedgerId());
+            entry.addValue(pos.getEntryId());
+        });
+        return markType(cm, CursorWal.ENTRY_TYPE_CM);
+    }
+
+    private static PositionInfo markType(PositionInfo pi, long type) {
+        var p = pi.addProperty();
+        p.setName(CursorWal.ENTRY_TYPE_PROPERTY);
+        p.setValue(type);
+        return pi;
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LegacyAckPersistence.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/LegacyAckPersistence.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import io.github.merlimat.slog.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReadWriteLock;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.proto.BatchedEntryDeletionIndexInfo;
+import org.apache.bookkeeper.mledger.proto.LongListMap;
+import org.apache.bookkeeper.mledger.proto.LongProperty;
+import org.apache.bookkeeper.mledger.proto.MessageRange;
+import org.apache.bookkeeper.mledger.proto.PositionInfo;
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableInt;
+
+/**
+ * Legacy {@link AckPersistence}: writes a single {@link PositionInfo} entry per flush
+ * directly to the cursor ledger. No chunking — if serialized data exceeds BK's entry
+ * size limit, ack ranges are truncated by {@code managedLedgerMaxUnackedRangesToPersist}.
+ *
+ * <p>Serialization format depends on config:
+ * <ul>
+ *   <li>{@code persistentUnackedRangesWithMultipleEntriesEnabled=true}: per-ledger RoaringBitmap bytes.</li>
+ *   <li>{@code persistIndividualAckAsLongArray=true} (default): compact packed-long representation.</li>
+ *   <li>Fallback: classic flat {@link MessageRange} list.</li>
+ * </ul>
+ */
+class LegacyAckPersistence implements AckPersistence {
+
+    static final Logger log = Logger.get(LegacyAckPersistence.class);
+
+    private final ManagedLedgerConfig config;
+    private final ReadWriteLock lock;
+    private final OpenTelemetryManagedCursorStats otelStats;
+    private final ManagedCursor cursor;
+
+    private final PositionInfo reusablePositionInfo = new PositionInfo();
+    private volatile int serializedSize;
+    private final AtomicBoolean lastCursorDataFullyPersistable = new AtomicBoolean(true);
+    private final AtomicBoolean lastBatchDeletedIndexFullyPersistable = new AtomicBoolean(true);
+
+    LegacyAckPersistence(ManagedLedgerConfig config, ReadWriteLock lock,
+                         OpenTelemetryManagedCursorStats otelStats, ManagedCursor cursor) {
+        this.config = config;
+        this.lock = lock;
+        this.otelStats = otelStats;
+        this.cursor = cursor;
+    }
+
+    @Override
+    public CompletableFuture<PersistResult> persist(
+            LedgerHandle lh, Position mdPos, Map<String, Long> properties,
+            BitmapAckState ackState) {
+        var pi = reusablePositionInfo;
+        pi.clear();
+        pi.setLedgerId(mdPos.getLedgerId())
+                .setEntryId(mdPos.getEntryId())
+                .addAllBatchedEntryDeletionIndexInfos(
+                        buildBatchEntryDeletionIndexInfoList(ackState, config.getMaxBatchDeletedIndexToPersist()))
+                .addAllProperties(buildPropertiesMap(properties));
+
+        if (config.isPersistentUnackedRangesWithMultipleEntriesEnabled()) {
+            lock.readLock().lock();
+            try {
+                pi.addAllIndividualDeletedMessageRanges(
+                        buildBitmapPropertiesMap(ackState.toSerializedBitmaps()));
+            } catch (Exception e) {
+                log.warn().exception(e).log("Failed to serialize individualDeletedMessages");
+            } finally {
+                lock.readLock().unlock();
+            }
+        } else {
+            Map<Long, long[]> internalRanges = null;
+            if (config.isPersistIndividualAckAsLongArray()) {
+                lock.readLock().lock();
+                try {
+                    internalRanges = ackState.toRanges(config.getMaxUnackedRangesToPersist());
+                } catch (Exception e) {
+                    log.warn().exception(e).log("Failed to serialize individualDeletedMessages");
+                } finally {
+                    lock.readLock().unlock();
+                }
+            }
+            if (internalRanges != null && !internalRanges.isEmpty()) {
+                pi.addAllIndividualDeletedMessageRanges(buildLongPropertiesMap(internalRanges));
+            } else {
+                pi.addAllIndividualDeletedMessages(
+                        buildIndividualDeletedMessageRanges(ackState, config.getMaxUnackedRangesToPersist()));
+            }
+        }
+
+        var future = new CompletableFuture<PersistResult>();
+        byte[] data = pi.toByteArray();
+        lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
+            if (rc == BKException.Code.OK) {
+                future.complete(new PersistResult(data.length, entryId));
+            } else {
+                future.completeExceptionally(BKException.create(rc));
+            }
+        }, null);
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<RecoveredState> recover(LedgerHandle lh) {
+        long lac = lh.getLastAddConfirmed();
+        if (lac < 0) {
+            return CompletableFuture.failedFuture(
+                    new org.apache.bookkeeper.mledger.ManagedLedgerException("Cursor ledger has no entries"));
+        }
+        var future = new CompletableFuture<RecoveredState>();
+        lh.asyncReadEntries(lac, lac, (rc, handle, seq, ctx) -> {
+            if (rc != BKException.Code.OK) {
+                future.completeExceptionally(BKException.create(rc));
+                return;
+            }
+            if (!seq.hasMoreElements()) {
+                future.completeExceptionally(
+                        new org.apache.bookkeeper.mledger.ManagedLedgerException("Empty read result"));
+                return;
+            }
+            LedgerEntry entry = seq.nextElement();
+            byte[] bytes = entry.getEntry();
+            PositionInfo pi = new PositionInfo();
+            pi.parseFrom(bytes);
+            future.complete(new RecoveredState(pi, lac, bytes.length));
+        }, null);
+        return future;
+    }
+
+    @Override
+    public int getSerializedSize() {
+        return serializedSize;
+    }
+
+    // ---- helpers ----
+
+    private static List<LongProperty> buildPropertiesMap(Map<String, Long> properties) {
+        if (properties == null || properties.isEmpty()) return Collections.emptyList();
+        var props = new ArrayList<LongProperty>(properties.size());
+        properties.forEach((k, v) -> props.add(new LongProperty().setName(k).setValue(v)));
+        return props;
+    }
+
+    private List<LongListMap> buildBitmapPropertiesMap(Map<Long, byte[]> bitmaps) {
+        var result = new ArrayList<LongListMap>(bitmaps.size());
+        var size = new MutableInt();
+        bitmaps.forEach((ledgerId, bitmap) -> {
+            var entry = new LongListMap().setKey(ledgerId).setBitmap(bitmap);
+            result.add(entry);
+            size.add(entry.getSerializedSize());
+        });
+        this.serializedSize = size.toInteger();
+        return result;
+    }
+
+    private List<LongListMap> buildLongPropertiesMap(Map<Long, long[]> properties) {
+        if (properties.isEmpty()) return Collections.emptyList();
+        var result = new ArrayList<LongListMap>();
+        var size = new MutableInt();
+        properties.forEach((id, ranges) -> {
+            if (ranges == null || ranges.length == 0) return;
+            var lm = new LongListMap().setKey(id);
+            for (long range : ranges) lm.addValue(range);
+            result.add(lm);
+            size.add(lm.getSerializedSize());
+        });
+        this.serializedSize = size.toInteger();
+        return result;
+    }
+
+    @Override
+    public List<MessageRange> buildIndividualDeletedMessageRanges(BitmapAckState ackState, int maxRanges) {
+        lock.writeLock().lock();
+        try {
+            if (ackState.isEmpty()) {
+                this.serializedSize = 0;
+                return Collections.emptyList();
+            }
+            var acksSerializedSize = new AtomicInteger(0);
+            var rangeList = new ArrayList<MessageRange>();
+            var truncated = new MutableBoolean(false);
+            ackState.forEachRawRange((lowerKey, lowerValue, upperKey, upperValue) -> {
+                if (rangeList.size() >= maxRanges) { truncated.setTrue(); return false; }
+                var mr = new MessageRange();
+                mr.setLowerEndpoint().setLedgerId(lowerKey).setEntryId(lowerValue);
+                mr.setUpperEndpoint().setLedgerId(upperKey).setEntryId(upperValue);
+                acksSerializedSize.addAndGet(mr.getSerializedSize());
+                rangeList.add(mr);
+                return true;
+            });
+            this.serializedSize = acksSerializedSize.get();
+            ackState.resetDirtyKeys();
+            if (truncated.booleanValue()) {
+                if (otelStats != null) otelStats.incrementPersistUnackedRangesTruncated(cursor);
+                if (lastCursorDataFullyPersistable.compareAndSet(true, false)) {
+                    log.warn().attr("totalRanges", ackState.size()).attr("maxRanges", maxRanges)
+                            .log("Individually deleted message ranges exceed managedLedgerMaxUnackedRangesToPersist.");
+                }
+            } else {
+                lastCursorDataFullyPersistable.compareAndSet(false, true);
+            }
+            return rangeList;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public List<BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList(
+            BitmapAckState ackState, int maxIndexes) {
+        lock.readLock().lock();
+        try {
+            var result = ackState.buildBatchEntryDeletionIndexInfoList(maxIndexes);
+            int total = ackState.getBatchDeletedIndexesSize();
+            if (result.size() < total) {
+                if (otelStats != null) otelStats.incrementPersistBatchDeletedIndexesTruncated(cursor);
+                if (lastBatchDeletedIndexFullyPersistable.compareAndSet(true, false)) {
+                    log.warn().attr("totalIndexes", total).attr("maxIndexes", maxIndexes)
+                            .log("Batch deleted indexes exceed managedLedgerMaxBatchDeletedIndexToPersist.");
+                }
+            } else {
+                lastBatchDeletedIndexFullyPersistable.compareAndSet(false, true);
+            }
+            return result;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -36,18 +36,15 @@ import io.github.merlimat.slog.Logger;
 import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,12 +59,10 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.stream.LongStream;
-import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
 import org.apache.bookkeeper.client.AsyncCallback.OpenCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
-import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.client.api.BKException.Code;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
@@ -99,12 +94,10 @@ import org.apache.bookkeeper.mledger.proto.LongProperty;
 import org.apache.bookkeeper.mledger.proto.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MessageRange;
-import org.apache.bookkeeper.mledger.proto.NestedPositionInfo;
 import org.apache.bookkeeper.mledger.proto.PositionInfo;
 import org.apache.bookkeeper.mledger.proto.StringProperty;
 import org.apache.bookkeeper.mledger.util.ManagedLedgerUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.policies.data.ManagedLedgerInternalStats;
@@ -113,7 +106,6 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet;
 import org.apache.pulsar.common.util.collections.LongPairRangeSet.LongPairConsumer;
 import org.apache.pulsar.metadata.api.Stat;
-import org.jspecify.annotations.Nullable;
 
 @SuppressWarnings("checkstyle:javadoctype")
 public class ManagedCursorImpl implements ManagedCursor {
@@ -199,17 +191,29 @@ public class ManagedCursorImpl implements ManagedCursor {
     private static final LongPairConsumer<Position> positionRangeConverter = PositionFactory::create;
 
     private static final LongPairConsumer<PositionRecyclable> recyclePositionRangeConverter = PositionRecyclable::get;
-    protected final PositionRangeSet individualDeletedMessages;
 
-    // Maintain the deletion status for batch messages
-    // (ledgerId, entryId) -> deletion indexes
-    @Getter
-    @VisibleForTesting
-    @Nullable protected final ConcurrentSkipListMap<Position, BitSet> batchDeletedIndexes;
+    /** In-memory individual and batch ack state. */
+    protected final BitmapAckState ackState;
+
     protected final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    // Reusable LightProto object for cursor position serialization (used only from persistPositionToLedger)
-    private final PositionInfo reusablePositionInfo = new PositionInfo();
+    private final CursorWal individualAckCursorWAL;
+
+    // Ack persistence strategy: legacy path or PIP-488 DE+CM.
+    private final AckPersistence ackPersistence;
+    // Volatile CM hint fields, updated by DeCmAckPersistence's cmAckedCallback and
+    // piggybacked onto the next persistPositionMetaStore ZK write (rollover/close/fallback).
+    // This avoids a separate ZK write that would race with the main path's optimistic lock.
+    private volatile long pendingCmHintLedgerId = -1;
+    private volatile long pendingCmHintEntryId = -1;
+    // DE+CM old cursor ledger GC: track ledger IDs that may be referenced by CM.
+    // Cleared when they fall below oldestReferencedCursorLedgerId.
+    private final java.util.Set<Long> oldCursorLedgerIds = new java.util.concurrent.ConcurrentHashMap<Long, Boolean>().keySet(true);
+    private volatile long oldestReferencedCursorLedgerId = Long.MAX_VALUE;
+
+    // entry-type discriminator stored in PositionInfo.properties (LongProperty).
+    // Definitions live in CursorWal; reused here for build helpers.
+    // (ManagedCursorImpl.ENTRY_TYPE_* aliases kept for readability at call sites.)
 
     private RateLimiter markDeleteLimiter;
     // The cursor is considered "dirty" when there are mark-delete updates that are only applied in memory,
@@ -222,16 +226,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     private long entriesReadCount;
     private long entriesReadSize;
-    private int individualDeletedMessagesSerializedSize;
     private static final String COMPACTION_CURSOR_NAME = "__compaction";
     private volatile boolean cacheReadEntry = false;
 
     // active state cache in ManagedCursor. It should be in sync with the state in activeCursors in ManagedLedger.
     private volatile boolean isActive = false;
-
-    // Emit the truncation WARN logs exactly once per crossing.
-    private final AtomicBoolean lastCursorDataFullyPersistable = new AtomicBoolean(true);
-    private final AtomicBoolean lastBatchDeletedIndexFullyPersistable = new AtomicBoolean(true);
 
     // This is a lock used to update the registration state of the cursor in the managed ledger.
     private final Object registerToWaitingCursorsLock = new Object();
@@ -259,11 +258,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 MarkDeleteCallback callback, Object ctx, Runnable alignAcknowledgeStatusAfterPersisted) {
             if (alignAcknowledgeStatusAfterPersisted == null) {
                 alignAcknowledgeStatusAfterPersisted = () -> {
-                    if (batchDeletedIndexes != null) {
-                        batchDeletedIndexes.subMap(PositionFactory.EARLIEST,
-                                false, PositionFactory.create(newPosition.getLedgerId(),
-                                        newPosition.getEntryId()), true).clear();
-                    }
+                    ackState.removeBatchAcksAtOrBefore(newPosition);
                     persistentMarkDeletePosition = newPosition;
                 };
             }
@@ -370,12 +365,33 @@ public class ManagedCursorImpl implements ManagedCursor {
         this.ledger = ledger;
         this.name = cursorName;
         this.log = slog.with().ctx(ledger.getLogger()).attr("cursor", name).build();
-        this.individualDeletedMessages = new PositionRangeSet(positionRangeConverter,
-                getConfig().isPersistentUnackedRangesWithMultipleEntriesEnabled());
-        if (getConfig().isDeletionAtBatchIndexLevelEnabled()) {
-            this.batchDeletedIndexes = new ConcurrentSkipListMap<>();
+        // enableMultiEntry controls whether markDirty runs on each addOpenClosed. Both
+        // persistentUnackedRangesWithMultipleEntriesEnabled (P1: sharded PositionInfo) and
+        // persistentUnackedRangesWithPerLedgerEntryEnabled (P2: DE+CM) need dirty tracking to drive per-msgLedger writes.
+        boolean enableDirtyTracking = getConfig().isPersistentUnackedRangesWithMultipleEntriesEnabled()
+                || getConfig().isPersistentUnackedRangesWithPerLedgerEntryEnabled();
+        this.ackState = new BitmapAckState(positionRangeConverter, enableDirtyTracking,
+                getConfig().isDeletionAtBatchIndexLevelEnabled());
+        this.individualAckCursorWAL = new CursorWal(
+                getConfig().getPersistentUnackedRangesMaxEntrySize(),
+                bookkeeper,
+                getConfig().getPassword());
+        // Ack persistence strategy: legacy (includes P1 sharded via WAL) or PIP-488 DE+CM.
+        var factory = ledger.getFactory();
+        var otelStats = factory != null ? factory.getOpenTelemetryManagedCursorStats() : null;
+        if (getConfig().isPersistentUnackedRangesWithPerLedgerEntryEnabled()) {
+            this.ackPersistence = new IndividualAckStatePersistence(
+                    individualAckCursorWAL,
+                    lock,
+                    (cursorLedgerId, cmEntryId) -> {
+                        ManagedCursorImpl.this.pendingCmHintLedgerId = cursorLedgerId;
+                        ManagedCursorImpl.this.pendingCmHintEntryId = cmEntryId;
+                    },
+                    otelStats,
+                    this);
         } else {
-            this.batchDeletedIndexes = null;
+            this.ackPersistence = new LegacyAckPersistence(
+                    getConfig(), lock, otelStats, this);
         }
         this.digestType = BookKeeper.DigestType.fromApiDigestType(getConfig().getDigestType());
         PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER.set(this, 0);
@@ -410,7 +426,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public boolean isCursorDataFullyPersistable() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.size() <= getConfig().getMaxUnackedRangesToPersist();
+            return ackState.size() <= getConfig().getMaxUnackedRangesToPersist();
         } finally {
             lock.readLock().unlock();
         }
@@ -581,6 +597,11 @@ public class ManagedCursorImpl implements ManagedCursor {
                         recoverIndividualDeletedMessages(info.getIndividualDeletedMessagesCount(),
                                 info::getIndividualDeletedMessageAt);
                     }
+                    if (getConfig().isDeletionAtBatchIndexLevelEnabled()
+                            && info.getBatchedEntryDeletionIndexInfosCount() > 0) {
+                        recoverBatchDeletedIndexes(info.getBatchedEntryDeletionIndexInfosCount(),
+                                info::getBatchedEntryDeletionIndexInfoAt);
+                    }
 
                     Map<String, Long> recoveredProperties = Collections.emptyMap();
                     if (info.getPropertiesCount() > 0) {
@@ -632,49 +653,53 @@ public class ManagedCursorImpl implements ManagedCursor {
                 return;
             }
 
-            // Read the last entry in the ledger
-            long lastEntryInLedger = lh.getLastAddConfirmed();
-
-            if (lastEntryInLedger < 0) {
+            if (lh.getLastAddConfirmed() < 0) {
                 log.warn().attr("ledgerId", ledgerId).log("Error reading from metadata ledger: no entries in ledger");
                 // Rewind to last cursor snapshot available
                 initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
                 return;
             }
 
-            lh.asyncReadEntries(lastEntryInLedger, lastEntryInLedger, (rc1, lh1, seq, ctx1) -> {
-                log.debug().attr("rc", rc1).attr("entryId", lh1.getLastAddConfirmed()).log("readComplete");
-                if (isBkErrorNotRecoverable(rc1) || (rc1 != BKException.Code.OK && ledgerForceRecovery)) {
-                    log.error()
-                            .attr("ledgerId", ledgerId)
-                            .attr("errorMessage", BKException.getMessage(rc1))
-                            .log("Error reading from metadata ledger");
-                    // Rewind to the oldest entry available
-                    initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
-                    return;
-                } else if (rc1 != BKException.Code.OK) {
+            CompletableFuture<AckPersistence.RecoveredState> recoverFuture;
+            // Pass ZK CM hint (if present) to the store so DE+CM recovery can skip scan-back.
+            if (info.hasLastCmCursorLedgerId()) {
+                ackPersistence.setZkCmHint(info.getLastCmCursorLedgerId(), info.getLastCmEntryId());
+            }
+            recoverFuture = ackPersistence.recover(lh);
+            recoverFuture.whenComplete((recovered, error) -> {
+                if (error != null) {
+                    Throwable cause = FutureUtil.unwrapCompletionException(error);
+                    int readRc = BKException.getExceptionCode(cause);
+                    // WAL-detected corruption (parse failure, checksum mismatch, mixed
+                    // sequenceId, etc.) surfaces as non-BKException. Treat those as
+                    // unrecoverable and rewind to the rollback position instead of failing
+                    // the cursor recovery. BK read errors keep their original rc-driven routing.
+                    boolean walCorruption = !(cause instanceof BKException);
+                    if (walCorruption || isBkErrorNotRecoverable(readRc)
+                            || (readRc != BKException.Code.OK && ledgerForceRecovery)) {
+                        log.error()
+                                .attr("ledgerId", ledgerId)
+                                .exception(cause)
+                                .log("Error reading from metadata ledger");
+                        initialize(getRollbackPosition(info), Collections.emptyMap(), cursorProperties, callback);
+                        return;
+                    }
                     log.warn()
                             .attr("ledgerId", ledgerId)
-                            .attr("errorMessage", BKException.getMessage(rc1))
+                            .exception(cause)
                             .log("Error reading from metadata ledger");
-
-                    callback.operationFailed(createManagedLedgerException(rc1));
+                    callback.operationFailed(createManagedLedgerException(cause));
                     return;
                 }
 
-                LedgerEntry entry = seq.nextElement();
-                mbean.addReadCursorLedgerSize(entry.getLength());
-                PositionInfo positionInfo = new PositionInfo();
-                try {
-                    positionInfo.parseFrom(entry.getEntry());
-                } catch (Exception e) {
-                    callback.operationFailed(new ManagedLedgerException(e));
-                    return;
-                }
+                log.debug()
+                        .attr("entryId", recovered.commitEntryId())
+                        .log("Read cursor state from metadata ledger");
+                mbean.addReadCursorLedgerSize(recovered.stateSize());
+                PositionInfo positionInfo = recovered.positionInfo();
 
                 Map<String, Long> recoveredProperties = Collections.emptyMap();
                 if (positionInfo.getPropertiesCount() > 0) {
-                    // Recover properties map
                     recoveredProperties = new HashMap<>();
                     for (int i = 0; i < positionInfo.getPropertiesCount(); i++) {
                         LongProperty property = positionInfo.getPropertyAt(i);
@@ -691,7 +716,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
                 recoveredCursor(position, recoveredProperties, cursorProperties, lh);
                 callback.operationComplete();
-            }, null);
+            });
         };
         try {
             bookkeeper.asyncOpenLedger(ledgerId, digestType, getConfig().getPassword(), openCallback,
@@ -709,16 +734,31 @@ public class ManagedCursorImpl implements ManagedCursor {
         } else if (positionInfo.getIndividualDeletedMessageRangesCount() > 0) {
             lock.writeLock().lock();
             try {
-                Map<Long, long[]> rangeMap = new HashMap<>(positionInfo.getIndividualDeletedMessageRangesCount());
-                for (int i = 0; i < positionInfo.getIndividualDeletedMessageRangesCount(); i++) {
-                    LongListMap list = positionInfo.getIndividualDeletedMessageRangeAt(i);
-                    long[] values = new long[list.getValuesCount()];
-                    for (int idx = 0; idx < values.length; idx++) {
-                        values[idx] = list.getValueAt(idx);
+                LongListMap first = positionInfo.getIndividualDeletedMessageRangeAt(0);
+                if (first.hasBitmap()) {
+                    Map<Long, byte[]> bitmaps = new HashMap<>(
+                            positionInfo.getIndividualDeletedMessageRangesCount());
+                    for (int i = 0; i < positionInfo.getIndividualDeletedMessageRangesCount(); i++) {
+                        LongListMap list = positionInfo.getIndividualDeletedMessageRangeAt(i);
+                        if (!list.hasBitmap()) {
+                            throw new IllegalArgumentException("Mixed individual ack bitmap encodings");
+                        }
+                        bitmaps.put(list.getKey(), list.getBitmap());
                     }
-                    rangeMap.put(list.getKey(), values);
+                    ackState.recoverFromBitmaps(bitmaps);
+                } else {
+                    Map<Long, long[]> rangeMap = new HashMap<>(
+                            positionInfo.getIndividualDeletedMessageRangesCount());
+                    for (int i = 0; i < positionInfo.getIndividualDeletedMessageRangesCount(); i++) {
+                        LongListMap list = positionInfo.getIndividualDeletedMessageRangeAt(i);
+                        long[] values = new long[list.getValuesCount()];
+                        for (int idx = 0; idx < values.length; idx++) {
+                            values[idx] = list.getValueAt(idx);
+                        }
+                        rangeMap.put(list.getKey(), values);
+                    }
+                    ackState.recoverFromRanges(rangeMap);
                 }
-                individualDeletedMessages.build(rangeMap);
             } catch (Exception e) {
                 log.warn().exception(e).log("Failed to recover individualDeletedMessages from serialized data");
             } finally {
@@ -727,85 +767,21 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private List<LongListMap> buildLongPropertiesMap(Map<Long, long[]> properties) {
-        if (properties.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<LongListMap> longListMap = new ArrayList<>();
-        MutableInt serializedSize = new MutableInt();
-        properties.forEach((id, ranges) -> {
-            if (ranges == null || ranges.length <= 0) {
-                return;
-            }
-            LongListMap lm = new LongListMap().setKey(id);
-            for (long range : ranges) {
-                lm.addValue(range);
-            }
-            longListMap.add(lm);
-            serializedSize.add(lm.getSerializedSize());
-        });
-        individualDeletedMessagesSerializedSize = serializedSize.toInteger();
-        return longListMap;
-    }
-
     @VisibleForTesting
     void recoverIndividualDeletedMessages(int count, IntFunction<MessageRange> accessor) {
         lock.writeLock().lock();
         try {
-            individualDeletedMessages.clear();
-            for (int i = 0; i < count; i++) {
-                MessageRange messageRange = accessor.apply(i);
-                NestedPositionInfo lowerEndpoint = messageRange.getLowerEndpoint();
-                NestedPositionInfo upperEndpoint = messageRange.getUpperEndpoint();
-
-                if (lowerEndpoint.getLedgerId() == upperEndpoint.getLedgerId()) {
-                    individualDeletedMessages.addOpenClosed(lowerEndpoint.getLedgerId(), lowerEndpoint.getEntryId(),
-                            upperEndpoint.getLedgerId(), upperEndpoint.getEntryId());
-                } else {
-                    // Store message ranges after splitting them by ledger ID
-                    LedgerInfo lowerEndpointLedgerInfo = ledger.getLedgersInfo().get(lowerEndpoint.getLedgerId());
-                    if (lowerEndpointLedgerInfo != null) {
-                        individualDeletedMessages.addOpenClosed(lowerEndpoint.getLedgerId(), lowerEndpoint.getEntryId(),
-                                lowerEndpoint.getLedgerId(), lowerEndpointLedgerInfo.getEntries() - 1);
-                    } else {
-                        log.warn()
-                                .attr("ledgerId", lowerEndpoint.getLedgerId())
-                                .attr("entryId", lowerEndpoint.getEntryId())
-                                .log("No ledger info of lower endpoint");
-                    }
-
-                    for (LedgerInfo li : ledger.getLedgersInfo()
-                            .subMap(lowerEndpoint.getLedgerId(), false, upperEndpoint.getLedgerId(), false).values()) {
-                        individualDeletedMessages.addOpenClosed(li.getLedgerId(), -1, li.getLedgerId(),
-                                li.getEntries() - 1);
-                    }
-
-                    individualDeletedMessages.addOpenClosed(upperEndpoint.getLedgerId(), -1,
-                            upperEndpoint.getLedgerId(), upperEndpoint.getEntryId());
-                }
-            }
+            ackState.clear();
+            ackState.recoverFromMessageRanges(count, accessor, () -> ledger.getLedgersInfo());
         } finally {
             lock.writeLock().unlock();
         }
     }
 
     private void recoverBatchDeletedIndexes(int count, IntFunction<BatchedEntryDeletionIndexInfo> accessor) {
-        Objects.requireNonNull(batchDeletedIndexes);
         lock.writeLock().lock();
         try {
-            this.batchDeletedIndexes.clear();
-            for (int i = 0; i < count; i++) {
-                BatchedEntryDeletionIndexInfo batchDeletedIndexInfo = accessor.apply(i);
-                if (batchDeletedIndexInfo.getDeleteSetsCount() > 0) {
-                    long[] array = new long[batchDeletedIndexInfo.getDeleteSetsCount()];
-                    for (int j = 0; j < array.length; j++) {
-                        array[j] = batchDeletedIndexInfo.getDeleteSetAt(j);
-                    }
-                    this.batchDeletedIndexes.put(
-                            PositionFactory.create(batchDeletedIndexInfo.getPosition().getLedgerId(),
-                                    batchDeletedIndexInfo.getPosition().getEntryId()), BitSet.valueOf(array));
-                }
-            }
+            ackState.recoverBatchDeletedIndexes(count, accessor);
         } finally {
             lock.writeLock().unlock();
         }
@@ -1262,7 +1238,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public int getTotalNonContiguousDeletedMessagesRange() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.size();
+            return ackState.size();
         } finally {
             lock.readLock().unlock();
         }
@@ -1270,7 +1246,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public int getNonContiguousDeletedMessagesRangeSerializedSize() {
-        return this.individualDeletedMessagesSerializedSize;
+        return ackPersistence.getSerializedSize();
     }
 
     @Override
@@ -1303,7 +1279,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             Range<Position> backlogRange = Range.openClosed(markDeletePosition, lastPosition);
-            deletedCount = individualDeletedMessages.cardinality(
+            deletedCount = ackState.cardinality(
                     backlogRange.lowerEndpoint().getLedgerId(), backlogRange.lowerEndpoint().getEntryId(),
                     backlogRange.upperEndpoint().getLedgerId(), backlogRange.upperEndpoint().getEntryId());
         } finally {
@@ -1395,7 +1371,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             while (nextPosition.compareTo(lastPosition) <= 0) {
-                Range<Position> deletedRange = individualDeletedMessages.rangeContaining(
+                Range<Position> deletedRange = ackState.rangeContaining(
                         nextPosition.getLedgerId(), nextPosition.getEntryId());
                 if (deletedRange == null) {
                     return true;
@@ -1636,12 +1612,13 @@ public class ManagedCursorImpl implements ManagedCursor {
                 long entries = getNumberOfEntries(Range.openClosed(markDeletePosition, newMarkDeletePosition));
                 MSG_CONSUMED_COUNTER_UPDATER.addAndGet(ManagedCursorImpl.this, entries);
             }
-            individualDeletedMessages.removeAtMost(newMarkDeletePosition.getLedgerId(),
+            ackState.removeAtMost(newMarkDeletePosition.getLedgerId(),
                     newMarkDeletePosition.getEntryId());
+            ackPersistence.onMarkDeleteAdvance(newMarkDeletePosition.getLedgerId());
 
             // Entries already acknowledged, which is larger than the new mark deleted position.
             MutableLong ackedEntriesAfterMdPosition = new MutableLong();
-            individualDeletedMessages.forEach((r) -> {
+            ackState.forEach((r) -> {
                 for (long i = r.lowerEndpoint().getEntryId() + 1; i <= r.upperEndpoint().getEntryId(); i++) {
                     ackedEntriesAfterMdPosition.incrementAndGet();
                 }
@@ -1652,16 +1629,13 @@ public class ManagedCursorImpl implements ManagedCursor {
             markDeletePosition = newMarkDeletePosition;
             lastMarkDeleteEntry = new MarkDeleteEntry(newMarkDeletePosition, isCompactionCursor()
                     ? getProperties() : Collections.emptyMap(), null, null);
-            individualDeletedMessages.clear();
-            if (batchDeletedIndexes != null) {
-                batchDeletedIndexes.clear();
-                AckSetStateUtil.maybeGetAckSetState(newReadPosition).ifPresent(ackSetState -> {
-                    long[] resetWords = ackSetState.getAckSet();
-                    if (resetWords != null) {
-                        batchDeletedIndexes.put(newReadPosition, BitSet.valueOf(resetWords));
-                    }
-                });
-            }
+            ackState.clear();
+            AckSetStateUtil.maybeGetAckSetState(newReadPosition).ifPresent(ackSetState -> {
+                long[] resetWords = ackSetState.getAckSet();
+                if (resetWords != null) {
+                    ackState.putBatchAck(newReadPosition, resetWords);
+                }
+            });
 
             Position oldReadPosition = readPosition;
             if (oldReadPosition.compareTo(newReadPosition) >= 0) {
@@ -1927,7 +1901,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         lock.readLock().lock();
         try {
-            deletedEntriesCount = individualDeletedMessages.cardinality(
+            deletedEntriesCount = ackState.cardinality(
                     range.lowerEndpoint().getLedgerId(), range.lowerEndpoint().getEntryId(),
                     range.upperEndpoint().getLedgerId(), range.upperEndpoint().getEntryId());
         } finally {
@@ -2117,7 +2091,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             InvidualDeletedMessagesHandlingState state = new InvidualDeletedMessagesHandlingState(markDeletePosition);
-            individualDeletedMessages.forEach((r) -> {
+            ackState.forEach((r) -> {
                 try {
                     state.endPosition = r.lowerEndpoint();
                     if (state.startPosition.compareTo(state.endPosition) <= 0) {
@@ -2190,7 +2164,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             if (newMarkDeletePosition.getLedgerId() == oldMarkDeletePosition.getLedgerId()
                     && newMarkDeletePosition.getEntryId() == oldMarkDeletePosition.getEntryId() + 1) {
                 // Mark-deleting the position next to current one
-                skippedEntries = individualDeletedMessages.contains(newMarkDeletePosition.getLedgerId(),
+                skippedEntries = ackState.contains(newMarkDeletePosition.getLedgerId(),
                         newMarkDeletePosition.getEntryId()) ? 0 : 1;
             } else {
                 skippedEntries = getNumberOfEntries(Range.openClosed(oldMarkDeletePosition, newMarkDeletePosition));
@@ -2201,9 +2175,9 @@ public class ManagedCursorImpl implements ManagedCursor {
             // eg: (2:10..3:15] can be returned as (2:10..2:15],[3:0..3:15]. So, try to iterate over connected range and
             // found the last non-connected range which gives new markDeletePosition
             while (positionAfterNewMarkDelete.compareTo(ledger.lastConfirmedEntry) <= 0) {
-                if (individualDeletedMessages.contains(positionAfterNewMarkDelete.getLedgerId(),
+                if (ackState.contains(positionAfterNewMarkDelete.getLedgerId(),
                         positionAfterNewMarkDelete.getEntryId())) {
-                    Range<Position> rangeToBeMarkDeleted = individualDeletedMessages.rangeContaining(
+                    Range<Position> rangeToBeMarkDeleted = ackState.rangeContaining(
                             positionAfterNewMarkDelete.getLedgerId(), positionAfterNewMarkDelete.getEntryId());
                     newMarkDeletePosition = rangeToBeMarkDeleted.upperEndpoint();
                     positionAfterNewMarkDelete = ledger.getNextValidPosition(newMarkDeletePosition);
@@ -2223,7 +2197,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         // markDelete-position and clear out deletedMsgSet
         markDeletePosition = newMarkDeletePosition;
-        individualDeletedMessages.removeAtMost(markDeletePosition.getLedgerId(), markDeletePosition.getEntryId());
+        ackState.removeAtMost(markDeletePosition.getLedgerId(), markDeletePosition.getEntryId());
 
         MutableBoolean readPositionUpdated = new MutableBoolean(false);
         Position updatedReadPosition = READ_POSITION_UPDATER.updateAndGet(this, currentReadPosition -> {
@@ -2339,22 +2313,14 @@ public class ManagedCursorImpl implements ManagedCursor {
         return AckSetStateUtil.maybeGetAckSetState(position)
                 .map(AckSetState::getAckSet)
                 .map(ackSet -> {
-                    if (batchDeletedIndexes == null) {
+                    if (!ackState.isBatchIndexAckEnabled()) {
                         return ledger.getPreviousPosition(position);
                     }
-                    // In order to prevent the batch index recorded in batchDeletedIndexes from rolling back,
-                    // only update batchDeletedIndexes when the submitted batch index is greater
-                    // than the recorded index.
-                    final var givenBitSet = BitSet.valueOf(ackSet);
-                    batchDeletedIndexes.compute(position, (k, v) -> {
-                        if (v == null || givenBitSet.nextSetBit(0) > v.nextSetBit(0)) {
-                            return givenBitSet;
-                        } else {
-                            return v;
-                        }
-                    });
+                    // Store or update the ackSet (keep only if more permissive — higher first set bit).
+                    ackState.putBatchAck(position, ackSet);
                     final var newPosition = ledger.getPreviousPosition(position);
-                    batchDeletedIndexes.subMap(PositionFactory.EARLIEST, newPosition).clear();
+                    // Remove batch ack entries that have fallen behind the mark-delete advance.
+                    ackState.removeBatchAcksBefore(newPosition);
                     return newPosition;
                 })
                 .orElse(position);
@@ -2586,7 +2552,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         try {
             log.debug()
                     .attr("positions", positions)
-                    .attr("deletedMessages", individualDeletedMessages)
+                    .attr("deletedMessages", ackState)
                     .attr("markDeletePosition", markDeletePosition)
                     .log("Deleting individual messages");
 
@@ -2602,17 +2568,13 @@ public class ManagedCursorImpl implements ManagedCursor {
                 }
 
                 if (internalIsMessageDeleted(position)) {
-                    if (batchDeletedIndexes != null) {
-                        batchDeletedIndexes.remove(position);
-                    }
+                    ackState.removeBatchAck(position);
                     log.debug().attr("position", position).log("Position was already deleted");
                     continue;
                 }
                 long[] ackSet = AckSetStateUtil.getAckSetArrayOrNull(position);
                 if (ackSet == null || ackSet.length == 0) {
-                    if (batchDeletedIndexes != null) {
-                        batchDeletedIndexes.remove(position);
-                    }
+                    ackState.removeBatchAck(position);
                     // Add a range (prev, pos] to the set. Adding the previous entry as an open limit to the range will
                     // make the RangeSet recognize the "continuity" between adjacent Positions.
                     // Before https://github.com/apache/pulsar/pull/21105 is merged, the range does not support crossing
@@ -2623,29 +2585,28 @@ public class ManagedCursorImpl implements ManagedCursor {
                     } else {
                         previousPosition = ledger.getPreviousPosition(position);
                     }
-                    individualDeletedMessages.addOpenClosed(previousPosition.getLedgerId(),
+                    ackState.addOpenClosed(previousPosition.getLedgerId(),
                         previousPosition.getEntryId(), position.getLedgerId(), position.getEntryId());
                     MSG_CONSUMED_COUNTER_UPDATER.incrementAndGet(this);
 
-                    log.debug().attr("deletedMessages", individualDeletedMessages).log("Individually deleted messages");
-                } else if (batchDeletedIndexes != null) {
-                    final var givenBitSet = BitSet.valueOf(ackSet);
-                    final var bitSet = batchDeletedIndexes.computeIfAbsent(position, __ -> givenBitSet);
-                    if (givenBitSet != bitSet) {
-                        bitSet.and(givenBitSet);
-                    }
-                    if (bitSet.isEmpty()) {
+                    log.debug().attr("deletedMessages", ackState).log("Individually deleted messages");
+                } else if (ackState.isBatchIndexAckEnabled()) {
+                    // Mark this ledger dirty so the next DE+CM flush writes a DE carrying
+                    // the batch ack (even if the ledger has no individual ack bitmap change).
+                    ackState.markExternalDirty(position.getLedgerId());
+                    boolean fullyAcked = ackState.mergeBatchAck(position, ackSet);
+                    if (fullyAcked) {
                         Position previousPosition = ledger.getPreviousPosition(position);
-                        individualDeletedMessages.addOpenClosed(previousPosition.getLedgerId(),
+                        ackState.addOpenClosed(previousPosition.getLedgerId(),
                             previousPosition.getEntryId(),
                             position.getLedgerId(), position.getEntryId());
                         MSG_CONSUMED_COUNTER_UPDATER.incrementAndGet(this);
-                        batchDeletedIndexes.remove(position);
+                        ackState.removeBatchAck(position);
                     }
                 }
             }
 
-            if (individualDeletedMessages.isEmpty()) {
+            if (ackState.isEmpty()) {
                 // No changes to individually deleted messages, so nothing to do at this point
                 skipMarkDeleteBecauseAckedNothing = true;
                 return;
@@ -2653,14 +2614,14 @@ public class ManagedCursorImpl implements ManagedCursor {
 
             // If the lower bound of the range set is the current mark delete position, then we can trigger a new
             // mark-delete to the upper bound of the first range segment
-            Range<Position> range = individualDeletedMessages.firstRange();
+            Range<Position> range = ackState.firstRange();
 
             // If the upper bound is before the mark-delete position, we need to move ahead as these
-            // individualDeletedMessages are now irrelevant
+            // individually deleted messages are now irrelevant
             if (range.upperEndpoint().compareTo(markDeletePosition) <= 0) {
-                individualDeletedMessages.removeAtMost(markDeletePosition.getLedgerId(),
+                ackState.removeAtMost(markDeletePosition.getLedgerId(),
                         markDeletePosition.getEntryId());
-                range = individualDeletedMessages.firstRange();
+                range = ackState.firstRange();
             }
 
             if (range == null) {
@@ -2687,7 +2648,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             log.warn()
                     .attr("errorMessage", e.getMessage())
                     .exception(e)
-                    .log("Error while updating individualDeletedMessages");
+                    .log("Error while updating individually deleted messages");
             callback.deleteFailed(getManagedLedgerException(e), ctx);
             return;
         } finally {
@@ -2763,9 +2724,9 @@ public class ManagedCursorImpl implements ManagedCursor {
                     entries.get(entries.size() - 1).getPosition());
             log.debug()
                     .attr("entriesRange", entriesRange)
-                    .attr("deletedMessages", individualDeletedMessages)
+                    .attr("deletedMessages", ackState)
                     .log("Filtering entries");
-            Range<Position> span = individualDeletedMessages.isEmpty() ? null : individualDeletedMessages.span();
+            Range<Position> span = ackState.isEmpty() ? null : ackState.span();
             if (span == null || !entriesRange.isConnected(span)) {
                 // There are no individually deleted messages in this entry list, no need to perform filtering
                 log.debug().attr("entriesRange", entriesRange).log("No filtering needed for entries");
@@ -2773,7 +2734,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             } else {
                 // Remove from the entry list all the entries that were already marked for deletion
                 return Lists.newArrayList(Collections2.filter(entries, entry -> {
-                    boolean includeEntry = !individualDeletedMessages.contains(entry.getLedgerId(), entry.getEntryId());
+                    boolean includeEntry = !ackState.contains(entry.getLedgerId(), entry.getEntryId());
                     if (!includeEntry) {
                         log.debug().attr("position", entry.getPosition()).log("Filtering entry, already deleted");
 
@@ -2974,7 +2935,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             return cursorLedger != null
                     && !isCursorLedgerReadOnly
                     && getConfig().getMaxUnackedRangesToPersist() > 0
-                    && individualDeletedMessages.size() > getConfig().getMaxUnackedRangesToPersistInMetadataStore();
+                    && ackState.size() > getConfig().getMaxUnackedRangesToPersistInMetadataStore();
         } finally {
             lock.readLock().unlock();
         }
@@ -2997,13 +2958,20 @@ public class ManagedCursorImpl implements ManagedCursor {
                 .setMarkDeleteLedgerId(position.getLedgerId())
                 .setMarkDeleteEntryId(position.getEntryId())
                 .setLastActive(lastActive);
+        // Piggyback CM hint (P2) onto this ZK write so recovery can skip scan-back.
+        if (pendingCmHintLedgerId >= 0) {
+            info.setLastCmCursorLedgerId(pendingCmHintLedgerId);
+            info.setLastCmEntryId(pendingCmHintEntryId);
+        }
 
         info.addAllProperties(buildPropertiesMap(properties));
         info.addAllCursorProperties(buildStringPropertiesMap(cursorProperties));
         if (persistIndividualDeletedMessageRanges) {
-            info.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
+            info.addAllIndividualDeletedMessages(ackPersistence.buildIndividualDeletedMessageRanges(
+                    ackState, getConfig().getMaxUnackedRangesToPersist()));
             if (getConfig().isDeletionAtBatchIndexLevelEnabled()) {
-                info.addAllBatchedEntryDeletionIndexInfos(buildBatchEntryDeletionIndexInfoList());
+                info.addAllBatchedEntryDeletionIndexInfos(ackPersistence.buildBatchEntryDeletionIndexInfoList(
+                        ackState, getConfig().getMaxBatchDeletedIndexToPersist()));
             }
         }
 
@@ -3123,7 +3091,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     /**
      * Manually acknowledge all entries in the lost ledger.
      * - Since this is an uncommon event, we focus on maintainability. So we do not modify
-     *   {@link #individualDeletedMessages} and {@link #batchDeletedIndexes}, but call
+     *   {@link #ackState}, but call
      *   {@link #asyncDelete(Position, AsyncCallbacks.DeleteCallback, Object)}.
      * - This method is valid regardless of the consumer ACK type.
      * - If there is a consumer ack request after this event, it will also work.
@@ -3157,7 +3125,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     /**
      * Manually acknowledge all entries from startPosition to endPosition.
      * - Since this is an uncommon event, we focus on maintainability. So we do not modify
-     *   {@link #individualDeletedMessages} and {@link #batchDeletedIndexes}, but call
+     *   {@link #ackState}, but call
      *   {@link #asyncDelete(Position, AsyncCallbacks.DeleteCallback, Object)}.
      * - This method is valid regardless of the consumer ACK type.
      * - If there is a consumer ack request after this event, it will also work.
@@ -3183,7 +3151,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 .log("Entries are lost, auto-acknowledging in subscription (autoSkipNonRecoverableData=true)");
         try {
             for (long i = startEntryId; i < endEntryId; i++) {
-                if (!individualDeletedMessages.contains(ledgerId, i)) {
+                if (!ackState.contains(ledgerId, i)) {
                     asyncDelete(PositionFactory.create(ledgerId, i), new AsyncCallbacks.DeleteCallback() {
                         @Override
                         public void deleteComplete(Object ctx) {
@@ -3286,6 +3254,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             if (newLedgerHandle == null) {
                 return;
             }
+            ackPersistence.onLedgerRollover();
             MarkDeleteEntry mdEntry = lastMarkDeleteEntry;
             // Created the ledger, now write the last position content
             persistPositionToLedger(newLedgerHandle, mdEntry, new VoidCallback() {
@@ -3378,180 +3347,52 @@ public class ManagedCursorImpl implements ManagedCursor {
         return stringProperties;
     }
 
-    private List<MessageRange> buildIndividualDeletedMessageRanges() {
-        lock.writeLock().lock();
-        try {
-            if (individualDeletedMessages.isEmpty()) {
-                this.individualDeletedMessagesSerializedSize = 0;
-                return Collections.emptyList();
-            }
-
-            AtomicInteger acksSerializedSize = new AtomicInteger(0);
-            List<MessageRange> rangeList = new ArrayList<>();
-            final int maxRanges = getConfig().getMaxUnackedRangesToPersist();
-            final MutableBoolean truncated = new MutableBoolean(false);
-
-            individualDeletedMessages.forEachRawRange((lowerKey, lowerValue, upperKey, upperValue) -> {
-                if (rangeList.size() >= maxRanges) {
-                    truncated.setTrue();
-                    return false;
-                }
-                MessageRange messageRange = new MessageRange();
-                messageRange.setLowerEndpoint()
-                        .setLedgerId(lowerKey)
-                        .setEntryId(lowerValue);
-                messageRange.setUpperEndpoint()
-                        .setLedgerId(upperKey)
-                        .setEntryId(upperValue);
-
-                acksSerializedSize.addAndGet(messageRange.getSerializedSize());
-                rangeList.add(messageRange);
-
-                return true;
-            });
-
-            this.individualDeletedMessagesSerializedSize = acksSerializedSize.get();
-            individualDeletedMessages.resetDirtyKeys();
-
-            if (truncated.booleanValue()) {
-                ledger.getFactory().getOpenTelemetryManagedCursorStats()
-                        .incrementPersistUnackedRangesTruncated(this);
-                if (lastCursorDataFullyPersistable.compareAndSet(true, false)) {
-                    int totalRanges = individualDeletedMessages.size();
-                    log.warn()
-                        .attr("totalRanges", totalRanges)
-                        .attr("maxRanges", maxRanges)
-                        .attr("truncated", totalRanges - rangeList.size())
-                        .log("Individually deleted message ranges exceed"
-                            + " managedLedgerMaxUnackedRangesToPersist."
-                            + " Acknowledged messages beyond this limit are not persisted"
-                            + " and will be replayed on broker restart."
-                            + " Consider raising managedLedgerMaxUnackedRangesToPersist,"
-                            + " verifying managedLedgerPersistIndividualAckAsLongArray=true (the default),"
-                            + " and setting managedCursorInfoCompressionType=LZ4 to reduce the persisted size.");
-                }
-            } else {
-                lastCursorDataFullyPersistable.compareAndSet(false, true);
-            }
-
-            return rangeList;
-        } finally {
-            lock.writeLock().unlock();
-        }
-    }
-
-    private List<BatchedEntryDeletionIndexInfo> buildBatchEntryDeletionIndexInfoList() {
-        lock.readLock().lock();
-        try {
-            if (batchDeletedIndexes == null || batchDeletedIndexes.isEmpty()) {
-                return Collections.emptyList();
-            }
-            List<BatchedEntryDeletionIndexInfo> result = new ArrayList<>();
-            final var iterator = batchDeletedIndexes.entrySet().iterator();
-            int maxIndexes = getConfig().getMaxBatchDeletedIndexToPersist();
-            while (iterator.hasNext() && result.size() < maxIndexes) {
-                final var entry = iterator.next();
-                BatchedEntryDeletionIndexInfo batchDeletedIndexInfo = new BatchedEntryDeletionIndexInfo();
-                batchDeletedIndexInfo.setPosition()
-                        .setLedgerId(entry.getKey().getLedgerId())
-                        .setEntryId(entry.getKey().getEntryId());
-                long[] array = entry.getValue().toLongArray();
-                for (long l : array) {
-                    batchDeletedIndexInfo.addDeleteSet(l);
-                }
-                result.add(batchDeletedIndexInfo);
-            }
-
-            if (iterator.hasNext()) {
-                ledger.getFactory().getOpenTelemetryManagedCursorStats()
-                        .incrementPersistBatchDeletedIndexesTruncated(this);
-                if (lastBatchDeletedIndexFullyPersistable.compareAndSet(true, false)) {
-                    int totalIndexes = batchDeletedIndexes.size();
-                    log.warn()
-                        .attr("totalIndexes", totalIndexes)
-                        .attr("maxIndexes", maxIndexes)
-                        .attr("truncated", totalIndexes - result.size())
-                        .log("Batch deleted indexes exceed"
-                            + " managedLedgerMaxBatchDeletedIndexToPersist."
-                            + " Partially acknowledged batch messages beyond this limit are not persisted"
-                            + " and will be replayed on broker restart."
-                            + " Consider raising managedLedgerMaxBatchDeletedIndexToPersist"
-                            + " and setting managedCursorInfoCompressionType=LZ4 to reduce the persisted size.");
-                }
-            } else {
-                lastBatchDeletedIndexFullyPersistable.compareAndSet(false, true);
-            }
-
-            return result;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
     void persistPositionToLedger(final LedgerHandle lh, MarkDeleteEntry mdEntry, final VoidCallback callback,
                                  boolean ignoreClosedStateAfterFailure) {
         Position position = mdEntry.newPosition;
-        PositionInfo pi = reusablePositionInfo;
-        pi.clear();
-        pi.setLedgerId(position.getLedgerId())
-                .setEntryId(position.getEntryId())
-                .addAllBatchedEntryDeletionIndexInfos(buildBatchEntryDeletionIndexInfoList())
-                .addAllProperties(buildPropertiesMap(mdEntry.properties));
+        ackPersistence.persist(lh, position, mdEntry.properties, ackState)
+                .whenComplete((result, error) -> {
+                    if (error == null) {
+                        positionPersistedToLedger(lh, position, result.totalBytes(), callback);
+                    } else {
+                        positionPersistenceToLedgerFailed(lh, position, mdEntry, callback,
+                                ignoreClosedStateAfterFailure,
+                                FutureUtil.unwrapCompletionException(error));
+                    }
+                });
+    }
 
-        Map<Long, long[]> internalRanges = null;
-        if (getConfig().isPersistIndividualAckAsLongArray()) {
-            lock.readLock().lock();
-            try {
-                internalRanges = individualDeletedMessages.toRanges(getConfig().getMaxUnackedRangesToPersist());
-            } catch (Exception e) {
-                log.warn().exception(e).log("Failed to serialize individualDeletedMessages");
-            } finally {
-                lock.readLock().unlock();
-            }
+
+    private void positionPersistedToLedger(LedgerHandle ledgerHandle, Position position, long persistedSize,
+                                           VoidCallback callback) {
+        log.debug()
+                .attr("position", position)
+                .attr("ledgerId", ledgerHandle.getId())
+                .log("Updated position in meta-ledger");
+
+        rolloverLedgerIfNeeded(ledgerHandle);
+        mbean.persistToLedger(true);
+        mbean.addWriteCursorLedgerSize(persistedSize);
+        callback.operationComplete();
+    }
+
+    private void positionPersistenceToLedgerFailed(LedgerHandle ledgerHandle, Position position,
+                                                   MarkDeleteEntry mdEntry, VoidCallback callback,
+                                                   boolean ignoreClosedStateAfterFailure, Throwable error) {
+        if (!ignoreClosedStateAfterFailure && state.isClosed()) {
+            // After closing the cursor, an in-progress persistence task can fail with LedgerClosedException.
+            callback.operationFailed(new CursorAlreadyClosedException(String.format("%s %s skipped this"
+                    + " persistence, because the cursor already closed", ledger.getName(), name)));
+            return;
         }
-        if (internalRanges != null && !internalRanges.isEmpty()) {
-            pi.addAllIndividualDeletedMessageRanges(buildLongPropertiesMap(internalRanges));
-        } else {
-            pi.addAllIndividualDeletedMessages(buildIndividualDeletedMessageRanges());
-        }
-
-        log.debug().attr("ledgerId", lh.getId()).attr("position", position).log("Appending to cursor ledger");
-
-        requireNonNull(lh);
-        byte[] data = pi.toByteArray();
-        lh.asyncAddEntry(data, (rc, lh1, entryId, ctx) -> {
-            if (rc == BKException.Code.OK) {
-                log.debug()
-                        .attr("position", position)
-                        .attr("ledgerId", lh1.getId())
-                        .log("Updated position in meta-ledger");
-
-                rolloverLedgerIfNeeded(lh1);
-
-                mbean.persistToLedger(true);
-                mbean.addWriteCursorLedgerSize(data.length);
-                callback.operationComplete();
-            } else {
-                if (!ignoreClosedStateAfterFailure && state.isClosed()) {
-                    // After closed the cursor, the in-progress persistence task will get a
-                    // BKException.Code.LedgerClosedException.
-                    callback.operationFailed(new CursorAlreadyClosedException(String.format("%s %s skipped this"
-                            + " persistence, because the cursor already closed", ledger.getName(), name)));
-                    return;
-                }
-                log.warn()
-                        .attr("position", position)
-                        .attr("ledgerId", lh1.getId())
-                        .attr("errorMessage", BKException.getMessage(rc))
-                        .log("Error updating position in meta-ledger");
-                // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
-                // in the meantime the mark-delete will be queued.
-                STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
-
-                // Before giving up, try to persist the position in the metadata store.
-                persistPositionToMetaStore(mdEntry, callback);
-            }
-        }, null);
+        log.warn()
+                .attr("position", position)
+                .attr("ledgerId", ledgerHandle.getId())
+                .exception(error)
+                .log("Error updating position in meta-ledger");
+        // A write error fences the ledger. Create a new one while persisting the position in the metadata store.
+        STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
+        persistPositionToMetaStore(mdEntry, callback);
     }
 
     public boolean periodicRollover() {
@@ -3637,7 +3478,17 @@ public class ManagedCursorImpl implements ManagedCursor {
                 // At this point the position had already been safely markdeleted
                 callback.operationComplete();
 
-                asyncDeleteLedger(oldLedger);
+                // Delete old cursor ledger only when DE+CM is NOT active — DE+CM keeps
+                // cross-ledger references to old DEs. Old ledger GC is deferred.
+                if (ackPersistence.shouldGcOldCursorLedgerOnRollover()) {
+                    asyncDeleteLedger(oldLedger);
+                } else if (oldLedger != null) {
+                    oldCursorLedgerIds.add(oldLedger.getId());
+                    // Compute oldest referenced cursor ledger from CM's DE index.
+                    // Ledgers below this threshold can be safely deleted.
+                    updateOldestReferencedCursorLedger();
+                    gcOldCursorLedgers();
+                }
             }
 
             @Override
@@ -3648,6 +3499,46 @@ public class ManagedCursorImpl implements ManagedCursor {
                 deleteLedgerAsync(lh).thenRun(() -> callback.operationFailed(e));
             }
         }, false);
+    }
+
+    /**
+     * Compute the minimum cursorLedgerId referenced by the current CM index.
+     * Called after rollover to determine which old cursor ledgers are safe to GC.
+     */
+    private void updateOldestReferencedCursorLedger() {
+        long min = ackPersistence.getOldestReferencedCursorLedgerId();
+        if (min > 0) {
+            oldestReferencedCursorLedgerId = min;
+        }
+    }
+
+    /**
+     * Delete old cursor ledgers that are no longer referenced by any DE in the current CM.
+     * Safe to call from any callback thread — uses concurrent set + async delete.
+     */
+    private void gcOldCursorLedgers() {
+        if (oldestReferencedCursorLedgerId == Long.MAX_VALUE) {
+            return;
+        }
+        var toDelete = new java.util.ArrayList<Long>();
+        var it = oldCursorLedgerIds.iterator();
+        while (it.hasNext()) {
+            long id = it.next();
+            if (id < oldestReferencedCursorLedgerId) {
+                toDelete.add(id);
+                it.remove();
+            }
+        }
+        for (long id : toDelete) {
+            log.debug().attr("ledgerId", id).log("GC old cursor ledger — no longer referenced by CM");
+            bookkeeper.asyncDeleteLedger(id, (rc, ctx) -> {
+                if (rc != BKException.Code.OK) {
+                    log.warn().attr("ledgerId", id)
+                            .attr("errorMessage", BKException.getMessage(rc))
+                            .log("Failed to GC old cursor ledger");
+                }
+            }, null);
+        }
     }
 
     /**
@@ -3896,7 +3787,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public String getIndividuallyDeletedMessages() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.toString();
+            return ackState.toString();
         } finally {
             lock.readLock().unlock();
         }
@@ -3904,7 +3795,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @VisibleForTesting
     public LongPairRangeSet<Position> getIndividuallyDeletedMessagesSet() {
-        return individualDeletedMessages;
+        return ackState.getIndividualDeletedMessages();
     }
 
     public Position processIndividuallyDeletedMessagesAndGetMarkDeletedPosition(
@@ -3913,7 +3804,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         lock.readLock().lock();
         try {
             mdp = markDeletePosition;
-            individualDeletedMessages.forEach(processor);
+            ackState.forEach(processor);
         } finally {
             lock.readLock().unlock();
         }
@@ -3934,22 +3825,13 @@ public class ManagedCursorImpl implements ManagedCursor {
     // it avoids unnecessary lock nesting.
     private boolean internalIsMessageDeleted(Position position) {
         return position.compareTo(markDeletePosition) <= 0
-                || individualDeletedMessages.contains(position.getLedgerId(), position.getEntryId());
+                || ackState.contains(position.getLedgerId(), position.getEntryId());
     }
 
     //this method will return a copy of the position's ack set
     @Override
     public long[] getBatchPositionAckSet(Position position) {
-        if (batchDeletedIndexes != null) {
-            final var bitSet = batchDeletedIndexes.get(position);
-            if (bitSet == null) {
-                return null;
-            } else {
-                return bitSet.toLongArray();
-            }
-        } else {
-            return null;
-        }
+        return ackState.getBatchPositionAckSet(position);
     }
 
     /**
@@ -3962,7 +3844,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public Position getNextAvailablePosition(Position position) {
         lock.readLock().lock();
         try {
-            Range<Position> range = individualDeletedMessages.rangeContaining(position.getLedgerId(),
+            Range<Position> range = ackState.rangeContaining(position.getLedgerId(),
                     position.getEntryId());
             if (range != null) {
                 Position nextPosition = range.upperEndpoint().getNext();
@@ -3983,7 +3865,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public boolean isIndividuallyDeletedEntriesEmpty() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.isEmpty();
+            return ackState.isEmpty();
         } finally {
             lock.readLock().unlock();
         }
@@ -4025,7 +3907,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     public Range<Position> getLastIndividualDeletedRange() {
         lock.readLock().lock();
         try {
-            return individualDeletedMessages.lastRange();
+            return ackState.lastRange();
         } finally {
             lock.readLock().unlock();
         }
@@ -4048,12 +3930,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public long[] getDeletedBatchIndexesAsLongArray(Position position) {
-        if (batchDeletedIndexes != null) {
-            final var bitSet = batchDeletedIndexes.get(position);
-            return bitSet == null ? null : bitSet.toLongArray();
-        } else {
-            return null;
-        }
+        return ackState.getBatchPositionAckSet(position);
     }
 
     @Override
@@ -4142,25 +4019,19 @@ public class ManagedCursorImpl implements ManagedCursor {
                 (NonDurableCursorImpl) ledger.newNonDurableCursor(getMarkDeletedPosition(), nonDurableCursorName);
         lock.readLock().lock();
         try {
-            if (individualDeletedMessages != null) {
-                this.individualDeletedMessages.forEach(range -> {
-                    newNonDurableCursor.individualDeletedMessages.addOpenClosed(
-                            range.lowerEndpoint().getLedgerId(),
-                            range.lowerEndpoint().getEntryId(),
-                            range.upperEndpoint().getLedgerId(),
-                            range.upperEndpoint().getEntryId());
-                    return true;
-                });
-            }
+            ackState.forEach(range -> {
+                newNonDurableCursor.ackState.addOpenClosed(
+                        range.lowerEndpoint().getLedgerId(),
+                        range.lowerEndpoint().getEntryId(),
+                        range.upperEndpoint().getLedgerId(),
+                        range.upperEndpoint().getEntryId());
+                return true;
+            });
         } finally {
             lock.readLock().unlock();
         }
-        if (batchDeletedIndexes != null) {
-            Objects.requireNonNull(newNonDurableCursor.batchDeletedIndexes);
-            for (final var entry : this.batchDeletedIndexes.entrySet()) {
-                newNonDurableCursor.batchDeletedIndexes.put(entry.getKey(), (BitSet) entry.getValue().clone());
-            }
-        }
+        ackState.forEachBatchDeletedIndex((pos, bitSet) ->
+                newNonDurableCursor.ackState.putBatchAck(pos, bitSet));
         return newNonDurableCursor;
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionRangeSet.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/PositionRangeSet.java
@@ -22,13 +22,17 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import io.github.merlimat.slog.Logger;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectSortedMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
@@ -282,6 +286,12 @@ class PositionRangeSet implements LongPairRangeSet<Position> {
         return internalBitSetMap;
     }
 
+    Map<Long, byte[]> toSerializedBitmaps() {
+        Map<Long, byte[]> serializedBitmaps = new HashMap<>(rangeBitmapMap.size());
+        rangeBitmapMap.forEach((ledgerId, bitmap) -> serializedBitmaps.put(ledgerId, bitmap.serialize()));
+        return serializedBitmaps;
+    }
+
     @Override
     public void build(Map<Long, long[]> internalRange) {
         rangeBitmapMap.clear();
@@ -289,6 +299,21 @@ class PositionRangeSet implements LongPairRangeSet<Position> {
 
         internalRange.forEach((ledgerId, ranges) -> {
             rangeBitmapMap.put(ledgerId.longValue(), LongBitmaps.deserializeFromLongArray(ranges));
+        });
+        invalidateCaches();
+    }
+
+    void buildFromSerializedBitmaps(Map<Long, byte[]> serializedBitmaps) {
+        rangeBitmapMap.clear();
+        resetDirtyKeys();
+
+        serializedBitmaps.forEach((ledgerId, serializedBitmap) -> {
+            ByteBuf buffer = Unpooled.wrappedBuffer(serializedBitmap);
+            try {
+                rangeBitmapMap.put(ledgerId.longValue(), LongBitmaps.deserialize(buffer));
+            } finally {
+                buffer.release();
+            }
         });
         invalidateCaches();
     }
@@ -453,7 +478,11 @@ class PositionRangeSet implements LongPairRangeSet<Position> {
     private void markDirty(long lowerLedgerId, long upperLedgerId) {
         // Original semantics: dirtyLedgers.addOpenClosed(k1, 0, k2, 0), which in LongPair ordering
         // is (k1, k2] on ledger ids. LongBitmap.add(from, to) is half-open [from, to), so shift both
-        // bounds. Same-ledger or inverted range is a no-op.
+        // bounds for cross-ledger acks.
+        //
+        // Same-ledger acks (the common individual-ack case) must also mark the ledger dirty;
+        // earlier code skipped them via `upperLedgerId <= lowerLedgerId`, which made the
+        // dirty tracker useless for the PIP-488 DE+CM flush path. Fixed here.
         //
         // Note: Ledger IDs are 64-bit longs, but LongBitmap supports unsigned 32-bit range [0, 2^32-1].
         // In practice, BookKeeper ledger IDs rarely exceed Integer.MAX_VALUE. If upperLedgerId exceeds
@@ -461,7 +490,7 @@ class PositionRangeSet implements LongPairRangeSet<Position> {
         // 1. The dirty tracker is an optimization hint for selective persistence
         // 2. Missing a dirty mark means conservative full-ledger write (safe, just slower)
         // 3. Real-world ledger IDs stay well within 32-bit range
-        if (upperLedgerId <= lowerLedgerId || lowerLedgerId < 0) {
+        if (lowerLedgerId < 0) {
             return;
         }
         if (lowerLedgerId >= Integer.MAX_VALUE || upperLedgerId > Integer.MAX_VALUE) {
@@ -471,7 +500,76 @@ class PositionRangeSet implements LongPairRangeSet<Position> {
                     .log("Skipping dirty tracking for ledger ID at/exceeding Integer.MAX_VALUE");
             return;
         }
+        if (upperLedgerId == lowerLedgerId) {
+            // Same-ledger ack: mark just this one ledger dirty.
+            dirtyLedgers.add(lowerLedgerId, lowerLedgerId + 1);
+            return;
+        }
+        if (upperLedgerId < lowerLedgerId) {
+            return;
+        }
+        // Cross-ledger: (lowerLedgerId, upperLedgerId] → dirty range [lowerLedgerId+1, upperLedgerId]
         dirtyLedgers.add(lowerLedgerId + 1, upperLedgerId + 1);
+    }
+
+    /**
+     * Returns a snapshot of currently-dirty ledger IDs and clears the dirty tracker.
+     * Used by the DE+CM flush path to know which ledgers need a new DE entry.
+     *
+     * <p>The returned set is mutable; the caller owns it.
+     */
+    Set<Long> snapshotAndClearDirtyLedgers() {
+        Set<Long> snapshot = new HashSet<>();
+        dirtyLedgers.forEachLong(snapshot::add);
+        dirtyLedgers.clear();
+        return snapshot;
+    }
+
+    /**
+     * Restores dirty markers for the given ledgers. Used to roll back a failed DE append
+     * so the next flush retries the same ledgers.
+     */
+    void restoreDirtyLedgers(Set<Long> ledgerIds) {
+        for (long ledgerId : ledgerIds) {
+            if (ledgerId >= 0 && ledgerId <= Integer.MAX_VALUE) {
+                dirtyLedgers.add(ledgerId, ledgerId + 1);
+            }
+        }
+    }
+
+    /**
+     * Returns the RoaringBitmap native serialization for a single ledger, or {@code null}
+     * if the ledger has no individual ack state. Used by the DE+CM flush path to build
+     * one DE per dirty ledger.
+     */
+    byte[] bitmapOf(long ledgerId) {
+        LongBitmap bitmap = rangeBitmapMap.get(ledgerId);
+        return bitmap == null ? null : bitmap.serialize();
+    }
+
+    /**
+     * Marks a ledger as dirty without requiring an individual ack mutation. Used when
+     * batch-level ack updates occur on a ledger that has no new individual ack — the
+     * next DE+CM flush must still write a DE for that ledger to persist the batch ack.
+     */
+    void markExternalDirty(long ledgerId) {
+        if (enableMultiEntry && ledgerId >= 0 && ledgerId <= Integer.MAX_VALUE) {
+            dirtyLedgers.add(ledgerId, ledgerId + 1);
+        }
+    }
+
+    /**
+     * Mark every ledger that currently has ack state as dirty. Used before cursor-ledger
+     * rollover so the new ledger gets a full set of DE entries referencing the new
+     * cursor ledger (not the old one that is about to be deleted).
+     */
+    void markAllDirty() {
+        if (!enableMultiEntry) return;
+        rangeBitmapMap.forEach((ledgerId, bitmap) -> {
+            if (!bitmap.isEmpty() && ledgerId >= 0 && ledgerId <= Integer.MAX_VALUE) {
+                dirtyLedgers.add(ledgerId, ledgerId + 1);
+            }
+        });
     }
 
     private boolean isValid(long ledgerId, long entryId) {

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -75,15 +75,21 @@ message ManagedLedgerInfo {
 message PositionInfo {
     required int64 ledgerId = 1;
     required int64 entryId = 2;
-    repeated MessageRange individualDeletedMessages = 3;
+    repeated MessageRange individualDeletedMessages = 3; // [deprecated] use individualDeletedMessageRanges
 
-    // Additional custom properties associated with
-    // the current cursor position
     repeated LongProperty properties = 4;
 
-    // Store which index in the batch message has been deleted
     repeated BatchedEntryDeletionIndexInfo batchedEntryDeletionIndexInfo = 5;
     repeated LongListMap individualDeletedMessageRanges = 6;
+
+    optional CursorStateChunk cursorStateChunk = 7;
+}
+
+// Chunk envelope for splitting a large PositionInfo across multiple BK entries.
+message CursorStateChunk {
+    optional int32 partIndex = 1;
+    optional int32 partCount = 2;
+    optional bytes payload = 3;
 }
 
 message NestedPositionInfo {
@@ -94,6 +100,7 @@ message NestedPositionInfo {
 message LongListMap {
     required int64 key = 1;
     repeated int64 values  = 2;
+    optional bytes bitmap = 3; // RoaringBitmap serialization (per-ledger ack state)
 }
 
 message MessageRange {
@@ -140,6 +147,11 @@ message ManagedCursorInfo {
     // Additional custom properties associated with
     // the cursor
     repeated StringProperty cursorProperties = 8;
+
+    // Location of the most recent Checkpoint Marker in the cursor ledger.
+    // When present, recovery reads this entry directly instead of scanning backwards.
+    optional int64 lastCmCursorLedgerId = 9;
+    optional int64 lastCmEntryId = 10;
 }
 
 enum CompressionType {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/CursorWalTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/CursorWalTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.mledger.proto.CursorStateChunk;
+import org.apache.bookkeeper.mledger.proto.PositionInfo;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link CursorWal} covering the three paths that the end-to-end
+ * {@code ManagedCursorTest} cases do not exercise:
+ *
+ * <ol>
+ *   <li>Partial-write recovery (broker crash after N part chunks but before commit chunk) —
+ *       exercises {@code scanBackForCommit} / {@code scanBackBatched}.</li>
+ *   <li>partIndex continuity broken — exercises the
+ *       {@code "Part index continuity broken"} throw branch.</li>
+ *   <li>Exact {@code data.length == maxEntrySize} boundary — single entry vs first chunked form.</li>
+ * </ol>
+ */
+public class CursorWalTest extends MockedBookKeeperTestCase {
+
+    private static final byte[] PASSWORD = "test".getBytes();
+
+    private LedgerHandle newLedger() throws BKException, InterruptedException {
+        return bkc.createLedger(3, 3, DigestType.CRC32C, PASSWORD);
+    }
+
+    private static PositionInfo newPiWithPayload(int desiredSizeBytes) {
+        // Pad with LongListMap entries (~12 bytes each) until we reach the desired payload size.
+        PositionInfo pi = new PositionInfo().setLedgerId(1).setEntryId(1);
+        long key = 0;
+        while (pi.toByteArray().length < desiredSizeBytes) {
+            pi.addIndividualDeletedMessageRange().setKey(key++).addValue(0xFFFF_FFFFL);
+        }
+        return pi;
+    }
+
+    /**
+     * Append a full group, then write a dangling part chunk (no commit) to simulate a broker
+     * crash mid-append. {@code readLatest} must skip the orphan and return the first group.
+     */
+    @Test(timeOut = 20000)
+    public void testPartialChunkGroupRecoverFromPreviousCommit() throws Exception {
+        CursorWal wal = new CursorWal(1024);
+
+        PositionInfo first = new PositionInfo().setLedgerId(100).setEntryId(50);
+        first.addIndividualDeletedMessageRange().setKey(7L).addValue(0xABCDL);
+
+        try (LedgerHandle lh = newLedger()) {
+            // Write group A in full.
+            wal.append(lh, first).get(5, TimeUnit.SECONDS);
+
+            // Now write an orphan part chunk (partIndex = 0, no commit to follow).
+            PositionInfo orphan = new PositionInfo().setLedgerId(100).setEntryId(51);
+            orphan.setCursorStateChunk()
+                    .setPartIndex(0)
+                    .setPartCount(2)
+                    .setPayload(new byte[]{1, 2, 3, 4});
+            lh.addEntry(orphan.toByteArray());
+
+            CursorWal.RecoveredState state =
+                    wal.recover(lh).get(5, TimeUnit.SECONDS);
+
+            // Recovery must have skipped the orphan and replayed group A.
+            assertThat(state.positionInfo().hasCursorStateChunk()).isFalse();
+            assertThat(state.positionInfo().getLedgerId()).isEqualTo(100);
+            assertThat(state.positionInfo().getEntryId()).isEqualTo(50);
+            assertThat(state.positionInfo().getIndividualDeletedMessageRangesCount()).isEqualTo(1);
+            assertThat(state.positionInfo().getIndividualDeletedMessageRangeAt(0).getKey())
+                    .isEqualTo(7L);
+        }
+    }
+
+    /**
+     * Build a chunk group by hand with deliberately broken partIndex continuity at position 1
+     * (partIndex jumps 0 → 5 instead of 0 → 1). {@code readLatest} must fail rather than
+     * silently assemble corrupted state.
+     */
+    @Test(timeOut = 20000)
+    public void testPartIndexContinuityFailsRecovery() throws Exception {
+        try (LedgerHandle lh = newLedger()) {
+            // Part 0: valid, partIndex=0, partCount=2.
+            PositionInfo part0 = new PositionInfo().setLedgerId(1).setEntryId(1);
+            part0.setCursorStateChunk()
+                    .setPartIndex(0)
+                    .setPartCount(2)
+                    .setPayload(new byte[]{1, 2, 3, 4});
+            lh.addEntry(part0.toByteArray());
+
+            // Part 1: deliberately broken partIndex (5 instead of 1).
+            PositionInfo part1Broken = new PositionInfo().setLedgerId(1).setEntryId(1);
+            part1Broken.setCursorStateChunk()
+                    .setPartIndex(5)
+                    .setPartCount(2)
+                    .setPayload(new byte[]{5, 6, 7, 8});
+            lh.addEntry(part1Broken.toByteArray());
+
+            // Commit chunk (partIndex == partCount == 2).
+            PositionInfo commit = new PositionInfo().setLedgerId(1).setEntryId(1);
+            commit.setCursorStateChunk()
+                    .setPartIndex(2)
+                    .setPartCount(2);
+            lh.addEntry(commit.toByteArray());
+
+            assertThatThrownBy(() -> CursorWal.readLatest(lh).get(5, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Part index continuity broken");
+        }
+    }
+
+    /**
+     * At exactly {@code data.length == maxEntrySize} we must take the single-entry path
+     * (no {@link CursorStateChunk} envelope). At {@code maxEntrySize == data.length - 1}
+     * (when ≥ 1024) we must take the chunked path.
+     */
+    @Test(timeOut = 20000)
+    public void testExactBoundarySingleVsChunked() throws Exception {
+        // Construct a PositionInfo whose serialized form is comfortably above 1024 bytes
+        // (the minimum maxEntrySize), so we can test both sides of the boundary.
+        PositionInfo pi = new PositionInfo().setLedgerId(42).setEntryId(7);
+        for (long key = 0; key < 200; key++) {
+            pi.addIndividualDeletedMessageRange().setKey(key).addValue(0xFFFF_FFFFL);
+        }
+        int dataLen = pi.toByteArray().length;
+        assertThat(dataLen).isGreaterThan(1024);
+
+        // Case 1: maxEntrySize == dataLen → single entry, no envelope.
+        try (LedgerHandle lh1 = newLedger()) {
+            CursorWal wal = new CursorWal(dataLen);
+            wal.append(lh1, pi).get(5, TimeUnit.SECONDS);
+
+            CursorWal.RecoveredState state =
+                    CursorWal.readLatest(lh1).get(5, TimeUnit.SECONDS);
+            assertThat(state.positionInfo().hasCursorStateChunk()).isFalse();
+            assertThat(state.positionInfo().getIndividualDeletedMessageRangesCount())
+                    .isEqualTo(pi.getIndividualDeletedMessageRangesCount());
+        }
+
+        // Case 2: maxEntrySize == dataLen - 1 → chunked, multiple entries.
+        int chunkedMax = Math.max(1024, dataLen - 1);
+        try (LedgerHandle lh2 = newLedger()) {
+            CursorWal wal = new CursorWal(chunkedMax);
+            wal.append(lh2, pi).get(5, TimeUnit.SECONDS);
+
+            // The very last entry must be a commit chunk.
+            long lac = lh2.getLastAddConfirmed();
+            assertThat(lac).isGreaterThan(0);
+
+            CursorWal.RecoveredState state =
+                    CursorWal.readLatest(lh2).get(5, TimeUnit.SECONDS);
+            // Recovered PositionInfo comes from reassembled bytes, so it is not the wrapper.
+            assertThat(state.positionInfo().hasCursorStateChunk()).isFalse();
+            assertThat(state.positionInfo().getIndividualDeletedMessageRangesCount())
+                    .isEqualTo(pi.getIndividualDeletedMessageRangesCount());
+            // Sanity: last entry on the ledger IS the commit chunk (partIndex == partCount).
+            try (LedgerHandle read = bkc.openLedgerNoRecovery(
+                    lh2.getId(), DigestType.CRC32C, PASSWORD)) {
+                PositionInfo lastPi = new PositionInfo();
+                lastPi.parseFrom(read.readEntries(lac, lac).nextElement().getEntry());
+                assertThat(lastPi.hasCursorStateChunk()).isTrue();
+                CursorStateChunk csc = lastPi.getCursorStateChunk();
+                assertThat(csc.getPartIndex()).isEqualTo(csc.getPartCount());
+            }
+        }
+    }
+}

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -4714,6 +4714,415 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(deletedIndexes.get(0).getEnd(), 3);
     }
 
+    @Test(timeOut = 30000)
+    public void testMultiEntryIndividualAckStatePersistAndRecover() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithMultipleEntriesEnabled(true);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setMaxBatchDeletedIndexToPersist(1000);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_multi_entry_individual_ack_state";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 320; i++) {
+            positions.add(ledger.addEntry(("entry-" + i).getBytes(Encoding)));
+        }
+
+        Map<String, Long> properties = Map.of("checkpoint", 42L);
+        cursor.markDelete(positions.get(0), properties);
+        for (int i = 2; i < 180; i += 2) {
+            cursor.delete(positions.get(i));
+        }
+        for (int i = 200; i < 280; i++) {
+            deleteBatchIndex(cursor, positions.get(i), 64,
+                    Lists.newArrayList(new IntRange().setStart(1).setEnd(31)));
+        }
+        assertThat(cursor.getDeletedBatchIndexesAsLongArray(positions.get(240))).isNotEmpty();
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        ledger.close();
+
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(0));
+        assertThat(cursor.getProperties()).containsEntry("checkpoint", 42L);
+        assertThat(cursor.isMessageDeleted(positions.get(100))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(101))).isFalse();
+        List<IntRange> recoveredBatchIndexes =
+                getAckedIndexRange(cursor.getDeletedBatchIndexesAsLongArray(positions.get(240)), 64);
+        assertThat(recoveredBatchIndexes).hasSize(1);
+        assertThat(recoveredBatchIndexes.get(0).getStart()).isEqualTo(1);
+        assertThat(recoveredBatchIndexes.get(0).getEnd()).isEqualTo(31);
+        ledger.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testBatchIndexesRecoverFromMetadataStoreAfterCursorLedgerFailure() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithMultipleEntriesEnabled(true);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_batch_indexes_metadata_fallback";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            positions.add(ledger.addEntry(("entry-" + i).getBytes(Encoding)));
+        }
+
+        cursor.markDelete(positions.get(0));
+        ManagedCursorImpl cursorBeforeFallback = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeFallback.getCursorLedger()).isNotNegative());
+        assertThat(cursor.closeCursorLedger()).isTrue();
+        deleteBatchIndex(cursor, positions.get(5), 32,
+                Lists.newArrayList(new IntRange().setStart(4).setEnd(20)));
+        ledger.close();
+
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<IntRange> recoveredBatchIndexes =
+                getAckedIndexRange(cursor.getDeletedBatchIndexesAsLongArray(positions.get(5)), 32);
+        assertThat(recoveredBatchIndexes).hasSize(1);
+        assertThat(recoveredBatchIndexes.get(0).getStart()).isEqualTo(4);
+        assertThat(recoveredBatchIndexes.get(0).getEnd()).isEqualTo(20);
+        ledger.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testLegacyLongArrayWithSingleAckHole() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistIndividualAckAsLongArray(true);
+        config.setPersistentUnackedRangesWithMultipleEntriesEnabled(false);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_legacy_long_array_single_ack_hole";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int messageNumber = 1; messageNumber <= 5; messageNumber++) {
+            positions.add(ledger.addEntry(("message-" + messageNumber).getBytes(Encoding)));
+        }
+
+        cursor.delete(positions.get(0));
+        cursor.delete(positions.get(1));
+        cursor.delete(positions.get(3));
+        cursor.delete(positions.get(4));
+
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(1));
+        assertThat(cursor.getIndividuallyDeletedMessagesSet().asRanges())
+                .containsExactly(Range.openClosed(positions.get(2), positions.get(4)));
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        long cursorLedgerId = cursor.getCursorLedger();
+        ledger.close();
+
+        try (LedgerHandle cursorLedger = bkc.openLedgerNoRecovery(cursorLedgerId, DigestType.CRC32C,
+                config.getPassword())) {
+            PositionInfo persisted = CursorWal.readLatest(cursorLedger).get(5, TimeUnit.SECONDS)
+                    .positionInfo();
+
+            assertThat(persisted.getLedgerId()).isEqualTo(positions.get(1).getLedgerId());
+            assertThat(persisted.getEntryId()).isEqualTo(positions.get(1).getEntryId());
+            assertThat(persisted.hasCursorStateChunk()).isFalse();
+            assertThat(persisted.getIndividualDeletedMessageRangesCount()).isEqualTo(1);
+            assertThat(persisted.getIndividualDeletedMessageRangeAt(0).getKey())
+                    .isEqualTo(positions.get(0).getLedgerId());
+            assertThat(persisted.getIndividualDeletedMessageRangeAt(0).getValuesCount()).isEqualTo(2);
+            assertThat(persisted.getIndividualDeletedMessageRangeAt(0).getValueAt(0)).isEqualTo(24L);
+            assertThat(persisted.getIndividualDeletedMessageRangeAt(0).getValueAt(1)).isZero();
+            assertThat(BitSet.valueOf(new long[] {
+                    persisted.getIndividualDeletedMessageRangeAt(0).getValueAt(0),
+                    persisted.getIndividualDeletedMessageRangeAt(0).getValueAt(1)
+            }).toLongArray()).containsExactly(24L);
+        }
+
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(1));
+        assertThat(cursor.isMessageDeleted(positions.get(0))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(1))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(4))).isTrue();
+        ledger.close();
+    }
+
+    /**
+     * PIP-488 P2 end-to-end: enable DE+CM flag, perform individual acks, reopen, verify state.
+     * Mirrors the assertions of {@code testLegacyLongArrayWithSingleAckHole} but exercises the
+     * MDE + DE + CM write path and CM-fast-path recovery.
+     */
+    @Test(timeOut = 30000)
+    public void testDeCmIndividualAckPersistAndRecover() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithPerLedgerEntryEnabled(true);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_de_cm_individual_ack_persist_and_recover";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int messageNumber = 1; messageNumber <= 5; messageNumber++) {
+            positions.add(ledger.addEntry(("message-" + messageNumber).getBytes(Encoding)));
+        }
+
+        cursor.delete(positions.get(0));
+        cursor.delete(positions.get(1));
+        cursor.delete(positions.get(3));
+        cursor.delete(positions.get(4));
+
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(1));
+        assertThat(cursor.getIndividuallyDeletedMessagesSet().asRanges())
+                .containsExactly(Range.openClosed(positions.get(2), positions.get(4)));
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        long cursorLedgerId = cursor.getCursorLedger();
+        ledger.close();
+
+        // Reopen and verify recovery via the CM fast path.
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(1));
+        assertThat(cursor.isMessageDeleted(positions.get(0))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(1))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(4))).isTrue();
+        ledger.close();
+    }
+
+    /**
+     * PIP-488 P2 phase 2: with CM triggers suppressed (high maxTailEntries + long interval),
+     * only the first flush writes a CM. Subsequent flushes append MDE + DE only, and recovery
+     * must use the tail-replay path: scan back to the lone CM, forward-replay the tail to
+     * pick up every DE override.
+     */
+    @Test(timeOut = 30000)
+    public void testDeCmTailReplayRecovery() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithPerLedgerEntryEnabled(true);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_de_cm_tail_replay_recovery";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            positions.add(ledger.addEntry(("msg-" + i).getBytes(Encoding)));
+        }
+
+        cursor.markDelete(positions.get(0));
+        cursor.delete(positions.get(2));
+        cursor.delete(positions.get(4));
+        cursor.delete(positions.get(6));
+        cursor.delete(positions.get(8));
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        ledger.close();
+
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(0));
+        assertThat(cursor.isMessageDeleted(positions.get(1))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(4))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(5))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(6))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(7))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(8))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(9))).isFalse();
+        ledger.close();
+    }
+
+    /**
+     * PIP-488 P2: multi-msgLedger + cursor-ledger rollover. Writes enough entries to
+     * trigger at least one message-ledger rollover, acks across multiple msgLedgers, forces
+     * a cursor-ledger rollover by setting a small metadataMaxEntriesPerLedger, then reopens.
+     * Recovery must correctly restore individual ack state across all msgLedgers.
+     */
+    @Test(timeOut = 60000)
+    public void testDeCmMultiMsgLedgerWithCursorRollover() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithPerLedgerEntryEnabled(true);
+        config.setMaxEntriesPerLedger(5); // small message-ledger to trigger rollover quickly
+        config.setMetadataMaxEntriesPerLedger(100); // cursor ledger big enough for DE+CM
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_de_cm_multi_ledger_rollover";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        // Write 30 entries → at least 6 message ledgers (5 entries/ledger).
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            positions.add(ledger.addEntry(("msg-" + i).getBytes(Encoding)));
+        }
+
+        // Mark-delete the first entry, then individually ack scattered entries across ledgers.
+        cursor.markDelete(positions.get(0));
+        cursor.delete(positions.get(3));
+        cursor.delete(positions.get(7));
+        cursor.delete(positions.get(12));
+        cursor.delete(positions.get(20));
+        cursor.delete(positions.get(25));
+
+        // Verify pre-recovery state.
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(7))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(12))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(20))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(25))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(5))).isFalse();
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        ledger.close();
+
+        // Reopen and verify recovery across multiple msgLedgers + cursor-ledger rollover.
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(0));
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(7))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(12))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(20))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(25))).isTrue();
+        // Non-acked should not be deleted.
+        assertThat(cursor.isMessageDeleted(positions.get(5))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(10))).isFalse();
+        assertThat(cursor.isMessageDeleted(positions.get(15))).isFalse();
+
+        ledger.close();
+    }
+
+    /**
+     * PIP-488 P2: cursor ledger rollover + GC. After rollover, old cursor ledgers
+     * that are no longer referenced by any DE should be deleted. Verifies that ack state
+     * survives rollover and that old ledgers are eventually cleaned up.
+     */
+    @Test(timeOut = 60000)
+    public void testDeCmCursorLedgerRolloverAndGC() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithPerLedgerEntryEnabled(true);
+        config.setMaxEntriesPerLedger(5);
+        config.setMetadataMaxEntriesPerLedger(100);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_de_cm_cursor_rollover_gc";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            positions.add(ledger.addEntry(("msg-" + i).getBytes(Encoding)));
+        }
+
+        cursor.markDelete(positions.get(0));
+        cursor.delete(positions.get(2));
+        cursor.delete(positions.get(5));
+        cursor.delete(positions.get(10));
+        cursor.delete(positions.get(15));
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(5))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(10))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(15))).isTrue();
+
+        ledger.close();
+
+        // Reopen and verify recovery across any cursor-ledger rollovers.
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(0));
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(5))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(10))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(15))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(3))).isFalse();
+        ledger.close();
+    }
+
+    /**
+     * PIP-488 P2: batch ack persist + recovery via DE+CM. Verifies that batch ack entries
+     * stored inside DE entries are correctly recovered (the recoverFromCmFastPath must
+     * copy batchedEntryDeletionIndexInfo from each DE into the merged PositionInfo).
+     */
+    @Test(timeOut = 30000)
+    public void testDeCmBatchAckPersistAndRecover() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setPersistentUnackedRangesWithPerLedgerEntryEnabled(true);
+        config.setMaxUnackedRangesToPersistInMetadataStore(-1);
+        config.setMaxBatchDeletedIndexToPersist(1000);
+        config.setThrottleMarkDelete(0);
+
+        String ledgerName = "test_de_cm_batch_ack";
+        ManagedLedger ledger = factory.open(ledgerName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+        List<Position> positions = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            positions.add(ledger.addEntry(("entry-" + i).getBytes(Encoding)));
+        }
+
+        cursor.markDelete(positions.get(0));
+        cursor.delete(positions.get(2));
+        deleteBatchIndex(cursor, positions.get(5), 32,
+                Lists.newArrayList(new IntRange().setStart(1).setEnd(10)));
+        deleteBatchIndex(cursor, positions.get(7), 32,
+                Lists.newArrayList(new IntRange().setStart(5).setEnd(15)));
+
+        assertThat(cursor.getDeletedBatchIndexesAsLongArray(positions.get(5))).isNotEmpty();
+        assertThat(cursor.getDeletedBatchIndexesAsLongArray(positions.get(7))).isNotEmpty();
+
+        ManagedCursorImpl cursorBeforeRecovery = cursor;
+        Awaitility.await().untilAsserted(
+                () -> assertThat(cursorBeforeRecovery.getCursorLedger()).isNotNegative());
+        ledger.close();
+
+        ledger = factory.open(ledgerName, config);
+        cursor = (ManagedCursorImpl) ledger.openCursor("c1");
+
+        assertThat(cursor.getMarkDeletedPosition()).isEqualTo(positions.get(0));
+        assertThat(cursor.isMessageDeleted(positions.get(2))).isTrue();
+        assertThat(cursor.isMessageDeleted(positions.get(1))).isFalse();
+
+        List<IntRange> batch5 = getAckedIndexRange(
+                cursor.getDeletedBatchIndexesAsLongArray(positions.get(5)), 32);
+        assertThat(batch5).hasSize(1);
+        assertThat(batch5.get(0).getStart()).isEqualTo(1);
+        assertThat(batch5.get(0).getEnd()).isEqualTo(10);
+
+        List<IntRange> batch7 = getAckedIndexRange(
+                cursor.getDeletedBatchIndexesAsLongArray(positions.get(7)), 32);
+        assertThat(batch7).hasSize(1);
+        assertThat(batch7.get(0).getStart()).isEqualTo(5);
+        assertThat(batch7.get(0).getEnd()).isEqualTo(15);
+
+        ledger.close();
+    }
+
     private void deleteBatchIndex(ManagedCursor cursor, Position position, int batchSize,
                                   List<IntRange> deleteIndexes) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -2784,6 +2784,21 @@ public class ServiceConfiguration implements PulsarConfiguration {
         doc = "If enabled, the maximum \"acknowledgment holes\" will not be limited and \"acknowledgment holes\" "
                 + "are stored in multiple entries.")
     private boolean persistentUnackedRangesWithMultipleEntriesEnabled = false;
+
+    @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "Maximum BookKeeper entry payload used when cursor acknowledgment state is split into multiple "
+                    + "entries.",
+            minValue = 1024)
+    private int persistentUnackedRangesMaxEntrySize = maxMessageSize;
+
+    @FieldContext(
+            category = CATEGORY_STORAGE_ML,
+            doc = "When enabled, individual ack state is persisted as one Data Entry per dirty "
+                    + "message-ledger plus a Checkpoint Marker, instead of a single-snapshot "
+                    + "PositionInfo per flush.")
+    private boolean persistentUnackedRangesWithPerLedgerEntryEnabled = false;
+
     @Deprecated
     @FieldContext(
         category = CATEGORY_STORAGE_ML,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2281,6 +2281,8 @@ public class BrokerService implements Closeable {
                     .setPersistIndividualAckAsLongArray(serviceConfig.isManagedLedgerPersistIndividualAckAsLongArray());
             managedLedgerConfig.setPersistentUnackedRangesWithMultipleEntriesEnabled(
                     serviceConfig.isPersistentUnackedRangesWithMultipleEntriesEnabled());
+            managedLedgerConfig.setPersistentUnackedRangesMaxEntrySize(serviceConfig.getPersistentUnackedRangesMaxEntrySize())
+            managedLedgerConfig.setPersistentUnackedRangesWithPerLedgerEntryEnabled(serviceConfig.isPersistentUnackedRangesWithPerLedgerEntryEnabled());
             managedLedgerConfig.setMaxUnackedRangesToPersistInMetadataStore(
                     serviceConfig.getManagedLedgerMaxUnackedRangesToPersistInMetadataStore());
             managedLedgerConfig.setMaxEntriesPerLedger(serviceConfig.getManagedLedgerMaxEntriesPerLedger());


### PR DESCRIPTION
## Motivation

The current cursor persistence writes the entire subscription's individual ack state as a single `PositionInfo` entry per flush. This causes:

1. **Write amplification** — the full ack state is re-serialized every flush even when only one message-ledger changed
2. **Size cliff** — entries exceeding BookKeeper's 5MB limit are silently truncated by `managedLedgerMaxUnackedRangesToPersist`, losing acknowledged messages
3. **Recovery memory pressure** — the full state is loaded into memory at once on broker failover

## Modifications

Introduce a per-msgLedger **Data Entry (DE)** + **Checkpoint Marker (CM)** model, controlled by `persistentUnackedRangesWithPerLedgerEntryEnabled` (default `false`).

### Architecture

```
AckPersistence (interface)
├── LegacyAckPersistence          — single PositionInfo per flush (unchanged)
└── IndividualAckStatePersistence — DE + CM model
      └── CursorWal               — BK I/O (transparent chunking)

BitmapAckState (in-memory)
  ├── PositionRangeSet             — per-ledger RoaringBitmap + dirty tracking
  └── batch ack tracking
```

### Wire format (per-ledger-entry mode)

Each flush writes:
1. One **DE** per dirty message-ledger: RoaringBitmap ack state + batch ack indexes
2. One **CM**: mark-delete position + properties + DE index (`msgLedgerId → entry position`)

Recovery reads the last entry (always a CM), parallel-fetches all referenced DEs, and merges into a synthetic `PositionInfo`.

### Key features

- **Backward compatible**: feature flag default off, legacy path unchanged
- **Cross-ledger DE references**: old cursor ledgers are retained for CM references
- **Old cursor ledger GC**: based on `oldestReferencedCursorLedgerId`, cleaned up on mark-delete advance and rollover
- **ZK hint**: CM location piggybacked onto existing ZK writes for faster recovery
- **Transparent chunking**: `CursorWal` splits oversized entries via `CursorStateChunk` envelopes

### Proto changes

- `CursorStateChunk`: simplified to 3 fields (`partIndex`, `partCount`, `payload`)
- `LongListMap.bitmap`: RoaringBitmap native serialization field (field 3)
- `ManagedCursorInfo.lastCmCursorLedgerId/lastCmEntryId`: ZK recovery hint (fields 9, 10)

### Config changes

- `persistentUnackedRangesWithPerLedgerEntryEnabled` (default `false`): enables DE+CM model
- `persistentUnackedRangesMaxEntrySize` default raised from 1MB to `maxMessageSize` (5MB)

## Test plan

- [x] `testDeCmIndividualAckPersistAndRecover` — individual ack persist + recover via DE+CM
- [x] `testDeCmBatchAckPersistAndRecover` — batch ack entries stored inside DEs are correctly recovered
- [x] `testDeCmMultiMsgLedgerWithCursorRollover` — ack across multiple message-ledgers + recovery
- [x] `testDeCmCursorLedgerRolloverAndGC` — cursor ledger rollover with cross-ledger DE references + GC
- [x] `testMultiEntryIndividualAckStatePersistAndRecover` — bitmap serialization format via legacy path
- [x] `testLegacyLongArrayWithSingleAckHole` — legacy long-array format backward compatibility
- [x] `CursorWalTest` — chunked entry assembly, partial write recovery, partIndex continuity, boundary
- [x] Full `ManagedCursorTest` suite (84 tests) passes with zero regressions