### PR TITLE
[improve][io] Replace Spring Framework with cron-utils in CronTriggerer

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,7 +116,8 @@ jna = "5.18.1"
 java-semver = "0.9.0"
 oshi = "6.4.0"
 netty-reactive-streams = "2.0.6"
-cron-utils = "9.1.6"
+# 9.2.0+ is required for CronType.SPRING53 (Spring 5.3+ cron syntax)
+cron-utils = "9.2.1"
 failsafe = "3.3.2"
 disruptor = "3.4.3"
 ant = "1.10.12"
@@ -166,7 +167,6 @@ skyscreamer = "1.5.0"
 # misc
 zstd-jni = "1.5.7-3"
 lz4java = "1.11.1"
-spring = "6.2.12"
 kubernetesclient = "26.0.0"
 aws-sdk = "1.12.788"
 hadoop3 = "3.5.0"
@@ -424,8 +424,7 @@ restassured = { module = "io.rest-assured:rest-assured", version.ref = "restassu
 jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "skyscreamer" }
 zstd-jni = { module = "com.github.luben:zstd-jni", version.ref = "zstd-jni" }
 lz4-java = { module = "at.yawk.lz4:lz4-java", version.ref = "lz4java" }
-spring-context = { module = "org.springframework:spring-context", version.ref = "spring" }
-spring-core = { module = "org.springframework:spring-core", version.ref = "spring" }
+cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }
 kubernetes-client-java = { module = "io.kubernetes:client-java", version.ref = "kubernetesclient" }
 kubernetes-client-java-api-fluent = { module = "io.kubernetes:client-java-api-fluent", version.ref = "kubernetesclient" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }

--- a/pulsar-broker/build.gradle.kts
+++ b/pulsar-broker/build.gradle.kts
@@ -126,7 +126,6 @@ dependencies {
     testImplementation(libs.bcprov.jdk18on)
     testImplementation(libs.commons.math3)
     testImplementation(libs.okhttp3)
-    testImplementation(libs.spring.core)
     testImplementation(libs.vertx.core)
     testImplementation(libs.wiremock)
     testImplementation(libs.consolecaptor)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiHealthCheckTest.java
@@ -50,7 +50,6 @@ import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.compaction.Compactor;
 import org.awaitility.Awaitility;
 import org.mockito.Mockito;
-import org.springframework.util.CollectionUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -108,12 +107,12 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
             assertFalse(future.isCompletedExceptionally());
         });
         Awaitility.await().untilAsserted(() ->
-                assertTrue(CollectionUtils.isEmpty(admin.topics()
+                assertTrue(admin.topics()
                         .getSubscriptions(testHealthCheckTopic).stream()
                         // All system topics are using compaction, even though is not explicitly set in the policies.
                         .filter(v -> !v.equals(Compactor.COMPACTION_SUBSCRIPTION))
                         .collect(Collectors.toList())
-                ))
+                        .isEmpty())
         );
     }
 
@@ -238,12 +237,12 @@ public class AdminApiHealthCheckTest extends MockedPulsarServiceBaseTest {
         }
         // To ensure we don't have any subscription, the producers and readers are closed.
         Awaitility.await().untilAsserted(() ->
-                assertTrue(CollectionUtils.isEmpty(admin.topics()
+                assertTrue(admin.topics()
                         .getSubscriptions(testHealthCheckTopic).stream()
                         // All system topics are using compaction, even though is not explicitly set in the policies.
                         .filter(v -> !v.equals(Compactor.COMPACTION_SUBSCRIPTION))
                         .collect(Collectors.toList())
-                ))
+                        .isEmpty())
         );
     }
 

--- a/pulsar-io/batch-data-generator/build.gradle.kts
+++ b/pulsar-io/batch-data-generator/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(libs.slog)
     api(project(":pulsar-io:pulsar-io-core"))
     implementation(project(":pulsar-io:pulsar-io-batch-discovery-triggerers"))
-    implementation(libs.spring.context)
     api(libs.jfairy)
     implementation(libs.avro)
 

--- a/pulsar-io/batch-discovery-triggerers/build.gradle.kts
+++ b/pulsar-io/batch-discovery-triggerers/build.gradle.kts
@@ -24,5 +24,5 @@ plugins {
 dependencies {
     implementation(libs.slog)
     api(project(":pulsar-io:pulsar-io-core"))
-    implementation(libs.spring.context)
+    implementation(libs.cron.utils)
 }

--- a/pulsar-io/batch-discovery-triggerers/src/main/java/org/apache/pulsar/io/batchdiscovery/CronTriggerer.java
+++ b/pulsar-io/batch-discovery-triggerers/src/main/java/org/apache/pulsar/io/batchdiscovery/CronTriggerer.java
@@ -18,26 +18,47 @@
  */
 package org.apache.pulsar.io.batchdiscovery;
 
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.CustomLog;
 import org.apache.pulsar.io.core.BatchSourceTriggerer;
 import org.apache.pulsar.io.core.SourceContext;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.support.CronTrigger;
 
 /**
  * This is an implementation of BatchSourceTriggerer that triggers based on a cron expression.
  * BatchSource developers using this should pass the json string of a map that contains
  * "__CRON__" key with the appropriate cron expression. The triggerer will trigger based on this expression.
  *
+ * <p>The expression uses the six field syntax {@code second minute hour day-of-month month day-of-week},
+ * including the {@code L}, {@code W} and {@code #} qualifiers and the {@code @hourly} / {@code @daily} /
+ * {@code @weekly} / {@code @monthly} / {@code @yearly} / {@code @annually} / {@code @midnight} macros.
+ * Firing times are resolved in the JVM's default time zone.
  */
 @CustomLog
 public class CronTriggerer implements BatchSourceTriggerer {
   public static final String CRON_KEY = "__CRON__";
+
+  private static final CronParser CRON_PARSER =
+          new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING53));
+
   private String cronExpression;
-  private ThreadPoolTaskScheduler scheduler;
+  private ExecutionTime executionTime;
+  private ScheduledExecutorService scheduler;
 
   @Override
   public void init(Map<String, Object> config, SourceContext sourceContext) {
@@ -46,25 +67,83 @@ public class CronTriggerer implements BatchSourceTriggerer {
     } else {
       throw new IllegalArgumentException("Cron Trigger is not provided with Cron String");
     }
-    scheduler = new ThreadPoolTaskScheduler();
-    scheduler.setThreadNamePrefix(String.format("%s/%s/%s-cron-triggerer-",
-            sourceContext.getTenant(), sourceContext.getNamespace(), sourceContext.getSourceName()));
+    // Fail on a malformed expression here rather than at the first scheduling attempt.
+    executionTime = parse(cronExpression);
+
+    String threadNamePrefix = String.format("%s/%s/%s-cron-triggerer-",
+            sourceContext.getTenant(), sourceContext.getNamespace(), sourceContext.getSourceName());
+    scheduler = Executors.newSingleThreadScheduledExecutor(newThreadFactory(threadNamePrefix));
 
     log.info().attr("cronExpression", cronExpression).log("Initialized CronTrigger");
   }
 
   @Override
   public void start(Consumer<String> trigger) {
-
-    scheduler.initialize();
-    scheduler.schedule(() -> trigger.accept("CRON"), new CronTrigger(cronExpression));
+    scheduleNext(trigger, ZonedDateTime.now());
   }
 
   @Override
   public void stop() {
     if (scheduler != null) {
-      scheduler.shutdown();
+      scheduler.shutdownNow();
     }
   }
-}
 
+  /**
+   * Schedules the next firing after {@code from} and re-arms once the trigger returns. Firings therefore
+   * never overlap, and a slow trigger delays rather than stacks up the following ones. This is how the
+   * previously used Spring {@code CronTrigger} behaved: it derived the next execution from the completion
+   * time of the last one.
+   */
+  private void scheduleNext(Consumer<String> trigger, ZonedDateTime from) {
+    Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(from);
+    if (nextExecution.isEmpty()) {
+      log.warn().attr("cronExpression", cronExpression)
+              .log("Cron expression has no further execution time, the triggerer will not fire again");
+      return;
+    }
+    ZonedDateTime scheduledTime = nextExecution.get();
+    long delayMillis = Math.max(0, Duration.between(ZonedDateTime.now(), scheduledTime).toMillis());
+    try {
+      scheduler.schedule(() -> {
+        try {
+          trigger.accept("CRON");
+        } catch (Throwable t) {
+          log.error().exception(t).attr("cronExpression", cronExpression).log("Cron trigger failed");
+        }
+        // Never derive the following execution from an instant before the slot just fired: the executor
+        // can wake up a hair early, which would otherwise fire the very same slot a second time.
+        ZonedDateTime completionTime = ZonedDateTime.now();
+        scheduleNext(trigger, completionTime.isBefore(scheduledTime) ? scheduledTime : completionTime);
+      }, delayMillis, TimeUnit.MILLISECONDS);
+    } catch (RejectedExecutionException e) {
+      // stop() was called, either before start() got going or while a firing was in flight.
+      log.debug().attr("cronExpression", cronExpression).log("Cron triggerer is stopped, not scheduling again");
+    }
+  }
+
+  /**
+   * Parses a cron expression into its schedule. Package private so that the schedule this triggerer
+   * derives from an expression can be asserted directly.
+   *
+   * @throws IllegalArgumentException if the expression is not a valid cron expression
+   */
+  static ExecutionTime parse(String cronExpression) {
+    return ExecutionTime.forCron(CRON_PARSER.parse(normalizeMacro(cronExpression)));
+  }
+
+  /**
+   * Spring's {@code CronExpression} matched the {@code @daily} style macros case insensitively while
+   * cron-utils only accepts them in lower case. Lower casing a leading {@code @} expression keeps such
+   * configurations working; any other expression is passed through untouched.
+   */
+  private static String normalizeMacro(String expression) {
+    String trimmed = expression == null ? "" : expression.trim();
+    return trimmed.startsWith("@") ? trimmed.toLowerCase(Locale.ROOT) : expression;
+  }
+
+  private static ThreadFactory newThreadFactory(String threadNamePrefix) {
+    AtomicInteger threadCount = new AtomicInteger(1);
+    return runnable -> new Thread(runnable, threadNamePrefix + threadCount.getAndIncrement());
+  }
+}

--- a/pulsar-io/batch-discovery-triggerers/src/test/java/org/apache/pulsar/io/batchdiscovery/CronTriggererTest.java
+++ b/pulsar-io/batch-discovery-triggerers/src/test/java/org/apache/pulsar/io/batchdiscovery/CronTriggererTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.batchdiscovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pulsar.io.core.SourceContext;
+import org.awaitility.Awaitility;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link CronTriggerer}.
+ *
+ * <p>The expected firing times below are the ones the Spring {@code CronTrigger} implementation that this
+ * triggerer previously used produced for the same expressions, so they pin down the cron dialect that
+ * existing BatchSource configurations rely on.
+ */
+public class CronTriggererTest {
+
+  private static final ZonedDateTime BASE = ZonedDateTime.parse("2026-08-04T10:15:30Z"); // a Tuesday
+
+  @DataProvider(name = "cronExpressions")
+  public Object[][] cronExpressions() {
+    return new Object[][]{
+        // plain six-field expressions
+        {"* * * * * *", "2026-08-04T10:15:31Z"},
+        {"0 0/5 * * * *", "2026-08-04T10:20:00Z"},
+        {"0 15 10 * * *", "2026-08-05T10:15:00Z"},
+        {"0 0 0 * * *", "2026-08-05T00:00:00Z"},
+        {"0 0 0 1 * *", "2026-09-01T00:00:00Z"},
+        // day-of-week, by name and by number, case insensitive
+        {"0 0 0 * * MON", "2026-08-10T00:00:00Z"},
+        {"0 0 0 * * mon", "2026-08-10T00:00:00Z"},
+        {"0 0 0 * * 1-5", "2026-08-05T00:00:00Z"},
+        {"0 0 0 * * SAT,SUN", "2026-08-08T00:00:00Z"},
+        // the L / LW / # qualifiers
+        {"0 0 0 L * *", "2026-08-31T00:00:00Z"},
+        {"0 0 0 LW * *", "2026-08-31T00:00:00Z"},
+        {"0 0 0 * * 5#3", "2026-08-21T00:00:00Z"},
+        {"0 0 0 * * FRIL", "2026-08-28T00:00:00Z"},
+        // leap day, which is only reachable years later
+        {"0 0 0 29 2 *", "2028-02-29T00:00:00Z"},
+        // macros, which Spring matched case insensitively
+        {"@hourly", "2026-08-04T11:00:00Z"},
+        {"@HOURLY", "2026-08-04T11:00:00Z"},
+        {"@daily", "2026-08-05T00:00:00Z"},
+        {"@DAILY", "2026-08-05T00:00:00Z"},
+        {"@midnight", "2026-08-05T00:00:00Z"},
+        {"@weekly", "2026-08-09T00:00:00Z"},
+        {"@monthly", "2026-09-01T00:00:00Z"},
+        {"@yearly", "2027-01-01T00:00:00Z"},
+        {"@annually", "2027-01-01T00:00:00Z"},
+        // surrounding whitespace was tolerated too
+        {" 0 0 0 * * * ", "2026-08-05T00:00:00Z"},
+    };
+  }
+
+  @Test(dataProvider = "cronExpressions")
+  public void testNextExecution(String cronExpression, String expectedNextExecution) {
+    Optional<ZonedDateTime> next = CronTriggerer.parse(cronExpression).nextExecution(BASE);
+    assertThat(next).hasValue(ZonedDateTime.parse(expectedNextExecution));
+  }
+
+  @Test
+  public void testExpressionThatNeverFiresAgain() {
+    // February 30th never comes around.
+    assertThat(CronTriggerer.parse("0 0 0 30 2 *").nextExecution(BASE)).isEmpty();
+  }
+
+  @Test
+  public void testInvalidCronExpressionIsRejectedOnInit() {
+    for (String invalid : new String[]{"not-a-cron", "", "0 0 0", "99 0 0 * * *", "@bogus"}) {
+      assertThatThrownBy(() -> newTriggerer(invalid))
+          .describedAs("expression '%s'", invalid)
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void testMissingCronExpressionIsRejectedOnInit() {
+    assertThatThrownBy(() -> new CronTriggerer().init(Collections.emptyMap(), newSourceContext()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cron Trigger is not provided with Cron String");
+  }
+
+  @Test
+  public void testTriggersRepeatedlyOnSchedule() throws Exception {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    CopyOnWriteArrayList<String> events = new CopyOnWriteArrayList<>();
+    try {
+      triggerer.start(events::add);
+      Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> events.size() >= 3);
+    } finally {
+      triggerer.stop();
+    }
+    assertThat(events).containsOnly("CRON");
+  }
+
+  @Test
+  public void testStopPreventsFurtherTriggers() {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    AtomicInteger triggerCount = new AtomicInteger();
+    triggerer.start(event -> triggerCount.incrementAndGet());
+    Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> triggerCount.get() >= 1);
+
+    triggerer.stop();
+    int countAtStop = triggerCount.get();
+    // Anything already running may still complete, but nothing new may be scheduled after that.
+    Awaitility.await().pollDelay(Duration.ofSeconds(3)).atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> assertThat(triggerCount.get()).isLessThanOrEqualTo(countAtStop + 1));
+  }
+
+  @Test
+  public void testStopIsSafeBeforeStartAndWhenCalledTwice() {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    assertThatCode(() -> {
+      triggerer.stop();
+      triggerer.stop();
+      // start() after stop() must not blow up, it simply never fires.
+      triggerer.start(event -> { });
+    }).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testTriggerRunsOnANamedThread() throws Exception {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    CopyOnWriteArrayList<String> threadNames = new CopyOnWriteArrayList<>();
+    CountDownLatch fired = new CountDownLatch(1);
+    try {
+      triggerer.start(event -> {
+        threadNames.add(Thread.currentThread().getName());
+        fired.countDown();
+      });
+      assertThat(fired.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      triggerer.stop();
+    }
+    assertThat(threadNames).first().asString().startsWith("test-tenant/test-ns/test-source-cron-triggerer-");
+  }
+
+  @Test
+  public void testTriggerFailureDoesNotStopTheSchedule() throws Exception {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    AtomicInteger triggerCount = new AtomicInteger();
+    try {
+      triggerer.start(event -> {
+        triggerCount.incrementAndGet();
+        throw new RuntimeException("simulated discovery failure");
+      });
+      // A throwing trigger must not kill the scheduling loop.
+      Awaitility.await().atMost(Duration.ofSeconds(30)).until(() -> triggerCount.get() >= 3);
+    } finally {
+      triggerer.stop();
+    }
+  }
+
+  @Test
+  public void testTriggersDoNotOverlap() throws Exception {
+    CronTriggerer triggerer = newTriggerer("* * * * * *");
+    AtomicInteger concurrent = new AtomicInteger();
+    AtomicInteger maxConcurrent = new AtomicInteger();
+    CountDownLatch firedTwice = new CountDownLatch(2);
+    try {
+      triggerer.start(event -> {
+        maxConcurrent.accumulateAndGet(concurrent.incrementAndGet(), Math::max);
+        try {
+          // Overrun the one second period so overlapping firings would show up here.
+          Thread.sleep(1500);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          concurrent.decrementAndGet();
+          firedTwice.countDown();
+        }
+      });
+      assertThat(firedTwice.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      triggerer.stop();
+    }
+    assertThat(maxConcurrent.get()).isEqualTo(1);
+  }
+
+  private static CronTriggerer newTriggerer(String cronExpression) {
+    CronTriggerer triggerer = new CronTriggerer();
+    triggerer.init(Map.of(CronTriggerer.CRON_KEY, cronExpression), newSourceContext());
+    return triggerer;
+  }
+
+  private static SourceContext newSourceContext() {
+    SourceContext sourceContext = mock(SourceContext.class);
+    when(sourceContext.getTenant()).thenReturn("test-tenant");
+    when(sourceContext.getNamespace()).thenReturn("test-ns");
+    when(sourceContext.getSourceName()).thenReturn("test-source");
+    return sourceContext;
+  }
+}


### PR DESCRIPTION
### Motivation

`CronTriggerer` was the only production use of the Spring Framework in the Pulsar code base. It pulled `spring-context` and `spring-core` (3.3 MB) into the batch-source connector NARs just to parse a cron expression and run a timer.

Removing the dependency also removes Pulsar's exposure to Spring Framework CVEs. The pinned version, 6.2.12, falls within the affected range (`6.2.0` -> `6.2.18.1`) of four CVEs published on 2026-06-09:

| CVE | Issue |
|---|---|
| [CVE-2026-41848](https://www.cve.org/CVERecord?id=CVE-2026-41848) | Denial of service via ReDoS in `AntPathMatcher` (CWE-1333) |
| [CVE-2026-41850](https://www.cve.org/CVERecord?id=CVE-2026-41850) | Algorithmic denial of service via SpEL expressions (CWE-407) |
| [CVE-2026-41851](https://www.cve.org/CVERecord?id=CVE-2026-41851) | Denial of service via an unbounded SpEL expression cache (CWE-770) |
| [CVE-2026-41852](https://www.cve.org/CVERecord?id=CVE-2026-41852) | Arbitrary zero-argument method invocation in SpEL (CWE-863) |

Pulsar only used Spring's cron scheduling, so it neither evaluated SpEL nor used `AntPathMatcher`, and was unlikely to be exploitable through those paths. Dropping the dependency nevertheless removes the flagged artifacts from the connector NARs and ends the need to track Spring CVEs at all.

### Modifications

- Replace `ThreadPoolTaskScheduler` + `CronTrigger` with [cron-utils](https://github.com/jmrozanec/cron-utils) (`CronType.SPRING53`; 175 kB, Apache-2.0, `slf4j-api` its only dependency) and a self-rescheduling single-threaded `ScheduledExecutorService`. The next firing is derived from the completion time of the previous one, so firings never overlap — matching how Spring's `CronTrigger` behaved.
- Lower-case leading-`@` expressions before parsing: Spring matched the `@daily` style macros case-insensitively, cron-utils only accepts lower case.
- Parse the expression in `init()`, so a malformed expression fails there rather than at the first scheduling attempt.
- Drop the now unused `spring-context` from `batch-data-generator` (cron-utils is bundled into the NAR transitively) and `spring-core` from the broker test dependencies, replacing the single `CollectionUtils.isEmpty()` use in `AdminApiHealthCheckTest` with `List.isEmpty()`.
- Remove the `spring` version and both library aliases from the version catalog, and wire up the previously orphaned `cron-utils` version, bumped `9.1.6` -> `9.2.1` because `CronType.SPRING53` requires 9.2.0+.

#### Backward compatibility of the cron dialect

Existing `__CRON__` configurations must keep working, so the replacement was validated against Spring rather than assumed. A differential harness compared `CronExpression` (Spring 6.2.12) with cron-utils `SPRING53` over **4,589,882** next-fire comparisons — 528 expressions x 8 time zones x 37 start instants x 6 chained steps:

- **No parsing differences.** Six-field syntax, `L` / `W` / `LW` / `#` / `?`, named and numeric day-of-week, all seven macros, whitespace and case all agree, and both reject the same malformed input with `IllegalArgumentException`.
- **99.9944% identical firing times.** All 255 differing results are in DST-observing zones, where an expression falling in a shifted or repeated hour can lose one firing per year. There were **no** differences in fixed-offset zones (UTC, `Asia/Kolkata`, `America/Sao_Paulo`).

Quartz was also evaluated and rejected: it cannot parse 15 of 17 of the expressions used here — including `* * * * * *` from `BatchSourceTest` — because it forbids specifying both day-of-month and day-of-week, and it numbers day-of-week `1=SUN` against Spring's `1=MON`, which would silently shift every numeric schedule by a day.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Adds `CronTriggererTest` (33 cases), covering the cron dialect, repeated scheduling, `stop()` behaviour, thread naming, non-overlapping firings and trigger-failure handling. The expected firing times were generated from Spring itself, so they pin down the previous behaviour.
- Verified locally: `CronTriggererTest` green over 6 consecutive runs with retries disabled; `quickCheck`, `sanityCheck`, `spotlessCheck`, `checkstyleMain`, `checkstyleTest` all pass; `BatchSourceExecutorTest`, `BatchSourceConfigParseTest`, `SourceConfigUtilsTest`, `TestCmdSources` and `AdminApiHealthCheckTest` pass.
- Confirmed the built `pulsar-io-batch-data-generator` NAR now bundles `cron-utils-9.2.1.jar` and no Spring jars.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Dependency changes: removes `org.springframework:spring-context` and `org.springframework:spring-core` (6.2.12) from the build entirely; adds `com.cronutils:cron-utils` 9.2.1 (Apache-2.0) to `pulsar-io-batch-discovery-triggerers`. No LICENSE/NOTICE updates are needed — the server and shell distributions exclude `.nar` files, so the Spring jars were never listed there.
