### PR TITLE
[Fix][broker]Get a fenced error when loading a topic that does not allowed the cluster to access

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2055,7 +2055,7 @@ public class BrokerService implements Closeable {
                                         .thenCompose(__ -> context.trace("pre-create compacted sub",
                                                 persistentTopic.preCreateSubscriptionForCompactionIfNeeded()))
                                         .thenCompose(__ -> context.trace("replication",
-                                                persistentTopic.initCheckReplication()))
+                                                persistentTopic.initializeCheckReplication()))
                                         .thenCompose(v -> context.trace("deduplication",
                                                 persistentTopic.checkDeduplicationStatus()))
                                         .thenRun(() -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2055,7 +2055,7 @@ public class BrokerService implements Closeable {
                                         .thenCompose(__ -> context.trace("pre-create compacted sub",
                                                 persistentTopic.preCreateSubscriptionForCompactionIfNeeded()))
                                         .thenCompose(__ -> context.trace("replication",
-                                                persistentTopic.checkReplication()))
+                                                persistentTopic.initCheckReplication()))
                                         .thenCompose(v -> context.trace("deduplication",
                                                 persistentTopic.checkDeduplicationStatus()))
                                         .thenRun(() -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -340,6 +340,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     // For active topics, the ledger provides the timestamp directly, so this cache is cleared.
     private volatile long cachedLastPublishTimestamp;
 
+    @Getter
+    private final CompletableFuture<Void> initializedReplicationCheck = new CompletableFuture<Void>();
+    private final AtomicBoolean replicationInitialized = new AtomicBoolean(false);
+
     /***
      * We use 3 futures to prevent a new closing if there is an in-progress deletion or closing.  We make Pulsar return
      * the in-progress one when it is called the second time.
@@ -2023,8 +2027,39 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return future;
     }
 
+    public CompletableFuture<Boolean> initCheckReplication() {
+        tryInitializeReplicationCheck();
+        return initializedReplicationCheck.thenApply(__ -> {
+            return this.isClosingOrDeleting;
+        });
+    }
+
+    public boolean tryInitializeReplicationCheck() {
+        if (replicationInitialized.compareAndSet(false, true)) {
+            CompletableFuture<Void> future = internalCheckReplication();
+            future.whenComplete((res, ex) -> {
+                if (ex != null) {
+                    initializedReplicationCheck.completeExceptionally(ex);
+                } else {
+                    initializedReplicationCheck.complete(null);
+                }
+            });
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @Override
     public CompletableFuture<Void> checkReplication() {
+        if (tryInitializeReplicationCheck()) {
+            return initializedReplicationCheck;
+        } else {
+            return internalCheckReplication();
+        }
+    }
+
+    public CompletableFuture<Void> internalCheckReplication() {
         TopicName name = TopicName.get(topic);
         if (NamespaceService.isHeartbeatNamespace(name)
                 || ExtensibleLoadManagerImpl.isInternalTopic(topic)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2031,9 +2031,10 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
      *
      * <p>The initialization state is tracked separately from regular replication checks so that a concurrent
      * policy update does not start a second initial check. The check itself is still dispatched through
-     * {@link #checkReplication()} to preserve overrides supplied by {@link org.apache.pulsar.broker.service.TopicFactory}.
+     * {@link #checkReplication()} to preserve overrides supplied by
+     * {@link org.apache.pulsar.broker.service.TopicFactory}.
      */
-    public CompletableFuture<Void> initializeCheckReplication() {
+    public final CompletableFuture<Void> initializeCheckReplication() {
         if (initialReplicationCheckInitialized.compareAndSet(false, true)) {
             try {
                 checkReplication().whenComplete((__, ex) -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -340,9 +340,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
     // For active topics, the ledger provides the timestamp directly, so this cache is cleared.
     private volatile long cachedLastPublishTimestamp;
 
-    @Getter
-    private final CompletableFuture<Void> initializedReplicationCheck = new CompletableFuture<Void>();
-    private final AtomicBoolean replicationInitialized = new AtomicBoolean(false);
+    private final CompletableFuture<Void> initialReplicationCheck = new CompletableFuture<>();
+    private final AtomicBoolean initialReplicationCheckInitialized = new AtomicBoolean(false);
 
     /***
      * We use 3 futures to prevent a new closing if there is an in-progress deletion or closing.  We make Pulsar return
@@ -2027,39 +2026,48 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         return future;
     }
 
-    public CompletableFuture<Boolean> initCheckReplication() {
-        tryInitializeReplicationCheck();
-        return initializedReplicationCheck.thenApply(__ -> {
-            return this.isClosingOrDeleting;
-        });
-    }
-
-    public boolean tryInitializeReplicationCheck() {
-        if (replicationInitialized.compareAndSet(false, true)) {
-            CompletableFuture<Void> future = internalCheckReplication();
-            future.whenComplete((res, ex) -> {
-                if (ex != null) {
-                    initializedReplicationCheck.completeExceptionally(ex);
-                } else {
-                    initializedReplicationCheck.complete(null);
-                }
-            });
-            return true;
-        } else {
-            return false;
+    /**
+     * Starts the replication check used while loading a topic.
+     *
+     * <p>The initialization state is tracked separately from regular replication checks so that a concurrent
+     * policy update does not start a second initial check. The check itself is still dispatched through
+     * {@link #checkReplication()} to preserve overrides supplied by {@link org.apache.pulsar.broker.service.TopicFactory}.
+     */
+    public CompletableFuture<Void> initializeCheckReplication() {
+        if (initialReplicationCheckInitialized.compareAndSet(false, true)) {
+            try {
+                checkReplication().whenComplete((__, ex) -> {
+                    if (ex != null) {
+                        initialReplicationCheck.completeExceptionally(ex);
+                    } else {
+                        initialReplicationCheck.complete(null);
+                    }
+                });
+            } catch (Throwable t) {
+                // checkReplication is overridable, so an implementation can fail before returning its future.
+                initialReplicationCheck.completeExceptionally(t);
+            }
         }
+        // Do not expose the mutable internal future: callers can cancel or complete a CompletableFuture.
+        return initialReplicationCheck.thenApply(__ -> null);
     }
 
     @Override
     public CompletableFuture<Void> checkReplication() {
-        if (tryInitializeReplicationCheck()) {
-            return initializedReplicationCheck;
-        } else {
-            return internalCheckReplication();
+        if (initialReplicationCheckInitialized.compareAndSet(false, true)) {
+            internalCheckReplication().whenComplete((__, ex) -> {
+                if (ex != null) {
+                    initialReplicationCheck.completeExceptionally(ex);
+                } else {
+                    initialReplicationCheck.complete(null);
+                }
+            });
+            return initialReplicationCheck.thenApply(__ -> null);
         }
+        return internalCheckReplication();
     }
 
-    public CompletableFuture<Void> internalCheckReplication() {
+    private CompletableFuture<Void> internalCheckReplication() {
         TopicName name = TopicName.get(topic);
         if (NamespaceService.isHeartbeatNamespace(name)
                 || ExtensibleLoadManagerImpl.isInternalTopic(topic)) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -71,18 +71,6 @@ public class SystemTopic extends PersistentTopic {
     }
 
     @Override
-    public CompletableFuture<Boolean> initCheckReplication() {
-        if (SystemTopicNames.isTopicPoliciesSystemTopic(topic)) {
-            return super.initCheckReplication();
-        }
-        // Since the txn system topic is not allowed to access anymore, we should delete data.
-        if (SystemTopicNames.isTransactionBufferOrPendingAckSystemTopicName(TopicName.get(topic))) {
-            return super.removeTopicIfLocalClusterNotAllowed().thenApply(__ -> true);
-        }
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<Void> checkReplication() {
         if (SystemTopicNames.isTopicPoliciesSystemTopic(topic)) {
             return super.checkReplication();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SystemTopic.java
@@ -71,6 +71,18 @@ public class SystemTopic extends PersistentTopic {
     }
 
     @Override
+    public CompletableFuture<Boolean> initCheckReplication() {
+        if (SystemTopicNames.isTopicPoliciesSystemTopic(topic)) {
+            return super.initCheckReplication();
+        }
+        // Since the txn system topic is not allowed to access anymore, we should delete data.
+        if (SystemTopicNames.isTransactionBufferOrPendingAckSystemTopicName(TopicName.get(topic))) {
+            return super.removeTopicIfLocalClusterNotAllowed().thenApply(__ -> true);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Void> checkReplication() {
         if (SystemTopicNames.isTopicPoliciesSystemTopic(topic)) {
             return super.checkReplication();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -231,7 +231,7 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
     @DataProvider
     public Object[][] removeClusterLevels() {
         return new Object[][] {
-            //{"namespace"},
+            {"namespace"},
             {"topic"}
         };
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -346,10 +346,10 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
 
         CompletableFuture<Optional<Topic>> future = pulsar1.getBrokerService().getTopic(topicP1, true);
         if ("topic".equals(removeClusterLevel)) {
-            future.get(30, TimeUnit.SECONDS);
+            future.get(90, TimeUnit.SECONDS);
         } else {
             try {
-                future.get(30, TimeUnit.SECONDS);
+                future.get(90, TimeUnit.SECONDS);
                 fail("Should have thrown an exception since the __change_event topic can not be access anymore");
             } catch (Exception e) {
                 assertTrue(e.getMessage().contains("Namespace missing local cluster name"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -231,7 +231,7 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
     @DataProvider
     public Object[][] removeClusterLevels() {
         return new Object[][] {
-            {"namespace"},
+            //{"namespace"},
             {"topic"}
         };
     }
@@ -342,6 +342,12 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
             assertEquals(localPolicies2.get().getPublishRate(), publishRateAddLocal2,
                 "Remote cluster should have local policies: publish rate.");
         });
+
+        CompletableFuture<Optional<Topic>> future = pulsar1.getBrokerService().getTopic(topicP1, true);
+        Awaitility.await().atMost(1, TimeUnit.HOURS).untilAsserted(() -> {
+            assertTrue(future.isDone());
+        });
+        assertFalse(future.isCompletedExceptionally());
 
         // cleanup.
         if ("topic".equals(removeClusterLevel)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -345,22 +345,16 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
         });
 
         CompletableFuture<Optional<Topic>> future = pulsar1.getBrokerService().getTopic(topicP1, true);
-        Awaitility.await().untilAsserted(() -> {
-            assertTrue(future.isDone());
-        });
         if ("topic".equals(removeClusterLevel)) {
-            assertFalse(future.isCompletedExceptionally());
+            future.get(30, TimeUnit.SECONDS);
         } else {
-            assertTrue(future.isCompletedExceptionally());
             try {
-                future.get();
+                future.get(30, TimeUnit.SECONDS);
                 fail("Should have thrown an exception since the __change_event topic can not be access anymore");
             } catch (Exception e) {
                 assertTrue(e.getMessage().contains("Namespace missing local cluster name"));
             }
         }
-
-
         // cleanup.
         if ("topic".equals(removeClusterLevel)) {
             admin1.namespaces().setNamespaceReplicationClusters(ns1, new HashSet<>(Arrays.asList(cluster2)), true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -345,7 +345,7 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
         });
 
         CompletableFuture<Optional<Topic>> future = pulsar1.getBrokerService().getTopic(topicP1, true);
-        Awaitility.await().atMost(1, TimeUnit.HOURS).untilAsserted(() -> {
+        Awaitility.await().untilAsserted(() -> {
             assertTrue(future.isDone());
         });
         if ("topic".equals(removeClusterLevel)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/OneWayReplicatorUsingGlobalPartitionedTest.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.broker.service.TopicPoliciesService.GetType.LOCA
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -347,7 +348,18 @@ public class OneWayReplicatorUsingGlobalPartitionedTest extends OneWayReplicator
         Awaitility.await().atMost(1, TimeUnit.HOURS).untilAsserted(() -> {
             assertTrue(future.isDone());
         });
-        assertFalse(future.isCompletedExceptionally());
+        if ("topic".equals(removeClusterLevel)) {
+            assertFalse(future.isCompletedExceptionally());
+        } else {
+            assertTrue(future.isCompletedExceptionally());
+            try {
+                future.get();
+                fail("Should have thrown an exception since the __change_event topic can not be access anymore");
+            } catch (Exception e) {
+                assertTrue(e.getMessage().contains("Namespace missing local cluster name"));
+            }
+        }
+
 
         // cleanup.
         if ("topic".equals(removeClusterLevel)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
@@ -76,6 +76,7 @@ public class PersistentTopicInitializeDelayTest extends BrokerTestBase {
 
         Optional<Topic> topic = optionalFuture.get(15, TimeUnit.SECONDS);
         assertTrue(topic.isPresent());
+        assertEquals(MyPersistentTopic.checkReplicationInvocationCount.get(), 1);
     }
 
     public static class MyTopicFactory implements TopicFactory {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicInitializeDelayTest.java
@@ -72,6 +72,7 @@ public class PersistentTopicInitializeDelayTest extends BrokerTestBase {
         admin.topicPolicies().setMaxConsumers(topicName, 10);
         Awaitility.await().untilAsserted(() -> assertEquals(admin.topicPolicies().getMaxConsumers(topicName), 10));
         admin.topics().unload(topicName);
+        MyPersistentTopic.checkReplicationInvocationCount.set(0);
         CompletableFuture<Optional<Topic>> optionalFuture = pulsar.getBrokerService().getTopic(topicName, true);
 
         Optional<Topic> topic = optionalFuture.get(15, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

The conditions under which the issue occurs:
- two clusters `[cluster-a, cluster-b]` share configuration metadata store.
- enabled namespace-level replication `public/default`
- disabled topic-level replication `public/default/tp-1`: `[cluster-b]`
  - `cluster-a` can not access the topic anymore. 
- `on cluster-a`: you will get a topic fenced error when calling `BrokerService.getTopic(topic, createIfMissing)`.

How it occurs:

- create topic obj 
- initialize 
- register listener to `TopicPoliciesService` 
- load latest topic-level policies if exists 
  - initialise policies: checkReplication 
  - initialise other policies.
- init finished 
- check replication, which was called by BrokerService 
- check deduplication, which was called by BrokerService

`step-4` and `step-6`, Broker checked replication twice; the first one will delete the topic, and the second one will get a fenced error.


```
2026-08-03T03:23:46,878+0000 [bookkeeper-ml-scheduler-OrderedScheduler-0-0] ERROR io.streamnative.pulsar.handlers.kop.TopicLoadingService - [[id: 0xe3b25093, L:/***- R:/127.0.0.6:***]][RequestHeader(***)] Failed to getTopic persistent://public/default/tp-1
java.util.concurrent.CompletionException: org.apache.pulsar.broker.service.BrokerServiceException$TopicFencedException: Topic is already fenced
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(Unknown Source)
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$removeTopicIfLocalClusterNotAllowed$71(PersistentTopic.java:2086)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(Unknown Source)
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.removeTopicIfLocalClusterNotAllowed(PersistentTopic.java:2082)
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.checkReplication(PersistentTopic.java:1948)
	at io.streamnative.pulsar.handlers.kop.topic.KopPersistentTopic.checkReplication(KopPersistentTopic.java:185)
	at org.apache.pulsar.broker.service.BrokerService$2.lambda$openLedgerComplete$1(BrokerService.java:1887)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
	at org.apache.pulsar.metadata.cache.impl.MetadataCacheImpl.lambda$readValueFromStore$1(MetadataCacheImpl.java:171)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.postFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
```


### Modifications

Let the method `checkReplication` just be called once.

### Todo list, which will be improved with separate PRs

- [ ] make it throw a NotAllowed error in the above case; it might break something.
  - It should also improve performance, to avoid loading the managed ledger up. 
- [ ] improve readability for the class `TopicPolicyListenerWrapper`

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment