### PR TITLE
[fix][admin] Avoid creating subscriptions when peeking messages if auto-creation is disabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3102,9 +3102,8 @@ public class PersistentTopicsBase extends AdminResource {
                     PersistentReplicator repl = getReplicatorReference(subName, (PersistentTopic) topic);
                     entry = repl.peekNthMessage(messagePosition);
                 } else {
-                    PersistentSubscription sub =
-                            (PersistentSubscription) getSubscriptionReference(subName, (PersistentTopic) topic);
-                    entry = sub.peekNthMessage(messagePosition);
+                    entry = findOrCreateSubscriptionAsync(subName, (PersistentTopic) topic)
+                            .thenCompose(sub -> sub.peekNthMessage(messagePosition));
                 }
             }
             return entry.thenApply(e -> Pair.of(e, (PersistentTopic) topic));
@@ -4729,20 +4728,35 @@ public class PersistentTopicsBase extends AdminResource {
     }
 
     /**
-     * Get the Subscription object reference from the Topic reference.
+     * Find the subscription or create it when automatic subscription creation is allowed.
      */
-    private Subscription getSubscriptionReference(String subName, PersistentTopic topic) {
-        try {
-            Subscription sub = topic.getSubscription(subName);
-            if (sub == null) {
-                sub = topic.createSubscription(subName,
-                        InitialPosition.Earliest, false, null).get();
-            }
-
-            return checkNotNull(sub);
-        } catch (Exception e) {
-            throw new RestException(Status.NOT_FOUND, getSubNotFoundErrorMessage(topicName.toString(), subName));
+    private CompletableFuture<Subscription> findOrCreateSubscriptionAsync(String subName, PersistentTopic topic) {
+        Subscription subscription = topic.getSubscription(subName);
+        if (subscription != null) {
+            return CompletableFuture.completedFuture(subscription);
         }
+
+        return pulsar().getBrokerService().isAllowAutoSubscriptionCreationAsync(topicName)
+                .thenCompose(isAllowed -> {
+                    Subscription existingSubscription = topic.getSubscription(subName);
+                    if (existingSubscription != null) {
+                        return CompletableFuture.completedFuture(existingSubscription);
+                    }
+                    if (!isAllowed) {
+                        return CompletableFuture.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                                String.format("Subscription %s does not exist for topic %s and automatic "
+                                                + "subscription creation is disabled",
+                                        subName, topicName)));
+                    }
+                    return topic.createSubscription(subName, InitialPosition.Earliest, false, null)
+                            .handle((createdSubscription, ex) -> {
+                                if (ex != null || createdSubscription == null) {
+                                    throw new RestException(Status.NOT_FOUND,
+                                            getSubNotFoundErrorMessage(topicName.toString(), subName));
+                                }
+                                return createdSubscription;
+                            });
+                });
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2256,7 +2256,9 @@ public class PersistentTopics extends PersistentTopicsBase {
                     + " exist"),
             @ApiResponse(responseCode = "405",
                     description = "Skipping messages on a non-persistent topic is not allowed"),
-            @ApiResponse(responseCode = "412", description = "Topic name is not valid"),
+            @ApiResponse(responseCode = "412",
+                    description = "Topic name is not valid, or the subscription does not exist and automatic "
+                            + "subscription creation is disabled"),
             @ApiResponse(responseCode = "500", description = "Internal server error"),
             @ApiResponse(responseCode = "503", description = "Failed to validate global cluster configuration")})
     public void peekNthMessage(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/PersistentTopicsTest.java
@@ -99,6 +99,7 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.AutoSubscriptionCreationOverride;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -1145,9 +1146,20 @@ public class PersistentTopicsTest extends MockedPulsarServiceBaseTest {
             producer.send("test" + i);
         }
 
+        admin.namespaces().setAutoSubscriptionCreation("tenant-xyz/ns-abc",
+                AutoSubscriptionCreationOverride.builder().allowAutoSubscriptionCreation(false).build());
+        PulsarAdminException.PreconditionFailedException exception = Assert.expectThrows(
+                PulsarAdminException.PreconditionFailedException.class,
+                () -> admin.topics().peekMessages(partitionedTopic, subscriptionName, 3));
+        Assert.assertEquals(exception.getStatusCode(), Response.Status.PRECONDITION_FAILED.getStatusCode());
+        Assert.assertTrue(admin.topics().getSubscriptions(partitionedTopic).isEmpty());
+
+        admin.namespaces().setAutoSubscriptionCreation("tenant-xyz/ns-abc",
+                AutoSubscriptionCreationOverride.builder().allowAutoSubscriptionCreation(true).build());
         List<Message<byte[]>> messages = admin.topics().peekMessages(partitionedTopic, subscriptionName, 3);
 
         Assert.assertEquals(messages.size(), 3);
+        Assert.assertEquals(admin.topics().getSubscriptions(partitionedTopic), List.of(subscriptionName));
 
         producer.close();
     }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -1500,6 +1500,8 @@ public interface Topics {
      *             Don't have admin permission
      * @throws NotFoundException
      *             Topic or subscription does not exist
+     * @throws PreconditionFailedException
+     *             Subscription does not exist and automatic subscription creation is disabled
      * @throws PulsarAdminException
      *             Unexpected error
      */
@@ -1533,6 +1535,8 @@ public interface Topics {
      *             Don't have admin permission
      * @throws NotFoundException
      *             Topic or subscription does not exist
+     * @throws PreconditionFailedException
+     *             Subscription does not exist and automatic subscription creation is disabled
      * @throws PulsarAdminException
      *             Unexpected error
      */


### PR DESCRIPTION
### Motivation

The peek messages Admin API implicitly creates a subscription at the earliest position when the requested subscription does not exist. This creation currently bypasses the effective `allowAutoSubscriptionCreation` policy at the topic, namespace, and broker levels.

As a result, a read-oriented Admin operation can create subscription metadata, retain backlog, and consume subscription quota even when automatic subscription creation is disabled.

### Modifications

- Check the effective automatic subscription creation policy before implicitly creating a subscription for peek messages.
- Preserve the existing behavior of creating the subscription at the earliest position when automatic creation is allowed.
- Return HTTP 412 Precondition Failed when the subscription does not exist and automatic creation is disabled.
- Keep the subscription lookup and creation path asynchronous.
- Document the REST and Java Admin API behavior.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

- Extended `PersistentTopicsTest.testPeekWithSubscriptionNameNotExist` to verify that:
  - peeking does not create a subscription when automatic subscription creation is disabled;
  - the Java Admin client receives `PreconditionFailedException`;
  - peeking continues to create the subscription and return messages when automatic creation is enabled.
- Ran the relevant broker and client-admin-api Checkstyle tasks.
- Compiled the affected broker and client-admin-api modules.

### Does this pull request potentially affect one of the following parts:

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
  - `peekMessages` now reports `PreconditionFailedException` when the subscription is missing and automatic creation is disabled.
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [x] The REST endpoints
  - The peek message endpoint returns HTTP 412 for the rejected implicit subscription creation.
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment
