### PR TITLE
[fix][broker] Authorize cluster listing requests

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ClustersBase.java
@@ -91,7 +91,8 @@ public class ClustersBase extends AdminResource {
             @ApiResponse(responseCode = "500", description = "Internal server error.")
     })
     public void getClusters(@Suspended AsyncResponse asyncResponse) {
-        clusterResources().listAsync()
+        validateBothSuperuserAndClusterOperation(null, ClusterOperation.LIST_CLUSTERS)
+                .thenCompose(__ -> clusterResources().listAsync())
                 .thenApply(HashSet::new)
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -257,7 +257,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
     @SuppressWarnings("unchecked")
     public void clusters() throws Exception {
         assertEquals(asyncRequests(ctx -> clusters.getClusters(ctx)), new HashSet<>());
-        verify(clusters, never()).validateSuperUserAccessAsync();
+        verify(clusters, times(1)).validateSuperUserAccessAsync();
 
         asyncRequests(ctx -> clusters.createCluster(ctx,
                 "use", ClusterDataImpl.builder().serviceUrl("http://broker.messaging.use.example.com:8080").build()));
@@ -458,7 +458,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         } catch (RestException e) {
             assertEquals(e.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }
-        verify(clusters, times(24)).validateSuperUserAccessAsync();
+        verify(clusters, times(28)).validateSuperUserAccessAsync();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ClusterEndpointsAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/ClusterEndpointsAuthorizationTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.admin;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import java.util.LinkedHashSet;
@@ -104,6 +105,20 @@ public class ClusterEndpointsAuthorizationTest extends MockedPulsarStandalone {
         super.close();
     }
 
+
+    @Test
+    public void testGetClusters() throws PulsarAdminException {
+        superUserAdmin.clusters().getClusters();
+        // test allow cluster operation
+        verify(spyAuthorizationService)
+                .allowClusterOperationAsync(isNull(), eq(ClusterOperation.LIST_CLUSTERS), any(), any(), any());
+        // fallback to superuser
+        verify(spyAuthorizationService).isSuperUser(any(), any());
+
+        // ---- test nobody
+        Assert.assertThrows(PulsarAdminException.NotAuthorizedException.class,
+                () -> nobodyAdmin.clusters().getClusters());
+    }
 
     @Test
     public void testGetCluster() throws PulsarAdminException {


### PR DESCRIPTION
Fixes #26100

### Motivation

`GET /admin/v2/clusters` returned cluster names without invoking the cluster authorization path. Authenticated users without the global cluster-list permission could therefore enumerate clusters.

### Modifications

Authorize cluster listing with `ClusterOperation.LIST_CLUSTERS` using the established `null` global-resource scope before reading cluster metadata. Added endpoint-level coverage for authorized and denied requests, including verification of the authorization operation and scope.

This is intentionally a v5/master-only behavior change: third-party `AuthorizationProvider` implementations must support this cluster operation and global `null` scope for non-superuser requests.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- `gradlew.bat --no-daemon --rerun-tasks :pulsar-broker:test -PtestRetryCount=0 --tests org.apache.pulsar.broker.admin.ClusterEndpointsAuthorizationTest`
- `gradlew.bat --no-daemon --rerun-tasks :pulsar-broker:spotlessJavaCheck :pulsar-broker:checkstyleMain :pulsar-broker:checkstyleTest`
- `git diff --check`

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment