### PR TITLE
[fix][broker] Prevent Key_Shared out-of-order replay starvation at the end of topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static org.apache.pulsar.broker.service.StickyKeyConsumerSelector.STICKY_KEY_HASH_NOT_SET;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NavigableSet;
@@ -43,7 +44,7 @@ public class MessageRedeliveryController {
     private final boolean allowOutOfOrderDelivery;
     private final boolean isClassicDispatcher;
     private final ConcurrentBitmapSortedLongPairSet messagesToRedeliver;
-    private final ConcurrentLongLongPairHashMap positionToStickyKeyHash;
+    private ConcurrentLongLongPairHashMap positionToStickyKeyHash;
     private final ConcurrentLongLongHashMap hashesRefCount;
 
     public MessageRedeliveryController(boolean allowOutOfOrderDelivery) {
@@ -54,14 +55,26 @@ public class MessageRedeliveryController {
         this.allowOutOfOrderDelivery = allowOutOfOrderDelivery;
         this.isClassicDispatcher = isClassicDispatcher;
         this.messagesToRedeliver = new ConcurrentBitmapSortedLongPairSet();
-        this.positionToStickyKeyHash = ConcurrentLongLongPairHashMap
-                .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
         if (!allowOutOfOrderDelivery) {
+            this.positionToStickyKeyHash = newPositionToStickyKeyHashMap();
             this.hashesRefCount = ConcurrentLongLongHashMap
                     .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
         } else {
+            this.positionToStickyKeyHash = null;
             this.hashesRefCount = null;
         }
+    }
+
+    private static ConcurrentLongLongPairHashMap newPositionToStickyKeyHashMap() {
+        return ConcurrentLongLongPairHashMap.newBuilder()
+                .concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
+    }
+
+    private ConcurrentLongLongPairHashMap ensurePositionToStickyKeyHashMap() {
+        if (positionToStickyKeyHash == null) {
+            positionToStickyKeyHash = newPositionToStickyKeyHashMap();
+        }
+        return positionToStickyKeyHash;
     }
 
     public void add(long ledgerId, long entryId) {
@@ -73,11 +86,13 @@ public class MessageRedeliveryController {
             if (!isClassicDispatcher && stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
                 throw new IllegalArgumentException("Sticky key hash is not set. It is required.");
             }
-        } else if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
-            // Non-Key_Shared dispatchers use the sentinel hash and do not need position-to-hash filtering.
+        } else if (isClassicDispatcher || stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
+            // Classic out-of-order dispatchers never read position hashes. Non-classic dispatchers normalize real
+            // sticky-key hashes away from the sentinel, so the sentinel denotes a replay position without a known hash.
             messagesToRedeliver.add(ledgerId, entryId);
             return;
         }
+        ConcurrentLongLongPairHashMap positionToStickyKeyHash = ensurePositionToStickyKeyHashMap();
         boolean inserted = positionToStickyKeyHash.putIfAbsent(ledgerId, entryId, stickyKeyHash, 0);
         if (!inserted) {
             positionToStickyKeyHash.put(ledgerId, entryId, stickyKeyHash, 0);
@@ -95,6 +110,10 @@ public class MessageRedeliveryController {
     }
 
     private void removeFromStickyKeyHash(long ledgerId, long entryId) {
+        ConcurrentLongLongPairHashMap positionToStickyKeyHash = this.positionToStickyKeyHash;
+        if (positionToStickyKeyHash == null) {
+            return;
+        }
         LongPair value = positionToStickyKeyHash.get(ledgerId, entryId);
         if (value != null) {
             boolean removed = positionToStickyKeyHash.remove(ledgerId, entryId, value.first, 0);
@@ -110,6 +129,10 @@ public class MessageRedeliveryController {
     }
 
     public Long getHash(long ledgerId, long entryId) {
+        ConcurrentLongLongPairHashMap positionToStickyKeyHash = this.positionToStickyKeyHash;
+        if (positionToStickyKeyHash == null) {
+            return null;
+        }
         LongPair value = positionToStickyKeyHash.get(ledgerId, entryId);
         if (value == null) {
             return null;
@@ -121,7 +144,8 @@ public class MessageRedeliveryController {
         boolean bitsCleared = messagesToRedeliver.removeUpTo(markDeleteLedgerId, markDeleteEntryId + 1);
         // Only remove the hashes when bits have been cleared. Removing hashes is a relatively expensive operation,
         // so we should only do it when necessary.
-        if (bitsCleared) {
+        ConcurrentLongLongPairHashMap positionToStickyKeyHash = this.positionToStickyKeyHash;
+        if (bitsCleared && positionToStickyKeyHash != null && !positionToStickyKeyHash.isEmpty()) {
             List<LongPair> keysToRemove = new ArrayList<>();
             positionToStickyKeyHash.forEach((ledgerId, entryId, stickyKeyHash, none) -> {
                 if (ledgerId < markDeleteLedgerId || (ledgerId == markDeleteLedgerId && entryId <= markDeleteEntryId)) {
@@ -139,7 +163,9 @@ public class MessageRedeliveryController {
     }
 
     public void clear() {
-        positionToStickyKeyHash.clear();
+        if (positionToStickyKeyHash != null) {
+            positionToStickyKeyHash.clear();
+        }
         if (!allowOutOfOrderDelivery) {
             hashesRefCount.clear();
         }
@@ -197,5 +223,10 @@ public class MessageRedeliveryController {
      */
     public int size() {
         return messagesToRedeliver.size();
+    }
+
+    @VisibleForTesting
+    boolean isPositionToStickyKeyHashInitialized() {
+        return positionToStickyKeyHash != null;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -44,7 +44,11 @@ public class MessageRedeliveryController {
     private final boolean allowOutOfOrderDelivery;
     private final boolean isClassicDispatcher;
     private final ConcurrentBitmapSortedLongPairSet messagesToRedeliver;
+    // Not final: under out-of-order delivery, whether this map is ever needed isn't known at construction time. Only a
+    // Key_Shared dispatcher records hashes; a plain Shared dispatcher never does. The map is therefore allocated when
+    // add() first receives a real hash. Classic out-of-order returns before that allocation regardless of the hash.
     private ConcurrentLongLongPairHashMap positionToStickyKeyHash;
+    // Final by contrast: this map is needed exactly when ordering is enforced, which is known at construction time.
     private final ConcurrentLongLongHashMap hashesRefCount;
 
     public MessageRedeliveryController(boolean allowOutOfOrderDelivery) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryController.java
@@ -43,7 +43,7 @@ public class MessageRedeliveryController {
     private final boolean allowOutOfOrderDelivery;
     private final boolean isClassicDispatcher;
     private final ConcurrentBitmapSortedLongPairSet messagesToRedeliver;
-    private final ConcurrentLongLongPairHashMap hashesToBeBlocked;
+    private final ConcurrentLongLongPairHashMap positionToStickyKeyHash;
     private final ConcurrentLongLongHashMap hashesRefCount;
 
     public MessageRedeliveryController(boolean allowOutOfOrderDelivery) {
@@ -54,13 +54,12 @@ public class MessageRedeliveryController {
         this.allowOutOfOrderDelivery = allowOutOfOrderDelivery;
         this.isClassicDispatcher = isClassicDispatcher;
         this.messagesToRedeliver = new ConcurrentBitmapSortedLongPairSet();
+        this.positionToStickyKeyHash = ConcurrentLongLongPairHashMap
+                .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
         if (!allowOutOfOrderDelivery) {
-            this.hashesToBeBlocked = ConcurrentLongLongPairHashMap
-                    .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
             this.hashesRefCount = ConcurrentLongLongHashMap
                     .newBuilder().concurrencyLevel(2).expectedItems(128).autoShrink(true).build();
         } else {
-            this.hashesToBeBlocked = null;
             this.hashesRefCount = null;
         }
     }
@@ -74,30 +73,32 @@ public class MessageRedeliveryController {
             if (!isClassicDispatcher && stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
                 throw new IllegalArgumentException("Sticky key hash is not set. It is required.");
             }
-            boolean inserted = hashesToBeBlocked.putIfAbsent(ledgerId, entryId, stickyKeyHash, 0);
-            if (!inserted) {
-                hashesToBeBlocked.put(ledgerId, entryId, stickyKeyHash, 0);
-            } else {
-                // Return -1 means the key was not present
-                long stored = hashesRefCount.get(stickyKeyHash);
-                hashesRefCount.put(stickyKeyHash, stored > 0 ? ++stored : 1);
-            }
+        } else if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
+            // Non-Key_Shared dispatchers use the sentinel hash and do not need position-to-hash filtering.
+            messagesToRedeliver.add(ledgerId, entryId);
+            return;
+        }
+        boolean inserted = positionToStickyKeyHash.putIfAbsent(ledgerId, entryId, stickyKeyHash, 0);
+        if (!inserted) {
+            positionToStickyKeyHash.put(ledgerId, entryId, stickyKeyHash, 0);
+        } else if (!allowOutOfOrderDelivery) {
+            // Return -1 means the key was not present
+            long stored = hashesRefCount.get(stickyKeyHash);
+            hashesRefCount.put(stickyKeyHash, stored > 0 ? ++stored : 1);
         }
         messagesToRedeliver.add(ledgerId, entryId);
     }
 
     public void remove(long ledgerId, long entryId) {
-        if (!allowOutOfOrderDelivery) {
-            removeFromHashBlocker(ledgerId, entryId);
-        }
+        removeFromStickyKeyHash(ledgerId, entryId);
         messagesToRedeliver.remove(ledgerId, entryId);
     }
 
-    private void removeFromHashBlocker(long ledgerId, long entryId) {
-        LongPair value = hashesToBeBlocked.get(ledgerId, entryId);
+    private void removeFromStickyKeyHash(long ledgerId, long entryId) {
+        LongPair value = positionToStickyKeyHash.get(ledgerId, entryId);
         if (value != null) {
-            boolean removed = hashesToBeBlocked.remove(ledgerId, entryId, value.first, 0);
-            if (removed) {
+            boolean removed = positionToStickyKeyHash.remove(ledgerId, entryId, value.first, 0);
+            if (removed && !allowOutOfOrderDelivery) {
                 long exists = hashesRefCount.get(value.first);
                 if (exists == 1) {
                     hashesRefCount.remove(value.first, exists);
@@ -109,7 +110,7 @@ public class MessageRedeliveryController {
     }
 
     public Long getHash(long ledgerId, long entryId) {
-        LongPair value = hashesToBeBlocked.get(ledgerId, entryId);
+        LongPair value = positionToStickyKeyHash.get(ledgerId, entryId);
         if (value == null) {
             return null;
         }
@@ -118,17 +119,17 @@ public class MessageRedeliveryController {
 
     public void removeAllUpTo(long markDeleteLedgerId, long markDeleteEntryId) {
         boolean bitsCleared = messagesToRedeliver.removeUpTo(markDeleteLedgerId, markDeleteEntryId + 1);
-        // only if bits have been clear, and we are not allowing out of order delivery, we need to remove the hashes
-        // removing hashes is a relatively expensive operation, so we should only do it when necessary
-        if (bitsCleared && !allowOutOfOrderDelivery) {
+        // Only remove the hashes when bits have been cleared. Removing hashes is a relatively expensive operation,
+        // so we should only do it when necessary.
+        if (bitsCleared) {
             List<LongPair> keysToRemove = new ArrayList<>();
-            hashesToBeBlocked.forEach((ledgerId, entryId, stickyKeyHash, none) -> {
+            positionToStickyKeyHash.forEach((ledgerId, entryId, stickyKeyHash, none) -> {
                 if (ledgerId < markDeleteLedgerId || (ledgerId == markDeleteLedgerId && entryId <= markDeleteEntryId)) {
                     keysToRemove.add(new LongPair(ledgerId, entryId));
                 }
             });
             for (LongPair longPair : keysToRemove) {
-                removeFromHashBlocker(longPair.first, longPair.second);
+                removeFromStickyKeyHash(longPair.first, longPair.second);
             }
         }
     }
@@ -138,8 +139,8 @@ public class MessageRedeliveryController {
     }
 
     public void clear() {
+        positionToStickyKeyHash.clear();
         if (!allowOutOfOrderDelivery) {
-            hashesToBeBlocked.clear();
             hashesRefCount.clear();
         }
         messagesToRedeliver.clear();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -340,6 +340,8 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             // instead issue a normal read that waits at the end of the topic for new entries. That would leave
             // deliverable messages stuck in the replay queue or the delayed delivery tracker until an unrelated event
             // (such as a consumer flow request) triggers another read, stalling dispatch (issue #21554).
+            // The former "allowOutOfOrderDelivery ||" escape here was dropped once ReplayPositionFilter started
+            // filtering out-of-order replay positions by available permits; don't re-add it without removing that.
             skipNextReplayToTriggerLookAhead = true;
             // skip backoff delay before reading ahead in the "look ahead" mode to prevent any additional latency
             skipNextBackoff = true;
@@ -585,11 +587,16 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         private final Map<Consumer, MutableInt> availablePermitsMap = new HashMap<>();
         // tracks the hashes that have been blocked during the filtering
         // it is necessary to block all later messages after a hash gets blocked so that ordering is preserved
-        private final Set<Long> alreadyBlockedHashes = new HashSet<>();
+        private final Set<Long> hashesBlockedForOrdering = new HashSet<>();
 
         @Override
         public boolean test(Position position) {
-            // lookup the sticky key hash for the entry at the replay position
+            // Out-of-order delivery relaxes ordering, not routing: filterAndGroupEntriesForDispatching selects the
+            // owning consumer by hash in both modes, so the hash is needed in both. It feeds the permit check below,
+            // which keeps this read's bounded budget (see MessageRedeliveryController#getMessagesToReplayNow) off
+            // positions that dispatch would only push straight back into the replay queue. Under out-of-order delivery,
+            // that check and the no-consumer check are the only live rejections here, and they made the
+            // "allowOutOfOrderDelivery ||" look-ahead escape removable.
             Long stickyKeyHash = redeliveryMessages.getHash(position.getLedgerId(), position.getEntryId());
             if (stickyKeyHash == null) {
                 // The sticky key hash is missing for delayed messages and positions added through hash-less
@@ -601,7 +608,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
             // check if the hash is already blocked, if so, then replaying of the position should be skipped
             // to preserve ordering
-            if (alreadyBlockedHashes.contains(stickyKeyHash)) {
+            if (hashesBlockedForOrdering.contains(stickyKeyHash)) {
                 return false;
             }
 
@@ -636,7 +643,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
         private void blockStickyKeyHashIfOrderingRequired(long stickyKeyHash) {
             if (!allowOutOfOrderDelivery) {
-                alreadyBlockedHashes.add(stickyKeyHash);
+                hashesBlockedForOrdering.add(stickyKeyHash);
             }
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -328,24 +328,18 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         acquirePermitsForDeliveredMessages(topic, cursor, totalEntries, totalMessagesSent, totalBytesSent);
 
         // trigger read more messages if necessary
-        if (triggerLookAhead.booleanValue() && (allowOutOfOrderDelivery || cursor.hasMoreEntries())) {
+        if (triggerLookAhead.booleanValue() && cursor.hasMoreEntries()) {
             // When all messages get filtered and no messages are sent, we should read more entries, "look ahead"
             // so that a possible next batch of messages might contain messages that can be dispatched.
             // This is done only when there's a consumer with available permits, and it's not able to make progress
             // because of blocked hashes. Without this rule we would be looking ahead in the stream while the
             // new consumers are not ready to accept the new messages,
             // therefore would be most likely only increase the distance between read-position and mark-delete position.
-            // When ordered delivery is required, look-ahead is engaged only when the cursor has more entries.
-            // Otherwise the next readMoreEntries call would skip replaying the replay queue and pulling due messages
-            // from the delayed delivery tracker, and instead issue a normal read that waits at the end of the topic
-            // for new entries. That would leave deliverable messages stuck in the replay queue or the delayed
-            // delivery tracker until an unrelated event (such as a consumer flow request) triggers another read,
-            // stalling dispatch (issue #21554).
-            // When out-of-order delivery is allowed, look-ahead is engaged unconditionally, as before. In that mode
-            // the replay queue doesn't track sticky key hashes, so the replay position filter cannot exclude
-            // messages for consumers without available permits, and each replay would re-read and discard the same
-            // undispatchable messages. Ending the cycle with a look-ahead attempt (that waits at the end of the
-            // topic when there is nothing to read) prevents such repeated read-and-discard loops.
+            // Look-ahead is engaged only when the cursor has more entries. Otherwise the next readMoreEntries call
+            // would skip replaying the replay queue and pulling due messages from the delayed delivery tracker, and
+            // instead issue a normal read that waits at the end of the topic for new entries. That would leave
+            // deliverable messages stuck in the replay queue or the delayed delivery tracker until an unrelated event
+            // (such as a consumer flow request) triggers another read, stalling dispatch (issue #21554).
             skipNextReplayToTriggerLookAhead = true;
             // skip backoff delay before reading ahead in the "look ahead" mode to prevent any additional latency
             // only skip the delay if there are more entries to read
@@ -596,13 +590,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
         @Override
         public boolean test(Position position) {
-            // if out of order delivery is allowed, then any position will be replayed
-            if (isAllowOutOfOrderDelivery()) {
-                return true;
-            }
             // lookup the sticky key hash for the entry at the replay position
             Long stickyKeyHash = redeliveryMessages.getHash(position.getLedgerId(), position.getEntryId());
-            if (stickyKeyHash == null) {
+            if (stickyKeyHash == null || stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
                 // the sticky key hash is missing for delayed messages, the filtering will happen at the time of
                 // dispatch after reading the entry from the ledger
                 log.debug()
@@ -612,7 +602,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
             // check if the hash is already blocked, if so, then replaying of the position should be skipped
             // to preserve ordering
-            if (alreadyBlockedHashes.contains(stickyKeyHash)) {
+            if (!allowOutOfOrderDelivery && alreadyBlockedHashes.contains(stickyKeyHash)) {
                 return false;
             }
 
@@ -620,7 +610,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Consumer consumer = selector.select(stickyKeyHash.intValue());
             // skip replaying the message position if there's no assigned consumer
             if (consumer == null) {
-                alreadyBlockedHashes.add(stickyKeyHash);
+                if (!allowOutOfOrderDelivery) {
+                    alreadyBlockedHashes.add(stickyKeyHash);
+                }
                 return false;
             }
 
@@ -630,14 +622,18 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                             k -> new MutableInt(getAvailablePermits(consumer)));
             // skip replaying the message position if the consumer has no available permits
             if (availablePermits.intValue() <= 0) {
-                alreadyBlockedHashes.add(stickyKeyHash);
+                if (!allowOutOfOrderDelivery) {
+                    alreadyBlockedHashes.add(stickyKeyHash);
+                }
                 return false;
             }
 
             if (drainingHashesRequired
                     && drainingHashesTracker.shouldBlockStickyKeyHash(consumer, stickyKeyHash.intValue())) {
                 // the hash is draining and the consumer is not the draining consumer
-                alreadyBlockedHashes.add(stickyKeyHash);
+                if (!allowOutOfOrderDelivery) {
+                    alreadyBlockedHashes.add(stickyKeyHash);
+                }
                 return false;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -342,8 +342,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             // (such as a consumer flow request) triggers another read, stalling dispatch (issue #21554).
             skipNextReplayToTriggerLookAhead = true;
             // skip backoff delay before reading ahead in the "look ahead" mode to prevent any additional latency
-            // only skip the delay if there are more entries to read
-            skipNextBackoff = cursor.hasMoreEntries();
+            skipNextBackoff = true;
             return true;
         }
 
@@ -592,9 +591,9 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
         public boolean test(Position position) {
             // lookup the sticky key hash for the entry at the replay position
             Long stickyKeyHash = redeliveryMessages.getHash(position.getLedgerId(), position.getEntryId());
-            if (stickyKeyHash == null || stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
-                // the sticky key hash is missing for delayed messages, the filtering will happen at the time of
-                // dispatch after reading the entry from the ledger
+            if (stickyKeyHash == null) {
+                // The sticky key hash is missing for delayed messages and positions added through hash-less
+                // redelivery paths. Filtering will happen at dispatch time after reading the entry from the ledger.
                 log.debug()
                         .attr("position", position)
                         .log("replay of entry at position doesn't contain sticky key hash.");
@@ -602,7 +601,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             }
             // check if the hash is already blocked, if so, then replaying of the position should be skipped
             // to preserve ordering
-            if (!allowOutOfOrderDelivery && alreadyBlockedHashes.contains(stickyKeyHash)) {
+            if (alreadyBlockedHashes.contains(stickyKeyHash)) {
                 return false;
             }
 
@@ -610,9 +609,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
             Consumer consumer = selector.select(stickyKeyHash.intValue());
             // skip replaying the message position if there's no assigned consumer
             if (consumer == null) {
-                if (!allowOutOfOrderDelivery) {
-                    alreadyBlockedHashes.add(stickyKeyHash);
-                }
+                blockStickyKeyHashIfOrderingRequired(stickyKeyHash);
                 return false;
             }
 
@@ -622,23 +619,25 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
                             k -> new MutableInt(getAvailablePermits(consumer)));
             // skip replaying the message position if the consumer has no available permits
             if (availablePermits.intValue() <= 0) {
-                if (!allowOutOfOrderDelivery) {
-                    alreadyBlockedHashes.add(stickyKeyHash);
-                }
+                blockStickyKeyHashIfOrderingRequired(stickyKeyHash);
                 return false;
             }
 
             if (drainingHashesRequired
                     && drainingHashesTracker.shouldBlockStickyKeyHash(consumer, stickyKeyHash.intValue())) {
                 // the hash is draining and the consumer is not the draining consumer
-                if (!allowOutOfOrderDelivery) {
-                    alreadyBlockedHashes.add(stickyKeyHash);
-                }
+                blockStickyKeyHashIfOrderingRequired(stickyKeyHash);
                 return false;
             }
 
             availablePermits.decrement();
             return true;
+        }
+
+        private void blockStickyKeyHashIfOrderingRequired(long stickyKeyHash) {
+            if (!allowOutOfOrderDelivery) {
+                alreadyBlockedHashes.add(stickyKeyHash);
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersClassic.java
@@ -554,8 +554,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
 
     @Override
     protected synchronized NavigableSet<Position> filterOutEntriesWillBeDiscarded(NavigableSet<Position> src) {
-        // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
-        // So skip this filter out.
+        // Keep the classic out-of-order behavior: replay positions are not filtered before reading.
         if (isAllowOutOfOrderDelivery()) {
             return src;
         }
@@ -603,8 +602,7 @@ public class PersistentStickyKeyDispatcherMultipleConsumersClassic
      */
     @Override
     protected boolean hasConsumersNeededNormalRead() {
-        // The variable "hashesToBeBlocked" and "recentlyJoinedConsumers" will be null if "isAllowOutOfOrderDelivery()",
-        // So the method "filterOutEntriesWillBeDiscarded" will filter out nothing, just return "true" here.
+        // Classic out-of-order replay filtering is bypassed, so normal reads do not need the ordered-mode escape check.
         if (isAllowOutOfOrderDelivery()) {
             return true;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryControllerTest.java
@@ -51,27 +51,27 @@ public class MessageRedeliveryControllerTest {
         ConcurrentBitmapSortedLongPairSet messagesToRedeliver =
                 (ConcurrentBitmapSortedLongPairSet) messagesToRedeliverField.get(controller);
 
-        Field hashesToBeBlockedField = MessageRedeliveryController.class.getDeclaredField("hashesToBeBlocked");
-        hashesToBeBlockedField.setAccessible(true);
-        ConcurrentLongLongPairHashMap hashesToBeBlocked = (ConcurrentLongLongPairHashMap) hashesToBeBlockedField
-                .get(controller);
+        Field positionToStickyKeyHashField = MessageRedeliveryController.class
+                .getDeclaredField("positionToStickyKeyHash");
+        positionToStickyKeyHashField.setAccessible(true);
+        ConcurrentLongLongPairHashMap positionToStickyKeyHash = (ConcurrentLongLongPairHashMap)
+                positionToStickyKeyHashField.get(controller);
 
         Field hashesRefCountField = MessageRedeliveryController.class.getDeclaredField("hashesRefCount");
         hashesRefCountField.setAccessible(true);
         ConcurrentLongLongHashMap hashesRefCount = (ConcurrentLongLongHashMap) hashesRefCountField.get(controller);
 
+        assertNotNull(positionToStickyKeyHash);
         if (allowOutOfOrderDelivery) {
-            assertNull(hashesToBeBlocked);
             assertNull(hashesRefCount);
         } else {
-            assertNotNull(hashesToBeBlocked);
             assertNotNull(hashesRefCount);
         }
 
         assertTrue(controller.isEmpty());
         assertEquals(messagesToRedeliver.size(), 0);
+        assertEquals(positionToStickyKeyHash.size(), 0);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 0);
             assertEquals(hashesRefCount.size(), 0);
         }
 
@@ -82,10 +82,10 @@ public class MessageRedeliveryControllerTest {
         assertEquals(messagesToRedeliver.size(), 2);
         assertTrue(messagesToRedeliver.contains(1, 1));
         assertTrue(messagesToRedeliver.contains(1, 2));
+        assertEquals(positionToStickyKeyHash.size(), 0);
+        assertFalse(positionToStickyKeyHash.containsKey(1, 1));
+        assertFalse(positionToStickyKeyHash.containsKey(1, 2));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 0);
-            assertFalse(hashesToBeBlocked.containsKey(1, 1));
-            assertFalse(hashesToBeBlocked.containsKey(1, 2));
             assertEquals(hashesRefCount.size(), 0);
         }
 
@@ -96,8 +96,8 @@ public class MessageRedeliveryControllerTest {
         assertEquals(messagesToRedeliver.size(), 0);
         assertFalse(messagesToRedeliver.contains(1, 1));
         assertFalse(messagesToRedeliver.contains(1, 2));
+        assertEquals(positionToStickyKeyHash.size(), 0);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 0);
             assertEquals(hashesRefCount.size(), 0);
         }
 
@@ -110,11 +110,11 @@ public class MessageRedeliveryControllerTest {
         assertTrue(messagesToRedeliver.contains(2, 1));
         assertTrue(messagesToRedeliver.contains(2, 2));
         assertTrue(messagesToRedeliver.contains(2, 3));
+        assertEquals(positionToStickyKeyHash.size(), 3);
+        assertEquals(positionToStickyKeyHash.get(2, 1).first, 100);
+        assertEquals(positionToStickyKeyHash.get(2, 2).first, 101);
+        assertEquals(positionToStickyKeyHash.get(2, 3).first, 101);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 3);
-            assertEquals(hashesToBeBlocked.get(2, 1).first, 100);
-            assertEquals(hashesToBeBlocked.get(2, 2).first, 101);
-            assertEquals(hashesToBeBlocked.get(2, 3).first, 101);
             assertEquals(hashesRefCount.size(), 2);
             assertEquals(hashesRefCount.get(100), 1);
             assertEquals(hashesRefCount.get(101), 2);
@@ -123,9 +123,9 @@ public class MessageRedeliveryControllerTest {
         controller.remove(2, 1);
         controller.remove(2, 2);
 
+        assertEquals(positionToStickyKeyHash.size(), 1);
+        assertEquals(positionToStickyKeyHash.get(2, 3).first, 101);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 1);
-            assertEquals(hashesToBeBlocked.get(2, 3).first, 101);
             assertEquals(hashesRefCount.size(), 1);
             assertEquals(hashesRefCount.get(100), -1);
             assertEquals(hashesRefCount.get(101), 1);
@@ -135,9 +135,8 @@ public class MessageRedeliveryControllerTest {
         assertTrue(controller.isEmpty());
         assertEquals(messagesToRedeliver.size(), 0);
         assertTrue(messagesToRedeliver.isEmpty());
+        assertEquals(positionToStickyKeyHash.size(), 0);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 0);
-            assertTrue(hashesToBeBlocked.isEmpty());
             assertEquals(hashesRefCount.size(), 0);
             assertTrue(hashesRefCount.isEmpty());
         }
@@ -156,12 +155,12 @@ public class MessageRedeliveryControllerTest {
         assertTrue(messagesToRedeliver.contains(2, 2));
         assertTrue(messagesToRedeliver.contains(3, 1));
         assertTrue(messagesToRedeliver.contains(3, 2));
+        assertEquals(positionToStickyKeyHash.size(), 4);
+        assertEquals(positionToStickyKeyHash.get(2, 1).first, 200);
+        assertEquals(positionToStickyKeyHash.get(2, 2).first, 201);
+        assertEquals(positionToStickyKeyHash.get(3, 1).first, 300);
+        assertEquals(positionToStickyKeyHash.get(3, 2).first, 301);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 4);
-            assertEquals(hashesToBeBlocked.get(2, 1).first, 200);
-            assertEquals(hashesToBeBlocked.get(2, 2).first, 201);
-            assertEquals(hashesToBeBlocked.get(3, 1).first, 300);
-            assertEquals(hashesToBeBlocked.get(3, 2).first, 301);
             assertEquals(hashesRefCount.size(), 4);
             assertEquals(hashesRefCount.get(200), 1);
             assertEquals(hashesRefCount.get(201), 1);
@@ -172,9 +171,9 @@ public class MessageRedeliveryControllerTest {
         controller.removeAllUpTo(3, 1);
         assertEquals(messagesToRedeliver.size(), 1);
         assertTrue(messagesToRedeliver.contains(3, 2));
+        assertEquals(positionToStickyKeyHash.size(), 1);
+        assertEquals(positionToStickyKeyHash.get(3, 2).first, 301);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 1);
-            assertEquals(hashesToBeBlocked.get(3, 2).first, 301);
             assertEquals(hashesRefCount.size(), 1);
             assertEquals(hashesRefCount.get(301), 1);
         }
@@ -182,8 +181,8 @@ public class MessageRedeliveryControllerTest {
         controller.removeAllUpTo(5, 10);
         assertTrue(controller.isEmpty());
         assertEquals(messagesToRedeliver.size(), 0);
+        assertEquals(positionToStickyKeyHash.size(), 0);
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesToBeBlocked.size(), 0);
             assertEquals(hashesRefCount.size(), 0);
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryControllerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/MessageRedeliveryControllerTest.java
@@ -18,20 +18,16 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.broker.service.StickyKeyConsumerSelector.STICKY_KEY_HASH_NOT_SET;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.TreeSet;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.PositionFactory;
-import org.apache.bookkeeper.util.collections.ConcurrentLongLongHashMap;
-import org.apache.pulsar.common.util.collections.ConcurrentLongLongPairHashMap;
-import org.apache.pulsar.utils.ConcurrentBitmapSortedLongPairSet;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -43,102 +39,61 @@ public class MessageRedeliveryControllerTest {
     }
 
     @Test(dataProvider = "allowOutOfOrderDelivery", timeOut = 10000)
-    public void testAddAndRemove(boolean allowOutOfOrderDelivery) throws Exception {
+    public void testAddAndRemove(boolean allowOutOfOrderDelivery) {
         MessageRedeliveryController controller = new MessageRedeliveryController(allowOutOfOrderDelivery);
 
-        Field messagesToRedeliverField = MessageRedeliveryController.class.getDeclaredField("messagesToRedeliver");
-        messagesToRedeliverField.setAccessible(true);
-        ConcurrentBitmapSortedLongPairSet messagesToRedeliver =
-                (ConcurrentBitmapSortedLongPairSet) messagesToRedeliverField.get(controller);
-
-        Field positionToStickyKeyHashField = MessageRedeliveryController.class
-                .getDeclaredField("positionToStickyKeyHash");
-        positionToStickyKeyHashField.setAccessible(true);
-        ConcurrentLongLongPairHashMap positionToStickyKeyHash = (ConcurrentLongLongPairHashMap)
-                positionToStickyKeyHashField.get(controller);
-
-        Field hashesRefCountField = MessageRedeliveryController.class.getDeclaredField("hashesRefCount");
-        hashesRefCountField.setAccessible(true);
-        ConcurrentLongLongHashMap hashesRefCount = (ConcurrentLongLongHashMap) hashesRefCountField.get(controller);
-
-        assertNotNull(positionToStickyKeyHash);
-        if (allowOutOfOrderDelivery) {
-            assertNull(hashesRefCount);
-        } else {
-            assertNotNull(hashesRefCount);
-        }
-
+        assertEquals(controller.isPositionToStickyKeyHashInitialized(), !allowOutOfOrderDelivery);
         assertTrue(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 0);
-        assertEquals(positionToStickyKeyHash.size(), 0);
-        if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 0);
-        }
+        assertEquals(controller.size(), 0);
 
         controller.add(1, 1);
         controller.add(1, 2);
 
         assertFalse(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 2);
-        assertTrue(messagesToRedeliver.contains(1, 1));
-        assertTrue(messagesToRedeliver.contains(1, 2));
-        assertEquals(positionToStickyKeyHash.size(), 0);
-        assertFalse(positionToStickyKeyHash.containsKey(1, 1));
-        assertFalse(positionToStickyKeyHash.containsKey(1, 2));
-        if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 0);
-        }
+        assertEquals(controller.size(), 2);
+        assertNull(controller.getHash(1, 1));
+        assertNull(controller.getHash(1, 2));
+        assertEquals(controller.isPositionToStickyKeyHashInitialized(), !allowOutOfOrderDelivery);
 
         controller.remove(1, 1);
         controller.remove(1, 2);
 
         assertTrue(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 0);
-        assertFalse(messagesToRedeliver.contains(1, 1));
-        assertFalse(messagesToRedeliver.contains(1, 2));
-        assertEquals(positionToStickyKeyHash.size(), 0);
-        if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 0);
-        }
+        assertEquals(controller.size(), 0);
 
         controller.add(2, 1, 100);
         controller.add(2, 2, 101);
         controller.add(2, 3, 101);
 
         assertFalse(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 3);
-        assertTrue(messagesToRedeliver.contains(2, 1));
-        assertTrue(messagesToRedeliver.contains(2, 2));
-        assertTrue(messagesToRedeliver.contains(2, 3));
-        assertEquals(positionToStickyKeyHash.size(), 3);
-        assertEquals(positionToStickyKeyHash.get(2, 1).first, 100);
-        assertEquals(positionToStickyKeyHash.get(2, 2).first, 101);
-        assertEquals(positionToStickyKeyHash.get(2, 3).first, 101);
+        assertEquals(controller.size(), 3);
+        assertTrue(controller.isPositionToStickyKeyHashInitialized());
+        assertEquals(controller.getHash(2, 1), Long.valueOf(100));
+        assertEquals(controller.getHash(2, 2), Long.valueOf(101));
+        assertEquals(controller.getHash(2, 3), Long.valueOf(101));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 2);
-            assertEquals(hashesRefCount.get(100), 1);
-            assertEquals(hashesRefCount.get(101), 2);
+            assertTrue(controller.containsStickyKeyHash(100));
+            assertTrue(controller.containsStickyKeyHash(101));
         }
 
         controller.remove(2, 1);
         controller.remove(2, 2);
 
-        assertEquals(positionToStickyKeyHash.size(), 1);
-        assertEquals(positionToStickyKeyHash.get(2, 3).first, 101);
+        assertEquals(controller.size(), 1);
+        assertNull(controller.getHash(2, 1));
+        assertNull(controller.getHash(2, 2));
+        assertEquals(controller.getHash(2, 3), Long.valueOf(101));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 1);
-            assertEquals(hashesRefCount.get(100), -1);
-            assertEquals(hashesRefCount.get(101), 1);
+            assertFalse(controller.containsStickyKeyHash(100));
+            assertTrue(controller.containsStickyKeyHash(101));
         }
 
         controller.clear();
         assertTrue(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 0);
-        assertTrue(messagesToRedeliver.isEmpty());
-        assertEquals(positionToStickyKeyHash.size(), 0);
+        assertEquals(controller.size(), 0);
+        assertNull(controller.getHash(2, 3));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 0);
-            assertTrue(hashesRefCount.isEmpty());
+            assertFalse(controller.containsStickyKeyHash(101));
         }
 
         controller.add(2, 2, 201);
@@ -150,41 +105,69 @@ public class MessageRedeliveryControllerTest {
         controller.add(1, 1, 100);
 
         controller.removeAllUpTo(1, 3);
-        assertEquals(messagesToRedeliver.size(), 4);
-        assertTrue(messagesToRedeliver.contains(2, 1));
-        assertTrue(messagesToRedeliver.contains(2, 2));
-        assertTrue(messagesToRedeliver.contains(3, 1));
-        assertTrue(messagesToRedeliver.contains(3, 2));
-        assertEquals(positionToStickyKeyHash.size(), 4);
-        assertEquals(positionToStickyKeyHash.get(2, 1).first, 200);
-        assertEquals(positionToStickyKeyHash.get(2, 2).first, 201);
-        assertEquals(positionToStickyKeyHash.get(3, 1).first, 300);
-        assertEquals(positionToStickyKeyHash.get(3, 2).first, 301);
+        assertEquals(controller.size(), 4);
+        assertNull(controller.getHash(1, 1));
+        assertNull(controller.getHash(1, 2));
+        assertNull(controller.getHash(1, 3));
+        assertEquals(controller.getHash(2, 1), Long.valueOf(200));
+        assertEquals(controller.getHash(2, 2), Long.valueOf(201));
+        assertEquals(controller.getHash(3, 1), Long.valueOf(300));
+        assertEquals(controller.getHash(3, 2), Long.valueOf(301));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 4);
-            assertEquals(hashesRefCount.get(200), 1);
-            assertEquals(hashesRefCount.get(201), 1);
-            assertEquals(hashesRefCount.get(300), 1);
-            assertEquals(hashesRefCount.get(301), 1);
+            assertFalse(controller.containsStickyKeyHash(100));
+            assertFalse(controller.containsStickyKeyHash(101));
+            assertTrue(controller.containsStickyKeyHash(200));
+            assertTrue(controller.containsStickyKeyHash(201));
+            assertTrue(controller.containsStickyKeyHash(300));
+            assertTrue(controller.containsStickyKeyHash(301));
         }
 
         controller.removeAllUpTo(3, 1);
-        assertEquals(messagesToRedeliver.size(), 1);
-        assertTrue(messagesToRedeliver.contains(3, 2));
-        assertEquals(positionToStickyKeyHash.size(), 1);
-        assertEquals(positionToStickyKeyHash.get(3, 2).first, 301);
+        assertEquals(controller.size(), 1);
+        assertNull(controller.getHash(2, 1));
+        assertNull(controller.getHash(2, 2));
+        assertNull(controller.getHash(3, 1));
+        assertEquals(controller.getHash(3, 2), Long.valueOf(301));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 1);
-            assertEquals(hashesRefCount.get(301), 1);
+            assertFalse(controller.containsStickyKeyHash(200));
+            assertFalse(controller.containsStickyKeyHash(201));
+            assertFalse(controller.containsStickyKeyHash(300));
+            assertTrue(controller.containsStickyKeyHash(301));
         }
 
         controller.removeAllUpTo(5, 10);
         assertTrue(controller.isEmpty());
-        assertEquals(messagesToRedeliver.size(), 0);
-        assertEquals(positionToStickyKeyHash.size(), 0);
+        assertEquals(controller.size(), 0);
+        assertNull(controller.getHash(3, 2));
         if (!allowOutOfOrderDelivery) {
-            assertEquals(hashesRefCount.size(), 0);
+            assertFalse(controller.containsStickyKeyHash(301));
         }
+    }
+
+    @Test(timeOut = 10000)
+    public void testOutOfOrderSentinelHashDoesNotInitializePositionHashMap() {
+        MessageRedeliveryController controller = new MessageRedeliveryController(true);
+
+        controller.add(1, 1, STICKY_KEY_HASH_NOT_SET);
+
+        assertFalse(controller.isPositionToStickyKeyHashInitialized());
+        assertEquals(controller.size(), 1);
+        assertNull(controller.getHash(1, 1));
+
+        controller.removeAllUpTo(1, 1);
+        assertTrue(controller.isEmpty());
+        assertFalse(controller.isPositionToStickyKeyHashInitialized());
+    }
+
+    @Test(timeOut = 10000)
+    public void testClassicOutOfOrderDoesNotInitializePositionHashMap() {
+        MessageRedeliveryController controller = new MessageRedeliveryController(true, true);
+
+        controller.add(1, 1, 100);
+
+        assertFalse(controller.isPositionToStickyKeyHashInitialized());
+        assertEquals(controller.size(), 1);
+        assertNull(controller.getHash(1, 1));
     }
 
     @Test(dataProvider = "allowOutOfOrderDelivery", timeOut = 10000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -479,6 +479,11 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
         allEntries.forEach(Entry::release);
     }
 
+    @DataProvider(name = "allowOutOfOrderDelivery")
+    private Object[][] allowOutOfOrderDelivery() {
+        return new Object[][] { { false }, { true } };
+    }
+
     /**
      * Reproduces the dispatch stall behind the flaky
      * KeySharedSubscriptionTest.testContinueDispatchMessagesWhenMessageDelayed (issue #21554).
@@ -489,11 +494,6 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
      * in the replay queue for consumers with available permits were then stuck until an unrelated event, such as a
      * consumer flow request, triggered another read.
      */
-    @DataProvider(name = "allowOutOfOrderDelivery")
-    private Object[][] allowOutOfOrderDelivery() {
-        return new Object[][] { { false }, { true } };
-    }
-
     @Test(dataProvider = "allowOutOfOrderDelivery", timeOut = 30000)
     public void testLookAheadNotEngagedWhenCursorHasNoMoreEntries(boolean allowOutOfOrderDelivery) throws Exception {
         persistentDispatcher.close();
@@ -582,6 +582,56 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
                 "The replayed message for consumer1 with available permits should have been dispatched");
 
         allEntries.forEach(Entry::release);
+    }
+
+    @Test(timeOut = 10000)
+    public void testOutOfOrderReplayFilterDoesNotSpendReadBudgetOnConsumerWithoutPermits() {
+        persistentDispatcher.close();
+        persistentDispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(
+                topicMock, cursorMock, subscriptionMock, configMock,
+                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT)
+                        .setAllowOutOfOrderDelivery(true));
+
+        persistentDispatcher.addConsumer(consumerMock).join();
+
+        Consumer slowConsumer = createMockConsumer();
+        doReturn("consumer2").when(slowConsumer).consumerName();
+        doReturn(0).when(slowConsumer).getAvailablePermits();
+        persistentDispatcher.addConsumer(slowConsumer).join();
+
+        StickyKeyConsumerSelector selector = persistentDispatcher.getSelector();
+        String keyForConsumer = generateKeyForConsumer(selector, consumerMock);
+        String keyForSlowConsumer = generateKeyForConsumer(selector, slowConsumer);
+        Entry entry1 = createEntry(1, 1, "message1", 1, keyForSlowConsumer);
+        Entry entry2 = createEntry(1, 2, "message2", 2, keyForSlowConsumer);
+        Entry entry3 = createEntry(1, 3, "message3", 3, keyForConsumer);
+        List<Entry> entries = List.of(entry1, entry2, entry3);
+
+        try {
+            for (Entry entry : entries) {
+                ((EntryImpl) entry).retain();
+                persistentDispatcher.addEntryToReplay(entry);
+            }
+
+            Set<Position> positions = persistentDispatcher.getMessagesToReplayNow(1, Long.MAX_VALUE);
+            assertThat(positions).containsExactly(entry3.getPosition());
+        } finally {
+            entries.forEach(Entry::release);
+        }
+    }
+
+    @Test(timeOut = 10000)
+    public void testOutOfOrderReplayFilterIncludesPositionWithoutStickyKeyHash() {
+        persistentDispatcher.close();
+        persistentDispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(
+                topicMock, cursorMock, subscriptionMock, configMock,
+                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT)
+                        .setAllowOutOfOrderDelivery(true));
+
+        assertTrue(persistentDispatcher.addMessageToReplay(1, 1));
+
+        Set<Position> positions = persistentDispatcher.getMessagesToReplayNow(1, Long.MAX_VALUE);
+        assertThat(positions).containsExactly(PositionFactory.create(1, 1));
     }
 
     @Test(timeOut = 30000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumersTest.java
@@ -489,14 +489,20 @@ public class PersistentStickyKeyDispatcherMultipleConsumersTest {
      * in the replay queue for consumers with available permits were then stuck until an unrelated event, such as a
      * consumer flow request, triggered another read.
      */
-    @Test(timeOut = 30000)
-    public void testLookAheadNotEngagedWhenCursorHasNoMoreEntries() throws Exception {
+    @DataProvider(name = "allowOutOfOrderDelivery")
+    private Object[][] allowOutOfOrderDelivery() {
+        return new Object[][] { { false }, { true } };
+    }
+
+    @Test(dataProvider = "allowOutOfOrderDelivery", timeOut = 30000)
+    public void testLookAheadNotEngagedWhenCursorHasNoMoreEntries(boolean allowOutOfOrderDelivery) throws Exception {
         persistentDispatcher.close();
 
         // the mocked executor doesn't support schedule(), so run the rescheduled read directly
         persistentDispatcher = new PersistentStickyKeyDispatcherMultipleConsumers(
                 topicMock, cursorMock, subscriptionMock, configMock,
-                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT)) {
+                new KeySharedMeta().setKeySharedMode(KeySharedMode.AUTO_SPLIT)
+                        .setAllowOutOfOrderDelivery(allowOutOfOrderDelivery)) {
             @Override
             protected void reScheduleReadInMs(long readAfterMs) {
                 orderedExecutor.execute(this::readMoreEntries);


### PR DESCRIPTION
### Motivation

PR #26236 deliberately kept look-ahead enabled when `allowOutOfOrderDelivery` was true to prevent repeated read-and-discard cycles. At that time, the out-of-order replay queue did not retain position-to-sticky-key-hash mappings, so replay selection could not skip entries assigned to consumers without available permits.

At the end of a topic, that loop brake can cause the next cycle to skip replay and park a normal read while a later replay entry is still eligible for delivery. Dispatch then remains stalled until an unrelated event, such as a consumer flow request, triggers another read.

This change removes that starvation while preserving the convergence property introduced by #26236. Known replay hashes are retained and checked against consumer permits before spending the replay read budget. Hash-less positions are still admitted once and, if rejected during dispatch, are requeued with their calculated hash so subsequent replay cycles can filter them.

### Modifications

- Retain position-to-sticky-key-hash mappings for modern out-of-order Key_Shared replay entries with known hashes.
- Lazily allocate the position-hash map so plain Shared, classic out-of-order, and hash-less replay paths do not pay its fixed memory cost.
- Filter known out-of-order replay positions by their selected consumer's available permits.
- Trigger look-ahead only when the cursor has more entries, preventing a normal read from being parked at the end of the topic while eligible replay entries remain.
- Preserve classic out-of-order replay behavior and simplify redundant replay-filter conditions and comments.
- Add deterministic coverage for the constrained replay read-budget scenario, hash-less and sentinel paths, lazy allocation, and sticky-key ref-count cleanup.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment