### PR TITLE
[fix][sec][branch-4.2] Upgrade Spring to 7.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@ flexible messaging model and an intuitive client API.</description>
     <okio.version>3.17.0</okio.version>
     <nsq-client.version>1.0</nsq-client.version>
     <cron-utils.version>9.1.6</cron-utils.version>
-    <spring.version>6.2.12</spring.version>
+    <spring.version>7.0.8</spring.version>
     <apache-http-client.version>4.5.14</apache-http-client.version>
     <apache-httpcomponents.version>4.4.16</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>


### PR DESCRIPTION
### Motivation

Spring Framework 6.2.12, currently used on `branch-4.2`, is affected by four CVEs disclosed on 2026-06-09:

| CVE | Severity (CVSS) | Issue | Affected artifact |
| --- | --- | --- | --- |
| [CVE-2026-41848](https://github.com/advisories/GHSA-659m-px2c-25wj) | Low (3.7) | Denial of service via ReDoS in `AntPathMatcher` (CWE-1333) | `spring-core` |
| [CVE-2026-41850](https://github.com/advisories/GHSA-r5w3-xv2f-j59q) | High (7.5) | Algorithmic denial of service via SpEL expressions (CWE-407) | `spring-expression` |
| [CVE-2026-41851](https://github.com/advisories/GHSA-wxpp-56q6-5pcg) | Medium (5.3) | Denial of service via an unbounded SpEL expression cache (CWE-770) | `spring-expression` |
| [CVE-2026-41852](https://github.com/advisories/GHSA-9f52-rjqv-25qv) | Low (3.7) | Arbitrary zero-argument method invocation in SpEL (CWE-863) | `spring-expression` |

**Why 7.0.8 and not 6.2.19?** Both release lines contain the fixes, but Spring Framework 6.2 reached
end-of-life on 2026-06-30, making 6.2.19 the final release on that line. Staying on 6.2.x would leave
`branch-4.2` without a supported upgrade path for any future Spring CVE. Spring Framework 7.0 is
supported until 2027-07-31.

**Exposure in Pulsar.** Pulsar does not evaluate SpEL expressions or use `AntPathMatcher`, so there is
no known exploitable path — this upgrade is dependency hygiene that also clears the CVEs from security
scanners. Spring is a `test`-scoped dependency of `pulsar-broker` and `pulsar-client-tools`, so it is
**not** part of the server or shell distributions; it ships only inside the `pulsar-io-canal` and
`pulsar-io-batch-data-generator` connector NARs.

This change is specific to `branch-4.2`. On `master` the Spring dependency has been removed entirely
(replaced by `cron-utils` in #26269), so there is no corresponding upstream commit to cherry-pick.

### Modifications

Bump the `spring.version` property in the root `pom.xml` from `6.2.12` to `7.0.8`.

This is the complete change; no source modifications were required. Spring Framework 7.0 requires
JDK 17+, which `branch-4.2` already targets (`maven.compiler.source`/`target` are both `17`).

The upgrade affects three modules, which are the only ones declaring Spring dependencies:

- `pulsar-io/batch-discovery-triggerers` — the only Pulsar source file using a Spring API is
  `CronTriggerer`, which uses `ThreadPoolTaskScheduler` and `CronTrigger`. Both are unchanged in 7.0.
- `pulsar-io/batch-data-generator` — declares `spring-context`; no direct Spring API usage.
- `pulsar-io/canal` — declares Spring for the bundled `canal.client`/`canal.common` libraries, which
  themselves reference only 5 Spring methods (`BeanUtils.copyProperties`, and `ReflectionUtils`
  `findField`/`getField`/`makeAccessible`/`setField`). All 5 are present in 7.0.8 with identical
  signatures, so the major-version bump is binary compatible for this connector.

No `LICENSE`/`NOTICE` updates are needed: no distribution `LICENSE.bin.txt` lists Spring jars. (The
existing `NOTICE.bin.txt` mention of Spring is an attribution for Apache Commons Lang borrowing
`StringUtils.containsWhitespace()`, and is unrelated to the Spring version.)

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a dependency version upgrade without new test coverage. It was verified as follows:

- All three affected modules compile cleanly from scratch against Spring 7.0.8 with `release 17`
  (`mvn test-compile` with the build cache disabled).
- `mvn dependency:tree` resolves `spring-core`, `spring-aop`, `spring-beans`, `spring-context`,
  `spring-expression`, `spring-jdbc`, `spring-tx` and `spring-orm` uniformly at `7.0.8` with no
  version conflicts.
- Binary compatibility of the bundled canal libraries was checked by extracting the Spring method
  references from their class files and confirming each signature still exists in the 7.0.8 jars.
- `checkstyle:check` and `license:check` pass for all three modules.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [x] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

Spring Framework is upgraded from 6.2.12 to 7.0.8. Spring is not on the broker runtime classpath; the
upgraded jars are bundled only in the `pulsar-io-canal` and `pulsar-io-batch-data-generator` connector
NARs.
